### PR TITLE
add source_implementations/delete

### DIFF
--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -263,6 +263,25 @@ paths:
           description: Source Implementation not found
         "422":
           $ref: "#/components/responses/InvalidInput"
+  /v1/source_implementations/delete:
+    post:
+      tags:
+      - source_implementation
+      summary: Delete a source implementation
+      operationId: deleteSourceImplementation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SourceImplementationIdRequestBody"
+        required: true
+      responses:
+        "204":
+          description: The resource was deleted successfully.
+        "404":
+          description: Source Implementation not found
+        "422":
+          $ref: "#/components/responses/InvalidInput"
   /v1/source_implementations/check_connection:
     post:
       tags:

--- a/dataline-config/src/main/resources/json/SourceConnectionImplementation.json
+++ b/dataline-config/src/main/resources/json/SourceConnectionImplementation.json
@@ -8,7 +8,8 @@
     "sourceSpecificationId",
     "sourceImplementationId",
     "workspaceId",
-    "configuration"
+    "configuration",
+    "tombstone"
   ],
   "additionalProperties": false,
   "properties": {

--- a/dataline-config/src/main/resources/json/SourceConnectionImplementation.json
+++ b/dataline-config/src/main/resources/json/SourceConnectionImplementation.json
@@ -2,8 +2,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/SourceConnectionConfiguration.json",
   "title": "SourceConnectionConfiguration",
-  "description": "information required for connection to a destination.",  "type": "object",
-  "required": ["sourceSpecificationId", "sourceImplementationId", "workspaceId","configuration"],
+  "description": "information required for connection to a destination.",
+  "type": "object",
+  "required": [
+    "sourceSpecificationId",
+    "sourceImplementationId",
+    "workspaceId",
+    "configuration"
+  ],
   "additionalProperties": false,
   "properties": {
     "sourceSpecificationId": {
@@ -20,6 +26,10 @@
     },
     "configuration": {
       "description": "type any. information here varies by integration. this data is validated against a specification"
+    },
+    "tombstone": {
+      "description": "if not set or false, the configuration is active. if true, then this configuration is permanently off.",
+      "type": "boolean"
     }
   }
 }

--- a/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
+++ b/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
@@ -172,6 +172,12 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   }
 
   @Override
