### PR TITLE
add WebackendConnectionsHandler with unit test

### DIFF
--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -27,28 +27,28 @@ info:
     name: MIT
     url: "https://opensource.org/licenses/MIT"
 tags:
-  - name: workspace
-    description: Workspace related resources.
-  - name: source
-    description: Source related resources.
-  - name: source_specification
-    description: Source specification related resources.
-  - name: source_implementation
-    description: Source implementation related resources.
-  - name: destination
-    description: Destination related resources.
-  - name: destination_specification
-    description: Destination specification related resources.
-  - name: destination_implementation
-    description: Destination implementation related resources.
-  - name: connection
-    description: Connection between sources and destinations.
+- name: workspace
+  description: Workspace related resources.
+- name: source
+  description: Source related resources.
+- name: source_specification
+  description: Source specification related resources.
+- name: source_implementation
+  description: Source implementation related resources.
+- name: destination
+  description: Destination related resources.
+- name: destination_specification
+  description: Destination specification related resources.
+- name: destination_implementation
+  description: Destination implementation related resources.
+- name: connection
+  description: Connection between sources and destinations.
 
 paths:
   /v1/workspaces/get:
     post:
       tags:
-        - workspace
+      - workspace
       summary: Find workspace by ID
       operationId: getWorkspace
       requestBody:
@@ -71,7 +71,7 @@ paths:
   /v1/workspaces/get_by_slug:
     post:
       tags:
-        - workspace
+      - workspace
       summary: Find workspace by slug
       operationId: getWorkspaceBySlug
       requestBody:
@@ -94,7 +94,7 @@ paths:
   /v1/workspaces/update:
     post:
       tags:
-        - workspace
+      - workspace
       summary: Update workspace state
       operationId: updateWorkspace
       requestBody:
@@ -117,7 +117,7 @@ paths:
   /v1/sources/list:
     post:
       tags:
-        - source
+      - source
       summary: List all of the sources that Dataline supports
       operationId: listSources
       responses:
@@ -130,7 +130,7 @@ paths:
   /v1/sources/get:
     post:
       tags:
-        - source
+      - source
       summary: Get source
       operationId: getSource
       requestBody:
@@ -153,7 +153,7 @@ paths:
   /v1/source_specifications/get:
     post:
       tags:
-        - source_specification
+      - source_specification
       summary: Get specification for a source.
       operationId: getSourceSpecification
       requestBody:
@@ -176,7 +176,7 @@ paths:
   /v1/source_implementations/create:
     post:
       tags:
-        - source_implementation
+      - source_implementation
       summary: Create a source implementation
       operationId: createSourceImplementation
       requestBody:
@@ -197,7 +197,7 @@ paths:
   /v1/source_implementations/update:
     post:
       tags:
-        - source_implementation
+      - source_implementation
       summary: Update a source
       operationId: updateSourceImplementation
       requestBody:
@@ -220,7 +220,7 @@ paths:
   /v1/source_implementations/list:
     post:
       tags:
-        - source_implementation
+      - source_implementation
       summary: List source implementations for workspace
       operationId: listSourceImplementationsForWorkspace
       requestBody:
@@ -243,7 +243,7 @@ paths:
   /v1/source_implementations/get:
     post:
       tags:
-        - source_implementation
+      - source_implementation
       summary: Get source implementation
       operationId: getSourceImplementation
       requestBody:
@@ -266,7 +266,7 @@ paths:
   /v1/source_implementations/delete:
     post:
       tags:
-        - source_implementation
+      - source_implementation
       summary: Delete a source implementation
       operationId: deleteSourceImplementation
       requestBody:
@@ -285,7 +285,7 @@ paths:
   /v1/source_implementations/check_connection:
     post:
       tags:
-        - source_implementation
+      - source_implementation
       summary: Check connection to the source implementation
       operationId: checkConnectionToSourceImplementation
       requestBody:
@@ -308,7 +308,7 @@ paths:
   /v1/source_implementations/discover_schema:
     post:
       tags:
-        - source_implementation
+      - source_implementation
       summary: Discover the schema of the source implementation
       operationId: discoverSchemaForSourceImplementation
       requestBody:
@@ -331,7 +331,7 @@ paths:
   /v1/destinations/list:
     post:
       tags:
-        - destination
+      - destination
       summary: List all of the destinations that Dataline supports
       operationId: listDestinations
       responses:
@@ -344,7 +344,7 @@ paths:
   /v1/destinations/get:
     post:
       tags:
-        - destination
+      - destination
       summary: Get destination
       operationId: getDestination
       requestBody:
@@ -367,7 +367,7 @@ paths:
   /v1/destination_specifications/get:
     post:
       tags:
-        - destination_specification
+      - destination_specification
       summary: Get specification for a destination
       operationId: getDestinationSpecification
       requestBody:
@@ -390,7 +390,7 @@ paths:
   /v1/destination_implementations/create:
     post:
       tags:
-        - destination_implementation
+      - destination_implementation
       summary: Create a destination implementation
       operationId: createDestinationImplementation
       requestBody:
@@ -411,7 +411,7 @@ paths:
   /v1/destination_implementations/update:
     post:
       tags:
-        - destination_implementation
+      - destination_implementation
       summary: Update a destination implementation
       operationId: updateDestinationImplementation
       requestBody:
@@ -432,7 +432,7 @@ paths:
   /v1/destination_implementations/list:
     post:
       tags:
-        - destination_implementation
+      - destination_implementation
       summary: List configured destinations for a workspace
       operationId: listDestinationImplementationsForWorkspace
       requestBody:
@@ -455,7 +455,7 @@ paths:
   /v1/destination_implementations/get:
     post:
       tags:
-        - destination_implementation
+      - destination_implementation
       summary: get configured destination
       operationId: getDestinationImplementation
       requestBody:
@@ -478,7 +478,7 @@ paths:
   /v1/destination_implementations/check_connection:
     post:
       tags:
-        - destination_implementation
+      - destination_implementation
       summary: Check connection to the destination implementation
       operationId: checkConnectionToDestinationImplementation
       requestBody:
@@ -501,7 +501,7 @@ paths:
   /v1/connections/create:
     post:
       tags:
-        - connection
+      - connection
       summary: Create a connection between a source implementation and a destination implementation
       operationId: createConnection
       requestBody:
@@ -522,7 +522,7 @@ paths:
   /v1/connections/update:
     post:
       tags:
-        - connection
+      - connection
       summary: Updated a connection status
       operationId: updateConnection
       requestBody:
@@ -543,7 +543,7 @@ paths:
   /v1/connections/list:
     post:
       tags:
-        - connection
+      - connection
       summary: Returns all connections for a workspace.
       operationId: listConnectionsForWorkspace
       requestBody:
@@ -566,7 +566,7 @@ paths:
   /v1/connections/get:
     post:
       tags:
-        - connection
+      - connection
       summary: Get a connection
       operationId: getConnection
       requestBody:
@@ -589,7 +589,7 @@ paths:
   /v1/web_backend/connections/list:
     post:
       tags:
-        - connection
+      - connection
       summary: Returns all connections for a workspace.
       operationId: webBackendListConnectionsForWorkspace
       requestBody:
@@ -612,7 +612,7 @@ paths:
   /v1/connections/sync:
     post:
       tags:
-        - connection
+      - connection
       summary: Trigger a manual sync of the connection
       operationId: syncConnection
       requestBody:
@@ -635,7 +635,7 @@ paths:
   /v1/jobs/list:
     post:
       tags:
-        - jobs
+      - jobs
       summary: Returns recent jobs for a connection. Jobs are returned in descending order by createdAt.
       operationId: listJobsFor
       requestBody:
@@ -658,7 +658,7 @@ paths:
   /v1/jobs/get:
     post:
       tags:
-        - jobs
+      - jobs
       summary: Get information about a job
       operationId: getJobInfo
       requestBody:
@@ -682,8 +682,8 @@ externalDocs:
   description: Find out more about Dataline
   url: "http://dataline.io"
 servers:
-  - url: "https://virtserver.swaggerhub.com/cgardens6/dataline/1.0.0"
-  - url: "http://virtserver.swaggerhub.com/cgardens6/dataline/1.0.0"
+- url: "https://virtserver.swaggerhub.com/cgardens6/dataline/1.0.0"
+- url: "http://virtserver.swaggerhub.com/cgardens6/dataline/1.0.0"
 components:
   securitySchemes:
     bearerAuth:
@@ -698,17 +698,17 @@ components:
     WorkspaceIdRequestBody:
       type: object
       required:
-        - workspaceId
+      - workspaceId
       properties:
         workspaceId:
           $ref: "#/components/schemas/WorkspaceId"
     WorkspaceRead:
       type: object
       required:
-        - workspaceId
-        - name
-        - slug
-        - initialSetupComplete
+      - workspaceId
+      - name
+      - slug
+      - initialSetupComplete
       properties:
         workspaceId:
           $ref: "#/components/schemas/WorkspaceId"
@@ -721,11 +721,11 @@ components:
     WorkspaceUpdate:
       type: object
       required:
-        - workspaceId
-        - initialSetupComplete
-        - anonymousDataCollection
-        - news
-        - securityUpdates
+      - workspaceId
+      - initialSetupComplete
+      - anonymousDataCollection
+      - news
+      - securityUpdates
       properties:
         workspaceId:
           $ref: "#/components/schemas/WorkspaceId"
@@ -744,7 +744,7 @@ components:
     SlugRequestBody:
       type: object
       required:
-        - slug
+      - slug
       properties:
         slug:
           type: string
@@ -755,15 +755,15 @@ components:
     SourceIdRequestBody:
       type: object
       required:
-        - sourceId
+      - sourceId
       properties:
         sourceId:
           $ref: "#/components/schemas/SourceId"
     SourceRead:
       type: object
       required:
-        - sourceId
-        - name
+      - sourceId
+      - name
       properties:
         sourceId:
           $ref: "#/components/schemas/SourceId"
@@ -772,7 +772,7 @@ components:
     SourceReadList:
       type: object
       required:
-        - sources
+      - sources
       properties:
         sources:
           type: array
@@ -785,9 +785,9 @@ components:
     SourceSpecificationRead:
       type: object
       required:
-        - sourceSpecificationId
-        - sourceId
-        - specification
+      - sourceSpecificationId
+      - sourceId
+      - specification
       properties:
         sourceSpecificationId:
           $ref: "#/components/schemas/SourceSpecificationId"
@@ -803,7 +803,7 @@ components:
     SourceImplementationIdRequestBody:
       type: object
       required:
-        - sourceId
+      - sourceId
       properties:
         sourceImplementationId:
           $ref: "#/components/schemas/SourceImplementationId"
@@ -813,9 +813,9 @@ components:
     SourceImplementationCreate:
       type: object
       required:
-        - workspaceId
-        - sourceSpecificationId
-        - connectionConfiguration
+      - workspaceId
+      - sourceSpecificationId
+      - connectionConfiguration
       properties:
         workspaceId:
           $ref: "#/components/schemas/WorkspaceId"
@@ -826,8 +826,8 @@ components:
     SourceImplementationUpdate:
       type: object
       required:
-        - sourceImplementationId
-        - connectionConfiguration
+      - sourceImplementationId
+      - connectionConfiguration
       properties:
         sourceImplementationId:
           $ref: "#/components/schemas/SourceImplementationId"
@@ -836,11 +836,11 @@ components:
     SourceImplementationRead:
       type: object
       required:
-        - sourceId
-        - sourceImplementationId
-        - workspaceId
-        - sourceSpecificationId
-        - connectionConfiguration
+      - sourceId
+      - sourceImplementationId
+      - workspaceId
+      - sourceSpecificationId
+      - connectionConfiguration
       properties:
         sourceId:
           $ref: "#/components/schemas/SourceId"
@@ -855,7 +855,7 @@ components:
     SourceImplementationReadList:
       type: object
       required:
-        - sources
+      - sources
       properties:
         sources:
           type: array
@@ -864,7 +864,7 @@ components:
     SourceImplementationDiscoverSchemaRead:
       type: object
       required:
-        - schema
+      - schema
       properties:
         schema:
           $ref: "#/components/schemas/SourceSchema"
@@ -875,15 +875,15 @@ components:
     DestinationIdRequestBody:
       type: object
       required:
-        - destinationId
+      - destinationId
       properties:
         destinationId:
           $ref: "#/components/schemas/DestinationId"
     DestinationRead:
       type: object
       required:
-        - destinationId
-        - name
+      - destinationId
+      - name
       properties:
         destinationId:
           $ref: "#/components/schemas/DestinationId"
@@ -892,7 +892,7 @@ components:
     DestinationReadList:
       type: object
       required:
-        - destinations
+      - destinations
       properties:
         destinations:
           type: array
@@ -905,9 +905,9 @@ components:
     DestinationSpecificationRead:
       type: object
       required:
-        - destinationSpecificationId
-        - destinationId
-        - specification
+      - destinationSpecificationId
+      - destinationId
+      - specification
       properties:
         destinationSpecificationId:
           $ref: "#/components/schemas/DestinationSpecificationId"
@@ -923,16 +923,16 @@ components:
     DestinationImplementationIdRequestBody:
       type: object
       required:
-        - destinationImplementationId
+      - destinationImplementationId
       properties:
         destinationImplementationId:
           $ref: "#/components/schemas/SourceImplementationId"
     DestinationImplementationCreate:
       type: object
       required:
-        - workspaceId
-        - destinationSpecificationId
-        - connectionConfiguration
+      - workspaceId
+      - destinationSpecificationId
+      - connectionConfiguration
       properties:
         workspaceId:
           $ref: "#/components/schemas/WorkspaceId"
@@ -944,8 +944,8 @@ components:
     DestinationImplementationUpdate:
       type: object
       required:
-        - destinationImplementationId
-        - connectionConfiguration
+      - destinationImplementationId
+      - connectionConfiguration
       properties:
         destinationImplementationId:
           $ref: "#/components/schemas/DestinationImplementationId"
@@ -955,11 +955,11 @@ components:
     DestinationImplementationRead:
       type: object
       required:
