### PR TITLE
Trigger Manual Jobs from API

### DIFF
--- a/dataline-config/src/main/resources/json/JobConfig.json
+++ b/dataline-config/src/main/resources/json/JobConfig.json
@@ -10,19 +10,23 @@
     "configType": {
       "type": "string",
       "enum": [
-        "checkConnection",
+        "checkConnectionSource",
+        "checkConnectionDestination",
         "discoverSchema",
         "sync"
       ]
     },
-    "checkConnection": {
+    "checkConnectionSource": {
       "$ref": "SourceConnectionImplementation.json"
     },
+    "checkConnectionDestination": {
+      "$ref": "DestinationConnectionImplementation.json"
+    },
     "discoverSchema": {
-      "type": "string"
+      "$ref": "SourceConnectionImplementation.json"
     },
     "sync": {
-      "type": "string"
+      "$ref": "JobSyncConfig.json"
     }
   }
 }

--- a/dataline-config/src/main/resources/json/JobOutput.json
+++ b/dataline-config/src/main/resources/json/JobOutput.json
@@ -19,7 +19,7 @@
       "$ref": "StandardConnectionStatus.json"
     },
     "discoverSchema": {
-      "type": "string"
+      "$ref": "StandardDiscoveryOutput.json"
     },
     "sync": {
       "type": "string"

--- a/dataline-config/src/main/resources/json/JobOutput.json
+++ b/dataline-config/src/main/resources/json/JobOutput.json
@@ -22,7 +22,7 @@
       "$ref": "StandardDiscoveryOutput.json"
     },
     "sync": {
-      "type": "string"
+      "$ref": "JobSyncOutput.json"
     }
   }
 }

--- a/dataline-config/src/main/resources/json/JobSyncConfig.json
+++ b/dataline-config/src/main/resources/json/JobSyncConfig.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/JobSyncConfig.json",
+  "title": "JobSyncConfig",
+  "description": "job sync config",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "sourceConnectionImplementation",
+    "destinationConnectionImplementation",
+    "standardSync"
+  ],
+  "properties": {
+    "sourceConnectionImplementation": {
+      "$ref": "SourceConnectionImplementation.json"
+    },
+    "destinationConnectionImplementation": {
+      "$ref": "DestinationConnectionImplementation.json"
+    },
+    "standardSync": {
+      "$ref": "StandardSync.json"
+    }
+  }
+}

--- a/dataline-config/src/main/resources/json/JobSyncOutput.json
+++ b/dataline-config/src/main/resources/json/JobSyncOutput.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/JobSyncConfig.json",
+  "title": "JobSyncConfig",
+  "description": "job sync config",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "standardSyncSummary",
+    "state"
+  ],
+  "properties": {
+    "standardSyncSummary": {
+      "$ref": "StandardSyncSummary.json"
+    },
+    "state": {
+      "$ref": "State.json"
+    }
+  }
+}

--- a/dataline-scheduler-persistence/src/main/java/io/dataline/scheduler/persistence/DefaultSchedulerPersistence.java
+++ b/dataline-scheduler-persistence/src/main/java/io/dataline/scheduler/persistence/DefaultSchedulerPersistence.java
@@ -25,9 +25,12 @@
 package io.dataline.scheduler.persistence;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dataline.config.DestinationConnectionImplementation;
 import io.dataline.config.JobConfig;
 import io.dataline.config.JobOutput;
+import io.dataline.config.JobSyncConfig;
 import io.dataline.config.SourceConnectionImplementation;
+import io.dataline.config.StandardSync;
 import io.dataline.db.DatabaseHelper;
 import java.io.IOException;
 import java.sql.SQLException;
@@ -35,7 +38,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
-import java.util.UUID;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.jooq.Record;
 import org.slf4j.Logger;
@@ -49,14 +51,62 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
     this.connectionPool = connectionPool;
   }
 
