### PR TITLE
Attempt running singer taps from a docker container

### DIFF
--- a/dataline-workers/src/test/java/io/dataline/workers/BaseWorkerTestCase.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/BaseWorkerTestCase.java
@@ -6,7 +6,9 @@ import java.nio.file.Paths;
 import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class BaseWorkerTestCase {
   private Path workspaceDirectory;
 

--- a/singer.Dockerfile
+++ b/singer.Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.7.8-alpine3.11
+
+ENV SINGER_ROOT /lib/singer
+RUN mkdir -p $SINGER_ROOT
+
+COPY . /code/
+WORKDIR /code
+
+# postgres taps need postgres binaries & build-base (gcc)
+RUN pwd && apk update && apk add postgresql-dev=12.2-r0 build-base=0.5-r1 \
+    && . tools/singer/install_connector.sh "tap-postgres" "tap-postgres" "0.1.0" \
+    && . tools/singer/install_connector.sh "target-postgres" "singer-target-postgres" "0.2.4"
+
+CMD ["/bin/bash"]

--- a/singer.Dockerfile
+++ b/singer.Dockerfile
@@ -12,3 +12,8 @@ RUN pwd && apk update && apk add postgresql-dev=12.2-r0 build-base=0.5-r1 \
     && . tools/singer/install_connector.sh "target-postgres" "singer-target-postgres" "0.2.4"
 
 CMD ["/bin/bash"]
+
+# intended to be built & run with the following:
+# docker build -f singer.Dockerfile -t dataline/singer-libs .
+# docker run -d --network=host dataline/singer-libs /
+# TODO figure out how to run singer commands from local tests inside the singer container

--- a/tools/singer/install_connector.sh
+++ b/tools/singer/install_connector.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+. tools/lib/lib.sh
+
+_python() {
+  python3.7 "$@"
+}
+
+USAGE="./tools/singer/$(basename "$0") <python_venv_name> <pip_package_name> <pip_package_version> <singer_root - pass inline or as env variable SINGER_ROOT>
+"
+
+[[ -z $1 ]] && echo "Venv not provided" && error "$USAGE"
+[[ -z $2 ]] && echo "pip package name not provided" && error "$USAGE"
+[[ -z $3 ]] && echo "pip package version not provided" && error "$USAGE"
+[[ -z $4 ]] && [[ -z $SINGER_ROOT ]] && echo "singer root not provided" && error "$USAGE"
+
+VENV_NAME=$1 && shift
+PIP_PACKAGE_NAME=$1 && shift
+PIP_PACKAGE_VERSION=$1 && shift
+[[ -z "$SINGER_ROOT" ]] && SINGER_ROOT=$1 && shift
+
+echo "Creating Virutal Environment for $PIP_PACKAGE_NAME v$PIP_PACKAGE_VERSION in $SINGER_ROOT/"
+cd "$SINGER_ROOT"
+# Create virutal env directory
+_python -m venv "$VENV_NAME"
+. "$VENV_NAME/bin/activate"
+_python -m pip install --upgrade pip
+_python -m pip install "$PIP_PACKAGE_NAME==$PIP_PACKAGE_VERSION"
+_python -m pip check && echo "No package conflicts" || exit 1
+deactivate
+cd -


### PR DESCRIPTION
## Problem
Singer binaries (and their environments) used in java tests should be the exact same as what we ship in our docker container. While it's easy to isolate Singer binaries (they're stored in a single folder), it's not easy to isolate their dependencies. For example, `tap-postgres` requires `pg_config` and `gcc` to be installed on the host machine/container. By default, `alpine-linux` does not ship with these dependencies, so we'd need a custom instruction in the Dockerfile to install them. But without building the container then running tests inside it (or encountering a bug while running it), we don't know if the local env in which tests succeeded accurately mirrors the docker container we produce. 

## Potential solutions
1. Not an MVP problem. Let's manually rig up our local envs to match the docker image as closely as possible, run into these bugs and add them into our Dockerfile until we figure out a better way. 
2. Create a docker container containing all singer libs and their dependencies, and make our intellij/build tests run inside that Docker container. 

This draft PR is me exploring solution no.2. Resolution of this problem is currently blocking writing any real tests for singer workers, so I'll need to figure this out to be able to meaningfully complete workers. 

EDIT: I think i will go for solution 1 since I realized the docker container runs tests as part of its build process, so we'll catch any issues I'm worried about here. Ignore the docker file for now, will generate singer binaries as part of the build. 