### PR TITLE
add connectionsHandler

### DIFF
--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -899,7 +899,7 @@ components:
         name:
           type: string
           description: Optional name of the connection
-        sourceImplementationIdId:
+        sourceImplementationId:
           $ref: "#/components/schemas/SourceImplementationId"
         destinationImplementationId:
           $ref: "#/components/schemas/DestinationImplementationId"
@@ -920,7 +920,6 @@ components:
       - sourceImplementationId
       - destinationImplementationId
       - syncSchema
-      - schedule
       - status
       properties:
         connectionId:
@@ -940,7 +939,6 @@ components:
       - destinationImplementationId
       - syncMode
       - schema
-      - schedule
       - status
       properties:
         connectionId:
@@ -979,22 +977,14 @@ components:
       - inactive
       - deprecated
     ConnectionSchedule:
-      type: object
-      oneOf:
-      - $ref: "#/components/schemas/ScheduleImplementation"
-      - $ref: "#/components/schemas/NoOpSchedule"
-    NoOpSchedule:
-      type: string
-      enum:
-      - noop
-    ScheduleImplementation:
+      description: if null, then no schedule is set.
       type: object
       required:
       - units
       - timeUnit
       properties:
         units:
-          type: number
+          type: integer
         timeUnit:
           type: string
           enum:
@@ -1021,30 +1011,33 @@ components:
         tables:
           type: array
           items:
-            type: object
-            required:
-            - name
-            - columns
-            properties:
-              name:
-                type: string
-              columns:
-                type: array
-                items:
-                  type: object
-                  required:
-                  - name
-                  - dataType
-                  properties:
-                    name:
-                      type: string
-                    dataType:
-                      type: string
-                      enum:
-                      - string
-                      - number
-                      - uuid
-                      - boolean
+            $ref: "#/components/schemas/SourceSchemaTable"
+    SourceSchemaColumn:
+      type: object
+      required:
+      - name
+      - dataType
+      properties:
+        name:
+          type: string
+        dataType:
+          type: string
+          enum:
+          - string
+          - number
+          - boolean
+    SourceSchemaTable:
+      type: object
+      required:
+      - name
+      - columns
+      properties:
+        name:
+          type: string
+        columns:
+          type: array
+          items:
+            $ref: "#/components/schemas/SourceSchemaColumn"
   responses:
     InvalidInput:
       description: Invalid Input

--- a/dataline-config-persistence/build.gradle
+++ b/dataline-config-persistence/build.gradle
@@ -3,6 +3,8 @@ dependencies {
 
     implementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.8"
     implementation group: "com.networknt", name: "json-schema-validator", version: "1.0.42"
+    // needed so that we can follow $ref when parsing json. jackson does not support this natively.
+    implementation 'me.andrz.jackson:jackson-json-reference-core:0.3.2'
 
     implementation project(':dataline-config')
 }

--- a/dataline-config/build.gradle
+++ b/dataline-config/build.gradle
@@ -9,4 +9,5 @@ dependencies {
 
 jsonSchema2Pojo {
     targetPackage = 'io.dataline.config'
+    removeOldOutput = false
 }

--- a/dataline-config/src/main/resources/json/StandardDataSchema.json
+++ b/dataline-config/src/main/resources/json/StandardDataSchema.json
@@ -13,44 +13,53 @@
         "tables": {
           "type": "array",
           "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "columns"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "columns": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "name",
-                    "dataType"
-                  ],
-                  "additionalProperties": false,
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "dataType": {
-                      "type": "string",
-                      "enum": [
-                        "string",
-                        "number",
-                        "boolean"
-                      ]
-                    }
-                  }
-                }
-              }
-            }
+            "$ref": "StandardDataSchema.json#/definitions/table"
           }
         }
       }
+    },
+    "table": {
+      "type": "object",
+      "required": [
+        "name",
+        "columns"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "$ref": "StandardDataSchema.json#/definitions/column"
+          }
+        }
+      }
+    },
+    "column": {
+      "type": "object",
+      "required": [
+        "name",
+        "dataType"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "dataType": {
+          "$ref": "StandardDataSchema.json#/definitions/dataType"
+        }
+      }
+    },
+    "dataType": {
+      "type": "string",
+      "enum": [
+        "string",
+        "number",
+        "boolean"
+      ]
     }
   }
 }

--- a/dataline-config/src/main/resources/json/StandardSync.json
+++ b/dataline-config/src/main/resources/json/StandardSync.json
@@ -1,19 +1,50 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/StandardSyncConfiguration.json",
+  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/StandardSync.json",
   "title": "StandardSync",
   "description": "configuration required for sync for ALL taps",
   "type": "object",
-  "required": ["syncMode", "schema"],
+  "required": [
+    "sourceImplementationId",
+    "destinationImplementationId",
+    "name",
+    "syncMode",
+    "schema"
+  ],
   "additionalProperties": false,
   "properties": {
+    "sourceImplementationId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "destinationImplementationId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "connectionId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "name": {
+      "type": "string"
+    },
     "syncMode": {
       "type": "string",
-      "enum": ["full_refresh", "append"]
+      "enum": [
+        "full_refresh",
+        "append"
+      ]
     },
     "schema": {
-      "description": "describes the elements of the schema that will be synced.",
       "$ref": "StandardDataSchema.json#/definitions/schema"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "active",
+        "inactive",
+        "deprecated"
+      ]
     }
   }
 }

--- a/dataline-config/src/main/resources/json/StandardSyncSchedule.json
+++ b/dataline-config/src/main/resources/json/StandardSyncSchedule.json
@@ -1,17 +1,43 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/StandardScheduleConfiguration.json",
+  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/StandardSyncSchedule.json",
+  "description": "ideally this should be a union but java codegen does not handle the union type properly.",
   "title": "StandardScheduleConfiguration",
   "type": "object",
