### PR TITLE
add simple job history api interface

### DIFF
--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -590,6 +590,52 @@ paths:
           description: Connection not found
         "422":
           $ref: "#/components/responses/InvalidInput"
+  /v1/jobs/list:
+    post:
+      tags:
+        - jobs
+      summary: Returns recent jobs for a connection.
+      operationId: listJobsFor
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionIdRequestBody"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JobReadList"
+        "404":
+          description: Connection not found
+        "422":
+          $ref: "#/components/responses/InvalidInput"
+  /v1/jobs/get:
+    post:
+      tags:
+        - jobs
+      summary: Get information about a job
+      operationId: getJobInfo
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/JobIdRequestBody"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JobInfoRead"
+        "404":
+          description: Job not found
+        "422":
+          $ref: "#/components/responses/InvalidInput"
 externalDocs:
   description: Find out more about Dataline
   url: "http://dataline.io"
@@ -1062,11 +1108,11 @@ components:
       properties:
         id:
           $ref: "#/components/schemas/JobId"
-    Job:
+    JobRead:
       type: object
       required:
         - id
-        - connection
+        - connection_id
         - created_at
         - started_at
         - updated_at
@@ -1074,8 +1120,8 @@ components:
       properties:
         id:
           $ref: "#/components/schemas/JobId"
-        connection:
-          $ref: "#/components/schemas/ConnectionRead"
+        connection_id:
+          $ref: "#/components/schemas/ConnectionId"
         created_at:
           type: integer
           format: int64
@@ -1093,6 +1139,39 @@ components:
             - failed
             - completed
             - cancelled
+    JobReadList:
+      type: object
+      required:
+        - jobs
+      properties:
+        jobs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JobRead"
+    JobInfoRead:
+      type: object
+      required:
+        - job
+        - logs
+      properties:
+        job:
+          $ref: "#/components/schemas/JobRead"
+        logs:
+          $ref: "#/components/schemas/LogRead"
+    LogRead:
+      type: object
+      required:
+        - stdout
+        - stderr
+      properties:
+        stdout:
+          type: array
+          items:
+            type: string
+        stderr:
+          type: array
+          items:
+            type: string
     # General
     CheckConnectionRead:
       type: object

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerWrapper.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerWrapper.java
@@ -25,7 +25,7 @@
 package io.dataline.scheduler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dataline.api.model.Job;
+import io.dataline.api.model.JobRead;
 import io.dataline.config.ConnectionImplementation;
 import io.dataline.config.DestinationConnectionImplementation;
 import io.dataline.config.SourceConnectionImplementation;
@@ -95,7 +95,7 @@ public class WorkerWrapper<InputType, OutputType> implements Runnable {
   public void run() {
     LOGGER.info("Executing worker wrapper...");
     try {
-      setJobStatus(connectionPool, jobId, Job.StatusEnum.RUNNING);
+      setJobStatus(connectionPool, jobId, JobRead.StatusEnum.RUNNING);
 
       // fetch input.
       final io.dataline.scheduler.Job job = persistence.getJob(jobId);
@@ -111,10 +111,10 @@ public class WorkerWrapper<InputType, OutputType> implements Runnable {
 
       switch (outputAndStatus.getStatus()) {
         case FAILED:
-          setJobStatus(connectionPool, jobId, Job.StatusEnum.FAILED);
+          setJobStatus(connectionPool, jobId, JobRead.StatusEnum.FAILED);
           break;
         case SUCCESSFUL:
-          setJobStatus(connectionPool, jobId, Job.StatusEnum.COMPLETED);
+          setJobStatus(connectionPool, jobId, JobRead.StatusEnum.COMPLETED);
           break;
       }
 
@@ -128,12 +128,12 @@ public class WorkerWrapper<InputType, OutputType> implements Runnable {
       }
     } catch (Exception e) {
       LOGGER.error("Worker Error", e);
-      setJobStatus(connectionPool, jobId, Job.StatusEnum.FAILED);
+      setJobStatus(connectionPool, jobId, JobRead.StatusEnum.FAILED);
     }
   }
 
   private static void setJobStatus(
-      BasicDataSource connectionPool, long jobId, Job.StatusEnum status) {
+      BasicDataSource connectionPool, long jobId, JobRead.StatusEnum status) {
     LOGGER.info("Setting job status to " + status + " for job " + jobId);
     LocalDateTime now = LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
 

--- a/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
+++ b/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
@@ -71,11 +71,10 @@ import io.dataline.server.handlers.SourceSpecificationsHandler;
 import io.dataline.server.handlers.SourcesHandler;
 import io.dataline.server.handlers.WorkspacesHandler;
 import io.dataline.server.validation.IntegrationSchemaValidation;
-import org.apache.commons.dbcp2.BasicDataSource;
-import org.apache.commons.lang3.NotImplementedException;
-
 import javax.validation.Valid;
 import javax.ws.rs.Path;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.commons.lang3.NotImplementedException;
 
 @Path("/v1")
 public class ConfigurationApi implements io.dataline.api.V1Api {

--- a/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
+++ b/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
@@ -40,6 +40,9 @@ import io.dataline.api.model.DestinationImplementationUpdate;
 import io.dataline.api.model.DestinationRead;
 import io.dataline.api.model.DestinationReadList;
 import io.dataline.api.model.DestinationSpecificationRead;
+import io.dataline.api.model.JobIdRequestBody;
+import io.dataline.api.model.JobInfoRead;
+import io.dataline.api.model.JobReadList;
 import io.dataline.api.model.SlugRequestBody;
 import io.dataline.api.model.SourceIdRequestBody;
 import io.dataline.api.model.SourceImplementationCreate;
@@ -68,9 +71,11 @@ import io.dataline.server.handlers.SourceSpecificationsHandler;
 import io.dataline.server.handlers.SourcesHandler;
 import io.dataline.server.handlers.WorkspacesHandler;
 import io.dataline.server.validation.IntegrationSchemaValidation;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.commons.lang3.NotImplementedException;
+
 import javax.validation.Valid;
 import javax.ws.rs.Path;
-import org.apache.commons.dbcp2.BasicDataSource;
 
 @Path("/v1")
 public class ConfigurationApi implements io.dataline.api.V1Api {
@@ -198,6 +203,16 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   public DestinationSpecificationRead getDestinationSpecification(
       @Valid DestinationIdRequestBody destinationIdRequestBody) {
     return destinationSpecificationsHandler.getDestinationSpecification(destinationIdRequestBody);
+  }
+
+  @Override
+  public JobReadList listJobsFor(@Valid ConnectionIdRequestBody connectionIdRequestBody) {
+    throw new NotImplementedException("listJobsFor not supported yet");
+  }
+
+  @Override
+  public JobInfoRead getJobInfo(@Valid JobIdRequestBody jobIdRequestBody) {
+    throw new NotImplementedException("getJobInfo not supported yet");
   }
 
   // DESTINATION IMPLEMENTATION


### PR DESCRIPTION
## What
The frontend needs to be able to list jobs for a connection and show metadata about that job.

## How
This PR defines the interface for exposing some simple endpoints with this information. 

Eventually, we'll probably want additional features like:
- job history pagination
- log line pagination
- different query methods

But for now it seems fine to keep it simple and dictate the amount of data shown on the backend. 

I'm imagining a single "log line" here could be something like a stack trace which would be `<pre>` formatted on the frontend.
