### PR TITLE
ensure test dir exists

### DIFF
--- a/dataline-workers/src/test/java/io/dataline/workers/BaseWorkerTestCase.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/BaseWorkerTestCase.java
@@ -47,6 +47,7 @@ public abstract class BaseWorkerTestCase {
 
   @BeforeAll
   public void init() throws IOException {
+    FileUtils.forceMkdir(new File("/tmp/tests"));
     workspaceDirectory = Files.createTempDirectory(Path.of("/tmp/tests"), "dataline");
     System.out.println("Workspace directory: " + workspaceDirectory.toString());
   }


### PR DESCRIPTION
Previous PR https://github.com/datalineio/dataline/pull/100 doesn't guarantee that the test dir exists. In this PR we force it to exist.

error message:
```
SingerDiscoveryWorkerTest > initializationError FAILED
    java.nio.file.NoSuchFileException: /tmp/tests/dataline16133127975457675360
```