### PR TITLE
Apply Dataline schema to discovered singer catalog

### DIFF
--- a/dataline-config/src/main/resources/json/SingerCatalog.json
+++ b/dataline-config/src/main/resources/json/SingerCatalog.json
@@ -52,7 +52,9 @@
     "SingerTableSchema": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["properties"],
+      "required": [
+        "properties"
+      ],
       "description": "The JSON schema for the stream. This struct is weird because it's essentially modeling the properties field of a jsonschema object.",
       "properties": {
         "type": {
@@ -60,6 +62,9 @@
         },
         "properties": {
           "$ref": "SingerCatalog.json#/definitions/SingerColumnMap"
+        },
+        "definitions": {
+          "description": "placeholder for definitions that are included since it is all jsonchema."
         }
       }
     },
@@ -85,6 +90,15 @@
         "selected": {
           "description": "Deprecated: Some legacy Taps handle stream and field selection by looking for \"selected\": true directly in the stream's schema in the catalog.json file (called properties.json in legacy taps).",
           "type": "boolean"
+        },
+        "minimum": {
+          "type": "integer"
+        },
+        "maximum": {
+          "type": "integer"
+        },
+        "maxLength": {
+          "type": "integer"
         }
       }
     },
@@ -93,13 +107,13 @@
       "additionalProperties": false,
       "required": [
         "metadata",
-        "breadcrumbs"
+        "breadcrumb"
       ],
       "properties": {
         "metadata": {
           "$ref": "SingerCatalog.json#/definitions/SingerMetadataChild"
         },
-        "breadcrumbs": {
+        "breadcrumb": {
           "type": "array",
           "items": {
             "type": "string"

--- a/dataline-config/src/main/resources/json/SingerCatalog.json
+++ b/dataline-config/src/main/resources/json/SingerCatalog.json
@@ -12,102 +12,195 @@
     "streams": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "tap_stream_id",
-          "stream",
-          "schema"
-        ],
-        "properties": {
-          "tap_stream_id": {
-            "type": "string"
-          },
-          "stream": {
-            "type": "string"
-          },
-          "schema": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string"
-              },
-              "properties": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "object",
-                  "required": [
-                    "type"
-                  ],
-                  "properties": {
-                    "type": {
-                      "$ref": "SingerCatalog.json#/definitions/SingerType"
-                    },
-                    "format": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "metadata": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "metadata"
-        ],
-        "properties": {
-          "metadata": {
-            "type": "object",
-            "properties": {
-              "inclusion": {
-                "type": "string",
-                "enum": [
-                  "available",
-                  "?"
-                ]
-              },
-              "table-key-properties": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "selected": {
-                "type": "boolean"
-              },
-              "validation-replication-keys": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "schema-name": {
-                "type": "string"
-              }
-            }
-          },
-          "breadcrumbs": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
+        "$ref": "SingerCatalog.json#/definitions/SingerStream"
       }
     }
   },
   "definitions": {
+    "SingerStream": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tap_stream_id",
+        "stream",
+        "schema"
+      ],
+      "properties": {
+        "stream": {
+          "type": "string",
+          "description": "The name of the stream."
+        },
+        "tap_stream_id": {
+          "type": "string",
+          "description": "The unique identifier for the stream. This is allowed to be different from the name of the stream in order to allow for sources that have duplicate stream names."
+        },
+        "schema": {
+          "$ref": "SingerCatalog.json#/definitions/SingerTableSchema"
+        },
+        "table_name": {
+          "type": "string",
+          "description": "For a database source, the name of the table."
+        },
+        "metadata": {
+          "type": "array",
+          "items": {
+            "$ref": "SingerCatalog.json#/definitions/SingerMetadata"
+          }
+        }
+      }
+    },
+    "SingerTableSchema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["properties"],
+      "description": "The JSON schema for the stream. This struct is weird because it's essentially modeling the properties field of a jsonschema object.",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "SingerCatalog.json#/definitions/SingerColumnMap"
+        }
+      }
+    },
+    "SingerColumnMap": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "SingerCatalog.json#/definitions/SingerColumn"
+      }
+    },
+    "SingerColumn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "$ref": "SingerCatalog.json#/definitions/SingerType"
+        },
+        "format": {
+          "type": "string"
+        },
+        "selected": {
+          "description": "Deprecated: Some legacy Taps handle stream and field selection by looking for \"selected\": true directly in the stream's schema in the catalog.json file (called properties.json in legacy taps).",
+          "type": "boolean"
+        }
+      }
+    },
+    "SingerMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "metadata",
+        "breadcrumbs"
+      ],
+      "properties": {
+        "metadata": {
+          "$ref": "SingerCatalog.json#/definitions/SingerMetadataChild"
+        },
+        "breadcrumbs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SingerMetadataChild": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [],
+      "properties": {
+        "selected": {
+          "description": "Non-Discoverable: Indicates that this node in the schema has been selected by the user for replication.",
+          "type": "boolean"
+        },
+        "replication-method": {
+          "description": "Non-Discoverable: Either FULL_TABLE, INCREMENTAL, or LOG_BASED. The replication method to use for a stream.",
+          "type": "string",
+          "enum": [
+            "FULL_TABLE",
+            "INCREMENTAL",
+            "LOG_BASED"
+          ]
+        },
+        "replication-key": {
+          "description": "Non-Discoverable: The name of a property in the source to use as a \"bookmark\". For example, this will often be an \"updated-at\" field or an auto-incrementing primary key (requires replication-method",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "view-key-properties": {
+          "description": "Non Discoverable: List of key properties for a database view.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "inclusion": {
+          "description": "Discoverable: available means the field is available for selection, and the tap will only emit values for that field if it is marked with \"selected\": true. automatic means that the tap will emit values for the field. unsupported means that the field exists in the source data but the tap is unable to provide it.",
+          "type": "string",
+          "enum": [
+            "available",
+            "automatic",
+            "unsupported"
+          ]
+        },
+        "selected-by-default": {
+          "description": "Discoverable: Indicates if a node in the schema should be replicated if a user has not expressed any opinion on whether or not to replicate it.",
+          "type": "boolean"
+        },
+        "valid-replication-keys": {
+          "description": "Discoverable: List of the fields that could be used as replication keys.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "forced-replication-method": {
+          "description": "Discoverable: Used to force the replication method to either FULL_TABLE or INCREMENTAL.",
+          "type": "boolean"
+        },
+        "table-key-properties": {
+          "description": "Discoverable: List of key properties for a database table.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "schema-name": {
+          "description": "Discoverable: The name of the stream.",
+          "type": "string"
+        },
+        "is-view": {
+          "description": "Discoverable: Indicates whether a stream corresponds to a database view.",
+          "type": "boolean"
+        },
+        "row-count": {
+          "description": "Discoverable: Number of rows in a database table/view.",
+          "type": "integer"
+        },
+        "database-name": {
+          "description": "Discoverable: Name of database.",
+          "type": "string"
+        },
+        "sql-datatype": {
+          "description": "Discoverable: Represents the datatype of a database column."
+        }
+      }
+    },
     "SingerType": {
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["string", "integer", "null", "boolean"]
+        "enum": [
+          "string",
+          "integer",
+          "null",
+          "boolean"
+        ]
       }
     }
   }

