### PR TITLE
hotfix: getConfigs and add destination configuration

### DIFF
--- a/dataline-config-init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/e28a1a10-214a-4051-8cf4-79b6f88719cd.json
+++ b/dataline-config-init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/e28a1a10-214a-4051-8cf4-79b6f88719cd.json
@@ -1,0 +1,18 @@
+{
+  "destinationId": "22f6c74f-5699-40ff-833c-4a879ea40133",
+  "destinationSpecificationId": "e28a1a10-214a-4051-8cf4-79b6f88719cd",
+  "specification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "BigQuery Destination Spec",
+    "type": "object",
+    "required": [
+      "serviceAccount"
+    ],
+    "additionalProperties": false,
+    "properties": {
+      "serviceAccount": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/dataline-config-init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/2168516a-5c9a-4582-90dc-5e3a01e3f607.json
+++ b/dataline-config-init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/2168516a-5c9a-4582-90dc-5e3a01e3f607.json
@@ -3,7 +3,7 @@
   "sourceSpecificationId": "2168516a-5c9a-4582-90dc-5e3a01e3f607",
   "specification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Postgres",
+    "title": "Postgres Source Spec",
     "type": "object",
     "required": [
       "host",

--- a/dataline-config-init/src/main/resources/config/STANDARD_DESTINATION/22f6c74f-5699-40ff-833c-4a879ea40133.json
+++ b/dataline-config-init/src/main/resources/config/STANDARD_DESTINATION/22f6c74f-5699-40ff-833c-4a879ea40133.json
@@ -1,0 +1,4 @@
+{
+  "destinationId": "22f6c74f-5699-40ff-833c-4a879ea40133",
+  "name": "BigQuery"
+}

--- a/dataline-config-persistence/src/main/java/io/dataline/config/persistence/DefaultConfigPersistence.java
+++ b/dataline-config-persistence/src/main/java/io/dataline/config/persistence/DefaultConfigPersistence.java
@@ -136,6 +136,7 @@ public class DefaultConfigPersistence implements ConfigPersistence {
 
   private Set<Path> getFiles(PersistenceConfigType persistenceConfigType) {
     Path configDirPath = getConfigDirectory(persistenceConfigType);
+    ensureDirectory(configDirPath);
     try {
       return Files.list(configDirPath).collect(Collectors.toSet());
     } catch (IOException e) {


### PR DESCRIPTION
## What
* Fixes a bug where if the resource directory for a config type did not exist, the config persistence would throw an error. Fixed it by creating that directory before trying to read it.
* Add big query as a destination for sake of example in the UI.

note: merging now to unblock artem. feel free to review posthumously. i suspect this is a non-controversial PR. 