### PR TITLE
add column selected field to the API

### DIFF
--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -612,7 +612,7 @@ paths:
   /v1/jobs/list:
     post:
       tags:
-        - jobs
+      - jobs
       summary: Returns recent jobs for a connection.
       operationId: listJobsFor
       requestBody:
@@ -635,7 +635,7 @@ paths:
   /v1/jobs/get:
     post:
       tags:
-        - jobs
+      - jobs
       summary: Get information about a job
       operationId: getJobInfo
       requestBody:
@@ -1020,7 +1020,7 @@ components:
       - sourceImplementationId
       - destinationImplementationId
       - syncMode
-      - schema
+      - syncSchema
       - status
       properties:
         connectionId:
@@ -1090,11 +1090,25 @@ components:
     SourceSchema:
       description: describes the available schema.
       type: object
+      required:
+      - tables
       properties:
         tables:
           type: array
           items:
             $ref: "#/components/schemas/SourceSchemaTable"
+    SourceSchemaTable:
+      type: object
+      required:
+      - name
+      - columns
+      properties:
+        name:
+          type: string
+        columns:
+          type: array
+          items:
+            $ref: "#/components/schemas/SourceSchemaColumn"
     SourceSchemaColumn:
       type: object
       required:
@@ -1114,18 +1128,6 @@ components:
       - string
       - number
       - boolean
-    SourceSchemaTable:
-      type: object
-      required:
-      - name
-      - columns
-      properties:
-        name:
-          type: string
-        columns:
-          type: array
-          items:
-            $ref: "#/components/schemas/SourceSchemaColumn"
     # SCHEDULER
     JobId:
       type: integer
@@ -1133,15 +1135,15 @@ components:
     JobConfigType:
       type: string
       enum:
-        - checkConnectionSource
-        - checkConnectionDestination
-        - discoverSchema
-        - sync
+      - checkConnectionSource
+      - checkConnectionDestination
+      - discoverSchema
+      - sync
     JobListRequestBody:
       type: object
       required:
-        - config_type
-        - config_id
+      - config_type
+      - config_id
       properties:
         config_type:
           $ref: "#/components/schemas/JobConfigType"
@@ -1150,19 +1152,19 @@ components:
     JobIdRequestBody:
       type: object
       required:
-        - id
+      - id
       properties:
         id:
           $ref: "#/components/schemas/JobId"
     JobRead:
       type: object
       required:
-        - id
-        - config_type
-        - config_id
-        - created_at
-        - updated_at
-        - status
+      - id
+      - config_type
+      - config_id
+      - created_at
+      - updated_at
+      - status
       properties:
         id:
           $ref: "#/components/schemas/JobId"
@@ -1182,15 +1184,15 @@ components:
         status:
           type: string
           enum:
-            - pending
-            - running
-            - failed
-            - completed
-            - cancelled
+          - pending
+          - running
+          - failed
+          - completed
+          - cancelled
     JobReadList:
       type: object
       required:
-        - jobs
+      - jobs
       properties:
         jobs:
           type: array
@@ -1199,8 +1201,8 @@ components:
     JobInfoRead:
       type: object
       required:
-        - job
-        - logs
+      - job
+      - logs
       properties:
         job:
           $ref: "#/components/schemas/JobRead"
@@ -1209,8 +1211,8 @@ components:
     LogRead:
       type: object
       required:
-        - stdout
-        - stderr
+      - stdout
+      - stderr
       properties:
         stdout:
           type: array

--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -1100,11 +1100,14 @@ components:
       required:
       - name
       - dataType
+      - selected
       properties:
         name:
           type: string
         dataType:
           $ref: "#/components/schemas/DataType"
+        selected:
+          type: boolean
     DataType:
       type: string
       enum:

--- a/dataline-server/src/main/java/io/dataline/server/converters/SchemaConverter.java
+++ b/dataline-server/src/main/java/io/dataline/server/converters/SchemaConverter.java
@@ -49,6 +49,7 @@ public class SchemaConverter {
                                 persistenceColumn.setName(apiColumn.getName());
                                 persistenceColumn.setDataType(
                                     toPersistenceDataType(apiColumn.getDataType()));
+                                persistenceColumn.setSelected(apiColumn.getSelected());
                                 return persistenceColumn;
                               })
                           .collect(Collectors.toList());
@@ -56,6 +57,8 @@ public class SchemaConverter {
                   final Table persistenceTable = new Table();
                   persistenceTable.setName(apiTable.getName());
                   persistenceTable.setColumns(persistenceColumns);
+                  persistenceTable.setSelected(
+                      persistenceColumns.stream().anyMatch(Column::getSelected));
 
                   return persistenceTable;
                 })
@@ -80,6 +83,7 @@ public class SchemaConverter {
                                 apiColumn.setName(persistenceColumn.getName());
                                 apiColumn.setDataType(
                                     toApiDataType(persistenceColumn.getDataType()));
+                                apiColumn.setSelected(persistenceColumn.getSelected());
                                 return apiColumn;
                               })
                           .collect(Collectors.toList());

--- a/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
@@ -289,10 +289,12 @@ class ConnectionsHandlerTest {
     final Column column = new Column();
     column.setDataType(DataType.STRING);
     column.setName("id");
+    column.setSelected(true);
 
     final Table table = new Table();
     table.setName("users");
     table.setColumns(Lists.newArrayList(column));
+    table.setSelected(true);
 
     final Schema schema = new Schema();
     schema.setTables(Lists.newArrayList(table));
@@ -304,6 +306,7 @@ class ConnectionsHandlerTest {
     final SourceSchemaColumn column = new SourceSchemaColumn();
     column.setDataType(io.dataline.api.model.DataType.STRING);
     column.setName("id");
+    column.setSelected(true);
 
     final SourceSchemaTable table = new SourceSchemaTable();
     table.setName("users");


### PR DESCRIPTION
## What
* We added added the `selected` field to our internal data model to track whether or not a column should be synced, but we never piped it through to the API. This PR handles that.
* reformats parts of config.yaml
* fixes require term to match field name in config.yaml