-        - destinationId
-        - destinationImplementationId
-        - workspaceId
-        - destinationSpecificationId
-        - connectionConfiguration
+      - destinationId
+      - destinationImplementationId
+      - workspaceId
+      - destinationSpecificationId
+      - connectionConfiguration
       properties:
         destinationId:
           $ref: "#/components/schemas/DestinationId"
@@ -975,7 +975,7 @@ components:
     DestinationImplementationReadList:
       type: object
       required:
-        - destinations
+      - destinations
       properties:
         destinations:
           type: array
@@ -988,17 +988,17 @@ components:
     ConnectionIdRequestBody:
       type: object
       required:
-        - connectionId
+      - connectionId
       properties:
         connectionId:
           $ref: "#/components/schemas/ConnectionId"
     ConnectionCreate:
       type: object
       required:
-        - sourceImplementationId
-        - destinationImplementationId
-        - syncMode
-        - status
+      - sourceImplementationId
+      - destinationImplementationId
+      - syncMode
+      - status
       properties:
         name:
           type: string
@@ -1010,8 +1010,8 @@ components:
         syncMode:
           type: string
           enum:
-            - full_refresh
-            - append
+          - full_refresh
+          - append
         syncSchema:
           $ref: "#/components/schemas/SourceSchema"
         schedule:
@@ -1021,10 +1021,10 @@ components:
     ConnectionUpdate:
       type: object
       required:
-        - sourceImplementationId
-        - destinationImplementationId
-        - syncSchema
-        - status
+      - sourceImplementationId
+      - destinationImplementationId
+      - syncSchema
+      - status
       properties:
         connectionId:
           $ref: "#/components/schemas/ConnectionId"
@@ -1037,13 +1037,13 @@ components:
     ConnectionRead:
       type: object
       required:
-        - connectionId
-        - name
-        - sourceImplementationId
-        - destinationImplementationId
-        - syncMode
-        - syncSchema
-        - status
+      - connectionId
+      - name
+      - sourceImplementationId
+      - destinationImplementationId
+      - syncMode
+      - syncSchema
+      - status
       properties:
         connectionId:
           $ref: "#/components/schemas/ConnectionId"
@@ -1056,8 +1056,8 @@ components:
         syncMode:
           type: string
           enum:
-            - full_refresh
-            - append
+          - full_refresh
+          - append
         syncSchema:
           $ref: "#/components/schemas/SourceSchema"
         schedule:
@@ -1067,7 +1067,7 @@ components:
     ConnectionReadList:
       type: object
       required:
-        - connections
+      - connections
       properties:
         connections:
           type: array
@@ -1077,15 +1077,15 @@ components:
       type: string
       description: Active means that data is flowing through the connection. Inactive means it is not. Deprecated means the connection is off and cannot be re-activated. the schema field describes the elements of the schema that will be synced.
       enum:
-        - active
-        - inactive
-        - deprecated
+      - active
+      - inactive
+      - deprecated
     ConnectionSchedule:
       description: if null, then no schedule is set.
       type: object
       required:
-        - units
-        - timeUnit
+      - units
+      - timeUnit
       properties:
         units:
           type: integer
@@ -1093,27 +1093,27 @@ components:
         timeUnit:
           type: string
           enum:
-            - minutes
-            - hours
-            - days
-            - weeks
-            - months
+          - minutes
+          - hours
+          - days
+          - weeks
+          - months
     ConnectionSyncRead:
       type: object
       required:
-        - status
+      - status
       properties:
         status:
           type: string
           enum:
-            - success
-            - fail
+          - success
+          - fail
     # SCHEMA
     SourceSchema:
       description: describes the available schema.
       type: object
       required:
-        - tables
+      - tables
       properties:
         tables:
           type: array
@@ -1122,8 +1122,8 @@ components:
     SourceSchemaTable:
       type: object
       required:
-        - name
-        - columns
+      - name
+      - columns
       properties:
         name:
           type: string
@@ -1134,9 +1134,9 @@ components:
     SourceSchemaColumn:
       type: object
       required:
-        - name
-        - dataType
-        - selected
+      - name
+      - dataType
+      - selected
       properties:
         name:
           type: string
@@ -1147,9 +1147,9 @@ components:
     DataType:
       type: string
       enum:
-        - string
-        - number
-        - boolean
+      - string
+      - number
+      - boolean
     # SCHEDULER
     JobId:
       type: integer
@@ -1157,15 +1157,15 @@ components:
     JobConfigType:
       type: string
       enum:
-        - checkConnectionSource
-        - checkConnectionDestination
-        - discoverSchema
-        - sync
+      - checkConnectionSource
+      - checkConnectionDestination
+      - discoverSchema
+      - sync
     JobListRequestBody:
       type: object
       required:
-        - config_type
-        - config_id
+      - config_type
+      - config_id
       properties:
         config_type:
           $ref: "#/components/schemas/JobConfigType"
@@ -1174,19 +1174,19 @@ components:
     JobIdRequestBody:
       type: object
       required:
-        - id
+      - id
       properties:
         id:
           $ref: "#/components/schemas/JobId"
     JobRead:
       type: object
       required:
-        - id
-        - config_type
-        - config_id
-        - created_at
-        - updated_at
-        - status
+      - id
+      - config_type
+      - config_id
+      - created_at
+      - updated_at
+      - status
       properties:
         id:
           $ref: "#/components/schemas/JobId"
@@ -1206,15 +1206,15 @@ components:
         status:
           type: string
           enum:
-            - pending
-            - running
-            - failed
-            - completed
-            - cancelled
+          - pending
+          - running
+          - failed
+          - completed
+          - cancelled
     JobReadList:
       type: object
       required:
-        - jobs
+      - jobs
       properties:
         jobs:
           type: array
@@ -1223,8 +1223,8 @@ components:
     JobInfoRead:
       type: object
       required:
-        - job
-        - logs
+      - job
+      - logs
       properties:
         job:
           $ref: "#/components/schemas/JobRead"
@@ -1233,8 +1233,8 @@ components:
     LogRead:
       type: object
       required:
-        - stdout
-        - stderr
+      - stdout
+      - stderr
       properties:
         stdout:
           type: array
@@ -1248,27 +1248,27 @@ components:
     CheckConnectionRead:
       type: object
       required:
-        - status
+      - status
       properties:
         status:
           type: string
           enum:
-            - success
-            - failure
+          - success
+          - failure
         message:
           type: string
     # Web Backend
     WbConnectionRead:
       type: object
       required:
-        - connectionId
-        - name
-        - sourceImplementationId
-        - destinationImplementationId
-        - syncMode
-        - syncSchema
-        - status
-        - source
+      - connectionId
+      - name
+      - sourceImplementationId
+      - destinationImplementationId
+      - syncMode
+      - syncSchema
+      - status
+      - source
       properties:
         connectionId:
           $ref: "#/components/schemas/ConnectionId"
@@ -1281,8 +1281,8 @@ components:
         syncMode:
           type: string
           enum:
-            - full_refresh
-            - append
+          - full_refresh
+          - append
         syncSchema:
           $ref: "#/components/schemas/SourceSchema"
         schedule:
@@ -1298,7 +1298,7 @@ components:
     WbConnectionReadList:
       type: object
       required:
-        - connections
+      - connections
       properties:
         connections:
           type: array
@@ -1309,4 +1309,4 @@ components:
       description: Invalid Input
 # apply the security globally to all operations
 security:
-  - bearerAuth: []
+- bearerAuth: []

--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -27,28 +27,28 @@ info:
     name: MIT
     url: "https://opensource.org/licenses/MIT"
 tags:
-- name: workspace
-  description: Workspace related resources.
-- name: source
-  description: Source related resources.
-- name: source_specification
-  description: Source specification related resources.
-- name: source_implementation
-  description: Source implementation related resources.
-- name: destination
-  description: Destination related resources.
-- name: destination_specification
-  description: Destination specification related resources.
-- name: destination_implementation
-  description: Destination implementation related resources.
-- name: connection
-  description: Connection between sources and destinations.
+  - name: workspace
+    description: Workspace related resources.
+  - name: source
+    description: Source related resources.
+  - name: source_specification
+    description: Source specification related resources.
+  - name: source_implementation
+    description: Source implementation related resources.
+  - name: destination
+    description: Destination related resources.
+  - name: destination_specification
+    description: Destination specification related resources.
+  - name: destination_implementation
+    description: Destination implementation related resources.
+  - name: connection
+    description: Connection between sources and destinations.
 
 paths:
   /v1/workspaces/get:
     post:
       tags:
-      - workspace
+        - workspace
       summary: Find workspace by ID
       operationId: getWorkspace
       requestBody:
@@ -71,7 +71,7 @@ paths:
   /v1/workspaces/get_by_slug:
     post:
       tags:
-      - workspace
+        - workspace
       summary: Find workspace by slug
       operationId: getWorkspaceBySlug
       requestBody:
@@ -94,7 +94,7 @@ paths:
   /v1/workspaces/update:
     post:
       tags:
-      - workspace
+        - workspace
       summary: Update workspace state
       operationId: updateWorkspace
       requestBody:
@@ -117,7 +117,7 @@ paths:
   /v1/sources/list:
     post:
       tags:
-      - source
+        - source
       summary: List all of the sources that Dataline supports
       operationId: listSources
       responses:
@@ -130,7 +130,7 @@ paths:
   /v1/sources/get:
     post:
       tags:
-      - source
+        - source
       summary: Get source
       operationId: getSource
       requestBody:
@@ -153,7 +153,7 @@ paths:
   /v1/source_specifications/get:
     post:
       tags:
-      - source_specification
+        - source_specification
       summary: Get specification for a source.
       operationId: getSourceSpecification
       requestBody:
@@ -176,7 +176,7 @@ paths:
   /v1/source_implementations/create:
     post:
       tags:
-      - source_implementation
+        - source_implementation
       summary: Create a source implementation
       operationId: createSourceImplementation
       requestBody:
@@ -197,7 +197,7 @@ paths:
   /v1/source_implementations/update:
     post:
       tags:
-      - source_implementation
+        - source_implementation
       summary: Update a source
       operationId: updateSourceImplementation
       requestBody:
@@ -220,7 +220,7 @@ paths:
   /v1/source_implementations/list:
     post:
       tags:
-      - source_implementation
+        - source_implementation
       summary: List source implementations for workspace
       operationId: listSourceImplementationsForWorkspace
       requestBody:
@@ -243,7 +243,7 @@ paths:
   /v1/source_implementations/get:
     post:
       tags:
-      - source_implementation
+        - source_implementation
       summary: Get source implementation
       operationId: getSourceImplementation
       requestBody:
@@ -266,7 +266,7 @@ paths:
   /v1/source_implementations/delete:
     post:
       tags:
-      - source_implementation
+        - source_implementation
       summary: Delete a source implementation
       operationId: deleteSourceImplementation
       requestBody:
@@ -285,7 +285,7 @@ paths:
   /v1/source_implementations/check_connection:
     post:
       tags:
-      - source_implementation
+        - source_implementation
       summary: Check connection to the source implementation
       operationId: checkConnectionToSourceImplementation
       requestBody:
@@ -308,7 +308,7 @@ paths:
   /v1/source_implementations/discover_schema:
     post:
       tags:
-      - source_implementation
+        - source_implementation
       summary: Discover the schema of the source implementation
       operationId: discoverSchemaForSourceImplementation
       requestBody:
@@ -331,7 +331,7 @@ paths:
   /v1/destinations/list:
     post:
       tags:
-      - destination
+        - destination
       summary: List all of the destinations that Dataline supports
       operationId: listDestinations
       responses:
@@ -344,7 +344,7 @@ paths:
   /v1/destinations/get:
     post:
       tags:
-      - destination
+        - destination
       summary: Get destination
       operationId: getDestination
       requestBody:
@@ -367,7 +367,7 @@ paths:
   /v1/destination_specifications/get:
     post:
       tags:
-      - destination_specification
+        - destination_specification
       summary: Get specification for a destination
       operationId: getDestinationSpecification
       requestBody:
@@ -390,7 +390,7 @@ paths:
   /v1/destination_implementations/create:
     post:
       tags:
-      - destination_implementation
+        - destination_implementation
       summary: Create a destination implementation
       operationId: createDestinationImplementation
       requestBody:
@@ -411,7 +411,7 @@ paths:
   /v1/destination_implementations/update:
     post:
       tags:
-      - destination_implementation
+        - destination_implementation
       summary: Update a destination implementation
       operationId: updateDestinationImplementation
       requestBody:
@@ -432,7 +432,7 @@ paths:
   /v1/destination_implementations/list:
     post:
       tags:
-      - destination_implementation
+        - destination_implementation
       summary: List configured destinations for a workspace
       operationId: listDestinationImplementationsForWorkspace
       requestBody:
@@ -455,7 +455,7 @@ paths:
   /v1/destination_implementations/get:
     post:
       tags:
-      - destination_implementation
+        - destination_implementation
       summary: get configured destination
       operationId: getDestinationImplementation
       requestBody:
@@ -478,7 +478,7 @@ paths:
   /v1/destination_implementations/check_connection:
     post:
       tags:
-      - destination_implementation
+        - destination_implementation
       summary: Check connection to the destination implementation
       operationId: checkConnectionToDestinationImplementation
       requestBody:
@@ -501,7 +501,7 @@ paths:
   /v1/connections/create:
     post:
       tags:
-      - connection
+        - connection
       summary: Create a connection between a source implementation and a destination implementation
       operationId: createConnection
       requestBody:
@@ -522,7 +522,7 @@ paths:
   /v1/connections/update:
     post:
       tags:
-      - connection
+        - connection
       summary: Updated a connection status
       operationId: updateConnection
       requestBody:
@@ -543,7 +543,7 @@ paths:
   /v1/connections/list:
     post:
       tags:
-      - connection
+        - connection
       summary: Returns all connections for a workspace.
       operationId: listConnectionsForWorkspace
       requestBody:
@@ -566,7 +566,7 @@ paths:
   /v1/connections/get:
     post:
       tags:
-      - connection
+        - connection
       summary: Get a connection
       operationId: getConnection
       requestBody:
