### PR TITLE
[RFC] separate tap and target in sync worker

### DIFF
--- a/dataline-config/src/main/resources/json/JobSyncTapConfig.json
+++ b/dataline-config/src/main/resources/json/JobSyncTapConfig.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/JobSyncConfig.json",
+  "title": "JobSyncConfig",
+  "description": "job sync config",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "sourceConnectionImplementation",
+    "destinationConnectionImplementation",
+    "standardSync"
+  ],
+  "properties": {
+    "sourceConnectionImplementation": {
+      "$ref": "SourceConnectionImplementation.json"
+    },
+    "standardSync": {
+      "$ref": "StandardSync.json"
+    }
+  }
+}

--- a/dataline-config/src/main/resources/json/JobSyncTargetConfig.json
+++ b/dataline-config/src/main/resources/json/JobSyncTargetConfig.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/JobSyncConfig.json",
+  "title": "JobSyncConfig",
+  "description": "job sync config",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "sourceConnectionImplementation",
+    "destinationConnectionImplementation",
+    "standardSync"
+  ],
+  "properties": {
+    "destinationConnectionImplementation": {
+      "$ref": "DestinationConnectionImplementation.json"
+    },
+    "standardSync": {
+      "$ref": "StandardSync.json"
+    }
+  }
+}

--- a/dataline-config/src/main/resources/json/SingerCatalog.json
+++ b/dataline-config/src/main/resources/json/SingerCatalog.json
@@ -27,29 +27,7 @@
             "type": "string"
           },
           "schema": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string"
-              },
-              "properties": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "object",
-                  "required": [
-                    "type"
-                  ],
-                  "properties": {
-                    "type": {
-                      "$ref": "SingerCatalog.json#/definitions/SingerType"
-                    },
-                    "format": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
+            "$ref": "SingerSchema.json"
           }
         }
       }
@@ -99,15 +77,6 @@
             }
           }
         }
-      }
-    }
-  },
-  "definitions": {
-    "SingerType": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "enum": ["string", "integer", "null", "boolean"]
       }
     }
   }

--- a/dataline-config/src/main/resources/json/SingerProtocol.json
+++ b/dataline-config/src/main/resources/json/SingerProtocol.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/JobConfig.json",
+  "title": "JobConfig",
+  "description": "job config",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["configType"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "RECORD",
+        "SCHEMA",
+        "STATE"
+      ]
+    },
+    "record": {
+      "$ref": "SingerRecordMessage.json"
+    },
+    "schema": {
+      "$ref": "SingerSchemaMessage.json"
+    },
+    "state": {
+      "$ref": "SingerStateMessage.json"
+    }
+  }
+}

--- a/dataline-config/src/main/resources/json/SingerRecordMessage.json
+++ b/dataline-config/src/main/resources/json/SingerRecordMessage.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/SingerRecordMessage.json",
+  "title": "SingerRecordMessage",
+  "description": "singer protocol: record https://github.com/singer-io/getting-started/blob/master/docs/SPEC.md#record-message",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "stream",
+    "time_extracted",
+    "record"
+  ],
+  "properties": {
+    "type": {
+      "const": "RECORD"
+    },
+    "stream": {
+      "type": "string"
+    },
+    "time_extracted": {
+      "type": "string",
+      "description": "timestamp"
+    },
+    "record": {
+      "description": "no schema, just a map of string to object!"
+    }
+  }
+}

--- a/dataline-config/src/main/resources/json/SingerSchema.json
+++ b/dataline-config/src/main/resources/json/SingerSchema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/SingerSchema.json",
+  "title": "SingerSchema",
+  "description": "the schema of the singer catalog",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "streams"
+  ],
+  "properties": {
+    "type": {
+      "type": "string"
+    },
+    "properties": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "$ref": "SingerSchema.json#/definitions/SingerType"
+          },
+          "format": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "SingerType": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["string", "integer", "null", "boolean"]
+      }
+    }
+  }
+}