-  "required": ["timeUnit", "units"],
+  "required": [
+    "manual",
+    "connectionId"
+  ],
   "additionalProperties": false,
   "properties": {
-    "timeUnit": {
+    "connectionId": {
       "type": "string",
-      "enum": ["minutes", "hours", "days", "weeks"]
+      "format": "uuid"
     },
-    "units": {
-      "type": "integer"
+    "schedule": {
+      "type": "object",
+      "required": [
+        "timeUnit",
+        "units"
+      ],
+      "properties": {
+        "timeUnit": {
+          "type": "string",
+          "enum": [
+            "minutes",
+            "hours",
+            "days",
+            "weeks",
+            "months"
+          ]
+        },
+        "units": {
+          "type": "integer"
+        }
+      }
+    },
+    "manual": {
+      "type": "boolean"
     }
   }
 }

--- a/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
+++ b/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
@@ -3,6 +3,7 @@ package io.dataline.server.apis;
 import io.dataline.api.model.*;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.DefaultConfigPersistence;
+import io.dataline.server.errors.KnownException;
 import io.dataline.server.handlers.*;
 import io.dataline.server.handlers.SourceImplementationsHandler;
 import io.dataline.server.handlers.SourceSpecificationsHandler;
@@ -21,6 +22,7 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   private final DestinationsHandler destinationsHandler;
   private final DestinationSpecificationsHandler destinationSpecificationsHandler;
   private final DestinationImplementationsHandler destinationImplementationsHandler;
+  private final ConnectionsHandler connectionsHandler;
 
   public ConfigurationApi() {
     // todo: configure with env variable.
@@ -36,6 +38,7 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
     destinationSpecificationsHandler = new DestinationSpecificationsHandler(configPersistence);
     destinationImplementationsHandler =
         new DestinationImplementationsHandler(configPersistence, integrationSchemaValidation);
+    connectionsHandler = new ConnectionsHandler(configPersistence);
   }
 
   // WORKSPACE
@@ -105,13 +108,13 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   @Override
   public SourceImplementationTestConnectionRead testConnectionToSourceImplementation(
       @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
-    return null;
+    throw new KnownException(404, "Not implemented");
   }
 
   @Override
   public SourceImplementationDiscoverSchemaRead discoverSchemaForSourceImplementation(
       @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
-    return null;
+    throw new KnownException(404, "Not implemented");
   }
 
   // DESTINATION
@@ -166,28 +169,28 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   // CONNECTION
 
   @Override
-  public ConnectionReadList listConnectionsForWorkspace(
-      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
-    return null;
-  }
-
-  @Override
-  public ConnectionRead getConnection(@Valid ConnectionIdRequestBody connectionIdRequestBody) {
-    return null;
-  }
-
-  @Override
   public ConnectionRead createConnection(@Valid ConnectionCreate connectionCreate) {
-    return null;
-  }
-
-  @Override
-  public ConnectionSyncRead syncConnection(@Valid ConnectionIdRequestBody connectionIdRequestBody) {
-    return null;
+    return connectionsHandler.createConnection(connectionCreate);
   }
 
   @Override
   public ConnectionRead updateConnection(@Valid ConnectionUpdate connectionUpdate) {
-    return null;
+    return connectionsHandler.updateConnection(connectionUpdate);
+  }
+
+  @Override
+  public ConnectionReadList listConnectionsForWorkspace(
+      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+    return connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody);
+  }
+
+  @Override
+  public ConnectionRead getConnection(@Valid ConnectionIdRequestBody connectionIdRequestBody) {
+    return connectionsHandler.getConnection(connectionIdRequestBody);
+  }
+
+  @Override
+  public ConnectionSyncRead syncConnection(@Valid ConnectionIdRequestBody connectionIdRequestBody) {
+    throw new KnownException(404, "Not implemented");
   }
 }