@@ -589,7 +589,7 @@ paths:
   /v1/web_backend/connections/list:
     post:
       tags:
-      - connection
+        - connection
       summary: Returns all connections for a workspace.
       operationId: webBackendListConnectionsForWorkspace
       requestBody:
@@ -612,7 +612,7 @@ paths:
   /v1/connections/sync:
     post:
       tags:
-      - connection
+        - connection
       summary: Trigger a manual sync of the connection
       operationId: syncConnection
       requestBody:
@@ -635,7 +635,7 @@ paths:
   /v1/jobs/list:
     post:
       tags:
-      - jobs
+        - jobs
       summary: Returns recent jobs for a connection. Jobs are returned in descending order by createdAt.
       operationId: listJobsFor
       requestBody:
@@ -658,7 +658,7 @@ paths:
   /v1/jobs/get:
     post:
       tags:
-      - jobs
+        - jobs
       summary: Get information about a job
       operationId: getJobInfo
       requestBody:
@@ -682,8 +682,8 @@ externalDocs:
   description: Find out more about Dataline
   url: "http://dataline.io"
 servers:
-- url: "https://virtserver.swaggerhub.com/cgardens6/dataline/1.0.0"
-- url: "http://virtserver.swaggerhub.com/cgardens6/dataline/1.0.0"
+  - url: "https://virtserver.swaggerhub.com/cgardens6/dataline/1.0.0"
+  - url: "http://virtserver.swaggerhub.com/cgardens6/dataline/1.0.0"
 components:
   securitySchemes:
     bearerAuth:
@@ -698,17 +698,17 @@ components:
     WorkspaceIdRequestBody:
       type: object
       required:
-      - workspaceId
+        - workspaceId
       properties:
         workspaceId:
           $ref: "#/components/schemas/WorkspaceId"
     WorkspaceRead:
       type: object
       required:
-      - workspaceId
-      - name
-      - slug
-      - initialSetupComplete
+        - workspaceId
+        - name
+        - slug
+        - initialSetupComplete
       properties:
         workspaceId:
           $ref: "#/components/schemas/WorkspaceId"
@@ -721,11 +721,11 @@ components:
     WorkspaceUpdate:
       type: object
       required:
-      - workspaceId
-      - initialSetupComplete
-      - anonymousDataCollection
-      - news
-      - securityUpdates
+        - workspaceId
+        - initialSetupComplete
+        - anonymousDataCollection
+        - news
+        - securityUpdates
       properties:
         workspaceId:
           $ref: "#/components/schemas/WorkspaceId"
@@ -744,7 +744,7 @@ components:
     SlugRequestBody:
       type: object
       required:
-      - slug
+        - slug
       properties:
         slug:
           type: string
@@ -755,15 +755,15 @@ components:
     SourceIdRequestBody:
       type: object
       required:
-      - sourceId
+        - sourceId
       properties:
         sourceId:
           $ref: "#/components/schemas/SourceId"
     SourceRead:
       type: object
       required:
-      - sourceId
-      - name
+        - sourceId
+        - name
       properties:
         sourceId:
           $ref: "#/components/schemas/SourceId"
@@ -772,7 +772,7 @@ components:
     SourceReadList:
       type: object
       required:
-      - sources
+        - sources
       properties:
         sources:
           type: array
@@ -785,9 +785,9 @@ components:
     SourceSpecificationRead:
       type: object
       required:
-      - sourceSpecificationId
-      - sourceId
-      - specification
+        - sourceSpecificationId
+        - sourceId
+        - specification
       properties:
         sourceSpecificationId:
           $ref: "#/components/schemas/SourceSpecificationId"
@@ -803,7 +803,7 @@ components:
     SourceImplementationIdRequestBody:
       type: object
       required:
-      - sourceId
+        - sourceId
       properties:
         sourceImplementationId:
           $ref: "#/components/schemas/SourceImplementationId"
@@ -813,9 +813,9 @@ components:
     SourceImplementationCreate:
       type: object
       required:
-      - workspaceId
-      - sourceSpecificationId
-      - connectionConfiguration
+        - workspaceId
+        - sourceSpecificationId
+        - connectionConfiguration
       properties:
         workspaceId:
           $ref: "#/components/schemas/WorkspaceId"
@@ -826,8 +826,8 @@ components:
     SourceImplementationUpdate:
       type: object
       required:
-      - sourceImplementationId
-      - connectionConfiguration
+        - sourceImplementationId
+        - connectionConfiguration
       properties:
         sourceImplementationId:
           $ref: "#/components/schemas/SourceImplementationId"
@@ -836,11 +836,11 @@ components:
     SourceImplementationRead:
       type: object
       required:
-      - sourceId
-      - sourceImplementationId
-      - workspaceId
-      - sourceSpecificationId
-      - connectionConfiguration
+        - sourceId
+        - sourceImplementationId
+        - workspaceId
+        - sourceSpecificationId
+        - connectionConfiguration
       properties:
         sourceId:
           $ref: "#/components/schemas/SourceId"
@@ -855,7 +855,7 @@ components:
     SourceImplementationReadList:
       type: object
       required:
-      - sources
+        - sources
       properties:
         sources:
           type: array
@@ -864,7 +864,7 @@ components:
     SourceImplementationDiscoverSchemaRead:
       type: object
       required:
-      - schema
+        - schema
       properties:
         schema:
           $ref: "#/components/schemas/SourceSchema"
@@ -875,15 +875,15 @@ components:
     DestinationIdRequestBody:
       type: object
       required:
-      - destinationId
+        - destinationId
       properties:
         destinationId:
           $ref: "#/components/schemas/DestinationId"
     DestinationRead:
       type: object
       required:
-      - destinationId
-      - name
+        - destinationId
+        - name
       properties:
         destinationId:
           $ref: "#/components/schemas/DestinationId"
@@ -892,7 +892,7 @@ components:
     DestinationReadList:
       type: object
       required:
-      - destinations
+        - destinations
       properties:
         destinations:
           type: array
@@ -905,9 +905,9 @@ components:
     DestinationSpecificationRead:
       type: object
       required:
-      - destinationSpecificationId
-      - destinationId
-      - specification
+        - destinationSpecificationId
+        - destinationId
+        - specification
       properties:
         destinationSpecificationId:
           $ref: "#/components/schemas/DestinationSpecificationId"
@@ -923,16 +923,16 @@ components:
     DestinationImplementationIdRequestBody:
       type: object
       required:
-      - destinationImplementationId
+        - destinationImplementationId
       properties:
         destinationImplementationId:
           $ref: "#/components/schemas/SourceImplementationId"
     DestinationImplementationCreate:
       type: object
       required:
-      - workspaceId
-      - destinationSpecificationId
-      - connectionConfiguration
+        - workspaceId
+        - destinationSpecificationId
+        - connectionConfiguration
       properties:
         workspaceId:
           $ref: "#/components/schemas/WorkspaceId"
@@ -944,8 +944,8 @@ components:
     DestinationImplementationUpdate:
       type: object
       required:
-      - destinationImplementationId
-      - connectionConfiguration
+        - destinationImplementationId
+        - connectionConfiguration
       properties:
         destinationImplementationId:
           $ref: "#/components/schemas/DestinationImplementationId"
@@ -955,11 +955,11 @@ components:
     DestinationImplementationRead:
       type: object
       required:
-      - destinationId
-      - destinationImplementationId
-      - workspaceId
-      - destinationSpecificationId
-      - connectionConfiguration
+        - destinationId
+        - destinationImplementationId
+        - workspaceId
+        - destinationSpecificationId
+        - connectionConfiguration
       properties:
         destinationId:
           $ref: "#/components/schemas/DestinationId"
@@ -975,7 +975,7 @@ components:
     DestinationImplementationReadList:
       type: object
       required:
-      - destinations
+        - destinations
       properties:
         destinations:
           type: array
@@ -988,17 +988,17 @@ components:
     ConnectionIdRequestBody:
       type: object
       required:
-      - connectionId
+        - connectionId
       properties:
         connectionId:
           $ref: "#/components/schemas/ConnectionId"
     ConnectionCreate:
       type: object
       required:
-      - sourceImplementationId
-      - destinationImplementationId
-      - syncMode
-      - status
+        - sourceImplementationId
+        - destinationImplementationId
+        - syncMode
+        - status
       properties:
         name:
           type: string
@@ -1010,8 +1010,8 @@ components:
         syncMode:
           type: string
           enum:
-          - full_refresh
-          - append
+            - full_refresh
+            - append
         syncSchema:
           $ref: "#/components/schemas/SourceSchema"
         schedule:
@@ -1021,10 +1021,10 @@ components:
     ConnectionUpdate:
       type: object
       required:
-      - sourceImplementationId
-      - destinationImplementationId
-      - syncSchema
-      - status
+        - sourceImplementationId
+        - destinationImplementationId
+        - syncSchema
+        - status
       properties:
         connectionId:
           $ref: "#/components/schemas/ConnectionId"
@@ -1037,13 +1037,13 @@ components:
     ConnectionRead:
       type: object
       required:
-      - connectionId
-      - name
-      - sourceImplementationId
-      - destinationImplementationId
-      - syncMode
-      - syncSchema
-      - status
+        - connectionId
+        - name
+        - sourceImplementationId
+        - destinationImplementationId
+        - syncMode
+        - syncSchema
+        - status
       properties:
         connectionId:
           $ref: "#/components/schemas/ConnectionId"
@@ -1056,8 +1056,8 @@ components:
         syncMode:
           type: string
           enum:
-          - full_refresh
-          - append
+            - full_refresh
+            - append
         syncSchema:
           $ref: "#/components/schemas/SourceSchema"
         schedule:
@@ -1067,7 +1067,7 @@ components:
     ConnectionReadList:
       type: object
       required:
-      - connections
+        - connections
       properties:
         connections:
           type: array
@@ -1077,15 +1077,15 @@ components:
       type: string
       description: Active means that data is flowing through the connection. Inactive means it is not. Deprecated means the connection is off and cannot be re-activated. the schema field describes the elements of the schema that will be synced.
       enum:
-      - active
-      - inactive
-      - deprecated
+        - active
+        - inactive
+        - deprecated
     ConnectionSchedule:
       description: if null, then no schedule is set.
       type: object
       required:
-      - units
-      - timeUnit
+        - units
+        - timeUnit
       properties:
         units:
           type: integer
@@ -1093,27 +1093,27 @@ components:
         timeUnit:
           type: string
           enum:
-          - minutes
-          - hours
-          - days
-          - weeks
-          - months
+            - minutes
+            - hours
+            - days
+            - weeks
+            - months
     ConnectionSyncRead:
       type: object
       required:
-      - status
+        - status
       properties:
         status:
           type: string
           enum:
-          - success
-          - fail
+            - success
+            - fail
     # SCHEMA
     SourceSchema:
       description: describes the available schema.
       type: object
       required:
-      - tables
+        - tables
       properties:
         tables:
           type: array
@@ -1122,8 +1122,8 @@ components:
     SourceSchemaTable:
       type: object
       required:
-      - name
-      - columns
+        - name
+        - columns
       properties:
         name:
           type: string
@@ -1134,9 +1134,9 @@ components:
     SourceSchemaColumn:
       type: object
       required:
-      - name
-      - dataType
-      - selected
+        - name
+        - dataType
+        - selected
       properties:
         name:
           type: string
@@ -1147,9 +1147,9 @@ components:
     DataType:
       type: string
       enum:
-      - string
-      - number
-      - boolean
+        - string
+        - number
+        - boolean
     # SCHEDULER
     JobId:
       type: integer
@@ -1157,15 +1157,15 @@ components:
     JobConfigType:
       type: string
       enum:
-      - checkConnectionSource
-      - checkConnectionDestination
-      - discoverSchema
-      - sync
+        - checkConnectionSource
+        - checkConnectionDestination
+        - discoverSchema
+        - sync
     JobListRequestBody:
       type: object
       required:
-      - config_type
-      - config_id
+        - config_type
+        - config_id
       properties:
         config_type:
           $ref: "#/components/schemas/JobConfigType"
@@ -1174,19 +1174,19 @@ components:
     JobIdRequestBody:
       type: object
       required:
-      - id
+        - id
       properties:
         id:
           $ref: "#/components/schemas/JobId"
     JobRead:
       type: object
       required:
-      - id
-      - config_type
-      - config_id
-      - created_at
-      - updated_at
-      - status
+        - id
+        - config_type
+        - config_id
+        - created_at
+        - updated_at
+        - status
       properties:
         id:
           $ref: "#/components/schemas/JobId"
@@ -1206,15 +1206,15 @@ components:
         status:
           type: string
           enum:
-          - pending
-          - running
-          - failed
-          - completed
-          - cancelled
+            - pending
+            - running
+            - failed
+            - completed
+            - cancelled
     JobReadList:
       type: object
       required:
-      - jobs
+        - jobs
       properties:
         jobs:
           type: array
@@ -1223,8 +1223,8 @@ components:
     JobInfoRead:
       type: object
       required:
-      - job
-      - logs
+        - job
+        - logs
       properties:
         job:
           $ref: "#/components/schemas/JobRead"
@@ -1233,8 +1233,8 @@ components:
     LogRead:
       type: object
       required:
-      - stdout
-      - stderr
+        - stdout
+        - stderr
       properties:
         stdout:
           type: array
@@ -1248,27 +1248,27 @@ components:
     CheckConnectionRead:
       type: object
       required:
-      - status
+        - status
       properties:
         status:
           type: string
           enum:
-          - success
-          - failure
+            - success
+            - failure
         message:
           type: string
     # Web Backend
     WbConnectionRead:
       type: object
       required:
-      - connectionId
-      - name
-      - sourceImplementationId
-      - destinationImplementationId
-      - syncMode
-      - syncSchema
-      - status
-      - source
+        - connectionId
+        - name
+        - sourceImplementationId
+        - destinationImplementationId
+        - syncMode
+        - syncSchema
+        - status
+        - source
       properties:
         connectionId:
           $ref: "#/components/schemas/ConnectionId"
@@ -1281,8 +1281,8 @@ components:
         syncMode:
           type: string
           enum:
