### PR TITLE
validate json schema on write

### DIFF
--- a/dataline-config-persistence/src/main/java/io/dataline/config/persistence/ConfigPersistence.java
+++ b/dataline-config-persistence/src/main/java/io/dataline/config/persistence/ConfigPersistence.java
@@ -33,5 +33,6 @@ public interface ConfigPersistence {
   <T> Set<T> getConfigs(PersistenceConfigType persistenceConfigType, Class<T> clazz)
       throws JsonValidationException;
 
-  <T> void writeConfig(PersistenceConfigType persistenceConfigType, String configId, T config);
+  <T> void writeConfig(PersistenceConfigType persistenceConfigType, String configId, T config)
+      throws JsonValidationException;
 }

--- a/dataline-config-persistence/src/main/java/io/dataline/config/persistence/DefaultConfigPersistence.java
+++ b/dataline-config-persistence/src/main/java/io/dataline/config/persistence/DefaultConfigPersistence.java
@@ -99,7 +99,7 @@ public class DefaultConfigPersistence implements ConfigPersistence {
       PersistenceConfigType persistenceConfigType, String configId, T config)
       throws JsonValidationException {
     synchronized (lock) {
-      // validate file with schema
+      // validate config with schema
       validateJson(objectMapper.valueToTree(config), persistenceConfigType);
 
       final Path configPath = getConfigPath(persistenceConfigType, configId);

--- a/dataline-config-persistence/src/test/java/io/dataline/config/persistence/DefaultConfigPersistenceTest.java
+++ b/dataline-config-persistence/src/test/java/io/dataline/config/persistence/DefaultConfigPersistenceTest.java
@@ -25,6 +25,7 @@
 package io.dataline.config.persistence;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -109,7 +110,7 @@ class DefaultConfigPersistenceTest {
   }
 
   @Test
-  void writeConfig() throws IOException {
+  void writeConfig() throws IOException, JsonValidationException {
     final ObjectMapper objectMapper = new ObjectMapper();
 
     StandardSource standardSource = generateStandardSource();
@@ -133,5 +134,21 @@ class DefaultConfigPersistenceTest {
     // check reading to json
     final JsonNode actualJson = objectMapper.readTree(expectedPath.toFile());
     assertEquals(expectedJson, actualJson);
+  }
+
+  @Test
+  void writeConfigInvalidConfig() {
+    StandardSource standardSource = generateStandardSource();
+    standardSource.setName(null);
+
+    try {
+      configPersistence.writeConfig(
+          PersistenceConfigType.STANDARD_SOURCE,
+          standardSource.getSourceId().toString(),
+          standardSource);
+    } catch (JsonValidationException e) {
+      return;
+    }
+    fail("expected to throw invalid json exception.");
   }
 }

--- a/dataline-server/src/main/java/io/dataline/server/ServerApp.java
+++ b/dataline-server/src/main/java/io/dataline/server/ServerApp.java
@@ -30,6 +30,7 @@ import io.dataline.server.errors.InvalidInputExceptionMapper;
 import io.dataline.server.errors.InvalidJsonExceptionMapper;
 import io.dataline.server.errors.KnownExceptionMapper;
 import io.dataline.server.errors.UncaughtExceptionMapper;
+import java.util.logging.Level;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -42,8 +43,6 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.logging.Level;
 
 public class ServerApp {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerApp.class);

--- a/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
@@ -94,7 +94,8 @@ public class ConnectionsHandler {
   }
 
   private void writeStandardSync(StandardSync standardSync) {
-    configPersistence.writeConfig(
+    ConfigFetchers.writeConfig(
+        configPersistence,
         PersistenceConfigType.STANDARD_SYNC,
         standardSync.getConnectionId().toString(),
         standardSync);
@@ -102,7 +103,8 @@ public class ConnectionsHandler {
 
   // todo (cgardens) - stored on sync id (there is no schedule id concept). this is non-intuitive.
   private void writeSchedule(StandardSyncSchedule schedule) {
-    configPersistence.writeConfig(
+    ConfigFetchers.writeConfig(
+        configPersistence,
         PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
         schedule.getConnectionId().toString(),
         schedule);

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
@@ -175,7 +175,8 @@ public class DestinationImplementationsHandler {
     destinationConnectionImplementation.setDestinationImplementationId(destinationImplementationId);
     destinationConnectionImplementation.setConfiguration(configuration);
 
-    configPersistence.writeConfig(
+    ConfigFetchers.writeConfig(
+        configPersistence,
         PersistenceConfigType.DESTINATION_CONNECTION_IMPLEMENTATION,
         destinationImplementationId.toString(),
         destinationConnectionImplementation);

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -171,7 +171,8 @@ public class SourceImplementationsHandler {
     sourceConnectionImplementation.setSourceImplementationId(sourceImplementationId);
     sourceConnectionImplementation.setConfiguration(configuration);
 
-    configPersistence.writeConfig(
+    ConfigFetchers.writeConfig(
+        configPersistence,
         PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
         sourceImplementationId.toString(),
         sourceConnectionImplementation);

--- a/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/WorkspacesHandler.java
@@ -78,8 +78,11 @@ public class WorkspacesHandler {
     persistedWorkspace.setAnonymousDataCollection(workspaceUpdate.getAnonymousDataCollection());
     persistedWorkspace.setNews(workspaceUpdate.getNews());
     persistedWorkspace.setSecurityUpdates(workspaceUpdate.getSecurityUpdates());
-    configPersistence.writeConfig(
-        PersistenceConfigType.STANDARD_WORKSPACE, workspaceId.toString(), persistedWorkspace);
+    ConfigFetchers.writeConfig(
+        configPersistence,
+        PersistenceConfigType.STANDARD_WORKSPACE,
+        workspaceId.toString(),
+        persistedWorkspace);
 
     return getWorkspaceFromId(workspaceUpdate.getWorkspaceId());
   }

--- a/dataline-server/src/main/java/io/dataline/server/helpers/ConfigFetchers.java
+++ b/dataline-server/src/main/java/io/dataline/server/helpers/ConfigFetchers.java
@@ -69,6 +69,19 @@ public class ConfigFetchers {
     }
   }
 
+  // wrap json validation errors for usages in API handlers.
+  public static <T> void writeConfig(
+      ConfigPersistence configPersistence,
+      PersistenceConfigType persistenceConfigType,
+      String configId,
+      T config) {
+    try {
+      configPersistence.writeConfig(persistenceConfigType, configId, config);
+    } catch (JsonValidationException e) {
+      throw getInvalidException(e);
+    }
+  }
+
   public static Set<StandardSource> getStandardSources(ConfigPersistence configPersistence) {
     try {
       return configPersistence.getConfigs(

--- a/dataline-server/src/test/java/io/dataline/server/fixtures/DestinationSpecificationFixtures.java
+++ b/dataline-server/src/test/java/io/dataline/server/fixtures/DestinationSpecificationFixtures.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dataline.config.DestinationConnectionSpecification;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.PersistenceConfigType;
+import io.dataline.server.helpers.ConfigFetchers;
 import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
@@ -55,7 +56,8 @@ public class DestinationSpecificationFixtures {
     destinationConnectionSpecification.setDestinationSpecificationId(destinationSpecificationId);
     destinationConnectionSpecification.setSpecification(specificationJson.toString());
 
-    configPersistence.writeConfig(
+    ConfigFetchers.writeConfig(
+        configPersistence,
         PersistenceConfigType.DESTINATION_CONNECTION_SPECIFICATION,
         destinationSpecificationId.toString(),
         destinationConnectionSpecification);


### PR DESCRIPTION
closes https://github.com/datalineio/dataline/issues/51

## What
* validate that a config meets its json schema when we write it. right now we only validate on read which doesn't make a whole lot of sense.