### PR TITLE
run tests in default docker mountpoints

### DIFF
--- a/dataline-workers/src/test/java/io/dataline/workers/BaseWorkerTestCase.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/BaseWorkerTestCase.java
@@ -42,7 +42,7 @@ public abstract class BaseWorkerTestCase {
 
   @BeforeAll
   public void init() throws IOException {
-    workspaceDirectory = Files.createTempDirectory("dataline");
+    workspaceDirectory = Files.createTempDirectory(Path.of("/tmp/tests"), "dataline");
     System.out.println("Workspace directory: " + workspaceDirectory.toString());
   }
 


### PR DESCRIPTION
## What
By default, docker doesn't whitelist mounting volumes from `/var`. We ensure that test directories run from `/var` so no local changes are needed by the developer. 
