### PR TITLE
Use JsonNode to play well with frontend

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -66,7 +66,7 @@ WORKDIR /app
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/${WAIT_VERSION}/wait wait
 RUN chmod +x wait
 
-COPY --from=build /code/dataline-config-init/src/main/resources/config data/config
+COPY --from=build /code/dataline-config/init/src/main/resources/config data/config
 COPY --from=build /code/${APPLICATION}/build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
@@ -88,7 +88,7 @@ WORKDIR /app
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/${WAIT_VERSION}/wait wait
 RUN chmod +x wait
 
-COPY --from=build /code/dataline-config-init/src/main/resources/config data/config
+COPY --from=build /code/dataline-config/init/src/main/resources/config data/config
 COPY --from=build /code/${APPLICATION}/build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,8 @@ subprojects {
             implementation project(':dataline-commons')
         }
 
+        implementation(platform("com.fasterxml.jackson:jackson-bom:2.10.4"))
+
         implementation group: 'com.google.guava', name: 'guava', version: '29.0-jre'
 
         implementation group: 'commons-io', name: 'commons-io', version: '2.7'

--- a/dataline-api/build.gradle
+++ b/dataline-api/build.gradle
@@ -8,7 +8,7 @@ def specFile = "$projectDir/src/main/openapi/config.yaml".toString()
 openApiGenerate {
     generatorName = "jaxrs-spec"
     inputSpec = specFile
-    outputDir = "$buildDir/generated".toString()
+    outputDir = "$buildDir/generated"
 
     apiPackage = "io.dataline.api"
     invokerPackage = "io.dataline.api.invoker"
@@ -24,7 +24,7 @@ openApiGenerate {
 }
 
 dependencies {
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.11.2'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
 
     implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.2'
 

--- a/dataline-api/build.gradle
+++ b/dataline-api/build.gradle
@@ -14,6 +14,13 @@ openApiGenerate {
     invokerPackage = "io.dataline.api.invoker"
     modelPackage = "io.dataline.api.model"
 
+    importMappings = [
+        'SourceSpecification' : 'com.fasterxml.jackson.databind.JsonNode',
+        'SourceConfiguration' : 'com.fasterxml.jackson.databind.JsonNode',
+        'DestinationSpecification' : 'com.fasterxml.jackson.databind.JsonNode',
+        'DestinationConfiguration' : 'com.fasterxml.jackson.databind.JsonNode',
+    ]
+
     generateApiDocumentation = false
 
     configOptions = [
@@ -25,6 +32,7 @@ openApiGenerate {
 
 dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
 
     implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.2'
 

--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -793,7 +793,7 @@ components:
           $ref: "#/components/schemas/SourceSpecificationId"
         sourceId:
           $ref: "#/components/schemas/SourceId"
-        connectionSpecification:
+        connectionSpecification12345:
           description: The specification for what values are required to configure the source.
           example: { user: { type: string } }
     # SOURCE IMPLEMENTATION
@@ -821,7 +821,7 @@ components:
           $ref: "#/components/schemas/WorkspaceId"
         sourceSpecificationId:
           $ref: "#/components/schemas/SourceSpecificationId"
-        connectionConfiguration:
+        connectionConfiguration12345:
           $ref: "#/components/schemas/SourceConfigurationField"
     SourceImplementationUpdate:
       type: object
@@ -831,7 +831,7 @@ components:
       properties:
         sourceImplementationId:
           $ref: "#/components/schemas/SourceImplementationId"
-        connectionConfiguration:
+        connectionConfiguration12345:
           $ref: "#/components/schemas/SourceConfigurationField"
     SourceImplementationRead:
       type: object
@@ -850,7 +850,7 @@ components:
           $ref: "#/components/schemas/WorkspaceId"
         sourceSpecificationId:
           $ref: "#/components/schemas/SourceSpecificationId"
-        connectionConfiguration:
+        connectionConfiguration12345:
           $ref: "#/components/schemas/SourceConfigurationField"
     SourceImplementationReadList:
       type: object
@@ -913,7 +913,7 @@ components:
           $ref: "#/components/schemas/DestinationSpecificationId"
         destinationId:
           $ref: "#/components/schemas/DestinationId"
-        connectionSpecification:
+        connectionSpecification12345:
           description: The specification for what values are required to configure the destination.
           example: { user: { type: string } }
     # DESTINATION IMPLEMENTATION
@@ -927,6 +927,9 @@ components:
       properties:
         destinationImplementationId:
           $ref: "#/components/schemas/SourceImplementationId"
+    DestinationConfigurationField:
+      description: The values required to configure the destination. The schema for this must match the schema return by destination_specifications/get for the destination.
+      example: { user: "charles" }
     DestinationImplementationCreate:
       type: object
       required:
@@ -938,9 +941,8 @@ components:
           $ref: "#/components/schemas/WorkspaceId"
         destinationSpecificationId:
           $ref: "#/components/schemas/DestinationSpecificationId"
-        connectionConfiguration:
-          description: The values required to configure the destination. The schema for this must match the schema return by destination_specifications/get for the source.
-          example: { user: "charles" }
+        connectionConfiguration12345:
+          $ref: "#/components/schemas/DestinationConfigurationField"
     DestinationImplementationUpdate:
       type: object
       required:
@@ -949,9 +951,8 @@ components:
       properties:
         destinationImplementationId:
           $ref: "#/components/schemas/DestinationImplementationId"
-        connectionConfiguration:
-          description: The values required to configure the destination. The schema for this must match the schema return by destination_specifications/get for the source.
-          example: { user: "charles" }
+        connectionConfiguration12345:
+          $ref: "#/components/schemas/DestinationConfigurationField"
     DestinationImplementationRead:
       type: object
       required:
@@ -969,9 +970,8 @@ components:
           $ref: "#/components/schemas/WorkspaceId"
         destinationSpecificationId:
           $ref: "#/components/schemas/DestinationSpecificationId"
-        connectionConfiguration:
-          description: The values required to configure the destination. The schema for this must match the schema return by destination_specifications/get for the source.
-          example: { user: "charles" }
+        connectionConfiguration12345:
+          $ref: "#/components/schemas/DestinationConfigurationField"
     DestinationImplementationReadList:
       type: object
       required:

--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -782,6 +782,9 @@ components:
     SourceSpecificationId:
       type: string
       format: uuid
+    SourceSpecification:
+      description: The specification for what values are required to configure the source.
+      example: { user: { type: string } }
     SourceSpecificationRead:
       type: object
       required:
@@ -794,8 +797,7 @@ components:
         sourceId:
           $ref: "#/components/schemas/SourceId"
         connectionSpecification:
-          description: The specification for what values are required to configure the source.
-          example: { user: { type: string } }
+          $ref: "#/components/schemas/SourceSpecification"
     # SOURCE IMPLEMENTATION
     SourceImplementationId:
       type: string
@@ -807,7 +809,7 @@ components:
       properties:
         sourceImplementationId:
           $ref: "#/components/schemas/SourceImplementationId"
-    SourceConfigurationField:
+    SourceConfiguration:
       description: The values required to configure the source. The schema for this must match the schema return by source_specifications/get for the source.
       example: { user: "charles" }
     SourceImplementationCreate:
@@ -822,7 +824,7 @@ components:
         sourceSpecificationId:
           $ref: "#/components/schemas/SourceSpecificationId"
         connectionConfiguration:
-          $ref: "#/components/schemas/SourceConfigurationField"
+          $ref: "#/components/schemas/SourceConfiguration"
     SourceImplementationUpdate:
       type: object
       required:
@@ -832,7 +834,7 @@ components:
         sourceImplementationId:
           $ref: "#/components/schemas/SourceImplementationId"
         connectionConfiguration:
-          $ref: "#/components/schemas/SourceConfigurationField"
+          $ref: "#/components/schemas/SourceConfiguration"
     SourceImplementationRead:
       type: object
       required:
@@ -851,7 +853,7 @@ components:
         sourceSpecificationId:
           $ref: "#/components/schemas/SourceSpecificationId"
         connectionConfiguration:
-          $ref: "#/components/schemas/SourceConfigurationField"
+          $ref: "#/components/schemas/SourceConfiguration"
     SourceImplementationReadList:
       type: object
       required:
@@ -902,6 +904,9 @@ components:
     DestinationSpecificationId:
       type: string
       format: uuid
+    DestinationSpecification:
+      description: The specification for what values are required to configure the destination.
+      example: { user: { type: string } }
     DestinationSpecificationRead:
       type: object
       required:
@@ -914,8 +919,7 @@ components:
         destinationId:
           $ref: "#/components/schemas/DestinationId"
         connectionSpecification:
-          description: The specification for what values are required to configure the destination.
-          example: { user: { type: string } }
+          $ref: "#/components/schemas/DestinationSpecification"
     # DESTINATION IMPLEMENTATION
     DestinationImplementationId:
       type: string
@@ -927,7 +931,7 @@ components:
       properties:
         destinationImplementationId:
           $ref: "#/components/schemas/SourceImplementationId"
-    DestinationConfigurationField:
+    DestinationConfiguration:
       description: The values required to configure the destination. The schema for this must match the schema return by destination_specifications/get for the destination.
       example: { user: "charles" }
     DestinationImplementationCreate:
@@ -942,7 +946,7 @@ components:
         destinationSpecificationId:
           $ref: "#/components/schemas/DestinationSpecificationId"
         connectionConfiguration:
-          $ref: "#/components/schemas/DestinationConfigurationField"
+          $ref: "#/components/schemas/DestinationConfiguration"
     DestinationImplementationUpdate:
       type: object
       required:
@@ -952,7 +956,7 @@ components:
         destinationImplementationId:
           $ref: "#/components/schemas/DestinationImplementationId"
         connectionConfiguration:
-          $ref: "#/components/schemas/DestinationConfigurationField"
+          $ref: "#/components/schemas/DestinationConfiguration"
     DestinationImplementationRead:
       type: object
       required:
@@ -971,7 +975,7 @@ components:
         destinationSpecificationId:
           $ref: "#/components/schemas/DestinationSpecificationId"
         connectionConfiguration:
-          $ref: "#/components/schemas/DestinationConfigurationField"
+          $ref: "#/components/schemas/DestinationConfiguration"
     DestinationImplementationReadList:
       type: object
       required:

--- a/dataline-api/src/main/openapi/config.yaml
+++ b/dataline-api/src/main/openapi/config.yaml
@@ -793,7 +793,7 @@ components:
           $ref: "#/components/schemas/SourceSpecificationId"
         sourceId:
           $ref: "#/components/schemas/SourceId"
-        connectionSpecification12345:
+        connectionSpecification:
           description: The specification for what values are required to configure the source.
           example: { user: { type: string } }
     # SOURCE IMPLEMENTATION
@@ -821,7 +821,7 @@ components:
           $ref: "#/components/schemas/WorkspaceId"
         sourceSpecificationId:
           $ref: "#/components/schemas/SourceSpecificationId"
-        connectionConfiguration12345:
+        connectionConfiguration:
           $ref: "#/components/schemas/SourceConfigurationField"
     SourceImplementationUpdate:
       type: object
@@ -831,7 +831,7 @@ components:
       properties:
         sourceImplementationId:
           $ref: "#/components/schemas/SourceImplementationId"
-        connectionConfiguration12345:
+        connectionConfiguration:
           $ref: "#/components/schemas/SourceConfigurationField"
     SourceImplementationRead:
       type: object
@@ -850,7 +850,7 @@ components:
           $ref: "#/components/schemas/WorkspaceId"
         sourceSpecificationId:
           $ref: "#/components/schemas/SourceSpecificationId"
-        connectionConfiguration12345:
+        connectionConfiguration:
           $ref: "#/components/schemas/SourceConfigurationField"
     SourceImplementationReadList:
       type: object
@@ -913,7 +913,7 @@ components:
           $ref: "#/components/schemas/DestinationSpecificationId"
         destinationId:
           $ref: "#/components/schemas/DestinationId"
-        connectionSpecification12345:
+        connectionSpecification:
           description: The specification for what values are required to configure the destination.
           example: { user: { type: string } }
     # DESTINATION IMPLEMENTATION
@@ -941,7 +941,7 @@ components:
           $ref: "#/components/schemas/WorkspaceId"
         destinationSpecificationId:
           $ref: "#/components/schemas/DestinationSpecificationId"
-        connectionConfiguration12345:
+        connectionConfiguration:
           $ref: "#/components/schemas/DestinationConfigurationField"
     DestinationImplementationUpdate:
       type: object
@@ -951,7 +951,7 @@ components:
       properties:
         destinationImplementationId:
           $ref: "#/components/schemas/DestinationImplementationId"
-        connectionConfiguration12345:
+        connectionConfiguration:
           $ref: "#/components/schemas/DestinationConfigurationField"
     DestinationImplementationRead:
       type: object
@@ -970,7 +970,7 @@ components:
           $ref: "#/components/schemas/WorkspaceId"
         destinationSpecificationId:
           $ref: "#/components/schemas/DestinationSpecificationId"
-        connectionConfiguration12345:
+        connectionConfiguration:
           $ref: "#/components/schemas/DestinationConfigurationField"
     DestinationImplementationReadList:
       type: object

--- a/dataline-commons/build.gradle
+++ b/dataline-commons/build.gradle
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.9.8"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
 }

--- a/dataline-commons/src/main/java/io/dataline/commons/json/Jsons.java
+++ b/dataline-commons/src/main/java/io/dataline/commons/json/Jsons.java
@@ -43,10 +43,6 @@ public class Jsons {
     }
   }
 
-  public static String serializeJsonNode(final JsonNode jsonNode) {
-    return jsonNode.toString();
-  }
-
   public static <T> T deserialize(final String jsonString, final Class<T> klass) {
     try {
       return OBJECT_MAPPER.readValue(jsonString, klass);

--- a/dataline-commons/src/test/java/io/dataline/commons/json/JsonsTest.java
+++ b/dataline-commons/src/test/java/io/dataline/commons/json/JsonsTest.java
@@ -38,10 +38,7 @@ class JsonsTest {
     Assertions.assertEquals(
         "{\"str\":\"abc\",\"num\":999,\"numLong\":888}",
         Jsons.serialize(new ToClass("abc", 999, 888L)));
-  }
 
-  @Test
-  void testSerializeMap() {
     Assertions.assertEquals(
         "{\"test\":\"abc\",\"test2\":\"def\"}",
         Jsons.serialize(
@@ -54,7 +51,13 @@ class JsonsTest {
   void testSerializeJsonNode() {
     Assertions.assertEquals(
         "{\"str\":\"abc\",\"num\":999,\"numLong\":888}",
-        Jsons.serializeJsonNode(Jsons.jsonNode(new ToClass("abc", 999, 888L))));
+        Jsons.serialize(Jsons.jsonNode(new ToClass("abc", 999, 888L))));
+
+    Assertions.assertEquals(
+        "{\"test\":\"abc\",\"test2\":\"def\"}",
+        Jsons.serialize(Jsons.jsonNode(ImmutableMap.of(
+            "test", "abc",
+            "test2", "def"))));
   }
 
   @Test
@@ -66,7 +69,9 @@ class JsonsTest {
 
   @Test
   void testDeserializeToJsonNode() {
-    Assertions.assertEquals("{\"str\":\"abc\"}", Jsons.deserialize("{\"str\":\"abc\"}").toString());
+    Assertions.assertEquals(
+        "{\"str\":\"abc\"}",
+        Jsons.deserialize("{\"str\":\"abc\"}").toString());
 
     Assertions.assertEquals(
         "[{\"str\":\"abc\"},{\"str\":\"abc\"}]",
@@ -87,10 +92,12 @@ class JsonsTest {
   @Test
   void testTryDeserializeToJsonNode() {
     Assertions.assertEquals(
-        Jsons.deserialize("{\"str\":\"abc\"}"), Jsons.tryDeserialize("{\"str\":\"abc\"}").get());
+        Jsons.deserialize("{\"str\":\"abc\"}"),
+        Jsons.tryDeserialize("{\"str\":\"abc\"}").get());
 
     Assertions.assertEquals(
-        Optional.empty(), Jsons.tryDeserialize("{\"str\":\"abc\", \"num\": 999, \"test}"));
+        Optional.empty(),
+        Jsons.tryDeserialize("{\"str\":\"abc\", \"num\": 999, \"test}"));
   }
 
   @Test
@@ -106,6 +113,18 @@ class JsonsTest {
                 "test", "abc",
                 "test2", "def"))
             .toString());
+
+    Assertions.assertEquals(
+        "{\"test\":\"abc\",\"test2\":{\"inner\":1}}",
+        Jsons.jsonNode(
+            ImmutableMap.of(
+                "test", "abc",
+                "test2", ImmutableMap.of("inner", 1)))
+            .toString());
+
+    Assertions.assertEquals(
+        Jsons.jsonNode(new ToClass("abc", 999, 888L)),
+        Jsons.jsonNode(Jsons.jsonNode(new ToClass("abc", 999, 888L))));
   }
 
   private static class ToClass {

--- a/dataline-config/models/build.gradle
+++ b/dataline-config/models/build.gradle
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
-    implementation 'javax.validation:validation-api:1.1.0.Final'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.7'
+    implementation group: 'javax.validation', name: 'validation-api', version: '1.1.0.Final'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
 }
 
 jsonSchema2Pojo {

--- a/dataline-config/models/src/main/resources/json/DestinationConnectionImplementation.json
+++ b/dataline-config/models/src/main/resources/json/DestinationConnectionImplementation.json
@@ -24,7 +24,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "configurationJson": {
+    "configuration": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/DestinationConnectionImplementation.json
+++ b/dataline-config/models/src/main/resources/json/DestinationConnectionImplementation.json
@@ -24,7 +24,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "configurationJson12345": {
+    "configurationJson": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/DestinationConnectionImplementation.json
+++ b/dataline-config/models/src/main/resources/json/DestinationConnectionImplementation.json
@@ -25,8 +25,9 @@
       "format": "uuid"
     },
     "configurationJson": {
-      "type": "string",
-      "description": "Integration specific blob. Must be a valid JSON string."
+      "description": "Integration specific blob. Must be a valid JSON string.",
+      "type": "object",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     }
   }
 }

--- a/dataline-config/models/src/main/resources/json/DestinationConnectionImplementation.json
+++ b/dataline-config/models/src/main/resources/json/DestinationConnectionImplementation.json
@@ -24,7 +24,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "configurationJson": {
+    "configurationJson12345": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/DestinationConnectionSpecification.json
+++ b/dataline-config/models/src/main/resources/json/DestinationConnectionSpecification.json
@@ -15,7 +15,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "specificationJson": {
+    "specificationJson12345": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/DestinationConnectionSpecification.json
+++ b/dataline-config/models/src/main/resources/json/DestinationConnectionSpecification.json
@@ -15,7 +15,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "specificationJson12345": {
+    "specificationJson": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/DestinationConnectionSpecification.json
+++ b/dataline-config/models/src/main/resources/json/DestinationConnectionSpecification.json
@@ -15,7 +15,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "specificationJson": {
+    "specification": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/DestinationConnectionSpecification.json
+++ b/dataline-config/models/src/main/resources/json/DestinationConnectionSpecification.json
@@ -16,8 +16,9 @@
       "format": "uuid"
     },
     "specificationJson": {
-      "type": "string",
-      "description": "Integration specific blob. Must be a valid JSON string."
+      "description": "Integration specific blob. Must be a valid JSON string.",
+      "type": "object",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     }
   }
 }

--- a/dataline-config/models/src/main/resources/json/JobCheckConnectionConfig.json
+++ b/dataline-config/models/src/main/resources/json/JobCheckConnectionConfig.json
@@ -7,7 +7,7 @@
   "additionalProperties": false,
   "required": ["connectionConfiguration", "dockerImage"],
   "properties": {
-    "connectionConfigurationJson12345": {
+    "connectionConfigurationJson": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/JobCheckConnectionConfig.json
+++ b/dataline-config/models/src/main/resources/json/JobCheckConnectionConfig.json
@@ -7,7 +7,7 @@
   "additionalProperties": false,
   "required": ["connectionConfiguration", "dockerImage"],
   "properties": {
-    "connectionConfigurationJson": {
+    "connectionConfiguration": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/JobCheckConnectionConfig.json
+++ b/dataline-config/models/src/main/resources/json/JobCheckConnectionConfig.json
@@ -7,7 +7,7 @@
   "additionalProperties": false,
   "required": ["connectionConfiguration", "dockerImage"],
   "properties": {
-    "connectionConfigurationJson": {
+    "connectionConfigurationJson12345": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/JobCheckConnectionConfig.json
+++ b/dataline-config/models/src/main/resources/json/JobCheckConnectionConfig.json
@@ -8,8 +8,9 @@
   "required": ["connectionConfiguration", "dockerImage"],
   "properties": {
     "connectionConfigurationJson": {
-      "type": "string",
-      "description": "Integration specific blob. Must be a valid JSON string."
+      "description": "Integration specific blob. Must be a valid JSON string.",
+      "type": "object",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     },
     "dockerImage": {
       "type": "string"

--- a/dataline-config/models/src/main/resources/json/JobDiscoverSchemaConfig.json
+++ b/dataline-config/models/src/main/resources/json/JobDiscoverSchemaConfig.json
@@ -7,7 +7,7 @@
   "additionalProperties": false,
   "required": ["connectionConfiguration", "dockerImage"],
   "properties": {
-    "connectionConfigurationJson12345": {
+    "connectionConfigurationJson": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/JobDiscoverSchemaConfig.json
+++ b/dataline-config/models/src/main/resources/json/JobDiscoverSchemaConfig.json
@@ -7,7 +7,7 @@
   "additionalProperties": false,
   "required": ["connectionConfiguration", "dockerImage"],
   "properties": {
-    "connectionConfigurationJson": {
+    "connectionConfiguration": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/JobDiscoverSchemaConfig.json
+++ b/dataline-config/models/src/main/resources/json/JobDiscoverSchemaConfig.json
@@ -7,7 +7,7 @@
   "additionalProperties": false,
   "required": ["connectionConfiguration", "dockerImage"],
   "properties": {
-    "connectionConfigurationJson": {
+    "connectionConfigurationJson12345": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/JobDiscoverSchemaConfig.json
+++ b/dataline-config/models/src/main/resources/json/JobDiscoverSchemaConfig.json
@@ -8,8 +8,9 @@
   "required": ["connectionConfiguration", "dockerImage"],
   "properties": {
     "connectionConfigurationJson": {
-      "type": "string",
-      "description": "Integration specific blob. Must be a valid JSON string."
+      "description": "Integration specific blob. Must be a valid JSON string.",
+      "type": "object",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     },
     "dockerImage": {
       "type": "string"

--- a/dataline-config/models/src/main/resources/json/SingerMessage.json
+++ b/dataline-config/models/src/main/resources/json/SingerMessage.json
@@ -23,7 +23,7 @@
     "record": {
       "description": "record message: must me a JSON object",
       "type": "object",
-      "javaName": "recordJson12345",
+      "javaName": "recordJson",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     },
     "schema": {
@@ -47,7 +47,7 @@
     "value": {
       "description": "value message: must me a JSON object",
       "type": "object",
-      "javaName": "valueJson12345",
+      "javaName": "valueJson",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     }
   }

--- a/dataline-config/models/src/main/resources/json/SingerMessage.json
+++ b/dataline-config/models/src/main/resources/json/SingerMessage.json
@@ -23,7 +23,6 @@
     "record": {
       "description": "record message: must me a JSON object",
       "type": "object",
-      "javaName": "recordJson",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     },
     "schema": {
@@ -47,7 +46,6 @@
     "value": {
       "description": "value message: must me a JSON object",
       "type": "object",
-      "javaName": "valueJson",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     }
   }

--- a/dataline-config/models/src/main/resources/json/SingerMessage.json
+++ b/dataline-config/models/src/main/resources/json/SingerMessage.json
@@ -22,7 +22,9 @@
     },
     "record": {
       "description": "record message: must me a JSON object",
-      "type": "string"
+      "type": "object",
+      "javaName": "recordJson",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     },
     "schema": {
       "description": "schema message: the schema",
@@ -43,7 +45,10 @@
       }
     },
     "value": {
-      "description": "state message: no schema, just a map of string to object!"
+      "description": "value message: must me a JSON object",
+      "type": "object",
+      "javaName": "valueJson",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     }
   }
 }

--- a/dataline-config/models/src/main/resources/json/SingerMessage.json
+++ b/dataline-config/models/src/main/resources/json/SingerMessage.json
@@ -23,7 +23,7 @@
     "record": {
       "description": "record message: must me a JSON object",
       "type": "object",
-      "javaName": "recordJson",
+      "javaName": "recordJson12345",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     },
     "schema": {
@@ -47,7 +47,7 @@
     "value": {
       "description": "value message: must me a JSON object",
       "type": "object",
-      "javaName": "valueJson",
+      "javaName": "valueJson12345",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     }
   }

--- a/dataline-config/models/src/main/resources/json/SourceConnectionImplementation.json
+++ b/dataline-config/models/src/main/resources/json/SourceConnectionImplementation.json
@@ -25,7 +25,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "configurationJson": {
+    "configurationJson12345": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/SourceConnectionImplementation.json
+++ b/dataline-config/models/src/main/resources/json/SourceConnectionImplementation.json
@@ -26,8 +26,9 @@
       "format": "uuid"
     },
     "configurationJson": {
-      "type": "string",
-      "description": "Integration specific blob. Must be a valid JSON string."
+      "description": "Integration specific blob. Must be a valid JSON string.",
+      "type": "object",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     },
     "tombstone": {
       "description": "if not set or false, the configuration is active. if true, then this configuration is permanently off.",

--- a/dataline-config/models/src/main/resources/json/SourceConnectionImplementation.json
+++ b/dataline-config/models/src/main/resources/json/SourceConnectionImplementation.json
@@ -25,7 +25,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "configurationJson": {
+    "configuration": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/SourceConnectionImplementation.json
+++ b/dataline-config/models/src/main/resources/json/SourceConnectionImplementation.json
@@ -25,7 +25,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "configurationJson12345": {
+    "configurationJson": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/SourceConnectionSpecification.json
+++ b/dataline-config/models/src/main/resources/json/SourceConnectionSpecification.json
@@ -15,7 +15,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "specificationJson": {
+    "specificationJson12345": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/SourceConnectionSpecification.json
+++ b/dataline-config/models/src/main/resources/json/SourceConnectionSpecification.json
@@ -15,7 +15,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "specificationJson12345": {
+    "specificationJson": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/SourceConnectionSpecification.json
+++ b/dataline-config/models/src/main/resources/json/SourceConnectionSpecification.json
@@ -15,7 +15,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "specificationJson": {
+    "specification": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/SourceConnectionSpecification.json
+++ b/dataline-config/models/src/main/resources/json/SourceConnectionSpecification.json
@@ -16,8 +16,9 @@
       "format": "uuid"
     },
     "specificationJson": {
-      "type": "string",
-      "description": "Integration specific blob. Must be a valid JSON string."
+      "description": "Integration specific blob. Must be a valid JSON string.",
+      "type": "object",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     }
   }
 }

--- a/dataline-config/models/src/main/resources/json/StandardCheckConnectionInput.json
+++ b/dataline-config/models/src/main/resources/json/StandardCheckConnectionInput.json
@@ -8,8 +8,9 @@
   "additionalProperties": false,
   "properties": {
     "connectionConfigurationJson": {
-      "type": "string",
-      "description": "Integration specific blob. Must be a valid JSON string."
+      "description": "Integration specific blob. Must be a valid JSON string.",
+      "type": "object",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     }
   }
 }

--- a/dataline-config/models/src/main/resources/json/StandardCheckConnectionInput.json
+++ b/dataline-config/models/src/main/resources/json/StandardCheckConnectionInput.json
@@ -7,7 +7,7 @@
   "required": ["connectionConfiguration"],
   "additionalProperties": false,
   "properties": {
-    "connectionConfigurationJson": {
+    "connectionConfigurationJson12345": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/StandardCheckConnectionInput.json
+++ b/dataline-config/models/src/main/resources/json/StandardCheckConnectionInput.json
@@ -7,7 +7,7 @@
   "required": ["connectionConfiguration"],
   "additionalProperties": false,
   "properties": {
-    "connectionConfigurationJson": {
+    "connectionConfiguration": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/StandardCheckConnectionInput.json
+++ b/dataline-config/models/src/main/resources/json/StandardCheckConnectionInput.json
@@ -7,7 +7,7 @@
   "required": ["connectionConfiguration"],
   "additionalProperties": false,
   "properties": {
-    "connectionConfigurationJson12345": {
+    "connectionConfigurationJson": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/StandardDiscoverSchemaInput.json
+++ b/dataline-config/models/src/main/resources/json/StandardDiscoverSchemaInput.json
@@ -8,8 +8,9 @@
   "additionalProperties": false,
   "properties": {
     "connectionConfigurationJson": {
-      "type": "string",
-      "description": "Integration specific blob. Must be a valid JSON string."
+      "description": "Integration specific blob. Must be a valid JSON string.",
+      "type": "object",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     }
   }
 }

--- a/dataline-config/models/src/main/resources/json/StandardDiscoverSchemaInput.json
+++ b/dataline-config/models/src/main/resources/json/StandardDiscoverSchemaInput.json
@@ -7,7 +7,7 @@
   "required": ["connectionConfiguration"],
   "additionalProperties": false,
   "properties": {
-    "connectionConfigurationJson": {
+    "connectionConfigurationJson12345": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/StandardDiscoverSchemaInput.json
+++ b/dataline-config/models/src/main/resources/json/StandardDiscoverSchemaInput.json
@@ -7,7 +7,7 @@
   "required": ["connectionConfiguration"],
   "additionalProperties": false,
   "properties": {
-    "connectionConfigurationJson": {
+    "connectionConfiguration": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/StandardDiscoverSchemaInput.json
+++ b/dataline-config/models/src/main/resources/json/StandardDiscoverSchemaInput.json
@@ -7,7 +7,7 @@
   "required": ["connectionConfiguration"],
   "additionalProperties": false,
   "properties": {
-    "connectionConfigurationJson12345": {
+    "connectionConfigurationJson": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/State.json
+++ b/dataline-config/models/src/main/resources/json/State.json
@@ -11,7 +11,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "stateJson": {
+    "stateJson12345": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/State.json
+++ b/dataline-config/models/src/main/resources/json/State.json
@@ -11,7 +11,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "stateJson": {
+    "state": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/State.json
+++ b/dataline-config/models/src/main/resources/json/State.json
@@ -11,7 +11,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "stateJson12345": {
+    "stateJson": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",
       "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"

--- a/dataline-config/models/src/main/resources/json/State.json
+++ b/dataline-config/models/src/main/resources/json/State.json
@@ -12,8 +12,9 @@
       "format": "uuid"
     },
     "stateJson": {
-      "type": "string",
-      "description": "Integration specific blob. Must be a valid JSON string."
+      "description": "Integration specific blob. Must be a valid JSON string.",
+      "type": "object",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
     }
   }
 }

--- a/dataline-config/persistence/build.gradle
+++ b/dataline-config/persistence/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: '2.7'
 
-    implementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.8"
-    implementation group: "com.networknt", name: "json-schema-validator", version: "1.0.42"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+    implementation group: 'com.networknt', name: 'json-schema-validator', version: '1.0.42'
     // needed so that we can follow $ref when parsing json. jackson does not support this natively.
     implementation 'me.andrz.jackson:jackson-json-reference-core:0.3.2'
 

--- a/dataline-scheduler/build.gradle
+++ b/dataline-scheduler/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
 
     implementation project(':dataline-config:models')
     implementation project(':dataline-config:persistence')

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/DefaultSchedulerPersistence.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/DefaultSchedulerPersistence.java
@@ -68,7 +68,7 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
             sourceImplementation.getSourceImplementationId().toString());
 
     final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig();
-    jobCheckConnectionConfig.setConnectionConfigurationJson(sourceImplementation.getConfigurationJson());
+    jobCheckConnectionConfig.setConnectionConfiguration(sourceImplementation.getConfiguration());
     jobCheckConnectionConfig.setDockerImage(
         Integrations.findBySpecId(sourceImplementation.getSourceSpecificationId())
             .getCheckConnectionImage());
@@ -89,7 +89,7 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
             destinationImplementation.getDestinationImplementationId().toString());
 
     final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig();
-    jobCheckConnectionConfig.setConnectionConfigurationJson(destinationImplementation.getConfigurationJson());
+    jobCheckConnectionConfig.setConnectionConfiguration(destinationImplementation.getConfiguration());
     jobCheckConnectionConfig.setDockerImage(
         Integrations.findBySpecId(destinationImplementation.getDestinationSpecificationId())
             .getCheckConnectionImage());
@@ -111,7 +111,7 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
             sourceImplementation.getSourceImplementationId().toString());
 
     final JobDiscoverSchemaConfig jobDiscoverSchemaConfig = new JobDiscoverSchemaConfig();
-    jobDiscoverSchemaConfig.setConnectionConfigurationJson(sourceImplementation.getConfigurationJson());
+    jobDiscoverSchemaConfig.setConnectionConfiguration(sourceImplementation.getConfiguration());
     jobDiscoverSchemaConfig.setDockerImage(
         Integrations.findBySpecId(sourceImplementation.getSourceSpecificationId())
             .getDiscoverSchemaImage());

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/DefaultSchedulerPersistence.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/DefaultSchedulerPersistence.java
@@ -68,7 +68,7 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
             sourceImplementation.getSourceImplementationId().toString());
 
     final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig();
-    jobCheckConnectionConfig.setConnectionConfigurationJson12345(sourceImplementation.getConfigurationJson12345());
+    jobCheckConnectionConfig.setConnectionConfigurationJson(sourceImplementation.getConfigurationJson());
     jobCheckConnectionConfig.setDockerImage(
         Integrations.findBySpecId(sourceImplementation.getSourceSpecificationId())
             .getCheckConnectionImage());
@@ -89,7 +89,7 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
             destinationImplementation.getDestinationImplementationId().toString());
 
     final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig();
-    jobCheckConnectionConfig.setConnectionConfigurationJson12345(destinationImplementation.getConfigurationJson12345());
+    jobCheckConnectionConfig.setConnectionConfigurationJson(destinationImplementation.getConfigurationJson());
     jobCheckConnectionConfig.setDockerImage(
         Integrations.findBySpecId(destinationImplementation.getDestinationSpecificationId())
             .getCheckConnectionImage());
@@ -111,7 +111,7 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
             sourceImplementation.getSourceImplementationId().toString());
 
     final JobDiscoverSchemaConfig jobDiscoverSchemaConfig = new JobDiscoverSchemaConfig();
-    jobDiscoverSchemaConfig.setConnectionConfigurationJson12345(sourceImplementation.getConfigurationJson12345());
+    jobDiscoverSchemaConfig.setConnectionConfigurationJson(sourceImplementation.getConfigurationJson());
     jobDiscoverSchemaConfig.setDockerImage(
         Integrations.findBySpecId(sourceImplementation.getSourceSpecificationId())
             .getDiscoverSchemaImage());

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/DefaultSchedulerPersistence.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/DefaultSchedulerPersistence.java
@@ -68,8 +68,7 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
             sourceImplementation.getSourceImplementationId().toString());
 
     final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig();
-    jobCheckConnectionConfig.setConnectionConfigurationJson(
-        sourceImplementation.getConfigurationJson());
+    jobCheckConnectionConfig.setConnectionConfigurationJson12345(sourceImplementation.getConfigurationJson12345());
     jobCheckConnectionConfig.setDockerImage(
         Integrations.findBySpecId(sourceImplementation.getSourceSpecificationId())
             .getCheckConnectionImage());
@@ -90,8 +89,7 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
             destinationImplementation.getDestinationImplementationId().toString());
 
     final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig();
-    jobCheckConnectionConfig.setConnectionConfigurationJson(
-        destinationImplementation.getConfigurationJson());
+    jobCheckConnectionConfig.setConnectionConfigurationJson12345(destinationImplementation.getConfigurationJson12345());
     jobCheckConnectionConfig.setDockerImage(
         Integrations.findBySpecId(destinationImplementation.getDestinationSpecificationId())
             .getCheckConnectionImage());
@@ -113,8 +111,7 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
             sourceImplementation.getSourceImplementationId().toString());
 
     final JobDiscoverSchemaConfig jobDiscoverSchemaConfig = new JobDiscoverSchemaConfig();
-    jobDiscoverSchemaConfig.setConnectionConfigurationJson(
-        sourceImplementation.getConfigurationJson());
+    jobDiscoverSchemaConfig.setConnectionConfigurationJson12345(sourceImplementation.getConfigurationJson12345());
     jobDiscoverSchemaConfig.setDockerImage(
         Integrations.findBySpecId(sourceImplementation.getSourceSpecificationId())
             .getDiscoverSchemaImage());

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
@@ -130,14 +130,14 @@ public class WorkerRunner implements Runnable {
 
   private static StandardCheckConnectionInput getCheckConnectionInput(JobCheckConnectionConfig config) {
     final StandardCheckConnectionInput checkConnectionInput = new StandardCheckConnectionInput();
-    checkConnectionInput.setConnectionConfigurationJson(config.getConnectionConfigurationJson());
+    checkConnectionInput.setConnectionConfigurationJson12345(config.getConnectionConfigurationJson12345());
 
     return checkConnectionInput;
   }
 
   private static StandardDiscoverSchemaInput getDiscoverSchemaInput(JobDiscoverSchemaConfig config) {
     final StandardDiscoverSchemaInput discoverSchemaInput = new StandardDiscoverSchemaInput();
-    discoverSchemaInput.setConnectionConfigurationJson(config.getConnectionConfigurationJson());
+    discoverSchemaInput.setConnectionConfigurationJson12345(config.getConnectionConfigurationJson12345());
 
     return discoverSchemaInput;
   }

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
@@ -130,14 +130,14 @@ public class WorkerRunner implements Runnable {
 
   private static StandardCheckConnectionInput getCheckConnectionInput(JobCheckConnectionConfig config) {
     final StandardCheckConnectionInput checkConnectionInput = new StandardCheckConnectionInput();
-    checkConnectionInput.setConnectionConfigurationJson(config.getConnectionConfigurationJson());
+    checkConnectionInput.setConnectionConfiguration(config.getConnectionConfiguration());
 
     return checkConnectionInput;
   }
 
   private static StandardDiscoverSchemaInput getDiscoverSchemaInput(JobDiscoverSchemaConfig config) {
     final StandardDiscoverSchemaInput discoverSchemaInput = new StandardDiscoverSchemaInput();
-    discoverSchemaInput.setConnectionConfigurationJson(config.getConnectionConfigurationJson());
+    discoverSchemaInput.setConnectionConfiguration(config.getConnectionConfiguration());
 
     return discoverSchemaInput;
   }

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
@@ -130,14 +130,14 @@ public class WorkerRunner implements Runnable {
 
   private static StandardCheckConnectionInput getCheckConnectionInput(JobCheckConnectionConfig config) {
     final StandardCheckConnectionInput checkConnectionInput = new StandardCheckConnectionInput();
-    checkConnectionInput.setConnectionConfigurationJson12345(config.getConnectionConfigurationJson12345());
+    checkConnectionInput.setConnectionConfigurationJson(config.getConnectionConfigurationJson());
 
     return checkConnectionInput;
   }
 
   private static StandardDiscoverSchemaInput getDiscoverSchemaInput(JobDiscoverSchemaConfig config) {
     final StandardDiscoverSchemaInput discoverSchemaInput = new StandardDiscoverSchemaInput();
-    discoverSchemaInput.setConnectionConfigurationJson12345(config.getConnectionConfigurationJson12345());
+    discoverSchemaInput.setConnectionConfigurationJson(config.getConnectionConfigurationJson());
 
     return discoverSchemaInput;
   }

--- a/dataline-server/build.gradle
+++ b/dataline-server/build.gradle
@@ -12,8 +12,8 @@ dependencies {
     implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: '2.31'
     implementation group: 'org.glassfish.jersey.ext', name: 'jersey-bean-validation', version: '2.31'
 
-    implementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.8"
-    implementation group: "com.networknt", name: "json-schema-validator", version: "1.0.42"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+    implementation group: 'com.networknt', name: 'json-schema-validator', version: '1.0.42'
 
 
     implementation project(':dataline-api')

--- a/dataline-server/build.gradle
+++ b/dataline-server/build.gradle
@@ -30,7 +30,7 @@ application {
 
 run {
     // default for running on local machine.
-    environment "CONFIG_ROOT", new File(".").absolutePath + "data/config"
+    environment "CONFIG_ROOT", rootProject.file('data/config')
     environment "VERSION", "0.1.0"
     environment "DATABASE_USER", "postgres"
     environment "DATABASE_PASSWORD", ""

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
@@ -31,7 +31,6 @@ import io.dataline.api.model.DestinationImplementationRead;
 import io.dataline.api.model.DestinationImplementationReadList;
 import io.dataline.api.model.DestinationImplementationUpdate;
 import io.dataline.api.model.WorkspaceIdRequestBody;
-import io.dataline.commons.json.Jsons;
 import io.dataline.config.DestinationConnectionImplementation;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.JsonValidationException;

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
@@ -67,7 +67,7 @@ public class DestinationImplementationsHandler {
     // validate configuration
     validateDestinationImplementation(
         destinationImplementationCreate.getDestinationSpecificationId(),
-        Jsons.jsonNode(destinationImplementationCreate.getConnectionConfiguration()));
+        destinationImplementationCreate.getConnectionConfiguration());
 
     // persist
     final UUID destinationImplementationId = uuidGenerator.get();
@@ -75,7 +75,7 @@ public class DestinationImplementationsHandler {
         destinationImplementationCreate.getDestinationSpecificationId(),
         destinationImplementationCreate.getWorkspaceId(),
         destinationImplementationId,
-        Jsons.jsonNode(destinationImplementationCreate.getConnectionConfiguration()));
+        destinationImplementationCreate.getConnectionConfiguration());
 
     // read configuration from db
     return getDestinationImplementationInternal(destinationImplementationId);
@@ -90,14 +90,14 @@ public class DestinationImplementationsHandler {
     // validate configuration
     validateDestinationImplementation(
         persistedDestinationImplementation.getDestinationSpecificationId(),
-        Jsons.jsonNode(destinationImplementationUpdate.getConnectionConfiguration()));
+        destinationImplementationUpdate.getConnectionConfiguration());
 
     // persist
     persistDestinationConnectionImplementation(
         persistedDestinationImplementation.getDestinationSpecificationId(),
         persistedDestinationImplementation.getWorkspaceId(),
         destinationImplementationUpdate.getDestinationImplementationId(),
-        Jsons.jsonNode(destinationImplementationUpdate.getConnectionConfiguration()));
+        destinationImplementationUpdate.getConnectionConfiguration());
 
     // read configuration from db
     return getDestinationImplementationInternal(

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
@@ -24,12 +24,14 @@
 
 package io.dataline.server.handlers;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.dataline.api.model.DestinationImplementationCreate;
 import io.dataline.api.model.DestinationImplementationIdRequestBody;
 import io.dataline.api.model.DestinationImplementationRead;
 import io.dataline.api.model.DestinationImplementationReadList;
 import io.dataline.api.model.DestinationImplementationUpdate;
 import io.dataline.api.model.WorkspaceIdRequestBody;
+import io.dataline.commons.json.Jsons;
 import io.dataline.config.DestinationConnectionImplementation;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.JsonValidationException;
@@ -65,7 +67,7 @@ public class DestinationImplementationsHandler {
     // validate configuration
     validateDestinationImplementation(
         destinationImplementationCreate.getDestinationSpecificationId(),
-        (String) destinationImplementationCreate.getConnectionConfiguration());
+        Jsons.jsonNode(destinationImplementationCreate.getConnectionConfiguration12345()));
 
     // persist
     final UUID destinationImplementationId = uuidGenerator.get();
@@ -73,7 +75,7 @@ public class DestinationImplementationsHandler {
         destinationImplementationCreate.getDestinationSpecificationId(),
         destinationImplementationCreate.getWorkspaceId(),
         destinationImplementationId,
-        (String) destinationImplementationCreate.getConnectionConfiguration());
+        Jsons.jsonNode(destinationImplementationCreate.getConnectionConfiguration12345()));
 
     // read configuration from db
     return getDestinationImplementationInternal(destinationImplementationId);
@@ -88,14 +90,14 @@ public class DestinationImplementationsHandler {
     // validate configuration
     validateDestinationImplementation(
         persistedDestinationImplementation.getDestinationSpecificationId(),
-        (String) destinationImplementationUpdate.getConnectionConfiguration());
+        Jsons.jsonNode(destinationImplementationUpdate.getConnectionConfiguration12345()));
 
     // persist
     persistDestinationConnectionImplementation(
         persistedDestinationImplementation.getDestinationSpecificationId(),
         persistedDestinationImplementation.getWorkspaceId(),
         destinationImplementationUpdate.getDestinationImplementationId(),
-        (String) destinationImplementationUpdate.getConnectionConfiguration());
+        Jsons.jsonNode(destinationImplementationUpdate.getConnectionConfiguration12345()));
 
     // read configuration from db
     return getDestinationImplementationInternal(
@@ -150,7 +152,7 @@ public class DestinationImplementationsHandler {
         retrievedDestinationConnectionImplementation, destinationId);
   }
 
-  private void validateDestinationImplementation(UUID destinationConnectionSpecificationId, String implementationJson) {
+  private void validateDestinationImplementation(UUID destinationConnectionSpecificationId, JsonNode implementationJson) {
     try {
       validator.validateDestinationConnectionConfiguration(destinationConnectionSpecificationId, implementationJson);
     } catch (JsonValidationException e) {
@@ -165,13 +167,13 @@ public class DestinationImplementationsHandler {
   private void persistDestinationConnectionImplementation(UUID destinationSpecificationId,
                                                           UUID workspaceId,
                                                           UUID destinationImplementationId,
-                                                          String configurationJson) {
+                                                          JsonNode configurationJson) {
     final DestinationConnectionImplementation destinationConnectionImplementation =
         new DestinationConnectionImplementation();
     destinationConnectionImplementation.setDestinationSpecificationId(destinationSpecificationId);
     destinationConnectionImplementation.setWorkspaceId(workspaceId);
     destinationConnectionImplementation.setDestinationImplementationId(destinationImplementationId);
-    destinationConnectionImplementation.setConfigurationJson(configurationJson);
+    destinationConnectionImplementation.setConfigurationJson12345(configurationJson);
 
     ConfigFetchers.writeConfig(
         configPersistence,
@@ -191,8 +193,7 @@ public class DestinationImplementationsHandler {
         destinationConnectionImplementation.getWorkspaceId());
     destinationImplementationRead.setDestinationSpecificationId(
         destinationConnectionImplementation.getDestinationSpecificationId());
-    destinationImplementationRead.setConnectionConfiguration(
-        destinationConnectionImplementation.getConfigurationJson());
+    destinationImplementationRead.setConnectionConfiguration12345(destinationConnectionImplementation.getConfigurationJson12345());
 
     return destinationImplementationRead;
   }

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
@@ -173,7 +173,7 @@ public class DestinationImplementationsHandler {
     destinationConnectionImplementation.setDestinationSpecificationId(destinationSpecificationId);
     destinationConnectionImplementation.setWorkspaceId(workspaceId);
     destinationConnectionImplementation.setDestinationImplementationId(destinationImplementationId);
-    destinationConnectionImplementation.setConfigurationJson(configurationJson);
+    destinationConnectionImplementation.setConfiguration(configurationJson);
 
     ConfigFetchers.writeConfig(
         configPersistence,
@@ -193,7 +193,7 @@ public class DestinationImplementationsHandler {
         destinationConnectionImplementation.getWorkspaceId());
     destinationImplementationRead.setDestinationSpecificationId(
         destinationConnectionImplementation.getDestinationSpecificationId());
-    destinationImplementationRead.setConnectionConfiguration(destinationConnectionImplementation.getConfigurationJson());
+    destinationImplementationRead.setConnectionConfiguration(destinationConnectionImplementation.getConfiguration());
 
     return destinationImplementationRead;
   }

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationImplementationsHandler.java
@@ -67,7 +67,7 @@ public class DestinationImplementationsHandler {
     // validate configuration
     validateDestinationImplementation(
         destinationImplementationCreate.getDestinationSpecificationId(),
-        Jsons.jsonNode(destinationImplementationCreate.getConnectionConfiguration12345()));
+        Jsons.jsonNode(destinationImplementationCreate.getConnectionConfiguration()));
 
     // persist
     final UUID destinationImplementationId = uuidGenerator.get();
@@ -75,7 +75,7 @@ public class DestinationImplementationsHandler {
         destinationImplementationCreate.getDestinationSpecificationId(),
         destinationImplementationCreate.getWorkspaceId(),
         destinationImplementationId,
-        Jsons.jsonNode(destinationImplementationCreate.getConnectionConfiguration12345()));
+        Jsons.jsonNode(destinationImplementationCreate.getConnectionConfiguration()));
 
     // read configuration from db
     return getDestinationImplementationInternal(destinationImplementationId);
@@ -90,14 +90,14 @@ public class DestinationImplementationsHandler {
     // validate configuration
     validateDestinationImplementation(
         persistedDestinationImplementation.getDestinationSpecificationId(),
-        Jsons.jsonNode(destinationImplementationUpdate.getConnectionConfiguration12345()));
+        Jsons.jsonNode(destinationImplementationUpdate.getConnectionConfiguration()));
 
     // persist
     persistDestinationConnectionImplementation(
         persistedDestinationImplementation.getDestinationSpecificationId(),
         persistedDestinationImplementation.getWorkspaceId(),
         destinationImplementationUpdate.getDestinationImplementationId(),
-        Jsons.jsonNode(destinationImplementationUpdate.getConnectionConfiguration12345()));
+        Jsons.jsonNode(destinationImplementationUpdate.getConnectionConfiguration()));
 
     // read configuration from db
     return getDestinationImplementationInternal(
@@ -173,7 +173,7 @@ public class DestinationImplementationsHandler {
     destinationConnectionImplementation.setDestinationSpecificationId(destinationSpecificationId);
     destinationConnectionImplementation.setWorkspaceId(workspaceId);
     destinationConnectionImplementation.setDestinationImplementationId(destinationImplementationId);
-    destinationConnectionImplementation.setConfigurationJson12345(configurationJson);
+    destinationConnectionImplementation.setConfigurationJson(configurationJson);
 
     ConfigFetchers.writeConfig(
         configPersistence,
@@ -193,7 +193,7 @@ public class DestinationImplementationsHandler {
         destinationConnectionImplementation.getWorkspaceId());
     destinationImplementationRead.setDestinationSpecificationId(
         destinationConnectionImplementation.getDestinationSpecificationId());
-    destinationImplementationRead.setConnectionConfiguration12345(destinationConnectionImplementation.getConfigurationJson12345());
+    destinationImplementationRead.setConnectionConfiguration(destinationConnectionImplementation.getConfigurationJson());
 
     return destinationImplementationRead;
   }

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationSpecificationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationSpecificationsHandler.java
@@ -62,8 +62,7 @@ public class DestinationSpecificationsHandler {
   }
 
   private static DestinationSpecificationRead toDestinationSpecificationRead(DestinationConnectionSpecification destinationConnectionSpecification) {
-    final DestinationSpecificationRead destinationSpecificationRead =
-        new DestinationSpecificationRead();
+    final DestinationSpecificationRead destinationSpecificationRead =        new DestinationSpecificationRead();
     destinationSpecificationRead.setDestinationId(
         destinationConnectionSpecification.getDestinationId());
     destinationSpecificationRead.setDestinationSpecificationId(

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationSpecificationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationSpecificationsHandler.java
@@ -68,7 +68,7 @@ public class DestinationSpecificationsHandler {
         destinationConnectionSpecification.getDestinationId());
     destinationSpecificationRead.setDestinationSpecificationId(
         destinationConnectionSpecification.getDestinationSpecificationId());
-    destinationSpecificationRead.setConnectionSpecification(destinationConnectionSpecification.getSpecificationJson());
+    destinationSpecificationRead.setConnectionSpecification(destinationConnectionSpecification.getSpecification());
 
     return destinationSpecificationRead;
   }

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationSpecificationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationSpecificationsHandler.java
@@ -68,8 +68,7 @@ public class DestinationSpecificationsHandler {
         destinationConnectionSpecification.getDestinationId());
     destinationSpecificationRead.setDestinationSpecificationId(
         destinationConnectionSpecification.getDestinationSpecificationId());
-    destinationSpecificationRead.setConnectionSpecification(
-        destinationConnectionSpecification.getSpecificationJson());
+    destinationSpecificationRead.setConnectionSpecification12345(destinationConnectionSpecification.getSpecificationJson12345());
 
     return destinationSpecificationRead;
   }

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationSpecificationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationSpecificationsHandler.java
@@ -68,7 +68,7 @@ public class DestinationSpecificationsHandler {
         destinationConnectionSpecification.getDestinationId());
     destinationSpecificationRead.setDestinationSpecificationId(
         destinationConnectionSpecification.getDestinationSpecificationId());
-    destinationSpecificationRead.setConnectionSpecification12345(destinationConnectionSpecification.getSpecificationJson12345());
+    destinationSpecificationRead.setConnectionSpecification(destinationConnectionSpecification.getSpecificationJson());
 
     return destinationSpecificationRead;
   }

--- a/dataline-server/src/main/java/io/dataline/server/handlers/DestinationSpecificationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/DestinationSpecificationsHandler.java
@@ -62,7 +62,7 @@ public class DestinationSpecificationsHandler {
   }
 
   private static DestinationSpecificationRead toDestinationSpecificationRead(DestinationConnectionSpecification destinationConnectionSpecification) {
-    final DestinationSpecificationRead destinationSpecificationRead =        new DestinationSpecificationRead();
+    final DestinationSpecificationRead destinationSpecificationRead = new DestinationSpecificationRead();
     destinationSpecificationRead.setDestinationId(
         destinationConnectionSpecification.getDestinationId());
     destinationSpecificationRead.setDestinationSpecificationId(

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -24,12 +24,14 @@
 
 package io.dataline.server.handlers;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.dataline.api.model.SourceImplementationCreate;
 import io.dataline.api.model.SourceImplementationIdRequestBody;
 import io.dataline.api.model.SourceImplementationRead;
 import io.dataline.api.model.SourceImplementationReadList;
 import io.dataline.api.model.SourceImplementationUpdate;
 import io.dataline.api.model.WorkspaceIdRequestBody;
+import io.dataline.commons.json.Jsons;
 import io.dataline.config.SourceConnectionImplementation;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.JsonValidationException;
@@ -65,7 +67,7 @@ public class SourceImplementationsHandler {
     // validate configuration
     validateSourceImplementation(
         sourceImplementationCreate.getSourceSpecificationId(),
-        (String) sourceImplementationCreate.getConnectionConfiguration());
+        Jsons.jsonNode(sourceImplementationCreate.getConnectionConfiguration12345()));
 
     // persist
     final UUID sourceImplementationId = uuidGenerator.get();
@@ -74,7 +76,7 @@ public class SourceImplementationsHandler {
         sourceImplementationCreate.getWorkspaceId(),
         sourceImplementationId,
         false,
-        (String) sourceImplementationCreate.getConnectionConfiguration());
+        Jsons.jsonNode(sourceImplementationCreate.getConnectionConfiguration12345()));
 
     // read configuration from db
     return getSourceImplementationReadInternal(sourceImplementationId);
@@ -89,7 +91,7 @@ public class SourceImplementationsHandler {
     // validate configuration
     validateSourceImplementation(
         persistedSourceImplementation.getSourceSpecificationId(),
-        (String) sourceImplementationUpdate.getConnectionConfiguration());
+        Jsons.jsonNode(sourceImplementationUpdate.getConnectionConfiguration12345()));
 
     // persist
     persistSourceConnectionImplementation(
@@ -97,7 +99,7 @@ public class SourceImplementationsHandler {
         persistedSourceImplementation.getWorkspaceId(),
         sourceImplementationUpdate.getSourceImplementationId(),
         persistedSourceImplementation.getTombstone(),
-        (String) sourceImplementationUpdate.getConnectionConfiguration());
+        Jsons.jsonNode(sourceImplementationUpdate.getConnectionConfiguration12345()));
 
     // read configuration from db
     return getSourceImplementationReadInternal(
@@ -147,7 +149,7 @@ public class SourceImplementationsHandler {
         persistedSourceImplementation.getWorkspaceId(),
         persistedSourceImplementation.getSourceImplementationId(),
         true,
-        (String) persistedSourceImplementation.getConnectionConfiguration());
+        Jsons.jsonNode(persistedSourceImplementation.getConnectionConfiguration12345()));
   }
 
   private SourceConnectionImplementation getSourceConnectionImplementationInternal(UUID sourceImplementationId) {
@@ -169,10 +171,9 @@ public class SourceImplementationsHandler {
     return toSourceImplementationRead(retrievedSourceConnectionImplementation, sourceId);
   }
 
-  private void validateSourceImplementation(UUID sourceConnectionSpecificationId, String implementationJson) {
+  private void validateSourceImplementation(UUID sourceConnectionSpecificationId, JsonNode implementationJson) {
     try {
-      validator.validateSourceConnectionConfiguration(
-          sourceConnectionSpecificationId, implementationJson);
+      validator.validateSourceConnectionConfiguration(sourceConnectionSpecificationId, implementationJson);
     } catch (JsonValidationException e) {
       throw new KnownException(
           422,
@@ -186,14 +187,14 @@ public class SourceImplementationsHandler {
                                                      UUID workspaceId,
                                                      UUID sourceImplementationId,
                                                      boolean tombstone,
-                                                     String configurationJson) {
+                                                     JsonNode configurationJson) {
     final SourceConnectionImplementation sourceConnectionImplementation =
         new SourceConnectionImplementation();
     sourceConnectionImplementation.setSourceSpecificationId(sourceSpecificationId);
     sourceConnectionImplementation.setWorkspaceId(workspaceId);
     sourceConnectionImplementation.setSourceImplementationId(sourceImplementationId);
     sourceConnectionImplementation.setTombstone(tombstone);
-    sourceConnectionImplementation.setConfigurationJson(configurationJson);
+    sourceConnectionImplementation.setConfigurationJson12345(configurationJson);
 
     ConfigFetchers.writeConfig(
         configPersistence,
@@ -210,8 +211,7 @@ public class SourceImplementationsHandler {
     sourceImplementationRead.setWorkspaceId(sourceConnectionImplementation.getWorkspaceId());
     sourceImplementationRead.setSourceSpecificationId(
         sourceConnectionImplementation.getSourceSpecificationId());
-    sourceImplementationRead.setConnectionConfiguration(
-        sourceConnectionImplementation.getConfigurationJson());
+    sourceImplementationRead.setConnectionConfiguration12345(sourceConnectionImplementation.getConfigurationJson12345());
 
     return sourceImplementationRead;
   }

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -67,7 +67,7 @@ public class SourceImplementationsHandler {
     // validate configuration
     validateSourceImplementation(
         sourceImplementationCreate.getSourceSpecificationId(),
-        Jsons.jsonNode(sourceImplementationCreate.getConnectionConfiguration12345()));
+        Jsons.jsonNode(sourceImplementationCreate.getConnectionConfiguration()));
 
     // persist
     final UUID sourceImplementationId = uuidGenerator.get();
@@ -76,7 +76,7 @@ public class SourceImplementationsHandler {
         sourceImplementationCreate.getWorkspaceId(),
         sourceImplementationId,
         false,
-        Jsons.jsonNode(sourceImplementationCreate.getConnectionConfiguration12345()));
+        Jsons.jsonNode(sourceImplementationCreate.getConnectionConfiguration()));
 
     // read configuration from db
     return getSourceImplementationReadInternal(sourceImplementationId);
@@ -91,7 +91,7 @@ public class SourceImplementationsHandler {
     // validate configuration
     validateSourceImplementation(
         persistedSourceImplementation.getSourceSpecificationId(),
-        Jsons.jsonNode(sourceImplementationUpdate.getConnectionConfiguration12345()));
+        Jsons.jsonNode(sourceImplementationUpdate.getConnectionConfiguration()));
 
     // persist
     persistSourceConnectionImplementation(
@@ -99,7 +99,7 @@ public class SourceImplementationsHandler {
         persistedSourceImplementation.getWorkspaceId(),
         sourceImplementationUpdate.getSourceImplementationId(),
         persistedSourceImplementation.getTombstone(),
-        Jsons.jsonNode(sourceImplementationUpdate.getConnectionConfiguration12345()));
+        Jsons.jsonNode(sourceImplementationUpdate.getConnectionConfiguration()));
 
     // read configuration from db
     return getSourceImplementationReadInternal(
@@ -149,7 +149,7 @@ public class SourceImplementationsHandler {
         persistedSourceImplementation.getWorkspaceId(),
         persistedSourceImplementation.getSourceImplementationId(),
         true,
-        Jsons.jsonNode(persistedSourceImplementation.getConnectionConfiguration12345()));
+        Jsons.jsonNode(persistedSourceImplementation.getConnectionConfiguration()));
   }
 
   private SourceConnectionImplementation getSourceConnectionImplementationInternal(UUID sourceImplementationId) {
@@ -194,7 +194,7 @@ public class SourceImplementationsHandler {
     sourceConnectionImplementation.setWorkspaceId(workspaceId);
     sourceConnectionImplementation.setSourceImplementationId(sourceImplementationId);
     sourceConnectionImplementation.setTombstone(tombstone);
-    sourceConnectionImplementation.setConfigurationJson12345(configurationJson);
+    sourceConnectionImplementation.setConfigurationJson(configurationJson);
 
     ConfigFetchers.writeConfig(
         configPersistence,
@@ -211,7 +211,7 @@ public class SourceImplementationsHandler {
     sourceImplementationRead.setWorkspaceId(sourceConnectionImplementation.getWorkspaceId());
     sourceImplementationRead.setSourceSpecificationId(
         sourceConnectionImplementation.getSourceSpecificationId());
-    sourceImplementationRead.setConnectionConfiguration12345(sourceConnectionImplementation.getConfigurationJson12345());
+    sourceImplementationRead.setConnectionConfiguration(sourceConnectionImplementation.getConfigurationJson());
 
     return sourceImplementationRead;
   }

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -67,7 +67,7 @@ public class SourceImplementationsHandler {
     // validate configuration
     validateSourceImplementation(
         sourceImplementationCreate.getSourceSpecificationId(),
-        Jsons.jsonNode(sourceImplementationCreate.getConnectionConfiguration()));
+        sourceImplementationCreate.getConnectionConfiguration());
 
     // persist
     final UUID sourceImplementationId = uuidGenerator.get();
@@ -76,7 +76,7 @@ public class SourceImplementationsHandler {
         sourceImplementationCreate.getWorkspaceId(),
         sourceImplementationId,
         false,
-        Jsons.jsonNode(sourceImplementationCreate.getConnectionConfiguration()));
+        sourceImplementationCreate.getConnectionConfiguration());
 
     // read configuration from db
     return getSourceImplementationReadInternal(sourceImplementationId);
@@ -91,7 +91,7 @@ public class SourceImplementationsHandler {
     // validate configuration
     validateSourceImplementation(
         persistedSourceImplementation.getSourceSpecificationId(),
-        Jsons.jsonNode(sourceImplementationUpdate.getConnectionConfiguration()));
+        sourceImplementationUpdate.getConnectionConfiguration());
 
     // persist
     persistSourceConnectionImplementation(
@@ -99,7 +99,7 @@ public class SourceImplementationsHandler {
         persistedSourceImplementation.getWorkspaceId(),
         sourceImplementationUpdate.getSourceImplementationId(),
         persistedSourceImplementation.getTombstone(),
-        Jsons.jsonNode(sourceImplementationUpdate.getConnectionConfiguration()));
+        sourceImplementationUpdate.getConnectionConfiguration());
 
     // read configuration from db
     return getSourceImplementationReadInternal(
@@ -149,7 +149,7 @@ public class SourceImplementationsHandler {
         persistedSourceImplementation.getWorkspaceId(),
         persistedSourceImplementation.getSourceImplementationId(),
         true,
-        Jsons.jsonNode(persistedSourceImplementation.getConnectionConfiguration()));
+        persistedSourceImplementation.getConnectionConfiguration());
   }
 
   private SourceConnectionImplementation getSourceConnectionImplementationInternal(UUID sourceImplementationId) {

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -31,7 +31,6 @@ import io.dataline.api.model.SourceImplementationRead;
 import io.dataline.api.model.SourceImplementationReadList;
 import io.dataline.api.model.SourceImplementationUpdate;
 import io.dataline.api.model.WorkspaceIdRequestBody;
-import io.dataline.commons.json.Jsons;
 import io.dataline.config.SourceConnectionImplementation;
 import io.dataline.config.persistence.ConfigPersistence;
 import io.dataline.config.persistence.JsonValidationException;

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceImplementationsHandler.java
@@ -194,7 +194,7 @@ public class SourceImplementationsHandler {
     sourceConnectionImplementation.setWorkspaceId(workspaceId);
     sourceConnectionImplementation.setSourceImplementationId(sourceImplementationId);
     sourceConnectionImplementation.setTombstone(tombstone);
-    sourceConnectionImplementation.setConfigurationJson(configurationJson);
+    sourceConnectionImplementation.setConfiguration(configurationJson);
 
     ConfigFetchers.writeConfig(
         configPersistence,
@@ -211,7 +211,7 @@ public class SourceImplementationsHandler {
     sourceImplementationRead.setWorkspaceId(sourceConnectionImplementation.getWorkspaceId());
     sourceImplementationRead.setSourceSpecificationId(
         sourceConnectionImplementation.getSourceSpecificationId());
-    sourceImplementationRead.setConnectionConfiguration(sourceConnectionImplementation.getConfigurationJson());
+    sourceImplementationRead.setConnectionConfiguration(sourceConnectionImplementation.getConfiguration());
 
     return sourceImplementationRead;
   }

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceSpecificationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceSpecificationsHandler.java
@@ -64,7 +64,7 @@ public class SourceSpecificationsHandler {
     sourceSpecificationRead.setSourceId(sourceConnectionSpecification.getSourceId());
     sourceSpecificationRead.setSourceSpecificationId(
         sourceConnectionSpecification.getSourceSpecificationId());
-    sourceSpecificationRead.setConnectionSpecification(sourceConnectionSpecification.getSpecificationJson());
+    sourceSpecificationRead.setConnectionSpecification(sourceConnectionSpecification.getSpecification());
 
     return sourceSpecificationRead;
   }

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceSpecificationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceSpecificationsHandler.java
@@ -64,8 +64,7 @@ public class SourceSpecificationsHandler {
     sourceSpecificationRead.setSourceId(sourceConnectionSpecification.getSourceId());
     sourceSpecificationRead.setSourceSpecificationId(
         sourceConnectionSpecification.getSourceSpecificationId());
-    sourceSpecificationRead.setConnectionSpecification(
-        sourceConnectionSpecification.getSpecificationJson());
+    sourceSpecificationRead.setConnectionSpecification12345(sourceConnectionSpecification.getSpecificationJson12345());
 
     return sourceSpecificationRead;
   }

--- a/dataline-server/src/main/java/io/dataline/server/handlers/SourceSpecificationsHandler.java
+++ b/dataline-server/src/main/java/io/dataline/server/handlers/SourceSpecificationsHandler.java
@@ -64,7 +64,7 @@ public class SourceSpecificationsHandler {
     sourceSpecificationRead.setSourceId(sourceConnectionSpecification.getSourceId());
     sourceSpecificationRead.setSourceSpecificationId(
         sourceConnectionSpecification.getSourceSpecificationId());
-    sourceSpecificationRead.setConnectionSpecification12345(sourceConnectionSpecification.getSpecificationJson12345());
+    sourceSpecificationRead.setConnectionSpecification(sourceConnectionSpecification.getSpecificationJson());
 
     return sourceSpecificationRead;
   }

--- a/dataline-server/src/main/java/io/dataline/server/validation/IntegrationSchemaValidation.java
+++ b/dataline-server/src/main/java/io/dataline/server/validation/IntegrationSchemaValidation.java
@@ -51,7 +51,7 @@ public class IntegrationSchemaValidation {
         ConfigFetchers.getSourceConnectionSpecification(
             configPersistence, sourceConnectionSpecificationId);
 
-    final JsonNode schemaJson = sourceConnectionSpecification.getSpecificationJson12345();
+    final JsonNode schemaJson = sourceConnectionSpecification.getSpecificationJson();
 
     jsonSchemaValidation.validateThrow(schemaJson, configJson);
   }
@@ -62,7 +62,7 @@ public class IntegrationSchemaValidation {
         ConfigFetchers.getDestinationConnectionSpecification(
             configPersistence, destinationConnectionSpecificationId);
 
-    final JsonNode schemaJson = destinationConnectionSpecification.getSpecificationJson12345();
+    final JsonNode schemaJson = destinationConnectionSpecification.getSpecificationJson();
 
     jsonSchemaValidation.validateThrow(schemaJson, configJson);
   }

--- a/dataline-server/src/main/java/io/dataline/server/validation/IntegrationSchemaValidation.java
+++ b/dataline-server/src/main/java/io/dataline/server/validation/IntegrationSchemaValidation.java
@@ -25,7 +25,6 @@
 package io.dataline.server.validation;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.dataline.commons.json.Jsons;
 import io.dataline.config.DestinationConnectionSpecification;
 import io.dataline.config.SourceConnectionSpecification;
 import io.dataline.config.persistence.ConfigPersistence;
@@ -46,28 +45,24 @@ public class IntegrationSchemaValidation {
     this.jsonSchemaValidation = new JsonSchemaValidation();
   }
 
-  public void validateSourceConnectionConfiguration(UUID sourceConnectionSpecificationId, String configurationJson)
+  public void validateSourceConnectionConfiguration(UUID sourceConnectionSpecificationId, JsonNode configJson)
       throws JsonValidationException {
     final SourceConnectionSpecification sourceConnectionSpecification =
         ConfigFetchers.getSourceConnectionSpecification(
             configPersistence, sourceConnectionSpecificationId);
 
-    final JsonNode schemaJson =
-        Jsons.deserialize(sourceConnectionSpecification.getSpecificationJson());
-    final JsonNode configJson = Jsons.deserialize(configurationJson);
+    final JsonNode schemaJson = sourceConnectionSpecification.getSpecificationJson12345();
 
     jsonSchemaValidation.validateThrow(schemaJson, configJson);
   }
 
-  public void validateDestinationConnectionConfiguration(UUID destinationConnectionSpecificationId, String configurationJson)
+  public void validateDestinationConnectionConfiguration(UUID destinationConnectionSpecificationId, JsonNode configJson)
       throws JsonValidationException {
     final DestinationConnectionSpecification destinationConnectionSpecification =
         ConfigFetchers.getDestinationConnectionSpecification(
             configPersistence, destinationConnectionSpecificationId);
 
-    final JsonNode schemaJson =
-        Jsons.deserialize(destinationConnectionSpecification.getSpecificationJson());
-    final JsonNode configJson = Jsons.deserialize(configurationJson);
+    final JsonNode schemaJson = destinationConnectionSpecification.getSpecificationJson12345();
 
     jsonSchemaValidation.validateThrow(schemaJson, configJson);
   }

--- a/dataline-server/src/main/java/io/dataline/server/validation/IntegrationSchemaValidation.java
+++ b/dataline-server/src/main/java/io/dataline/server/validation/IntegrationSchemaValidation.java
@@ -51,7 +51,7 @@ public class IntegrationSchemaValidation {
         ConfigFetchers.getSourceConnectionSpecification(
             configPersistence, sourceConnectionSpecificationId);
 
-    final JsonNode schemaJson = sourceConnectionSpecification.getSpecificationJson();
+    final JsonNode schemaJson = sourceConnectionSpecification.getSpecification();
 
     jsonSchemaValidation.validateThrow(schemaJson, configJson);
   }
@@ -62,7 +62,7 @@ public class IntegrationSchemaValidation {
         ConfigFetchers.getDestinationConnectionSpecification(
             configPersistence, destinationConnectionSpecificationId);
 
-    final JsonNode schemaJson = destinationConnectionSpecification.getSpecificationJson();
+    final JsonNode schemaJson = destinationConnectionSpecification.getSpecification();
 
     jsonSchemaValidation.validateThrow(schemaJson, configJson);
   }

--- a/dataline-server/src/test/java/io/dataline/server/handlers/DestinationImplementationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/DestinationImplementationsHandlerTest.java
@@ -101,7 +101,7 @@ class DestinationImplementationsHandlerTest {
     destinationConnectionImplementation.setWorkspaceId(workspaceId);
     destinationConnectionImplementation.setDestinationSpecificationId(destinationSpecificationId);
     destinationConnectionImplementation.setDestinationImplementationId(destinationImplementationId);
-    destinationConnectionImplementation.setConfigurationJson12345(implementationJson);
+    destinationConnectionImplementation.setConfigurationJson(implementationJson);
 
     return destinationConnectionImplementation;
   }
@@ -130,7 +130,7 @@ class DestinationImplementationsHandlerTest {
         destinationConnectionImplementation.getWorkspaceId());
     destinationImplementationCreate.setDestinationSpecificationId(
         destinationConnectionSpecification.getDestinationSpecificationId());
-    destinationImplementationCreate.setConnectionConfiguration12345(
+    destinationImplementationCreate.setConnectionConfiguration(
         getTestImplementationJson());
 
     final DestinationImplementationRead actualDestinationImplementationRead =
@@ -147,7 +147,7 @@ class DestinationImplementationsHandlerTest {
         destinationConnectionImplementation.getWorkspaceId());
     expectedDestinationImplementationRead.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
-    expectedDestinationImplementationRead.setConnectionConfiguration12345(
+    expectedDestinationImplementationRead.setConnectionConfiguration(
         getTestImplementationJson());
 
     assertEquals(expectedDestinationImplementationRead, actualDestinationImplementationRead);
@@ -155,7 +155,7 @@ class DestinationImplementationsHandlerTest {
     verify(validator)
         .validateDestinationConnectionConfiguration(
             destinationConnectionSpecification.getDestinationSpecificationId(),
-            destinationConnectionImplementation.getConfigurationJson12345());
+            destinationConnectionImplementation.getConfigurationJson());
 
     verify(configPersistence)
         .writeConfig(
@@ -167,7 +167,7 @@ class DestinationImplementationsHandlerTest {
   @Test
   void testUpdateDestinationImplementation()
       throws JsonValidationException, ConfigNotFoundException {
-    final JsonNode newConfiguration = destinationConnectionImplementation.getConfigurationJson12345();
+    final JsonNode newConfiguration = destinationConnectionImplementation.getConfigurationJson();
 
     ((ObjectNode) newConfiguration).put("apiKey", "987-xyz");
 
@@ -179,7 +179,7 @@ class DestinationImplementationsHandlerTest {
         destinationConnectionImplementation.getDestinationSpecificationId());
     expectedDestinationConnectionImplementation.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
-    expectedDestinationConnectionImplementation.setConfigurationJson12345(newConfiguration);
+    expectedDestinationConnectionImplementation.setConfigurationJson(newConfiguration);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.DESTINATION_CONNECTION_IMPLEMENTATION,
@@ -198,7 +198,7 @@ class DestinationImplementationsHandlerTest {
         new DestinationImplementationUpdate();
     destinationImplementationUpdate.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
-    destinationImplementationUpdate.setConnectionConfiguration12345(newConfiguration);
+    destinationImplementationUpdate.setConnectionConfiguration(newConfiguration);
     final DestinationImplementationRead actualDestinationImplementationRead =
         destinationImplementationsHandler.updateDestinationImplementation(
             destinationImplementationUpdate);
@@ -213,7 +213,7 @@ class DestinationImplementationsHandlerTest {
         destinationConnectionImplementation.getWorkspaceId());
     expectedDestinationImplementationRead.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
-    expectedDestinationImplementationRead.setConnectionConfiguration12345(newConfiguration);
+    expectedDestinationImplementationRead.setConnectionConfiguration(newConfiguration);
 
     assertEquals(expectedDestinationImplementationRead, actualDestinationImplementationRead);
 
@@ -248,8 +248,8 @@ class DestinationImplementationsHandlerTest {
         destinationConnectionImplementation.getWorkspaceId());
     expectedDestinationImplementationRead.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
-    expectedDestinationImplementationRead.setConnectionConfiguration12345(
-        destinationConnectionImplementation.getConfigurationJson12345());
+    expectedDestinationImplementationRead.setConnectionConfiguration(
+        destinationConnectionImplementation.getConfigurationJson());
 
     final DestinationImplementationIdRequestBody destinationImplementationIdRequestBody =
         new DestinationImplementationIdRequestBody();
@@ -287,8 +287,8 @@ class DestinationImplementationsHandlerTest {
         destinationConnectionImplementation.getWorkspaceId());
     expectedDestinationImplementationRead.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
-    expectedDestinationImplementationRead.setConnectionConfiguration12345(
-        destinationConnectionImplementation.getConfigurationJson12345());
+    expectedDestinationImplementationRead.setConnectionConfiguration(
+        destinationConnectionImplementation.getConfigurationJson());
 
     final WorkspaceIdRequestBody workspaceIdRequestBody = new WorkspaceIdRequestBody();
     workspaceIdRequestBody.setWorkspaceId(destinationConnectionImplementation.getWorkspaceId());

--- a/dataline-server/src/test/java/io/dataline/server/handlers/DestinationImplementationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/DestinationImplementationsHandlerTest.java
@@ -82,11 +82,11 @@ class DestinationImplementationsHandlerTest {
         new DestinationImplementationsHandler(configPersistence, validator, uuidGenerator);
   }
 
-  private String getTestImplementationJson() throws IOException {
+  private JsonNode getTestImplementationJson() throws IOException {
     final Path path =
         Paths.get("../dataline-server/src/test/resources/json/TestImplementation.json");
 
-    return Files.readString(path);
+    return Jsons.deserialize(Files.readString(path));
   }
 
   private DestinationConnectionImplementation generateDestinationImplementation(UUID destinationSpecificationId)
@@ -94,14 +94,14 @@ class DestinationImplementationsHandlerTest {
     final UUID workspaceId = UUID.randomUUID();
     final UUID destinationImplementationId = UUID.randomUUID();
 
-    String implementationJson = getTestImplementationJson();
+    JsonNode implementationJson = getTestImplementationJson();
 
     final DestinationConnectionImplementation destinationConnectionImplementation =
         new DestinationConnectionImplementation();
     destinationConnectionImplementation.setWorkspaceId(workspaceId);
     destinationConnectionImplementation.setDestinationSpecificationId(destinationSpecificationId);
     destinationConnectionImplementation.setDestinationImplementationId(destinationImplementationId);
-    destinationConnectionImplementation.setConfigurationJson(implementationJson);
+    destinationConnectionImplementation.setConfigurationJson12345(implementationJson);
 
     return destinationConnectionImplementation;
   }
@@ -130,8 +130,8 @@ class DestinationImplementationsHandlerTest {
         destinationConnectionImplementation.getWorkspaceId());
     destinationImplementationCreate.setDestinationSpecificationId(
         destinationConnectionSpecification.getDestinationSpecificationId());
-    destinationImplementationCreate.setConnectionConfiguration(
-        getTestImplementationJson().toString());
+    destinationImplementationCreate.setConnectionConfiguration12345(
+        getTestImplementationJson());
 
     final DestinationImplementationRead actualDestinationImplementationRead =
         destinationImplementationsHandler.createDestinationImplementation(
@@ -147,15 +147,15 @@ class DestinationImplementationsHandlerTest {
         destinationConnectionImplementation.getWorkspaceId());
     expectedDestinationImplementationRead.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
-    expectedDestinationImplementationRead.setConnectionConfiguration(
-        getTestImplementationJson().toString());
+    expectedDestinationImplementationRead.setConnectionConfiguration12345(
+        getTestImplementationJson());
 
     assertEquals(expectedDestinationImplementationRead, actualDestinationImplementationRead);
 
     verify(validator)
         .validateDestinationConnectionConfiguration(
             destinationConnectionSpecification.getDestinationSpecificationId(),
-            destinationConnectionImplementation.getConfigurationJson());
+            destinationConnectionImplementation.getConfigurationJson12345());
 
     verify(configPersistence)
         .writeConfig(
@@ -167,8 +167,7 @@ class DestinationImplementationsHandlerTest {
   @Test
   void testUpdateDestinationImplementation()
       throws JsonValidationException, ConfigNotFoundException {
-    final JsonNode newConfiguration =
-        Jsons.deserialize(destinationConnectionImplementation.getConfigurationJson());
+    final JsonNode newConfiguration = destinationConnectionImplementation.getConfigurationJson12345();
 
     ((ObjectNode) newConfiguration).put("apiKey", "987-xyz");
 
@@ -180,7 +179,7 @@ class DestinationImplementationsHandlerTest {
         destinationConnectionImplementation.getDestinationSpecificationId());
     expectedDestinationConnectionImplementation.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
-    expectedDestinationConnectionImplementation.setConfigurationJson(newConfiguration.toString());
+    expectedDestinationConnectionImplementation.setConfigurationJson12345(newConfiguration);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.DESTINATION_CONNECTION_IMPLEMENTATION,
@@ -199,7 +198,7 @@ class DestinationImplementationsHandlerTest {
         new DestinationImplementationUpdate();
     destinationImplementationUpdate.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
-    destinationImplementationUpdate.setConnectionConfiguration(newConfiguration.toString());
+    destinationImplementationUpdate.setConnectionConfiguration12345(newConfiguration);
     final DestinationImplementationRead actualDestinationImplementationRead =
         destinationImplementationsHandler.updateDestinationImplementation(
             destinationImplementationUpdate);
@@ -214,7 +213,7 @@ class DestinationImplementationsHandlerTest {
         destinationConnectionImplementation.getWorkspaceId());
     expectedDestinationImplementationRead.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
-    expectedDestinationImplementationRead.setConnectionConfiguration(newConfiguration.toString());
+    expectedDestinationImplementationRead.setConnectionConfiguration12345(newConfiguration);
 
     assertEquals(expectedDestinationImplementationRead, actualDestinationImplementationRead);
 
@@ -249,8 +248,8 @@ class DestinationImplementationsHandlerTest {
         destinationConnectionImplementation.getWorkspaceId());
     expectedDestinationImplementationRead.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
-    expectedDestinationImplementationRead.setConnectionConfiguration(
-        destinationConnectionImplementation.getConfigurationJson());
+    expectedDestinationImplementationRead.setConnectionConfiguration12345(
+        destinationConnectionImplementation.getConfigurationJson12345());
 
     final DestinationImplementationIdRequestBody destinationImplementationIdRequestBody =
         new DestinationImplementationIdRequestBody();
@@ -288,8 +287,8 @@ class DestinationImplementationsHandlerTest {
         destinationConnectionImplementation.getWorkspaceId());
     expectedDestinationImplementationRead.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
-    expectedDestinationImplementationRead.setConnectionConfiguration(
-        destinationConnectionImplementation.getConfigurationJson());
+    expectedDestinationImplementationRead.setConnectionConfiguration12345(
+        destinationConnectionImplementation.getConfigurationJson12345());
 
     final WorkspaceIdRequestBody workspaceIdRequestBody = new WorkspaceIdRequestBody();
     workspaceIdRequestBody.setWorkspaceId(destinationConnectionImplementation.getWorkspaceId());

--- a/dataline-server/src/test/java/io/dataline/server/handlers/DestinationImplementationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/DestinationImplementationsHandlerTest.java
@@ -101,7 +101,7 @@ class DestinationImplementationsHandlerTest {
     destinationConnectionImplementation.setWorkspaceId(workspaceId);
     destinationConnectionImplementation.setDestinationSpecificationId(destinationSpecificationId);
     destinationConnectionImplementation.setDestinationImplementationId(destinationImplementationId);
-    destinationConnectionImplementation.setConfigurationJson(implementationJson);
+    destinationConnectionImplementation.setConfiguration(implementationJson);
 
     return destinationConnectionImplementation;
   }
@@ -155,7 +155,7 @@ class DestinationImplementationsHandlerTest {
     verify(validator)
         .validateDestinationConnectionConfiguration(
             destinationConnectionSpecification.getDestinationSpecificationId(),
-            destinationConnectionImplementation.getConfigurationJson());
+            destinationConnectionImplementation.getConfiguration());
 
     verify(configPersistence)
         .writeConfig(
@@ -167,7 +167,7 @@ class DestinationImplementationsHandlerTest {
   @Test
   void testUpdateDestinationImplementation()
       throws JsonValidationException, ConfigNotFoundException {
-    final JsonNode newConfiguration = destinationConnectionImplementation.getConfigurationJson();
+    final JsonNode newConfiguration = destinationConnectionImplementation.getConfiguration();
 
     ((ObjectNode) newConfiguration).put("apiKey", "987-xyz");
 
@@ -179,7 +179,7 @@ class DestinationImplementationsHandlerTest {
         destinationConnectionImplementation.getDestinationSpecificationId());
     expectedDestinationConnectionImplementation.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
-    expectedDestinationConnectionImplementation.setConfigurationJson(newConfiguration);
+    expectedDestinationConnectionImplementation.setConfiguration(newConfiguration);
 
     when(configPersistence.getConfig(
         PersistenceConfigType.DESTINATION_CONNECTION_IMPLEMENTATION,
@@ -249,7 +249,7 @@ class DestinationImplementationsHandlerTest {
     expectedDestinationImplementationRead.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
     expectedDestinationImplementationRead.setConnectionConfiguration(
-        destinationConnectionImplementation.getConfigurationJson());
+        destinationConnectionImplementation.getConfiguration());
 
     final DestinationImplementationIdRequestBody destinationImplementationIdRequestBody =
         new DestinationImplementationIdRequestBody();
@@ -288,7 +288,7 @@ class DestinationImplementationsHandlerTest {
     expectedDestinationImplementationRead.setDestinationImplementationId(
         destinationConnectionImplementation.getDestinationImplementationId());
     expectedDestinationImplementationRead.setConnectionConfiguration(
-        destinationConnectionImplementation.getConfigurationJson());
+        destinationConnectionImplementation.getConfiguration());
 
     final WorkspaceIdRequestBody workspaceIdRequestBody = new WorkspaceIdRequestBody();
     workspaceIdRequestBody.setWorkspaceId(destinationConnectionImplementation.getWorkspaceId());

--- a/dataline-server/src/test/java/io/dataline/server/handlers/DestinationSpecificationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/DestinationSpecificationsHandlerTest.java
@@ -67,8 +67,8 @@ class DestinationSpecificationsHandlerTest {
         destinationConnectionSpecification.getDestinationId());
     expectedDestinationSpecificationRead.setDestinationSpecificationId(
         destinationConnectionSpecification.getDestinationSpecificationId());
-    expectedDestinationSpecificationRead.setConnectionSpecification(
-        destinationConnectionSpecification.getSpecificationJson());
+    expectedDestinationSpecificationRead.setConnectionSpecification12345(
+        destinationConnectionSpecification.getSpecificationJson12345());
 
     final DestinationIdRequestBody destinationIdRequestBody = new DestinationIdRequestBody();
     destinationIdRequestBody.setDestinationId(

--- a/dataline-server/src/test/java/io/dataline/server/handlers/DestinationSpecificationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/DestinationSpecificationsHandlerTest.java
@@ -68,7 +68,7 @@ class DestinationSpecificationsHandlerTest {
     expectedDestinationSpecificationRead.setDestinationSpecificationId(
         destinationConnectionSpecification.getDestinationSpecificationId());
     expectedDestinationSpecificationRead.setConnectionSpecification(
-        destinationConnectionSpecification.getSpecificationJson());
+        destinationConnectionSpecification.getSpecification());
 
     final DestinationIdRequestBody destinationIdRequestBody = new DestinationIdRequestBody();
     destinationIdRequestBody.setDestinationId(

--- a/dataline-server/src/test/java/io/dataline/server/handlers/DestinationSpecificationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/DestinationSpecificationsHandlerTest.java
@@ -67,8 +67,8 @@ class DestinationSpecificationsHandlerTest {
         destinationConnectionSpecification.getDestinationId());
     expectedDestinationSpecificationRead.setDestinationSpecificationId(
         destinationConnectionSpecification.getDestinationSpecificationId());
-    expectedDestinationSpecificationRead.setConnectionSpecification12345(
-        destinationConnectionSpecification.getSpecificationJson12345());
+    expectedDestinationSpecificationRead.setConnectionSpecification(
+        destinationConnectionSpecification.getSpecificationJson());
 
     final DestinationIdRequestBody destinationIdRequestBody = new DestinationIdRequestBody();
     destinationIdRequestBody.setDestinationId(

--- a/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
@@ -38,7 +38,6 @@ import io.dataline.api.model.SourceImplementationRead;
 import io.dataline.api.model.SourceImplementationReadList;
 import io.dataline.api.model.SourceImplementationUpdate;
 import io.dataline.api.model.WorkspaceIdRequestBody;
-import io.dataline.commons.json.Jsons;
 import io.dataline.config.SourceConnectionImplementation;
 import io.dataline.config.SourceConnectionSpecification;
 import io.dataline.config.persistence.ConfigNotFoundException;
@@ -101,7 +100,7 @@ class SourceImplementationsHandlerTest {
     sourceImplementationCreate.setWorkspaceId(sourceConnectionImplementation.getWorkspaceId());
     sourceImplementationCreate.setSourceSpecificationId(
         sourceConnectionSpecification.getSourceSpecificationId());
-    sourceImplementationCreate.setConnectionConfiguration(
+    sourceImplementationCreate.setConnectionConfiguration12345(
         SourceImplementationHelpers.getTestImplementationJson());
 
     final SourceImplementationRead actualSourceImplementationRead =
@@ -110,7 +109,7 @@ class SourceImplementationsHandlerTest {
     SourceImplementationRead expectedSourceImplementationRead =
         SourceImplementationHelpers.getSourceImplementationRead(
             sourceConnectionImplementation, sourceConnectionSpecification.getSourceId());
-    expectedSourceImplementationRead.setConnectionConfiguration(
+    expectedSourceImplementationRead.setConnectionConfiguration12345(
         SourceImplementationHelpers.getTestImplementationJson());
 
     assertEquals(expectedSourceImplementationRead, actualSourceImplementationRead);
@@ -118,7 +117,7 @@ class SourceImplementationsHandlerTest {
     verify(validator)
         .validateSourceConnectionConfiguration(
             sourceConnectionSpecification.getSourceSpecificationId(),
-            sourceConnectionImplementation.getConfigurationJson());
+            sourceConnectionImplementation.getConfigurationJson12345());
 
     verify(configPersistence)
         .writeConfig(
@@ -129,8 +128,7 @@ class SourceImplementationsHandlerTest {
 
   @Test
   void testUpdateSourceImplementation() throws JsonValidationException, ConfigNotFoundException {
-    final JsonNode newConfiguration =
-        Jsons.deserialize(sourceConnectionImplementation.getConfigurationJson());
+    final JsonNode newConfiguration = sourceConnectionImplementation.getConfigurationJson12345();
     ((ObjectNode) newConfiguration).put("apiKey", "987-xyz");
 
     final SourceConnectionImplementation expectedSourceConnectionImplementation =
@@ -141,7 +139,7 @@ class SourceImplementationsHandlerTest {
         sourceConnectionImplementation.getSourceSpecificationId());
     expectedSourceConnectionImplementation.setSourceImplementationId(
         sourceConnectionImplementation.getSourceImplementationId());
-    expectedSourceConnectionImplementation.setConfigurationJson(newConfiguration.toString());
+    expectedSourceConnectionImplementation.setConfigurationJson12345(newConfiguration);
     expectedSourceConnectionImplementation.setTombstone(false);
 
     when(configPersistence.getConfig(
@@ -160,14 +158,14 @@ class SourceImplementationsHandlerTest {
     final SourceImplementationUpdate sourceImplementationUpdate = new SourceImplementationUpdate();
     sourceImplementationUpdate.setSourceImplementationId(
         sourceConnectionImplementation.getSourceImplementationId());
-    sourceImplementationUpdate.setConnectionConfiguration(newConfiguration.toString());
+    sourceImplementationUpdate.setConnectionConfiguration12345(newConfiguration);
     final SourceImplementationRead actualSourceImplementationRead =
         sourceImplementationsHandler.updateSourceImplementation(sourceImplementationUpdate);
 
     SourceImplementationRead expectedSourceImplementationRead =
         SourceImplementationHelpers.getSourceImplementationRead(
             sourceConnectionImplementation, sourceConnectionSpecification.getSourceId());
-    expectedSourceImplementationRead.setConnectionConfiguration(newConfiguration.toString());
+    expectedSourceImplementationRead.setConnectionConfiguration12345(newConfiguration);
 
     assertEquals(expectedSourceImplementationRead, actualSourceImplementationRead);
 
@@ -237,8 +235,7 @@ class SourceImplementationsHandlerTest {
 
   @Test
   void testDeleteSourceImplementation() throws JsonValidationException, ConfigNotFoundException {
-    final JsonNode newConfiguration =
-        Jsons.deserialize(sourceConnectionImplementation.getConfigurationJson());
+    final JsonNode newConfiguration = sourceConnectionImplementation.getConfigurationJson12345();
     ((ObjectNode) newConfiguration).put("apiKey", "987-xyz");
 
     final SourceConnectionImplementation expectedSourceConnectionImplementation =
@@ -249,8 +246,8 @@ class SourceImplementationsHandlerTest {
         sourceConnectionImplementation.getSourceSpecificationId());
     expectedSourceConnectionImplementation.setSourceImplementationId(
         sourceConnectionImplementation.getSourceImplementationId());
-    expectedSourceConnectionImplementation.setConfigurationJson(
-        sourceConnectionImplementation.getConfigurationJson());
+    expectedSourceConnectionImplementation.setConfigurationJson12345(
+        sourceConnectionImplementation.getConfigurationJson12345());
     expectedSourceConnectionImplementation.setTombstone(true);
 
     when(configPersistence.getConfig(

--- a/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
@@ -117,7 +117,7 @@ class SourceImplementationsHandlerTest {
     verify(validator)
         .validateSourceConnectionConfiguration(
             sourceConnectionSpecification.getSourceSpecificationId(),
-            sourceConnectionImplementation.getConfigurationJson());
+            sourceConnectionImplementation.getConfiguration());
 
     verify(configPersistence)
         .writeConfig(
@@ -128,7 +128,7 @@ class SourceImplementationsHandlerTest {
 
   @Test
   void testUpdateSourceImplementation() throws JsonValidationException, ConfigNotFoundException {
-    final JsonNode newConfiguration = sourceConnectionImplementation.getConfigurationJson();
+    final JsonNode newConfiguration = sourceConnectionImplementation.getConfiguration();
     ((ObjectNode) newConfiguration).put("apiKey", "987-xyz");
 
     final SourceConnectionImplementation expectedSourceConnectionImplementation =
@@ -139,7 +139,7 @@ class SourceImplementationsHandlerTest {
         sourceConnectionImplementation.getSourceSpecificationId());
     expectedSourceConnectionImplementation.setSourceImplementationId(
         sourceConnectionImplementation.getSourceImplementationId());
-    expectedSourceConnectionImplementation.setConfigurationJson(newConfiguration);
+    expectedSourceConnectionImplementation.setConfiguration(newConfiguration);
     expectedSourceConnectionImplementation.setTombstone(false);
 
     when(configPersistence.getConfig(
@@ -235,7 +235,7 @@ class SourceImplementationsHandlerTest {
 
   @Test
   void testDeleteSourceImplementation() throws JsonValidationException, ConfigNotFoundException {
-    final JsonNode newConfiguration = sourceConnectionImplementation.getConfigurationJson();
+    final JsonNode newConfiguration = sourceConnectionImplementation.getConfiguration();
     ((ObjectNode) newConfiguration).put("apiKey", "987-xyz");
 
     final SourceConnectionImplementation expectedSourceConnectionImplementation =
@@ -246,8 +246,8 @@ class SourceImplementationsHandlerTest {
         sourceConnectionImplementation.getSourceSpecificationId());
     expectedSourceConnectionImplementation.setSourceImplementationId(
         sourceConnectionImplementation.getSourceImplementationId());
-    expectedSourceConnectionImplementation.setConfigurationJson(
-        sourceConnectionImplementation.getConfigurationJson());
+    expectedSourceConnectionImplementation.setConfiguration(
+        sourceConnectionImplementation.getConfiguration());
     expectedSourceConnectionImplementation.setTombstone(true);
 
     when(configPersistence.getConfig(

--- a/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/SourceImplementationsHandlerTest.java
@@ -100,7 +100,7 @@ class SourceImplementationsHandlerTest {
     sourceImplementationCreate.setWorkspaceId(sourceConnectionImplementation.getWorkspaceId());
     sourceImplementationCreate.setSourceSpecificationId(
         sourceConnectionSpecification.getSourceSpecificationId());
-    sourceImplementationCreate.setConnectionConfiguration12345(
+    sourceImplementationCreate.setConnectionConfiguration(
         SourceImplementationHelpers.getTestImplementationJson());
 
     final SourceImplementationRead actualSourceImplementationRead =
@@ -109,7 +109,7 @@ class SourceImplementationsHandlerTest {
     SourceImplementationRead expectedSourceImplementationRead =
         SourceImplementationHelpers.getSourceImplementationRead(
             sourceConnectionImplementation, sourceConnectionSpecification.getSourceId());
-    expectedSourceImplementationRead.setConnectionConfiguration12345(
+    expectedSourceImplementationRead.setConnectionConfiguration(
         SourceImplementationHelpers.getTestImplementationJson());
 
     assertEquals(expectedSourceImplementationRead, actualSourceImplementationRead);
@@ -117,7 +117,7 @@ class SourceImplementationsHandlerTest {
     verify(validator)
         .validateSourceConnectionConfiguration(
             sourceConnectionSpecification.getSourceSpecificationId(),
-            sourceConnectionImplementation.getConfigurationJson12345());
+            sourceConnectionImplementation.getConfigurationJson());
 
     verify(configPersistence)
         .writeConfig(
@@ -128,7 +128,7 @@ class SourceImplementationsHandlerTest {
 
   @Test
   void testUpdateSourceImplementation() throws JsonValidationException, ConfigNotFoundException {
-    final JsonNode newConfiguration = sourceConnectionImplementation.getConfigurationJson12345();
+    final JsonNode newConfiguration = sourceConnectionImplementation.getConfigurationJson();
     ((ObjectNode) newConfiguration).put("apiKey", "987-xyz");
 
     final SourceConnectionImplementation expectedSourceConnectionImplementation =
@@ -139,7 +139,7 @@ class SourceImplementationsHandlerTest {
         sourceConnectionImplementation.getSourceSpecificationId());
     expectedSourceConnectionImplementation.setSourceImplementationId(
         sourceConnectionImplementation.getSourceImplementationId());
-    expectedSourceConnectionImplementation.setConfigurationJson12345(newConfiguration);
+    expectedSourceConnectionImplementation.setConfigurationJson(newConfiguration);
     expectedSourceConnectionImplementation.setTombstone(false);
 
     when(configPersistence.getConfig(
@@ -158,14 +158,14 @@ class SourceImplementationsHandlerTest {
     final SourceImplementationUpdate sourceImplementationUpdate = new SourceImplementationUpdate();
     sourceImplementationUpdate.setSourceImplementationId(
         sourceConnectionImplementation.getSourceImplementationId());
-    sourceImplementationUpdate.setConnectionConfiguration12345(newConfiguration);
+    sourceImplementationUpdate.setConnectionConfiguration(newConfiguration);
     final SourceImplementationRead actualSourceImplementationRead =
         sourceImplementationsHandler.updateSourceImplementation(sourceImplementationUpdate);
 
     SourceImplementationRead expectedSourceImplementationRead =
         SourceImplementationHelpers.getSourceImplementationRead(
             sourceConnectionImplementation, sourceConnectionSpecification.getSourceId());
-    expectedSourceImplementationRead.setConnectionConfiguration12345(newConfiguration);
+    expectedSourceImplementationRead.setConnectionConfiguration(newConfiguration);
 
     assertEquals(expectedSourceImplementationRead, actualSourceImplementationRead);
 
@@ -235,7 +235,7 @@ class SourceImplementationsHandlerTest {
 
   @Test
   void testDeleteSourceImplementation() throws JsonValidationException, ConfigNotFoundException {
-    final JsonNode newConfiguration = sourceConnectionImplementation.getConfigurationJson12345();
+    final JsonNode newConfiguration = sourceConnectionImplementation.getConfigurationJson();
     ((ObjectNode) newConfiguration).put("apiKey", "987-xyz");
 
     final SourceConnectionImplementation expectedSourceConnectionImplementation =
@@ -246,8 +246,8 @@ class SourceImplementationsHandlerTest {
         sourceConnectionImplementation.getSourceSpecificationId());
     expectedSourceConnectionImplementation.setSourceImplementationId(
         sourceConnectionImplementation.getSourceImplementationId());
-    expectedSourceConnectionImplementation.setConfigurationJson12345(
-        sourceConnectionImplementation.getConfigurationJson12345());
+    expectedSourceConnectionImplementation.setConfigurationJson(
+        sourceConnectionImplementation.getConfigurationJson());
     expectedSourceConnectionImplementation.setTombstone(true);
 
     when(configPersistence.getConfig(

--- a/dataline-server/src/test/java/io/dataline/server/handlers/SourceSpecificationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/SourceSpecificationsHandlerTest.java
@@ -64,8 +64,8 @@ class SourceSpecificationsHandlerTest {
     expectedSourceSpecificationRead.setSourceId(sourceConnectionSpecification.getSourceId());
     expectedSourceSpecificationRead.setSourceSpecificationId(
         sourceConnectionSpecification.getSourceSpecificationId());
-    expectedSourceSpecificationRead.setConnectionSpecification12345(
-        sourceConnectionSpecification.getSpecificationJson12345());
+    expectedSourceSpecificationRead.setConnectionSpecification(
+        sourceConnectionSpecification.getSpecificationJson());
 
     final SourceIdRequestBody sourceIdRequestBody = new SourceIdRequestBody();
     sourceIdRequestBody.setSourceId(expectedSourceSpecificationRead.getSourceId());

--- a/dataline-server/src/test/java/io/dataline/server/handlers/SourceSpecificationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/SourceSpecificationsHandlerTest.java
@@ -64,8 +64,8 @@ class SourceSpecificationsHandlerTest {
     expectedSourceSpecificationRead.setSourceId(sourceConnectionSpecification.getSourceId());
     expectedSourceSpecificationRead.setSourceSpecificationId(
         sourceConnectionSpecification.getSourceSpecificationId());
-    expectedSourceSpecificationRead.setConnectionSpecification(
-        sourceConnectionSpecification.getSpecificationJson());
+    expectedSourceSpecificationRead.setConnectionSpecification12345(
+        sourceConnectionSpecification.getSpecificationJson12345());
 
     final SourceIdRequestBody sourceIdRequestBody = new SourceIdRequestBody();
     sourceIdRequestBody.setSourceId(expectedSourceSpecificationRead.getSourceId());

--- a/dataline-server/src/test/java/io/dataline/server/handlers/SourceSpecificationsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/SourceSpecificationsHandlerTest.java
@@ -65,7 +65,7 @@ class SourceSpecificationsHandlerTest {
     expectedSourceSpecificationRead.setSourceSpecificationId(
         sourceConnectionSpecification.getSourceSpecificationId());
     expectedSourceSpecificationRead.setConnectionSpecification(
-        sourceConnectionSpecification.getSpecificationJson());
+        sourceConnectionSpecification.getSpecification());
 
     final SourceIdRequestBody sourceIdRequestBody = new SourceIdRequestBody();
     sourceIdRequestBody.setSourceId(expectedSourceSpecificationRead.getSourceId());

--- a/dataline-server/src/test/java/io/dataline/server/helpers/DestinationSpecificationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/DestinationSpecificationHelpers.java
@@ -46,7 +46,7 @@ public class DestinationSpecificationHelpers {
         new DestinationConnectionSpecification();
     destinationConnectionSpecification.setDestinationId(destinationId);
     destinationConnectionSpecification.setDestinationSpecificationId(destinationSpecificationId);
-    destinationConnectionSpecification.setSpecificationJson12345(Jsons.deserialize(Files.readString(path)));
+    destinationConnectionSpecification.setSpecificationJson(Jsons.deserialize(Files.readString(path)));
 
     return destinationConnectionSpecification;
   }

--- a/dataline-server/src/test/java/io/dataline/server/helpers/DestinationSpecificationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/DestinationSpecificationHelpers.java
@@ -46,7 +46,7 @@ public class DestinationSpecificationHelpers {
         new DestinationConnectionSpecification();
     destinationConnectionSpecification.setDestinationId(destinationId);
     destinationConnectionSpecification.setDestinationSpecificationId(destinationSpecificationId);
-    destinationConnectionSpecification.setSpecificationJson(Jsons.deserialize(Files.readString(path)));
+    destinationConnectionSpecification.setSpecification(Jsons.deserialize(Files.readString(path)));
 
     return destinationConnectionSpecification;
   }

--- a/dataline-server/src/test/java/io/dataline/server/helpers/DestinationSpecificationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/DestinationSpecificationHelpers.java
@@ -24,6 +24,7 @@
 
 package io.dataline.server.helpers;
 
+import io.dataline.commons.json.Jsons;
 import io.dataline.config.DestinationConnectionSpecification;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -45,7 +46,7 @@ public class DestinationSpecificationHelpers {
         new DestinationConnectionSpecification();
     destinationConnectionSpecification.setDestinationId(destinationId);
     destinationConnectionSpecification.setDestinationSpecificationId(destinationSpecificationId);
-    destinationConnectionSpecification.setSpecificationJson(Files.readString(path));
+    destinationConnectionSpecification.setSpecificationJson12345(Jsons.deserialize(Files.readString(path)));
 
     return destinationConnectionSpecification;
   }

--- a/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
@@ -24,7 +24,9 @@
 
 package io.dataline.server.helpers;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.dataline.api.model.SourceImplementationRead;
+import io.dataline.commons.json.Jsons;
 import io.dataline.config.SourceConnectionImplementation;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -34,33 +36,31 @@ import java.util.UUID;
 
 public class SourceImplementationHelpers {
 
-  public static SourceConnectionImplementation generateSourceImplementation(
-                                                                            UUID sourceSpecificationId)
+  public static SourceConnectionImplementation generateSourceImplementation(UUID sourceSpecificationId)
       throws IOException {
     final UUID workspaceId = UUID.randomUUID();
     final UUID sourceImplementationId = UUID.randomUUID();
 
-    String implementationJson = getTestImplementationJson();
+    JsonNode implementationJson = getTestImplementationJson();
 
     final SourceConnectionImplementation sourceConnectionImplementation =
         new SourceConnectionImplementation();
     sourceConnectionImplementation.setWorkspaceId(workspaceId);
     sourceConnectionImplementation.setSourceSpecificationId(sourceSpecificationId);
     sourceConnectionImplementation.setSourceImplementationId(sourceImplementationId);
-    sourceConnectionImplementation.setConfigurationJson(implementationJson);
+    sourceConnectionImplementation.setConfigurationJson12345(implementationJson);
     sourceConnectionImplementation.setTombstone(false);
 
     return sourceConnectionImplementation;
   }
 
-  public static String getTestImplementationJson() throws IOException {
+  public static JsonNode getTestImplementationJson() throws IOException {
     final Path path =
         Paths.get("../dataline-server/src/test/resources/json/TestImplementation.json");
-    return Files.readString(path);
+    return Jsons.deserialize(Files.readString(path));
   }
 
-  public static SourceImplementationRead getSourceImplementationRead(
-                                                                     SourceConnectionImplementation sourceImplementation,
+  public static SourceImplementationRead getSourceImplementationRead(SourceConnectionImplementation sourceImplementation,
                                                                      UUID sourceId) {
     SourceImplementationRead sourceImplementationRead = new SourceImplementationRead();
     sourceImplementationRead.setSourceId(sourceId);
@@ -69,8 +69,8 @@ public class SourceImplementationHelpers {
         sourceImplementation.getSourceSpecificationId());
     sourceImplementationRead.setSourceImplementationId(
         sourceImplementation.getSourceImplementationId());
-    sourceImplementationRead.setConnectionConfiguration(
-        sourceImplementation.getConfigurationJson());
+    sourceImplementationRead.setConnectionConfiguration12345(
+        sourceImplementation.getConfigurationJson12345());
 
     return sourceImplementationRead;
   }

--- a/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
@@ -48,7 +48,7 @@ public class SourceImplementationHelpers {
     sourceConnectionImplementation.setWorkspaceId(workspaceId);
     sourceConnectionImplementation.setSourceSpecificationId(sourceSpecificationId);
     sourceConnectionImplementation.setSourceImplementationId(sourceImplementationId);
-    sourceConnectionImplementation.setConfigurationJson12345(implementationJson);
+    sourceConnectionImplementation.setConfigurationJson(implementationJson);
     sourceConnectionImplementation.setTombstone(false);
 
     return sourceConnectionImplementation;
@@ -69,8 +69,8 @@ public class SourceImplementationHelpers {
         sourceImplementation.getSourceSpecificationId());
     sourceImplementationRead.setSourceImplementationId(
         sourceImplementation.getSourceImplementationId());
-    sourceImplementationRead.setConnectionConfiguration12345(
-        sourceImplementation.getConfigurationJson12345());
+    sourceImplementationRead.setConnectionConfiguration(
+        sourceImplementation.getConfigurationJson());
 
     return sourceImplementationRead;
   }

--- a/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/SourceImplementationHelpers.java
@@ -48,7 +48,7 @@ public class SourceImplementationHelpers {
     sourceConnectionImplementation.setWorkspaceId(workspaceId);
     sourceConnectionImplementation.setSourceSpecificationId(sourceSpecificationId);
     sourceConnectionImplementation.setSourceImplementationId(sourceImplementationId);
-    sourceConnectionImplementation.setConfigurationJson(implementationJson);
+    sourceConnectionImplementation.setConfiguration(implementationJson);
     sourceConnectionImplementation.setTombstone(false);
 
     return sourceConnectionImplementation;
@@ -70,7 +70,7 @@ public class SourceImplementationHelpers {
     sourceImplementationRead.setSourceImplementationId(
         sourceImplementation.getSourceImplementationId());
     sourceImplementationRead.setConnectionConfiguration(
-        sourceImplementation.getConfigurationJson());
+        sourceImplementation.getConfiguration());
 
     return sourceImplementationRead;
   }

--- a/dataline-server/src/test/java/io/dataline/server/helpers/SourceSpecificationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/SourceSpecificationHelpers.java
@@ -45,7 +45,7 @@ public class SourceSpecificationHelpers {
         new SourceConnectionSpecification();
     sourceConnectionSpecification.setSourceId(sourceId);
     sourceConnectionSpecification.setSourceSpecificationId(sourceSpecificationId);
-    sourceConnectionSpecification.setSpecificationJson(Jsons.deserialize(Files.readString(path)));
+    sourceConnectionSpecification.setSpecification(Jsons.deserialize(Files.readString(path)));
 
     return sourceConnectionSpecification;
   }

--- a/dataline-server/src/test/java/io/dataline/server/helpers/SourceSpecificationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/SourceSpecificationHelpers.java
@@ -45,7 +45,7 @@ public class SourceSpecificationHelpers {
         new SourceConnectionSpecification();
     sourceConnectionSpecification.setSourceId(sourceId);
     sourceConnectionSpecification.setSourceSpecificationId(sourceSpecificationId);
-    sourceConnectionSpecification.setSpecificationJson12345(Jsons.deserialize(Files.readString(path)));
+    sourceConnectionSpecification.setSpecificationJson(Jsons.deserialize(Files.readString(path)));
 
     return sourceConnectionSpecification;
   }

--- a/dataline-server/src/test/java/io/dataline/server/helpers/SourceSpecificationHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/SourceSpecificationHelpers.java
@@ -24,6 +24,7 @@
 
 package io.dataline.server.helpers;
 
+import io.dataline.commons.json.Jsons;
 import io.dataline.config.SourceConnectionSpecification;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -44,7 +45,7 @@ public class SourceSpecificationHelpers {
         new SourceConnectionSpecification();
     sourceConnectionSpecification.setSourceId(sourceId);
     sourceConnectionSpecification.setSourceSpecificationId(sourceSpecificationId);
-    sourceConnectionSpecification.setSpecificationJson(Files.readString(path));
+    sourceConnectionSpecification.setSpecificationJson12345(Jsons.deserialize(Files.readString(path)));
 
     return sourceConnectionSpecification;
   }

--- a/dataline-workers/build.gradle
+++ b/dataline-workers/build.gradle
@@ -8,7 +8,7 @@ configurations {
 
 dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.9.8"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
 
     implementation project(":dataline-config:models")
     implementation project(":dataline-db")

--- a/dataline-workers/src/main/java/io/dataline/workers/protocol/singer/MessageUtils.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocol/singer/MessageUtils.java
@@ -44,7 +44,7 @@ public class MessageUtils {
                                                   Instant timeExtracted) {
     final SingerMessage singerMessage = new SingerMessage();
     singerMessage.setType(SingerMessage.Type.RECORD);
-    singerMessage.setRecord(Jsons.serialize(record));
+    singerMessage.setRecordJson12345(record);
     singerMessage.setStream(tableName);
 
     Optional.ofNullable(timeExtracted)

--- a/dataline-workers/src/main/java/io/dataline/workers/protocol/singer/MessageUtils.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocol/singer/MessageUtils.java
@@ -44,7 +44,7 @@ public class MessageUtils {
                                                   Instant timeExtracted) {
     final SingerMessage singerMessage = new SingerMessage();
     singerMessage.setType(SingerMessage.Type.RECORD);
-    singerMessage.setRecordJson(record);
+    singerMessage.setRecord(record);
     singerMessage.setStream(tableName);
 
     Optional.ofNullable(timeExtracted)

--- a/dataline-workers/src/main/java/io/dataline/workers/protocol/singer/MessageUtils.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocol/singer/MessageUtils.java
@@ -44,7 +44,7 @@ public class MessageUtils {
                                                   Instant timeExtracted) {
     final SingerMessage singerMessage = new SingerMessage();
     singerMessage.setType(SingerMessage.Type.RECORD);
-    singerMessage.setRecordJson12345(record);
+    singerMessage.setRecordJson(record);
     singerMessage.setStream(tableName);
 
     Optional.ofNullable(timeExtracted)

--- a/dataline-workers/src/main/java/io/dataline/workers/protocol/singer/SingerMessageTracker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocol/singer/SingerMessageTracker.java
@@ -52,7 +52,7 @@ public class SingerMessageTracker implements Consumer<SingerMessage> {
     if (message.getType().equals(SingerMessage.Type.STATE)) {
       final State state = new State();
       state.setConnectionId(connectionId);
-      state.setStateJson(message.getValueJson());
+      state.setState(message.getValue());
       outputState.set(state);
     }
   }

--- a/dataline-workers/src/main/java/io/dataline/workers/protocol/singer/SingerMessageTracker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocol/singer/SingerMessageTracker.java
@@ -24,7 +24,6 @@
 
 package io.dataline.workers.protocol.singer;
 
-import io.dataline.commons.json.Jsons;
 import io.dataline.config.SingerMessage;
 import io.dataline.config.State;
 import java.util.Optional;
@@ -46,14 +45,14 @@ public class SingerMessageTracker implements Consumer<SingerMessage> {
   }
 
   @Override
-  public void accept(SingerMessage record) {
-    if (record.getType().equals(SingerMessage.Type.RECORD)) {
+  public void accept(SingerMessage message) {
+    if (message.getType().equals(SingerMessage.Type.RECORD)) {
       recordCount.incrementAndGet();
     }
-    if (record.getType().equals(SingerMessage.Type.STATE)) {
+    if (message.getType().equals(SingerMessage.Type.STATE)) {
       final State state = new State();
       state.setConnectionId(connectionId);
-      state.setStateJson(Jsons.serialize(record));
+      state.setStateJson12345(message.getValueJson12345());
       outputState.set(state);
     }
   }

--- a/dataline-workers/src/main/java/io/dataline/workers/protocol/singer/SingerMessageTracker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocol/singer/SingerMessageTracker.java
@@ -52,7 +52,7 @@ public class SingerMessageTracker implements Consumer<SingerMessage> {
     if (message.getType().equals(SingerMessage.Type.STATE)) {
       final State state = new State();
       state.setConnectionId(connectionId);
-      state.setStateJson12345(message.getValueJson12345());
+      state.setStateJson(message.getValueJson());
       outputState.set(state);
     }
   }

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerCheckConnectionWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerCheckConnectionWorker.java
@@ -55,7 +55,7 @@ public class SingerCheckConnectionWorker
       throws InvalidCredentialsException {
 
     final StandardDiscoverSchemaInput discoverSchemaInput = new StandardDiscoverSchemaInput();
-    discoverSchemaInput.setConnectionConfigurationJson(input.getConnectionConfigurationJson());
+    discoverSchemaInput.setConnectionConfigurationJson12345(input.getConnectionConfigurationJson12345());
 
     OutputAndStatus<StandardDiscoverSchemaOutput> outputAndStatus =
         singerDiscoverSchemaWorker.run(discoverSchemaInput, jobRoot);

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerCheckConnectionWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerCheckConnectionWorker.java
@@ -55,7 +55,7 @@ public class SingerCheckConnectionWorker
       throws InvalidCredentialsException {
 
     final StandardDiscoverSchemaInput discoverSchemaInput = new StandardDiscoverSchemaInput();
-    discoverSchemaInput.setConnectionConfigurationJson12345(input.getConnectionConfigurationJson12345());
+    discoverSchemaInput.setConnectionConfigurationJson(input.getConnectionConfigurationJson());
 
     OutputAndStatus<StandardDiscoverSchemaOutput> outputAndStatus =
         singerDiscoverSchemaWorker.run(discoverSchemaInput, jobRoot);

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerCheckConnectionWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerCheckConnectionWorker.java
@@ -55,7 +55,7 @@ public class SingerCheckConnectionWorker
       throws InvalidCredentialsException {
 
     final StandardDiscoverSchemaInput discoverSchemaInput = new StandardDiscoverSchemaInput();
-    discoverSchemaInput.setConnectionConfigurationJson(input.getConnectionConfigurationJson());
+    discoverSchemaInput.setConnectionConfiguration(input.getConnectionConfiguration());
 
     OutputAndStatus<StandardDiscoverSchemaOutput> outputAndStatus =
         singerDiscoverSchemaWorker.run(discoverSchemaInput, jobRoot);

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerDiscoverSchemaWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerDiscoverSchemaWorker.java
@@ -73,7 +73,7 @@ public class SingerDiscoverSchemaWorker
       throws InvalidCredentialsException {
     // todo (cgardens) - just getting original impl to line up with new iface for now. this can be
     // reduced.
-    final JsonNode configDotJson = discoverSchemaInput.getConnectionConfigurationJson12345();
+    final JsonNode configDotJson = discoverSchemaInput.getConnectionConfigurationJson();
 
     IOs.writeFile(jobRoot, CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
 

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerDiscoverSchemaWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerDiscoverSchemaWorker.java
@@ -73,7 +73,7 @@ public class SingerDiscoverSchemaWorker
       throws InvalidCredentialsException {
     // todo (cgardens) - just getting original impl to line up with new iface for now. this can be
     // reduced.
-    final JsonNode configDotJson = discoverSchemaInput.getConnectionConfigurationJson();
+    final JsonNode configDotJson = discoverSchemaInput.getConnectionConfiguration();
 
     IOs.writeFile(jobRoot, CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
 

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerDiscoverSchemaWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerDiscoverSchemaWorker.java
@@ -27,6 +27,7 @@ package io.dataline.workers.singer;
 import static io.dataline.workers.JobStatus.FAILED;
 import static io.dataline.workers.JobStatus.SUCCESSFUL;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.dataline.commons.io.IOs;
 import io.dataline.commons.json.Jsons;
 import io.dataline.config.Schema;
@@ -72,9 +73,9 @@ public class SingerDiscoverSchemaWorker
       throws InvalidCredentialsException {
     // todo (cgardens) - just getting original impl to line up with new iface for now. this can be
     // reduced.
-    final String configDotJson = discoverSchemaInput.getConnectionConfigurationJson();
+    final JsonNode configDotJson = discoverSchemaInput.getConnectionConfigurationJson12345();
 
-    IOs.writeFile(jobRoot, CONFIG_JSON_FILENAME, configDotJson);
+    IOs.writeFile(jobRoot, CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
 
     // exec
     try {

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTapFactory.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTapFactory.java
@@ -88,7 +88,7 @@ public class SingerTapFactory implements TapFactory<SingerMessage> {
   public Stream<SingerMessage> create(StandardTapConfig input, Path jobRoot) throws InvalidCredentialsException {
     OutputAndStatus<SingerCatalog> discoveryOutput = runDiscovery(input, jobRoot);
 
-    final JsonNode configDotJson = input.getSourceConnectionImplementation().getConfigurationJson();
+    final JsonNode configDotJson = input.getSourceConnectionImplementation().getConfiguration();
 
     final SingerCatalog selectedCatalog = SingerCatalogConverters.applySchemaToDiscoveredCatalog(
         discoveryOutput.getOutput().get(), input.getStandardSync().getSchema());
@@ -139,7 +139,7 @@ public class SingerTapFactory implements TapFactory<SingerMessage> {
   private OutputAndStatus<SingerCatalog> runDiscovery(StandardTapConfig input, Path jobRoot)
       throws InvalidCredentialsException {
     StandardDiscoverSchemaInput discoveryInput = new StandardDiscoverSchemaInput();
-    discoveryInput.setConnectionConfigurationJson(input.getSourceConnectionImplementation().getConfigurationJson());
+    discoveryInput.setConnectionConfiguration(input.getSourceConnectionImplementation().getConfiguration());
     Path discoverJobRoot = jobRoot.resolve(DISCOVERY_DIR);
     return discoverSchemaWorker.runInternal(discoveryInput, discoverJobRoot);
   }

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTapFactory.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTapFactory.java
@@ -88,7 +88,7 @@ public class SingerTapFactory implements TapFactory<SingerMessage> {
   public Stream<SingerMessage> create(StandardTapConfig input, Path jobRoot) throws InvalidCredentialsException {
     OutputAndStatus<SingerCatalog> discoveryOutput = runDiscovery(input, jobRoot);
 
-    final JsonNode configDotJson = input.getSourceConnectionImplementation().getConfigurationJson12345();
+    final JsonNode configDotJson = input.getSourceConnectionImplementation().getConfigurationJson();
 
     final SingerCatalog selectedCatalog = SingerCatalogConverters.applySchemaToDiscoveredCatalog(
         discoveryOutput.getOutput().get(), input.getStandardSync().getSchema());
@@ -139,7 +139,7 @@ public class SingerTapFactory implements TapFactory<SingerMessage> {
   private OutputAndStatus<SingerCatalog> runDiscovery(StandardTapConfig input, Path jobRoot)
       throws InvalidCredentialsException {
     StandardDiscoverSchemaInput discoveryInput = new StandardDiscoverSchemaInput();
-    discoveryInput.setConnectionConfigurationJson12345(input.getSourceConnectionImplementation().getConfigurationJson12345());
+    discoveryInput.setConnectionConfigurationJson(input.getSourceConnectionImplementation().getConfigurationJson());
     Path discoverJobRoot = jobRoot.resolve(DISCOVERY_DIR);
     return discoverSchemaWorker.runInternal(discoveryInput, discoverJobRoot);
   }

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTapFactory.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTapFactory.java
@@ -24,6 +24,7 @@
 
 package io.dataline.workers.singer;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
 import io.dataline.commons.io.IOs;
 import io.dataline.commons.json.Jsons;
@@ -87,14 +88,14 @@ public class SingerTapFactory implements TapFactory<SingerMessage> {
   public Stream<SingerMessage> create(StandardTapConfig input, Path jobRoot) throws InvalidCredentialsException {
     OutputAndStatus<SingerCatalog> discoveryOutput = runDiscovery(input, jobRoot);
 
-    final String configDotJson = input.getSourceConnectionImplementation().getConfigurationJson();
+    final JsonNode configDotJson = input.getSourceConnectionImplementation().getConfigurationJson12345();
 
     final SingerCatalog selectedCatalog = SingerCatalogConverters.applySchemaToDiscoveredCatalog(
         discoveryOutput.getOutput().get(), input.getStandardSync().getSchema());
     final String catalogDotJson = Jsons.serialize(selectedCatalog);
     final String stateDotJson = Jsons.serialize(input.getState());
 
-    IOs.writeFile(jobRoot, CONFIG_JSON_FILENAME, configDotJson);
+    IOs.writeFile(jobRoot, CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
     IOs.writeFile(jobRoot, CATALOG_JSON_FILENAME, catalogDotJson);
     IOs.writeFile(jobRoot, STATE_JSON_FILENAME, stateDotJson);
 
@@ -138,8 +139,7 @@ public class SingerTapFactory implements TapFactory<SingerMessage> {
   private OutputAndStatus<SingerCatalog> runDiscovery(StandardTapConfig input, Path jobRoot)
       throws InvalidCredentialsException {
     StandardDiscoverSchemaInput discoveryInput = new StandardDiscoverSchemaInput();
-    discoveryInput.setConnectionConfigurationJson(
-        input.getSourceConnectionImplementation().getConfigurationJson());
+    discoveryInput.setConnectionConfigurationJson12345(input.getSourceConnectionImplementation().getConfigurationJson12345());
     Path discoverJobRoot = jobRoot.resolve(DISCOVERY_DIR);
     return discoverSchemaWorker.runInternal(discoveryInput, discoverJobRoot);
   }

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTargetFactory.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTargetFactory.java
@@ -58,7 +58,7 @@ public class SingerTargetFactory implements TargetFactory<SingerMessage> {
 
   @Override
   public CloseableConsumer<SingerMessage> create(StandardTargetConfig targetConfig, Path jobRoot) {
-    final JsonNode configDotJson = targetConfig.getDestinationConnectionImplementation().getConfigurationJson12345();
+    final JsonNode configDotJson = targetConfig.getDestinationConnectionImplementation().getConfigurationJson();
 
     // write config.json to disk
     Path configPath = IOs.writeFile(jobRoot, CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTargetFactory.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTargetFactory.java
@@ -58,7 +58,7 @@ public class SingerTargetFactory implements TargetFactory<SingerMessage> {
 
   @Override
   public CloseableConsumer<SingerMessage> create(StandardTargetConfig targetConfig, Path jobRoot) {
-    final JsonNode configDotJson = targetConfig.getDestinationConnectionImplementation().getConfigurationJson();
+    final JsonNode configDotJson = targetConfig.getDestinationConnectionImplementation().getConfiguration();
 
     // write config.json to disk
     Path configPath = IOs.writeFile(jobRoot, CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTargetFactory.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTargetFactory.java
@@ -24,9 +24,11 @@
 
 package io.dataline.workers.singer;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Charsets;
 import io.dataline.commons.functional.CloseableConsumer;
 import io.dataline.commons.io.IOs;
+import io.dataline.commons.json.Jsons;
 import io.dataline.config.SingerMessage;
 import io.dataline.config.StandardTargetConfig;
 import io.dataline.workers.DefaultSyncWorker;
@@ -56,11 +58,10 @@ public class SingerTargetFactory implements TargetFactory<SingerMessage> {
 
   @Override
   public CloseableConsumer<SingerMessage> create(StandardTargetConfig targetConfig, Path jobRoot) {
-    final String configDotJson =
-        targetConfig.getDestinationConnectionImplementation().getConfigurationJson();
+    final JsonNode configDotJson = targetConfig.getDestinationConnectionImplementation().getConfigurationJson12345();
 
     // write config.json to disk
-    Path configPath = IOs.writeFile(jobRoot, CONFIG_JSON_FILENAME, configDotJson);
+    Path configPath = IOs.writeFile(jobRoot, CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
 
     try {
       final Process targetProcess =

--- a/dataline-workers/src/test/java/io/dataline/workers/PostgreSQLContainerTestHelper.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/PostgreSQLContainerTestHelper.java
@@ -24,15 +24,12 @@
 
 package io.dataline.workers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.dataline.commons.json.Jsons;
-import io.dataline.db.DatabaseHelper;
 import java.io.IOException;
-import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import org.apache.commons.dbcp2.BasicDataSource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.MountableFile;
 
@@ -46,21 +43,7 @@ public class PostgreSQLContainerTestHelper {
         "psql", "-d", db.getDatabaseName(), "-U", db.getUsername(), "-a", "-f", scriptPath);
   }
 
-  public static void wipePublicSchema(PostgreSQLContainer db) throws SQLException {
-    BasicDataSource connectionPool = getConnectionPool(db);
-    DatabaseHelper.execute(
-        connectionPool,
-        context -> {
-          context.execute("DROP SCHEMA public CASCADE;");
-          context.execute("CREATE SCHEMA public;");
-        });
-  }
-
-  public static BasicDataSource getConnectionPool(PostgreSQLContainer db) {
-    return DatabaseHelper.getConnectionPool(db.getUsername(), db.getPassword(), db.getJdbcUrl());
-  }
-
-  public static String getSingerTapConfig(PostgreSQLContainer db) throws JsonProcessingException {
+  public static JsonNode getSingerTapConfig(PostgreSQLContainer db) {
     return getSingerTapConfig(
         db.getUsername(),
         db.getPassword(),
@@ -69,11 +52,11 @@ public class PostgreSQLContainerTestHelper {
         String.valueOf(db.getFirstMappedPort()));
   }
 
-  public static String getSingerTapConfig(String user,
-                                          String password,
-                                          String host,
-                                          String dbname,
-                                          String port) {
+  public static JsonNode getSingerTapConfig(String user,
+                                            String password,
+                                            String host,
+                                            String dbname,
+                                            String port) {
     Map<String, String> creds = new HashMap<>();
     creds.put("user", user);
     creds.put("password", password);
@@ -81,36 +64,7 @@ public class PostgreSQLContainerTestHelper {
     creds.put("dbname", dbname);
     creds.put("port", port);
 
-    return Jsons.serialize(creds);
-  }
-
-  public static String getSingerTargetConfig(PostgreSQLContainer db)
-      throws JsonProcessingException {
-    return getSingerTargetConfig(
-        db.getUsername(),
-        db.getPassword(),
-        db.getHost(),
-        db.getDatabaseName(),
-        String.valueOf(db.getFirstMappedPort()),
-        "public");
-  }
-
-  // TODO this will be moved into Taps/Targets
-  public static String getSingerTargetConfig(String user,
-                                             String password,
-                                             String host,
-                                             String dbname,
-                                             String port,
-                                             String schema) {
-    Map<String, String> creds = new HashMap<>();
-    creds.put("postgres_username", user);
-    creds.put("postgres_schema", schema);
-    creds.put("postgres_password", password);
-    creds.put("postgres_host", host);
-    creds.put("postgres_database", dbname);
-    creds.put("postgres_port", port);
-
-    return Jsons.serialize(creds);
+    return Jsons.jsonNode(creds);
   }
 
 }

--- a/dataline-workers/src/test/java/io/dataline/workers/TestConfigHelpers.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/TestConfigHelpers.java
@@ -69,7 +69,7 @@ public class TestConfigHelpers {
 
     final SourceConnectionImplementation sourceConnectionConfig =
         new SourceConnectionImplementation();
-    sourceConnectionConfig.setConfigurationJson12345(sourceConnection);
+    sourceConnectionConfig.setConfigurationJson(sourceConnection);
     sourceConnectionConfig.setWorkspaceId(workspaceId);
     sourceConnectionConfig.setSourceSpecificationId(sourceSpecificationId);
     sourceConnectionConfig.setSourceImplementationId(sourceImplementationId);
@@ -77,7 +77,7 @@ public class TestConfigHelpers {
 
     final DestinationConnectionImplementation destinationConnectionConfig =
         new DestinationConnectionImplementation();
-    destinationConnectionConfig.setConfigurationJson12345(destinationConnection);
+    destinationConnectionConfig.setConfigurationJson(destinationConnection);
     destinationConnectionConfig.setWorkspaceId(workspaceId);
     destinationConnectionConfig.setDestinationSpecificationId(destinationSpecificationId);
     destinationConnectionConfig.setDestinationImplementationId(destinationImplementationId);
@@ -108,7 +108,7 @@ public class TestConfigHelpers {
 
     State state = new State();
     state.setConnectionId(connectionId);
-    state.setStateJson12345(Jsons.jsonNode(stateValue));
+    state.setStateJson(Jsons.jsonNode(stateValue));
 
     StandardSyncInput syncInput = new StandardSyncInput();
     syncInput.setDestinationConnectionImplementation(destinationConnectionConfig);

--- a/dataline-workers/src/test/java/io/dataline/workers/TestConfigHelpers.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/TestConfigHelpers.java
@@ -69,7 +69,7 @@ public class TestConfigHelpers {
 
     final SourceConnectionImplementation sourceConnectionConfig =
         new SourceConnectionImplementation();
-    sourceConnectionConfig.setConfigurationJson(sourceConnection);
+    sourceConnectionConfig.setConfiguration(sourceConnection);
     sourceConnectionConfig.setWorkspaceId(workspaceId);
     sourceConnectionConfig.setSourceSpecificationId(sourceSpecificationId);
     sourceConnectionConfig.setSourceImplementationId(sourceImplementationId);
@@ -77,7 +77,7 @@ public class TestConfigHelpers {
 
     final DestinationConnectionImplementation destinationConnectionConfig =
         new DestinationConnectionImplementation();
-    destinationConnectionConfig.setConfigurationJson(destinationConnection);
+    destinationConnectionConfig.setConfiguration(destinationConnection);
     destinationConnectionConfig.setWorkspaceId(workspaceId);
     destinationConnectionConfig.setDestinationSpecificationId(destinationSpecificationId);
     destinationConnectionConfig.setDestinationImplementationId(destinationImplementationId);
@@ -108,7 +108,7 @@ public class TestConfigHelpers {
 
     State state = new State();
     state.setConnectionId(connectionId);
-    state.setStateJson(Jsons.jsonNode(stateValue));
+    state.setState(Jsons.jsonNode(stateValue));
 
     StandardSyncInput syncInput = new StandardSyncInput();
     syncInput.setDestinationConnectionImplementation(destinationConnectionConfig);

--- a/dataline-workers/src/test/java/io/dataline/workers/TestConfigHelpers.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/TestConfigHelpers.java
@@ -24,6 +24,7 @@
 
 package io.dataline.workers;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.dataline.commons.json.Jsons;
 import io.dataline.config.Column;
 import io.dataline.config.DataType;
@@ -54,21 +55,21 @@ public class TestConfigHelpers {
     final UUID destinationImplementationId = UUID.randomUUID();
     final UUID connectionId = UUID.randomUUID();
 
-    final String sourceConnection =
-        Jsons.serialize(
+    final JsonNode sourceConnection =
+        Jsons.jsonNode(
             Map.of(
                 "apiKey", "123",
                 "region", "us-east"));
 
-    final String destinationConnection =
-        Jsons.serialize(
+    final JsonNode destinationConnection =
+        Jsons.jsonNode(
             Map.of(
                 "username", "dataline",
                 "token", "anau81b"));
 
     final SourceConnectionImplementation sourceConnectionConfig =
         new SourceConnectionImplementation();
-    sourceConnectionConfig.setConfigurationJson(sourceConnection);
+    sourceConnectionConfig.setConfigurationJson12345(sourceConnection);
     sourceConnectionConfig.setWorkspaceId(workspaceId);
     sourceConnectionConfig.setSourceSpecificationId(sourceSpecificationId);
     sourceConnectionConfig.setSourceImplementationId(sourceImplementationId);
@@ -76,7 +77,7 @@ public class TestConfigHelpers {
 
     final DestinationConnectionImplementation destinationConnectionConfig =
         new DestinationConnectionImplementation();
-    destinationConnectionConfig.setConfigurationJson(destinationConnection);
+    destinationConnectionConfig.setConfigurationJson12345(destinationConnection);
     destinationConnectionConfig.setWorkspaceId(workspaceId);
     destinationConnectionConfig.setDestinationSpecificationId(destinationSpecificationId);
     destinationConnectionConfig.setDestinationImplementationId(destinationImplementationId);
@@ -107,7 +108,7 @@ public class TestConfigHelpers {
 
     State state = new State();
     state.setConnectionId(connectionId);
-    state.setStateJson(stateValue);
+    state.setStateJson12345(Jsons.jsonNode(stateValue));
 
     StandardSyncInput syncInput = new StandardSyncInput();
     syncInput.setDestinationConnectionImplementation(destinationConnectionConfig);

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerCheckConnectionWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerCheckConnectionWorkerTest.java
@@ -29,6 +29,7 @@ import static io.dataline.workers.JobStatus.SUCCESSFUL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.dataline.config.StandardCheckConnectionInput;
 import io.dataline.config.StandardCheckConnectionOutput;
 import io.dataline.integrations.Integrations;
@@ -62,13 +63,13 @@ public class SingerCheckConnectionWorkerTest extends BaseWorkerTestCase {
   public void testNonexistentDb()
       throws IOException, InvalidCredentialsException, InvalidCatalogException {
     final String jobId = "1";
-    String fakeDbCreds =
+    JsonNode fakeDbCreds =
         PostgreSQLContainerTestHelper.getSingerTapConfig(
             "user", "pass", "localhost", "postgres", "111111");
 
     final StandardCheckConnectionInput standardCheckConnectionInput =
         new StandardCheckConnectionInput();
-    standardCheckConnectionInput.setConnectionConfigurationJson(fakeDbCreds);
+    standardCheckConnectionInput.setConnectionConfigurationJson12345(fakeDbCreds);
 
     SingerCheckConnectionWorker worker =
         new SingerCheckConnectionWorker(Integrations.POSTGRES_TAP.getCheckConnectionImage(), pbf);
@@ -86,7 +87,7 @@ public class SingerCheckConnectionWorkerTest extends BaseWorkerTestCase {
   public void testIncorrectAuthCredentials()
       throws IOException, InvalidCredentialsException, InvalidCatalogException {
     final String jobId = "1";
-    String incorrectCreds =
+    JsonNode incorrectCreds =
         PostgreSQLContainerTestHelper.getSingerTapConfig(
             db.getUsername(),
             "wrongpassword",
@@ -99,7 +100,7 @@ public class SingerCheckConnectionWorkerTest extends BaseWorkerTestCase {
 
     final StandardCheckConnectionInput standardCheckConnectionInput =
         new StandardCheckConnectionInput();
-    standardCheckConnectionInput.setConnectionConfigurationJson(incorrectCreds);
+    standardCheckConnectionInput.setConnectionConfigurationJson12345(incorrectCreds);
 
     OutputAndStatus<StandardCheckConnectionOutput> run =
         worker.run(standardCheckConnectionInput, createJobRoot(jobId));
@@ -116,11 +117,11 @@ public class SingerCheckConnectionWorkerTest extends BaseWorkerTestCase {
       throws IOException, InvalidCredentialsException, InvalidCatalogException {
     final String jobId = "1";
 
-    String creds = PostgreSQLContainerTestHelper.getSingerTapConfig(db);
+    JsonNode creds = PostgreSQLContainerTestHelper.getSingerTapConfig(db);
 
     final StandardCheckConnectionInput standardCheckConnectionInput =
         new StandardCheckConnectionInput();
-    standardCheckConnectionInput.setConnectionConfigurationJson(creds);
+    standardCheckConnectionInput.setConnectionConfigurationJson12345(creds);
 
     SingerCheckConnectionWorker worker =
         new SingerCheckConnectionWorker(Integrations.POSTGRES_TAP.getCheckConnectionImage(), pbf);

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerCheckConnectionWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerCheckConnectionWorkerTest.java
@@ -69,7 +69,7 @@ public class SingerCheckConnectionWorkerTest extends BaseWorkerTestCase {
 
     final StandardCheckConnectionInput standardCheckConnectionInput =
         new StandardCheckConnectionInput();
-    standardCheckConnectionInput.setConnectionConfigurationJson12345(fakeDbCreds);
+    standardCheckConnectionInput.setConnectionConfigurationJson(fakeDbCreds);
 
     SingerCheckConnectionWorker worker =
         new SingerCheckConnectionWorker(Integrations.POSTGRES_TAP.getCheckConnectionImage(), pbf);
@@ -100,7 +100,7 @@ public class SingerCheckConnectionWorkerTest extends BaseWorkerTestCase {
 
     final StandardCheckConnectionInput standardCheckConnectionInput =
         new StandardCheckConnectionInput();
-    standardCheckConnectionInput.setConnectionConfigurationJson12345(incorrectCreds);
+    standardCheckConnectionInput.setConnectionConfigurationJson(incorrectCreds);
 
     OutputAndStatus<StandardCheckConnectionOutput> run =
         worker.run(standardCheckConnectionInput, createJobRoot(jobId));
@@ -121,7 +121,7 @@ public class SingerCheckConnectionWorkerTest extends BaseWorkerTestCase {
 
     final StandardCheckConnectionInput standardCheckConnectionInput =
         new StandardCheckConnectionInput();
-    standardCheckConnectionInput.setConnectionConfigurationJson12345(creds);
+    standardCheckConnectionInput.setConnectionConfigurationJson(creds);
 
     SingerCheckConnectionWorker worker =
         new SingerCheckConnectionWorker(Integrations.POSTGRES_TAP.getCheckConnectionImage(), pbf);

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerCheckConnectionWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerCheckConnectionWorkerTest.java
@@ -34,7 +34,6 @@ import io.dataline.config.StandardCheckConnectionInput;
 import io.dataline.config.StandardCheckConnectionOutput;
 import io.dataline.integrations.Integrations;
 import io.dataline.workers.BaseWorkerTestCase;
-import io.dataline.workers.InvalidCatalogException;
 import io.dataline.workers.InvalidCredentialsException;
 import io.dataline.workers.OutputAndStatus;
 import io.dataline.workers.PostgreSQLContainerTestHelper;
@@ -61,7 +60,7 @@ public class SingerCheckConnectionWorkerTest extends BaseWorkerTestCase {
 
   @Test
   public void testNonexistentDb()
-      throws IOException, InvalidCredentialsException, InvalidCatalogException {
+      throws IOException, InvalidCredentialsException {
     final String jobId = "1";
     JsonNode fakeDbCreds =
         PostgreSQLContainerTestHelper.getSingerTapConfig(
@@ -69,7 +68,7 @@ public class SingerCheckConnectionWorkerTest extends BaseWorkerTestCase {
 
     final StandardCheckConnectionInput standardCheckConnectionInput =
         new StandardCheckConnectionInput();
-    standardCheckConnectionInput.setConnectionConfigurationJson(fakeDbCreds);
+    standardCheckConnectionInput.setConnectionConfiguration(fakeDbCreds);
 
     SingerCheckConnectionWorker worker =
         new SingerCheckConnectionWorker(Integrations.POSTGRES_TAP.getCheckConnectionImage(), pbf);
@@ -85,7 +84,7 @@ public class SingerCheckConnectionWorkerTest extends BaseWorkerTestCase {
 
   @Test
   public void testIncorrectAuthCredentials()
-      throws IOException, InvalidCredentialsException, InvalidCatalogException {
+      throws IOException, InvalidCredentialsException {
     final String jobId = "1";
     JsonNode incorrectCreds =
         PostgreSQLContainerTestHelper.getSingerTapConfig(
@@ -100,7 +99,7 @@ public class SingerCheckConnectionWorkerTest extends BaseWorkerTestCase {
 
     final StandardCheckConnectionInput standardCheckConnectionInput =
         new StandardCheckConnectionInput();
-    standardCheckConnectionInput.setConnectionConfigurationJson(incorrectCreds);
+    standardCheckConnectionInput.setConnectionConfiguration(incorrectCreds);
 
     OutputAndStatus<StandardCheckConnectionOutput> run =
         worker.run(standardCheckConnectionInput, createJobRoot(jobId));
@@ -114,14 +113,14 @@ public class SingerCheckConnectionWorkerTest extends BaseWorkerTestCase {
 
   @Test
   public void testSuccessfulConnection()
-      throws IOException, InvalidCredentialsException, InvalidCatalogException {
+      throws IOException, InvalidCredentialsException {
     final String jobId = "1";
 
     JsonNode creds = PostgreSQLContainerTestHelper.getSingerTapConfig(db);
 
     final StandardCheckConnectionInput standardCheckConnectionInput =
         new StandardCheckConnectionInput();
-    standardCheckConnectionInput.setConnectionConfigurationJson(creds);
+    standardCheckConnectionInput.setConnectionConfiguration(creds);
 
     SingerCheckConnectionWorker worker =
         new SingerCheckConnectionWorker(Integrations.POSTGRES_TAP.getCheckConnectionImage(), pbf);

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerDiscoverSchemaWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerDiscoverSchemaWorkerTest.java
@@ -66,7 +66,7 @@ public class SingerDiscoverSchemaWorkerTest extends BaseWorkerTestCase {
     JsonNode postgresCreds = PostgreSQLContainerTestHelper.getSingerTapConfig(db);
 
     final StandardDiscoverSchemaInput input = new StandardDiscoverSchemaInput();
-    input.setConnectionConfigurationJson(postgresCreds);
+    input.setConnectionConfiguration(postgresCreds);
 
     SingerDiscoverSchemaWorker worker =
         new SingerDiscoverSchemaWorker(Integrations.POSTGRES_TAP.getDiscoverSchemaImage(), pbf);
@@ -87,7 +87,7 @@ public class SingerDiscoverSchemaWorkerTest extends BaseWorkerTestCase {
     JsonNode postgresCreds = PostgreSQLContainerTestHelper.getSingerTapConfig(db);
 
     final StandardDiscoverSchemaInput input = new StandardDiscoverSchemaInput();
-    input.setConnectionConfigurationJson(postgresCreds);
+    input.setConnectionConfiguration(postgresCreds);
 
     SingerDiscoverSchemaWorker worker =
         new SingerDiscoverSchemaWorker(Integrations.POSTGRES_TAP.getDiscoverSchemaImage(), pbf);

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerDiscoverSchemaWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerDiscoverSchemaWorkerTest.java
@@ -29,6 +29,7 @@ import static io.dataline.workers.JobStatus.SUCCESSFUL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.dataline.commons.json.Jsons;
 import io.dataline.config.StandardDiscoverSchemaInput;
 import io.dataline.config.StandardDiscoverSchemaOutput;
@@ -62,16 +63,15 @@ public class SingerDiscoverSchemaWorkerTest extends BaseWorkerTestCase {
 
   @Test
   public void testPostgresDiscovery() throws IOException, InvalidCredentialsException {
-    final String jobId = "1";
-    String postgresCreds = PostgreSQLContainerTestHelper.getSingerTapConfig(db);
+    JsonNode postgresCreds = PostgreSQLContainerTestHelper.getSingerTapConfig(db);
 
     final StandardDiscoverSchemaInput input = new StandardDiscoverSchemaInput();
-    input.setConnectionConfigurationJson(postgresCreds);
+    input.setConnectionConfigurationJson12345(postgresCreds);
 
     SingerDiscoverSchemaWorker worker =
         new SingerDiscoverSchemaWorker(Integrations.POSTGRES_TAP.getDiscoverSchemaImage(), pbf);
 
-    OutputAndStatus<StandardDiscoverSchemaOutput> run = worker.run(input, createJobRoot(jobId));
+    OutputAndStatus<StandardDiscoverSchemaOutput> run = worker.run(input, createJobRoot("1"));
 
     assertEquals(SUCCESSFUL, run.getStatus());
 
@@ -83,12 +83,11 @@ public class SingerDiscoverSchemaWorkerTest extends BaseWorkerTestCase {
   }
 
   @Test
-  public void testCancellation() throws IOException, InterruptedException, ExecutionException {
-    final String jobId = "1";
-    String postgresCreds = PostgreSQLContainerTestHelper.getSingerTapConfig(db);
+  public void testCancellation() throws InterruptedException, ExecutionException {
+    JsonNode postgresCreds = PostgreSQLContainerTestHelper.getSingerTapConfig(db);
 
     final StandardDiscoverSchemaInput input = new StandardDiscoverSchemaInput();
-    input.setConnectionConfigurationJson(postgresCreds);
+    input.setConnectionConfigurationJson12345(postgresCreds);
 
     SingerDiscoverSchemaWorker worker =
         new SingerDiscoverSchemaWorker(Integrations.POSTGRES_TAP.getDiscoverSchemaImage(), pbf);
@@ -99,7 +98,7 @@ public class SingerDiscoverSchemaWorkerTest extends BaseWorkerTestCase {
             () -> {
               try {
                 OutputAndStatus<StandardDiscoverSchemaOutput> output =
-                    worker.run(input, createJobRoot(jobId));
+                    worker.run(input, createJobRoot("1"));
                 assertEquals(FAILED, output.getStatus());
               } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerDiscoverSchemaWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerDiscoverSchemaWorkerTest.java
@@ -66,7 +66,7 @@ public class SingerDiscoverSchemaWorkerTest extends BaseWorkerTestCase {
     JsonNode postgresCreds = PostgreSQLContainerTestHelper.getSingerTapConfig(db);
 
     final StandardDiscoverSchemaInput input = new StandardDiscoverSchemaInput();
-    input.setConnectionConfigurationJson12345(postgresCreds);
+    input.setConnectionConfigurationJson(postgresCreds);
 
     SingerDiscoverSchemaWorker worker =
         new SingerDiscoverSchemaWorker(Integrations.POSTGRES_TAP.getDiscoverSchemaImage(), pbf);
@@ -87,7 +87,7 @@ public class SingerDiscoverSchemaWorkerTest extends BaseWorkerTestCase {
     JsonNode postgresCreds = PostgreSQLContainerTestHelper.getSingerTapConfig(db);
 
     final StandardDiscoverSchemaInput input = new StandardDiscoverSchemaInput();
-    input.setConnectionConfigurationJson12345(postgresCreds);
+    input.setConnectionConfigurationJson(postgresCreds);
 
     SingerDiscoverSchemaWorker worker =
         new SingerDiscoverSchemaWorker(Integrations.POSTGRES_TAP.getDiscoverSchemaImage(), pbf);

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerTapFactoryTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerTapFactoryTest.java
@@ -94,8 +94,8 @@ class SingerTapFactoryTest {
     StandardTapConfig tapConfig =
         WorkerUtils.syncToTapConfig(TestConfigHelpers.createSyncConfig().getValue());
     StandardDiscoverSchemaInput discoverSchemaInput = new StandardDiscoverSchemaInput();
-    discoverSchemaInput.setConnectionConfigurationJson(
-        tapConfig.getSourceConnectionImplementation().getConfigurationJson());
+    discoverSchemaInput.setConnectionConfigurationJson12345(
+        tapConfig.getSourceConnectionImplementation().getConfigurationJson12345());
     ProcessBuilderFactory pbf = mock(ProcessBuilderFactory.class);
     ProcessBuilder processBuilder = mock(ProcessBuilder.class);
     Process process = mock(Process.class);

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerTapFactoryTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerTapFactoryTest.java
@@ -94,8 +94,8 @@ class SingerTapFactoryTest {
     StandardTapConfig tapConfig =
         WorkerUtils.syncToTapConfig(TestConfigHelpers.createSyncConfig().getValue());
     StandardDiscoverSchemaInput discoverSchemaInput = new StandardDiscoverSchemaInput();
-    discoverSchemaInput.setConnectionConfigurationJson12345(
-        tapConfig.getSourceConnectionImplementation().getConfigurationJson12345());
+    discoverSchemaInput.setConnectionConfigurationJson(
+        tapConfig.getSourceConnectionImplementation().getConfigurationJson());
     ProcessBuilderFactory pbf = mock(ProcessBuilderFactory.class);
     ProcessBuilder processBuilder = mock(ProcessBuilder.class);
     Process process = mock(Process.class);

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerTapFactoryTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerTapFactoryTest.java
@@ -94,8 +94,8 @@ class SingerTapFactoryTest {
     StandardTapConfig tapConfig =
         WorkerUtils.syncToTapConfig(TestConfigHelpers.createSyncConfig().getValue());
     StandardDiscoverSchemaInput discoverSchemaInput = new StandardDiscoverSchemaInput();
-    discoverSchemaInput.setConnectionConfigurationJson(
-        tapConfig.getSourceConnectionImplementation().getConfigurationJson());
+    discoverSchemaInput.setConnectionConfiguration(
+        tapConfig.getSourceConnectionImplementation().getConfiguration());
     ProcessBuilderFactory pbf = mock(ProcessBuilderFactory.class);
     ProcessBuilder processBuilder = mock(ProcessBuilder.class);
     Process process = mock(Process.class);


### PR DESCRIPTION
## What
Use JsonNode to play well with frontend
Remove the `Json` suffix now that we have type safety

## How
- json schema can tie our "any object" to JsonNode
- OpenAPI can tie our "any object" to JsonNode
- Fix Jackson dependency issue

## Checklist
- [x] Verify with @cgardens that the symmetric change in open api is correct

## Recommended reading order
1. `*.json`
1. the rest