-          - full_refresh
-          - append
+            - full_refresh
+            - append
         syncSchema:
           $ref: "#/components/schemas/SourceSchema"
         schedule:
@@ -1298,7 +1298,7 @@ components:
     WbConnectionReadList:
       type: object
       required:
-      - connections
+        - connections
       properties:
         connections:
           type: array
@@ -1309,4 +1309,4 @@ components:
       description: Invalid Input
 # apply the security globally to all operations
 security:
-- bearerAuth: []
+  - bearerAuth: []

--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -586,6 +586,29 @@ paths:
           description: Connection not found
         "422":
           $ref: "#/components/responses/InvalidInput"
+  /v1/web_backend/connections/list:
+    post:
+      tags:
+        - connection
+      summary: Returns all connections for a workspace.
+      operationId: webBackendListConnectionsForWorkspace
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkspaceIdRequestBody"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WbConnectionReadList"
+        "404":
+          description: Workspace not found
+        "422":
+          $ref: "#/components/responses/InvalidInput"
   /v1/connections/sync:
     post:
       tags:
@@ -613,7 +636,7 @@ paths:
     post:
       tags:
         - jobs
-      summary: Returns recent jobs for a connection.
+      summary: Returns recent jobs for a connection. Jobs are returned in descending order by createdAt.
       operationId: listJobsFor
       requestBody:
         content:
@@ -1234,6 +1257,53 @@ components:
             - failure
         message:
           type: string