--- a/dataline-config/src/main/resources/json/StandardDataSchema.json
+++ b/dataline-config/src/main/resources/json/StandardDataSchema.json
@@ -41,7 +41,8 @@
       "type": "object",
       "required": [
         "name",
-        "dataType"
+        "dataType",
+        "selected"
       ],
       "additionalProperties": false,
       "properties": {
@@ -50,6 +51,10 @@
         },
         "dataType": {
           "$ref": "DataType.json"
+        },
+        "selected": {
+          "description": "whether or not the column will be replicated.",
+          "type": "boolean"
         }
       }
     }

--- a/dataline-config/src/main/resources/json/StandardDataSchema.json
+++ b/dataline-config/src/main/resources/json/StandardDataSchema.json
@@ -29,6 +29,9 @@
         "name": {
           "type": "string"
         },
+        "selected": {
+          "type": "boolean"
+        },
         "columns": {
           "type": "array",
           "items": {

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerCatalogConverters.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerCatalogConverters.java
@@ -1,0 +1,133 @@
+package io.dataline.workers.singer;
+
+import com.fasterxml.jackson.databind.annotation.JsonAppend;
+import io.dataline.config.Column;
+import io.dataline.config.DataType;
+import io.dataline.config.Properties;
+import io.dataline.config.PropertiesProperty;
+import io.dataline.config.Schema;
+import io.dataline.config.SingerCatalog;
+import io.dataline.config.SingerSchema;
+import io.dataline.config.SingerType;
+import io.dataline.config.StandardDiscoveryOutput;
+import io.dataline.config.Stream;
+import io.dataline.config.Table;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SingerCatalogConverters {
+
+  public static SingerCatalog toCatalogBang(SingerCatalog catalog, Schema schema) {
+    Map<String, Table> tableNameToTable =
+        schema.getTables().stream().collect(Collectors.toMap(Table::getName, table -> table));
+
+    final List<Stream> updatedStreams = catalog.getStreams().stream().map(stream -> {
+      if (!tableNameToTable.containsKey(stream.getStream())) {
+        // recourse here is probably to run discovery again and update sync configuration.
+        throw new RuntimeException("could not find table in singer catalog.");
+      }
+      final Table table = tableNameToTable.get(stream.getStream());
+      final Map<String, Column> columnNameToColumn = table.getColumns().stream().collect(Collectors.toMap(Column::getName, column -> column));
+      stream.getSchema().getProperties().getAdditionalProperties().entrySet().stream().map((Map.Entry<String, PropertiesProperty> entry) -> {
+        if (columnNameToColumn.containsKey(entry.getKey())) {
+          // selected
+        } else {
+          // maybe this should happen or if it does, not selected.
+        }
+
+        return entry;
+      });
+
+      // rename this shit.
+      new Properties().setAdditionalProperty();
+      final SingerSchema singerSchema = new SingerSchema();
+      singerSchema.setProperties();
+      singerSchema.setType("???");
+      stream.setSchema();
+
+      return stream;
+    }).collect(Collectors.toList());
+
+    final SingerCatalog outputCatalog = new SingerCatalog();
+    outputCatalog.setStreams(updatedStreams);
+
+    return outputCatalog;
+  }
+
+  public static Schema toDatalineSchema(SingerCatalog catalog) {
+    List<Table> tableStream =
+        catalog.getStreams().stream()
+            .map(
+                stream -> {
+                  final Table table = new Table();
+                  table.setName(
+                      stream.getStream()); // todo (cgardens) - is stream the same as table name?
+                  table.setColumns(
+                      stream
+                          .getSchema()
+                          .getProperties()
+                          .getAdditionalProperties()
+                          .entrySet()
+                          .stream()
+                          .map(
+                              entry -> {
+                                final String columnName = entry.getKey();
+                                final PropertiesProperty columnMetadata = entry.getValue();
+                                final Column column = new Column();
+                                column.setName(columnName);
+                                column.setDataType(singerTypesToDataType(columnMetadata.getType()));
+                                return column;
+                              })
+                          .collect(Collectors.toList()));
+                  return table;
+                })
+            .collect(Collectors.toList());
+
+    final Schema schema = new Schema();
+    schema.setTables(tableStream);
+    return schema;
+  }
+
+  /**
+   * Singer tends to have 2 types for columns one of which is null. The null is pretty irrelevant,
+   * so look at types and find the first non-null one and use that.
+   *
+   * @param singerTypes - list of types discovered by singer.
+   * @return reduce down to one type which best matches the column's data type
+   */
+  private static DataType singerTypesToDataType(List<SingerType> singerTypes) {
+    return singerTypes.stream()
+        .filter(singerType -> !SingerType.NULL.equals(singerType))
+        .map(SingerCatalogConverters::singerTypeToDataType)
+        .findFirst()
+        .orElse(DataType.STRING);
+  }
+
+  /**
+   * Singer doesn't seem to have an official list of the data types that they support, so we will
+   * have to do our best here as we discover them. If it becomes too awful, we can just map types we
+   * don't recognize to string.
+   *
+   * @param singerType - singer's column data type
+   * @return best match for our own data type
+   */
+  private static DataType singerTypeToDataType(SingerType singerType) {
+    switch (singerType) {
+      case STRING:
+        return DataType.STRING;
+      case INTEGER:
+        return DataType.NUMBER;
+      case NULL:
+        //noinspection DuplicateBranchesInSwitch
+        return DataType.STRING; // todo (cgardens) - hackasaurus rex
+      case BOOLEAN:
+        return DataType.BOOLEAN;
+      default:
+        throw new RuntimeException(
+            String.format("could not map SingerType: %s to DataType", singerType));
+    }
+  }
+}

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerCatalogConverters.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerCatalogConverters.java
@@ -200,6 +200,7 @@ public class SingerCatalogConverters {
   }
 
   private static SingerMetadata cloneSingerMetadata(SingerMetadata toClone) {
+    // bad variable name. tradeoff to keep stuff on one line.
     SingerMetadataChild toClone2 = toClone.getMetadata();
     final SingerMetadataChild singerMetadataChild = new SingerMetadataChild();
     singerMetadataChild.setSelected(toClone2.getSelected());

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerDiscoveryWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerDiscoveryWorker.java
@@ -38,7 +38,6 @@ import io.dataline.workers.OutputAndStatus;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerDiscoveryWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerDiscoveryWorker.java
@@ -29,22 +29,16 @@ import static io.dataline.workers.JobStatus.SUCCESSFUL;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dataline.config.Column;
 import io.dataline.config.ConnectionImplementation;
-import io.dataline.config.DataType;
-import io.dataline.config.PropertiesProperty;
 import io.dataline.config.Schema;
 import io.dataline.config.SingerCatalog;
-import io.dataline.config.SingerType;
 import io.dataline.config.StandardDiscoveryOutput;
-import io.dataline.config.Table;
 import io.dataline.workers.DiscoverSchemaWorker;
 import io.dataline.workers.OutputAndStatus;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -134,80 +128,11 @@ public class SingerDiscoveryWorker
   }
 
   private static StandardDiscoveryOutput toDiscoveryOutput(SingerCatalog catalog) {
-    List<Table> tableStream =
-        catalog.getStreams().stream()
-            .map(
-                stream -> {
-                  final Table table = new Table();
-                  table.setName(
-                      stream.getStream()); // todo (cgardens) - is stream the same as table name?
-                  table.setColumns(
-                      stream
-                          .getSchema()
-                          .getProperties()
-                          .getAdditionalProperties()
-                          .entrySet()
-                          .stream()
-                          .map(
-                              entry -> {
-                                final String columnName = entry.getKey();
-                                final PropertiesProperty columnMetadata = entry.getValue();
-                                final Column column = new Column();
-                                column.setName(columnName);
-                                column.setDataType(singerTypesToDataType(columnMetadata.getType()));
-                                return column;
-                              })
-                          .collect(Collectors.toList()));
-                  return table;
-                })
-            .collect(Collectors.toList());
-
-    final Schema schema = new Schema();
-    schema.setTables(tableStream);
+    final Schema schema = SingerCatalogConverters.toDatalineSchema(catalog);
     final StandardDiscoveryOutput discoveryOutput = new StandardDiscoveryOutput();
     discoveryOutput.setSchema(schema);
 
     return discoveryOutput;
-  }
-
-  /**
-   * Singer tends to have 2 types for columns one of which is null. The null is pretty irrelevant,
-   * so look at types and find the first non-null one and use that.
-   *
-   * @param singerTypes - list of types discovered by singer.
-   * @return reduce down to one type which best matches the column's data type
-   */
-  private static DataType singerTypesToDataType(List<SingerType> singerTypes) {
-    return singerTypes.stream()
-        .filter(singerType -> !SingerType.NULL.equals(singerType))
-        .map(SingerDiscoveryWorker::singerTypeToDataType)
-        .findFirst()
-        .orElse(DataType.STRING);
-  }
-
-  /**
-   * Singer doesn't seem to have an official list of the data types that they support, so we will
-   * have to do our best here as we discover them. If it becomes too awful, we can just map types we
-   * don't recognize to string.
-   *
-   * @param singerType - singer's column data type
-   * @return best match for our own data type
-   */
-  private static DataType singerTypeToDataType(SingerType singerType) {
-    switch (singerType) {
-      case STRING:
-        return DataType.STRING;
-      case INTEGER:
-        return DataType.NUMBER;
-      case NULL:
-        //noinspection DuplicateBranchesInSwitch
-        return DataType.STRING; // todo (cgardens) - hackasaurus rex
-      case BOOLEAN:
-        return DataType.BOOLEAN;
-      default:
-        throw new RuntimeException(
-            String.format("could not map SingerType: %s to DataType", singerType));
-    }
   }
 
   @Override

--- a/dataline-workers/src/test/java/io/dataline/workers/BaseWorkerTestCase.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/BaseWorkerTestCase.java
@@ -24,7 +24,12 @@
 
 package io.dataline.workers;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import java.io.File;
 import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeAll;
@@ -54,5 +59,24 @@ public abstract class BaseWorkerTestCase {
       throw new RuntimeException(e);
     }
     return workspacePath;
+  }
+
+  protected String readResource(String name) {
+    URL resource = Resources.getResource(name);
+    try {
+      return Resources.toString(resource, Charset.defaultCharset());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected <T> T getJsonAsTyped(String file, Class<T> clazz) {
+    final URL resource = Resources.getResource(file);
+    final ObjectMapper objectMapper = new ObjectMapper();
+    try {
+      return objectMapper.readValue(new File(resource.getFile()), clazz);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerCatalogConvertersTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerCatalogConvertersTest.java
@@ -46,9 +46,9 @@ class SingerCatalogConvertersTest extends BaseWorkerTestCase {
     final SingerCatalog actualCatalog =
         SingerCatalogConverters.applySchemaToDiscoveredCatalog(catalog, datalineSchema);
 
-    expectedCatalog.getStreams().get(0).getMetadata().get(0).getMetadata().setSelected(true);
+    expectedCatalog.getStreams().get(0).getMetadata().get(0).getMetadata().setSelected(false);
     expectedCatalog.getStreams().get(0).getMetadata().get(1).getMetadata().setSelected(true);
-    expectedCatalog.getStreams().get(0).getMetadata().get(2).getMetadata().setSelected(false);
+    expectedCatalog.getStreams().get(0).getMetadata().get(2).getMetadata().setSelected(true);
 
     assertEquals(expectedCatalog, actualCatalog);
   }
@@ -59,7 +59,7 @@ class SingerCatalogConvertersTest extends BaseWorkerTestCase {
         getJsonAsTyped("simple_postgres_singer_catalog.json", SingerCatalog.class);
     final Schema expectedSchema =
         getJsonAsTyped("simple_postgres_schema.json", StandardDiscoveryOutput.class).getSchema();
-    expectedSchema.getTables().get(0).setSelected(null);
+    expectedSchema.getTables().get(0).setSelected(false);
     expectedSchema.getTables().get(0).getColumns().get(0).setSelected(true);
     expectedSchema.getTables().get(0).getColumns().get(1).setSelected(true);
 

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerCatalogConvertersTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerCatalogConvertersTest.java
@@ -1,0 +1,70 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.workers.singer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.dataline.config.Schema;
+import io.dataline.config.SingerCatalog;
+import io.dataline.config.StandardDiscoveryOutput;
+import io.dataline.workers.BaseWorkerTestCase;
+import org.junit.jupiter.api.Test;
+
+class SingerCatalogConvertersTest extends BaseWorkerTestCase {
+
+  @Test
+  void applySchemaToDiscoveredCatalog() {
+    final SingerCatalog catalog =
+        getJsonAsTyped("simple_postgres_singer_catalog.json", SingerCatalog.class);
+    final SingerCatalog expectedCatalog =
+        getJsonAsTyped("simple_postgres_singer_catalog.json", SingerCatalog.class);
+    final Schema datalineSchema =
+        getJsonAsTyped("simple_postgres_schema.json", StandardDiscoveryOutput.class).getSchema();
+
+    final SingerCatalog actualCatalog =
+        SingerCatalogConverters.applySchemaToDiscoveredCatalog(catalog, datalineSchema);
+
+    expectedCatalog.getStreams().get(0).getMetadata().get(0).getMetadata().setSelected(true);
+    expectedCatalog.getStreams().get(0).getMetadata().get(1).getMetadata().setSelected(true);
+    expectedCatalog.getStreams().get(0).getMetadata().get(2).getMetadata().setSelected(false);
+
+    assertEquals(expectedCatalog, actualCatalog);
+  }
+
+  @Test
+  void toDatalineSchema() {
+    final SingerCatalog catalog =
+        getJsonAsTyped("simple_postgres_singer_catalog.json", SingerCatalog.class);
+    final Schema expectedSchema =
+        getJsonAsTyped("simple_postgres_schema.json", StandardDiscoveryOutput.class).getSchema();
+    expectedSchema.getTables().get(0).setSelected(null);
+    expectedSchema.getTables().get(0).getColumns().get(0).setSelected(true);
+    expectedSchema.getTables().get(0).getColumns().get(1).setSelected(true);
+
+    final Schema actualSchema = SingerCatalogConverters.toDatalineSchema(catalog);
+
+    assertEquals(expectedSchema, actualSchema);
+  }
+}

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerDiscoveryWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerDiscoveryWorkerTest.java
@@ -77,7 +77,7 @@ public class SingerDiscoveryWorkerTest extends BaseWorkerTestCase {
 
     assertEquals(SUCCESSFUL, run.getStatus());
 
-    String expectedSchema = readResource("simple_postgres_schema.json");
+    String expectedSchema = readResource("simple_discovered_postgres_schema.json");
     final ObjectMapper objectMapper = new ObjectMapper();
     final String actualSchema = objectMapper.writeValueAsString(run.getOutput().get());
 

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerDiscoveryWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerDiscoveryWorkerTest.java
@@ -30,15 +30,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.io.Resources;
 import io.dataline.config.ConnectionImplementation;
 import io.dataline.config.StandardDiscoveryOutput;
 import io.dataline.workers.BaseWorkerTestCase;
 import io.dataline.workers.OutputAndStatus;
 import io.dataline.workers.PostgreSQLContainerHelper;
 import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.Charset;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -111,15 +108,6 @@ public class SingerDiscoveryWorkerTest extends BaseWorkerTestCase {
     TimeUnit.MILLISECONDS.sleep(50);
     worker.cancel();
     workerWasCancelled.get();
-  }
-
-  private String readResource(String name) {
-    URL resource = Resources.getResource(name);
-    try {
-      return Resources.toString(resource, Charset.defaultCharset());
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   private void assertJsonEquals(String s1, String s2) throws IOException {

--- a/dataline-workers/src/test/resources/simple_discovered_postgres_schema.json
+++ b/dataline-workers/src/test/resources/simple_discovered_postgres_schema.json
@@ -1,0 +1,22 @@
+{
+  "schema": {
+    "tables": [
+      {
+        "name": "id_and_name",
+        "selected": false,
+        "columns": [
+          {
+            "name": "name",
+            "dataType": "string",
+            "selected": true
+          },
+          {
+            "name": "id",
+            "dataType": "number",
+            "selected": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/dataline-workers/src/test/resources/simple_postgres_schema.json
+++ b/dataline-workers/src/test/resources/simple_postgres_schema.json
@@ -3,14 +3,17 @@
     "tables": [
       {
         "name": "id_and_name",
+        "selected": true,
         "columns": [
           {
             "name": "name",
-            "dataType": "string"
+            "dataType": "string",
+            "selected": false
           },
           {
             "name": "id",
-            "dataType": "number"
+            "dataType": "number",
+            "selected": true
           }
         ]
       }

--- a/dataline-workers/src/test/resources/simple_postgres_schema.json
+++ b/dataline-workers/src/test/resources/simple_postgres_schema.json
@@ -3,12 +3,12 @@
     "tables": [
       {
         "name": "id_and_name",
-        "selected": true,
+        "selected": false,
         "columns": [
           {
             "name": "name",
             "dataType": "string",
-            "selected": false
+            "selected": true
           },
           {
             "name": "id",


### PR DESCRIPTION
## What
* At sync time we run discover. Take in the discovered catalog. Apply configurations stored in Dataline schema (e.g. which columns to sync) to that discovered catalog. That catalog will then be used as input into a sync action.
* Add the `selected` concept to our schema. This is how we decide which tables, columns to sync.
* Updated json schema for singer catalogs to match singer documentation.
