### PR TITLE
Add dataline-commons to all java projects + fix .env

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 Properties env = new Properties()
-File envFile = new File('.env')
+File envFile = rootProject.file(".env")
 envFile.withInputStream { env.load(it) }
 
 if (!env.containsKey("VERSION")) {
@@ -67,6 +67,10 @@ subprojects {
     }
 
     dependencies {
+        if (project.name != "dataline-commons") {
+            implementation project(':dataline-commons')
+        }
+
         implementation group: 'com.google.guava', name: 'guava', version: '29.0-jre'
 
         implementation group: 'commons-io', name: 'commons-io', version: '2.7'

--- a/dataline-db/build.gradle
+++ b/dataline-db/build.gradle
@@ -8,7 +8,5 @@ dependencies {
     api 'org.jooq:jooq:3.13.4'
     api 'org.postgresql:postgresql:42.2.16'
 
-    implementation project(':dataline-commons')
-
     testImplementation "org.testcontainers:postgresql:1.14.3"
 }

--- a/dataline-scheduler/build.gradle
+++ b/dataline-scheduler/build.gradle
@@ -5,7 +5,6 @@ plugins {
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
 
-    implementation project(':dataline-commons')
     implementation project(':dataline-config')
     implementation project(':dataline-config-persistence')
     implementation project(':dataline-db')

--- a/dataline-server/build.gradle
+++ b/dataline-server/build.gradle
@@ -17,7 +17,6 @@ dependencies {
 
 
     implementation project(':dataline-api')
-    implementation project(':dataline-commons')
     implementation project(':dataline-config')
     implementation project(':dataline-config-persistence')
     implementation project(':dataline-config-init')

--- a/dataline-workers/build.gradle
+++ b/dataline-workers/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation "com.fasterxml.jackson.core:jackson-databind:2.9.8"
 
-    implementation project(":dataline-commons")
     implementation project(":dataline-config")
     implementation project(":dataline-db")
     implementation project(":dataline-integrations")


### PR DESCRIPTION
## What
- Add dataline-commons to all java projects
- Fix .env reading in IntelliJ when running only a subproject task
