### PR TITLE
Autogenerated API Java client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,8 @@ subprojects {
         }
 
         implementation(platform("com.fasterxml.jackson:jackson-bom:2.10.4"))
+        implementation(platform("org.glassfish.jersey:jersey-bom:2.31"))
+
 
         implementation group: 'com.google.guava', name: 'guava', version: '29.0-jre'
 

--- a/dataline-api/build.gradle
+++ b/dataline-api/build.gradle
@@ -1,13 +1,13 @@
 plugins {
-    id "org.openapi.generator" version "4.3.0"
+    id "org.openapi.generator" version "4.3.1"
     id "java-library"
 }
 
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask;
 
 def specFile = "$projectDir/src/main/openapi/config.yaml".toString()
-
 openApiGenerate {
+
     generatorName = "jaxrs-spec"
     inputSpec = specFile
     outputDir = "$buildDir/generated"
@@ -48,7 +48,7 @@ task generateApiClient(type: GenerateTask) {
             'DestinationConfiguration': 'com.fasterxml.jackson.databind.JsonNode',
     ]
 
-    library = "jersey2"
+    library = "native"
 
     generateApiDocumentation = false
 
@@ -57,6 +57,7 @@ task generateApiClient(type: GenerateTask) {
             generatePom  : "false",
             interfaceOnly: "true"
     ]
+
 }
 
 dependencies {
@@ -64,13 +65,10 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
-    // https://mvnrepository.com/artifact/org.glassfish.jersey.core/jersey-client
-    implementation group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '2.31'
-    // https://mvnrepository.com/artifact/org.glassfish.jersey.media/jersey-media-json-jackson
-    compile group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: '2.31'
-    // https://mvnrepository.com/artifact/org.glassfish.jersey.media/jersey-media-multipart
-    compile group: 'org.glassfish.jersey.media', name: 'jersey-media-multipart', version: '2.31'
-
+    implementation group: 'org.glassfish.jersey.core', name: 'jersey-client'
+    implementation group: 'org.glassfish.jersey.inject', name: 'jersey-hk2'
+    implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson'
+    implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-multipart'
 
     implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.2'
 
@@ -84,7 +82,7 @@ dependencies {
 sourceSets {
     main {
         java {
-            srcDirs "$buildDir/generated/src/gen/java", "$buildDir/generated/src/main/java"
+            srcDirs "$buildDir/generated/src/gen/java", "$buildDir/generated/src/main/java", "$projectDir/src/main/java"
         }
         resources {
             srcDir "$projectDir/src/main/openapi/"

--- a/dataline-api/build.gradle
+++ b/dataline-api/build.gradle
@@ -56,7 +56,6 @@ task generateApiClient(type: GenerateTask) {
             generatePom  : "false",
             interfaceOnly: "true"
     ]
-
 }
 
 dependencies {

--- a/dataline-api/build.gradle
+++ b/dataline-api/build.gradle
@@ -65,11 +65,6 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
-    implementation group: 'org.glassfish.jersey.core', name: 'jersey-client'
-    implementation group: 'org.glassfish.jersey.inject', name: 'jersey-hk2'
-    implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson'
-    implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-multipart'
-
     implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.2'
 
     implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'

--- a/dataline-api/build.gradle
+++ b/dataline-api/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id "java-library"
 }
 
+import org.openapitools.generator.gradle.plugin.tasks.GenerateTask;
+
 def specFile = "$projectDir/src/main/openapi/config.yaml".toString()
 
 openApiGenerate {
@@ -15,11 +17,38 @@ openApiGenerate {
     modelPackage = "io.dataline.api.model"
 
     importMappings = [
-        'SourceSpecification' : 'com.fasterxml.jackson.databind.JsonNode',
-        'SourceConfiguration' : 'com.fasterxml.jackson.databind.JsonNode',
-        'DestinationSpecification' : 'com.fasterxml.jackson.databind.JsonNode',
-        'DestinationConfiguration' : 'com.fasterxml.jackson.databind.JsonNode',
+            'SourceSpecification'     : 'com.fasterxml.jackson.databind.JsonNode',
+            'SourceConfiguration'     : 'com.fasterxml.jackson.databind.JsonNode',
+            'DestinationSpecification': 'com.fasterxml.jackson.databind.JsonNode',
+            'DestinationConfiguration': 'com.fasterxml.jackson.databind.JsonNode',
     ]
+
+    generateApiDocumentation = false
+
+    configOptions = [
+            dateLibrary  : "java8",
+            generatePom  : "false",
+            interfaceOnly: "true"
+    ]
+}
+
+task generateApiClient(type: GenerateTask) {
+    generatorName = "java"
+    inputSpec = specFile
+    outputDir = "$buildDir/generated"
+
+    apiPackage = "io.dataline.api.client"
+    invokerPackage = "io.dataline.api.client.invoker"
+    modelPackage = "io.dataline.api.client.model"
+
+    importMappings = [
+            'SourceSpecification'     : 'com.fasterxml.jackson.databind.JsonNode',
+            'SourceConfiguration'     : 'com.fasterxml.jackson.databind.JsonNode',
+            'DestinationSpecification': 'com.fasterxml.jackson.databind.JsonNode',
+            'DestinationConfiguration': 'com.fasterxml.jackson.databind.JsonNode',
+    ]
+
+    library = "jersey2"
 
     generateApiDocumentation = false
 
@@ -33,18 +62,29 @@ openApiGenerate {
 dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
+
+    // https://mvnrepository.com/artifact/org.glassfish.jersey.core/jersey-client
+    implementation group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '2.31'
+    // https://mvnrepository.com/artifact/org.glassfish.jersey.media/jersey-media-json-jackson
+    compile group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: '2.31'
+    // https://mvnrepository.com/artifact/org.glassfish.jersey.media/jersey-media-multipart
+    compile group: 'org.glassfish.jersey.media', name: 'jersey-media-multipart', version: '2.31'
+
 
     implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.2'
 
     implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
     implementation group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.1.1'
     implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
+
+    implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.1'
 }
 
 sourceSets {
     main {
         java {
-            srcDir "$buildDir/generated/src/gen/java"
+            srcDirs "$buildDir/generated/src/gen/java", "$buildDir/generated/src/main/java"
         }
         resources {
             srcDir "$projectDir/src/main/openapi/"
@@ -52,4 +92,4 @@ sourceSets {
     }
 }
 
-compileJava.dependsOn tasks.openApiGenerate
+compileJava.dependsOn tasks.openApiGenerate, tasks.generateApiClient

--- a/dataline-api/build.gradle
+++ b/dataline-api/build.gradle
@@ -3,8 +3,6 @@ plugins {
     id "java-library"
 }
 
-import org.openapitools.generator.gradle.plugin.tasks.GenerateTask;
-
 def specFile = "$projectDir/src/main/openapi/config.yaml".toString()
 openApiGenerate {
 
@@ -32,6 +30,7 @@ openApiGenerate {
     ]
 }
 
+import org.openapitools.generator.gradle.plugin.tasks.GenerateTask;
 task generateApiClient(type: GenerateTask) {
     generatorName = "java"
     inputSpec = specFile

--- a/dataline-api/src/main/java/DatalineApiClient.java
+++ b/dataline-api/src/main/java/DatalineApiClient.java
@@ -1,0 +1,72 @@
+import io.dataline.api.client.ConnectionApi;
+import io.dataline.api.client.DestinationApi;
+import io.dataline.api.client.DestinationImplementationApi;
+import io.dataline.api.client.DestinationSpecificationApi;
+import io.dataline.api.client.JobsApi;
+import io.dataline.api.client.SourceApi;
+import io.dataline.api.client.SourceImplementationApi;
+import io.dataline.api.client.SourceSpecificationApi;
+import io.dataline.api.client.WorkspaceApi;
+import io.dataline.api.client.invoker.ApiClient;
+
+public class DatalineApiClient {
+
+  private final ConnectionApi connectionApi;
+  private final DestinationApi destinationApi;
+  private final DestinationImplementationApi destinationImplementationApi;
+  private final DestinationSpecificationApi destinationSpecificationApi;
+  private final JobsApi jobsApi;
+  private final SourceApi sourceApi;
+  private final SourceImplementationApi sourceImplementationApi;
+  private final SourceSpecificationApi sourceSpecificationApi;
+  private final WorkspaceApi workspaceApi;
+
+  public DatalineApiClient(ApiClient apiClient) {
+    connectionApi = new ConnectionApi(apiClient);
+    destinationApi = new DestinationApi(apiClient);
+    destinationImplementationApi = new DestinationImplementationApi(apiClient);
+    destinationSpecificationApi = new DestinationSpecificationApi(apiClient);
+    jobsApi = new JobsApi(apiClient);
+    sourceApi = new SourceApi(apiClient);
+    sourceImplementationApi = new SourceImplementationApi(apiClient);
+    sourceSpecificationApi = new SourceSpecificationApi(apiClient);
+    workspaceApi = new WorkspaceApi(apiClient);
+  }
+
+  public ConnectionApi getConnectionApi() {
+    return connectionApi;
+  }
+
+  public DestinationApi getDestinationApi() {
+    return destinationApi;
+  }
+
+  public DestinationImplementationApi getDestinationImplementationApi() {
+    return destinationImplementationApi;
+  }
+
+  public DestinationSpecificationApi getDestinationSpecificationApi() {
+    return destinationSpecificationApi;
+  }
+
+  public JobsApi getJobsApi() {
+    return jobsApi;
+  }
+
+  public SourceApi getSourceApi() {
+    return sourceApi;
+  }
+
+  public SourceImplementationApi getSourceImplementationApi() {
+    return sourceImplementationApi;
+  }
+
+  public SourceSpecificationApi getSourceSpecificationApi() {
+    return sourceSpecificationApi;
+  }
+
+  public WorkspaceApi getWorkspaceApi() {
+    return workspaceApi;
+  }
+
+}

--- a/dataline-api/src/main/java/io/dataline/api/client/DatalineApiClient.java
+++ b/dataline-api/src/main/java/io/dataline/api/client/DatalineApiClient.java
@@ -45,7 +45,7 @@ import io.dataline.api.client.invoker.ApiClient;
  * To call the API type-safely, we'd do new FirstApi(new ApiClient()).get()  or new SecondApi(new ApiClient()).get(), which can get cumbersome
  * if we're interacting with many pieces of the API.
  *
- * This is currently manually maintained. We could look into autogenerating it if needed. 
+ * This is currently manually maintained. We could look into autogenerating it if needed.
  */
 public class DatalineApiClient {
 

--- a/dataline-api/src/main/java/io/dataline/api/client/DatalineApiClient.java
+++ b/dataline-api/src/main/java/io/dataline/api/client/DatalineApiClient.java
@@ -1,12 +1,29 @@
-import io.dataline.api.client.ConnectionApi;
-import io.dataline.api.client.DestinationApi;
-import io.dataline.api.client.DestinationImplementationApi;
-import io.dataline.api.client.DestinationSpecificationApi;
-import io.dataline.api.client.JobsApi;
-import io.dataline.api.client.SourceApi;
-import io.dataline.api.client.SourceImplementationApi;
-import io.dataline.api.client.SourceSpecificationApi;
-import io.dataline.api.client.WorkspaceApi;
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.api.client;
+
 import io.dataline.api.client.invoker.ApiClient;
 
 public class DatalineApiClient {

--- a/dataline-api/src/main/java/io/dataline/api/client/DatalineApiClient.java
+++ b/dataline-api/src/main/java/io/dataline/api/client/DatalineApiClient.java
@@ -3,23 +3,20 @@
  *
  * Copyright (c) 2020 Dataline
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 package io.dataline.api.client;
@@ -27,23 +24,14 @@ package io.dataline.api.client;
 import io.dataline.api.client.invoker.ApiClient;
 
 /**
- * This class is meant to consolidate all our API endpoints into a fluent-ish client. Currently, all open API generators create a separate class per
- * API "root-route". For example, if the OpenApiSpec.yml looks like:
+ * This class is meant to consolidate all our API endpoints into a fluent-ish client. Currently, all
+ * open API generators create a separate class per API "root-route". For example, if our API has two
+ * routes "/v1/First/get" and "/v1/Second/get", OpenAPI generates (essentially) the following files:
  *
- * paths:
- *   /v1/First/get:
- *      # definition goes here...
- *   /v1/Second/get:
- *      # definition goes here
+ * ApiClient.java, FirstApi.java, SecondApi.java
  *
- * OpenAPI generates (essentially) the following files:
- *
- * ApiClient.java
- * FirstApi.java
- * SecondApi.java
- *
- * To call the API type-safely, we'd do new FirstApi(new ApiClient()).get()  or new SecondApi(new ApiClient()).get(), which can get cumbersome
- * if we're interacting with many pieces of the API.
+ * To call the API type-safely, we'd do new FirstApi(new ApiClient()).get() or new SecondApi(new
+ * ApiClient()).get(), which can get cumbersome if we're interacting with many pieces of the API.
  *
  * This is currently manually maintained. We could look into autogenerating it if needed.
  */

--- a/dataline-api/src/main/java/io/dataline/api/client/DatalineApiClient.java
+++ b/dataline-api/src/main/java/io/dataline/api/client/DatalineApiClient.java
@@ -3,20 +3,23 @@
  *
  * Copyright (c) 2020 Dataline
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 package io.dataline.api.client;

--- a/dataline-api/src/main/java/io/dataline/api/client/DatalineApiClient.java
+++ b/dataline-api/src/main/java/io/dataline/api/client/DatalineApiClient.java
@@ -26,6 +26,27 @@ package io.dataline.api.client;
 
 import io.dataline.api.client.invoker.ApiClient;
 
+/**
+ * This class is meant to consolidate all our API endpoints into a fluent-ish client. Currently, all open API generators create a separate class per
+ * API "root-route". For example, if the OpenApiSpec.yml looks like:
+ *
+ * paths:
+ *   /v1/First/get:
+ *      # definition goes here...
+ *   /v1/Second/get:
+ *      # definition goes here
+ *
+ * OpenAPI generates (essentially) the following files:
+ *
+ * ApiClient.java
+ * FirstApi.java
+ * SecondApi.java
+ *
+ * To call the API type-safely, we'd do new FirstApi(new ApiClient()).get()  or new SecondApi(new ApiClient()).get(), which can get cumbersome
+ * if we're interacting with many pieces of the API.
+ *
+ * This is currently manually maintained. We could look into autogenerating it if needed. 
+ */
 public class DatalineApiClient {
 
   private final ConnectionApi connectionApi;

--- a/dataline-server/build.gradle
+++ b/dataline-server/build.gradle
@@ -7,10 +7,10 @@ dependencies {
     implementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.4.31.v20200723'
 
     implementation group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '2.3.3'
-    implementation group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet', version: '2.31'
-    implementation group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '2.31'
-    implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: '2.31'
-    implementation group: 'org.glassfish.jersey.ext', name: 'jersey-bean-validation', version: '2.31'
+    implementation group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet'
+    implementation group: 'org.glassfish.jersey.inject', name: 'jersey-hk2'
+    implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson'
+    implementation group: 'org.glassfish.jersey.ext', name: 'jersey-bean-validation'
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
     implementation group: 'com.networknt', name: 'json-schema-validator', version: '1.0.42'

--- a/dataline-tests/build.gradle
+++ b/dataline-tests/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     acceptanceTestsImplementation project(':dataline-api')
     acceptanceTestsImplementation project(':dataline-config:persistence')
 
-    acceptanceTestsImplementation "com.squareup.okhttp3:okhttp:4.8.1"
     acceptanceTestsImplementation "org.testcontainers:postgresql:1.14.3"
     acceptanceTestsImplementation "org.postgresql:postgresql:42.2.16"
     acceptanceTestsImplementation "com.fasterxml.jackson.core:jackson-databind"

--- a/dataline-tests/src/acceptanceTests/java/io/dataline/tests/acceptance/AcceptanceTests.java
+++ b/dataline-tests/src/acceptanceTests/java/io/dataline/tests/acceptance/AcceptanceTests.java
@@ -26,8 +26,20 @@ package io.dataline.tests.acceptance;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.IOException;
+import java.util.UUID;
+
+import io.dataline.api.client.ConnectionApi;
+import io.dataline.api.client.SourceApi;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
+
+import io.dataline.api.client.invoker.ApiClient;
+import io.dataline.api.client.invoker.Configuration;
 import io.dataline.api.model.SourceIdRequestBody;
 import io.dataline.api.model.SourceImplementationCreate;
 import io.dataline.api.model.SourceImplementationRead;
@@ -35,22 +47,25 @@ import io.dataline.api.model.SourceReadList;
 import io.dataline.api.model.SourceSpecificationRead;
 import io.dataline.commons.json.Jsons;
 import io.dataline.config.persistence.PersistenceConstants;
-import java.io.IOException;
-import java.util.UUID;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.PostgreSQLContainer;
 
 public class AcceptanceTests {
 
   static final MediaType JSON_CONTENT = MediaType.get("application/json; charset=utf-8");
   static final String SERVER_URL = "http://localhost:8001/api/v1/";
   static final OkHttpClient HTTP_CLIENT = new OkHttpClient();
+
+  static{
+    ApiClient apiClient;
+
+    Configuration.setDefaultApiClient(apiClient);
+  }
+  ConnectionApi connectionApi = new ConnectionApi();
+
 
   static PostgreSQLContainer PSQL_DB1;
 
@@ -62,6 +77,10 @@ public class AcceptanceTests {
 
   @Test
   public void testCreateSourceImplementation() throws IOException {
+
+//    new SourceApi().getSource()
+
+
     UUID postgresSourceId = getPostgresSourceId();
     SourceSpecificationRead sourceSpecRead =
         callApi("source_specifications/get", new SourceIdRequestBody().sourceId(postgresSourceId), SourceSpecificationRead.class);


### PR DESCRIPTION
## What
Autogenerate a type-safe java client to interact with the API. This is more ergonomic when hitting the API from java code and more importantly will cause Acceptance Tests to fail if the API contract is updated in backwards-incompatible way. 

## Reading Order
1. `dataline-api/build.gradle`
1. `AcceptanceTests.java`
1. `DatalineApiClient.java`
1. everything else

