### PR TITLE
remove version and tables from standard sync summary

### DIFF
--- a/dataline-config/src/main/resources/json/StandardSyncSummary.json
+++ b/dataline-config/src/main/resources/json/StandardSyncSummary.json
@@ -4,10 +4,10 @@
   "title": "StandardSyncSummary",
   "description": "standard information output by ALL taps for a sync step (our version of state.json)",
   "type": "object",
-  "required": ["attemptId", "recordsSynced", "status", "startTime", "endTime"],
+  "required": ["jobId", "recordsSynced", "status", "startTime", "endTime"],
   "additionalProperties": false,
   "properties": {
-    "attemptId": {
+    "jobId": {
       "type": "string",
       "format": "uuid"
     },

--- a/dataline-config/src/main/resources/json/StandardSyncSummary.json
+++ b/dataline-config/src/main/resources/json/StandardSyncSummary.json
@@ -4,7 +4,7 @@
   "title": "StandardSyncSummary",
   "description": "standard information output by ALL taps for a sync step (our version of state.json)",
   "type": "object",
-  "required": ["attemptId", "tables", "recordsSynced", "version", "status", "startTime", "endTime"],
+  "required": ["attemptId", "recordsSynced", "status", "startTime", "endTime"],
   "additionalProperties": false,
   "properties": {
     "attemptId": {
@@ -13,29 +13,11 @@
     },
     "status": {
       "type": "string",
-      "enum": ["pending", "in_progress","completed", "failed", "cancelled"]
+      "enum": ["completed", "failed", "cancelled"]
     },
     "recordsSynced": {
       "type": "integer",
       "minValue": 0
-    },
-    "version": {
-      "type": "integer"
-    },
-    "tables": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "lastRecord": {
-            "description": "blob of the last record",
-            "type": "object"
-          },
-          "version": {
-            "type": "integer"
-          }
-        }
-      }
     },
     "startTime": {
       "type": "integer"


### PR DESCRIPTION
## What
Some of the fields on `StandardSyncSummary` won't be used, so removing them until we have a more developed idea about what the state management abstraction should look like. 