+    # Web Backend
+    WbConnectionRead:
+      type: object
+      required:
+        - connectionId
+        - name
+        - sourceImplementationId
+        - destinationImplementationId
+        - syncMode
+        - syncSchema
+        - status
+        - source
+      properties:
+        connectionId:
+          $ref: "#/components/schemas/ConnectionId"
+        name:
+          type: string
+        sourceImplementationId:
+          $ref: "#/components/schemas/SourceImplementationId"
+        destinationImplementationId:
+          $ref: "#/components/schemas/DestinationImplementationId"
+        syncMode:
+          type: string
+          enum:
+            - full_refresh
+            - append
+        syncSchema:
+          $ref: "#/components/schemas/SourceSchema"
+        schedule:
+          $ref: "#/components/schemas/ConnectionSchedule"
+        status:
+          $ref: "#/components/schemas/ConnectionStatus"
+        source:
+          $ref: "#/components/schemas/SourceImplementationRead"
+        lastSync:
+          description: epoch time of last sync. null if no sync has taken place.
+          type: integer
+          format: int64
+    WbConnectionReadList:
+      type: object
+      required:
+        - connections
+      properties:
+        connections:
+          type: array
+          items:
+            $ref: "#/components/schemas/WbConnectionRead"
   responses:
     InvalidInput:
       description: Invalid Input

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/DefaultSchedulerPersistence.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/DefaultSchedulerPersistence.java
@@ -216,7 +216,7 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
       String scope = ScopeHelper.createScope(configType, configId);
       return DatabaseHelper.query(
           connectionPool,
-          ctx -> ctx.fetch("SELECT * FROM jobs WHERE scope = ?", scope).stream()
+          ctx -> ctx.fetch("SELECT * FROM jobs WHERE scope = ? ORDER BY created_at DESC", scope).stream()
               .map(DefaultSchedulerPersistence::getJobFromRecord)
               .collect(Collectors.toList()));
     } catch (SQLException e) {

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/SchedulerPersistence.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/SchedulerPersistence.java
@@ -50,9 +50,8 @@ public interface SchedulerPersistence {
   Job getJob(long jobId) throws IOException;
 
   /**
-   *
    * @param configType - type of config, e.g. sync
-   * @param configId - id of that config
+   * @param configId   - id of that config
    * @return lists job in descending order by created_at
    * @throws IOException - what you do when you IO
    */

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/SchedulerPersistence.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/SchedulerPersistence.java
@@ -51,7 +51,7 @@ public interface SchedulerPersistence {
 
   /**
    * @param configType - type of config, e.g. sync
-   * @param configId   - id of that config
+   * @param configId - id of that config
    * @return lists job in descending order by created_at
    * @throws IOException - what you do when you IO
    */

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/SchedulerPersistence.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/SchedulerPersistence.java
@@ -49,6 +49,13 @@ public interface SchedulerPersistence {
 
   Job getJob(long jobId) throws IOException;
 
+  /**
+   *
+   * @param configType - type of config, e.g. sync
+   * @param configId - id of that config
+   * @return lists job in descending order by created_at
+   * @throws IOException - what you do when you IO
+   */
   List<Job> listJobs(JobConfig.ConfigType configType, String configId) throws IOException;
 
 }

--- a/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
+++ b/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
@@ -150,7 +150,7 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
 
   @Override
   public SourceSpecificationRead getSourceSpecification(
-      @Valid SourceIdRequestBody sourceIdRequestBody) {
+                                                        @Valid SourceIdRequestBody sourceIdRequestBody) {
     return sourceSpecificationsHandler.getSourceSpecification(sourceIdRequestBody);
   }
 
@@ -158,44 +158,44 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
 
   @Override
   public SourceImplementationRead createSourceImplementation(
-      @Valid SourceImplementationCreate sourceImplementationCreate) {
+                                                             @Valid SourceImplementationCreate sourceImplementationCreate) {
     return sourceImplementationsHandler.createSourceImplementation(sourceImplementationCreate);
   }
 
   @Override
   public SourceImplementationRead updateSourceImplementation(
-      @Valid SourceImplementationUpdate sourceImplementationUpdate) {
+                                                             @Valid SourceImplementationUpdate sourceImplementationUpdate) {
     return sourceImplementationsHandler.updateSourceImplementation(sourceImplementationUpdate);
   }
 
   @Override
   public SourceImplementationReadList listSourceImplementationsForWorkspace(
-      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+                                                                            @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return sourceImplementationsHandler.listSourceImplementationsForWorkspace(
         workspaceIdRequestBody);
   }
 
   @Override
   public SourceImplementationRead getSourceImplementation(
-      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+                                                          @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return sourceImplementationsHandler.getSourceImplementation(sourceImplementationIdRequestBody);
   }
 
   @Override
   public void deleteSourceImplementation(
-      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+                                         @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     sourceImplementationsHandler.deleteSourceImplementation(sourceImplementationIdRequestBody);
   }
 
   @Override
   public CheckConnectionRead checkConnectionToSourceImplementation(
-      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+                                                                   @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return schedulerHandler.checkSourceImplementationConnection(sourceImplementationIdRequestBody);
   }
 
   @Override
   public SourceImplementationDiscoverSchemaRead discoverSchemaForSourceImplementation(
-      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+                                                                                      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return schedulerHandler.discoverSchemaForSourceImplementation(
         sourceImplementationIdRequestBody);
   }
@@ -216,42 +216,42 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
 
   @Override
   public DestinationSpecificationRead getDestinationSpecification(
-      @Valid DestinationIdRequestBody destinationIdRequestBody) {
+                                                                  @Valid DestinationIdRequestBody destinationIdRequestBody) {
     return destinationSpecificationsHandler.getDestinationSpecification(destinationIdRequestBody);
   }
 
   // DESTINATION IMPLEMENTATION
   @Override
   public DestinationImplementationRead createDestinationImplementation(
-      @Valid DestinationImplementationCreate destinationImplementationCreate) {
+                                                                       @Valid DestinationImplementationCreate destinationImplementationCreate) {
     return destinationImplementationsHandler.createDestinationImplementation(
         destinationImplementationCreate);
   }
 
   @Override
   public DestinationImplementationRead updateDestinationImplementation(
-      @Valid DestinationImplementationUpdate destinationImplementationUpdate) {
+                                                                       @Valid DestinationImplementationUpdate destinationImplementationUpdate) {
     return destinationImplementationsHandler.updateDestinationImplementation(
         destinationImplementationUpdate);
   }
 
   @Override
   public DestinationImplementationReadList listDestinationImplementationsForWorkspace(
-      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+                                                                                      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return destinationImplementationsHandler.listDestinationImplementationsForWorkspace(
         workspaceIdRequestBody);
   }
 
   @Override
   public DestinationImplementationRead getDestinationImplementation(
-      @Valid DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
+                                                                    @Valid DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
     return destinationImplementationsHandler.getDestinationImplementation(
         destinationImplementationIdRequestBody);
   }
 
   @Override
   public CheckConnectionRead checkConnectionToDestinationImplementation(
-      @Valid DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
+                                                                        @Valid DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
     return schedulerHandler.checkDestinationImplementationConnection(
         destinationImplementationIdRequestBody);
   }
@@ -270,7 +270,7 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
 
   @Override
   public ConnectionReadList listConnectionsForWorkspace(
-      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+                                                        @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody);
   }
 
@@ -300,7 +300,7 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
 
   @Override
   public WbConnectionReadList webBackendListConnectionsForWorkspace(
-      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+                                                                    @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return webBackendConnectionsHandler.webBackendListConnectionsForWorkspace(
         workspaceIdRequestBody);
   }

--- a/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
+++ b/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
@@ -149,53 +149,45 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   // SOURCE SPECIFICATION
 
   @Override
-  public SourceSpecificationRead getSourceSpecification(
-                                                        @Valid SourceIdRequestBody sourceIdRequestBody) {
+  public SourceSpecificationRead getSourceSpecification(@Valid SourceIdRequestBody sourceIdRequestBody) {
     return sourceSpecificationsHandler.getSourceSpecification(sourceIdRequestBody);
   }
 
   // SOURCE IMPLEMENTATION
 
   @Override
-  public SourceImplementationRead createSourceImplementation(
-                                                             @Valid SourceImplementationCreate sourceImplementationCreate) {
+  public SourceImplementationRead createSourceImplementation(@Valid SourceImplementationCreate sourceImplementationCreate) {
     return sourceImplementationsHandler.createSourceImplementation(sourceImplementationCreate);
   }
 
   @Override
-  public SourceImplementationRead updateSourceImplementation(
-                                                             @Valid SourceImplementationUpdate sourceImplementationUpdate) {
+  public SourceImplementationRead updateSourceImplementation(@Valid SourceImplementationUpdate sourceImplementationUpdate) {
     return sourceImplementationsHandler.updateSourceImplementation(sourceImplementationUpdate);
   }
 
   @Override
-  public SourceImplementationReadList listSourceImplementationsForWorkspace(
-                                                                            @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+  public SourceImplementationReadList listSourceImplementationsForWorkspace(@Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return sourceImplementationsHandler.listSourceImplementationsForWorkspace(
         workspaceIdRequestBody);
   }
 
   @Override
-  public SourceImplementationRead getSourceImplementation(
-                                                          @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+  public SourceImplementationRead getSourceImplementation(@Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return sourceImplementationsHandler.getSourceImplementation(sourceImplementationIdRequestBody);
   }
 
   @Override
-  public void deleteSourceImplementation(
-                                         @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+  public void deleteSourceImplementation(@Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     sourceImplementationsHandler.deleteSourceImplementation(sourceImplementationIdRequestBody);
   }
 
   @Override
-  public CheckConnectionRead checkConnectionToSourceImplementation(
-                                                                   @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+  public CheckConnectionRead checkConnectionToSourceImplementation(@Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return schedulerHandler.checkSourceImplementationConnection(sourceImplementationIdRequestBody);
   }
 
   @Override
-  public SourceImplementationDiscoverSchemaRead discoverSchemaForSourceImplementation(
-                                                                                      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+  public SourceImplementationDiscoverSchemaRead discoverSchemaForSourceImplementation(@Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return schedulerHandler.discoverSchemaForSourceImplementation(
         sourceImplementationIdRequestBody);
   }
@@ -215,29 +207,25 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   // DESTINATION SPECIFICATION
 
   @Override
-  public DestinationSpecificationRead getDestinationSpecification(
-                                                                  @Valid DestinationIdRequestBody destinationIdRequestBody) {
+  public DestinationSpecificationRead getDestinationSpecification(@Valid DestinationIdRequestBody destinationIdRequestBody) {
     return destinationSpecificationsHandler.getDestinationSpecification(destinationIdRequestBody);
   }
 
   // DESTINATION IMPLEMENTATION
   @Override
-  public DestinationImplementationRead createDestinationImplementation(
-                                                                       @Valid DestinationImplementationCreate destinationImplementationCreate) {
+  public DestinationImplementationRead createDestinationImplementation(@Valid DestinationImplementationCreate destinationImplementationCreate) {
     return destinationImplementationsHandler.createDestinationImplementation(
         destinationImplementationCreate);
   }
 
   @Override
-  public DestinationImplementationRead updateDestinationImplementation(
-                                                                       @Valid DestinationImplementationUpdate destinationImplementationUpdate) {
+  public DestinationImplementationRead updateDestinationImplementation(@Valid DestinationImplementationUpdate destinationImplementationUpdate) {
     return destinationImplementationsHandler.updateDestinationImplementation(
         destinationImplementationUpdate);
   }
 
   @Override
-  public DestinationImplementationReadList listDestinationImplementationsForWorkspace(
-                                                                                      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+  public DestinationImplementationReadList listDestinationImplementationsForWorkspace(@Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return destinationImplementationsHandler.listDestinationImplementationsForWorkspace(
         workspaceIdRequestBody);
   }
@@ -250,8 +238,7 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   }
 
   @Override
-  public CheckConnectionRead checkConnectionToDestinationImplementation(
-                                                                        @Valid DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
+  public CheckConnectionRead checkConnectionToDestinationImplementation(@Valid DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
     return schedulerHandler.checkDestinationImplementationConnection(
         destinationImplementationIdRequestBody);
   }
@@ -269,8 +256,7 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   }
 
   @Override
-  public ConnectionReadList listConnectionsForWorkspace(
-                                                        @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+  public ConnectionReadList listConnectionsForWorkspace(@Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody);
   }
 
@@ -299,8 +285,7 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   // WEB BACKEND
 
   @Override
-  public WbConnectionReadList webBackendListConnectionsForWorkspace(
-                                                                    @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+  public WbConnectionReadList webBackendListConnectionsForWorkspace(@Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return webBackendConnectionsHandler.webBackendListConnectionsForWorkspace(
         workspaceIdRequestBody);
   }

--- a/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
+++ b/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
@@ -55,6 +55,7 @@ import io.dataline.api.model.SourceImplementationUpdate;
 import io.dataline.api.model.SourceRead;
 import io.dataline.api.model.SourceReadList;
 import io.dataline.api.model.SourceSpecificationRead;
+import io.dataline.api.model.WbConnectionReadList;
 import io.dataline.api.model.WorkspaceIdRequestBody;
 import io.dataline.api.model.WorkspaceRead;
 import io.dataline.api.model.WorkspaceUpdate;
@@ -71,6 +72,7 @@ import io.dataline.server.handlers.SchedulerHandler;
 import io.dataline.server.handlers.SourceImplementationsHandler;
 import io.dataline.server.handlers.SourceSpecificationsHandler;
 import io.dataline.server.handlers.SourcesHandler;
+import io.dataline.server.handlers.WebBackendConnectionsHandler;
 import io.dataline.server.handlers.WorkspacesHandler;
 import io.dataline.server.validation.IntegrationSchemaValidation;
 import java.nio.file.Path;
@@ -90,6 +92,7 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   private final ConnectionsHandler connectionsHandler;
   private final SchedulerHandler schedulerHandler;
   private final JobHistoryHandler jobHistoryHandler;
+  private final WebBackendConnectionsHandler webBackendConnectionsHandler;
 
   public ConfigurationApi(final Path dbRoot, BasicDataSource connectionPool) {
     ConfigPersistence configPersistence = new DefaultConfigPersistence(dbRoot);
@@ -109,6 +112,9 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
         new DefaultSchedulerPersistence(connectionPool);
     schedulerHandler = new SchedulerHandler(configPersistence, schedulerPersistence);
     jobHistoryHandler = new JobHistoryHandler(schedulerPersistence);
+    webBackendConnectionsHandler =
+        new WebBackendConnectionsHandler(
+            connectionsHandler, sourceImplementationsHandler, jobHistoryHandler);
   }
 
   // WORKSPACE
@@ -143,45 +149,53 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   // SOURCE SPECIFICATION
 
   @Override
-  public SourceSpecificationRead getSourceSpecification(@Valid SourceIdRequestBody sourceIdRequestBody) {
+  public SourceSpecificationRead getSourceSpecification(
+                                                        @Valid SourceIdRequestBody sourceIdRequestBody) {
     return sourceSpecificationsHandler.getSourceSpecification(sourceIdRequestBody);
   }
 
   // SOURCE IMPLEMENTATION
 
   @Override
-  public SourceImplementationRead createSourceImplementation(@Valid SourceImplementationCreate sourceImplementationCreate) {
+  public SourceImplementationRead createSourceImplementation(
+                                                             @Valid SourceImplementationCreate sourceImplementationCreate) {
     return sourceImplementationsHandler.createSourceImplementation(sourceImplementationCreate);
   }
 
   @Override
-  public SourceImplementationRead updateSourceImplementation(@Valid SourceImplementationUpdate sourceImplementationUpdate) {
+  public SourceImplementationRead updateSourceImplementation(
+                                                             @Valid SourceImplementationUpdate sourceImplementationUpdate) {
     return sourceImplementationsHandler.updateSourceImplementation(sourceImplementationUpdate);
   }
 
   @Override
-  public SourceImplementationReadList listSourceImplementationsForWorkspace(@Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+  public SourceImplementationReadList listSourceImplementationsForWorkspace(
+                                                                            @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return sourceImplementationsHandler.listSourceImplementationsForWorkspace(
         workspaceIdRequestBody);
   }
 
   @Override
-  public SourceImplementationRead getSourceImplementation(@Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+  public SourceImplementationRead getSourceImplementation(
+                                                          @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return sourceImplementationsHandler.getSourceImplementation(sourceImplementationIdRequestBody);
   }
 
   @Override
-  public void deleteSourceImplementation(@Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+  public void deleteSourceImplementation(
+                                         @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     sourceImplementationsHandler.deleteSourceImplementation(sourceImplementationIdRequestBody);
   }
 
   @Override
-  public CheckConnectionRead checkConnectionToSourceImplementation(@Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+  public CheckConnectionRead checkConnectionToSourceImplementation(
+                                                                   @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return schedulerHandler.checkSourceImplementationConnection(sourceImplementationIdRequestBody);
   }
 
   @Override
-  public SourceImplementationDiscoverSchemaRead discoverSchemaForSourceImplementation(@Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+  public SourceImplementationDiscoverSchemaRead discoverSchemaForSourceImplementation(
+                                                                                      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return schedulerHandler.discoverSchemaForSourceImplementation(
         sourceImplementationIdRequestBody);
   }
@@ -201,37 +215,43 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   // DESTINATION SPECIFICATION
 
   @Override
-  public DestinationSpecificationRead getDestinationSpecification(@Valid DestinationIdRequestBody destinationIdRequestBody) {
+  public DestinationSpecificationRead getDestinationSpecification(
+                                                                  @Valid DestinationIdRequestBody destinationIdRequestBody) {
     return destinationSpecificationsHandler.getDestinationSpecification(destinationIdRequestBody);
   }
 
   // DESTINATION IMPLEMENTATION
   @Override
-  public DestinationImplementationRead createDestinationImplementation(@Valid DestinationImplementationCreate destinationImplementationCreate) {
+  public DestinationImplementationRead createDestinationImplementation(
+                                                                       @Valid DestinationImplementationCreate destinationImplementationCreate) {
     return destinationImplementationsHandler.createDestinationImplementation(
         destinationImplementationCreate);
   }
 
   @Override
-  public DestinationImplementationRead updateDestinationImplementation(@Valid DestinationImplementationUpdate destinationImplementationUpdate) {
+  public DestinationImplementationRead updateDestinationImplementation(
+                                                                       @Valid DestinationImplementationUpdate destinationImplementationUpdate) {
     return destinationImplementationsHandler.updateDestinationImplementation(
         destinationImplementationUpdate);
   }
 
   @Override
-  public DestinationImplementationReadList listDestinationImplementationsForWorkspace(@Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+  public DestinationImplementationReadList listDestinationImplementationsForWorkspace(
+                                                                                      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return destinationImplementationsHandler.listDestinationImplementationsForWorkspace(
         workspaceIdRequestBody);
   }
 
   @Override
-  public DestinationImplementationRead getDestinationImplementation(@Valid DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
+  public DestinationImplementationRead getDestinationImplementation(
+                                                                    @Valid DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
     return destinationImplementationsHandler.getDestinationImplementation(
         destinationImplementationIdRequestBody);
   }
 
   @Override
-  public CheckConnectionRead checkConnectionToDestinationImplementation(@Valid DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
+  public CheckConnectionRead checkConnectionToDestinationImplementation(
+                                                                        @Valid DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
     return schedulerHandler.checkDestinationImplementationConnection(
         destinationImplementationIdRequestBody);
   }
@@ -249,7 +269,8 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   }
 
   @Override
-  public ConnectionReadList listConnectionsForWorkspace(@Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+  public ConnectionReadList listConnectionsForWorkspace(
+                                                        @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody);
   }
 
@@ -273,6 +294,15 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
   @Override
   public JobInfoRead getJobInfo(@Valid JobIdRequestBody jobIdRequestBody) {
     return jobHistoryHandler.getJobInfo(jobIdRequestBody);
+  }
+
+  // WEB BACKEND
+
+  @Override
+  public WbConnectionReadList webBackendListConnectionsForWorkspace(
+                                                                    @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+    return webBackendConnectionsHandler.webBackendListConnectionsForWorkspace(
+        workspaceIdRequestBody);
   }
 
 }

--- a/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
+++ b/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
@@ -150,7 +150,7 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
 
   @Override
   public SourceSpecificationRead getSourceSpecification(
-                                                        @Valid SourceIdRequestBody sourceIdRequestBody) {
+      @Valid SourceIdRequestBody sourceIdRequestBody) {
     return sourceSpecificationsHandler.getSourceSpecification(sourceIdRequestBody);
   }
 
@@ -158,44 +158,44 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
 
   @Override
   public SourceImplementationRead createSourceImplementation(
-                                                             @Valid SourceImplementationCreate sourceImplementationCreate) {
+      @Valid SourceImplementationCreate sourceImplementationCreate) {
     return sourceImplementationsHandler.createSourceImplementation(sourceImplementationCreate);
   }
 
   @Override
   public SourceImplementationRead updateSourceImplementation(
-                                                             @Valid SourceImplementationUpdate sourceImplementationUpdate) {
+      @Valid SourceImplementationUpdate sourceImplementationUpdate) {
     return sourceImplementationsHandler.updateSourceImplementation(sourceImplementationUpdate);
   }
 
   @Override
   public SourceImplementationReadList listSourceImplementationsForWorkspace(
-                                                                            @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return sourceImplementationsHandler.listSourceImplementationsForWorkspace(
         workspaceIdRequestBody);
   }
 
   @Override
   public SourceImplementationRead getSourceImplementation(
-                                                          @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return sourceImplementationsHandler.getSourceImplementation(sourceImplementationIdRequestBody);
   }
 
   @Override
   public void deleteSourceImplementation(
-                                         @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     sourceImplementationsHandler.deleteSourceImplementation(sourceImplementationIdRequestBody);
   }
 
   @Override
   public CheckConnectionRead checkConnectionToSourceImplementation(
-                                                                   @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return schedulerHandler.checkSourceImplementationConnection(sourceImplementationIdRequestBody);
   }
 
   @Override
   public SourceImplementationDiscoverSchemaRead discoverSchemaForSourceImplementation(
-                                                                                      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
+      @Valid SourceImplementationIdRequestBody sourceImplementationIdRequestBody) {
     return schedulerHandler.discoverSchemaForSourceImplementation(
         sourceImplementationIdRequestBody);
   }
@@ -216,42 +216,42 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
 
   @Override
   public DestinationSpecificationRead getDestinationSpecification(
-                                                                  @Valid DestinationIdRequestBody destinationIdRequestBody) {
+      @Valid DestinationIdRequestBody destinationIdRequestBody) {
     return destinationSpecificationsHandler.getDestinationSpecification(destinationIdRequestBody);
   }
 
   // DESTINATION IMPLEMENTATION
   @Override
   public DestinationImplementationRead createDestinationImplementation(
-                                                                       @Valid DestinationImplementationCreate destinationImplementationCreate) {
+      @Valid DestinationImplementationCreate destinationImplementationCreate) {
     return destinationImplementationsHandler.createDestinationImplementation(
         destinationImplementationCreate);
   }
 
   @Override
   public DestinationImplementationRead updateDestinationImplementation(
-                                                                       @Valid DestinationImplementationUpdate destinationImplementationUpdate) {
+      @Valid DestinationImplementationUpdate destinationImplementationUpdate) {
     return destinationImplementationsHandler.updateDestinationImplementation(
         destinationImplementationUpdate);
   }
 
   @Override
   public DestinationImplementationReadList listDestinationImplementationsForWorkspace(
-                                                                                      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return destinationImplementationsHandler.listDestinationImplementationsForWorkspace(
         workspaceIdRequestBody);
   }
 
   @Override
   public DestinationImplementationRead getDestinationImplementation(
-                                                                    @Valid DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
+      @Valid DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
     return destinationImplementationsHandler.getDestinationImplementation(
         destinationImplementationIdRequestBody);
   }
 
   @Override
   public CheckConnectionRead checkConnectionToDestinationImplementation(
-                                                                        @Valid DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
+      @Valid DestinationImplementationIdRequestBody destinationImplementationIdRequestBody) {
     return schedulerHandler.checkDestinationImplementationConnection(
         destinationImplementationIdRequestBody);
   }
@@ -270,7 +270,7 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
 
   @Override
   public ConnectionReadList listConnectionsForWorkspace(
-                                                        @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody);
   }
 
@@ -300,7 +300,7 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
 
   @Override
   public WbConnectionReadList webBackendListConnectionsForWorkspace(
-                                                                    @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
+      @Valid WorkspaceIdRequestBody workspaceIdRequestBody) {
     return webBackendConnectionsHandler.webBackendListConnectionsForWorkspace(
         workspaceIdRequestBody);
   }

--- a/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
+++ b/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
@@ -96,25 +96,19 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
 
   public ConfigurationApi(final Path dbRoot, BasicDataSource connectionPool) {
     ConfigPersistence configPersistence = new DefaultConfigPersistence(dbRoot);
-    final IntegrationSchemaValidation integrationSchemaValidation =
-        new IntegrationSchemaValidation(configPersistence);
+    final IntegrationSchemaValidation integrationSchemaValidation = new IntegrationSchemaValidation(configPersistence);
     workspacesHandler = new WorkspacesHandler(configPersistence);
     sourcesHandler = new SourcesHandler(configPersistence);
     sourceSpecificationsHandler = new SourceSpecificationsHandler(configPersistence);
-    sourceImplementationsHandler =
-        new SourceImplementationsHandler(configPersistence, integrationSchemaValidation);
+    sourceImplementationsHandler = new SourceImplementationsHandler(configPersistence, integrationSchemaValidation);
     destinationsHandler = new DestinationsHandler(configPersistence);
     destinationSpecificationsHandler = new DestinationSpecificationsHandler(configPersistence);
-    destinationImplementationsHandler =
-        new DestinationImplementationsHandler(configPersistence, integrationSchemaValidation);
+    destinationImplementationsHandler = new DestinationImplementationsHandler(configPersistence, integrationSchemaValidation);
     connectionsHandler = new ConnectionsHandler(configPersistence);
-    final SchedulerPersistence schedulerPersistence =
-        new DefaultSchedulerPersistence(connectionPool);
+    final SchedulerPersistence schedulerPersistence = new DefaultSchedulerPersistence(connectionPool);
     schedulerHandler = new SchedulerHandler(configPersistence, schedulerPersistence);
     jobHistoryHandler = new JobHistoryHandler(schedulerPersistence);
-    webBackendConnectionsHandler =
-        new WebBackendConnectionsHandler(
-            connectionsHandler, sourceImplementationsHandler, jobHistoryHandler);
+    webBackendConnectionsHandler = new WebBackendConnectionsHandler(connectionsHandler, sourceImplementationsHandler, jobHistoryHandler);
   }
 
   // WORKSPACE

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -66,7 +66,7 @@ public class SourceImplementationsHandler {
     // validate configuration
     validateSourceImplementation(
         sourceImplementationCreate.getSourceSpecificationId(),
-        (String) sourceImplementationCreate.getConnectionConfiguration());
+        Jsons.serialize(sourceImplementationCreate.getConnectionConfiguration()));
 
     // persist
     final UUID sourceImplementationId = uuidGenerator.get();

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -30,7 +30,6 @@ import io.dataline.api.model.SourceImplementationRead;
 import io.dataline.api.model.SourceImplementationReadList;
 import io.dataline.api.model.SourceImplementationUpdate;
 import io.dataline.api.model.WorkspaceIdRequestBody;
-import io.dataline.commons.json.Jsons;
 import io.dataline.config.SourceConnectionImplementation;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.JsonValidationException;
@@ -66,7 +65,7 @@ public class SourceImplementationsHandler {
     // validate configuration
     validateSourceImplementation(
         sourceImplementationCreate.getSourceSpecificationId(),
-        Jsons.serialize(sourceImplementationCreate.getConnectionConfiguration()));
+        (String) sourceImplementationCreate.getConnectionConfiguration());
 
     // persist
     final UUID sourceImplementationId = uuidGenerator.get();

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -30,6 +30,7 @@ import io.dataline.api.model.SourceImplementationRead;
 import io.dataline.api.model.SourceImplementationReadList;
 import io.dataline.api.model.SourceImplementationUpdate;
 import io.dataline.api.model.WorkspaceIdRequestBody;
+import io.dataline.commons.json.Jsons;
 import io.dataline.config.SourceConnectionImplementation;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.JsonValidationException;

--- a/dataline-server/src/main/java/io/dataline/server/handlers/WebBackendConnectionsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/WebBackendConnectionsHandler.java
@@ -44,16 +44,16 @@ public class WebBackendConnectionsHandler {
   private final JobHistoryHandler jobHistoryHandler;
 
   public WebBackendConnectionsHandler(
-                                      ConnectionsHandler connectionsHandler,
-                                      SourceImplementationsHandler sourceImplementationsHandler,
-                                      JobHistoryHandler jobHistoryHandler) {
+      ConnectionsHandler connectionsHandler,
+      SourceImplementationsHandler sourceImplementationsHandler,
+      JobHistoryHandler jobHistoryHandler) {
     this.connectionsHandler = connectionsHandler;
     this.sourceImplementationsHandler = sourceImplementationsHandler;
     this.jobHistoryHandler = jobHistoryHandler;
   }
 
   public WbConnectionReadList webBackendListConnectionsForWorkspace(
-                                                                    WorkspaceIdRequestBody workspaceIdRequestBody) {
+      WorkspaceIdRequestBody workspaceIdRequestBody) {
     final ConnectionReadList connectionReadList =
         connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody);
 

--- a/dataline-server/src/main/java/io/dataline/server/handlers/WebBackendConnectionsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/WebBackendConnectionsHandler.java
@@ -1,0 +1,106 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.server.handlers;
+
+import io.dataline.api.model.ConnectionReadList;
+import io.dataline.api.model.JobConfigType;
+import io.dataline.api.model.JobListRequestBody;
+import io.dataline.api.model.JobReadList;
+import io.dataline.api.model.SourceImplementationIdRequestBody;
+import io.dataline.api.model.SourceImplementationRead;
+import io.dataline.api.model.WbConnectionRead;
+import io.dataline.api.model.WbConnectionReadList;
+import io.dataline.api.model.WorkspaceIdRequestBody;
+import io.dataline.commons.enums.Enums;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class WebBackendConnectionsHandler {
+
+  private final ConnectionsHandler connectionsHandler;
+  private final SourceImplementationsHandler sourceImplementationsHandler;
+  private final JobHistoryHandler jobHistoryHandler;
+
+  public WebBackendConnectionsHandler(
+                                      ConnectionsHandler connectionsHandler,
+                                      SourceImplementationsHandler sourceImplementationsHandler,
+                                      JobHistoryHandler jobHistoryHandler) {
+    this.connectionsHandler = connectionsHandler;
+    this.sourceImplementationsHandler = sourceImplementationsHandler;
+    this.jobHistoryHandler = jobHistoryHandler;
+  }
+
+  public WbConnectionReadList webBackendListConnectionsForWorkspace(
+                                                                    WorkspaceIdRequestBody workspaceIdRequestBody) {
+    final ConnectionReadList connectionReadList =
+        connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody);
+
+    final List<WbConnectionRead> reads =
+        connectionReadList.getConnections().stream()
+            .map(
+                connectionRead -> {
+                  final SourceImplementationIdRequestBody sourceImplementationIdRequestBody =
+                      new SourceImplementationIdRequestBody();
+                  sourceImplementationIdRequestBody.setSourceImplementationId(
+                      connectionRead.getSourceImplementationId());
+                  final SourceImplementationRead sourceImplementation =
+                      sourceImplementationsHandler.getSourceImplementation(
+                          sourceImplementationIdRequestBody);
+
+                  final JobListRequestBody jobListRequestBody = new JobListRequestBody();
+                  jobListRequestBody.setConfigId(connectionRead.getConnectionId().toString());
+                  jobListRequestBody.setConfigType(JobConfigType.SYNC);
+                  final JobReadList jobReadList = jobHistoryHandler.listJobsFor(jobListRequestBody);
+
+                  final WbConnectionRead wbConnectionRead = new WbConnectionRead();
+                  wbConnectionRead.setConnectionId(connectionRead.getConnectionId());
+                  wbConnectionRead.setSourceImplementationId(
+                      connectionRead.getSourceImplementationId());
+                  wbConnectionRead.setDestinationImplementationId(
+                      connectionRead.getDestinationImplementationId());
+                  wbConnectionRead.setName(connectionRead.getName());
+                  wbConnectionRead.setSyncSchema(connectionRead.getSyncSchema());
+                  wbConnectionRead.setStatus(connectionRead.getStatus());
+                  wbConnectionRead.setSyncMode(
+                      Enums.convertTo(
+                          connectionRead.getSyncMode(), WbConnectionRead.SyncModeEnum.class));
+                  wbConnectionRead.setSchedule(connectionRead.getSchedule());
+                  jobReadList.getJobs().stream()
+                      .findFirst()
+                      .ifPresent(job -> wbConnectionRead.setLastSync(job.getCreatedAt()));
+
+                  wbConnectionRead.setSource(sourceImplementation);
+
+                  return wbConnectionRead;
+                })
+            .collect(Collectors.toList());
+
+    final WbConnectionReadList readList = new WbConnectionReadList();
+    readList.setConnections(reads);
+
+    return readList;
+  }
+
+}

--- a/dataline-server/src/main/java/io/dataline/server/handlers/WebBackendConnectionsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/WebBackendConnectionsHandler.java
@@ -44,16 +44,16 @@ public class WebBackendConnectionsHandler {
   private final JobHistoryHandler jobHistoryHandler;
 
   public WebBackendConnectionsHandler(
-      ConnectionsHandler connectionsHandler,
-      SourceImplementationsHandler sourceImplementationsHandler,
-      JobHistoryHandler jobHistoryHandler) {
+                                      ConnectionsHandler connectionsHandler,
+                                      SourceImplementationsHandler sourceImplementationsHandler,
+                                      JobHistoryHandler jobHistoryHandler) {
     this.connectionsHandler = connectionsHandler;
     this.sourceImplementationsHandler = sourceImplementationsHandler;
     this.jobHistoryHandler = jobHistoryHandler;
   }
 
   public WbConnectionReadList webBackendListConnectionsForWorkspace(
-      WorkspaceIdRequestBody workspaceIdRequestBody) {
+                                                                    WorkspaceIdRequestBody workspaceIdRequestBody) {
     final ConnectionReadList connectionReadList =
         connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody);
 

--- a/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
@@ -91,13 +91,13 @@ class ConnectionsHandlerTest {
         PersistenceConfigType.STANDARD_SYNC,
         standardSync.getConnectionId().toString(),
         StandardSync.class))
-            .thenReturn(standardSync);
+        .thenReturn(standardSync);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
         standardSyncSchedule.getConnectionId().toString(),
         StandardSyncSchedule.class))
-            .thenReturn(standardSyncSchedule);
+        .thenReturn(standardSyncSchedule);
 
     final ConnectionCreate connectionCreate = new ConnectionCreate();
     connectionCreate.setSourceImplementationId(standardSync.getSourceImplementationId());
@@ -166,15 +166,15 @@ class ConnectionsHandlerTest {
         PersistenceConfigType.STANDARD_SYNC,
         standardSync.getConnectionId().toString(),
         StandardSync.class))
-            .thenReturn(standardSync)
-            .thenReturn(updatedStandardSync);
+        .thenReturn(standardSync)
+        .thenReturn(updatedStandardSync);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
         standardSyncSchedule.getConnectionId().toString(),
         StandardSyncSchedule.class))
-            .thenReturn(standardSyncSchedule)
-            .thenReturn(updatedPersistenceSchedule);
+        .thenReturn(standardSyncSchedule)
+        .thenReturn(updatedPersistenceSchedule);
 
     final ConnectionRead actualConnectionRead =
         connectionsHandler.updateConnection(connectionUpdate);
@@ -210,13 +210,13 @@ class ConnectionsHandlerTest {
         PersistenceConfigType.STANDARD_SYNC,
         standardSync.getConnectionId().toString(),
         StandardSync.class))
-            .thenReturn(standardSync);
+        .thenReturn(standardSync);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
         standardSync.getConnectionId().toString(),
         StandardSyncSchedule.class))
-            .thenReturn(standardSyncSchedule);
+        .thenReturn(standardSyncSchedule);
 
     final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody();
     connectionIdRequestBody.setConnectionId(standardSync.getConnectionId());
@@ -239,14 +239,14 @@ class ConnectionsHandlerTest {
         PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
         sourceImplementation.getSourceImplementationId().toString(),
         SourceConnectionImplementation.class))
-            .thenReturn(sourceImplementation);
+        .thenReturn(sourceImplementation);
 
     // mock get schedule for the now verified connection
     when(configPersistence.getConfig(
         PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
         standardSync.getConnectionId().toString(),
         StandardSyncSchedule.class))
-            .thenReturn(standardSyncSchedule);
+        .thenReturn(standardSyncSchedule);
 
     final WorkspaceIdRequestBody workspaceIdRequestBody = new WorkspaceIdRequestBody();
     workspaceIdRequestBody.setWorkspaceId(sourceImplementation.getWorkspaceId());

--- a/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/ConnectionsHandlerTest.java
@@ -91,13 +91,13 @@ class ConnectionsHandlerTest {
         PersistenceConfigType.STANDARD_SYNC,
         standardSync.getConnectionId().toString(),
         StandardSync.class))
-        .thenReturn(standardSync);
+            .thenReturn(standardSync);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
         standardSyncSchedule.getConnectionId().toString(),
         StandardSyncSchedule.class))
-        .thenReturn(standardSyncSchedule);
+            .thenReturn(standardSyncSchedule);
 
     final ConnectionCreate connectionCreate = new ConnectionCreate();
     connectionCreate.setSourceImplementationId(standardSync.getSourceImplementationId());
@@ -166,15 +166,15 @@ class ConnectionsHandlerTest {
         PersistenceConfigType.STANDARD_SYNC,
         standardSync.getConnectionId().toString(),
         StandardSync.class))
-        .thenReturn(standardSync)
-        .thenReturn(updatedStandardSync);
+            .thenReturn(standardSync)
+            .thenReturn(updatedStandardSync);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
         standardSyncSchedule.getConnectionId().toString(),
         StandardSyncSchedule.class))
-        .thenReturn(standardSyncSchedule)
-        .thenReturn(updatedPersistenceSchedule);
+            .thenReturn(standardSyncSchedule)
+            .thenReturn(updatedPersistenceSchedule);
 
     final ConnectionRead actualConnectionRead =
         connectionsHandler.updateConnection(connectionUpdate);
@@ -210,13 +210,13 @@ class ConnectionsHandlerTest {
         PersistenceConfigType.STANDARD_SYNC,
         standardSync.getConnectionId().toString(),
         StandardSync.class))
-        .thenReturn(standardSync);
+            .thenReturn(standardSync);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
         standardSync.getConnectionId().toString(),
         StandardSyncSchedule.class))
-        .thenReturn(standardSyncSchedule);
+            .thenReturn(standardSyncSchedule);
 
     final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody();
     connectionIdRequestBody.setConnectionId(standardSync.getConnectionId());
@@ -239,14 +239,14 @@ class ConnectionsHandlerTest {
         PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
         sourceImplementation.getSourceImplementationId().toString(),
         SourceConnectionImplementation.class))
-        .thenReturn(sourceImplementation);
+            .thenReturn(sourceImplementation);
 
     // mock get schedule for the now verified connection
     when(configPersistence.getConfig(
         PersistenceConfigType.STANDARD_SYNC_SCHEDULE,
         standardSync.getConnectionId().toString(),
         StandardSyncSchedule.class))
-        .thenReturn(standardSyncSchedule);
+            .thenReturn(standardSyncSchedule);
 
     final WorkspaceIdRequestBody workspaceIdRequestBody = new WorkspaceIdRequestBody();
     workspaceIdRequestBody.setWorkspaceId(sourceImplementation.getWorkspaceId());

--- a/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
@@ -89,13 +89,13 @@ class SourceImplementationsHandlerTest {
         PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
         sourceConnectionImplementation.getSourceImplementationId().toString(),
         SourceConnectionImplementation.class))
-            .thenReturn(sourceConnectionImplementation);
+        .thenReturn(sourceConnectionImplementation);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
         sourceConnectionSpecification.getSourceSpecificationId().toString(),
         SourceConnectionSpecification.class))
-            .thenReturn(sourceConnectionSpecification);
+        .thenReturn(sourceConnectionSpecification);
 
     final SourceImplementationCreate sourceImplementationCreate = new SourceImplementationCreate();
     sourceImplementationCreate.setWorkspaceId(sourceConnectionImplementation.getWorkspaceId());
@@ -148,14 +148,14 @@ class SourceImplementationsHandlerTest {
         PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
         sourceConnectionImplementation.getSourceImplementationId().toString(),
         SourceConnectionImplementation.class))
-            .thenReturn(sourceConnectionImplementation)
-            .thenReturn(expectedSourceConnectionImplementation);
+        .thenReturn(sourceConnectionImplementation)
+        .thenReturn(expectedSourceConnectionImplementation);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
         sourceConnectionSpecification.getSourceSpecificationId().toString(),
         SourceConnectionSpecification.class))
