### PR TITLE
add docker to base img

### DIFF
--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/SchedulerApp.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/SchedulerApp.java
@@ -26,15 +26,14 @@ package io.dataline.scheduler;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.dataline.db.DatabaseHelper;
-import org.apache.commons.dbcp2.BasicDataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The SchedulerApp is responsible for finding new scheduled jobs that need to be run and to launch

--- a/dataline-server/src/main/java/io/dataline/server/ServerApp.java
+++ b/dataline-server/src/main/java/io/dataline/server/ServerApp.java
@@ -30,6 +30,7 @@ import io.dataline.server.errors.InvalidInputExceptionMapper;
 import io.dataline.server.errors.InvalidJsonExceptionMapper;
 import io.dataline.server.errors.KnownExceptionMapper;
 import io.dataline.server.errors.UncaughtExceptionMapper;
+import java.util.logging.Level;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -42,8 +43,6 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.logging.Level;
 
 public class ServerApp {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerApp.class);

--- a/java_base.Dockerfile
+++ b/java_base.Dockerfile
@@ -1,5 +1,8 @@
 # Build artifact
 FROM openjdk:14.0.2-slim
+# Install curl
+RUN apt-get update; apt-get install -y curl
+RUN curl -fsSL https://get.docker.com | sh -
 
 WORKDIR /code
 

--- a/java_base.Dockerfile
+++ b/java_base.Dockerfile
@@ -1,6 +1,7 @@
 # Build artifact
 FROM openjdk:14.0.2-slim
-# Install curl
+
+# Install curl then docker
 RUN apt-get update; apt-get install -y curl
 RUN curl -fsSL https://get.docker.com | sh -
 

--- a/tools/app/test.sh
+++ b/tools/app/test.sh
@@ -6,7 +6,7 @@ set -e
 
 main() {
   assert_root
-  docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ~/.gradle:/home/gradle/.gradle -t dataline/java-base:dev /bin/sh -c ./gradlew test --no-daemon -g /home/gradle/.gradle
+  docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ~/.gradle:/home/gradle/.gradle -t dataline/java-base:dev /bin/sh -c './gradlew test --no-daemon -g /home/gradle/.gradle'
   docker run --rm -t dataline/webapp-base:dev /bin/sh -c 'CI=true npm run test'
 }
 


### PR DESCRIPTION
## What
Currently `docker` is needed to run tests, but isn't available inside the java_base image used to run tests. Ideally we can use the docker java client instead of doing this, but until then this is a recourse. 