### PR TITLE
Config Fetching Helpers

### DIFF
--- a/dataline-config-persistence/src/test/java/io/dataline/config/persistence/DefaultConfigPersistenceTest.java
+++ b/dataline-config-persistence/src/test/java/io/dataline/config/persistence/DefaultConfigPersistenceTest.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-scheduler-persistence/src/main/java/io/dataline/scheduler/persistence/SchedulerPersistence.java
+++ b/dataline-scheduler-persistence/src/main/java/io/dataline/scheduler/persistence/SchedulerPersistence.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-scheduler-persistence/src/main/java/io/dataline/scheduler/persistence/SchedulerPersistence.java
+++ b/dataline-scheduler-persistence/src/main/java/io/dataline/scheduler/persistence/SchedulerPersistence.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- *
+ * 
  * Copyright (c) 2020 Dataline
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-server/src/main/java/io/dataline/server/converters/SchemaConverter.java
+++ b/dataline-server/src/main/java/io/dataline/server/converters/SchemaConverter.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
@@ -43,6 +43,8 @@ import io.dataline.config.persistence.JsonValidationException;
 import io.dataline.config.persistence.PersistenceConfigType;
 import io.dataline.server.converters.SchemaConverter;
 import io.dataline.server.errors.KnownException;
+import io.dataline.server.helpers.ConfigFetchers;
+
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -146,59 +148,32 @@ public class ConnectionsHandler {
   // todo (cgardens) - this is a disaster without a relational db.
   public ConnectionReadList listConnectionsForWorkspace(
       WorkspaceIdRequestBody workspaceIdRequestBody) {
-    try {
 
-      final List<ConnectionRead> reads =
-          configPersistence
-              // read all connections.
-              .getConfigs(PersistenceConfigType.STANDARD_SYNC, StandardSync.class)
-              .stream()
-              // filter out connections attached to source implementations NOT associated with the
-              // workspace
-              .filter(
-                  standardSync -> {
-                    try {
-                      return configPersistence
-                          .getConfig(
-                              PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
-                              standardSync.getSourceImplementationId().toString(),
-                              SourceConnectionImplementation.class)
-                          .getWorkspaceId()
-                          .equals(workspaceIdRequestBody.getWorkspaceId());
-                    } catch (JsonValidationException e) {
-                      throw new KnownException(
-                          422,
-                          String.format(
-                              "The provided configuration does not fulfill the specification. Errors: %s",
-                              e.getMessage()));
-                    } catch (ConfigNotFoundException e) {
-                      throw new KnownException(
-                          422,
-                          String.format(
-                              "Could not find source connection implementation for source implementation: %s.",
-                              standardSync.getSourceImplementationId()));
-                    }
-                  })
-              // pull the sync schedule
-              // convert to api format
-              .map(
-                  standardSync -> {
-                    final StandardSyncSchedule syncSchedule =
-                        getSyncSchedule(standardSync.getConnectionId());
-                    return toConnectionRead(standardSync, syncSchedule);
-                  })
-              .collect(Collectors.toList());
+    final List<ConnectionRead> reads =
+        // read all connections.
+        ConfigFetchers.getStandardSyncs(configPersistence).stream()
+            // filter out connections attached to source implementations NOT associated with the
+            // workspace
+            .filter(
+                standardSync ->
+                    ConfigFetchers.getSourceConnectionImplementation(
+                            configPersistence, standardSync.getSourceImplementationId())
+                        .getWorkspaceId()
+                        .equals(workspaceIdRequestBody.getWorkspaceId()))
 
-      final ConnectionReadList connectionReadList = new ConnectionReadList();
-      connectionReadList.setConnections(reads);
-      return connectionReadList;
-    } catch (JsonValidationException e) {
-      throw new KnownException(
-          422,
-          String.format(
-              "Attempted to retrieve a configuration does not fulfill the specification. Errors: %s",
-              e.getMessage()));
-    }
+            // pull the sync schedule
+            // convert to api format
+            .map(
+                standardSync -> {
+                  final StandardSyncSchedule syncSchedule =
+                      getSyncSchedule(standardSync.getConnectionId());
+                  return toConnectionRead(standardSync, syncSchedule);
+                })
+            .collect(Collectors.toList());
+
+    final ConnectionReadList connectionReadList = new ConnectionReadList();
+    connectionReadList.setConnections(reads);
+    return connectionReadList;
   }
 
   public ConnectionRead getConnection(ConnectionIdRequestBody connectionIdRequestBody) {
@@ -215,38 +190,11 @@ public class ConnectionsHandler {
   }
 
   private StandardSync getStandardSync(UUID connectionId) {
-    try {
-      return configPersistence.getConfig(
-          PersistenceConfigType.STANDARD_SYNC, connectionId.toString(), StandardSync.class);
-    } catch (JsonValidationException e) {
-      throw new KnownException(
-          422,
-          String.format(
-              "The provided configuration does not fulfill the specification. Errors: %s",
-              e.getMessage()));
-    } catch (ConfigNotFoundException e) {
-      throw new KnownException(
-          422,
-          String.format("Could not find sync configuration for connection: %s.", connectionId));
-    }
+    return ConfigFetchers.getStandardSync(configPersistence, connectionId);
   }
 
   private StandardSyncSchedule getSyncSchedule(UUID connectionId) {
-    try {
-      return configPersistence.getConfig(
-          PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
-          connectionId.toString(),
-          StandardSyncSchedule.class);
-    } catch (JsonValidationException e) {
-      throw new KnownException(
-          422,
-          String.format(
-              "The provided configuration does not fulfill the specification. Errors: %s",
-              e.getMessage()));
-    } catch (ConfigNotFoundException e) {
-      throw new KnownException(
-          422, String.format("Could not find sync schedule for connection: %s.", connectionId));
-    }
+    return ConfigFetchers.getStandardSyncSchedule(configPersistence, connectionId);
   }
 
   private ConnectionRead toConnectionRead(

--- a/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- *
+ * 
  * Copyright (c) 2020 Dataline
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -34,17 +34,12 @@ import io.dataline.api.model.ConnectionUpdate;
 import io.dataline.api.model.WorkspaceIdRequestBody;
 import io.dataline.commons.enums.Enums;
 import io.dataline.config.Schedule;
-import io.dataline.config.SourceConnectionImplementation;
 import io.dataline.config.StandardSync;
 import io.dataline.config.StandardSyncSchedule;
-import io.dataline.config.persistence.ConfigNotFoundException;
 import io.dataline.config.persistence.ConfigPersistence;
-import io.dataline.config.persistence.JsonValidationException;
 import io.dataline.config.persistence.PersistenceConfigType;
 import io.dataline.server.converters.SchemaConverter;
-import io.dataline.server.errors.KnownException;
 import io.dataline.server.helpers.ConfigFetchers;
-
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- *
+ * 
  * Copyright (c) 2020 Dataline
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,10 +33,10 @@ import io.dataline.api.model.WorkspaceIdRequestBody;
 import io.dataline.config.DestinationConnectionImplementation;
 import io.dataline.config.persistence.ConfigNotFoundException;
 import io.dataline.config.persistence.ConfigPersistence;
-import io.dataline.server.helpers.ConfigFetchers;
 import io.dataline.config.persistence.JsonValidationException;
 import io.dataline.config.persistence.PersistenceConfigType;
 import io.dataline.server.errors.KnownException;
+import io.dataline.server.helpers.ConfigFetchers;
 import io.dataline.server.validation.IntegrationSchemaValidation;
 import java.util.List;
 import java.util.UUID;
@@ -136,22 +136,9 @@ public class DestinationImplementationsHandler {
       UUID destinationImplementationId) {
     // read configuration from db
     final DestinationConnectionImplementation retrievedDestinationConnectionImplementation;
-    try {
-      retrievedDestinationConnectionImplementation =
-          ConfigFetchers.getDestinationConnectionImplementation(
-              configPersistence, destinationImplementationId);
-    } catch (JsonValidationException e) {
-      throw new KnownException(
-          422,
-          String.format(
-              "The provided configuration does not fulfill the specification. Errors: %s",
-              e.getMessage()));
-    } catch (ConfigNotFoundException e) {
-      throw new KnownException(
-          422,
-          String.format(
-              "Could not find destination implementation: %s.", destinationImplementationId));
-    }
+    retrievedDestinationConnectionImplementation =
+        ConfigFetchers.getDestinationConnectionImplementation(
+            configPersistence, destinationImplementationId);
 
     return toDestinationImplementationRead(retrievedDestinationConnectionImplementation);
   }

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationSpecificationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationSpecificationsHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- *
+ * 
  * Copyright (c) 2020 Dataline
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,8 +28,6 @@ import io.dataline.api.model.DestinationIdRequestBody;
 import io.dataline.api.model.DestinationSpecificationRead;
 import io.dataline.config.DestinationConnectionSpecification;
 import io.dataline.config.persistence.ConfigPersistence;
-import io.dataline.config.persistence.JsonValidationException;
-import io.dataline.config.persistence.PersistenceConfigType;
 import io.dataline.server.errors.KnownException;
 import io.dataline.server.helpers.ConfigFetchers;
 

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationSpecificationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationSpecificationsHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationsHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- *
+ * 
  * Copyright (c) 2020 Dataline
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,13 +28,8 @@ import io.dataline.api.model.DestinationIdRequestBody;
 import io.dataline.api.model.DestinationRead;
 import io.dataline.api.model.DestinationReadList;
 import io.dataline.config.StandardDestination;
-import io.dataline.config.persistence.ConfigNotFoundException;
 import io.dataline.config.persistence.ConfigPersistence;
-import io.dataline.config.persistence.JsonValidationException;
-import io.dataline.config.persistence.PersistenceConfigType;
-import io.dataline.server.errors.KnownException;
 import io.dataline.server.helpers.ConfigFetchers;
-
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationsHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationsHandler.java
@@ -33,7 +33,10 @@ import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.JsonValidationException;
 import io.dataline.config.persistence.PersistenceConfigType;
 import io.dataline.server.errors.KnownException;
+import io.dataline.server.helpers.ConfigFetchers;
+
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class DestinationsHandler {
@@ -45,16 +48,10 @@ public class DestinationsHandler {
 
   public DestinationReadList listDestinations() {
     final List<DestinationRead> destinationReads;
-    try {
-      destinationReads =
-          configPersistence
-              .getConfigs(PersistenceConfigType.STANDARD_DESTINATION, StandardDestination.class)
-              .stream()
-              .map(DestinationsHandler::toDestinationRead)
-              .collect(Collectors.toList());
-    } catch (JsonValidationException e) {
-      throw new KnownException(422, e.getMessage(), e);
-    }
+    destinationReads =
+        ConfigFetchers.getStandardDestinations(configPersistence).stream()
+            .map(DestinationsHandler::toDestinationRead)
+            .collect(Collectors.toList());
 
     final DestinationReadList destinationReadList = new DestinationReadList();
     destinationReadList.setDestinations(destinationReads);
@@ -62,17 +59,9 @@ public class DestinationsHandler {
   }
 
   public DestinationRead getDestination(DestinationIdRequestBody destinationIdRequestBody) {
-    final String destinationId = destinationIdRequestBody.getDestinationId().toString();
-    final StandardDestination standardDestination;
-    try {
-      standardDestination =
-          configPersistence.getConfig(
-              PersistenceConfigType.STANDARD_DESTINATION, destinationId, StandardDestination.class);
-    } catch (ConfigNotFoundException e) {
-      throw new KnownException(404, e.getMessage(), e);
-    } catch (JsonValidationException e) {
-      throw new KnownException(422, e.getMessage(), e);
-    }
+    final UUID destinationId = destinationIdRequestBody.getDestinationId();
+    final StandardDestination standardDestination =
+        ConfigFetchers.getStandardDestination(configPersistence, destinationId);
     return toDestinationRead(standardDestination);
   }
 

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SchedulerHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SchedulerHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -41,8 +41,8 @@ import io.dataline.scheduler.persistence.Job;
 import io.dataline.scheduler.persistence.JobStatus;
 import io.dataline.scheduler.persistence.SchedulerPersistence;
 import io.dataline.server.converters.SchemaConverter;
-import java.io.IOException;
 import io.dataline.server.helpers.ConfigFetchers;
+import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SchedulerHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SchedulerHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- *
+ * 
  * Copyright (c) 2020 Dataline
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,17 +36,13 @@ import io.dataline.config.SourceConnectionImplementation;
 import io.dataline.config.StandardConnectionStatus;
 import io.dataline.config.StandardDiscoveryOutput;
 import io.dataline.config.StandardSync;
-import io.dataline.config.persistence.ConfigNotFoundException;
 import io.dataline.config.persistence.ConfigPersistence;
-import io.dataline.config.persistence.JsonValidationException;
-import io.dataline.config.persistence.PersistenceConfigType;
 import io.dataline.scheduler.persistence.Job;
 import io.dataline.scheduler.persistence.JobStatus;
 import io.dataline.scheduler.persistence.SchedulerPersistence;
 import io.dataline.server.converters.SchemaConverter;
-import io.dataline.server.errors.KnownException;
 import java.io.IOException;
-import java.util.UUID;
+import io.dataline.server.helpers.ConfigFetchers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,8 +63,8 @@ public class SchedulerHandler {
       SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
 
     final SourceConnectionImplementation connectionImplementation =
-        getSourceConnectionImplementation(
-            sourceImplementationIdRequestBody.getSourceImplementationId());
+        ConfigFetchers.getSourceConnectionImplementation(
+            configPersistence, sourceImplementationIdRequestBody.getSourceImplementationId());
 
     final long jobId;
     try {
@@ -86,7 +82,8 @@ public class SchedulerHandler {
       DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
 
     final DestinationConnectionImplementation connectionImplementation =
-        getDestinationConnectionImplementation(
+        ConfigFetchers.getDestinationConnectionImplementation(
+            configPersistence,
             destinationImplementationIdRequestBody.getDestinationImplementationId());
 
     final long jobId;
@@ -104,8 +101,8 @@ public class SchedulerHandler {
   public SourceImplementationDiscoverSchemaRead discoverSchemaForSourceImplementation(
       SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     final SourceConnectionImplementation connectionImplementation =
-        getSourceConnectionImplementation(
-            sourceImplementationIdRequestBody.getSourceImplementationId());
+        ConfigFetchers.getSourceConnectionImplementation(
+            configPersistence, sourceImplementationIdRequestBody.getSourceImplementationId());
 
     final long jobId;
     try {
@@ -131,22 +128,16 @@ public class SchedulerHandler {
 
   public ConnectionSyncRead syncConnection(ConnectionIdRequestBody connectionIdRequestBody) {
     final StandardSync standardSync;
-    try {
-      standardSync =
-          configPersistence.getConfig(
-              PersistenceConfigType.STANDARD_SYNC,
-              connectionIdRequestBody.getConnectionId().toString(),
-              StandardSync.class);
-    } catch (ConfigNotFoundException e) {
-      throw new KnownException(404, "Standard Sync not found");
-    } catch (JsonValidationException e) {
-      throw new RuntimeException(e);
-    }
+    standardSync =
+        ConfigFetchers.getStandardSync(
+            configPersistence, connectionIdRequestBody.getConnectionId());
 
     final SourceConnectionImplementation sourceConnectionImplementation =
-        getSourceConnectionImplementation(standardSync.getSourceImplementationId());
+        ConfigFetchers.getSourceConnectionImplementation(
+            configPersistence, standardSync.getSourceImplementationId());
     final DestinationConnectionImplementation destinationConnectionImplementation =
-        getDestinationConnectionImplementation(standardSync.getDestinationImplementationId());
+        ConfigFetchers.getDestinationConnectionImplementation(
+            configPersistence, standardSync.getDestinationImplementationId());
 
     // todo (cgardens) - should it be mandatory that the API insert state? or does the schedule do
     //   that?
@@ -168,34 +159,6 @@ public class SchedulerHandler {
             : ConnectionSyncRead.StatusEnum.FAIL);
 
     return read;
-  }
-
-  private SourceConnectionImplementation getSourceConnectionImplementation(
-      UUID sourceImplementationId) {
-    try {
-      return configPersistence.getConfig(
-          PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
-          sourceImplementationId.toString(),
-          SourceConnectionImplementation.class);
-    } catch (ConfigNotFoundException e) {
-      throw new KnownException(404, "Source Implementation not found");
-    } catch (JsonValidationException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private DestinationConnectionImplementation getDestinationConnectionImplementation(
-      UUID destinationImplementationId) {
-    try {
-      return configPersistence.getConfig(
-          PersistenceConfigType.DESTINATION_CONNECTION_IMPLEMENTATION,
-          destinationImplementationId.toString(),
-          DestinationConnectionImplementation.class);
-    } catch (ConfigNotFoundException e) {
-      throw new KnownException(404, "Destination Implementation not found");
-    } catch (JsonValidationException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   private Job waitUntilJobIsTerminalOrTimeout(long jobId) {

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- *
+ * 
  * Copyright (c) 2020 Dataline
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceSpecificationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceSpecificationsHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceSpecificationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceSpecificationsHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- *
+ * 
  * Copyright (c) 2020 Dataline
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,8 +28,6 @@ import io.dataline.api.model.SourceIdRequestBody;
 import io.dataline.api.model.SourceSpecificationRead;
 import io.dataline.config.SourceConnectionSpecification;
 import io.dataline.config.persistence.ConfigPersistence;
-import io.dataline.config.persistence.JsonValidationException;
-import io.dataline.config.persistence.PersistenceConfigType;
 import io.dataline.server.errors.KnownException;
 import io.dataline.server.helpers.ConfigFetchers;
 

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourcesHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourcesHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourcesHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourcesHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- *
+ * 
  * Copyright (c) 2020 Dataline
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,13 +28,8 @@ import io.dataline.api.model.SourceIdRequestBody;
 import io.dataline.api.model.SourceRead;
 import io.dataline.api.model.SourceReadList;
 import io.dataline.config.StandardSource;
-import io.dataline.config.persistence.ConfigNotFoundException;
 import io.dataline.config.persistence.ConfigPersistence;
-import io.dataline.config.persistence.JsonValidationException;
-import io.dataline.config.persistence.PersistenceConfigType;
-import io.dataline.server.errors.KnownException;
 import io.dataline.server.helpers.ConfigFetchers;
-
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;

--- a/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- *
+ * 
  * Copyright (c) 2020 Dataline
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,14 +29,10 @@ import io.dataline.api.model.WorkspaceIdRequestBody;
 import io.dataline.api.model.WorkspaceRead;
 import io.dataline.api.model.WorkspaceUpdate;
 import io.dataline.config.StandardWorkspace;
-import io.dataline.config.persistence.ConfigNotFoundException;
 import io.dataline.config.persistence.ConfigPersistence;
-import io.dataline.config.persistence.JsonValidationException;
 import io.dataline.config.persistence.PersistenceConfigType;
 import io.dataline.config.persistence.PersistenceConstants;
-import io.dataline.server.errors.KnownException;
 import io.dataline.server.helpers.ConfigFetchers;
-
 import java.util.UUID;
 
 public class WorkspacesHandler {

--- a/dataline-server/src/main/java/io/dataline/server/helpers/ConfigFetchers.java
+++ b/dataline-server/src/main/java/io/dataline/server/helpers/ConfigFetchers.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-server/src/main/java/io/dataline/server/helpers/ConfigFetchers.java
+++ b/dataline-server/src/main/java/io/dataline/server/helpers/ConfigFetchers.java
@@ -1,0 +1,234 @@
+package io.dataline.server.helpers;
+
+import io.dataline.config.DestinationConnectionImplementation;
+import io.dataline.config.DestinationConnectionSpecification;
+import io.dataline.config.SourceConnectionImplementation;
+import io.dataline.config.SourceConnectionSpecification;
+import io.dataline.config.StandardDestination;
+import io.dataline.config.StandardSource;
+import io.dataline.config.StandardSync;
+import io.dataline.config.StandardSyncSchedule;
+import io.dataline.config.StandardWorkspace;
+import io.dataline.config.persistence.ConfigNotFoundException;
+import io.dataline.config.persistence.ConfigPersistence;
+import io.dataline.config.persistence.JsonValidationException;
+import io.dataline.config.persistence.PersistenceConfigType;
+import io.dataline.server.errors.KnownException;
+
+import java.util.Set;
+import java.util.UUID;
+
+public class ConfigFetchers {
+
+  public static StandardWorkspace getStandardWorkspace(
+      ConfigPersistence configPersistence, UUID workspaceId) {
+    try {
+      return configPersistence.getConfig(
+          PersistenceConfigType.STANDARD_WORKSPACE,
+          workspaceId.toString(),
+          StandardWorkspace.class);
+    } catch (ConfigNotFoundException e) {
+      throw getConfigNotFoundException(e, "standardWorkspace", workspaceId);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    }
+  }
+
+  public static StandardSource getStandardSource(
+      ConfigPersistence configPersistence, UUID sourceId) {
+    try {
+      return configPersistence.getConfig(
+          PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
+          sourceId.toString(),
+          StandardSource.class);
+    } catch (ConfigNotFoundException e) {
+      throw getConfigNotFoundException(e, "standardSource", sourceId);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    }
+  }
+
+  public static Set<StandardSource> getStandardSources(ConfigPersistence configPersistence) {
+    try {
+      return configPersistence.getConfigs(
+          PersistenceConfigType.STANDARD_DESTINATION, StandardSource.class);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    }
+  }
+
+  public static SourceConnectionSpecification getSourceConnectionSpecification(
+      ConfigPersistence configPersistence, UUID sourceSpecificationId) {
+    try {
+      return configPersistence.getConfig(
+          PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
+          sourceSpecificationId.toString(),
+          SourceConnectionSpecification.class);
+    } catch (ConfigNotFoundException e) {
+      throw getConfigNotFoundException(e, "sourceConnectionSpecification", sourceSpecificationId);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    }
+  }
+
+  public static Set<SourceConnectionSpecification> getSourceConnectionSpecifications(
+      ConfigPersistence configPersistence) {
+    try {
+      return configPersistence.getConfigs(
+          PersistenceConfigType.DESTINATION_CONNECTION_SPECIFICATION,
+          SourceConnectionSpecification.class);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    }
+  }
+
+  public static SourceConnectionImplementation getSourceConnectionImplementation(
+      ConfigPersistence configPersistence, UUID sourceImplementationId) {
+    try {
+      return configPersistence.getConfig(
+          PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
+          sourceImplementationId.toString(),
+          SourceConnectionImplementation.class);
+    } catch (ConfigNotFoundException e) {
+      throw getConfigNotFoundException(e, "sourceConnectionImplementation", sourceImplementationId);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    }
+  }
+
+  public static Set<SourceConnectionImplementation> getSourceConnectionImplementations(
+      ConfigPersistence configPersistence) {
+    try {
+      return configPersistence.getConfigs(
+          PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
+          SourceConnectionImplementation.class);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    }
+  }
+
+  public static StandardDestination getStandardDestination(
+      ConfigPersistence configPersistence, UUID destinationId) {
+    try {
+      return configPersistence.getConfig(
+          PersistenceConfigType.STANDARD_DESTINATION,
+          destinationId.toString(),
+          StandardDestination.class);
+    } catch (ConfigNotFoundException e) {
+      throw getConfigNotFoundException(e, "standardDestination", destinationId);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    }
+  }
+
+  public static Set<StandardDestination> getStandardDestinations(
+      ConfigPersistence configPersistence) {
+    try {
+      return configPersistence.getConfigs(
+          PersistenceConfigType.STANDARD_DESTINATION, StandardDestination.class);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    }
+  }
+
+  public static DestinationConnectionSpecification getDestinationConnectionSpecification(
+      ConfigPersistence configPersistence, UUID destinationSpecificationId) {
+    try {
+      return configPersistence.getConfig(
+          PersistenceConfigType.DESTINATION_CONNECTION_SPECIFICATION,
+          destinationSpecificationId.toString(),
+          DestinationConnectionSpecification.class);
+    } catch (ConfigNotFoundException e) {
+      throw getConfigNotFoundException(
+          e, "destinationConnectionSpecification", destinationSpecificationId);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    }
+  }
+
+  public static Set<DestinationConnectionSpecification> getDestinationConnectionSpecifications(
+      ConfigPersistence configPersistence) {
+    try {
+      return configPersistence.getConfigs(
+          PersistenceConfigType.DESTINATION_CONNECTION_SPECIFICATION,
+          DestinationConnectionSpecification.class);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    }
+  }
+
+  public static DestinationConnectionImplementation getDestinationConnectionImplementation(
+      ConfigPersistence configPersistence, UUID destinationImplementationId) {
+    try {
+      return configPersistence.getConfig(
+          PersistenceConfigType.DESTINATION_CONNECTION_IMPLEMENTATION,
+          destinationImplementationId.toString(),
+          DestinationConnectionImplementation.class);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    } catch (ConfigNotFoundException e) {
+      throw getConfigNotFoundException(
+          e, "destinationConnectionImplementation", destinationImplementationId);
+    }
+  }
+
+  public static Set<DestinationConnectionImplementation> getDestinationConnectionImplementations(
+      ConfigPersistence configPersistence) {
+    try {
+      return configPersistence.getConfigs(
+          PersistenceConfigType.DESTINATION_CONNECTION_IMPLEMENTATION,
+          DestinationConnectionImplementation.class);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    }
+  }
+
+  public static StandardSync getStandardSync(
+      ConfigPersistence configPersistence, UUID connectionId) {
+    try {
+      return configPersistence.getConfig(
+          PersistenceConfigType.STANDARD_SYNC, connectionId.toString(), StandardSync.class);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    } catch (ConfigNotFoundException e) {
+      throw getConfigNotFoundException(e, "connection", connectionId);
+    }
+  }
+
+  public static Set<StandardSync> getStandardSyncs(ConfigPersistence configPersistence) {
+    try {
+      return configPersistence.getConfigs(PersistenceConfigType.STANDARD_SYNC, StandardSync.class);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    }
+  }
+
+  public static StandardSyncSchedule getStandardSyncSchedule(
+      ConfigPersistence configPersistence, UUID connectionId) {
+    try {
+      return configPersistence.getConfig(
+          PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
+          connectionId.toString(),
+          StandardSyncSchedule.class);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    } catch (ConfigNotFoundException e) {
+      throw getConfigNotFoundException(e, "syncSchedule", connectionId);
+    }
+  }
+
+  private static KnownException getConfigNotFoundException(
+      Throwable e, String configName, UUID id) {
+    return new KnownException(
+        422, String.format("Could not find sync configuration for %s: %s.", configName, id), e);
+  }
+
+  private static KnownException getInvalidException(Throwable e) {
+    return new KnownException(
+        422,
+        String.format(
+            "The provided configuration does not fulfill the specification. Errors: %s",
+            e.getMessage()),
+        e);
+  }
+}

--- a/dataline-server/src/main/java/io/dataline/server/helpers/ConfigFetchers.java
+++ b/dataline-server/src/main/java/io/dataline/server/helpers/ConfigFetchers.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ * 
+ * Copyright (c) 2020 Dataline
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.dataline.server.helpers;
 
 import io.dataline.config.DestinationConnectionImplementation;
@@ -14,7 +38,6 @@ import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.JsonValidationException;
 import io.dataline.config.persistence.PersistenceConfigType;
 import io.dataline.server.errors.KnownException;
-
 import java.util.Set;
 import java.util.UUID;
 
@@ -38,9 +61,7 @@ public class ConfigFetchers {
       ConfigPersistence configPersistence, UUID sourceId) {
     try {
       return configPersistence.getConfig(
-          PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
-          sourceId.toString(),
-          StandardSource.class);
+          PersistenceConfigType.STANDARD_SOURCE, sourceId.toString(), StandardSource.class);
     } catch (ConfigNotFoundException e) {
       throw getConfigNotFoundException(e, "standardSource", sourceId);
     } catch (JsonValidationException e) {
@@ -51,7 +72,7 @@ public class ConfigFetchers {
   public static Set<StandardSource> getStandardSources(ConfigPersistence configPersistence) {
     try {
       return configPersistence.getConfigs(
-          PersistenceConfigType.STANDARD_DESTINATION, StandardSource.class);
+          PersistenceConfigType.STANDARD_SOURCE, StandardSource.class);
     } catch (JsonValidationException e) {
       throw getInvalidException(e);
     }
@@ -75,7 +96,7 @@ public class ConfigFetchers {
       ConfigPersistence configPersistence) {
     try {
       return configPersistence.getConfigs(
-          PersistenceConfigType.DESTINATION_CONNECTION_SPECIFICATION,
+          PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
           SourceConnectionSpecification.class);
     } catch (JsonValidationException e) {
       throw getInvalidException(e);

--- a/dataline-server/src/main/java/io/dataline/server/validation/IntegrationSchemaValidation.java
+++ b/dataline-server/src/main/java/io/dataline/server/validation/IntegrationSchemaValidation.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Dataline
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/dataline-server/src/main/java/io/dataline/server/validation/IntegrationSchemaValidation.java
+++ b/dataline-server/src/main/java/io/dataline/server/validation/IntegrationSchemaValidation.java
@@ -1,18 +1,18 @@
 /*
  * MIT License
- *
+ * 
  * Copyright (c) 2020 Dataline
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,9 +32,7 @@ import io.dataline.config.persistence.ConfigNotFoundException;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.JsonSchemaValidation;
 import io.dataline.config.persistence.JsonValidationException;
-import io.dataline.config.persistence.PersistenceConfigType;
 import io.dataline.server.helpers.ConfigFetchers;
-
 import java.util.UUID;
 
 public class IntegrationSchemaValidation {

--- a/dataline-server/src/main/java/io/dataline/server/validation/IntegrationSchemaValidation.java
+++ b/dataline-server/src/main/java/io/dataline/server/validation/IntegrationSchemaValidation.java
@@ -33,6 +33,8 @@ import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.JsonSchemaValidation;
 import io.dataline.config.persistence.JsonValidationException;
 import io.dataline.config.persistence.PersistenceConfigType;
+import io.dataline.server.helpers.ConfigFetchers;
+
 import java.util.UUID;
 
 public class IntegrationSchemaValidation {
@@ -52,10 +54,8 @@ public class IntegrationSchemaValidation {
       UUID sourceConnectionSpecificationId, Object configuration)
       throws JsonValidationException, ConfigNotFoundException {
     final SourceConnectionSpecification sourceConnectionSpecification =
-        configPersistence.getConfig(
-            PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
-            sourceConnectionSpecificationId.toString(),
-            SourceConnectionSpecification.class);
+        ConfigFetchers.getSourceConnectionSpecification(
+            configPersistence, sourceConnectionSpecificationId);
 
     final JsonNode schemaJson =
         objectMapper.valueToTree(sourceConnectionSpecification.getSpecification());
@@ -68,10 +68,8 @@ public class IntegrationSchemaValidation {
       UUID destinationConnectionSpecificationId, Object configuration)
       throws JsonValidationException, ConfigNotFoundException {
     final DestinationConnectionSpecification destinationConnectionSpecification =
-        configPersistence.getConfig(
-            PersistenceConfigType.DESTINATION_CONNECTION_SPECIFICATION,
-            destinationConnectionSpecificationId.toString(),
-            DestinationConnectionSpecification.class);
+        ConfigFetchers.getDestinationConnectionSpecification(
+            configPersistence, destinationConnectionSpecificationId);
 
     final JsonNode schemaJson =
         objectMapper.valueToTree(destinationConnectionSpecification.getSpecification());


### PR DESCRIPTION
## What
* two common issues with fetching configs are:
  * they are verbose, especially with the error handling, which in the API is all standard
  * they are prone to error if the enum and the class don't match up
* the goal of this PR is to try to move this standard stuff into some helpers. I _think_ this is better than what we already had, but I'm not 100% tbh.

## Reading order
* start here `dataline-server/src/main/java/io/dataline/server/helpers/ConfigFetchers.java`
* everything else is just find and replace.