-            .thenReturn(sourceConnectionSpecification);
+        .thenReturn(sourceConnectionSpecification);
 
     final SourceImplementationUpdate sourceImplementationUpdate = new SourceImplementationUpdate();
     sourceImplementationUpdate.setSourceImplementationId(
@@ -184,13 +184,13 @@ class SourceImplementationsHandlerTest {
         PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
         sourceConnectionImplementation.getSourceImplementationId().toString(),
         SourceConnectionImplementation.class))
-            .thenReturn(sourceConnectionImplementation);
+        .thenReturn(sourceConnectionImplementation);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
         sourceConnectionSpecification.getSourceSpecificationId().toString(),
         SourceConnectionSpecification.class))
-            .thenReturn(sourceConnectionSpecification);
+        .thenReturn(sourceConnectionSpecification);
 
     SourceImplementationRead expectedSourceImplementationRead =
         SourceImplementationHelpers.getSourceImplementationRead(
@@ -213,13 +213,13 @@ class SourceImplementationsHandlerTest {
     when(configPersistence.getConfigs(
         PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
         SourceConnectionImplementation.class))
-            .thenReturn(Sets.newHashSet(sourceConnectionImplementation));
+        .thenReturn(Sets.newHashSet(sourceConnectionImplementation));
 
     when(configPersistence.getConfig(
         PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
         sourceConnectionSpecification.getSourceSpecificationId().toString(),
         SourceConnectionSpecification.class))
-            .thenReturn(sourceConnectionSpecification);
+        .thenReturn(sourceConnectionSpecification);
 
     SourceImplementationRead expectedSourceImplementationRead =
         SourceImplementationHelpers.getSourceImplementationRead(
@@ -257,14 +257,14 @@ class SourceImplementationsHandlerTest {
         PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
         sourceConnectionImplementation.getSourceImplementationId().toString(),
         SourceConnectionImplementation.class))
-            .thenReturn(sourceConnectionImplementation)
-            .thenReturn(expectedSourceConnectionImplementation);
+        .thenReturn(sourceConnectionImplementation)
+        .thenReturn(expectedSourceConnectionImplementation);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
         sourceConnectionSpecification.getSourceSpecificationId().toString(),
         SourceConnectionSpecification.class))
