### PR TITLE
run tests in test script

### DIFF
--- a/tools/app/test.sh
+++ b/tools/app/test.sh
@@ -6,7 +6,7 @@ set -e
 
 main() {
   assert_root
-  docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ~/.gradle:/home/gradle/.gradle -t dataline/java-base:dev /bin/sh -c ./gradlew test --no-daemon -g /home/gradle/.gradle
+  docker run -t --rm -v /var/run/docker.sock:/var/run/docker.sock -v ~/.gradle:/home/gradle/.gradle dataline/java-base:dev ./gradlew test --no-daemon -g /home/gradle/.gradle
   docker run --rm -t dataline/webapp-base:dev /bin/sh -c 'CI=true npm run test'
 }
 


### PR DESCRIPTION
## What & how
`test.sh` doesn't currently run tests because `/bin/sh -c` requires that the entire command be passed as an argument i.e: `sh -c 'cat myfile.txt'` instead of `sh -c cat myfile.txt`. This PR fixes that by removing `/bin/sh` altogether and just using the built-in docker way of passing in commands to avoid confusion. 


FYI build is failing but that's because the build failed due to other PRs. 