### PR TITLE
Operate on docker image workers

### DIFF
--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/JobSubmitter.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/JobSubmitter.java
@@ -25,13 +25,9 @@
 package io.dataline.scheduler;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dataline.api.model.ConnectionRead;
 import io.dataline.api.model.ConnectionSchedule;
 import io.dataline.db.DatabaseHelper;
-import io.dataline.workers.singer.SingerTap;
-import io.dataline.workers.singer.postgres_tap.SingerPostgresTapDiscoverWorker;
-import java.io.IOException;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -153,39 +149,7 @@ public class JobSubmitter implements Runnable {
         throw new RuntimeException("not implemented");
       case PENDING:
       case FAILED:
-        switch (job.getConfig().getConfigType()) {
-          case DISCOVER_SCHEMA:
-            // todo: get tap from job's config
-            SingerTap tap = SingerTap.POSTGRES;
-
-            ObjectMapper objectMapper = new ObjectMapper();
-            String configString = null;
-            try {
-              String rawConfigString =
-                  objectMapper.writeValueAsString(job.getConfig().getDiscoverSchema());
-              configString =
-                  objectMapper.writeValueAsString(
-                      objectMapper.readTree(rawConfigString).get("configuration"));
-
-              LOGGER.info("config json: " + configString); // todo: remove
-            } catch (IOException e) {
-              throw new RuntimeException(e);
-            }
-
-            threadPool.submit(
-                new WorkerWrapper<>(
-                    job.getId(),
-                    new SingerPostgresTapDiscoverWorker(),
-                    connectionPool,
-                    persistence));
-            LOGGER.info("Submitting job to thread pool...");
-            break;
-          case CHECK_CONNECTION:
-          case SYNC:
-            throw new RuntimeException("not implemented");
-            // todo: handle threadPool.submit(new WorkerWrapper<>(job.getId(), new EchoWorker(),
-            // connectionPool));
-        }
+        threadPool.submit(new WorkerRunner(job.getId(), connectionPool, persistence));
         break;
       case RUNNING:
         //  no-op

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRun.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRun.java
@@ -39,7 +39,20 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class WorkerRun<InputType, OutputType> {
+/**
+ * This class represents a single run of a worker. It handles making sure the correct inputs and
+ * outputs are passed to the selected worker. It also makes sures that the outputs of the worker are
+ * persisted to the db.
+ *
+ * <p>todo (cgardens) - this line between this abstraction and WorkerRunner is a little blurry. we
+ * can clarify it later. the main benefit is of this class is that it gives us some type safety when
+ * working with workers. you can probably make an argument that this class should not have access to
+ * the db.
+ *
+ * @param <InputType> - the type that the worker consumes.
+ * @param <OutputType> - the type that the worker outputs.
+ */
+public class WorkerRun<InputType, OutputType> implements Runnable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WorkerRun.class);
 
@@ -59,6 +72,7 @@ public class WorkerRun<InputType, OutputType> {
     this.connectionPool = connectionPool;
   }
 
+  @Override
   public void run() {
     LOGGER.info("Executing worker wrapper...");
     try {

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRun.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRun.java
@@ -52,16 +52,16 @@ import org.slf4j.LoggerFactory;
  * @param <InputType> - the type that the worker consumes.
  * @param <OutputType> - the type that the worker outputs.
  */
-public class WorkerWrapper<InputType, OutputType> implements Runnable {
+public class WorkerRun<InputType, OutputType> implements Runnable {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerWrapper.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerRun.class);
 
   private final long jobId;
   private InputType input;
   private final Worker<InputType, OutputType> worker;
   private final BasicDataSource connectionPool;
 
-  public WorkerWrapper(
+  public WorkerRun(
       long jobId,
       InputType input,
       Worker<InputType, OutputType> worker,

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRun.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRun.java
@@ -26,11 +26,6 @@ package io.dataline.scheduler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dataline.api.model.JobRead;
-import io.dataline.config.JobCheckConnectionConfig;
-import io.dataline.config.JobSyncConfig;
-import io.dataline.config.StandardCheckConnectionInput;
-import io.dataline.config.StandardDiscoverSchemaInput;
-import io.dataline.config.StandardSyncInput;
 import io.dataline.db.DatabaseHelper;
 import io.dataline.workers.OutputAndStatus;
 import io.dataline.workers.Worker;
@@ -44,35 +39,30 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class WorkerWrapper<InputType, OutputType> implements Runnable {
+public class WorkerRun<InputType, OutputType> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerWrapper.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerRun.class);
 
   private final long jobId;
+  private InputType input;
   private final Worker<InputType, OutputType> worker;
   private final BasicDataSource connectionPool;
-  private final SchedulerPersistence persistence;
 
-  public WorkerWrapper(
+  public WorkerRun(
       long jobId,
+      InputType input,
       Worker<InputType, OutputType> worker,
-      BasicDataSource connectionPool,
-      SchedulerPersistence persistence) {
+      BasicDataSource connectionPool) {
     this.jobId = jobId;
+    this.input = input;
     this.worker = worker;
     this.connectionPool = connectionPool;
-    this.persistence = persistence;
   }
 
-  @Override
   public void run() {
     LOGGER.info("Executing worker wrapper...");
     try {
       setJobStatus(connectionPool, jobId, JobRead.StatusEnum.RUNNING);
-
-      // fetch input.
-      final io.dataline.scheduler.Job job = persistence.getJob(jobId);
-      final InputType input = getInput(job);
 
       // todo (cgardens) - replace this with whatever the correct path is. probably dependency
       //   inject it based via env.
@@ -102,37 +92,6 @@ public class WorkerWrapper<InputType, OutputType> implements Runnable {
     } catch (Exception e) {
       LOGGER.error("Worker Error", e);
       setJobStatus(connectionPool, jobId, JobRead.StatusEnum.FAILED);
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private InputType getInput(io.dataline.scheduler.Job job) {
-    switch (job.getConfig().getConfigType()) {
-      case CHECK_CONNECTION:
-        final JobCheckConnectionConfig checkConnection = job.getConfig().getCheckConnection();
-        final StandardCheckConnectionInput checkConnectionInput =
-            new StandardCheckConnectionInput();
-        checkConnectionInput.setConnectionConfiguration(
-            checkConnection.getConnectionConfiguration());
-
-        return (InputType) checkConnectionInput;
-      case DISCOVER_SCHEMA:
-        final JobCheckConnectionConfig discoverSchema = job.getConfig().getCheckConnection();
-        final StandardDiscoverSchemaInput discoverSchemaInput = new StandardDiscoverSchemaInput();
-        discoverSchemaInput.setConnectionConfiguration(discoverSchema.getConnectionConfiguration());
-
-        return (InputType) discoverSchemaInput;
-      case SYNC:
-        final JobSyncConfig sync = job.getConfig().getSync();
-        final StandardSyncInput syncInput = new StandardSyncInput();
-        syncInput.setSourceConnectionImplementation(sync.getSourceConnectionImplementation());
-        syncInput.setDestinationConnectionImplementation(
-            sync.getDestinationConnectionImplementation());
-        syncInput.setStandardSync(sync.getStandardSync());
-
-        return (InputType) syncInput;
-      default:
-        throw new RuntimeException("Unrecognized config type: " + job.getConfig().getConfigType());
     }
   }
 

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
@@ -68,7 +68,7 @@ public class WorkerRunner implements Runnable {
       case CHECK_CONNECTION:
         final StandardCheckConnectionInput checkConnectionInput =
             getCheckConnectionInput(job.getConfig().getCheckConnection());
-        new WorkerWrapper<>(
+        new WorkerRun<>(
                 jobId,
                 checkConnectionInput,
                 new DockerCheckConnectionWorker(

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
@@ -1,0 +1,105 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.scheduler;
+
+import io.dataline.config.JobCheckConnectionConfig;
+import io.dataline.config.JobSyncConfig;
+import io.dataline.config.StandardCheckConnectionInput;
+import io.dataline.config.StandardDiscoverSchemaInput;
+import io.dataline.config.StandardSyncInput;
+import io.dataline.workers.DockerCheckConnectionWorker;
+import java.io.IOException;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WorkerRunner implements Runnable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerRunner.class);
+
+  private final long jobId;
+  private final BasicDataSource connectionPool;
+  private final SchedulerPersistence persistence;
+
+  public WorkerRunner(
+      long jobId, BasicDataSource connectionPool, SchedulerPersistence persistence) {
+    this.jobId = jobId;
+    this.connectionPool = connectionPool;
+    this.persistence = persistence;
+  }
+
+  @Override
+  public void run() {
+    final Job job;
+    try {
+      job = persistence.getJob(jobId);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    switch (job.getConfig().getConfigType()) {
+      case CHECK_CONNECTION:
+        final StandardCheckConnectionInput checkConnectionInput = getCheckConnectionInput(job);
+        new WorkerRun<>(
+                jobId,
+                checkConnectionInput,
+                new DockerCheckConnectionWorker(
+                    job.getConfig().getCheckConnection().getDockerImage()),
+                connectionPool)
+            .run();
+        break;
+      case DISCOVER_SCHEMA:
+        throw new RuntimeException("not implemented");
+      case SYNC:
+        throw new RuntimeException("not implemented");
+    }
+  }
+
+  private static StandardCheckConnectionInput getCheckConnectionInput(Job job) {
+    final JobCheckConnectionConfig checkConnection = job.getConfig().getCheckConnection();
+    final StandardCheckConnectionInput checkConnectionInput = new StandardCheckConnectionInput();
+    checkConnectionInput.setConnectionConfiguration(checkConnection.getConnectionConfiguration());
+
+    return checkConnectionInput;
+  }
+
+  private static StandardDiscoverSchemaInput getDiscoverSchemaInput(Job job) {
+    final JobCheckConnectionConfig discoverSchema = job.getConfig().getCheckConnection();
+    final StandardDiscoverSchemaInput discoverSchemaInput = new StandardDiscoverSchemaInput();
+    discoverSchemaInput.setConnectionConfiguration(discoverSchema.getConnectionConfiguration());
+
+    return discoverSchemaInput;
+  }
+
+  private static StandardSyncInput getSyncInput(Job job) {
+    final JobSyncConfig sync = job.getConfig().getSync();
+    final StandardSyncInput syncInput = new StandardSyncInput();
+    syncInput.setSourceConnectionImplementation(sync.getSourceConnectionImplementation());
+    syncInput.setDestinationConnectionImplementation(sync.getDestinationConnectionImplementation());
+    syncInput.setStandardSync(sync.getStandardSync());
+
+    return syncInput;
+  }
+}

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
@@ -35,6 +35,10 @@ import org.apache.commons.dbcp2.BasicDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * This class is a runnable that give a job id and db connection figures out how to run the
+ * appropriate worker for a given job.
+ */
 public class WorkerRunner implements Runnable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WorkerRunner.class);

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
@@ -25,6 +25,7 @@
 package io.dataline.scheduler;
 
 import io.dataline.config.JobCheckConnectionConfig;
+import io.dataline.config.JobDiscoverSchemaConfig;
 import io.dataline.config.JobSyncConfig;
 import io.dataline.config.StandardCheckConnectionInput;
 import io.dataline.config.StandardDiscoverSchemaInput;
@@ -65,7 +66,8 @@ public class WorkerRunner implements Runnable {
 
     switch (job.getConfig().getConfigType()) {
       case CHECK_CONNECTION:
-        final StandardCheckConnectionInput checkConnectionInput = getCheckConnectionInput(job);
+        final StandardCheckConnectionInput checkConnectionInput =
+            getCheckConnectionInput(job.getConfig().getCheckConnection());
         new WorkerRun<>(
                 jobId,
                 checkConnectionInput,
@@ -81,28 +83,28 @@ public class WorkerRunner implements Runnable {
     }
   }
 
-  private static StandardCheckConnectionInput getCheckConnectionInput(Job job) {
-    final JobCheckConnectionConfig checkConnection = job.getConfig().getCheckConnection();
+  private static StandardCheckConnectionInput getCheckConnectionInput(
+      JobCheckConnectionConfig config) {
     final StandardCheckConnectionInput checkConnectionInput = new StandardCheckConnectionInput();
-    checkConnectionInput.setConnectionConfiguration(checkConnection.getConnectionConfiguration());
+    checkConnectionInput.setConnectionConfiguration(config.getConnectionConfiguration());
 
     return checkConnectionInput;
   }
 
-  private static StandardDiscoverSchemaInput getDiscoverSchemaInput(Job job) {
-    final JobCheckConnectionConfig discoverSchema = job.getConfig().getCheckConnection();
+  private static StandardDiscoverSchemaInput getDiscoverSchemaInput(
+      JobDiscoverSchemaConfig config) {
     final StandardDiscoverSchemaInput discoverSchemaInput = new StandardDiscoverSchemaInput();
-    discoverSchemaInput.setConnectionConfiguration(discoverSchema.getConnectionConfiguration());
+    discoverSchemaInput.setConnectionConfiguration(config.getConnectionConfiguration());
 
     return discoverSchemaInput;
   }
 
-  private static StandardSyncInput getSyncInput(Job job) {
-    final JobSyncConfig sync = job.getConfig().getSync();
+  private static StandardSyncInput getSyncInput(JobSyncConfig config) {
     final StandardSyncInput syncInput = new StandardSyncInput();
-    syncInput.setSourceConnectionImplementation(sync.getSourceConnectionImplementation());
-    syncInput.setDestinationConnectionImplementation(sync.getDestinationConnectionImplementation());
-    syncInput.setStandardSync(sync.getStandardSync());
+    syncInput.setSourceConnectionImplementation(config.getSourceConnectionImplementation());
+    syncInput.setDestinationConnectionImplementation(
+        config.getDestinationConnectionImplementation());
+    syncInput.setStandardSync(config.getStandardSync());
 
     return syncInput;
   }

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
@@ -68,7 +68,7 @@ public class WorkerRunner implements Runnable {
       case CHECK_CONNECTION:
         final StandardCheckConnectionInput checkConnectionInput =
             getCheckConnectionInput(job.getConfig().getCheckConnection());
-        new WorkerRun<>(
+        new WorkerWrapper<>(
                 jobId,
                 checkConnectionInput,
                 new DockerCheckConnectionWorker(

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerWrapper.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerWrapper.java
@@ -52,16 +52,16 @@ import org.slf4j.LoggerFactory;
  * @param <InputType> - the type that the worker consumes.
  * @param <OutputType> - the type that the worker outputs.
  */
-public class WorkerRun<InputType, OutputType> implements Runnable {
+public class WorkerWrapper<InputType, OutputType> implements Runnable {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerRun.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerWrapper.class);
 
   private final long jobId;
   private InputType input;
   private final Worker<InputType, OutputType> worker;
   private final BasicDataSource connectionPool;
 
-  public WorkerRun(
+  public WorkerWrapper(
       long jobId,
       InputType input,
       Worker<InputType, OutputType> worker,

--- a/dataline-workers/src/main/java/io/dataline/workers/DockerCheckConnectionWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/DockerCheckConnectionWorker.java
@@ -50,7 +50,7 @@ public class DockerCheckConnectionWorker implements CheckConnectionWorker {
 
   @Override
   public OutputAndStatus<StandardCheckConnectionOutput> run(
-    StandardCheckConnectionInput standardCheckConnectionInput, Path workspacePath) {
+      StandardCheckConnectionInput standardCheckConnectionInput, Path workspacePath) {
     final ObjectMapper objectMapper = new ObjectMapper();
 
     // write input struct to docker image
@@ -61,7 +61,7 @@ public class DockerCheckConnectionWorker implements CheckConnectionWorker {
       throw new RuntimeException(e);
     }
     final Path configPath =
-      WorkerUtils.writeFileToWorkspace(workspacePath, INPUT, inputString); // wrong type
+        WorkerUtils.writeFileToWorkspace(workspacePath, INPUT, inputString); // wrong type
 
     // run it. patiently.
     try {
@@ -80,7 +80,7 @@ public class DockerCheckConnectionWorker implements CheckConnectionWorker {
       // read output struct. assume it is written to correct place.
       final String outputString = WorkerUtils.readFileFromWorkspace(workspacePath, OUTPUT);
       final StandardCheckConnectionOutput standardCheckConnectionOutput =
-        objectMapper.readValue(outputString, StandardCheckConnectionOutput.class);
+          objectMapper.readValue(outputString, StandardCheckConnectionOutput.class);
 
       return new OutputAndStatus<>(JobStatus.SUCCESSFUL, standardCheckConnectionOutput);
     } catch (IOException | InterruptedException e) {

--- a/dataline-workers/src/main/java/io/dataline/workers/DockerCheckConnectionWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/DockerCheckConnectionWorker.java
@@ -1,0 +1,98 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.workers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dataline.config.StandardCheckConnectionInput;
+import io.dataline.config.StandardCheckConnectionOutput;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DockerCheckConnectionWorker implements CheckConnectionWorker {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DockerCheckConnectionWorker.class);
+
+  private static final String INPUT = "input.json";
+  private static final String OUTPUT = "output.json";
+
+  private final String imageName;
+
+  Process tapProcess;
+
+  public DockerCheckConnectionWorker(String imageName) {
+    this.imageName = imageName;
+  }
+
+  @Override
+  public OutputAndStatus<StandardCheckConnectionOutput> run(
+    StandardCheckConnectionInput standardCheckConnectionInput, Path workspacePath) {
+    final ObjectMapper objectMapper = new ObjectMapper();
+
+    // write input struct to docker image
+    final String inputString;
+    try {
+      inputString = objectMapper.writeValueAsString(standardCheckConnectionInput);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+    final Path configPath =
+      WorkerUtils.writeFileToWorkspace(workspacePath, INPUT, inputString); // wrong type
+
+    // run it. patiently.
+    try {
+      String[] tapCmd = {
+        "docker", "run", workspacePath.toString(), imageName, "--config", configPath.toString()
+      };
+
+      LOGGER.debug("Tap command: {}", String.join(" ", tapCmd));
+
+      tapProcess = new ProcessBuilder().command(tapCmd).start();
+
+      while (!tapProcess.waitFor(1, TimeUnit.MINUTES)) {
+        LOGGER.debug("Waiting for worker");
+      }
+
+      // read output struct. assume it is written to correct place.
+      final String outputString = WorkerUtils.readFileFromWorkspace(workspacePath, OUTPUT);
+      final StandardCheckConnectionOutput standardCheckConnectionOutput =
+        objectMapper.readValue(outputString, StandardCheckConnectionOutput.class);
+
+      return new OutputAndStatus<>(JobStatus.SUCCESSFUL, standardCheckConnectionOutput);
+    } catch (IOException | InterruptedException e) {
+      LOGGER.error("DockerCheckConnectionWorker failed", e);
+      return new OutputAndStatus<>(JobStatus.FAILED, null);
+    }
+  }
+
+  @Override
+  public void cancel() {
+    if (tapProcess != null) {
+      WorkerUtils.cancelHelper(tapProcess);
+    }
+  }
+}

--- a/dataline-workers/src/main/java/io/dataline/workers/WorkerUtils.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/WorkerUtils.java
@@ -1,0 +1,69 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.workers;
+
+import io.dataline.workers.singer.BaseSingerWorker;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WorkerUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseSingerWorker.class);
+
+  public static Path writeFileToWorkspace(Path workspaceRoot, String fileName, String contents) {
+    try {
+      Path filePath = workspaceRoot.resolve(fileName);
+      FileUtils.writeStringToFile(filePath.toFile(), contents, StandardCharsets.UTF_8);
+      return filePath;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static String readFileFromWorkspace(Path workspaceRoot, String fileName) {
+    try {
+      Path filePath = workspaceRoot.resolve(fileName);
+      return FileUtils.readFileToString(filePath.toFile(), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static void cancelHelper(Process workerProcess) {
+    try {
+      workerProcess.destroy();
+      workerProcess.waitFor(10, TimeUnit.SECONDS);
+      if (workerProcess.isAlive()) {
+        workerProcess.destroyForcibly();
+      }
+    } catch (InterruptedException e) {
+      LOGGER.error("Exception when cancelling job.", e);
+    }
+  }
+}


### PR DESCRIPTION
## How
* All running a worker that accepts only a docker image name and executes it (**the holy grail we've been talking about for a couple weeks**).

## What
* Encapsulate worker selection in `WorkerRunner`
* Use `WorkerRunner` to select an appropriate worker. The options are `DockerCheckConnectionWorker`, `DockerDiscoverSchemaWorker`, and `DockerSyncWorker`. (note: I've only implemented the first of these 3).
* These `Docker*Workers` take in an image name and then docker run that image. They take care of passing in the appropriate inputs to the action (e.g. for check connection, they pass in the `StandardCheckConnectionInput`). They also extract the output of the actions as well.
  * **Open Question: Right now the contract with the docker container is a little nebulous. These workers assume that they just write the inputs to a known place on the file systems (that is mounted on the docker container that they run) and that the docker container outputs any output struct to a known location. Is there any other way of doing this or are we happy with this contract?**
* Add type safe execution of worker in WorkerRun


## Recommended reading order
1. `JobSubmitter.java`
1. `WorkerRunner.java`
1. `WorkerRun.java`
1. `DockerCheckConnectionWorker.java`
