### PR TITLE
Pass State into Sync Workers

### DIFF
--- a/dataline-config/src/main/resources/json/JobSyncConfig.json
+++ b/dataline-config/src/main/resources/json/JobSyncConfig.json
@@ -27,6 +27,14 @@
     },
     "destinationDockerImage": {
       "type": "string"
+    },
+    "state": {
+      "description": "optional state of the previous run. this object is defined per integration.",
+      "$ref": "State.json"
+    },
+    "standardSyncSummary": {
+      "description": "optional state of the previous run. this object is standard for any sync run.",
+      "$ref": "StandardSyncSummary.json"
     }
   }
 }

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/JobScheduler.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/JobScheduler.java
@@ -29,6 +29,8 @@ import io.dataline.config.StandardSync;
 import io.dataline.config.StandardSyncSchedule;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.db.DatabaseHelper;
+
+import java.io.IOException;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Optional;
@@ -62,41 +64,22 @@ public class JobScheduler implements Runnable {
     try {
       LOGGER.info("Running job-scheduler...");
 
-      scheduleJobs();
+      scheduleSyncJobs();
 
     } catch (Throwable e) {
       LOGGER.error("Job Scheduler Error", e);
     }
   }
 
-  private void scheduleJobs() throws SQLException {
+  private void scheduleSyncJobs() throws IOException {
     Set<StandardSync> activeConnections = getAllActiveConnections();
     for (StandardSync connection : activeConnections) {
       Optional<Job> lastJob =
-          DatabaseHelper.query(
-              connectionPool,
-              ctx -> {
-                Optional<Record> jobEntryOptional =
-                    ctx
-                        .fetch(
-                            "SELECT * FROM jobs WHERE scope = ? AND CAST(status AS VARCHAR) <> ? ORDER BY created_at DESC LIMIT 1",
-                            connection.getConnectionId().toString(),
-                            JobStatus.CANCELLED.toString().toLowerCase())
-                        .stream()
-                        .findFirst();
-
-                if (jobEntryOptional.isPresent()) {
-                  Record jobEntry = jobEntryOptional.get();
-                  Job job = DefaultSchedulerPersistence.getJobFromRecord(jobEntry);
-                  return Optional.of(job);
-                } else {
-                  return Optional.empty();
-                }
-              });
+          JobUtils.getLastSyncJobForConnectionId(connectionPool, connection.getConnectionId());
 
       if (lastJob.isEmpty()) {
         // pull configuration from connection.
-        JobUtils.createJobFromConnectionId(
+        JobUtils.createSyncJobFromConnectionId(
             schedulerPersistence, configPersistence, connection.getConnectionId());
       } else {
         final Job job = lastJob.get();
@@ -105,8 +88,8 @@ public class JobScheduler implements Runnable {
     }
   }
 
-  private void handleJob(UUID connectionId, Job job) {
-    switch (job.getStatus()) {
+  private void handleJob(UUID connectionId, Job previousJob) {
+    switch (previousJob.getStatus()) {
       case CANCELLED:
       case COMPLETED:
         final StandardSyncSchedule standardSyncSchedule =
@@ -117,14 +100,16 @@ public class JobScheduler implements Runnable {
         }
 
         long nextRunStart =
-            job.getUpdatedAt() + getIntervalInSeconds(standardSyncSchedule.getSchedule());
+            previousJob.getUpdatedAt() + getIntervalInSeconds(standardSyncSchedule.getSchedule());
         if (nextRunStart < Instant.now().getEpochSecond()) {
-          JobUtils.createJobFromConnectionId(schedulerPersistence, configPersistence, connectionId);
+          JobUtils.createSyncJobFromConnectionId(
+              schedulerPersistence, configPersistence, connectionId);
         }
         break;
         // todo (cgardens) - add max retry concept
       case FAILED:
-        JobUtils.createJobFromConnectionId(schedulerPersistence, configPersistence, connectionId);
+        JobUtils.createSyncJobFromConnectionId(
+            schedulerPersistence, configPersistence, connectionId);
         break;
       case PENDING:
       case RUNNING:

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/SchedulerPersistence.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/SchedulerPersistence.java
@@ -27,7 +27,13 @@ package io.dataline.scheduler;
 import io.dataline.config.DestinationConnectionImplementation;
 import io.dataline.config.SourceConnectionImplementation;
 import io.dataline.config.StandardSync;
+import io.dataline.config.StandardSyncSummary;
+import io.dataline.config.State;
+import org.apache.commons.dbcp2.BasicDataSource;
+
 import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface SchedulerPersistence {
   long createSourceCheckConnectionJob(SourceConnectionImplementation sourceImplementation)

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SchedulerHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SchedulerHandler.java
@@ -32,19 +32,27 @@ import io.dataline.api.model.SourceImplementationDiscoverSchemaRead;
 import io.dataline.api.model.SourceImplementationIdRequestBody;
 import io.dataline.commons.enums.Enums;
 import io.dataline.config.DestinationConnectionImplementation;
+import io.dataline.config.JobOutput;
 import io.dataline.config.SourceConnectionImplementation;
 import io.dataline.config.StandardCheckConnectionOutput;
 import io.dataline.config.StandardDiscoverSchemaOutput;
 import io.dataline.config.StandardSync;
+import io.dataline.config.StandardSyncOutput;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.scheduler.Job;
 import io.dataline.scheduler.JobStatus;
+import io.dataline.scheduler.JobUtils;
 import io.dataline.scheduler.SchedulerPersistence;
 import io.dataline.server.converters.SchemaConverter;
 import io.dataline.server.helpers.ConfigFetchers;
 import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.validation.constraints.NotNull;
 
 public class SchedulerHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerHandler.class);
@@ -129,10 +137,9 @@ public class SchedulerHandler {
   }
 
   public ConnectionSyncRead syncConnection(ConnectionIdRequestBody connectionIdRequestBody) {
+    @NotNull final UUID connectionId = connectionIdRequestBody.getConnectionId();
     final StandardSync standardSync;
-    standardSync =
-        ConfigFetchers.getStandardSync(
-            configPersistence, connectionIdRequestBody.getConnectionId());
+    standardSync = ConfigFetchers.getStandardSync(configPersistence, connectionId);
 
     final SourceConnectionImplementation sourceConnectionImplementation =
         ConfigFetchers.getSourceConnectionImplementation(
@@ -141,8 +148,6 @@ public class SchedulerHandler {
         ConfigFetchers.getDestinationConnectionImplementation(
             configPersistence, standardSync.getDestinationImplementationId());
 
-    // todo (cgardens) - should it be mandatory that the API insert state? or does the schedule do
-    //   that?
     final long jobId;
     try {
       jobId =


### PR DESCRIPTION
## What
* We need to pass the `State` and `StandardSyncSummary` from the previous sync run into the next sync run. 

## How
* Opted to mostly build this into DefaultSchedulerPersistence. In the future we can allow you to override previous state with another one by adding an overloaded `createSyncJob` method to the SchedulerPersistence iface.

## Recommended reading order
1. `DefaultSchedulerPersistence.java `
1. `JobUtils.ts`
1. the rest