--- a/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
@@ -9,17 +9,24 @@ import io.dataline.config.persistence.PersistenceConfigType;
 import io.dataline.server.errors.KnownException;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class ConnectionsHandler {
   private final ConfigPersistence configPersistence;
+  private final Supplier<UUID> uuidGenerator;
+
+  public ConnectionsHandler(ConfigPersistence configPersistence, Supplier<UUID> uuidGenerator) {
+    this.configPersistence = configPersistence;
+    this.uuidGenerator = uuidGenerator;
+  }
 
   public ConnectionsHandler(ConfigPersistence configPersistence) {
-    this.configPersistence = configPersistence;
+    this(configPersistence, UUID::randomUUID);
   }
 
   public ConnectionRead createConnection(ConnectionCreate connectionCreate) {
-    final UUID connectionId = UUID.randomUUID();
+    final UUID connectionId = uuidGenerator.get();
 
     // persist sync
     final StandardSync standardSync = new StandardSync();

--- a/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
@@ -1,0 +1,411 @@
+package io.dataline.server.handlers;
+
+import io.dataline.api.model.*;
+import io.dataline.config.*;
+import io.dataline.config.persistence.ConfigNotFoundException;
+import io.dataline.config.persistence.ConfigPersistence;
+import io.dataline.config.persistence.JsonValidationException;
+import io.dataline.config.persistence.PersistenceConfigType;
+import io.dataline.server.errors.KnownException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class ConnectionsHandler {
+  private final ConfigPersistence configPersistence;
+
+  public ConnectionsHandler(ConfigPersistence configPersistence) {
+    this.configPersistence = configPersistence;
+  }
+
+  public ConnectionRead createConnection(ConnectionCreate connectionCreate) {
+    final UUID connectionId = UUID.randomUUID();
+
+    // persist sync
+    final StandardSync standardSync = new StandardSync();
+    standardSync.setConnectionId(connectionId);
+    standardSync.setSourceImplementationId(connectionCreate.getSourceImplementationId());
+    standardSync.setDestinationImplementationId(connectionCreate.getDestinationImplementationId());
+    standardSync.setSyncMode(StandardSync.SyncMode.APPEND); // todo: for MVP we only support append.
+    standardSync.setSchema(toPersistenceSchema(connectionCreate.getSyncSchema()));
+    standardSync.setName(
+        connectionCreate.getName() != null ? connectionCreate.getName() : "default");
+    standardSync.setStatus(toPersistenceStatus(connectionCreate.getStatus()));
+    writeStandardSync(standardSync);
+
+    // persist schedule
+    final StandardSyncSchedule standardSyncSchedule = new StandardSyncSchedule();
+    standardSyncSchedule.setConnectionId(connectionId);
+    if (connectionCreate.getSchedule() != null) {
+      final Schedule schedule = new Schedule();
+      schedule.setTimeUnit(toPersistenceTimeUnit(connectionCreate.getSchedule().getTimeUnit()));
+      schedule.setUnits(connectionCreate.getSchedule().getUnits());
+      standardSyncSchedule.setManual(false);
+      standardSyncSchedule.setSchedule(schedule);
+    } else {
+      standardSyncSchedule.setManual(true);
+    }
+
+    writeSchedule(standardSyncSchedule);
+
+    return getConnectionInternal(connectionId);
+  }
+
+  private void writeStandardSync(StandardSync standardSync) {
+    configPersistence.writeConfig(
+        PersistenceConfigType.STANDARD_SYNC,
+        standardSync.getConnectionId().toString(),
+        standardSync);
+  }
+
+  // todo (cgardens) - stored on sync id (there is know schedule id concept). this is non-intuitive.
+  private void writeSchedule(StandardSyncSchedule schedule) {
+    configPersistence.writeConfig(
+        PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
+        schedule.getConnectionId().toString(),
+        schedule);
+  }
+
+  public ConnectionRead updateConnection(ConnectionUpdate connectionUpdate) {
+    final UUID connectionId = connectionUpdate.getConnectionId();
+
+    // get existing sync
+    final StandardSync persistedSync = getStandardSync(connectionId);
+    persistedSync.setSchema(toPersistenceSchema(connectionUpdate.getSyncSchema()));
+    persistedSync.setStatus(toPersistenceStatus(connectionUpdate.getStatus()));
+
+    // get existing schedule
+    final StandardSyncSchedule persistedSchedule = getSyncSchedule(connectionId);
+    if (connectionUpdate.getSchedule() != null) {
+      final Schedule schedule = new Schedule();
+      schedule.setTimeUnit(toPersistenceTimeUnit(connectionUpdate.getSchedule().getTimeUnit()));
+      schedule.setUnits(connectionUpdate.getSchedule().getUnits());
+
+      persistedSchedule.setSchedule(schedule);
+
+      persistedSchedule.setManual(false);
+    } else {
+      persistedSchedule.setSchedule(null);
+      persistedSchedule.setManual(true);
+    }
+
+    // persist sync
+    writeStandardSync(persistedSync);
+
+    // persist schedule
+    writeSchedule(persistedSchedule);
+
+    return getConnectionInternal(connectionId);
+  }
+
+  // todo (cgardens) - this is a disaster without a relational db.
+  public ConnectionReadList listConnectionsForWorkspace(
+      WorkspaceIdRequestBody workspaceIdRequestBody) {
+    try {
+
+      final List<ConnectionRead> reads =
+          configPersistence
+              // read all connections.
+              .getConfigs(PersistenceConfigType.STANDARD_SYNC, StandardSync.class)
+              .stream()
+              // filter out connections attached to source implementations NOT associated with the
+              // workspace
+              .filter(
+                  standardSync -> {
+                    try {
+                      return configPersistence
+                          .getConfig(
+                              PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
+                              standardSync.getSourceImplementationId().toString(),
+                              SourceConnectionImplementation.class)
+                          .getWorkspaceId()
+                          .equals(workspaceIdRequestBody.getWorkspaceId());
+                    } catch (JsonValidationException e) {
+                      throw new KnownException(
+                          422,
+                          String.format(
+                              "The provided configuration does not fulfill the specification. Errors: %s",
+                              e.getMessage()));
+                    } catch (ConfigNotFoundException e) {
+                      throw new KnownException(
+                          422,
+                          String.format(
+                              "Could not find source connection implementation for source implementation: %s.",
+                              standardSync.getSourceImplementationId()));
+                    }
+                  })
+              // pull the sync schedule
+              // convert to api format
+              .map(
+                  standardSync -> {
+                    final StandardSyncSchedule syncSchedule =
+                        getSyncSchedule(standardSync.getConnectionId());
+                    return toConnectionRead(standardSync, syncSchedule);
+                  })
+              .collect(Collectors.toList());
+
+      final ConnectionReadList connectionReadList = new ConnectionReadList();
+      connectionReadList.setConnections(reads);
+      return connectionReadList;
+    } catch (JsonValidationException e) {
+      throw new KnownException(
+          422,
+          String.format(
+              "Attempted to retrieve a configuration does not fulfill the specification. Errors: %s",
+              e.getMessage()));
+    }
+  }
+
+  public ConnectionRead getConnection(ConnectionIdRequestBody connectionIdRequestBody) {
+    return getConnectionInternal(connectionIdRequestBody.getConnectionId());
+  }
+
+  private StandardSync.Status toPersistenceStatus(ConnectionStatus apiStatus) {
+    switch (apiStatus) {
+      case ACTIVE:
+        return StandardSync.Status.ACTIVE;
+      case INACTIVE:
+        return StandardSync.Status.INACTIVE;
+      case DEPRECATED:
+        return StandardSync.Status.DEPRECATED;
+      default:
+        throw new RuntimeException(
+            String.format(
+                "No conversion from StandardSync.Status to StandardSync.Status for %s.",
+                apiStatus));
+    }
+  }
+
+  private ConnectionRead.SyncModeEnum toApiSyncMode(StandardSync.SyncMode persistenceStatus) {
+    switch (persistenceStatus) {
+      case FULL_REFRESH:
+        return ConnectionRead.SyncModeEnum.FULL_REFRESH;
+      case APPEND:
+        return ConnectionRead.SyncModeEnum.APPEND;
+      default:
+        throw new RuntimeException(
+            String.format(
+                "No conversion from ConnectionRead.SyncModeEnum to StandardSync.SyncMode for %s.",
+                persistenceStatus));
+    }
+  }
+
+  private ConnectionStatus toApiStatus(StandardSync.Status status) {
+    switch (status) {
+      case ACTIVE:
+        return ConnectionStatus.ACTIVE;
+      case INACTIVE:
+        return ConnectionStatus.INACTIVE;
+      case DEPRECATED:
+        return ConnectionStatus.DEPRECATED;
+      default:
+        throw new RuntimeException(
+            String.format(
+                "No conversion from StandardSync.Status to StandardSync.Status for %s.", status));
+    }
+  }
+
+  private Schedule.TimeUnit toPersistenceTimeUnit(ConnectionSchedule.TimeUnitEnum apiTimeUnit) {
+    switch (apiTimeUnit) {
+      case MINUTES:
+        return Schedule.TimeUnit.MINUTES;
+      case HOURS:
+        return Schedule.TimeUnit.HOURS;
+      case DAYS:
+        return Schedule.TimeUnit.DAYS;
+      case WEEKS:
+        return Schedule.TimeUnit.WEEKS;
+      case MONTHS:
+        return Schedule.TimeUnit.MONTHS;
+      default:
+        throw new RuntimeException(
+            String.format(
+                "No conversion from ConnectionSchedule.TimeUnitEnum to StandardSyncSchedule.TimeUnit for %s.",
+                apiTimeUnit));
+    }
+  }
+
+  private ConnectionSchedule.TimeUnitEnum toApiTimeUnit(Schedule.TimeUnit apiTimeUnit) {
+    switch (apiTimeUnit) {
+      case MINUTES:
+        return ConnectionSchedule.TimeUnitEnum.MINUTES;
+      case HOURS:
+        return ConnectionSchedule.TimeUnitEnum.HOURS;
+      case DAYS:
+        return ConnectionSchedule.TimeUnitEnum.DAYS;
+      case WEEKS:
+        return ConnectionSchedule.TimeUnitEnum.WEEKS;
+      case MONTHS:
+        return ConnectionSchedule.TimeUnitEnum.MONTHS;
+      default:
+        throw new RuntimeException(
+            String.format(
+                "No conversion from StandardSyncSchedule.TimeUnit to ConnectionSchedule.TimeUnitEnum for %s.",
+                apiTimeUnit));
+    }
+  }
+
+  private ConnectionRead getConnectionInternal(UUID connectionId) {
+    // read sync from db
+    final StandardSync standardSync = getStandardSync(connectionId);
+
+    // read schedule from db
+    final StandardSyncSchedule standardSyncSchedule = getSyncSchedule(connectionId);
+    return toConnectionRead(standardSync, standardSyncSchedule);
+  }
+
+  private StandardSync getStandardSync(UUID connectionId) {
+    try {
+      return configPersistence.getConfig(
+          PersistenceConfigType.STANDARD_SYNC, connectionId.toString(), StandardSync.class);
+    } catch (JsonValidationException e) {
+      throw new KnownException(
+          422,
+          String.format(
+              "The provided configuration does not fulfill the specification. Errors: %s",
+              e.getMessage()));
+    } catch (ConfigNotFoundException e) {
+      throw new KnownException(
+          422,
+          String.format("Could not find sync configuration for connection: %s.", connectionId));
+    }
+  }
+
+  private StandardSyncSchedule getSyncSchedule(UUID connectionId) {
+    try {
+      return configPersistence.getConfig(
+          PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
+          connectionId.toString(),
+          StandardSyncSchedule.class);
+    } catch (JsonValidationException e) {
+      throw new KnownException(
+          422,
+          String.format(
+              "The provided configuration does not fulfill the specification. Errors: %s",
+              e.getMessage()));
+    } catch (ConfigNotFoundException e) {
+      throw new KnownException(
+          422, String.format("Could not find sync schedule for connection: %s.", connectionId));
+    }
+  }
+
+  private ConnectionRead toConnectionRead(
+      StandardSync standardSync, StandardSyncSchedule standardSyncSchedule) {
+    final ConnectionSchedule apiSchedule;
+
+    standardSyncSchedule.setConnectionId(standardSyncSchedule.getConnectionId());
+    if (!standardSyncSchedule.getManual()) {
+      apiSchedule = new ConnectionSchedule();
+      apiSchedule.setTimeUnit(toApiTimeUnit(standardSyncSchedule.getSchedule().getTimeUnit()));
+      apiSchedule.setUnits(standardSyncSchedule.getSchedule().getUnits());
+    } else {
+      apiSchedule = null;
+    }
+
+    final ConnectionRead connectionRead = new ConnectionRead();
+    connectionRead.setConnectionId(standardSync.getConnectionId());
+    connectionRead.setSourceImplementationId(standardSync.getSourceImplementationId());
+    connectionRead.setDestinationImplementationId(standardSync.getDestinationImplementationId());
+    connectionRead.setStatus(toApiStatus(standardSync.getStatus()));
+    connectionRead.setSchedule(apiSchedule);
+    connectionRead.setSyncMode(toApiSyncMode(standardSync.getSyncMode()));
+    connectionRead.setName(standardSync.getName());
+    connectionRead.setSyncSchema(toApiSchema(standardSync.getSchema()));
+
+    return connectionRead;
+  }
+
+  // todo: figure out why the generator is namespacing the DataType enum by Column.
+  private Column.DataType toPersistenceDataType(SourceSchemaColumn.DataTypeEnum apiDataType) {
+    switch (apiDataType) {
+      case STRING:
+        return Column.DataType.STRING;
+      case NUMBER:
+        return Column.DataType.NUMBER;
+      case BOOLEAN:
+        return Column.DataType.BOOLEAN;
+      default:
+        throw new RuntimeException(
+            String.format(
+                "No conversion from SourceSchemaColumn.DataTypeEnum to Column.DataType for %s.",
+                apiDataType));
+    }
+  }
+
+  private SourceSchemaColumn.DataTypeEnum toApiDataType(Column.DataType persistenceDataType) {
+    switch (persistenceDataType) {
+      case STRING:
+        return SourceSchemaColumn.DataTypeEnum.STRING;
+      case NUMBER:
+        return SourceSchemaColumn.DataTypeEnum.NUMBER;
+      case BOOLEAN:
+        return SourceSchemaColumn.DataTypeEnum.BOOLEAN;
+      default:
+        throw new RuntimeException(
+            String.format(
+                "No conversion from Column.DataType to SourceSchemaColumn.DataTypeEnum for %s.",
+                persistenceDataType));
+    }
+  }
+
+  private Schema toPersistenceSchema(SourceSchema api) {
+    final List<Table> persistenceTables =
+        api.getTables().stream()
+            .map(
+                apiTable -> {
+                  final List<Column> persistenceColumns =
+                      apiTable.getColumns().stream()
+                          .map(
+                              apiColumn -> {
+                                final Column persistenceColumn = new Column();
+                                persistenceColumn.setName(apiColumn.getName());
+                                persistenceColumn.setDataType(
+                                    toPersistenceDataType(apiColumn.getDataType()));
+                                return persistenceColumn;
+                              })
+                          .collect(Collectors.toList());
+
+                  final Table persistenceTable = new Table();
+                  persistenceTable.setName(apiTable.getName());
+                  persistenceTable.setColumns(persistenceColumns);
+
+                  return persistenceTable;
+                })
+            .collect(Collectors.toList());
+
+    final Schema persistenceSchema = new Schema();
+    persistenceSchema.setTables(persistenceTables);
+    return persistenceSchema;
+  }
+
+  private SourceSchema toApiSchema(Schema persistenceSchema) {
+
+    final List<SourceSchemaTable> persistenceTables =
+        persistenceSchema.getTables().stream()
+            .map(
+                persistenceTable -> {
+                  final List<SourceSchemaColumn> apiColumns =
+                      persistenceTable.getColumns().stream()
+                          .map(
+                              persistenceColumn -> {
+                                final SourceSchemaColumn apiColumn = new SourceSchemaColumn();
+                                apiColumn.setName(persistenceColumn.getName());
+                                apiColumn.setDataType(
+                                    toApiDataType(persistenceColumn.getDataType()));
+                                return apiColumn;
+                              })
+                          .collect(Collectors.toList());
+
+                  final SourceSchemaTable apiTable = new SourceSchemaTable();
+                  apiTable.setName(persistenceTable.getName());
+                  apiTable.setColumns(apiColumns);
+
+                  return apiTable;
+                })
+            .collect(Collectors.toList());
+
+    final SourceSchema apiSchema = new SourceSchema();
+    apiSchema.setTables(persistenceTables);
+    return apiSchema;
+  }
+}

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
@@ -135,7 +135,7 @@ public class DestinationImplementationsHandler {
       throw new KnownException(
           422,
           String.format(
-              "Could not find destination specification: %s.", destinationImplementationId));
+              "Could not find destination implementation: %s.", destinationImplementationId));
     }
 
     return toDestinationImplementationRead(retrievedDestinationConnectionImplementation);

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -130,7 +130,7 @@ public class SourceImplementationsHandler {
               e.getMessage()));
     } catch (ConfigNotFoundException e) {
       throw new KnownException(
-          422, String.format("Could not find source specification: %s.", sourceImplementationId));
+          422, String.format("Could not find source implementation: %s.", sourceImplementationId));
     }
 
     return toSourceImplementationRead(retrievedSourceConnectionImplementation);