--- a/dataline-config/src/main/resources/json/SingerSchemaMessage.json
+++ b/dataline-config/src/main/resources/json/SingerSchemaMessage.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/SingerRecordMessage.json",
+  "title": "SingerRecordMessage",
+  "description": "singer protocol: schema. https://github.com/singer-io/getting-started/blob/master/docs/SPEC.md#schema-message",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "stream",
+    "schema",
+    "key_properties",
+    "bookmark_properties"
+  ],
+  "properties": {
+    "type": {
+      "const": "SCHEMA"
+    },
+    "stream": {
+      "type": "string"
+    },
+    "schema": {
+      "$ref": "SingerSchema.json"
+    },
+    "key_properties": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "bookmark_properties": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/dataline-config/src/main/resources/json/SingerStateMessage.json
+++ b/dataline-config/src/main/resources/json/SingerStateMessage.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/SingerStateMessage.json",
+  "title": "SingerStateMessage",
+  "description": "singer protocol: record https://github.com/singer-io/getting-started/blob/master/docs/SPEC.md#record-message",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "value"
+  ],
+  "properties": {
+    "type": {
+      "const": "STATE"
+    },
+    "value": {
+      "description": "no schema, just a map of string to object!"
+    }
+  }
+}

--- a/dataline-workers/src/main/java/io/dataline/workers/DefaultSyncWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/DefaultSyncWorker.java
@@ -1,0 +1,54 @@
+package io.dataline.workers;
+
+import io.dataline.config.JobSyncConfig;
+import io.dataline.config.JobSyncOutput;
+import io.dataline.config.JobSyncTapConfig;
+import io.dataline.config.JobSyncTargetConfig;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.stream.Stream;
+
+public class DefaultSyncWorker<T> implements SyncWorker {
+  private final SyncTap<T> tap;
+  private final SyncTarget<T> target;
+
+  // todo (cgardens) - each worker probably doesn't need the whole job config.
+  public DefaultSyncWorker(SyncTap<T> tap, SyncTarget<T> target) {
+    this.tap = tap;
+    this.target = target;
+  }
+
+  @Override
+  public OutputAndStatus<JobSyncOutput> run(JobSyncConfig syncConfig, String workspacePath)
+      throws InvalidCredentialsException, InvalidCatalogException {
+
+    final JobSyncTapConfig tapConfig = new JobSyncTapConfig();
+    tapConfig.setSourceConnectionImplementation(syncConfig.getSourceConnectionImplementation());
+    tapConfig.setStandardSync(syncConfig.getStandardSync());
+
+    final JobSyncTargetConfig targetConfig = new JobSyncTargetConfig();
+    targetConfig.setDestinationConnectionImplementation(
+        syncConfig.getDestinationConnectionImplementation());
+    targetConfig.setStandardSync(syncConfig.getStandardSync());
+
+    final JobSyncOutput output =
+        target.run(tap.run(tapConfig, workspacePath), targetConfig, workspacePath);
+
+    // todo (cgardens) - OutputAndStatus doesn't really work here. it's like both tap and target
+    //   need to return a promise for OutputAndStatus creation. But then that's kinda confusing too.
+    return new OutputAndStatus<>(JobStatus.SUCCESSFUL, output);
+  }
+
+  @Override
+  public void cancel() {}
+
+  public interface SyncTap<T> {
+    Stream<T> run(JobSyncTapConfig jobSyncTapConfig, String workspacePath);
+  }
+
+  public interface SyncTarget<T> {
+    JobSyncOutput run(
+        Stream<T> data, JobSyncTargetConfig jobSyncTargetConfig, String workspacePath);
+  }
+}

--- a/dataline-workers/src/main/java/io/dataline/workers/DefaultSyncWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/DefaultSyncWorker.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.dataline.workers;
 
 import io.dataline.config.JobSyncConfig;
@@ -5,23 +29,21 @@ import io.dataline.config.JobSyncOutput;
 import io.dataline.config.JobSyncTapConfig;
 import io.dataline.config.JobSyncTargetConfig;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.stream.Stream;
