### PR TITLE
Fix Enum Namespacing

### DIFF
--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -1032,11 +1032,13 @@ components:
         name:
           type: string
         dataType:
-          type: string
-          enum:
-          - string
-          - number
-          - boolean
+          $ref: "#/components/schemas/DataType"
+    DataType:
+      type: string
+      enum:
+      - string
+      - number
+      - boolean
     SourceSchemaTable:
       type: object
       required:

--- a/dataline-config-persistence/src/main/java/io/dataline/config/persistence/ConfigPersistence.java
+++ b/dataline-config-persistence/src/main/java/io/dataline/config/persistence/ConfigPersistence.java
@@ -34,4 +34,6 @@ public interface ConfigPersistence {
       throws JsonValidationException;
 
   <T> void writeConfig(PersistenceConfigType persistenceConfigType, String configId, T config);
+
+  // todo (cgardens) - get configs by attribute?
 }

--- a/dataline-config-persistence/src/main/java/io/dataline/config/persistence/ConfigPersistence.java
+++ b/dataline-config-persistence/src/main/java/io/dataline/config/persistence/ConfigPersistence.java
@@ -34,6 +34,4 @@ public interface ConfigPersistence {
       throws JsonValidationException;
 
   <T> void writeConfig(PersistenceConfigType persistenceConfigType, String configId, T config);
-
-  // todo (cgardens) - get configs by attribute?
 }

--- a/dataline-config/build.gradle
+++ b/dataline-config/build.gradle
@@ -9,5 +9,4 @@ dependencies {
 
 jsonSchema2Pojo {
     targetPackage = 'io.dataline.config'
-    removeOldOutput = false
 }

--- a/dataline-config/src/main/resources/json/DataType.json
+++ b/dataline-config/src/main/resources/json/DataType.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/DataType.json",
+  "title": "DataType",
+  "description": "standard data types.",
+    "type": "string",
+    "enum": [
+      "string",
+      "number",
+      "boolean"
+    ]
+}

--- a/dataline-config/src/main/resources/json/StandardDataSchema.json
+++ b/dataline-config/src/main/resources/json/StandardDataSchema.json
@@ -49,17 +49,9 @@
           "type": "string"
         },
         "dataType": {
-          "$ref": "StandardDataSchema.json#/definitions/dataType"
+          "$ref": "DataType.json"
         }
       }
-    },
-    "dataType": {
-      "type": "string",
-      "enum": [
-        "string",
-        "number",
-        "boolean"
-      ]
     }
   }
 }

--- a/dataline-server/src/main/java/io/dataline/server/converters/SchemaConverter.java
+++ b/dataline-server/src/main/java/io/dataline/server/converters/SchemaConverter.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.dataline.server.converters;
 
 import io.dataline.api.model.SourceSchema;
@@ -5,9 +29,9 @@ import io.dataline.api.model.SourceSchemaColumn;
 import io.dataline.api.model.SourceSchemaTable;
 import io.dataline.commons.enums.Enums;
 import io.dataline.config.Column;
+import io.dataline.config.DataType;
 import io.dataline.config.Schema;
 import io.dataline.config.Table;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -73,12 +97,11 @@ public class SchemaConverter {
     return apiSchema;
   }
 
