### PR TITLE
copy schema files from jar to fs

### DIFF
--- a/blah.json
+++ b/blah.json
@@ -1,0 +1,1 @@
+{ "sourceImplementationId":"68c1e91f-2d8b-4cdf-a87b-33124c1dc34f", "destinationImplementationId": "97b8d853-d33c-4513-afb4-6a421157a0ee", "syncMode": "full_refresh", "status": "active", "syncSchema": { "tables": [ { name: "tableName", "columns": [ { "name": "columnName", "dataType": "boolean" } ] } ] } }

--- a/blah.json
+++ b/blah.json
@@ -1,1 +1,0 @@
-{ "sourceImplementationId":"68c1e91f-2d8b-4cdf-a87b-33124c1dc34f", "destinationImplementationId": "97b8d853-d33c-4513-afb4-6a421157a0ee", "syncMode": "full_refresh", "status": "active", "syncSchema": { "tables": [ { name: "tableName", "columns": [ { "name": "columnName", "dataType": "boolean" } ] } ] } }

--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -969,7 +969,7 @@ components:
       - sourceImplementationId
       - destinationImplementationId
       - syncMode
-      - schema
+      - syncSchema
       - status
       properties:
         name:

--- a/dataline-config-persistence/src/main/java/io/dataline/config/persistence/DefaultConfigPersistence.java
+++ b/dataline-config-persistence/src/main/java/io/dataline/config/persistence/DefaultConfigPersistence.java
@@ -76,7 +76,7 @@ public class DefaultConfigPersistence implements ConfigPersistence {
 
     try {
       final Path configRoot = Files.createTempDirectory("").resolve(CONFIG_DIR);
-      FileUtils.forceMkdir(configRoot.toFile());
+      Files.createDirectories(configRoot);
 
       final FileSystem fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap());
       Path configPathInJar = fileSystem.getPath(CONFIG_PATH_IN_JAR);

--- a/dataline-config-persistence/src/main/java/io/dataline/config/persistence/DefaultConfigPersistence.java
+++ b/dataline-config-persistence/src/main/java/io/dataline/config/persistence/DefaultConfigPersistence.java
@@ -29,9 +29,13 @@ import com.google.common.annotations.VisibleForTesting;
 import io.dataline.commons.json.Jsons;
 import io.dataline.config.ConfigSchema;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -42,7 +46,9 @@ import org.apache.commons.io.FileUtils;
 
 // we force all interaction with disk storage to be effectively single threaded.
 public class DefaultConfigPersistence implements ConfigPersistence {
-
+  private static final String CONFIG_PATH_IN_JAR = "/json";
+  private static final String CONFIG_DIR = "schemas";
+  private static final Path configFilesRoot = getConfigFiles();
   private static final Object lock = new Object();
 
   private final JsonSchemaValidation jsonSchemaValidation;
@@ -51,6 +57,44 @@ public class DefaultConfigPersistence implements ConfigPersistence {
   public DefaultConfigPersistence(Path storageRoot) {
     this.storageRoot = storageRoot;
     jsonSchemaValidation = new JsonSchemaValidation();
+  }
+
+  /**
+   * JsonReferenceProcessor relies on all of the json in consumes being in a file system (not in a
+   * jar). This method copies all of the json configs out of the jar into a temporary directory so
+   * that JsonReferenceProcessor can find them.
+   *
+   * @return path where the config files can be found.
+   */
+  private static Path getConfigFiles() {
+    final URI uri;
+    try {
+      uri = ConfigSchema.class.getResource(CONFIG_PATH_IN_JAR).toURI();
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+
+    try {
+      final Path configRoot = Files.createTempDirectory("").resolve(CONFIG_DIR);
+      FileUtils.forceMkdir(configRoot.toFile());
+
+      final FileSystem fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap());
+      Path configPathInJar = fileSystem.getPath(CONFIG_PATH_IN_JAR);
+      Files.walk(configPathInJar, 1)
+          .forEach(
+              path -> {
+                if (path.toString().endsWith(".json")) {
+                  try {
+                    Files.copy(path, configRoot.resolve(path.getFileName().toString()));
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                }
+              });
+      return configRoot;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
@@ -116,19 +160,14 @@ public class DefaultConfigPersistence implements ConfigPersistence {
   JsonNode getSchema(PersistenceConfigType persistenceConfigType) {
     final String configSchemaFilename =
         standardConfigTypeToConfigSchema(persistenceConfigType).getSchemaFilename();
-    final String filenameWithPrefix = ConfigSchema.getSchemaDirectory() + configSchemaFilename;
-    final URL resource = ConfigSchema.class.getClassLoader().getResource(filenameWithPrefix);
-    if (resource == null) {
-      throw new RuntimeException(
-          String.format("Could not find resource for %s.", persistenceConfigType));
-    }
+    final Path configFilePath = configFilesRoot.resolve(configSchemaFilename);
 
     try {
       // JsonReferenceProcessor follows $ref in json objects. Jackson does not natively support
       // this.
       final JsonReferenceProcessor jsonReferenceProcessor = new JsonReferenceProcessor();
       jsonReferenceProcessor.setMaxDepth(-1); // no max.
-      return jsonReferenceProcessor.process(resource);
+      return jsonReferenceProcessor.process(configFilePath.toFile());
     } catch (IOException | JsonReferenceException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
## What
* `connections/create` has been broken since we move to pulling the json schemas from the jar.
* it was only caught now, because it only breaks in cases where the json schema uses the $ref keyword.

## How
* at startup copy all of the json schema from the into a a tmp directory so that the json processor can navigate the files.