-
+// T in this case is our protocol for communicating between tap and target. Likely we'll need to
+// open this up and have the protocol of the tap and that of the target and then dynamically we swap
+// in any protocol converter that we might need. Keeping it simple for now and assuming one
+// protocol--just using the singer protocol for point of example right now. #ijusttriggeredmichel.
 public class DefaultSyncWorker<T> implements SyncWorker {
   private final SyncTap<T> tap;
   private final SyncTarget<T> target;
 
-  // todo (cgardens) - each worker probably doesn't need the whole job config.
   public DefaultSyncWorker(SyncTap<T> tap, SyncTarget<T> target) {
     this.tap = tap;
     this.target = target;
   }
 
   @Override
-  public OutputAndStatus<JobSyncOutput> run(JobSyncConfig syncConfig, String workspacePath)
-      throws InvalidCredentialsException, InvalidCatalogException {
+  public OutputAndStatus<JobSyncOutput> run(JobSyncConfig syncConfig, String workspacePath) {
 
     final JobSyncTapConfig tapConfig = new JobSyncTapConfig();
     tapConfig.setSourceConnectionImplementation(syncConfig.getSourceConnectionImplementation());
@@ -42,13 +64,4 @@ public class DefaultSyncWorker<T> implements SyncWorker {
 
   @Override
   public void cancel() {}
-
-  public interface SyncTap<T> {
-    Stream<T> run(JobSyncTapConfig jobSyncTapConfig, String workspacePath);
-  }
-
-  public interface SyncTarget<T> {
-    JobSyncOutput run(
-        Stream<T> data, JobSyncTargetConfig jobSyncTargetConfig, String workspacePath);
-  }
 }

--- a/dataline-workers/src/main/java/io/dataline/workers/SyncTap.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/SyncTap.java
@@ -24,7 +24,9 @@
 
 package io.dataline.workers;
 
-import io.dataline.config.JobSyncConfig;
-import io.dataline.config.JobSyncOutput;
+import io.dataline.config.JobSyncTapConfig;
+import java.util.stream.Stream;
 
-public interface SyncWorker extends Worker<JobSyncConfig, JobSyncOutput> {}
+public interface SyncTap<T> {
+  Stream<T> run(JobSyncTapConfig jobSyncTapConfig, String workspacePath);
+}

--- a/dataline-workers/src/main/java/io/dataline/workers/SyncTarget.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/SyncTarget.java
@@ -24,7 +24,10 @@
 
 package io.dataline.workers;
 
-import io.dataline.config.JobSyncConfig;
 import io.dataline.config.JobSyncOutput;
+import io.dataline.config.JobSyncTargetConfig;
+import java.util.stream.Stream;
 
-public interface SyncWorker extends Worker<JobSyncConfig, JobSyncOutput> {}
+public interface SyncTarget<T> {
+  JobSyncOutput run(Stream<T> data, JobSyncTargetConfig jobSyncTargetConfig, String workspacePath);
+}

--- a/dataline-workers/src/main/java/io/dataline/workers/SyncWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/SyncWorker.java
@@ -1,0 +1,34 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.workers;
+
+import io.dataline.config.ConnectionImplementation;
+import io.dataline.config.JobConfig;
+import io.dataline.config.JobOutput;
+import io.dataline.config.JobSyncConfig;
+import io.dataline.config.JobSyncOutput;
+import io.dataline.config.StandardDiscoveryOutput;
+
+public interface SyncWorker extends Worker<JobSyncConfig, JobSyncOutput> {}

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerJsonIterator.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerJsonIterator.java
@@ -1,0 +1,76 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.workers.singer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+
+// todo (cgardens) - parsing on this isn't quite right yet. SingerProtocol has a hierarchy not in
+// the stream. Probably need to flatten.
+class SingerJsonIterator implements Iterator<SingerProtocol> {
+  private final ObjectMapper objectMapper;
+  private JsonParser jsonParser;
+
+  // https://cassiomolin.com/2019/08/19/combining-jackson-streaming-api-with-objectmapper-for-parsing-json/
+  public SingerJsonIterator(InputStream is) {
+    this.objectMapper = new ObjectMapper();
+    //      mapper.registerModule(new JavaTimeModule());
+    objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    try {
+      this.jsonParser = objectMapper.getFactory().createParser(is);
+
+      // Check the first token
+      if (jsonParser.nextToken() != JsonToken.START_ARRAY) {
+        throw new IllegalStateException("Expected content to be an array");
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    try {
+      return jsonParser.nextToken() != JsonToken.END_ARRAY;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public SingerProtocol next() {
+    try {
+      return objectMapper.readValue(jsonParser, SingerProtocol.class);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerProtocol.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerProtocol.java
@@ -22,9 +22,6 @@
  * SOFTWARE.
  */
 
-package io.dataline.workers;
+package io.dataline.workers.singer;
 
-import io.dataline.config.JobSyncConfig;
-import io.dataline.config.JobSyncOutput;
-
-public interface SyncWorker extends Worker<JobSyncConfig, JobSyncOutput> {}
+public class SingerProtocol {}

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTapWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTapWorker.java
@@ -69,9 +69,7 @@ public class SingerTapWorker implements SyncTap<SingerProtocol> {
               jobSyncTapConfig
                   .getStandardSync()
                   .getName()); // todo (cgardens) - convert to singer catalog.
-      stateDotJson =
-          objectMapper.writeValueAsString(jobSyncTapConfig.getStandardSync()); // placeholder.
-      //              jobSyncTapConfig.getState()); // todo (cgardens) - add this to the config!!!
+      stateDotJson = jobSyncTapConfig.getState()); // todo (cgardens) - add this to the config!!!
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTapWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTapWorker.java
@@ -1,0 +1,122 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.workers.singer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Streams;
+import io.dataline.config.JobSyncTapConfig;
+import io.dataline.workers.SyncTap;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SingerTapWorker implements SyncTap<SingerProtocol> {
+  private static Logger LOGGER = LoggerFactory.getLogger(SingerProtocol.class);
+  private static String CONFIG_JSON_FILENAME = "config.json";
+  private static String CATALOG_JSON_FILENAME = "catalog.json";
+  private static String STATE_JSON_FILENAME = "input_state.json";
+  private static String ERROR_LOG_FILENAME = "err.log";
+
+  private String singerExecutablePath;
+
+  public SingerTapWorker(String singerExecutablePath) {
+    this.singerExecutablePath = singerExecutablePath;
+  }
+
+  @SuppressWarnings("UnstableApiUsage")
+  @Override
+  public Stream<SingerProtocol> run(JobSyncTapConfig jobSyncTapConfig, String workspaceRoot) {
+    // todo (cgardens) - just getting original impl to line up with new iface for now. this can be
+    //   reduced.
+    final ObjectMapper objectMapper = new ObjectMapper();
+    final String configDotJson;
+    final String catalogDotJson;
+    final String stateDotJson;
+    try {
+      configDotJson =
+          objectMapper.writeValueAsString(
+              jobSyncTapConfig.getSourceConnectionImplementation().getConfiguration());
+      catalogDotJson =
+          objectMapper.writeValueAsString(
+              jobSyncTapConfig
+                  .getStandardSync()
+                  .getName()); // todo (cgardens) - convert to singer catalog.
+      stateDotJson =
+          objectMapper.writeValueAsString(jobSyncTapConfig.getStandardSync()); // placeholder.
+      //              jobSyncTapConfig.getState()); // todo (cgardens) - add this to the config!!!
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+
+    // write config.json to disk
+    String configPath = writeFileToWorkspace(workspaceRoot, CONFIG_JSON_FILENAME, configDotJson);
+    String catalogPath = writeFileToWorkspace(workspaceRoot, CATALOG_JSON_FILENAME, catalogDotJson);
+    String statePath = writeFileToWorkspace(workspaceRoot, STATE_JSON_FILENAME, stateDotJson);
+
+    Process tapProcess = null;
+    try {
+      tapProcess =
+          new ProcessBuilder()
+              .command(
+                  singerExecutablePath,
+                  "--config",
+                  configPath,
+                  "--catalog",
+                  catalogPath,
+                  "--state",
+                  statePath)
+              .start();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    final InputStream stdout = tapProcess.getInputStream();
+
+    final Iterator<SingerProtocol> singerJsonIterator = new SingerJsonIterator(stdout);
+    return Streams.stream(singerJsonIterator);
+  }
+
+  // todo (cgardens) - copy pasta for now. if we go this round move this out of BaseSingerWorker
+  // into a helper.
+  protected String writeFileToWorkspace(String workspaceRoot, String fileName, String contents) {
+    String filePath = getWorkspaceFilePath(workspaceRoot, fileName);
+    try (FileWriter fileWriter = new FileWriter(filePath)) {
+      fileWriter.write(contents);
+      return filePath;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private String getWorkspaceFilePath(String workspaceRoot, String fileName) {
+    return Path.of(workspaceRoot).resolve(fileName).toAbsolutePath().toString();
+  }
+}


### PR DESCRIPTION
## What
* Trying to figure out what it would look like to separate tap and target code so that an OSS contributor could implement one or the other. Currently, as a compromise for MVP, the sync worker has a tight coupling between tap and target. This PR is to start a conversation on how to break that. It's still more of a sketch than anything, but I'd like to get feedback early on this one.
## How
* The basic idea is that a contributor for a given tap would implement `SyncTap` which outputs a stream (for now just falling back on the Singer protocol) and for a given target would implement a `SyncTarget` which consumes the stream.
* The focus in this PR is on defining clear java interfaces for someone implementing the sync step for an integration (tap or target). I know we will want to support stuff outside of java, but java seems like a good place to start and provides good facility for describing interfaces.

## Reading Order
* Start reading `DefaultSyncWorker.java` and then read as much or as little from there as you want. 