--- a/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
@@ -1,47 +1,253 @@
 package io.dataline.server.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
-import io.dataline.api.model.*;
-import io.dataline.config.*;
-import io.dataline.config.persistence.ConfigPersistenceImpl;
+import com.google.common.collect.Sets;
+import io.dataline.api.model.ConnectionCreate;
+import io.dataline.api.model.ConnectionIdRequestBody;
+import io.dataline.api.model.ConnectionRead;
+import io.dataline.api.model.ConnectionReadList;
+import io.dataline.api.model.ConnectionSchedule;
+import io.dataline.api.model.ConnectionStatus;
+import io.dataline.api.model.ConnectionUpdate;
+import io.dataline.api.model.SourceSchema;
+import io.dataline.api.model.SourceSchemaColumn;
+import io.dataline.api.model.SourceSchemaTable;
+import io.dataline.api.model.WorkspaceIdRequestBody;
+import io.dataline.config.Column;
+import io.dataline.config.Schedule;
+import io.dataline.config.Schema;
+import io.dataline.config.SourceConnectionImplementation;
+import io.dataline.config.StandardSync;
+import io.dataline.config.StandardSyncSchedule;
+import io.dataline.config.Table;
+import io.dataline.config.persistence.ConfigNotFoundException;
+import io.dataline.config.persistence.ConfigPersistence;
+import io.dataline.config.persistence.JsonValidationException;
 import io.dataline.config.persistence.PersistenceConfigType;
 import io.dataline.server.helpers.SourceImplementationHelpers;
 import java.util.UUID;