+  public void deleteSourceImplementation(
+      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+    sourceImplementationsHandler.deleteSourceImplementation(sourceImplementationIdRequestBody);
+  }
+
+  @Override
   public CheckConnectionRead checkConnectionToSourceImplementation(
       @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return schedulerHandler.checkSourceImplementationConnection(sourceImplementationIdRequestBody);

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -189,14 +189,14 @@ public class SourceImplementationsHandler {
       UUID sourceSpecificationId,
       UUID workspaceId,
       UUID sourceImplementationId,
-      Boolean tombstone,
+      boolean tombstone,
       Object configuration) {
     final SourceConnectionImplementation sourceConnectionImplementation =
         new SourceConnectionImplementation();
     sourceConnectionImplementation.setSourceSpecificationId(sourceSpecificationId);
     sourceConnectionImplementation.setWorkspaceId(workspaceId);
     sourceConnectionImplementation.setSourceImplementationId(sourceImplementationId);
-    sourceConnectionImplementation.setTombstone(tombstone == null ? false : tombstone);
+    sourceConnectionImplementation.setTombstone(tombstone);
     sourceConnectionImplementation.setConfiguration(configuration);
 
     ConfigFetchers.writeConfig(

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -77,17 +77,19 @@ public class SourceImplementationsHandler {
         sourceImplementationCreate.getSourceSpecificationId(),
         sourceImplementationCreate.getWorkspaceId(),
         sourceImplementationId,
+        false,
         sourceImplementationCreate.getConnectionConfiguration());
 
     // read configuration from db
-    return getSourceImplementationInternal(sourceImplementationId);
+    return getSourceImplementationReadInternal(sourceImplementationId);
   }
 
   public SourceImplementationRead updateSourceImplementation(
       SourceImplementationUpdate sourceImplementationUpdate) {
     // get existing implementation
-    final SourceImplementationRead persistedSourceImplementation =
-        getSourceImplementationInternal(sourceImplementationUpdate.getSourceImplementationId());
+    final SourceConnectionImplementation persistedSourceImplementation =
+        getSourceConnectionImplementationInternal(
+            sourceImplementationUpdate.getSourceImplementationId());
 
     // validate configuration
     validateSourceImplementation(
@@ -99,16 +101,18 @@ public class SourceImplementationsHandler {
         persistedSourceImplementation.getSourceSpecificationId(),
         persistedSourceImplementation.getWorkspaceId(),
         sourceImplementationUpdate.getSourceImplementationId(),
+        persistedSourceImplementation.getTombstone(),
         sourceImplementationUpdate.getConnectionConfiguration());
 
     // read configuration from db
-    return getSourceImplementationInternal(sourceImplementationUpdate.getSourceImplementationId());
+    return getSourceImplementationReadInternal(
+        sourceImplementationUpdate.getSourceImplementationId());
   }
 
   public SourceImplementationRead getSourceImplementation(
       SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
 
-    return getSourceImplementationInternal(
+    return getSourceImplementationReadInternal(
         sourceImplementationIdRequestBody.getSourceImplementationId());
   }
 
@@ -131,11 +135,33 @@ public class SourceImplementationsHandler {
     return sourceImplementationReadList;
   }
 
-  private SourceImplementationRead getSourceImplementationInternal(UUID sourceImplementationId) {
+  public void deleteSourceImplementation(
+      SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+    // get existing implementation
+    final SourceImplementationRead persistedSourceImplementation =
+        getSourceImplementationReadInternal(
+            sourceImplementationIdRequestBody.getSourceImplementationId());
+
+    // persist
+    persistSourceConnectionImplementation(
+        persistedSourceImplementation.getSourceSpecificationId(),
+        persistedSourceImplementation.getWorkspaceId(),
+        persistedSourceImplementation.getSourceImplementationId(),
+        true,
+        persistedSourceImplementation.getConnectionConfiguration());
+  }
+
+  private SourceConnectionImplementation getSourceConnectionImplementationInternal(
+      UUID sourceImplementationId) {
+    return ConfigFetchers.getSourceConnectionImplementation(
+        configPersistence, sourceImplementationId);
+  }
+
+  private SourceImplementationRead getSourceImplementationReadInternal(
+      UUID sourceImplementationId) {
     // read configuration from db
-    final SourceConnectionImplementation retrievedSourceConnectionImplementation;
-    retrievedSourceConnectionImplementation =
-        ConfigFetchers.getSourceConnectionImplementation(configPersistence, sourceImplementationId);
+    final SourceConnectionImplementation retrievedSourceConnectionImplementation =
+        getSourceConnectionImplementationInternal(sourceImplementationId);
 
     return toSourceImplementationRead(retrievedSourceConnectionImplementation);
   }
@@ -163,12 +189,14 @@ public class SourceImplementationsHandler {
       UUID sourceSpecificationId,
       UUID workspaceId,
       UUID sourceImplementationId,
+      Boolean tombstone,
       Object configuration) {
     final SourceConnectionImplementation sourceConnectionImplementation =
         new SourceConnectionImplementation();
     sourceConnectionImplementation.setSourceSpecificationId(sourceSpecificationId);
     sourceConnectionImplementation.setWorkspaceId(workspaceId);
     sourceConnectionImplementation.setSourceImplementationId(sourceImplementationId);
+    sourceConnectionImplementation.setTombstone(tombstone == null ? false : tombstone);
     sourceConnectionImplementation.setConfiguration(configuration);
 
     ConfigFetchers.writeConfig(

--- a/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
@@ -79,7 +79,7 @@ class ConnectionsHandlerTest {
     uuidGenerator = mock(Supplier.class);
 
     sourceImplementation =
-        SourceImplementationHelpers.generateSourceImplementationMock(UUID.randomUUID());
+        SourceImplementationHelpers.generateSourceImplementation(UUID.randomUUID());
     standardSync = generateSync(sourceImplementation.getSourceImplementationId());
     standardSyncSchedule = generateSchedule(standardSync.getConnectionId());
 

--- a/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 import java.util.UUID;
 
 public class SourceImplementationHelpers {
-  public static SourceConnectionImplementation generateSourceImplementationMock(
+  public static SourceConnectionImplementation generateSourceImplementation(
       UUID sourceSpecificationId) {
     final UUID workspaceId = UUID.randomUUID();
     final UUID sourceImplementationId = UUID.randomUUID();
@@ -45,6 +45,7 @@ public class SourceImplementationHelpers {
     sourceConnectionImplementation.setSourceSpecificationId(sourceSpecificationId);
     sourceConnectionImplementation.setSourceImplementationId(sourceImplementationId);
     sourceConnectionImplementation.setConfiguration(implementationJson.toString());
+    sourceConnectionImplementation.setTombstone(false);
 
     return sourceConnectionImplementation;
   }


### PR DESCRIPTION
## What
* We need an endpoint to delete a source_implementation to meet UI spec.
* In order to the above, we need to have a way of marking something a deleted.

## How
* Add said endpoint.
* Added `tombstone` field to source_implementation, so mark that it's deleting. Opting to do this instead of actually deleting it for debugging purposes.