### PR TITLE
example of tap interface (with example implementation of postgres)

### DIFF
--- a/pg_integration/pgConfig.json
+++ b/pg_integration/pgConfig.json
@@ -64,6 +64,36 @@
         },
         "database": {
           "type": "string"
+        },
+        "sshConnection": {
+          "type": "object",
+          "oneOf": [
+            {
+              "title": "https",
+              "type": "null"
+            },
+            {
+              "title": "ssh",
+              "properties": {
+                "sshHost": {
+                  "title": "ssh host",
+                  "type": "string"
+                },
+                "sshPort": {
+                  "title": "ssh port",
+                  "type": "integer"
+                },
+                "sshUser": {
+                  "title": "ssh user",
+                  "type": "string"
+                },
+                "publicKey": {
+                  "title": "public key",
+                  "type": "string"
+                }
+              }
+            }
+          ]
         }
       }
     },

--- a/pg_integration/pgConfig.json
+++ b/pg_integration/pgConfig.json
@@ -1,0 +1,149 @@
+{
+  "id": "http://json-schema.org/geo",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "description": "sync configurations needed to configure a postgres tap",
+  "type": "object",
+  "definitions": {
+    "schema": {
+      "description": "describes the available schema.",
+      "type": "object",
+      "properties": {
+        "tables": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "columns"],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "columns": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["name", "dataType"],
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "dataType": {
+                      "type": "string",
+                      "enum": ["string", "number", "uuid", "boolean"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "postgresConnectionConfiguration": {
+      "description": "all configuration information needed for creating a connection.",
+      "type": "object",
+      "required": ["host", "port", "user"],
+      "properties": {
+        "host": {
+          "type": "string",
+          "format": "hostname"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63
+        },
+        "password": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63
+        },
+        "database": {
+          "type": "string"
+        }
+      }
+    },
+    "standardConnectionStatus": {
+      "description": "describes the result of a 'test connection' action.",
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["success", "failure"]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "standardDiscoveryOutput": {
+      "description": "describes the standard output for any discovery run.",
+      "type": "object",
+      "required": ["schema"],
+      "properties": {
+        "schema": {
+          "$ref": "#/definitions/schema"
+        }
+      }
+    },
+    "standardSyncConfiguration": {
+      "description": "configuration required for sync for ALL taps",
+      "type": "object",
+      "properties": {
+        "syncMode": {
+          "type": "string",
+          "enum": ["full_refresh", "append"]
+        }
+      }
+    },
+    "postgresSyncConfiguration": {
+      "description": "postgres specific configuration for sync step",
+      "type": "object",
+      "required": ["tables"],
+      "properties": {
+        "tables": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["columns"],
+            "properties": {
+              "columns": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "standardSyncOutput": {
+      "description": "standard information output by ALL taps for a sync step (our version of state.json)",
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["completed", "failed", "cancelled"]
+        },
+        "recordsSynced": {
+          "type": "integer"
+        },
+        "version": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/pg_integration/pgConfig.json
+++ b/pg_integration/pgConfig.json
@@ -110,8 +110,11 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["columns"],
+            "required": ["name", "columns"],
             "properties": {
+              "name": {
+                "type": "string"
+              },
               "columns": {
                 "type": "array",
                 "items": {

--- a/pg_integration/src/app.ts
+++ b/pg_integration/src/app.ts
@@ -1,0 +1,99 @@
+import {
+  DataType,
+  PostgresConnectionConfiguration,
+  PostgresSyncConfiguration,
+  StandardConnectionStatus,
+  StandardConnectionStatusStatus,
+  StandardDiscoveryOutput,
+  StandardSyncConfiguration,
+  StandardSyncOutput,
+  StandardSyncOutputStatus
+} from "./gen/postgresTap";
+
+// interface that must be implemented for each tap.
+interface ConduitTap<ConnectionConfiguration, SyncConfiguration, State> {
+  // test connection
+  testConnection(
+    connectionConfiguration: ConnectionConfiguration
+  ): StandardConnectionStatus;
+
+  // discover
+  discover(
+    connectionConfiguration: ConnectionConfiguration
+  ): StandardDiscoveryOutput;
+
+  // sync
+  sync(
+    connectionConfiguration: ConnectionConfiguration,
+    syncConfiguration: SyncConfiguration,
+    standardSyncConfiguration: StandardSyncConfiguration,
+    state: State
+  ): [StandardSyncOutput, State];
+}
+
+const postgresConduitTapImplementation: ConduitTap<
+  PostgresConnectionConfiguration,
+  PostgresSyncConfiguration,
+  any
+> = {
+  testConnection(
+    connectionConfiguration: PostgresConnectionConfiguration
+  ): StandardConnectionStatus {
+    // attempts to connect to postgres using connection configuration.
+    return { status: StandardConnectionStatusStatus.Success };
+  },
+
+  discover(
+    connectionConfiguration: PostgresConnectionConfiguration
+  ): StandardDiscoveryOutput {
+    // attempts to read the schema using connection configuration.
+    return {
+      schema: {
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                dataType: DataType.UUID
+              },
+              {
+                name: "username",
+                dataType: DataType.String
+              }
+            ]
+          }
+        ]
+      }
+    };
+  },
+  sync(
+    connectionConfiguration: PostgresConnectionConfiguration,
+    syncConfiguration: PostgresSyncConfiguration,
+    standardSyncConfiguration: StandardSyncConfiguration,
+    state: any
+  ): [StandardSyncOutput, any] {
+    // 1. runs singer discovery. obtains a catalog.json
+    // 2. uses contents of PostgresSyncConfiguration and standardSyncConfiguration to mutate the catalog.json so that the
+    // desired sync type is used and only the desired tables / columns are synced.
+    //   i. specifically in this case this requires taking the `syncMode` field from `standardSyncConfiguration` and
+    //   injecting it into the `replication-method` of each stream in he catalog json.
+    //   ii. in catalog.json removing any stream (table) or columns that are are not explicitly mentioned in
+    //   `PostgresSyncConfiguration`. validating that all tables / columns that are mentioned actually exist in the
+    //   catalog.
+    // 3. runs singer sync
+    // 4. outputs status of the run. also outputs the state file that singer producers. this is just stored as a blob.
+    return [
+      {
+        status: StandardSyncOutputStatus.Completed,
+        recordsSynced: 10,
+        version: 1596437234
+      },
+      {
+        _comment: "whatever garbage is in state.json"
+      }
+    ];
+  }
+};
+
+export { ConduitTap, postgresConduitTapImplementation };

--- a/pg_integration/src/gen/postgresTap.ts
+++ b/pg_integration/src/gen/postgresTap.ts
@@ -1,0 +1,130 @@
+/**
+ * sync configurations needed to configure a postgres tap
+ */
+export interface PostgresTap {
+  /**
+   * all configuration information needed for creating a connection.
+   */
+  postgresConnectionConfiguration?: PostgresConnectionConfiguration;
+  /**
+   * postgres specific configuration for sync step
+   */
+  postgresSyncConfiguration?: PostgresSyncConfiguration;
+  /**
+   * state file that singer tap users internally. not to be exposed to ender user
+   */
+  postgresSyncState?: { [key: string]: any };
+  /**
+   * describes the result of a 'test connection' action.
+   */
+  standardConnectionStatus?: StandardConnectionStatus;
+  /**
+   * describes the standard output for any discovery run.
+   */
+  standardDiscoveryOutput?: StandardDiscoveryOutput;
+  /**
+   * configuration required for sync for ALL taps
+   */
+  standardSyncConfiguration?: StandardSyncConfiguration;
+  /**
+   * standard information output by ALL taps for a sync step (our version of state.json)
+   */
+  standardSyncOutput?: StandardSyncOutput;
+}
+
+/**
+ * all configuration information needed for creating a connection.
+ */
+export interface PostgresConnectionConfiguration {
+  database?: string;
+  host: string;
+  password?: string;
+  port: number;
+  user: string;
+}
+
+/**
+ * postgres specific configuration for sync step
+ */
+export interface PostgresSyncConfiguration {
+  tables: PostgresSyncConfigurationTable[];
+}
+
+export interface PostgresSyncConfigurationTable {
+  columns: PurpleColumn[];
+}
+
+export interface PurpleColumn {
+  name: string;
+}
+
+/**
+ * describes the result of a 'test connection' action.
+ */
+export interface StandardConnectionStatus {
+  message?: string;
+  status: StandardConnectionStatusStatus;
+}
+
+export enum StandardConnectionStatusStatus {
+  Failure = "failure",
+  Success = "success"
+}
+
+/**
+ * describes the standard output for any discovery run.
+ */
+export interface StandardDiscoveryOutput {
+  schema: Schema;
+}
+
+/**
+ * describes the available schema.
+ */
+export interface Schema {
+  tables?: SchemaTable[];
+}
+
+export interface SchemaTable {
+  columns: FluffyColumn[];
+  name: string;
+}
+
+export interface FluffyColumn {
+  dataType: DataType;
+  name: string;
+}
+
+export enum DataType {
+  Boolean = "boolean",
+  Number = "number",
+  String = "string",
+  UUID = "uuid"
+}
+
+/**
+ * configuration required for sync for ALL taps
+ */
+export interface StandardSyncConfiguration {
+  syncMode?: SyncMode;
+}
+
+export enum SyncMode {
+  Append = "append",
+  FullRefresh = "full_refresh"
+}
+
+/**
+ * standard information output by ALL taps for a sync step (our version of state.json)
+ */
+export interface StandardSyncOutput {
+  recordsSynced?: number;
+  status?: StandardSyncOutputStatus;
+  version?: number;
+}
+
+export enum StandardSyncOutputStatus {
+  Cancelled = "cancelled",
+  Completed = "completed",
+  Failed = "failed"
+}

--- a/pg_integration/src/gen/postgresTap.ts
+++ b/pg_integration/src/gen/postgresTap.ts
@@ -11,10 +11,6 @@ export interface PostgresTap {
    */
   postgresSyncConfiguration?: PostgresSyncConfiguration;
   /**
-   * state file that singer tap users internally. not to be exposed to ender user
-   */
-  postgresSyncState?: { [key: string]: any };
-  /**
    * describes the result of a 'test connection' action.
    */
   standardConnectionStatus?: StandardConnectionStatus;
@@ -37,10 +33,10 @@ export interface PostgresTap {
  */
 export interface PostgresConnectionConfiguration {
   database?: string;
-  host: string;
+  host:      string;
   password?: string;
-  port: number;
-  user: string;
+  port:      number;
+  user:      string;
 }
 
 /**
@@ -52,6 +48,7 @@ export interface PostgresSyncConfiguration {
 
 export interface PostgresSyncConfigurationTable {
   columns: PurpleColumn[];
+  name:    string;
 }
 
 export interface PurpleColumn {
@@ -63,12 +60,12 @@ export interface PurpleColumn {
  */
 export interface StandardConnectionStatus {
   message?: string;
-  status: StandardConnectionStatusStatus;
+  status:   StandardConnectionStatusStatus;
 }
 
 export enum StandardConnectionStatusStatus {
   Failure = "failure",
-  Success = "success"
+  Success = "success",
 }
 
 /**
@@ -87,19 +84,19 @@ export interface Schema {
 
 export interface SchemaTable {
   columns: FluffyColumn[];
-  name: string;
+  name:    string;
 }
 
 export interface FluffyColumn {
   dataType: DataType;
-  name: string;
+  name:     string;
 }
 
 export enum DataType {
   Boolean = "boolean",
   Number = "number",
   String = "string",
-  UUID = "uuid"
+  UUID = "uuid",
 }
 
 /**
@@ -111,7 +108,7 @@ export interface StandardSyncConfiguration {
 
 export enum SyncMode {
   Append = "append",
-  FullRefresh = "full_refresh"
+  FullRefresh = "full_refresh",
 }
 
 /**
@@ -119,12 +116,12 @@ export enum SyncMode {
  */
 export interface StandardSyncOutput {
   recordsSynced?: number;
-  status?: StandardSyncOutputStatus;
-  version?: number;
+  status?:        StandardSyncOutputStatus;
+  version?:       number;
 }
 
 export enum StandardSyncOutputStatus {
   Cancelled = "cancelled",
   Completed = "completed",
-  Failed = "failed"
+  Failed = "failed",
 }


### PR DESCRIPTION
This PR attempts to describe the interface we would provide to implement taps against to get feedback on whether the interface makes sense. 

`pg_integration/pgConfig.json` describes all the types needed to implement a postgres tap. types prefaced with "standard" are types that will be used in ALL taps. types prefaced with "postgres".

`pg_integration/src/gen/postgresTap.ts` are the typescript types generated from `pg_integration/pgConfig.json`. used https://app.quicktype.io/ to generate the code from the [json-schema formatted](https://json-schema.org/understanding-json-schema/index.html) json.

`pg_integration/src/app.ts` describes the generic interface that will be used for each tap. then it also shows what that interface looks like when implemented for postgres. also added an example of what it might look like to have a generic singer tap so that the singer internals don't need to be implemented multiple times. in the case where we are trying to use an existing singer tap we just need to implement converters to and from singer and our types.
