### PR TITLE
validate request body against openapi schema

### DIFF
--- a/dataline-server/build.gradle
+++ b/dataline-server/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet', version: '2.31'
     implementation group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '2.31'
     implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: '2.31'
+    implementation group: 'org.glassfish.jersey.ext', name: 'jersey-bean-validation', version: '2.31'
 
     implementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.8"
     implementation group: "com.networknt", name: "json-schema-validator", version: "1.0.42"

--- a/dataline-server/src/main/java/io/dataline/server/ServerApp.java
+++ b/dataline-server/src/main/java/io/dataline/server/ServerApp.java
@@ -28,6 +28,7 @@ import io.dataline.db.DatabaseHelper;
 import io.dataline.server.apis.ConfigurationApi;
 import io.dataline.server.errors.InvalidInputExceptionMapper;
 import io.dataline.server.errors.InvalidJsonExceptionMapper;
+import io.dataline.server.errors.InvalidJsonInputExceptionMapper;
 import io.dataline.server.errors.KnownExceptionMapper;
 import io.dataline.server.errors.UncaughtExceptionMapper;
 import java.util.logging.Level;
@@ -40,6 +41,7 @@ import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJaxbJsonP
 import org.glassfish.jersey.logging.LoggingFeature;
 import org.glassfish.jersey.process.internal.RequestScoped;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,6 +67,7 @@ public class ServerApp {
 
     ResourceConfig rc =
         new ResourceConfig()
+            .property(ServerProperties.BV_SEND_ERROR_IN_RESPONSE, true)
             // todo (cgardens) - the CORs settings are wide open. will need to revisit when we add
             //   auth.
             // cors
@@ -81,8 +84,9 @@ public class ServerApp {
                   }
                 })
             // exception handling
-            .register(InvalidJsonExceptionMapper.class)
             .register(InvalidInputExceptionMapper.class)
+            .register(InvalidJsonExceptionMapper.class)
+            .register(InvalidJsonInputExceptionMapper.class)
             .register(KnownExceptionMapper.class)
             .register(UncaughtExceptionMapper.class)
             // needed so that the custom json exception mappers don't get overridden

--- a/dataline-server/src/main/java/io/dataline/server/ServerApp.java
+++ b/dataline-server/src/main/java/io/dataline/server/ServerApp.java
@@ -41,7 +41,6 @@ import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJaxbJsonP
 import org.glassfish.jersey.logging.LoggingFeature;
 import org.glassfish.jersey.process.internal.RequestScoped;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +66,6 @@ public class ServerApp {
 
     ResourceConfig rc =
         new ResourceConfig()
-            .property(ServerProperties.BV_SEND_ERROR_IN_RESPONSE, true)
             // todo (cgardens) - the CORs settings are wide open. will need to revisit when we add
             //   auth.
             // cors

--- a/dataline-server/src/main/java/io/dataline/server/errors/InvalidInputExceptionMapper.java
+++ b/dataline-server/src/main/java/io/dataline/server/errors/InvalidInputExceptionMapper.java
@@ -42,7 +42,7 @@ public class InvalidInputExceptionMapper implements ExceptionMapper<ConstraintVi
         .entity(
             new ObjectMapper()
                 .createObjectNode()
-                .put("message", "Invalid JSON")
+                .put("message", "The received object did not pass validation")
                 .put("details", prepareMessage(exception)))
         .type("application/json")
         .build();

--- a/dataline-server/src/main/java/io/dataline/server/errors/InvalidInputExceptionMapper.java
+++ b/dataline-server/src/main/java/io/dataline/server/errors/InvalidInputExceptionMapper.java
@@ -29,8 +29,11 @@ import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
 
 // https://www.baeldung.com/jersey-bean-validation#custom-exception-handler
+// handles exceptions related to the request body not matching the openapi config.
+@Provider
 public class InvalidInputExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
 
   @Override

--- a/dataline-server/src/main/java/io/dataline/server/errors/InvalidJsonInputExceptionMapper.java
+++ b/dataline-server/src/main/java/io/dataline/server/errors/InvalidJsonInputExceptionMapper.java
@@ -24,38 +24,24 @@
 
 package io.dataline.server.errors;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
 
-// https://www.baeldung.com/jersey-bean-validation#custom-exception-handler
-public class InvalidInputExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
-
+@Provider
+public class InvalidJsonInputExceptionMapper implements ExceptionMapper<JsonMappingException> {
   @Override
-  public Response toResponse(ConstraintViolationException exception) {
-    return Response.status(Response.Status.BAD_REQUEST)
+  public Response toResponse(JsonMappingException e) {
+    return Response.status(422)
         .entity(
             new ObjectMapper()
                 .createObjectNode()
-                .put("message", "Invalid JSON")
-                .put("details", prepareMessage(exception)))
+                .put("message", "The received object did not pass validation")
+                .put("details", e.getOriginalMessage())
+                .toString())
         .type("application/json")
         .build();
-  }
-
-  private String prepareMessage(ConstraintViolationException exception) {
-    StringBuilder message = new StringBuilder();
-    for (ConstraintViolation<?> cv : exception.getConstraintViolations()) {
-      message.append(
-          "property: "
-              + cv.getPropertyPath()
-              + " message: "
-              + cv.getMessage()
-              + " invalid value: "
-              + cv.getInvalidValue());
-    }
-    return message.toString();
   }
 }

--- a/dataline-server/src/main/java/io/dataline/server/errors/InvalidJsonInputExceptionMapper.java
+++ b/dataline-server/src/main/java/io/dataline/server/errors/InvalidJsonInputExceptionMapper.java
@@ -38,7 +38,7 @@ public class InvalidJsonInputExceptionMapper implements ExceptionMapper<JsonMapp
         .entity(
             new ObjectMapper()
                 .createObjectNode()
-                .put("message", "The received object did not pass validation")
+                .put("message", "Invalid JSON")
                 .put("details", e.getOriginalMessage())
                 .toString())
         .type("application/json")


### PR DESCRIPTION
## What
The API was not actually validating that the incoming request body matched the schema described in our open api config.

## How
* That needs to be explicitly turned using `jersey-bean-validation`.
* Added exception mapper to describe how the request body failed to match the spec.