-  public long createSourceCheckConnectionJob(
-      UUID sourceImplementation, SourceConnectionImplementation sourceImplementationJson)
+  @Override
+  public long createSourceCheckConnectionJob(SourceConnectionImplementation sourceImplementation)
       throws IOException {
-    final String scope = "sourceImplementation:" + sourceImplementation.toString();
+    final String scope =
+        "checkConnection:source:" + sourceImplementation.getSourceImplementationId();
 
     final JobConfig jobConfig = new JobConfig();
-    jobConfig.setCheckConnection(sourceImplementationJson);
+    jobConfig.setConfigType(JobConfig.ConfigType.CHECK_CONNECTION_SOURCE);
+    jobConfig.setCheckConnectionSource(sourceImplementation);
 
+    return createPendingJob(scope, jobConfig);
+  }
+
+  @Override
+  public long createDestinationCheckConnectionJob(
+      DestinationConnectionImplementation destinationImplementation) throws IOException {
+    final String scope =
+        "checkConnection:destination:" + destinationImplementation.getDestinationImplementationId();
+
+    final JobConfig jobConfig = new JobConfig();
+    jobConfig.setConfigType(JobConfig.ConfigType.CHECK_CONNECTION_DESTINATION);
+    jobConfig.setCheckConnectionDestination(destinationImplementation);
+
+    return createPendingJob(scope, jobConfig);
+  }
+
+  @Override
+  public long createDiscoverSchemaJob(SourceConnectionImplementation sourceImplementation)
+      throws IOException {
+
+    final String scope = "discoverSchema:" + sourceImplementation.getSourceImplementationId();
+
+    final JobConfig jobConfig = new JobConfig();
+    jobConfig.setConfigType(JobConfig.ConfigType.DISCOVER_SCHEMA);
+    jobConfig.setDiscoverSchema(sourceImplementation);
+
+    return createPendingJob(scope, jobConfig);
+  }
+
+  @Override
+  public long createSyncJob(
+      SourceConnectionImplementation sourceImplementation,
+      DestinationConnectionImplementation destinationImplementation,
+      StandardSync standardSync)
+      throws IOException {
+
+    final String scope = "sync:" + standardSync.getConnectionId();
+
+    final JobSyncConfig jobSyncConfig = new JobSyncConfig();
+    jobSyncConfig.setSourceConnectionImplementation(sourceImplementation);
+    jobSyncConfig.setDestinationConnectionImplementation(destinationImplementation);
+    jobSyncConfig.setStandardSync(standardSync);
+
+    final JobConfig jobConfig = new JobConfig();
+    jobConfig.setConfigType(JobConfig.ConfigType.SYNC);
+    jobConfig.setSync(jobSyncConfig);
     return createPendingJob(scope, jobConfig);
   }
 

--- a/dataline-scheduler-persistence/src/main/java/io/dataline/scheduler/persistence/SchedulerPersistence.java
+++ b/dataline-scheduler-persistence/src/main/java/io/dataline/scheduler/persistence/SchedulerPersistence.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,15 +24,27 @@
 
 package io.dataline.scheduler.persistence;
 
+import io.dataline.config.DestinationConnectionImplementation;
 import io.dataline.config.SourceConnectionImplementation;
+import io.dataline.config.StandardSync;
+
 import java.io.IOException;