-import org.junit.jupiter.api.AfterEach;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ConnectionsHandlerTest {
 
-  private ConfigPersistenceImpl configPersistence;
+  private ConfigPersistence configPersistence;
+  private Supplier<UUID> uuidGenerator;
+
   private StandardSync standardSync;
   private StandardSyncSchedule standardSyncSchedule;
   private ConnectionsHandler connectionsHandler;
   private SourceConnectionImplementation sourceImplementation;
 
+  @SuppressWarnings("unchecked")
   @BeforeEach
   void setUp() {
-    configPersistence = ConfigPersistenceImpl.getTest();
+    configPersistence = mock(ConfigPersistence.class);
+    uuidGenerator = mock(Supplier.class);
 
     sourceImplementation =
-        SourceImplementationHelpers.generateSourceImplementationMock(
-            configPersistence, UUID.randomUUID());
-    standardSync = createSyncMock(sourceImplementation.getSourceImplementationId());
-    standardSyncSchedule = creatScheduleMock(standardSync.getConnectionId());
+        SourceImplementationHelpers.generateSourceImplementationMock(UUID.randomUUID());
+    standardSync = generateSync(sourceImplementation.getSourceImplementationId());
+    standardSyncSchedule = generateSchedule(standardSync.getConnectionId());
 
-    connectionsHandler = new ConnectionsHandler(configPersistence);
+    connectionsHandler = new ConnectionsHandler(configPersistence, uuidGenerator);
   }
 
-  @AfterEach
-  void tearDown() {
-    configPersistence.deleteAll();
+  @Test
+  void testCreateConnection() throws JsonValidationException, ConfigNotFoundException {
+    when(uuidGenerator.get()).thenReturn(standardSync.getConnectionId());
+
+    when(configPersistence.getConfig(
+            PersistenceConfigType.STANDARD_SYNC,
+            standardSync.getConnectionId().toString(),
+            StandardSync.class))
+        .thenReturn(standardSync);
+
+    when(configPersistence.getConfig(
+            PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
+            standardSyncSchedule.getConnectionId().toString(),
+            StandardSyncSchedule.class))
+        .thenReturn(standardSyncSchedule);
+
+    final ConnectionCreate connectionCreate = new ConnectionCreate();
+    connectionCreate.setSourceImplementationId(standardSync.getSourceImplementationId());
+    connectionCreate.setDestinationImplementationId(standardSync.getDestinationImplementationId());
+    connectionCreate.setName("presto to hudi");
+    connectionCreate.setStatus(ConnectionStatus.ACTIVE);
+    // todo (cgardens) - the codegen auto-nests enums as subclasses. this won't work. we expect
+    //   these enums to be reusable in create, update, read.
+    connectionCreate.setSyncMode(ConnectionCreate.SyncModeEnum.APPEND);
+    connectionCreate.setSchedule(generateBasicSchedule());
+    connectionCreate.setSyncSchema(generateBasicApiSchema());
+
+    final ConnectionRead actualConnectionRead =
+        connectionsHandler.createConnection(connectionCreate);
+
+    final ConnectionRead expectedConnectionRead =
+        generateExpectedConnectionRead(
+            standardSync.getConnectionId(),
+            standardSync.getSourceImplementationId(),
+            standardSync.getDestinationImplementationId());
+
+    assertEquals(expectedConnectionRead, actualConnectionRead);
+
+    verify(configPersistence)
+        .writeConfig(
+            PersistenceConfigType.STANDARD_SYNC,
+            standardSync.getConnectionId().toString(),
+            standardSync);
+
+    verify(configPersistence)
+        .writeConfig(
+            PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
+            standardSyncSchedule.getConnectionId().toString(),
+            standardSyncSchedule);
   }
 
-  private StandardSync createSyncMock(UUID sourceImplementationId) {
+  @Test
+  void testUpdateConnection() throws JsonValidationException, ConfigNotFoundException {
+    final SourceSchema newApiSchema = generateBasicApiSchema();
+    newApiSchema.getTables().get(0).setName("azkaban_users");
+
+    final ConnectionUpdate connectionUpdate = new ConnectionUpdate();
+    connectionUpdate.setConnectionId(standardSync.getConnectionId());
+    connectionUpdate.setStatus(ConnectionStatus.INACTIVE);
+    connectionUpdate.setSchedule(null);
+    connectionUpdate.setSyncSchema(newApiSchema);
+
+    final Schema newPersistenceSchema = generateBasicPersistenceSchema();
+    newPersistenceSchema.getTables().get(0).setName("azkaban_users");
+
+    final StandardSync updatedStandardSync = new StandardSync();
+    updatedStandardSync.setConnectionId(standardSync.getConnectionId());
+    updatedStandardSync.setName("presto to hudi");
+    updatedStandardSync.setSourceImplementationId(standardSync.getSourceImplementationId());
+    updatedStandardSync.setDestinationImplementationId(
+        standardSync.getDestinationImplementationId());
+    updatedStandardSync.setSyncMode(standardSync.getSyncMode());
+    updatedStandardSync.setStatus(StandardSync.Status.INACTIVE);
+    updatedStandardSync.setSchema(newPersistenceSchema);
+
+    final StandardSyncSchedule updatedPersistenceSchedule = new StandardSyncSchedule();
+    updatedPersistenceSchedule.setConnectionId(standardSyncSchedule.getConnectionId());
+    updatedPersistenceSchedule.setManual(true);
+
+    when(configPersistence.getConfig(
+            PersistenceConfigType.STANDARD_SYNC,
+            standardSync.getConnectionId().toString(),
+            StandardSync.class))
+        .thenReturn(standardSync)
+        .thenReturn(updatedStandardSync);
+
+    when(configPersistence.getConfig(
+            PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
+            standardSyncSchedule.getConnectionId().toString(),
+            StandardSyncSchedule.class))
+        .thenReturn(standardSyncSchedule)
+        .thenReturn(updatedPersistenceSchedule);
+
+    final ConnectionRead actualConnectionRead =
+        connectionsHandler.updateConnection(connectionUpdate);
+
+    final ConnectionRead expectedConnectionRead =
+        generateExpectedConnectionRead(
+            standardSync.getConnectionId(),
+            standardSync.getSourceImplementationId(),
+            standardSync.getDestinationImplementationId());
+
+    expectedConnectionRead.setSchedule(null);
+    expectedConnectionRead.setSyncSchema(newApiSchema);
+    expectedConnectionRead.setStatus(ConnectionStatus.INACTIVE);
+
+    assertEquals(expectedConnectionRead, actualConnectionRead);
+
+    verify(configPersistence)
+        .writeConfig(
+            PersistenceConfigType.STANDARD_SYNC,
+            standardSync.getConnectionId().toString(),
+            updatedStandardSync);
+
+    verify(configPersistence)
+        .writeConfig(
+            PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
+            standardSyncSchedule.getConnectionId().toString(),
+            updatedPersistenceSchedule);
+  }
+
+  @Test
+  void testGetConnection() throws JsonValidationException, ConfigNotFoundException {
+    when(configPersistence.getConfig(
+            PersistenceConfigType.STANDARD_SYNC,
+            standardSync.getConnectionId().toString(),
+            StandardSync.class))
+        .thenReturn(standardSync);
+
+    when(configPersistence.getConfig(
+            PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
+            standardSync.getConnectionId().toString(),
+            StandardSyncSchedule.class))
+        .thenReturn(standardSyncSchedule);
+
+    final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody();
+    connectionIdRequestBody.setConnectionId(standardSync.getConnectionId());
+    final ConnectionRead actualConnectionRead =
+        connectionsHandler.getConnection(connectionIdRequestBody);
+
+    assertEquals(generateExpectedConnectionRead(), actualConnectionRead);
+  }
+
+  @Test
+  void testListConnectionsForWorkspace() throws JsonValidationException, ConfigNotFoundException {
+    // mock list off all syncs
+    when(configPersistence.getConfigs(PersistenceConfigType.STANDARD_SYNC, StandardSync.class))
+        .thenReturn(Sets.newHashSet(standardSync));
+
+    // mock get source connection impl (used to check that connection is associated with given
+    // workspace)
+    when(configPersistence.getConfig(
+            PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
+            sourceImplementation.getSourceImplementationId().toString(),
+            SourceConnectionImplementation.class))
+        .thenReturn(sourceImplementation);
+
+    // mock get schedule for the now verified connection
+    when(configPersistence.getConfig(
+            PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
+            standardSync.getConnectionId().toString(),
+            StandardSyncSchedule.class))
+        .thenReturn(standardSyncSchedule);
+
+    final WorkspaceIdRequestBody workspaceIdRequestBody = new WorkspaceIdRequestBody();
+    workspaceIdRequestBody.setWorkspaceId(sourceImplementation.getWorkspaceId());
+    final ConnectionReadList actualConnectionReadList =
+        connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody);
+
+    assertEquals(
+        generateExpectedConnectionRead(), actualConnectionReadList.getConnections().get(0));
+  }
+
+  private StandardSync generateSync(UUID sourceImplementationId) {
     final UUID connectionId = UUID.randomUUID();
 
+    final StandardSync standardSync = new StandardSync();
+    standardSync.setConnectionId(connectionId);
+    standardSync.setName("presto to hudi");
+    standardSync.setStatus(StandardSync.Status.ACTIVE);
+    standardSync.setSchema(generateBasicPersistenceSchema());
+    standardSync.setSourceImplementationId(sourceImplementationId);
+    standardSync.setDestinationImplementationId(UUID.randomUUID());
+    standardSync.setSyncMode(StandardSync.SyncMode.APPEND);
+
+    return standardSync;
+  }
+
+  private Schema generateBasicPersistenceSchema() {
     final Column column = new Column();
     column.setDataType(Column.DataType.STRING);
     column.setName("id");
@@ -53,22 +259,10 @@ class ConnectionsHandlerTest {
     final Schema schema = new Schema();
     schema.setTables(Lists.newArrayList(table));
 
-    final StandardSync standardSync = new StandardSync();
-    standardSync.setConnectionId(connectionId);
-    standardSync.setName("presto to hudi");
-    standardSync.setStatus(StandardSync.Status.ACTIVE);
-    standardSync.setSchema(schema);
-    standardSync.setSourceImplementationId(sourceImplementationId);
-    standardSync.setDestinationImplementationId(UUID.randomUUID());
-    standardSync.setSyncMode(StandardSync.SyncMode.APPEND);
-
-    configPersistence.writeConfig(
-        PersistenceConfigType.STANDARD_SYNC, connectionId.toString(), standardSync);
-
-    return standardSync;
+    return schema;
   }
 
-  private SourceSchema getBasicSchema() {
+  private SourceSchema generateBasicApiSchema() {
     final SourceSchemaColumn column = new SourceSchemaColumn();
     column.setDataType(SourceSchemaColumn.DataTypeEnum.STRING);
     column.setName("id");
@@ -83,7 +277,7 @@ class ConnectionsHandlerTest {
     return schema;
   }
 
-  private ConnectionSchedule getBasicSchedule() {
+  private ConnectionSchedule generateBasicSchedule() {
     final ConnectionSchedule connectionSchedule = new ConnectionSchedule();
     connectionSchedule.setTimeUnit(ConnectionSchedule.TimeUnitEnum.DAYS);
     connectionSchedule.setUnits(1);
@@ -91,7 +285,7 @@ class ConnectionsHandlerTest {
     return connectionSchedule;
   }
 
-  private ConnectionRead getExpectedConnectionRead(
+  private ConnectionRead generateExpectedConnectionRead(
       UUID connectionId, UUID sourceImplementationId, UUID destinationImplementationId) {
     final ConnectionRead expectedConnectionRead = new ConnectionRead();
     expectedConnectionRead.setConnectionId(connectionId);
@@ -100,20 +294,20 @@ class ConnectionsHandlerTest {
     expectedConnectionRead.setName("presto to hudi");
     expectedConnectionRead.setStatus(ConnectionStatus.ACTIVE);
     expectedConnectionRead.setSyncMode(ConnectionRead.SyncModeEnum.APPEND);
-    expectedConnectionRead.setSchedule(getBasicSchedule());
-    expectedConnectionRead.setSyncSchema(getBasicSchema());
+    expectedConnectionRead.setSchedule(generateBasicSchedule());
+    expectedConnectionRead.setSyncSchema(generateBasicApiSchema());
 
     return expectedConnectionRead;
   }
 
-  private ConnectionRead getExpectedConnectionRead() {
-    return getExpectedConnectionRead(
+  private ConnectionRead generateExpectedConnectionRead() {
+    return generateExpectedConnectionRead(
         standardSync.getConnectionId(),
         standardSync.getSourceImplementationId(),
         standardSync.getDestinationImplementationId());
   }
 
-  private StandardSyncSchedule creatScheduleMock(UUID connectionId) {
+  private StandardSyncSchedule generateSchedule(UUID connectionId) {
     final Schedule schedule = new Schedule();
     schedule.setTimeUnit(Schedule.TimeUnit.DAYS);
     schedule.setUnits(1);
@@ -123,90 +317,6 @@ class ConnectionsHandlerTest {
     standardSchedule.setSchedule(schedule);
     standardSchedule.setManual(false);
 
-    configPersistence.writeConfig(
-        PersistenceConfigType.STANDARD_SYNC_SCHEDULE, connectionId.toString(), standardSchedule);
-
     return standardSchedule;
-  }
-
-  @Test
-  void createConnection() {
-    final ConnectionCreate connectionCreate = new ConnectionCreate();
-    connectionCreate.setSourceImplementationId(standardSync.getSourceImplementationId());
-    connectionCreate.setDestinationImplementationId(standardSync.getDestinationImplementationId());
-    connectionCreate.setName("presto to hudi");
-    connectionCreate.setStatus(ConnectionStatus.ACTIVE);
-    // todo (cgardens) - the codegen auto-nests enums as subclasses. this won't work. we expect
-    // these
-    //   enums to be reusable in create, update, read.
-    connectionCreate.setSyncMode(ConnectionCreate.SyncModeEnum.APPEND);
-    connectionCreate.setSchedule(getBasicSchedule());
-    connectionCreate.setSyncSchema(getBasicSchema());
-
-    final ConnectionRead connection = connectionsHandler.createConnection(connectionCreate);
-
-    final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody();
-    connectionIdRequestBody.setConnectionId(connection.getConnectionId());
-    final ConnectionRead actualConnectionRead =
-        connectionsHandler.getConnection(connectionIdRequestBody);
-
-    final ConnectionRead expectedConnectionRead =
-        getExpectedConnectionRead(
-            connection.getConnectionId(),
-            standardSync.getSourceImplementationId(),
-            standardSync.getDestinationImplementationId());
-
-    assertEquals(expectedConnectionRead, actualConnectionRead);
-  }
-
-  @Test
-  void updateConnection() {
-    final SourceSchema newSchema = getBasicSchema();
-    newSchema.getTables().get(0).setName("azkaban_users");
-
-    final ConnectionUpdate connectionUpdate = new ConnectionUpdate();
-    connectionUpdate.setConnectionId(standardSync.getConnectionId());
-    connectionUpdate.setStatus(ConnectionStatus.INACTIVE);
-    connectionUpdate.setSchedule(null);
-    connectionUpdate.setSyncSchema(newSchema);
-
-    connectionsHandler.updateConnection(connectionUpdate);
-
-    final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody();
-    connectionIdRequestBody.setConnectionId(standardSync.getConnectionId());
-    final ConnectionRead actualConnectionRead =
-        connectionsHandler.getConnection(connectionIdRequestBody);
-
-    final ConnectionRead expectedConnectionRead =
-        getExpectedConnectionRead(
-            standardSync.getConnectionId(),
-            standardSync.getSourceImplementationId(),
-            standardSync.getDestinationImplementationId());
-
-    expectedConnectionRead.setSchedule(null);
-    expectedConnectionRead.setSyncSchema(newSchema);
-    expectedConnectionRead.setStatus(ConnectionStatus.INACTIVE);
-
-    assertEquals(expectedConnectionRead, actualConnectionRead);
-  }
-
-  @Test
-  void getConnection() {
-    final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody();
-    connectionIdRequestBody.setConnectionId(standardSync.getConnectionId());
-    final ConnectionRead actualConnectionRead =
-        connectionsHandler.getConnection(connectionIdRequestBody);
-
-    assertEquals(getExpectedConnectionRead(), actualConnectionRead);
-  }
-
-  @Test
-  void listConnectionsForWorkspace() {
-    final WorkspaceIdRequestBody workspaceIdRequestBody = new WorkspaceIdRequestBody();
-    workspaceIdRequestBody.setWorkspaceId(sourceImplementation.getWorkspaceId());
-    final ConnectionReadList actualConnectionReadList =
-        connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody);
-
-    assertEquals(getExpectedConnectionRead(), actualConnectionReadList.getConnections().get(0));
   }
 }

--- a/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
@@ -1,0 +1,212 @@
+package io.dataline.server.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.collect.Lists;
+import io.dataline.api.model.*;
+import io.dataline.config.*;
+import io.dataline.config.persistence.ConfigPersistenceImpl;
+import io.dataline.config.persistence.PersistenceConfigType;
+import io.dataline.server.helpers.SourceImplementationHelpers;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConnectionsHandlerTest {
+
+  private ConfigPersistenceImpl configPersistence;
+  private StandardSync standardSync;
+  private StandardSyncSchedule standardSyncSchedule;
+  private ConnectionsHandler connectionsHandler;
+  private SourceConnectionImplementation sourceImplementation;
+
+  @BeforeEach
+  void setUp() {
+    configPersistence = ConfigPersistenceImpl.getTest();
+
+    sourceImplementation =
+        SourceImplementationHelpers.generateSourceImplementationMock(
+            configPersistence, UUID.randomUUID());
+    standardSync = createSyncMock(sourceImplementation.getSourceImplementationId());
+    standardSyncSchedule = creatScheduleMock(standardSync.getConnectionId());
+
+    connectionsHandler = new ConnectionsHandler(configPersistence);
+  }
+
+  @AfterEach
+  void tearDown() {
+    configPersistence.deleteAll();
+  }
+
+  private StandardSync createSyncMock(UUID sourceImplementationId) {
+    final UUID connectionId = UUID.randomUUID();
+
+    final Column column = new Column();
+    column.setDataType(Column.DataType.STRING);
+    column.setName("id");
+
+    final Table table = new Table();
+    table.setName("users");
+    table.setColumns(Lists.newArrayList(column));
+
+    final Schema schema = new Schema();
+    schema.setTables(Lists.newArrayList(table));
+
+    final StandardSync standardSync = new StandardSync();
+    standardSync.setConnectionId(connectionId);
+    standardSync.setName("presto to hudi");
+    standardSync.setStatus(StandardSync.Status.ACTIVE);
+    standardSync.setSchema(schema);
+    standardSync.setSourceImplementationId(sourceImplementationId);
+    standardSync.setDestinationImplementationId(UUID.randomUUID());
+    standardSync.setSyncMode(StandardSync.SyncMode.APPEND);
+
+    configPersistence.writeConfig(
+        PersistenceConfigType.STANDARD_SYNC, connectionId.toString(), standardSync);
+
+    return standardSync;
+  }
+
+  private SourceSchema getBasicSchema() {
+    final SourceSchemaColumn column = new SourceSchemaColumn();
+    column.setDataType(SourceSchemaColumn.DataTypeEnum.STRING);
+    column.setName("id");
+
+    final SourceSchemaTable table = new SourceSchemaTable();
+    table.setName("users");
+    table.setColumns(Lists.newArrayList(column));
+
+    final SourceSchema schema = new SourceSchema();
+    schema.setTables(Lists.newArrayList(table));
+
+    return schema;
+  }
+
+  private ConnectionSchedule getBasicSchedule() {
+    final ConnectionSchedule connectionSchedule = new ConnectionSchedule();
+    connectionSchedule.setTimeUnit(ConnectionSchedule.TimeUnitEnum.DAYS);
+    connectionSchedule.setUnits(1);
+
+    return connectionSchedule;
+  }
+
+  private ConnectionRead getExpectedConnectionRead(
+      UUID connectionId, UUID sourceImplementationId, UUID destinationImplementationId) {
+    final ConnectionRead expectedConnectionRead = new ConnectionRead();
+    expectedConnectionRead.setConnectionId(connectionId);
+    expectedConnectionRead.setSourceImplementationId(sourceImplementationId);
+    expectedConnectionRead.setDestinationImplementationId(destinationImplementationId);
+    expectedConnectionRead.setName("presto to hudi");
+    expectedConnectionRead.setStatus(ConnectionStatus.ACTIVE);
+    expectedConnectionRead.setSyncMode(ConnectionRead.SyncModeEnum.APPEND);
+    expectedConnectionRead.setSchedule(getBasicSchedule());
+    expectedConnectionRead.setSyncSchema(getBasicSchema());
+
+    return expectedConnectionRead;
+  }
+
+  private ConnectionRead getExpectedConnectionRead() {
+    return getExpectedConnectionRead(
+        standardSync.getConnectionId(),
+        standardSync.getSourceImplementationId(),
+        standardSync.getDestinationImplementationId());
+  }
+
+  private StandardSyncSchedule creatScheduleMock(UUID connectionId) {
+    final Schedule schedule = new Schedule();
+    schedule.setTimeUnit(Schedule.TimeUnit.DAYS);
+    schedule.setUnits(1);
+
+    final StandardSyncSchedule standardSchedule = new StandardSyncSchedule();
+    standardSchedule.setConnectionId(connectionId);
+    standardSchedule.setSchedule(schedule);
+    standardSchedule.setManual(false);
+
+    configPersistence.writeConfig(
+        PersistenceConfigType.STANDARD_SYNC_SCHEDULE, connectionId.toString(), standardSchedule);
+
+    return standardSchedule;
+  }
+
+  @Test
+  void createConnection() {
+    final ConnectionCreate connectionCreate = new ConnectionCreate();
+    connectionCreate.setSourceImplementationId(standardSync.getSourceImplementationId());
+    connectionCreate.setDestinationImplementationId(standardSync.getDestinationImplementationId());
+    connectionCreate.setName("presto to hudi");
+    connectionCreate.setStatus(ConnectionStatus.ACTIVE);
+    // todo (cgardens) - the codegen auto-nests enums as subclasses. this won't work. we expect
+    // these
+    //   enums to be reusable in create, update, read.
+    connectionCreate.setSyncMode(ConnectionCreate.SyncModeEnum.APPEND);
+    connectionCreate.setSchedule(getBasicSchedule());
+    connectionCreate.setSyncSchema(getBasicSchema());
+
+    final ConnectionRead connection = connectionsHandler.createConnection(connectionCreate);
+
+    final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody();
+    connectionIdRequestBody.setConnectionId(connection.getConnectionId());
+    final ConnectionRead actualConnectionRead =
+        connectionsHandler.getConnection(connectionIdRequestBody);
+
+    final ConnectionRead expectedConnectionRead =
+        getExpectedConnectionRead(
+            connection.getConnectionId(),
+            standardSync.getSourceImplementationId(),
+            standardSync.getDestinationImplementationId());
+
+    assertEquals(expectedConnectionRead, actualConnectionRead);
+  }
+
+  @Test
+  void updateConnection() {
+    final SourceSchema newSchema = getBasicSchema();
+    newSchema.getTables().get(0).setName("azkaban_users");
+
+    final ConnectionUpdate connectionUpdate = new ConnectionUpdate();
+    connectionUpdate.setConnectionId(standardSync.getConnectionId());
+    connectionUpdate.setStatus(ConnectionStatus.INACTIVE);
+    connectionUpdate.setSchedule(null);
+    connectionUpdate.setSyncSchema(newSchema);
+
+    connectionsHandler.updateConnection(connectionUpdate);
+
+    final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody();
+    connectionIdRequestBody.setConnectionId(standardSync.getConnectionId());
+    final ConnectionRead actualConnectionRead =
+        connectionsHandler.getConnection(connectionIdRequestBody);
+
+    final ConnectionRead expectedConnectionRead =
+        getExpectedConnectionRead(
+            standardSync.getConnectionId(),
+            standardSync.getSourceImplementationId(),
+            standardSync.getDestinationImplementationId());
+
+    expectedConnectionRead.setSchedule(null);
+    expectedConnectionRead.setSyncSchema(newSchema);
+    expectedConnectionRead.setStatus(ConnectionStatus.INACTIVE);
+
+    assertEquals(expectedConnectionRead, actualConnectionRead);
+  }
+
+  @Test
+  void getConnection() {
+    final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody();
+    connectionIdRequestBody.setConnectionId(standardSync.getConnectionId());
+    final ConnectionRead actualConnectionRead =
+        connectionsHandler.getConnection(connectionIdRequestBody);
+
+    assertEquals(getExpectedConnectionRead(), actualConnectionRead);
+  }
+
+  @Test
+  void listConnectionsForWorkspace() {
+    final WorkspaceIdRequestBody workspaceIdRequestBody = new WorkspaceIdRequestBody();
+    workspaceIdRequestBody.setWorkspaceId(sourceImplementation.getWorkspaceId());
+    final ConnectionReadList actualConnectionReadList =
+        connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody);
+
+    assertEquals(getExpectedConnectionRead(), actualConnectionReadList.getConnections().get(0));
+  }
+}

--- a/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
@@ -21,6 +21,7 @@ import io.dataline.server.helpers.SourceSpecificationHelpers;
 import io.dataline.server.validation.IntegrationSchemaValidation;
 import java.io.File;
 import java.io.IOException;
+import io.dataline.server.helpers.SourceImplementationHelpers;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +41,11 @@ class SourceImplementationsHandlerTest {
     configPersistence = mock(ConfigPersistence.class);
     validator = mock(IntegrationSchemaValidation.class);
     uuidGenerator = mock(Supplier.class);
+    sourceConnectionSpecification =
+        SourceSpecificationHelpers.generateSourceSpecification();
+    sourceConnectionImplementation =
+        SourceImplementationHelpers.generateSourceImplementationMock(
+            configPersistence, sourceConnectionSpecification.getSourceSpecificationId());
 
     sourceConnectionSpecification = SourceSpecificationHelpers.generateSourceSpecification();
     sourceConnectionImplementation =
@@ -91,7 +97,8 @@ class SourceImplementationsHandlerTest {
     sourceImplementationCreate.setWorkspaceId(sourceConnectionImplementation.getWorkspaceId());
     sourceImplementationCreate.setSourceSpecificationId(
         sourceConnectionSpecification.getSourceSpecificationId());
-    sourceImplementationCreate.setConnectionConfiguration(getTestImplementationJson().toString());
+    sourceImplementationCreate.setConnectionConfiguration(
+        SourceImplementationHelpers.getTestImplementationJson().toString());
 
     final SourceImplementationRead actualSourceImplementationRead =
         sourceImplementationsHandler.createSourceImplementation(sourceImplementationCreate);
@@ -104,7 +111,7 @@ class SourceImplementationsHandlerTest {
     expectedSourceImplementationRead.setSourceImplementationId(
         sourceConnectionImplementation.getSourceImplementationId());
     expectedSourceImplementationRead.setConnectionConfiguration(
-        getTestImplementationJson().toString());
+        SourceImplementationHelpers.getTestImplementationJson().toString());
 
     assertEquals(expectedSourceImplementationRead, actualSourceImplementationRead);
 

--- a/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
@@ -17,11 +17,11 @@ import io.dataline.config.persistence.ConfigNotFoundException;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.JsonValidationException;
 import io.dataline.config.persistence.PersistenceConfigType;
+import io.dataline.server.helpers.SourceImplementationHelpers;
 import io.dataline.server.helpers.SourceSpecificationHelpers;
 import io.dataline.server.validation.IntegrationSchemaValidation;
 import java.io.File;
 import java.io.IOException;
-import io.dataline.server.helpers.SourceImplementationHelpers;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,11 +41,10 @@ class SourceImplementationsHandlerTest {
     configPersistence = mock(ConfigPersistence.class);
     validator = mock(IntegrationSchemaValidation.class);
     uuidGenerator = mock(Supplier.class);
-    sourceConnectionSpecification =
-        SourceSpecificationHelpers.generateSourceSpecification();
+    sourceConnectionSpecification = SourceSpecificationHelpers.generateSourceSpecification();
     sourceConnectionImplementation =
         SourceImplementationHelpers.generateSourceImplementationMock(
-            configPersistence, sourceConnectionSpecification.getSourceSpecificationId());
+            sourceConnectionSpecification.getSourceSpecificationId());
 
     sourceConnectionSpecification = SourceSpecificationHelpers.generateSourceSpecification();
     sourceConnectionImplementation =

--- a/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
@@ -1,0 +1,40 @@
+package io.dataline.server.helpers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dataline.config.SourceConnectionImplementation;
+import io.dataline.config.persistence.ConfigPersistence;
+import io.dataline.config.persistence.PersistenceConfigType;
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+public class SourceImplementationHelpers {
+  public static SourceConnectionImplementation generateSourceImplementationMock(
+      ConfigPersistence configPersistence, UUID sourceSpecificationId) {
+    final UUID workspaceId = UUID.randomUUID();
+    final UUID sourceImplementationId = UUID.randomUUID();
+
+    JsonNode implementationJson = getTestImplementationJson();
+
+    final SourceConnectionImplementation sourceConnectionImplementation =
+        new SourceConnectionImplementation();
+    sourceConnectionImplementation.setWorkspaceId(workspaceId);
+    sourceConnectionImplementation.setSourceSpecificationId(sourceSpecificationId);
+    sourceConnectionImplementation.setSourceImplementationId(sourceImplementationId);
+    sourceConnectionImplementation.setConfiguration(implementationJson.toString());
+
+    return sourceConnectionImplementation;
+  }
+
+  public static JsonNode getTestImplementationJson() {
+    final File implementationFile =
+        new File("../dataline-server/src/test/resources/json/TestImplementation.json");
+
+    try {
+      return new ObjectMapper().readTree(implementationFile);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
@@ -3,15 +3,13 @@ package io.dataline.server.helpers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dataline.config.SourceConnectionImplementation;
-import io.dataline.config.persistence.ConfigPersistence;
-import io.dataline.config.persistence.PersistenceConfigType;
 import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
 
 public class SourceImplementationHelpers {
   public static SourceConnectionImplementation generateSourceImplementationMock(
-      ConfigPersistence configPersistence, UUID sourceSpecificationId) {
+      UUID sourceSpecificationId) {
     final UUID workspaceId = UUID.randomUUID();
     final UUID sourceImplementationId = UUID.randomUUID();
 


### PR DESCRIPTION
## What
* add connectionsHandler
* add support for parsing json files that have $ref. jackson does not support this by default.
* API change: oneOfs don't seem to work as expected in java generation for openapi3 or jsonschema parsing. I was hoping for something like thrift or grpc where you had something like `wrapperObject.isA()`. instead it either just doesn't generate a usable object or generates an object with all of the fields. this is worth looking into more carefully, but for now, we just assume schedule is manual if it is null
* issue discovered: https://github.com/datalineio/dataline/issues/52
* issue discovered: https://github.com/datalineio/dataline/issues/51

Note: I need to propagate the change in how to handle unit tests down to this PR. I will use mocks like was suggested in an earlier PR and will integrate that before I merge. I don't think you need to block reviewing on that.