-            .thenReturn(sourceConnectionSpecification);
+        .thenReturn(sourceConnectionSpecification);
 
     final SourceImplementationIdRequestBody sourceImplementationIdRequestBody =
         new SourceImplementationIdRequestBody();

--- a/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
@@ -107,14 +107,9 @@ class SourceImplementationsHandlerTest {
     final SourceImplementationRead actualSourceImplementationRead =
         sourceImplementationsHandler.createSourceImplementation(sourceImplementationCreate);
 
-    SourceImplementationRead expectedSourceImplementationRead = new SourceImplementationRead();
-    expectedSourceImplementationRead.setSourceId(sourceConnectionSpecification.getSourceId());
-    expectedSourceImplementationRead.setSourceSpecificationId(
-        sourceConnectionSpecification.getSourceSpecificationId());
-    expectedSourceImplementationRead.setWorkspaceId(
-        sourceConnectionImplementation.getWorkspaceId());
-    expectedSourceImplementationRead.setSourceImplementationId(
-        sourceConnectionImplementation.getSourceImplementationId());
+    SourceImplementationRead expectedSourceImplementationRead =
+        SourceImplementationHelpers.getSourceImplementationRead(
+            sourceConnectionImplementation, sourceConnectionSpecification.getSourceId());
     expectedSourceImplementationRead.setConnectionConfiguration(
         SourceImplementationHelpers.getTestImplementationJson());
 
@@ -169,14 +164,9 @@ class SourceImplementationsHandlerTest {
     final SourceImplementationRead actualSourceImplementationRead =
         sourceImplementationsHandler.updateSourceImplementation(sourceImplementationUpdate);
 
-    SourceImplementationRead expectedSourceImplementationRead = new SourceImplementationRead();
-    expectedSourceImplementationRead.setSourceId(sourceConnectionSpecification.getSourceId());
-    expectedSourceImplementationRead.setSourceSpecificationId(
-        sourceConnectionSpecification.getSourceSpecificationId());
-    expectedSourceImplementationRead.setWorkspaceId(
-        sourceConnectionImplementation.getWorkspaceId());
-    expectedSourceImplementationRead.setSourceImplementationId(
-        sourceConnectionImplementation.getSourceImplementationId());
+    SourceImplementationRead expectedSourceImplementationRead =
+        SourceImplementationHelpers.getSourceImplementationRead(
+            sourceConnectionImplementation, sourceConnectionSpecification.getSourceId());
     expectedSourceImplementationRead.setConnectionConfiguration(newConfiguration.toString());
 
     assertEquals(expectedSourceImplementationRead, actualSourceImplementationRead);
@@ -202,16 +192,9 @@ class SourceImplementationsHandlerTest {
         SourceConnectionSpecification.class))
             .thenReturn(sourceConnectionSpecification);
 
-    SourceImplementationRead expectedSourceImplementationRead = new SourceImplementationRead();
-    expectedSourceImplementationRead.setSourceId(sourceConnectionSpecification.getSourceId());
-    expectedSourceImplementationRead.setSourceSpecificationId(
-        sourceConnectionImplementation.getSourceSpecificationId());
-    expectedSourceImplementationRead.setWorkspaceId(
-        sourceConnectionImplementation.getWorkspaceId());
-    expectedSourceImplementationRead.setSourceImplementationId(
-        sourceConnectionImplementation.getSourceImplementationId());
-    expectedSourceImplementationRead.setConnectionConfiguration(
-        sourceConnectionImplementation.getConfigurationJson());
+    SourceImplementationRead expectedSourceImplementationRead =
+        SourceImplementationHelpers.getSourceImplementationRead(
+            sourceConnectionImplementation, sourceConnectionSpecification.getSourceId());
 
     final SourceImplementationIdRequestBody sourceImplementationIdRequestBody =
         new SourceImplementationIdRequestBody();
@@ -238,16 +221,9 @@ class SourceImplementationsHandlerTest {
         SourceConnectionSpecification.class))
             .thenReturn(sourceConnectionSpecification);
 
-    SourceImplementationRead expectedSourceImplementationRead = new SourceImplementationRead();
-    expectedSourceImplementationRead.setSourceId(sourceConnectionSpecification.getSourceId());
-    expectedSourceImplementationRead.setSourceSpecificationId(
-        sourceConnectionImplementation.getSourceSpecificationId());
-    expectedSourceImplementationRead.setWorkspaceId(
-        sourceConnectionImplementation.getWorkspaceId());
-    expectedSourceImplementationRead.setSourceImplementationId(
-        sourceConnectionImplementation.getSourceImplementationId());
-    expectedSourceImplementationRead.setConnectionConfiguration(
-        sourceConnectionImplementation.getConfigurationJson());
+    SourceImplementationRead expectedSourceImplementationRead =
+        SourceImplementationHelpers.getSourceImplementationRead(
+            sourceConnectionImplementation, sourceConnectionSpecification.getSourceId());
 
     final WorkspaceIdRequestBody workspaceIdRequestBody = new WorkspaceIdRequestBody();
     workspaceIdRequestBody.setWorkspaceId(sourceConnectionImplementation.getWorkspaceId());
@@ -296,15 +272,6 @@ class SourceImplementationsHandlerTest {
         sourceConnectionImplementation.getSourceImplementationId());
 
     sourceImplementationsHandler.deleteSourceImplementation(sourceImplementationIdRequestBody);
-
-    SourceImplementationRead expectedSourceImplementationRead = new SourceImplementationRead();
-    expectedSourceImplementationRead.setSourceSpecificationId(
-        sourceConnectionSpecification.getSourceSpecificationId());
-    expectedSourceImplementationRead.setWorkspaceId(
-        sourceConnectionImplementation.getWorkspaceId());
-    expectedSourceImplementationRead.setSourceImplementationId(
-        sourceConnectionImplementation.getSourceImplementationId());
-    expectedSourceImplementationRead.setConnectionConfiguration(newConfiguration.toString());
 
     verify(configPersistence)
         .writeConfig(

--- a/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
@@ -89,13 +89,13 @@ class SourceImplementationsHandlerTest {
         PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
         sourceConnectionImplementation.getSourceImplementationId().toString(),
         SourceConnectionImplementation.class))
-        .thenReturn(sourceConnectionImplementation);
+            .thenReturn(sourceConnectionImplementation);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
         sourceConnectionSpecification.getSourceSpecificationId().toString(),
         SourceConnectionSpecification.class))
-        .thenReturn(sourceConnectionSpecification);
+            .thenReturn(sourceConnectionSpecification);
 
     final SourceImplementationCreate sourceImplementationCreate = new SourceImplementationCreate();
     sourceImplementationCreate.setWorkspaceId(sourceConnectionImplementation.getWorkspaceId());
@@ -148,14 +148,14 @@ class SourceImplementationsHandlerTest {
         PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
         sourceConnectionImplementation.getSourceImplementationId().toString(),
         SourceConnectionImplementation.class))
-        .thenReturn(sourceConnectionImplementation)
-        .thenReturn(expectedSourceConnectionImplementation);
+            .thenReturn(sourceConnectionImplementation)
+            .thenReturn(expectedSourceConnectionImplementation);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
         sourceConnectionSpecification.getSourceSpecificationId().toString(),
         SourceConnectionSpecification.class))
-        .thenReturn(sourceConnectionSpecification);
+            .thenReturn(sourceConnectionSpecification);
 
     final SourceImplementationUpdate sourceImplementationUpdate = new SourceImplementationUpdate();
     sourceImplementationUpdate.setSourceImplementationId(
@@ -184,13 +184,13 @@ class SourceImplementationsHandlerTest {
         PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
         sourceConnectionImplementation.getSourceImplementationId().toString(),
         SourceConnectionImplementation.class))
-        .thenReturn(sourceConnectionImplementation);
+            .thenReturn(sourceConnectionImplementation);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
         sourceConnectionSpecification.getSourceSpecificationId().toString(),
         SourceConnectionSpecification.class))
-        .thenReturn(sourceConnectionSpecification);
+            .thenReturn(sourceConnectionSpecification);
 
     SourceImplementationRead expectedSourceImplementationRead =
         SourceImplementationHelpers.getSourceImplementationRead(
@@ -213,13 +213,13 @@ class SourceImplementationsHandlerTest {
     when(configPersistence.getConfigs(
         PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
         SourceConnectionImplementation.class))
-        .thenReturn(Sets.newHashSet(sourceConnectionImplementation));
+            .thenReturn(Sets.newHashSet(sourceConnectionImplementation));
 
     when(configPersistence.getConfig(
         PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
         sourceConnectionSpecification.getSourceSpecificationId().toString(),
         SourceConnectionSpecification.class))
-        .thenReturn(sourceConnectionSpecification);
+            .thenReturn(sourceConnectionSpecification);
 
     SourceImplementationRead expectedSourceImplementationRead =
         SourceImplementationHelpers.getSourceImplementationRead(
@@ -257,14 +257,14 @@ class SourceImplementationsHandlerTest {
         PersistenceConfigType.SOURCE_CONNECTION_IMPLEMENTATION,
         sourceConnectionImplementation.getSourceImplementationId().toString(),
         SourceConnectionImplementation.class))
-        .thenReturn(sourceConnectionImplementation)
-        .thenReturn(expectedSourceConnectionImplementation);
+            .thenReturn(sourceConnectionImplementation)
+            .thenReturn(expectedSourceConnectionImplementation);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.SOURCE_CONNECTION_SPECIFICATION,
         sourceConnectionSpecification.getSourceSpecificationId().toString(),
         SourceConnectionSpecification.class))
-        .thenReturn(sourceConnectionSpecification);
+            .thenReturn(sourceConnectionSpecification);
 
     final SourceImplementationIdRequestBody sourceImplementationIdRequestBody =
         new SourceImplementationIdRequestBody();

