### PR TITLE
Implement Workspace and Source* API endpoints

### DIFF
--- a/data/config/STANDARD_WORKSPACE_CONFIGURATION/5ae6b09b-fdec-41af-aaf7-7d94cfc33ef6.json
+++ b/data/config/STANDARD_WORKSPACE_CONFIGURATION/5ae6b09b-fdec-41af-aaf7-7d94cfc33ef6.json
@@ -1,0 +1,6 @@
+{
+  "workspaceId": "5ae6b09b-fdec-41af-aaf7-7d94cfc33ef6",
+  "name": "default",
+  "slug": "default",
+  "initialSetupComplete": false
+}

--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -91,6 +91,29 @@ paths:
           description: Workspace not found
         "422":
           $ref: "#/components/responses/InvalidInput"
+  /v1/workspaces/update:
+    post:
+      tags:
+      - workspace
+      summary: Update workspace state
+      operationId: updateWorkspace
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkspaceUpdate"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkspaceRead"
+        "404":
+          description: Workspace not found
+        "422":
+          $ref: "#/components/responses/InvalidInput"
   /v1/sources/list:
     post:
       tags:
@@ -245,7 +268,7 @@ paths:
       tags:
       - source_implementation
       summary: Test connection to the source implementation
-      operationId: testConnectiontoSourceImplementation
+      operationId: testConnectionToSourceImplementation
       requestBody:
         content:
           application/json:
@@ -583,6 +606,28 @@ components:
         slug:
           type: string
         initialSetupComplete:
+          type: boolean
+    WorkspaceUpdate:
+      type: object
+      required:
+      - workspaceId
+      - initialSetupComplete
+      - anonymousDataCollection
+      - news
+      - securityUpdates
+      properties:
+        workspaceId:
+          $ref: "#/components/schemas/WorkspaceId"
+        email:
+          type: string
+          format: email
+        initialSetupComplete:
+          type: boolean
+        anonymousDataCollection:
+          type: boolean
+        news:
+          type: boolean
+        securityUpdates:
           type: boolean
     # SLUG
     SlugRequestBody:

--- a/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
+++ b/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
@@ -1,11 +1,8 @@
 package io.dataline.server.apis;
 
 import io.dataline.api.model.*;
-import io.dataline.config.persistence.ConfigNotFoundException;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.ConfigPersistenceImpl;
-import io.dataline.config.persistence.JsonValidationException;
-import io.dataline.server.errors.KnownException;
 import io.dataline.server.handlers.SourceImplementationsHandler;
 import io.dataline.server.handlers.SourceSpecificationsHandler;
 import io.dataline.server.handlers.SourcesHandler;

--- a/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
+++ b/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
@@ -1,11 +1,120 @@
 package io.dataline.server.apis;
 
 import io.dataline.api.model.*;