-  // todo: figure out why the generator is namespacing the DataType enum by Column.
-  public static Column.DataType toPersistenceDataType(SourceSchemaColumn.DataTypeEnum apiDataType) {
-    return Enums.convertTo(apiDataType, Column.DataType.class);
+  public static DataType toPersistenceDataType(io.dataline.api.model.DataType apiDataType) {
+    return Enums.convertTo(apiDataType, DataType.class);
   }
 
-  public static SourceSchemaColumn.DataTypeEnum toApiDataType(Column.DataType persistenceDataType) {
-    return Enums.convertTo(persistenceDataType, SourceSchemaColumn.DataTypeEnum.class);
+  public static io.dataline.api.model.DataType toApiDataType(DataType persistenceDataType) {
+    return Enums.convertTo(persistenceDataType, io.dataline.api.model.DataType.class);
   }
 }

--- a/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
@@ -31,18 +31,12 @@ import io.dataline.api.model.ConnectionReadList;
 import io.dataline.api.model.ConnectionSchedule;
 import io.dataline.api.model.ConnectionStatus;
 import io.dataline.api.model.ConnectionUpdate;
-import io.dataline.api.model.SourceSchema;
-import io.dataline.api.model.SourceSchemaColumn;
-import io.dataline.api.model.SourceSchemaTable;
 import io.dataline.api.model.WorkspaceIdRequestBody;
 import io.dataline.commons.enums.Enums;
-import io.dataline.config.Column;
 import io.dataline.config.Schedule;
-import io.dataline.config.Schema;
 import io.dataline.config.SourceConnectionImplementation;
 import io.dataline.config.StandardSync;
 import io.dataline.config.StandardSyncSchedule;
-import io.dataline.config.Table;
 import io.dataline.config.persistence.ConfigNotFoundException;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.JsonValidationException;
@@ -76,7 +70,8 @@ public class ConnectionsHandler {
     standardSync.setConnectionId(connectionId);
     standardSync.setSourceImplementationId(connectionCreate.getSourceImplementationId());
     standardSync.setDestinationImplementationId(connectionCreate.getDestinationImplementationId());
-    standardSync.setSyncMode(StandardSync.SyncMode.APPEND); // todo: for MVP we only support append.
+    // todo (cgardens): for MVP we only support append.
+    standardSync.setSyncMode(StandardSync.SyncMode.APPEND);
     standardSync.setSchema(SchemaConverter.toPersistenceSchema(connectionCreate.getSyncSchema()));
     standardSync.setName(
         connectionCreate.getName() != null ? connectionCreate.getName() : "default");
@@ -108,7 +103,7 @@ public class ConnectionsHandler {
         standardSync);
   }
 
-  // todo (cgardens) - stored on sync id (there is know schedule id concept). this is non-intuitive.
+  // todo (cgardens) - stored on sync id (there is no schedule id concept). this is non-intuitive.
   private void writeSchedule(StandardSyncSchedule schedule) {
     configPersistence.writeConfig(
         PersistenceConfigType.STANDARD_SYNC_SCHEDULE,

--- a/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
@@ -265,8 +265,8 @@ class ConnectionsHandlerTest {
     assertTrue(Enums.isCompatible(StandardSync.SyncMode.class, ConnectionRead.SyncModeEnum.class));
     assertTrue(Enums.isCompatible(StandardSync.Status.class, ConnectionStatus.class));
     assertTrue(Enums.isCompatible(ConnectionSchedule.TimeUnitEnum.class, Schedule.TimeUnit.class));
-    assertTrue(Enums.isCompatible(SourceSchemaColumn.DataTypeEnum.class, DataType.class));
-    assertTrue(Enums.isCompatible(DataType.class, SourceSchemaColumn.DataTypeEnum.class));
+    assertTrue(Enums.isCompatible(io.dataline.api.model.DataType.class, DataType.class));
+    assertTrue(Enums.isCompatible(DataType.class, io.dataline.api.model.DataType.class));
   }
 
   private StandardSync generateSync(UUID sourceImplementationId) {
@@ -301,7 +301,7 @@ class ConnectionsHandlerTest {
 
   private SourceSchema generateBasicApiSchema() {
     final SourceSchemaColumn column = new SourceSchemaColumn();
-    column.setDataType(SourceSchemaColumn.DataTypeEnum.STRING);
+    column.setDataType(io.dataline.api.model.DataType.STRING);
     column.setName("id");
 
     final SourceSchemaTable table = new SourceSchemaTable();

--- a/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
@@ -45,6 +45,7 @@ import io.dataline.api.model.SourceSchemaTable;
 import io.dataline.api.model.WorkspaceIdRequestBody;
 import io.dataline.commons.enums.Enums;
 import io.dataline.config.Column;
+import io.dataline.config.DataType;
 import io.dataline.config.Schedule;
 import io.dataline.config.Schema;
 import io.dataline.config.SourceConnectionImplementation;
@@ -264,8 +265,8 @@ class ConnectionsHandlerTest {
     assertTrue(Enums.isCompatible(StandardSync.SyncMode.class, ConnectionRead.SyncModeEnum.class));
     assertTrue(Enums.isCompatible(StandardSync.Status.class, ConnectionStatus.class));
     assertTrue(Enums.isCompatible(ConnectionSchedule.TimeUnitEnum.class, Schedule.TimeUnit.class));
-    assertTrue(Enums.isCompatible(SourceSchemaColumn.DataTypeEnum.class, Column.DataType.class));
-    assertTrue(Enums.isCompatible(Column.DataType.class, SourceSchemaColumn.DataTypeEnum.class));
+    assertTrue(Enums.isCompatible(SourceSchemaColumn.DataTypeEnum.class, DataType.class));
+    assertTrue(Enums.isCompatible(DataType.class, SourceSchemaColumn.DataTypeEnum.class));
   }
 
   private StandardSync generateSync(UUID sourceImplementationId) {
@@ -285,7 +286,7 @@ class ConnectionsHandlerTest {
 
   private Schema generateBasicPersistenceSchema() {
     final Column column = new Column();
-    column.setDataType(Column.DataType.STRING);
+    column.setDataType(DataType.STRING);
     column.setName("id");
 
     final Table table = new Table();


### PR DESCRIPTION
closes https://github.com/datalineio/dataline/issues/52

## What
* json2pojo was nesting generated enum classes under the classes in which they were used. This was annoying in some cases, because we wanted the same enum class to be useable by multiple different classes. e.g. `Column.DataType` => `DataType`
* DataType enum in the api was also namespace by parent class, prefer that it not be.

## How
* in json2pojo, apparently you need to put the enum in its own json file to get around the aggressive namespacing. now that that's done, it works fine.
* for openapi it was just a tweak to the config.