### PR TITLE
delete connection if source is deleted

### DIFF
--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -222,6 +222,7 @@ paths:
       tags:
         - source_implementation
       summary: List source implementations for workspace
+      description: List source implementations for workspace. Does not return deleted source imeplementations.
       operationId: listSourceImplementationsForWorkspace
       requestBody:
         content:
@@ -545,6 +546,7 @@ paths:
       tags:
         - connection
       summary: Returns all connections for a workspace.
+      description: List connections for workspace. Does not return deleted connections.
       operationId: listConnectionsForWorkspace
       requestBody:
         content:

--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -150,6 +150,7 @@ paths:
           description: Source not found
         "422":
           $ref: "#/components/responses/InvalidInput"
+  # todo (cgardens) - rename to source_specifications/get_latest_from_source_id
   /v1/source_specifications/get:
     post:
       tags:

--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -222,7 +222,7 @@ paths:
       tags:
         - source_implementation
       summary: List source implementations for workspace
-      description: List source implementations for workspace. Does not return deleted source imeplementations.
+      description: List source implementations for workspace. Does not return deleted source implementations.
       operationId: listSourceImplementationsForWorkspace
       requestBody:
         content:

--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -1027,8 +1027,7 @@ components:
     ConnectionUpdate:
       type: object
       required:
-        - sourceImplementationId
-        - destinationImplementationId
+        - connectionId
         - syncSchema
         - status
       properties:

--- a/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
+++ b/dataline-server/src/main/java/io/dataline/server/apis/ConfigurationApi.java
@@ -100,11 +100,11 @@ public class ConfigurationApi implements io.dataline.api.V1Api {
     workspacesHandler = new WorkspacesHandler(configPersistence);
     sourcesHandler = new SourcesHandler(configPersistence);
     sourceSpecificationsHandler = new SourceSpecificationsHandler(configPersistence);
-    sourceImplementationsHandler = new SourceImplementationsHandler(configPersistence, integrationSchemaValidation);
+    connectionsHandler = new ConnectionsHandler(configPersistence);
+    sourceImplementationsHandler = new SourceImplementationsHandler(configPersistence, integrationSchemaValidation, connectionsHandler);
     destinationsHandler = new DestinationsHandler(configPersistence);
     destinationSpecificationsHandler = new DestinationSpecificationsHandler(configPersistence);
     destinationImplementationsHandler = new DestinationImplementationsHandler(configPersistence, integrationSchemaValidation);
-    connectionsHandler = new ConnectionsHandler(configPersistence);
     final SchedulerPersistence schedulerPersistence = new DefaultSchedulerPersistence(connectionPool);
     schedulerHandler = new SchedulerHandler(configPersistence, schedulerPersistence);
     jobHistoryHandler = new JobHistoryHandler(schedulerPersistence);

--- a/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
@@ -164,7 +164,7 @@ public class ConnectionsHandler {
                     .getWorkspaceId()
                     .equals(workspaceIdRequestBody.getWorkspaceId()))
             // filter out deprecated connections
-            .filter(standardSync -> standardSync.getStatus().equals(StandardSync.Status.DEPRECATED))
+            .filter(standardSync -> !standardSync.getStatus().equals(StandardSync.Status.DEPRECATED))
             // pull the sync schedule
             // convert to api format
             .map(

--- a/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java
@@ -163,7 +163,8 @@ public class ConnectionsHandler {
                     configPersistence, standardSync.getSourceImplementationId())
                     .getWorkspaceId()
                     .equals(workspaceIdRequestBody.getWorkspaceId()))
-
+            // filter out deprecated connections
+            .filter(standardSync -> standardSync.getStatus().equals(StandardSync.Status.DEPRECATED))
             // pull the sync schedule
             // convert to api format
             .map(

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -121,10 +121,8 @@ public class SourceImplementationsHandler {
 
     final List<SourceImplementationRead> reads =
         ConfigFetchers.getSourceConnectionImplementations(configPersistence).stream()
-            .filter(
-                sourceConnectionImplementation -> sourceConnectionImplementation
-                    .getWorkspaceId()
-                    .equals(workspaceIdRequestBody.getWorkspaceId()))
+            .filter(sourceImpl -> sourceImpl.getWorkspaceId().equals(workspaceIdRequestBody.getWorkspaceId()))
+            .filter(sourceImpl -> !sourceImpl.getTombstone())
             .map(
                 sourceConnectionImplementation -> {
                   final UUID sourceId =


### PR DESCRIPTION
## What
* When we delete a source we should also delete any associated connections
* We should not show deleted connections in connections/list
* We should not show deleted source_implementations in source_implementations/list

## How
* Pass a connectionsHandler into sourceHandler. The way I see it, the other option is to split the handlers into model and handler (i.e. model and controller). I don't want to spend the time doing that refactor right now. I don't like this approach, and if the reviewer feels it's too terrible, I'm amenable to just do the model / controller refactor for connection.

## Recommended reading order
1. `dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java`
1. `dataline-server/src/main/java/io/dataline/server/handlers/ConnectionsHandler.java`
1. `dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java`
1. the rest