+import io.dataline.config.persistence.ConfigNotFoundException;
+import io.dataline.config.persistence.ConfigPersistence;
+import io.dataline.config.persistence.ConfigPersistenceImpl;
+import io.dataline.config.persistence.JsonValidationException;
+import io.dataline.server.errors.KnownException;
+import io.dataline.server.handlers.SourceImplementationsHandler;
+import io.dataline.server.handlers.SourceSpecificationsHandler;
+import io.dataline.server.handlers.SourcesHandler;
+import io.dataline.server.handlers.WorkspacesHandler;
 import javax.validation.Valid;
 import javax.ws.rs.Path;
 
 @Path("/v1")
 public class ConfigurationApi implements io.dataline.api.V1Api {
+  private final WorkspacesHandler workspacesHandler;
+  private final SourcesHandler sourcesHandler;
+  private final SourceSpecificationsHandler sourceSpecificationsHandler;
+  private final SourceImplementationsHandler sourceImplementationsHandler;
+
+  public ConfigurationApi() {
+    ConfigPersistence configPersistence = new ConfigPersistenceImpl();
+    workspacesHandler = new WorkspacesHandler(configPersistence);
+    sourcesHandler = new SourcesHandler(configPersistence);
+    sourceSpecificationsHandler = new SourceSpecificationsHandler(configPersistence);
+    sourceImplementationsHandler = new SourceImplementationsHandler(configPersistence);
+  }
+
+  // WORKSPACE
+
+  @Override
+  public WorkspaceRead getWorkspace(@Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+    return workspacesHandler.getWorkspace(workspaceIdRequestBody);
+  }
+
+  @Override
+  public WorkspaceRead getWorkspaceBySlug(@Valid SlugRequestBody slugRequestBody) {
+    return workspacesHandler.getWorkspaceBySlug(slugRequestBody);
+  }
+
+  @Override
+  public WorkspaceRead updateWorkspace(@Valid WorkspaceUpdate workspaceUpdate) {
+    return workspacesHandler.updateWorkspace(workspaceUpdate);
+  }
+
+  // SOURCE
+
+  @Override
+  public SourceReadList listSources() {
+    return sourcesHandler.listSources();
+  }
+
+  @Override
+  public SourceRead getSource(@Valid SourceIdRequestBody sourceIdRequestBody) {
+    return sourcesHandler.getSource(sourceIdRequestBody);
+  }
+
+  // SOURCE SPECIFICATION
+
+  @Override
+  public SourceSpecificationRead getSourceSpecification(
+      @Valid SourceIdRequestBody sourceIdRequestBody) {
+    return sourceSpecificationsHandler.getSourceSpecification(sourceIdRequestBody);
+  }
+
+  // SOURCE IMPLEMENTATION
+  @Override
+  public SourceImplementationRead createSourceImplementation(
+      @Valid SourceImplementationCreate sourceImplementationCreate) {
+    try {
+      return sourceImplementationsHandler.createSourceImplementation(sourceImplementationCreate);
+    } catch (JsonValidationException e) {
+      throw new KnownException(
+          422,
+          String.format(
+              "The provided configuration does not fulfill the specification. Errors: %s",
+              e.getMessage()));
+    } catch (ConfigNotFoundException e) {
+      throw new KnownException(
+          422,
+          String.format(
+              "Could not find source specification: %s.",
+              sourceImplementationCreate.getSourceSpecificationId()));
+    }
+  }
+
+  @Override
+  public SourceImplementationDiscoverSchemaRead discoverSchemaForSourceImplementation(
+      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+    return null;
+  }
+
+  @Override
+  public SourceImplementationRead getSourceImplementation(
+      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+    return null;
+  }
+
+  @Override
+  public SourceImplementationReadList getSourceImplementationsForWorkspace(
+      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+    return null;
+  }
+
+  @Override
+  public SourceImplementationTestConnectionRead testConnectionToSourceImplementation(
+      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+    return null;
+  }
+
+  @Override
+  public SourceImplementationRead updateSourceImplementation(
+      @Valid SourceImplementationUpdate sourceImplementationUpdate) {
+    return null;
+  }
 
   @Override
   public ConnectionRead createConnection(@Valid ConnectionCreate connectionCreate) {
@@ -15,18 +124,6 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   @Override
   public DestinationImplementationRead createDestinationImplementation(
       @Valid DestinationImplementationCreate destinationImplementationCreate) {
-    return null;
-  }
-
-  @Override
-  public SourceImplementationRead createSourceImplementation(
-      @Valid SourceImplementationCreate sourceImplementationCreate) {
-    return null;
-  }
-
-  @Override
-  public SourceImplementationDiscoverSchemaRead discoverSchemaForSourceImplementation(
-      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return null;
   }
 
@@ -53,39 +150,6 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   }
 
   @Override
-  public SourceRead getSource(@Valid SourceIdRequestBody sourceIdRequestBody) {
-    return null;
-  }
-
-  @Override
-  public SourceImplementationRead getSourceImplementation(
-      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
-    return null;
-  }
-
-  @Override
-  public SourceImplementationReadList getSourceImplementationsForWorkspace(
-      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
-    return null;
-  }
-
-  @Override
-  public SourceSpecificationRead getSourceSpecification(
-      @Valid SourceIdRequestBody sourceIdRequestBody) {
-    return null;
-  }
-
-  @Override
-  public WorkspaceRead getWorkspace(@Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
-    return null;
-  }
-
-  @Override
-  public WorkspaceRead getWorkspaceBySlug(@Valid SlugRequestBody slugRequestBody) {
-    return null;
-  }
-
-  @Override
   public ConnectionReadList listConnectionsForWorkspace(
       @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return null;
@@ -103,18 +167,7 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   }
 
   @Override
-  public SourceReadList listSources() {
-    return null;
-  }
-
-  @Override
   public ConnectionSyncRead syncConnection(@Valid ConnectionIdRequestBody connectionIdRequestBody) {
-    return null;
-  }
-
-  @Override
-  public SourceImplementationTestConnectionRead testConnectiontoSourceImplementation(
-      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return null;
   }
 
@@ -126,12 +179,6 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   @Override
   public DestinationImplementationRead updateDestinationImplementation(
       @Valid DestinationImplementationUpdate destinationImplementationUpdate) {
-    return null;
-  }
-
-  @Override
-  public SourceImplementationRead updateSourceImplementation(
-      @Valid SourceImplementationUpdate sourceImplementationUpdate) {
     return null;
   }
 }