-import java.util.UUID;
 
 public interface SchedulerPersistence {
 
-  // todo (cgardens) - add all other job types.
-  long createSourceCheckConnectionJob(
-      UUID sourceImplementation, SourceConnectionImplementation sourceImplementationJson)
+  long createSourceCheckConnectionJob(SourceConnectionImplementation sourceImplementation)
+      throws IOException;
+
+  long createDestinationCheckConnectionJob(
+      DestinationConnectionImplementation destinationImplementation) throws IOException;
+
+  long createDiscoverSchemaJob(SourceConnectionImplementation sourceImplementation)
+      throws IOException;
+
+  long createSyncJob(
+      SourceConnectionImplementation sourceImplementation,
+      DestinationConnectionImplementation destinationImplementation,
+      StandardSync standardSync)
       throws IOException;
 
   Job getJob(long jobId) throws IOException;

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SchedulerHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SchedulerHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,8 +31,11 @@ import io.dataline.api.model.DestinationImplementationIdRequestBody;
 import io.dataline.api.model.SourceImplementationDiscoverSchemaRead;
 import io.dataline.api.model.SourceImplementationIdRequestBody;
 import io.dataline.commons.enums.Enums;
+import io.dataline.config.DestinationConnectionImplementation;
 import io.dataline.config.SourceConnectionImplementation;
 import io.dataline.config.StandardConnectionStatus;
+import io.dataline.config.StandardDiscoveryOutput;
+import io.dataline.config.StandardSync;
 import io.dataline.config.persistence.ConfigNotFoundException;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.JsonValidationException;
@@ -40,8 +43,11 @@ import io.dataline.config.persistence.PersistenceConfigType;
 import io.dataline.scheduler.persistence.Job;
 import io.dataline.scheduler.persistence.JobStatus;
 import io.dataline.scheduler.persistence.SchedulerPersistence;
+import io.dataline.server.converters.SchemaConverter;
 import io.dataline.server.errors.KnownException;
 import java.io.IOException;
+import java.util.UUID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,24 +67,50 @@ public class SchedulerHandler {
   public CheckConnectionRead checkSourceImplementationConnection(
       SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
 
-    final SourceConnectionImplementation connectionImplementation;
-    try {
-      connectionImplementation =
-          configPersistence.getConfig(
-              PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
-              sourceImplementationIdRequestBody.getSourceImplementationId().toString(),
-              SourceConnectionImplementation.class);
-    } catch (ConfigNotFoundException e) {
-      throw new KnownException(404, "Source Implementation not found");
-    } catch (JsonValidationException e) {
-      throw new RuntimeException(e);
-    }
+    final SourceConnectionImplementation connectionImplementation =
+        getSourceConnectionImplementation(
+            sourceImplementationIdRequestBody.getSourceImplementationId());
 
     final long jobId;
     try {
-      jobId =
-          schedulerPersistence.createSourceCheckConnectionJob(
-              connectionImplementation.getSourceImplementationId(), connectionImplementation);
+      jobId = schedulerPersistence.createSourceCheckConnectionJob(connectionImplementation);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    LOGGER.info("jobId = " + jobId);
+    final Job job = waitUntilJobIsTerminalOrTimeout(jobId);
+    return reportConnectionStatus(job);
+  }
+
+  public CheckConnectionRead checkDestinationImplementationConnection(
+      DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
+
+    final DestinationConnectionImplementation connectionImplementation =
+        getDestinationConnectionImplementation(
+            destinationImplementationIdRequestBody.getDestinationImplementationId());
+
+    final long jobId;
+    try {
+      jobId = schedulerPersistence.createDestinationCheckConnectionJob(connectionImplementation);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    LOGGER.info("jobId = " + jobId);
+    final Job job = waitUntilJobIsTerminalOrTimeout(jobId);
+    return reportConnectionStatus(job);
+  }
+
+  public SourceImplementationDiscoverSchemaRead discoverSchemaForSourceImplementation(
+      SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+    final SourceConnectionImplementation connectionImplementation =
+        getSourceConnectionImplementation(
+            sourceImplementationIdRequestBody.getSourceImplementationId());
+
+    final long jobId;
+    try {
+      jobId = schedulerPersistence.createDiscoverSchemaJob(connectionImplementation);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -86,18 +118,85 @@ public class SchedulerHandler {
     LOGGER.info("jobId = " + jobId);
     final Job job = waitUntilJobIsTerminalOrTimeout(jobId);
 
-    final StandardConnectionStatus connectionStatus =
+    final StandardDiscoveryOutput discoveryOutput =
         job.getOutput()
             .orElseThrow(() -> new RuntimeException("Terminal job does not have an output"))
-            .getCheckConnection();
+            .getDiscoverSchema();
 
-    final CheckConnectionRead checkConnectionRead = new CheckConnectionRead();
+    final SourceImplementationDiscoverSchemaRead read =
+        new SourceImplementationDiscoverSchemaRead();
+    read.setSchema(SchemaConverter.toApiSchema(discoveryOutput.getSchema()));
 
-    checkConnectionRead.setStatus(
-        Enums.convertTo(connectionStatus.getStatus(), CheckConnectionRead.StatusEnum.class));
-    checkConnectionRead.setMessage(connectionStatus.getMessage());
+    return read;
+  }
 
-    return checkConnectionRead;
+  public ConnectionSyncRead syncConnection(ConnectionIdRequestBody connectionIdRequestBody) {
+    final StandardSync standardSync;
+    try {
+      standardSync =
+          configPersistence.getConfig(
+              PersistenceConfigType.STANDARD_SYNC,
+              connectionIdRequestBody.getConnectionId().toString(),
+              StandardSync.class);
+    } catch (ConfigNotFoundException e) {
+      throw new KnownException(404, "Standard Sync not found");
+    } catch (JsonValidationException e) {
+      throw new RuntimeException(e);
+    }
+
+    final SourceConnectionImplementation sourceConnectionImplementation =
+        getSourceConnectionImplementation(standardSync.getSourceImplementationId());
+    final DestinationConnectionImplementation destinationConnectionImplementation =
+        getDestinationConnectionImplementation(standardSync.getDestinationImplementationId());
+
+    // todo (cgardens) - should it be mandatory that the API insert state? or does the schedule do
+    //   that?
+    final long jobId;
+    try {
+      jobId =
+          schedulerPersistence.createSyncJob(
+              sourceConnectionImplementation, destinationConnectionImplementation, standardSync);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    final Job job = waitUntilJobIsTerminalOrTimeout(jobId);
+
+    final ConnectionSyncRead read = new ConnectionSyncRead();
+    read.setStatus(
+        job.getStatus().equals(JobStatus.COMPLETED)
+            ? ConnectionSyncRead.StatusEnum.SUCCESS
+            : ConnectionSyncRead.StatusEnum.FAIL);
+
+    return read;
+  }
+
+  private SourceConnectionImplementation getSourceConnectionImplementation(
+      UUID sourceImplementationId) {
+    try {
+      return configPersistence.getConfig(
+          PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
+          sourceImplementationId.toString(),
+          SourceConnectionImplementation.class);
+    } catch (ConfigNotFoundException e) {
+      throw new KnownException(404, "Source Implementation not found");
+    } catch (JsonValidationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private DestinationConnectionImplementation getDestinationConnectionImplementation(
+      UUID destinationImplementationId) {
+    try {
+      return configPersistence.getConfig(
+          PersistenceConfigType.DESTINATION_CONNECTION_IMPLEMENTATION,
+          destinationImplementationId.toString(),
+          DestinationConnectionImplementation.class);
+    } catch (ConfigNotFoundException e) {
+      throw new KnownException(404, "Destination Implementation not found");
+    } catch (JsonValidationException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private Job waitUntilJobIsTerminalOrTimeout(long jobId) {
@@ -128,17 +227,18 @@ public class SchedulerHandler {
     }
   }
 
-  public CheckConnectionRead checkDestinationImplementationConnection(
-      DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
-    throw new KnownException(404, "Not implemented");
-  }
+  private CheckConnectionRead reportConnectionStatus(Job job) {
+    final StandardConnectionStatus connectionStatus =
+        job.getOutput()
+            .orElseThrow(() -> new RuntimeException("Terminal job does not have an output"))
+            .getCheckConnection();
 
-  public SourceImplementationDiscoverSchemaRead discoverSchemaForSourceImplementation(
-      SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
-    throw new KnownException(404, "Not implemented");
-  }
+    final CheckConnectionRead checkConnectionRead = new CheckConnectionRead();
 
-  public ConnectionSyncRead syncConnection(ConnectionIdRequestBody connectionIdRequestBody) {
-    throw new KnownException(404, "Not implemented");
+    checkConnectionRead.setStatus(
+        Enums.convertTo(connectionStatus.getStatus(), CheckConnectionRead.StatusEnum.class));
+    checkConnectionRead.setMessage(connectionStatus.getMessage());
+
+    return checkConnectionRead;
   }
 }


### PR DESCRIPTION
## What
* This PR is the successor of https://github.com/datalineio/dataline/pull/68. In that PR we added functionality so that the API could manually trigger a checkConnection for a source. This PR we add the ability to trigger: checkConnection for a destination, discoverSchema, manual Sync.

## How
* with code and sweat.

## Recommended reading order
1. `dataline-server/src/main/java/io/dataline/server/handlers/SchedulerHandler.java`
1. `dataline-scheduler-persistence/src/main/java/io/dataline/scheduler/persistence/SchedulerPersistence.java`
1. `dataline-scheduler-persistence/src/main/java/io/dataline/scheduler/persistence/DefaultSchedulerPersistence.java`
1. `dataline-config/src/main/resources/json/JobSyncConfig.json`
1. `dataline-config/src/main/resources/json/JobSyncConfigOutput.json`
1. the rest