--- a/dataline-server/src/test/java/io/dataline/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -1,0 +1,136 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.server.handlers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.dataline.api.model.ConnectionRead;
+import io.dataline.api.model.ConnectionReadList;
+import io.dataline.api.model.JobConfigType;
+import io.dataline.api.model.JobListRequestBody;
+import io.dataline.api.model.JobRead;
+import io.dataline.api.model.JobReadList;
+import io.dataline.api.model.SourceImplementationIdRequestBody;
+import io.dataline.api.model.SourceImplementationRead;
+import io.dataline.api.model.WbConnectionRead;
+import io.dataline.api.model.WbConnectionReadList;
+import io.dataline.api.model.WorkspaceIdRequestBody;
+import io.dataline.commons.enums.Enums;
+import io.dataline.config.SourceConnectionImplementation;
+import io.dataline.config.StandardSync;
+import io.dataline.server.helpers.ConnectionHelpers;
+import io.dataline.server.helpers.SourceImplementationHelpers;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class WebBackendConnectionsHandlerTest {
+
+  private ConnectionsHandler connectionsHandler;
+  private SourceImplementationsHandler sourceImplementationsHandler;
+  private JobHistoryHandler jobHistoryHandler;
+  private WebBackendConnectionsHandler wbHandler;
+
+  private SourceImplementationRead sourceImplementationRead;
+  private ConnectionRead connectionRead;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    connectionsHandler = mock(ConnectionsHandler.class);
+    sourceImplementationsHandler = mock(SourceImplementationsHandler.class);
+    jobHistoryHandler = mock(JobHistoryHandler.class);
+    wbHandler = new WebBackendConnectionsHandler(connectionsHandler, sourceImplementationsHandler, jobHistoryHandler);
+
+    SourceConnectionImplementation sourceImplementation =
+        SourceImplementationHelpers.generateSourceImplementation(UUID.randomUUID());
+    sourceImplementationRead =
+        SourceImplementationHelpers.getSourceImplementationRead(
+            sourceImplementation, UUID.randomUUID());
+
+    final StandardSync standardSync =
+        ConnectionHelpers.generateSync(sourceImplementation.getSourceImplementationId());
+    connectionRead = ConnectionHelpers.generateExpectedConnectionRead(standardSync);
+  }
+
+  @Test
+  public void testWebBackendListConnectionsForWorkspace() {
+    final WorkspaceIdRequestBody workspaceIdRequestBody = new WorkspaceIdRequestBody();
+    workspaceIdRequestBody.setWorkspaceId(sourceImplementationRead.getWorkspaceId());
+
+    final ConnectionReadList connectionReadList = new ConnectionReadList();
+    connectionReadList.setConnections(Collections.singletonList(connectionRead));
+    when(connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody))
+        .thenReturn(connectionReadList);
+
+    final SourceImplementationIdRequestBody sourceImplementationIdRequestBody =
+        new SourceImplementationIdRequestBody();
+    sourceImplementationIdRequestBody.setSourceImplementationId(
+        connectionRead.getSourceImplementationId());
+    when(sourceImplementationsHandler.getSourceImplementation(sourceImplementationIdRequestBody))
+        .thenReturn(sourceImplementationRead);
+
+    Instant now = Instant.now();
+    final JobRead jobRead = new JobRead();
+    jobRead.setConfigId(connectionRead.getConnectionId().toString());
+    jobRead.setConfigType(JobConfigType.SYNC);
+    jobRead.setId(10L);
+    jobRead.setStatus(JobRead.StatusEnum.COMPLETED);
+    jobRead.setCreatedAt(now.getEpochSecond());
+    jobRead.setStartedAt(now.getEpochSecond());
+    jobRead.setUpdatedAt(now.getEpochSecond());
+
+    final JobReadList jobReadList = new JobReadList();
+    jobReadList.setJobs(Collections.singletonList(jobRead));
+    final JobListRequestBody jobListRequestBody = new JobListRequestBody();
+    jobListRequestBody.setConfigType(JobConfigType.SYNC);
+    jobListRequestBody.setConfigId(connectionRead.getConnectionId().toString());
+    when(jobHistoryHandler.listJobsFor(jobListRequestBody)).thenReturn(jobReadList);
+
+    final WbConnectionReadList wbConnectionReadList =
+        wbHandler.webBackendListConnectionsForWorkspace(workspaceIdRequestBody);
+
+    WbConnectionRead expected = new WbConnectionRead();
+    expected.setConnectionId(connectionRead.getConnectionId());
+    expected.setSourceImplementationId(connectionRead.getSourceImplementationId());
+    expected.setDestinationImplementationId(connectionRead.getDestinationImplementationId());
+    expected.setName(connectionRead.getName());
+    expected.setSyncSchema(connectionRead.getSyncSchema());
+    expected.setStatus(connectionRead.getStatus());
+    expected.setSyncMode(
+        Enums.convertTo(connectionRead.getSyncMode(), WbConnectionRead.SyncModeEnum.class));
+    expected.setSchedule(connectionRead.getSchedule());
+    expected.setSource(this.sourceImplementationRead);
+    expected.setLastSync(now.getEpochSecond());
+
+    assertEquals(1, wbConnectionReadList.getConnections().size());
+    assertEquals(expected, wbConnectionReadList.getConnections().get(0));
+  }
+
+}

--- a/dataline-server/src/test/java/io/dataline/server/helpers/ConnectionHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/ConnectionHelpers.java
@@ -1,0 +1,138 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.server.helpers;
+
+import com.google.common.collect.Lists;
+import io.dataline.api.model.ConnectionRead;
+import io.dataline.api.model.ConnectionSchedule;
+import io.dataline.api.model.ConnectionStatus;
+import io.dataline.api.model.SourceSchema;
+import io.dataline.api.model.SourceSchemaColumn;
+import io.dataline.api.model.SourceSchemaTable;
+import io.dataline.config.Column;
+import io.dataline.config.DataType;
+import io.dataline.config.Schedule;
+import io.dataline.config.Schema;
+import io.dataline.config.StandardSync;
+import io.dataline.config.StandardSyncSchedule;
+import io.dataline.config.Table;
+import java.util.UUID;
+
+public class ConnectionHelpers {
+
+  public static StandardSync generateSync(UUID sourceImplementationId) {
+    final UUID connectionId = UUID.randomUUID();
+
+    final StandardSync standardSync = new StandardSync();
+    standardSync.setConnectionId(connectionId);
+    standardSync.setName("presto to hudi");
+    standardSync.setStatus(StandardSync.Status.ACTIVE);
+    standardSync.setSchema(generateBasicPersistenceSchema());
+    standardSync.setSourceImplementationId(sourceImplementationId);
+    standardSync.setDestinationImplementationId(UUID.randomUUID());
+    standardSync.setSyncMode(StandardSync.SyncMode.APPEND);
+
+    return standardSync;
+  }
+
+  public static Schema generateBasicPersistenceSchema() {
+    final Column column = new Column();
+    column.setDataType(DataType.STRING);
+    column.setName("id");
+    column.setSelected(true);
+
+    final Table table = new Table();
+    table.setName("users");
+    table.setColumns(Lists.newArrayList(column));
+    table.setSelected(true);
+
+    final Schema schema = new Schema();
+    schema.setTables(Lists.newArrayList(table));
+
+    return schema;
+  }
+
+  public static SourceSchema generateBasicApiSchema() {
+    final SourceSchemaColumn column = new SourceSchemaColumn();
+    column.setDataType(io.dataline.api.model.DataType.STRING);
+    column.setName("id");
+    column.setSelected(true);
+
+    final SourceSchemaTable table = new SourceSchemaTable();
+    table.setName("users");
+    table.setColumns(Lists.newArrayList(column));
+
+    final SourceSchema schema = new SourceSchema();
+    schema.setTables(Lists.newArrayList(table));
+
+    return schema;
+  }
+
+  public static ConnectionSchedule generateBasicSchedule() {
+    final ConnectionSchedule connectionSchedule = new ConnectionSchedule();
+    connectionSchedule.setTimeUnit(ConnectionSchedule.TimeUnitEnum.DAYS);
+    connectionSchedule.setUnits(1L);
+
+    return connectionSchedule;
+  }
+
+  public static ConnectionRead generateExpectedConnectionRead(
+                                                              UUID connectionId,
+                                                              UUID sourceImplementationId,
+                                                              UUID destinationImplementationId) {
+    final ConnectionRead expectedConnectionRead = new ConnectionRead();
+    expectedConnectionRead.setConnectionId(connectionId);
+    expectedConnectionRead.setSourceImplementationId(sourceImplementationId);
+    expectedConnectionRead.setDestinationImplementationId(destinationImplementationId);
+    expectedConnectionRead.setName("presto to hudi");
+    expectedConnectionRead.setStatus(ConnectionStatus.ACTIVE);
+    expectedConnectionRead.setSyncMode(ConnectionRead.SyncModeEnum.APPEND);
+    expectedConnectionRead.setSchedule(generateBasicSchedule());
+    expectedConnectionRead.setSyncSchema(ConnectionHelpers.generateBasicApiSchema());
+
+    return expectedConnectionRead;
+  }
+
+  public static ConnectionRead generateExpectedConnectionRead(StandardSync standardSync) {
+    return generateExpectedConnectionRead(
+        standardSync.getConnectionId(),
+        standardSync.getSourceImplementationId(),
+        standardSync.getDestinationImplementationId());
+  }
+
+  public static StandardSyncSchedule generateSchedule(UUID connectionId) {
+    final Schedule schedule = new Schedule();
+    schedule.setTimeUnit(Schedule.TimeUnit.DAYS);
+    schedule.setUnits(1L);
+
+    final StandardSyncSchedule standardSchedule = new StandardSyncSchedule();
+    standardSchedule.setConnectionId(connectionId);
+    standardSchedule.setSchedule(schedule);
+    standardSchedule.setManual(false);
+
+    return standardSchedule;
+  }
+
+}

--- a/dataline-server/src/test/java/io/dataline/server/helpers/ConnectionHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/ConnectionHelpers.java
@@ -99,9 +99,9 @@ public class ConnectionHelpers {
   }
 
   public static ConnectionRead generateExpectedConnectionRead(
-                                                              UUID connectionId,
-                                                              UUID sourceImplementationId,
-                                                              UUID destinationImplementationId) {
+      UUID connectionId,
+      UUID sourceImplementationId,
+      UUID destinationImplementationId) {
     final ConnectionRead expectedConnectionRead = new ConnectionRead();
     expectedConnectionRead.setConnectionId(connectionId);
     expectedConnectionRead.setSourceImplementationId(sourceImplementationId);

--- a/dataline-server/src/test/java/io/dataline/server/helpers/ConnectionHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/ConnectionHelpers.java
@@ -99,9 +99,9 @@ public class ConnectionHelpers {
   }
 
   public static ConnectionRead generateExpectedConnectionRead(
-      UUID connectionId,
-      UUID sourceImplementationId,
-      UUID destinationImplementationId) {
+                                                              UUID connectionId,
+                                                              UUID sourceImplementationId,
+                                                              UUID destinationImplementationId) {
     final ConnectionRead expectedConnectionRead = new ConnectionRead();
     expectedConnectionRead.setConnectionId(connectionId);
     expectedConnectionRead.setSourceImplementationId(sourceImplementationId);

--- a/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 public class SourceImplementationHelpers {
 
   public static SourceConnectionImplementation generateSourceImplementation(
-      UUID sourceSpecificationId)
+                                                                            UUID sourceSpecificationId)
       throws IOException {
     final UUID workspaceId = UUID.randomUUID();
     final UUID sourceImplementationId = UUID.randomUUID();
@@ -60,8 +60,8 @@ public class SourceImplementationHelpers {
   }
 
   public static SourceImplementationRead getSourceImplementationRead(
-      SourceConnectionImplementation sourceImplementation,
-      UUID sourceId) {
+                                                                     SourceConnectionImplementation sourceImplementation,
+                                                                     UUID sourceId) {
     SourceImplementationRead sourceImplementationRead = new SourceImplementationRead();
     sourceImplementationRead.setSourceId(sourceId);
     sourceImplementationRead.setWorkspaceId(sourceImplementation.getWorkspaceId());

--- a/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
@@ -24,6 +24,7 @@
 
 package io.dataline.server.helpers;
 
+import io.dataline.api.model.SourceImplementationRead;
 import io.dataline.config.SourceConnectionImplementation;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -33,7 +34,8 @@ import java.util.UUID;
 
 public class SourceImplementationHelpers {
 
-  public static SourceConnectionImplementation generateSourceImplementation(UUID sourceSpecificationId)
+  public static SourceConnectionImplementation generateSourceImplementation(
+                                                                            UUID sourceSpecificationId)
       throws IOException {
     final UUID workspaceId = UUID.randomUUID();
     final UUID sourceImplementationId = UUID.randomUUID();
@@ -55,6 +57,22 @@ public class SourceImplementationHelpers {
     final Path path =
         Paths.get("../dataline-server/src/test/resources/json/TestImplementation.json");
     return Files.readString(path);
+  }
+
+  public static SourceImplementationRead getSourceImplementationRead(
+                                                                     SourceConnectionImplementation sourceImplementation,
+                                                                     UUID sourceId) {
+    SourceImplementationRead sourceImplementationRead = new SourceImplementationRead();
+    sourceImplementationRead.setSourceId(sourceId);
+    sourceImplementationRead.setWorkspaceId(sourceImplementation.getWorkspaceId());
+    sourceImplementationRead.setSourceSpecificationId(
+        sourceImplementation.getSourceSpecificationId());
+    sourceImplementationRead.setSourceImplementationId(
+        sourceImplementation.getSourceImplementationId());
+    sourceImplementationRead.setConnectionConfiguration(
+        sourceImplementation.getConfigurationJson());
+
+    return sourceImplementationRead;
   }
 
 }

--- a/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 public class SourceImplementationHelpers {
 
   public static SourceConnectionImplementation generateSourceImplementation(
-                                                                            UUID sourceSpecificationId)
+      UUID sourceSpecificationId)
       throws IOException {
     final UUID workspaceId = UUID.randomUUID();
     final UUID sourceImplementationId = UUID.randomUUID();
@@ -60,8 +60,8 @@ public class SourceImplementationHelpers {
   }
 
   public static SourceImplementationRead getSourceImplementationRead(
-                                                                     SourceConnectionImplementation sourceImplementation,
-                                                                     UUID sourceId) {
+      SourceConnectionImplementation sourceImplementation,
+      UUID sourceId) {
     SourceImplementationRead sourceImplementationRead = new SourceImplementationRead();
     sourceImplementationRead.setSourceId(sourceId);
     sourceImplementationRead.setWorkspaceId(sourceImplementation.getWorkspaceId());


### PR DESCRIPTION
## What
* the frontend needs an endpoint that returns both connection and source data together. this is the one we backend-like endpoint we are including in the MVP. 
```
connectionList [{
	name: "string",
	source: {
		sourceId: "string",
		sourceName: "string",
	},
	schedule: {
    units: 0,
    timeUnit: "minutes"
  },
	lastSync: "timestamp",
	status: "active"
}, ...]
```

## How
* constructed by composing existing handlers.
* refactored some test helpers along the way to reuse struct creation.
* added a contract to `listJobs` interface that jobs are returned in descending order by created_at

## Recommended reading order
1. api config`dataline-api/src/main/openapi/config.yaml`
1. `WebBackendConnectionsHandler.java`
1. the rest