--- a/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
+++ b/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
@@ -69,21 +69,7 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   @Override
   public SourceImplementationRead createSourceImplementation(
       @Valid SourceImplementationCreate sourceImplementationCreate) {
-    try {
-      return sourceImplementationsHandler.createSourceImplementation(sourceImplementationCreate);
-    } catch (JsonValidationException e) {
-      throw new KnownException(
-          422,
-          String.format(
-              "The provided configuration does not fulfill the specification. Errors: %s",
-              e.getMessage()));
-    } catch (ConfigNotFoundException e) {
-      throw new KnownException(
-          422,
-          String.format(
-              "Could not find source specification: %s.",
-              sourceImplementationCreate.getSourceSpecificationId()));
-    }
+    return sourceImplementationsHandler.createSourceImplementation(sourceImplementationCreate);
   }
 
   @Override

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -30,28 +30,28 @@ public class SourceImplementationsHandler {
 
       // persist
       final UUID sourceImplementationId = UUID.randomUUID();
-      final SourceConnectionImplementation sourceConnectionImplementation =
+      final SourceConnectionImplementation newSourceConnectionImplementation =
           new SourceConnectionImplementation();
-      sourceConnectionImplementation.setSourceSpecificationId(
+      newSourceConnectionImplementation.setSourceSpecificationId(
           sourceImplementationCreate.getSourceSpecificationId());
-      sourceConnectionImplementation.setSourceImplementationId(sourceImplementationId);
-      sourceConnectionImplementation.setConfiguration(
+      newSourceConnectionImplementation.setSourceImplementationId(sourceImplementationId);
+      newSourceConnectionImplementation.setConfiguration(
           sourceImplementationCreate.getConnectionConfiguration());
 
       configPersistence.writeConfig(
           PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
           sourceImplementationId.toString(),
-          sourceConnectionImplementation);
+          newSourceConnectionImplementation);
 
       // read configuration from db
-      final SourceConnectionImplementation sourceConnectionImplementation2 =
+      final SourceConnectionImplementation retrievedSourceConnectionImplementation =
           configPersistence.getConfig(
               PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
               sourceImplementationId.toString(),
               SourceConnectionImplementation.class);
 
-      return sourceConnectionImplementationToSourceImplementationRead(
-          sourceConnectionImplementation2);
+      return ToSourceImplementationRead(
+          retrievedSourceConnectionImplementation);
     } catch (JsonValidationException e) {
       throw new KnownException(
           422,
@@ -67,7 +67,7 @@ public class SourceImplementationsHandler {
     }
   }
 
-  private SourceImplementationRead sourceConnectionImplementationToSourceImplementationRead(
+  private SourceImplementationRead ToSourceImplementationRead(
       SourceConnectionImplementation sourceConnectionImplementation) {
     final SourceImplementationRead sourceImplementationRead = new SourceImplementationRead();
     sourceConnectionImplementation.setSourceImplementationId(

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -7,6 +7,7 @@ import io.dataline.config.persistence.ConfigNotFoundException;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.JsonValidationException;
 import io.dataline.config.persistence.PersistenceConfigType;
+import io.dataline.server.errors.KnownException;
 import io.dataline.server.validation.IntegrationSchemaValidation;
 import java.util.UUID;
 
@@ -18,8 +19,7 @@ public class SourceImplementationsHandler {
   }
 
   public SourceImplementationRead createSourceImplementation(
-      SourceImplementationCreate sourceImplementationCreate)
-      throws JsonValidationException, ConfigNotFoundException {
+      SourceImplementationCreate sourceImplementationCreate) {
     try {
       // validate configuration
       final IntegrationSchemaValidation validator =
@@ -50,8 +50,7 @@ public class SourceImplementationsHandler {
               sourceImplementationId.toString(),
               SourceConnectionImplementation.class);
 
-      return toSourceImplementationRead(
-          retrievedSourceConnectionImplementation);
+      return toSourceImplementationRead(retrievedSourceConnectionImplementation);
     } catch (JsonValidationException e) {
       throw new KnownException(
           422,

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -1,0 +1,69 @@
+package io.dataline.server.handlers;
+
+import io.dataline.api.model.SourceImplementationCreate;
+import io.dataline.api.model.SourceImplementationRead;
+import io.dataline.config.SourceConnectionImplementation;
+import io.dataline.config.persistence.ConfigNotFoundException;
+import io.dataline.config.persistence.ConfigPersistence;
+import io.dataline.config.persistence.JsonValidationException;
+import io.dataline.config.persistence.PersistenceConfigType;
+import io.dataline.server.validation.IntegrationSchemaValidation;
+import java.util.UUID;
+
+public class SourceImplementationsHandler {
+  private final ConfigPersistence configPersistence;
+
+  public SourceImplementationsHandler(ConfigPersistence configPersistence) {
+    this.configPersistence = configPersistence;
+  }
+
+  public SourceImplementationRead createSourceImplementation(
+      SourceImplementationCreate sourceImplementationCreate)
+      throws JsonValidationException, ConfigNotFoundException {
+
+    // validate configuration
+    final IntegrationSchemaValidation validator =
+        new IntegrationSchemaValidation(configPersistence);
+    validator.validateSourceConnectionConfiguration(
+        sourceImplementationCreate.getSourceSpecificationId(),
+        sourceImplementationCreate.getConnectionConfiguration());
+
+    // persist
+    final UUID sourceImplementationId = UUID.randomUUID();
+    final SourceConnectionImplementation sourceConnectionImplementation =
+        new SourceConnectionImplementation();
+    sourceConnectionImplementation.setSourceSpecificationId(
+        sourceImplementationCreate.getSourceSpecificationId());
+    sourceConnectionImplementation.setSourceImplementationId(sourceImplementationId);
+    sourceConnectionImplementation.setConfiguration(
+        sourceImplementationCreate.getConnectionConfiguration());
+
+    configPersistence.writeConfig(
+        PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
+        sourceImplementationId.toString(),
+        sourceConnectionImplementation);
+
+    // read configuration from db
+    final SourceConnectionImplementation sourceConnectionImplementation2 =
+        configPersistence.getConfig(
+            PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
+            sourceImplementationId.toString(),
+            SourceConnectionImplementation.class);
+
+    return sourceConnectionImplementationToSourceImplementationRead(
+        sourceConnectionImplementation2);
+  }
+
+  private SourceImplementationRead sourceConnectionImplementationToSourceImplementationRead(
+      SourceConnectionImplementation sourceConnectionImplementation) {
+    final SourceImplementationRead sourceImplementationRead = new SourceImplementationRead();
+    sourceConnectionImplementation.setSourceImplementationId(
+        sourceConnectionImplementation.getSourceImplementationId());
+    sourceConnectionImplementation.setSourceSpecificationId(
+        sourceConnectionImplementation.getSourceSpecificationId());
+    sourceConnectionImplementation.setConfiguration(
+        sourceConnectionImplementation.getConfiguration());
+
+    return sourceImplementationRead;
+  }
+}

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -50,7 +50,7 @@ public class SourceImplementationsHandler {
               sourceImplementationId.toString(),
               SourceConnectionImplementation.class);
 
-      return ToSourceImplementationRead(
+      return toSourceImplementationRead(
           retrievedSourceConnectionImplementation);
     } catch (JsonValidationException e) {
       throw new KnownException(
@@ -67,7 +67,7 @@ public class SourceImplementationsHandler {
     }
   }
 
-  private SourceImplementationRead ToSourceImplementationRead(
+  private SourceImplementationRead toSourceImplementationRead(
       SourceConnectionImplementation sourceConnectionImplementation) {
     final SourceImplementationRead sourceImplementationRead = new SourceImplementationRead();
     sourceConnectionImplementation.setSourceImplementationId(

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceSpecificationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceSpecificationsHandler.java
@@ -1,0 +1,59 @@
+package io.dataline.server.handlers;
+
+import io.dataline.api.model.SourceIdRequestBody;
+import io.dataline.api.model.SourceSpecificationRead;
+import io.dataline.config.SourceConnectionSpecification;
+import io.dataline.config.persistence.ConfigPersistence;
+import io.dataline.config.persistence.JsonValidationException;
+import io.dataline.config.persistence.PersistenceConfigType;
+import io.dataline.server.errors.KnownException;
+
+public class SourceSpecificationsHandler {
+  private final ConfigPersistence configPersistence;
+
+  public SourceSpecificationsHandler(ConfigPersistence configPersistence) {
+    this.configPersistence = configPersistence;
+  }
+
+  public SourceSpecificationRead getSourceSpecification(SourceIdRequestBody sourceIdRequestBody) {
+    final SourceConnectionSpecification sourceConnection;
+    try {
+      // todo (cgardens) - this is a shortcoming of rolling our own disk storage. since we are not
+      //   querying on a the primary key, we have to list all of the specification objects and then
+      //   filter.
+      sourceConnection =
+          configPersistence
+              .getConfigs(
+                  PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
+                  SourceConnectionSpecification.class)
+              .stream()
+              .filter(
+                  sourceSpecification ->
+                      sourceSpecification.getSourceId().equals(sourceIdRequestBody.getSourceId()))
+              .findFirst()
+              .orElseThrow(
+                  () ->
+                      new KnownException(
+                          404,
+                          String.format(
+                              "Could not find a source specification for source: %s",
+                              sourceIdRequestBody.getSourceId())));
+    } catch (JsonValidationException e) {
+      throw new KnownException(422, e.getMessage(), e);
+    }
+
+    return standardSourceToSourceRead(sourceConnection);
+  }
+
+  private static SourceSpecificationRead standardSourceToSourceRead(
+      SourceConnectionSpecification sourceConnectionSpecification) {
+    final SourceSpecificationRead sourceSpecificationRead = new SourceSpecificationRead();
+    sourceSpecificationRead.setSourceId(sourceConnectionSpecification.getSourceId());
+    sourceSpecificationRead.setSourceSpecificationId(
+        sourceConnectionSpecification.getSourceSpecificationId());
+    sourceSpecificationRead.setConnectionSpecification(
+        sourceConnectionSpecification.getSpecification());
+
+    return sourceSpecificationRead;
+  }
+}

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceSpecificationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceSpecificationsHandler.java
@@ -42,10 +42,10 @@ public class SourceSpecificationsHandler {
       throw new KnownException(422, e.getMessage(), e);
     }
 
-    return standardSourceToSourceRead(sourceConnection);
+    return toSourceSpecificationRead(sourceConnection);
   }
 
-  private static SourceSpecificationRead standardSourceToSourceRead(
+  private static SourceSpecificationRead toSourceSpecificationRead(
       SourceConnectionSpecification sourceConnectionSpecification) {
     final SourceSpecificationRead sourceSpecificationRead = new SourceSpecificationRead();
     sourceSpecificationRead.setSourceId(sourceConnectionSpecification.getSourceId());

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourcesHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourcesHandler.java
@@ -26,7 +26,7 @@ public class SourcesHandler {
           configPersistence
               .getConfigs(PersistenceConfigType.STANDARD_SOURCE, StandardSource.class)
               .stream()
-              .map(SourcesHandler::standardSourceToSourceRead)
+              .map(SourcesHandler::toSourceRead)
               .collect(Collectors.toList());
     } catch (JsonValidationException e) {
       throw new KnownException(422, e.getMessage(), e);
@@ -49,10 +49,10 @@ public class SourcesHandler {
     } catch (JsonValidationException e) {
       throw new KnownException(422, e.getMessage(), e);
     }
-    return standardSourceToSourceRead(standardSource);
+    return toSourceRead(standardSource);
   }
 
-  private static SourceRead standardSourceToSourceRead(StandardSource standardSource) {
+  private static SourceRead toSourceRead(StandardSource standardSource) {
     final SourceRead sourceRead = new SourceRead();
     sourceRead.setSourceId(standardSource.getSourceId());
     sourceRead.setName(standardSource.getName());

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourcesHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourcesHandler.java
@@ -1,0 +1,62 @@
+package io.dataline.server.handlers;
+
+import io.dataline.api.model.SourceIdRequestBody;
+import io.dataline.api.model.SourceRead;
+import io.dataline.api.model.SourceReadList;
+import io.dataline.config.StandardSource;
+import io.dataline.config.persistence.ConfigNotFoundException;
+import io.dataline.config.persistence.ConfigPersistence;
+import io.dataline.config.persistence.JsonValidationException;
+import io.dataline.config.persistence.PersistenceConfigType;
+import io.dataline.server.errors.KnownException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SourcesHandler {
+  private final ConfigPersistence configPersistence;
+
+  public SourcesHandler(ConfigPersistence configPersistence) {
+    this.configPersistence = configPersistence;
+  }
+
+  public SourceReadList listSources() {
+    final List<SourceRead> sourceReads;
+    try {
+      sourceReads =
+          configPersistence
+              .getConfigs(PersistenceConfigType.STANDARD_SOURCE, StandardSource.class)
+              .stream()
+              .map(SourcesHandler::standardSourceToSourceRead)
+              .collect(Collectors.toList());
+    } catch (JsonValidationException e) {
+      throw new KnownException(422, e.getMessage(), e);
+    }
+
+    final SourceReadList sourceReadList = new SourceReadList();
+    sourceReadList.setSources(sourceReads);
+    return sourceReadList;
+  }
+
+  public SourceRead getSource(SourceIdRequestBody sourceIdRequestBody) {
+    final String sourceId = sourceIdRequestBody.getSourceId().toString();
+    final StandardSource standardSource;
+    try {
+      standardSource =
+          configPersistence.getConfig(
+              PersistenceConfigType.STANDARD_SOURCE, sourceId, StandardSource.class);
+    } catch (ConfigNotFoundException e) {
+      throw new KnownException(404, e.getMessage(), e);
+    } catch (JsonValidationException e) {
+      throw new KnownException(422, e.getMessage(), e);
+    }
+    return standardSourceToSourceRead(standardSource);
+  }
+
+  private static SourceRead standardSourceToSourceRead(StandardSource standardSource) {
+    final SourceRead sourceRead = new SourceRead();
+    sourceRead.setSourceId(standardSource.getSourceId());
+    sourceRead.setName(standardSource.getName());
+
+    return sourceRead;
+  }
+}

--- a/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
@@ -11,7 +11,6 @@ import java.util.UUID;
 
 public class WorkspacesHandler {
   private final ConfigPersistence configPersistence;
-  
 
   public WorkspacesHandler(ConfigPersistence configPersistence) {
     this.configPersistence = configPersistence;

--- a/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
@@ -1,0 +1,79 @@
+package io.dataline.server.handlers;
+
+import io.dataline.api.model.SlugRequestBody;
+import io.dataline.api.model.WorkspaceIdRequestBody;
+import io.dataline.api.model.WorkspaceRead;
+import io.dataline.api.model.WorkspaceUpdate;
+import io.dataline.config.StandardWorkspaceConfiguration;
+import io.dataline.config.persistence.*;
+import io.dataline.server.errors.KnownException;
+import java.util.UUID;
+
+public class WorkspacesHandler {
+  private final ConfigPersistence configPersistence;
+
+  public WorkspacesHandler(ConfigPersistence configPersistence) {
+    this.configPersistence = configPersistence;
+  }
+
+  public WorkspaceRead getWorkspace(WorkspaceIdRequestBody workspaceIdRequestBody) {
+    return getWorkspaceFromId(workspaceIdRequestBody.getWorkspaceId());
+  }
+
+  @SuppressWarnings("unused")
+  public WorkspaceRead getWorkspaceBySlug(SlugRequestBody slugRequestBody) {
+    // for now we assume there is one workspace and it has a default uuid.
+    return getWorkspaceFromId(WorkspaceConstants.DEFAULT_WORKSPACE_ID);
+  }
+
+  private WorkspaceRead getWorkspaceFromId(UUID workspaceIdUuid) {
+    final String workspaceId = workspaceIdUuid.toString();
+    final StandardWorkspaceConfiguration workspace;
+    try {
+      workspace =
+          configPersistence.getConfig(
+              PersistenceConfigType.STANDARD_WORKSPACE,
+              workspaceId,
+              StandardWorkspaceConfiguration.class);
+    } catch (ConfigNotFoundException e) {
+      throw new KnownException(404, e.getMessage(), e);
+    } catch (JsonValidationException e) {
+      throw new KnownException(422, e.getMessage(), e);
+    }
+
+    final WorkspaceRead workspaceRead = new WorkspaceRead();
+    workspaceRead.setWorkspaceId(workspace.getWorkspaceId());
+    workspaceRead.setName(workspace.getName());
+    workspaceRead.setSlug(workspace.getSlug());
+    workspaceRead.setInitialSetupComplete(workspace.getInitialSetupComplete());
+
+    return workspaceRead;
+  }
+
+  public WorkspaceRead updateWorkspace(WorkspaceUpdate workspaceUpdate) {
+    final String workspaceId = workspaceUpdate.getWorkspaceId().toString();
+
+    final StandardWorkspaceConfiguration persistedWorkspace;
+    try {
+      persistedWorkspace =
+          configPersistence.getConfig(
+              PersistenceConfigType.STANDARD_WORKSPACE,
+              workspaceId,
+              StandardWorkspaceConfiguration.class);
+    } catch (ConfigNotFoundException e) {
+      throw new KnownException(404, e.getMessage(), e);
+    } catch (JsonValidationException e) {
+      throw new KnownException(422, e.getMessage(), e);
+    }
+
+    if (workspaceUpdate.getEmail() != null && !workspaceUpdate.getEmail().equals("")) {
+      persistedWorkspace.setEmail(workspaceUpdate.getEmail());
+    }
+    persistedWorkspace.setInitialSetupComplete(workspaceUpdate.getInitialSetupComplete());
+    persistedWorkspace.setAnonymousDataCollection(workspaceUpdate.getNews());
+    persistedWorkspace.setNews(workspaceUpdate.getNews());
+    persistedWorkspace.setSecurityUpdates(workspaceUpdate.getSecurityUpdates());
+
+    return getWorkspaceFromId(workspaceUpdate.getWorkspaceId());
+  }
+}

--- a/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
@@ -4,7 +4,7 @@ import io.dataline.api.model.SlugRequestBody;
 import io.dataline.api.model.WorkspaceIdRequestBody;
 import io.dataline.api.model.WorkspaceRead;
 import io.dataline.api.model.WorkspaceUpdate;
-import io.dataline.config.StandardWorkspaceConfiguration;
+import io.dataline.config.StandardWorkspace;
 import io.dataline.config.persistence.*;
 import io.dataline.server.errors.KnownException;
 import java.util.UUID;
@@ -28,13 +28,11 @@ public class WorkspacesHandler {
 
   private WorkspaceRead getWorkspaceFromId(UUID workspaceIdUuid) {
     final String workspaceId = workspaceIdUuid.toString();
-    final StandardWorkspaceConfiguration workspace;
+    final StandardWorkspace workspace;
     try {
       workspace =
           configPersistence.getConfig(
-              PersistenceConfigType.STANDARD_WORKSPACE,
-              workspaceId,
-              StandardWorkspaceConfiguration.class);
+              PersistenceConfigType.STANDARD_WORKSPACE, workspaceId, StandardWorkspace.class);
     } catch (ConfigNotFoundException e) {
       throw new KnownException(404, e.getMessage(), e);
     } catch (JsonValidationException e) {
@@ -53,13 +51,11 @@ public class WorkspacesHandler {
   public WorkspaceRead updateWorkspace(WorkspaceUpdate workspaceUpdate) {
     final String workspaceId = workspaceUpdate.getWorkspaceId().toString();
 
-    final StandardWorkspaceConfiguration persistedWorkspace;
+    final StandardWorkspace persistedWorkspace;
     try {
       persistedWorkspace =
           configPersistence.getConfig(
-              PersistenceConfigType.STANDARD_WORKSPACE,
-              workspaceId,
-              StandardWorkspaceConfiguration.class);
+              PersistenceConfigType.STANDARD_WORKSPACE, workspaceId, StandardWorkspace.class);
     } catch (ConfigNotFoundException e) {
       throw new KnownException(404, e.getMessage(), e);
     } catch (JsonValidationException e) {

--- a/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 
 public class WorkspacesHandler {
   private final ConfigPersistence configPersistence;
+  
 
   public WorkspacesHandler(ConfigPersistence configPersistence) {
     this.configPersistence = configPersistence;

--- a/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
@@ -70,7 +70,7 @@ public class WorkspacesHandler {
       persistedWorkspace.setEmail(workspaceUpdate.getEmail());
     }
     persistedWorkspace.setInitialSetupComplete(workspaceUpdate.getInitialSetupComplete());
-    persistedWorkspace.setAnonymousDataCollection(workspaceUpdate.getNews());
+    persistedWorkspace.setAnonymousDataCollection(workspaceUpdate.getAnonymousDataCollection());
     persistedWorkspace.setNews(workspaceUpdate.getNews());
     persistedWorkspace.setSecurityUpdates(workspaceUpdate.getSecurityUpdates());
 

--- a/dataline-server/src/main/java/io/dataline/server/validation/IntegrationSchemaValidation.java
+++ b/dataline-server/src/main/java/io/dataline/server/validation/IntegrationSchemaValidation.java
@@ -1,0 +1,37 @@
+package io.dataline.server.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dataline.config.SourceConnectionSpecification;
+import io.dataline.config.persistence.*;
+import java.util.UUID;
+
+public class IntegrationSchemaValidation {
+  private final ConfigPersistence configPersistence;
+
+  private final ObjectMapper objectMapper;
+  private final JsonSchemaValidation jsonSchemaValidation;
+
+  public IntegrationSchemaValidation(ConfigPersistence configPersistence) {
+    this.configPersistence = configPersistence;
+
+    this.objectMapper = new ObjectMapper();
+    jsonSchemaValidation = JsonSchemaValidation.getInstance();
+  }
+
+  public void validateSourceConnectionConfiguration(
+      UUID sourceConnectionSpecificationId, Object configuration)
+      throws JsonValidationException, ConfigNotFoundException {
+    final SourceConnectionSpecification sourceConnectionSpecification =
+        configPersistence.getConfig(
+            PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
+            sourceConnectionSpecificationId.toString(),
+            SourceConnectionSpecification.class);
+
+    final JsonNode schemaJson =
+        objectMapper.valueToTree(sourceConnectionSpecification.getSpecification());
+    final JsonNode configJson = objectMapper.valueToTree(configuration);
+
+    jsonSchemaValidation.validateThrow(schemaJson, configJson);
+  }
+}


### PR DESCRIPTION
Takes a first pass at implementing endpoints for the Workspace, Source, SourceSpecification, SourceImplementation resources. This informed a lot of the other more infrastructure-y PRs I just put up.

Of note...
* Since the API interface class is pretty huge, I split up each resource into its own handler primarily for code readability reasons. The idea is that the handler can essentially just be treated like "controller" in express or rails. In other words it is appropriate for there to be API interface specific logic in there. All the other layers of code, should not be concerned about this.