### PR TITLE
Worker Unit Tests Revisited

### DIFF
--- a/dataline-commons/src/main/java/io/dataline/commons/resources/MoreResources.java
+++ b/dataline-commons/src/main/java/io/dataline/commons/resources/MoreResources.java
@@ -27,14 +27,14 @@ package io.dataline.commons.resources;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
-public class Resourzes {
+public class MoreResources {
 
   @SuppressWarnings("UnstableApiUsage")
   public static String readResource(String name) throws IOException {
     URL resource = Resources.getResource(name);
-    return Resources.toString(resource, Charset.defaultCharset());
+    return Resources.toString(resource, StandardCharsets.UTF_8);
   }
 
 }

--- a/dataline-commons/src/main/java/io/dataline/commons/resources/Resourzes.java
+++ b/dataline-commons/src/main/java/io/dataline/commons/resources/Resourzes.java
@@ -22,32 +22,19 @@
  * SOFTWARE.
  */
 
-package io.dataline.workers.singer;
+package io.dataline.commons.resources;
 
-import io.dataline.workers.Worker;
-import java.nio.file.Path;
-import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.Charset;
 
-public abstract class BaseSingerWorker<InputType, OutputType> implements Worker<InputType, OutputType> {
+public class Resourzes {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(BaseSingerWorker.class);
-
-  protected void cancelHelper(Process workerProcess) {
-    try {
-      workerProcess.destroy();
-      workerProcess.waitFor(10, TimeUnit.SECONDS);
-      if (workerProcess.isAlive()) {
-        workerProcess.destroyForcibly();
-      }
-    } catch (InterruptedException e) {
-      LOGGER.error("Exception when cancelling job.", e);
-    }
-  }
-
-  protected static Path getFullPath(Path workspaceRoot, String fileName) {
-    return workspaceRoot.resolve(fileName);
+  @SuppressWarnings("UnstableApiUsage")
+  public static String readResource(String name) throws IOException {
+    URL resource = Resources.getResource(name);
+    return Resources.toString(resource, Charset.defaultCharset());
   }
 
 }

--- a/dataline-config/models/src/main/resources/json/StandardDiscoverSchemaOutput.json
+++ b/dataline-config/models/src/main/resources/json/StandardDiscoverSchemaOutput.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/StandardDiscoveryOutput.json",
-  "title": "StandardDiscoveryOutput",
+  "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/StandardDiscoverSchemaOutput.json",
+  "title": "StandardDiscoverSchemaOutput",
   "description": "describes the standard output for any discovery run.",
   "type": "object",
   "required": ["schema"],

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
@@ -84,22 +84,19 @@ public class WorkerRunner implements Runnable {
             jobId,
             jobRoot,
             checkConnectionInput,
-            new SingerCheckConnectionWorker(
-                job.getConfig().getCheckConnection().getDockerImage(), pbf),
+            new SingerCheckConnectionWorker(new SingerDiscoverSchemaWorker(job.getConfig().getDiscoverSchema().getDockerImage(), pbf)),
             connectionPool)
-                .run();
+            .run();
         break;
       case DISCOVER_SCHEMA:
-        final StandardDiscoverSchemaInput discoverSchemaInput =
-            getDiscoverSchemaInput(job.getConfig().getDiscoverSchema());
+        final StandardDiscoverSchemaInput discoverSchemaInput = getDiscoverSchemaInput(job.getConfig().getDiscoverSchema());
         new WorkerRun<>(
             jobId,
             jobRoot,
             discoverSchemaInput,
-            new SingerDiscoverSchemaWorker(
-                job.getConfig().getDiscoverSchema().getDockerImage(), pbf),
+            new SingerDiscoverSchemaWorker(job.getConfig().getDiscoverSchema().getDockerImage(), pbf),
             connectionPool)
-                .run();
+            .run();
         break;
       case SYNC:
         final StandardSyncInput syncInput = getSyncInput(job.getConfig().getSync());
@@ -114,14 +111,10 @@ public class WorkerRunner implements Runnable {
             // interoperate with SingerTap and SingerTarget now that they are split and
             // mediated in DefaultSyncWorker.
             new DefaultSyncWorker(
-                new SingerTapFactory(
-                    job.getConfig().getSync().getSourceDockerImage(),
-                    pbf,
-                    discoverSchemaWorker),
-                new SingerTargetFactory(
-                    job.getConfig().getSync().getDestinationDockerImage(), pbf)),
+                new SingerTapFactory(job.getConfig().getSync().getSourceDockerImage(), pbf, discoverSchemaWorker),
+                new SingerTargetFactory(job.getConfig().getSync().getDestinationDockerImage(), pbf)),
             connectionPool)
-                .run();
+            .run();
         break;
       default:
         throw new RuntimeException("Unexpected config type: " + job.getConfig().getConfigType());

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunner.java
@@ -86,7 +86,7 @@ public class WorkerRunner implements Runnable {
             checkConnectionInput,
             new SingerCheckConnectionWorker(new SingerDiscoverSchemaWorker(job.getConfig().getDiscoverSchema().getDockerImage(), pbf)),
             connectionPool)
-            .run();
+                .run();
         break;
       case DISCOVER_SCHEMA:
         final StandardDiscoverSchemaInput discoverSchemaInput = getDiscoverSchemaInput(job.getConfig().getDiscoverSchema());
@@ -96,7 +96,7 @@ public class WorkerRunner implements Runnable {
             discoverSchemaInput,
             new SingerDiscoverSchemaWorker(job.getConfig().getDiscoverSchema().getDockerImage(), pbf),
             connectionPool)
-            .run();
+                .run();
         break;
       case SYNC:
         final StandardSyncInput syncInput = getSyncInput(job.getConfig().getSync());
@@ -114,7 +114,7 @@ public class WorkerRunner implements Runnable {
                 new SingerTapFactory(job.getConfig().getSync().getSourceDockerImage(), pbf, discoverSchemaWorker),
                 new SingerTargetFactory(job.getConfig().getSync().getDestinationDockerImage(), pbf)),
             connectionPool)
-            .run();
+                .run();
         break;
       default:
         throw new RuntimeException("Unexpected config type: " + job.getConfig().getConfigType());

--- a/dataline-workers/src/main/java/io/dataline/workers/WorkerUtils.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/WorkerUtils.java
@@ -27,7 +27,6 @@ package io.dataline.workers;
 import io.dataline.config.StandardSyncInput;
 import io.dataline.config.StandardTapConfig;
 import io.dataline.config.StandardTargetConfig;
-import io.dataline.workers.singer.BaseSingerWorker;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -38,7 +37,7 @@ import org.slf4j.LoggerFactory;
 
 public class WorkerUtils {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(BaseSingerWorker.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerUtils.class);
 
   public static Path writeFile(Path path, String fileName, String contents) {
     try {

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerCheckConnectionWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerCheckConnectionWorker.java
@@ -29,10 +29,11 @@ import io.dataline.config.StandardCheckConnectionOutput;
 import io.dataline.config.StandardDiscoverSchemaInput;
 import io.dataline.config.StandardDiscoverSchemaOutput;
 import io.dataline.workers.CheckConnectionWorker;
+import io.dataline.workers.DiscoverSchemaWorker;
+import io.dataline.workers.InvalidCatalogException;
 import io.dataline.workers.InvalidCredentialsException;
 import io.dataline.workers.JobStatus;
 import io.dataline.workers.OutputAndStatus;
-import io.dataline.workers.process.ProcessBuilderFactory;
 import java.nio.file.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,19 +42,20 @@ public class SingerCheckConnectionWorker implements CheckConnectionWorker {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SingerCheckConnectionWorker.class);
 
-  private final SingerDiscoverSchemaWorker singerDiscoverSchemaWorker;
+  private final DiscoverSchemaWorker discoverSchemaWorker;
 
-  public SingerCheckConnectionWorker(final String imageName, final ProcessBuilderFactory pbf) {
-    this.singerDiscoverSchemaWorker = new SingerDiscoverSchemaWorker(imageName, pbf);
+  public SingerCheckConnectionWorker(DiscoverSchemaWorker discoverSchemaWorker) {
+    this.discoverSchemaWorker = discoverSchemaWorker;
   }
 
   @Override
-  public OutputAndStatus<StandardCheckConnectionOutput> run(StandardCheckConnectionInput input, Path jobRoot) throws InvalidCredentialsException {
+  public OutputAndStatus<StandardCheckConnectionOutput> run(StandardCheckConnectionInput input, Path jobRoot)
+      throws InvalidCredentialsException, InvalidCatalogException {
 
     final StandardDiscoverSchemaInput discoverSchemaInput = new StandardDiscoverSchemaInput();
     discoverSchemaInput.setConnectionConfiguration(input.getConnectionConfiguration());
 
-    OutputAndStatus<StandardDiscoverSchemaOutput> outputAndStatus = singerDiscoverSchemaWorker.run(discoverSchemaInput, jobRoot);
+    OutputAndStatus<StandardDiscoverSchemaOutput> outputAndStatus = discoverSchemaWorker.run(discoverSchemaInput, jobRoot);
     StandardCheckConnectionOutput output = new StandardCheckConnectionOutput();
     JobStatus jobStatus;
     if (outputAndStatus.getStatus() == JobStatus.SUCCESSFUL && outputAndStatus.getOutput().isPresent()) {
@@ -72,7 +74,7 @@ public class SingerCheckConnectionWorker implements CheckConnectionWorker {
 
   @Override
   public void cancel() {
-    singerDiscoverSchemaWorker.cancel();
+    discoverSchemaWorker.cancel();
   }
 
 }

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerCheckConnectionWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerCheckConnectionWorker.java
@@ -37,9 +37,7 @@ import java.nio.file.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SingerCheckConnectionWorker
-    extends BaseSingerWorker<StandardCheckConnectionInput, StandardCheckConnectionOutput>
-    implements CheckConnectionWorker {
+public class SingerCheckConnectionWorker implements CheckConnectionWorker {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SingerCheckConnectionWorker.class);
 
@@ -50,19 +48,15 @@ public class SingerCheckConnectionWorker
   }
 
   @Override
-  public OutputAndStatus<StandardCheckConnectionOutput> run(StandardCheckConnectionInput input,
-                                                            Path jobRoot)
-      throws InvalidCredentialsException {
+  public OutputAndStatus<StandardCheckConnectionOutput> run(StandardCheckConnectionInput input, Path jobRoot) throws InvalidCredentialsException {
 
     final StandardDiscoverSchemaInput discoverSchemaInput = new StandardDiscoverSchemaInput();
     discoverSchemaInput.setConnectionConfiguration(input.getConnectionConfiguration());
 
-    OutputAndStatus<StandardDiscoverSchemaOutput> outputAndStatus =
-        singerDiscoverSchemaWorker.run(discoverSchemaInput, jobRoot);
+    OutputAndStatus<StandardDiscoverSchemaOutput> outputAndStatus = singerDiscoverSchemaWorker.run(discoverSchemaInput, jobRoot);
     StandardCheckConnectionOutput output = new StandardCheckConnectionOutput();
     JobStatus jobStatus;
-    if (outputAndStatus.getStatus() == JobStatus.SUCCESSFUL
-        && outputAndStatus.getOutput().isPresent()) {
+    if (outputAndStatus.getStatus() == JobStatus.SUCCESSFUL && outputAndStatus.getOutput().isPresent()) {
       output.setStatus(StandardCheckConnectionOutput.Status.SUCCESS);
       jobStatus = JobStatus.SUCCESSFUL;
     } else {

--- a/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTapFactory.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/singer/SingerTapFactory.java
@@ -52,9 +52,12 @@ public class SingerTapFactory implements TapFactory<SingerMessage> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SingerTapFactory.class);
 
-  private static final String CONFIG_JSON_FILENAME = "tap_config.json";
-  private static final String CATALOG_JSON_FILENAME = "catalog.json";
-  private static final String STATE_JSON_FILENAME = "input_state.json";
+  @VisibleForTesting
+  static final String CONFIG_JSON_FILENAME = "tap_config.json";
+  @VisibleForTesting
+  static final String CATALOG_JSON_FILENAME = "catalog.json";
+  @VisibleForTesting
+  static final String STATE_JSON_FILENAME = "input_state.json";
   @VisibleForTesting
   static final String DISCOVERY_DIR = "discover";
 

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerCheckConnectionWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerCheckConnectionWorkerTest.java
@@ -24,114 +24,98 @@
 
 package io.dataline.workers.singer;
 
-import static io.dataline.workers.JobStatus.FAILED;
-import static io.dataline.workers.JobStatus.SUCCESSFUL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import io.dataline.commons.json.Jsons;
 import io.dataline.config.StandardCheckConnectionInput;
 import io.dataline.config.StandardCheckConnectionOutput;
-import io.dataline.integrations.Integrations;
+import io.dataline.config.StandardDiscoverSchemaInput;
+import io.dataline.config.StandardDiscoverSchemaOutput;
 import io.dataline.workers.BaseWorkerTestCase;
+import io.dataline.workers.DiscoverSchemaWorker;
+import io.dataline.workers.InvalidCatalogException;
 import io.dataline.workers.InvalidCredentialsException;
+import io.dataline.workers.JobStatus;
 import io.dataline.workers.OutputAndStatus;
-import io.dataline.workers.PostgreSQLContainerTestHelper;
 import java.io.IOException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import org.junit.jupiter.api.BeforeAll;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.PostgreSQLContainer;
 
 public class SingerCheckConnectionWorkerTest extends BaseWorkerTestCase {
 
-  private PostgreSQLContainer db;
+  private static final JsonNode CREDS = Jsons.jsonNode(ImmutableMap.builder().put("apiKey", "123").build());
 
-  @BeforeAll
-  public void initDb() throws SQLException {
-    db = new PostgreSQLContainer();
-    db.start();
-    Connection con =
-        DriverManager.getConnection(db.getJdbcUrl(), db.getUsername(), db.getPassword());
-    con.createStatement().execute("CREATE TABLE id_and_name (id integer, name VARCHAR(200));");
+  private Path jobRoot;
+  private StandardCheckConnectionInput input;
+  private StandardDiscoverSchemaInput discoverInput;
+  private DiscoverSchemaWorker discoverSchemaWorker;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    jobRoot = Files.createTempDirectory("");
+
+    input = new StandardCheckConnectionInput();
+    input.setConnectionConfiguration(CREDS);
+
+    discoverInput = new StandardDiscoverSchemaInput();
+    discoverInput.setConnectionConfiguration(CREDS);
+
+    discoverSchemaWorker = mock(DiscoverSchemaWorker.class);
   }
 
   @Test
-  public void testNonexistentDb()
-      throws IOException, InvalidCredentialsException {
-    final String jobId = "1";
-    JsonNode fakeDbCreds =
-        PostgreSQLContainerTestHelper.getSingerTapConfig(
-            "user", "pass", "localhost", "postgres", "111111");
+  public void testSuccessfulConnection() throws InvalidCredentialsException, InvalidCatalogException {
+    OutputAndStatus<StandardDiscoverSchemaOutput> discoverOutput =
+        new OutputAndStatus<>(JobStatus.SUCCESSFUL, mock(StandardDiscoverSchemaOutput.class));
+    when(discoverSchemaWorker.run(discoverInput, jobRoot)).thenReturn(discoverOutput);
 
-    final StandardCheckConnectionInput standardCheckConnectionInput =
-        new StandardCheckConnectionInput();
-    standardCheckConnectionInput.setConnectionConfiguration(fakeDbCreds);
+    final SingerCheckConnectionWorker worker = new SingerCheckConnectionWorker(discoverSchemaWorker);
+    final OutputAndStatus<StandardCheckConnectionOutput> output = worker.run(input, jobRoot);
 
-    SingerCheckConnectionWorker worker =
-        new SingerCheckConnectionWorker(Integrations.POSTGRES_TAP.getCheckConnectionImage(), pbf);
-    OutputAndStatus<StandardCheckConnectionOutput> run =
-        worker.run(standardCheckConnectionInput, createJobRoot(jobId));
+    assertEquals(JobStatus.SUCCESSFUL, output.getStatus());
+    assertTrue(output.getOutput().isPresent());
+    assertEquals(StandardCheckConnectionOutput.Status.SUCCESS, output.getOutput().get().getStatus());
+    assertNull(output.getOutput().get().getMessage());
 
-    assertEquals(FAILED, run.getStatus());
-    assertTrue(run.getOutput().isPresent());
-    assertEquals(StandardCheckConnectionOutput.Status.FAILURE, run.getOutput().get().getStatus());
-    // TODO Once log file locations are accessible externally, also verify the correct error message
-    // in the logs
+    verify(discoverSchemaWorker).run(discoverInput, jobRoot);
   }
 
   @Test
-  public void testIncorrectAuthCredentials()
-      throws IOException, InvalidCredentialsException {
-    final String jobId = "1";
-    JsonNode incorrectCreds =
-        PostgreSQLContainerTestHelper.getSingerTapConfig(
-            db.getUsername(),
-            "wrongpassword",
-            db.getHost(),
-            db.getDatabaseName(),
-            db.getFirstMappedPort() + "");
+  public void testFailedConnection() throws InvalidCredentialsException, InvalidCatalogException {
+    OutputAndStatus<StandardDiscoverSchemaOutput> discoverOutput = new OutputAndStatus<>(JobStatus.FAILED, null);
+    when(discoverSchemaWorker.run(discoverInput, jobRoot)).thenReturn(discoverOutput);
 
-    SingerCheckConnectionWorker worker =
-        new SingerCheckConnectionWorker(Integrations.POSTGRES_TAP.getCheckConnectionImage(), pbf);
+    final SingerCheckConnectionWorker worker = new SingerCheckConnectionWorker(discoverSchemaWorker);
+    final OutputAndStatus<StandardCheckConnectionOutput> output = worker.run(input, jobRoot);
 
-    final StandardCheckConnectionInput standardCheckConnectionInput =
-        new StandardCheckConnectionInput();
-    standardCheckConnectionInput.setConnectionConfiguration(incorrectCreds);
+    assertEquals(JobStatus.FAILED, output.getStatus());
+    assertTrue(output.getOutput().isPresent());
+    assertEquals(StandardCheckConnectionOutput.Status.FAILURE, output.getOutput().get().getStatus());
+    assertEquals("Failed to connect.", output.getOutput().get().getMessage());
 
-    OutputAndStatus<StandardCheckConnectionOutput> run =
-        worker.run(standardCheckConnectionInput, createJobRoot(jobId));
-
-    assertEquals(FAILED, run.getStatus());
-    assertTrue(run.getOutput().isPresent());
-    assertEquals(StandardCheckConnectionOutput.Status.FAILURE, run.getOutput().get().getStatus());
-    // TODO Once log file locations are accessible externally, also verify the correct error message
-    // in the logs
+    verify(discoverSchemaWorker).run(discoverInput, jobRoot);
   }
 
   @Test
-  public void testSuccessfulConnection()
-      throws IOException, InvalidCredentialsException {
-    final String jobId = "1";
+  public void testCancel() throws InvalidCredentialsException, InvalidCatalogException {
+    OutputAndStatus<StandardDiscoverSchemaOutput> discoverOutput =
+        new OutputAndStatus<>(JobStatus.SUCCESSFUL, mock(StandardDiscoverSchemaOutput.class));
+    when(discoverSchemaWorker.run(discoverInput, jobRoot)).thenReturn(discoverOutput);
 
-    JsonNode creds = PostgreSQLContainerTestHelper.getSingerTapConfig(db);
+    final SingerCheckConnectionWorker worker = new SingerCheckConnectionWorker(discoverSchemaWorker);
+    worker.run(input, jobRoot);
+    worker.cancel();
 
-    final StandardCheckConnectionInput standardCheckConnectionInput =
-        new StandardCheckConnectionInput();
-    standardCheckConnectionInput.setConnectionConfiguration(creds);
-
-    SingerCheckConnectionWorker worker =
-        new SingerCheckConnectionWorker(Integrations.POSTGRES_TAP.getCheckConnectionImage(), pbf);
-    OutputAndStatus<StandardCheckConnectionOutput> run =
-        worker.run(standardCheckConnectionInput, createJobRoot(jobId));
-
-    assertEquals(SUCCESSFUL, run.getStatus());
-    assertTrue(run.getOutput().isPresent());
-    assertEquals(StandardCheckConnectionOutput.Status.SUCCESS, run.getOutput().get().getStatus());
-    // TODO Once log file locations are accessible externally, also verify the correct error message
-    // in the logs
+    verify(discoverSchemaWorker).cancel();
   }
 
 }

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerCheckConnectionWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerCheckConnectionWorkerTest.java
@@ -108,7 +108,7 @@ public class SingerCheckConnectionWorkerTest extends BaseWorkerTestCase {
   @Test
   public void testCancel() throws InvalidCredentialsException, InvalidCatalogException {
     OutputAndStatus<StandardDiscoverSchemaOutput> discoverOutput =
-        new OutputAndStatus<>(JobStatus.SUCCESSFUL, mock(StandardDiscoverSchemaOutput.class));
+        new OutputAndStatus<>(JobStatus.SUCCESSFUL, new StandardDiscoverSchemaOutput());
     when(discoverSchemaWorker.run(discoverInput, jobRoot)).thenReturn(discoverOutput);
 
     final SingerCheckConnectionWorker worker = new SingerCheckConnectionWorker(discoverSchemaWorker);

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerDiscoverSchemaWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerDiscoverSchemaWorkerTest.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.dataline.commons.io.IOs;
 import io.dataline.commons.json.Jsons;
-import io.dataline.commons.resources.Resourzes;
+import io.dataline.commons.resources.MoreResources;
 import io.dataline.config.StandardDiscoverSchemaInput;
 import io.dataline.config.StandardDiscoverSchemaOutput;
 import io.dataline.workers.InvalidCredentialsException;
@@ -76,18 +76,18 @@ public class SingerDiscoverSchemaWorkerTest {
     when(process.waitFor(1, TimeUnit.MINUTES)).thenReturn(true);
 
     // this would be written by the docker process.
-    IOs.writeFile(jobRoot, "catalog.json", Resourzes.readResource("simple_postgres_singer_catalog.json"));
+    IOs.writeFile(jobRoot, "catalog.json", MoreResources.readResource("simple_postgres_singer_catalog.json"));
   }
 
   @Test
-  public void testPostgresDiscovery() throws IOException, InterruptedException, InvalidCredentialsException {
+  public void testDiscoverSchema() throws IOException, InterruptedException, InvalidCredentialsException {
     SingerDiscoverSchemaWorker worker = new SingerDiscoverSchemaWorker(IMAGE_NAME, pbf);
     OutputAndStatus<StandardDiscoverSchemaOutput> run = worker.run(input, jobRoot);
 
     assertEquals(JobStatus.SUCCESSFUL, run.getStatus());
 
     final StandardDiscoverSchemaOutput expectedOutput =
-        Jsons.deserialize(Resourzes.readResource("simple_discovered_postgres_schema.json"), StandardDiscoverSchemaOutput.class);
+        Jsons.deserialize(MoreResources.readResource("simple_discovered_postgres_schema.json"), StandardDiscoverSchemaOutput.class);
     final StandardDiscoverSchemaOutput actualOutput = run.getOutput().get();
 
     assertTrue(run.getOutput().isPresent());
@@ -108,7 +108,7 @@ public class SingerDiscoverSchemaWorkerTest {
   }
 
   @Test
-  public void testCancellation() throws InvalidCredentialsException {
+  public void testCancel() throws InvalidCredentialsException {
     SingerDiscoverSchemaWorker worker = new SingerDiscoverSchemaWorker(IMAGE_NAME, pbf);
     worker.run(input, jobRoot);
 

--- a/dataline-workers/src/test/java/io/dataline/workers/singer/SingerTapFactoryTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/singer/SingerTapFactoryTest.java
@@ -24,13 +24,17 @@
 
 package io.dataline.workers.singer;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
+import io.dataline.commons.io.IOs;
+import io.dataline.commons.json.Jsons;
 import io.dataline.config.SingerCatalog;
 import io.dataline.config.SingerColumn;
 import io.dataline.config.SingerColumnMap;
@@ -64,9 +68,6 @@ class SingerTapFactoryTest {
 
   private static final String IMAGE_NAME = "hudi:latest";
   private static final String JOB_ROOT_PREFIX = "workspace";
-  private static final String CONFIG_JSON_FILENAME = "tap_config.json";
-  private static final String CATALOG_JSON_FILENAME = "catalog.json";
-  private static final String STATE_JSON_FILENAME = "input_state.json";
   private static final String TABLE_NAME = "user_preferences";
   private static final String COLUMN_NAME = "favorite_color";
 
@@ -131,11 +132,11 @@ class SingerTapFactoryTest {
         jobRoot,
         IMAGE_NAME,
         "--config",
-        CONFIG_JSON_FILENAME,
+        SingerTapFactory.CONFIG_JSON_FILENAME,
         "--properties",
-        CATALOG_JSON_FILENAME,
+        SingerTapFactory.CATALOG_JSON_FILENAME,
         "--state",
-        STATE_JSON_FILENAME))
+        SingerTapFactory.STATE_JSON_FILENAME))
             .thenReturn(processBuilder);
     when(processBuilder.redirectError(errorLogPath.toFile())).thenReturn(processBuilder);
     when(processBuilder.start()).thenReturn(process);
@@ -148,9 +149,21 @@ class SingerTapFactoryTest {
     final Stream<SingerMessage> actual = tapFactory.create(tapConfig, jobRoot);
 
     assertTrue(Files.exists(jobRoot));
-    assertTrue(Files.exists(jobRoot.resolve("tap_config.json")));
-    assertTrue(Files.exists(jobRoot.resolve("catalog.json")));
-    assertTrue(Files.exists(jobRoot.resolve("input_state.json")));
+    assertTrue(Files.exists(jobRoot.resolve(SingerTapFactory.CONFIG_JSON_FILENAME)));
+    assertTrue(Files.exists(jobRoot.resolve(SingerTapFactory.CATALOG_JSON_FILENAME)));
+    assertTrue(Files.exists(jobRoot.resolve(SingerTapFactory.STATE_JSON_FILENAME)));
+
+    final JsonNode expectedConfig = Jsons.jsonNode(tapConfig.getSourceConnectionImplementation().getConfiguration());
+    final JsonNode actualConfig = Jsons.deserialize(IOs.readFile(jobRoot, SingerTapFactory.CONFIG_JSON_FILENAME));
+    assertEquals(expectedConfig, actualConfig);
+
+    final JsonNode expectedCatalog = Jsons.jsonNode(singerCatalog);
+    final JsonNode actualCatalog = Jsons.deserialize(IOs.readFile(jobRoot, SingerTapFactory.CATALOG_JSON_FILENAME));
+    assertEquals(expectedCatalog, actualCatalog);
+
+    final JsonNode expectedInputState = Jsons.jsonNode(tapConfig.getState());
+    final JsonNode actualInputState = Jsons.deserialize(IOs.readFile(jobRoot, SingerTapFactory.STATE_JSON_FILENAME));
+    assertEquals(expectedInputState, actualInputState);
 
     assertEquals(expected, actual.collect(Collectors.toList()));
 


### PR DESCRIPTION
## What
* Tests for SingerCheckConnectionWorker (change constructor to accept a DiscoverSchemaWorker to make testing / mock easier) -- the original test for these were more like integration tests.
* Tests for SingerDiscoverSchemaWorker -- the original test for these were more like integration tests.
* Update test SingerTapFactory
* Add Resourzes -- see inline comments