### PR TITLE
OSS Setup

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -1,0 +1,1 @@
+# Dataline Public Repo

--- a/tools/local_env/setup.sh
+++ b/tools/local_env/setup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+function _error() {
+  echo "$@"
+  exit 1
+}
+
+function main() {
+  [[ -e .root ]] || _error "Must run from root"
+
+  git remote add oss https://github.com/datalineio/public.git
+}
+
+main "$@"

--- a/tools/oss/push_oss.sh
+++ b/tools/oss/push_oss.sh
@@ -4,7 +4,7 @@ set -e
 
 _usage="
 Usage: ./tools/oss/push_oss.sh <target-branch> <force (optional)>
-Example: ./tools/oss/push_oss.sh my-branch force>
+Example: ./tools/oss/push_oss.sh my-branch force
 "
 
 function _error() {
@@ -80,4 +80,3 @@ function main() {
 }
 
 main "$@"
-

--- a/tools/oss/push_oss.sh
+++ b/tools/oss/push_oss.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -e
+
+_usage="
+Usage: ./tools/oss/push_oss.sh <target-branch> <force (optional)>
+Example: ./tools/oss/push_oss.sh my-branch force>
+"
+
+function _error() {
+  echo "$@"
+  echo "$_usage"
+  exit 1
+}
+
+function _in_sync_with_remote() {
+  # https://stackoverflow.com/a/3278427
+  git remote update
+  UPSTREAM='@{u}'
+  echo "checking local commit history against remote: $(git rev-parse --symbolic-full-name --abbrev-ref ${UPSTREAM})"
+  LOCAL=$(git rev-parse @)
+  REMOTE=$(git rev-parse "$UPSTREAM")
+  BASE=$(git merge-base @ "$UPSTREAM")
+
+  if [ $LOCAL = $REMOTE ]; then
+      echo "Up-to-date"
+  elif [ $LOCAL = $BASE ]; then
+      echo "Need to pull"
+  elif [ $REMOTE = $BASE ]; then
+      echo "Need to push"
+  else
+      echo "Diverged"
+  fi
+}
+
+function _on_master() {
+  # only push master to downstream repo.
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  if [[ "$CURRENT_BRANCH" != "master" ]]; then
+    _error 'Can only push to target branch master while on master branch.';
+    exit 1;
+  fi
+}
+
+# attempts to push the public dir to the specified branch in the dataline _public_ repository.
+# * verifies that the branch being pushed is in sync with the origin remote of the monorepo.
+# * allows force push (except when pushing to master--if you need to do this, do it manually).
+# * only allows pushes to master from the master branch.
+function main() {
+  [[ -e .root ]] || _error "Must run from root"
+  TARGET_BRANCH=$1; shift || _error "Missing target branch"
+  FORCE_RAW=$1;
+  FORCE=false
+
+  if [[ "$FORCE_RAW" = "force" ]]; then
+    FORCE=true
+  fi
+
+  echo "target branch: ${TARGET_BRANCH}"
+  echo "force: ${FORCE}"
+
+  # if pushing to master on the oss repo, must push from master.
+  if [[ "$TARGET_BRANCH" = "master" ]]; then
+    _on_master
+  fi
+
+  if [[ "$TARGET_BRANCH" = "master" && "$FORCE" = true ]]; then
+    _error "cannot force push to master."
+  fi
+
+  # do not push to oss repo, if local branch is not in sync with origin in monorepo.
+  _in_sync_with_remote
+
+  if [[ "$FORCE" = true ]]
+  then
+    git push oss `git subtree split --prefix public`:"${TARGET_BRANCH}"  --force
+  else
+    git subtree push --prefix=public oss "${TARGET_BRANCH}"
+  fi
+}
+
+main "$@"
+

--- a/tools/oss/push_oss.sh
+++ b/tools/oss/push_oss.sh
@@ -26,10 +26,13 @@ function _in_sync_with_remote() {
       echo "Up-to-date"
   elif [ $LOCAL = $BASE ]; then
       echo "Need to pull"
+      exit 1
   elif [ $REMOTE = $BASE ]; then
       echo "Need to push"
+      exit 1
   else
       echo "Diverged"
+      exit 1
   fi
 }
 


### PR DESCRIPTION
This PR proposes a mechanism for us to push updates to an open source mirror of a subdirectory in our main _private_ monorepo. This tools uses git subtrees based on their description [here](https://github.com/git/git/blob/master/contrib/subtree/git-subtree.txt). Definitely open to other approaches. I believe this is how rideOS used to it, and it seemed to work pretty smoothly.

Note: I have picked the name of our public repo (called it "public") arbitrarily for now just so I had something to develop against. We should change the name.

The `tools/local_env/setup.sh` currently just sets up the OSS repo as a remote.

The `tools/oss/push_oss.sh` script is meant to be run as an after hook on every push to master (or maybe just after we push to master _and_ the build is successful). See the comments in the script for more details on how it works. The key to the script is that it tries to lock down mirroring to master to avoid mistakes but still allow ease in mirroring to other branches in the OSS repo.

The `public` dir is also arbitrary. The idea being that anything in that dir will be mirrors into the public repo.

See https://github.com/datalineio/public/tree/test (the `test` branch on the public repo for an example of how the mirroring works).