### PR TITLE
add bigquery integration tests to build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,10 +41,6 @@ jobs:
       - name: Ensure no file change
         run: git diff-index --quiet HEAD
 
-      - name: Build Core Docker Images (Master branch only)
-        if: success() && github.ref == 'refs/heads/master'
-        run: docker-compose -f docker-compose.build.yaml build
-
       - name: Build Integration Docker Images (Master branch only)
         if: success() && github.ref == 'refs/heads/master'
         run: ./gradlew buildImage --no-daemon -g ${{ env.GRADLE_PATH }}
@@ -52,6 +48,10 @@ jobs:
       - name: Run Integration Tests (Master branch only)
         if: success() && github.ref == 'refs/heads/master'
         run: ./gradlew integrationTest --no-daemon -g ${{ env.GRADLE_PATH }}
+
+      - name: Build Core Docker Images (Master branch only)
+        if: success() && github.ref == 'refs/heads/master'
+        run: docker-compose -f docker-compose.build.yaml build
 
       - name: Run End-to-End Acceptance Tests (Master branch only)
         if: success() && github.ref == 'refs/heads/master'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run Integration Tests (Master branch only)
         if: success() && github.ref == 'refs/heads/master'
-        run: ./gradlew integrationTest --no-daemon -g ${{ env.GRADLE_PATH }}
+        run: CI=true ./gradlew integrationTest --no-daemon -g ${{ env.GRADLE_PATH }}
 
       - name: Build Core Docker Images (Master branch only)
         if: success() && github.ref == 'refs/heads/master'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,17 +42,17 @@ jobs:
         run: git diff-index --quiet HEAD
 
       - name: Build Integration Docker Images (Master branch only)
-        if: success()
+        if: success() && github.ref == 'refs/heads/master'
         run: ./gradlew buildImage --no-daemon -g ${{ env.GRADLE_PATH }}
 
       - name: Write BigQuery Integration Test Credentials (Master branch only)
-        if: success()
+        if: success() && github.ref == 'refs/heads/master'
         run: 'mkdir dataline-integrations/singer/bigquery/destination/config && echo "$BIGQUERY_INTEGRATION_TEST_CREDS" > dataline-integrations/singer/bigquery/destination/config/credentials.json'
         env:
           BIGQUERY_INTEGRATION_TEST_CREDS: ${{secrets.BIGQUERY_INTEGRATION_TEST_CREDS}}
 
       - name: Run Integration Tests (Master branch only)
-        if: success()
+        if: success() && github.ref == 'refs/heads/master'
         run: ./gradlew integrationTest --no-daemon -g ${{ env.GRADLE_PATH }}
 
       - name: Build Core Docker Images (Master branch only)

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,17 +42,17 @@ jobs:
         run: git diff-index --quiet HEAD
 
       - name: Build Integration Docker Images (Master branch only)
-        if: success() && github.ref == 'refs/heads/master'
+        if: success()
         run: ./gradlew buildImage --no-daemon -g ${{ env.GRADLE_PATH }}
 
       - name: Write BigQuery Integration Test Credentials (Master branch only)
-        if: success() && github.ref == 'refs/heads/master'
+        if: success()
         run: 'mkdir dataline-integrations/singer/bigquery/destination/config && echo "$BIGQUERY_INTEGRATION_TEST_CREDS" > dataline-integrations/singer/bigquery/destination/config/credentials.json'
         env:
           $BIGQUERY_INTEGRATION_TEST_CREDS: ${{secrets.BIGQUERY_INTEGRATION_TEST_CREDS}}
 
       - name: Run Integration Tests (Master branch only)
-        if: success() && github.ref == 'refs/heads/master'
+        if: success()
         run: CI=true ./gradlew integrationTest --no-daemon -g ${{ env.GRADLE_PATH }}
 
       - name: Build Core Docker Images (Master branch only)

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,11 +41,19 @@ jobs:
       - name: Ensure no file change
         run: git diff-index --quiet HEAD
 
-      - name: Build Docker Images (Master branch only)
+      - name: Build Core Docker Images (Master branch only)
         if: success() && github.ref == 'refs/heads/master'
         run: docker-compose -f docker-compose.build.yaml build
 
-      - name: Run Acceptance Tests (Master branch only)
+      - name: Build Integration Docker Images (Master branch only)
+        if: success() && github.ref == 'refs/heads/master'
+        run: ./gradlew buildImage --no-daemon -g ${{ env.GRADLE_PATH }}
+
+      - name: Run Integration Tests (Master branch only)
+        if: success() && github.ref == 'refs/heads/master'
+        run: ./gradlew integrationTest --no-daemon -g ${{ env.GRADLE_PATH }}
+
+      - name: Run End-to-End Acceptance Tests (Master branch only)
         if: success() && github.ref == 'refs/heads/master'
         run: ./tools/bin/acceptance_test.sh
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,7 +45,7 @@ jobs:
         if: success() && github.ref == 'refs/heads/master'
         run: ./gradlew buildImage --no-daemon -g ${{ env.GRADLE_PATH }}
 
-      - name: Write BigQuery Integration Test Credentials
+      - name: Write BigQuery Integration Test Credentials (Master branch only)
         if: success() && github.ref == 'refs/heads/master'
         run: 'mkdir dataline-integrations/singer/bigquery/destination/config && echo "$BIGQUERY_INTEGRATION_TEST_CREDS" > dataline-integrations/singer/bigquery/destination/config/credentials.json'
         env:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,6 +45,12 @@ jobs:
         if: success() && github.ref == 'refs/heads/master'
         run: ./gradlew buildImage --no-daemon -g ${{ env.GRADLE_PATH }}
 
+      - name: Write BigQuery Integration Test Credentials
+        if: success() && github.ref == 'refs/heads/master'
+        run: 'mkdir dataline-integrations/singer/bigquery/destination/config && echo "$BIGQUERY_INTEGRATION_TEST_CREDS" > dataline-integrations/singer/bigquery/destination/config/credentials.json'
+        env:
+          $BIGQUERY_INTEGRATION_TEST_CREDS: ${{secrets.BIGQUERY_INTEGRATION_TEST_CREDS}}
+
       - name: Run Integration Tests (Master branch only)
         if: success() && github.ref == 'refs/heads/master'
         run: CI=true ./gradlew integrationTest --no-daemon -g ${{ env.GRADLE_PATH }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -49,11 +49,11 @@ jobs:
         if: success()
         run: 'mkdir dataline-integrations/singer/bigquery/destination/config && echo "$BIGQUERY_INTEGRATION_TEST_CREDS" > dataline-integrations/singer/bigquery/destination/config/credentials.json'
         env:
-          $BIGQUERY_INTEGRATION_TEST_CREDS: ${{secrets.BIGQUERY_INTEGRATION_TEST_CREDS}}
+          BIGQUERY_INTEGRATION_TEST_CREDS: ${{secrets.BIGQUERY_INTEGRATION_TEST_CREDS}}
 
       - name: Run Integration Tests (Master branch only)
         if: success()
-        run: CI=true ./gradlew integrationTest --no-daemon -g ${{ env.GRADLE_PATH }}
+        run: ./gradlew integrationTest --no-daemon -g ${{ env.GRADLE_PATH }}
 
       - name: Build Core Docker Images (Master branch only)
         if: success() && github.ref == 'refs/heads/master'

--- a/dataline-integrations/README.md
+++ b/dataline-integrations/README.md
@@ -1,7 +1,0 @@
-# Integration Tests
-
-## Before Running
-
-## Running
-
-## Pushing Images

--- a/dataline-integrations/singer/bigquery/destination/README.md
+++ b/dataline-integrations/singer/bigquery/destination/README.md
@@ -1,0 +1,20 @@
+# BigQuery Test Configuration
+
+In order to test the BigQuery destination, you need a service account key file.
+
+## Community Contributor
+
+As a community contributor, you will need access to a GCP project and BigQuery to run tests.
+
+1. Go to the `Service Accounts` page on the GCP console
+1. Click on `+ Create Service Account" button
+1. Fill out a descriptive name/id/description
+1. Click the edit icon next to the service account you created on the `IAM` page
+1. Add the `BigQuery User` role
+1. Go back to the `Service Accounts` page and use the actions modal to `Create Key`
+1. Download this key as a JSON file
+1. Move and rename this file to `$DATALINE_PROJECT_ROOT/dataline-integrations/singer/bigquery/destination/config/credentials.json`
+
+## Dataline Employee
+1. Access the `BigQuery Integration Test User` secret on Rippling under the `Engineering` folder
+1. Create a file with the contents at `$DATALINE_PROJECT_ROOT/dataline-integrations/singer/bigquery/destination/config/credentials.json`

--- a/dataline-integrations/singer/bigquery/destination/build.gradle
+++ b/dataline-integrations/singer/bigquery/destination/build.gradle
@@ -27,9 +27,15 @@ dependencies {
     integrationTestImplementation project(':dataline-workers')
 }
 
+import groovy.json.JsonSlurper
+
+def credFile = new File(projectDir.absolutePath + "/config/credentials.json")
+def jsonSlurper = new JsonSlurper()
+def creds = jsonSlurper.parse(credFile)
+
 task integrationTest(type: Test) {
-    environment "GOOGLE_CLOUD_PROJECT", "eco-hangar-279116" // todo: get this from the cred file
-    environment "GOOGLE_APPLICATION_CREDENTIALS", new File("$projectDir").absolutePath + "/config/bigquery_creds.json"
+    environment "GOOGLE_CLOUD_PROJECT", creds["project_id"]
+    environment "GOOGLE_APPLICATION_CREDENTIALS", credFile.absolutePath
 
     testClassesDirs += sourceSets.integrationTest.output.classesDirs
     classpath += sourceSets.integrationTest.runtimeClasspath

--- a/dataline-integrations/singer/bigquery/destination/build.gradle
+++ b/dataline-integrations/singer/bigquery/destination/build.gradle
@@ -31,7 +31,13 @@ import groovy.json.JsonSlurper
 
 def credFile = new File(projectDir.absolutePath + "/config/credentials.json")
 def jsonSlurper = new JsonSlurper()
-def creds = jsonSlurper.parse(credFile)
+def creds = [:]
+
+try {
+    creds = jsonSlurper.parse(credFile)
+} catch(Exception e) {
+    // allow builds without credentials to work (integrationTest would still fail)
+}
 
 task integrationTest(type: Test) {
     environment "GOOGLE_CLOUD_PROJECT", creds["project_id"]

--- a/dataline-integrations/singer/bigquery/destination/docker/.dockerignore
+++ b/dataline-integrations/singer/bigquery/destination/docker/.dockerignore
@@ -1,0 +1,2 @@
+build
+build.gradle

--- a/dataline-integrations/singer/bigquery/destination/docker/build.gradle
+++ b/dataline-integrations/singer/bigquery/destination/docker/build.gradle
@@ -1,0 +1,10 @@
+plugins {
+    id 'com.bmuschko.docker-remote-api' version '6.6.1'
+}
+
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+
+task buildImage(type: DockerBuildImage) {
+    inputDir = file('.')
+    images.add('dataline/integration-singer-bigquery-destination:latest')
+}

--- a/dataline-integrations/singer/bigquery/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestBigQueryDestination.java
+++ b/dataline-integrations/singer/bigquery/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestBigQueryDestination.java
@@ -24,9 +24,6 @@
 
 package io.dataline.integration_tests.destinations;
 
-import static java.util.stream.Collectors.toList;
-import static org.junit.jupiter.api.Assertions.assertLinesMatch;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
@@ -58,6 +55,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 
 class TestBigQueryDestination {
 
@@ -161,14 +161,13 @@ class TestBigQueryDestination {
   }
 
   private void writeConfigFileToJobRoot() throws IOException {
-
-    String partialConfigString = new String(Files.readAllBytes(Paths.get("config/bigquery.json")));
-    JsonNode partialConfig = Jsons.deserialize(partialConfigString);
+    String credentialsJsonString = new String(Files.readAllBytes(Paths.get("config/credentials.json")));
+    JsonNode credentials = Jsons.deserialize(credentialsJsonString);
 
     Map<String, Object> fullConfig = new HashMap<>();
 
-    fullConfig.put("project_id", partialConfig.get("project_id").textValue());
-    fullConfig.put("credentials_json", partialConfig.get("credentials_json").textValue());
+    fullConfig.put("project_id", credentials.get("project_id").textValue());
+    fullConfig.put("credentials_json", credentialsJsonString);
     fullConfig.put("dataset_id", datasetName);
     fullConfig.put("disable_collection", true);
     fullConfig.put("default_target_schema", datasetName);

--- a/dataline-integrations/singer/bigquery/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestBigQueryDestination.java
+++ b/dataline-integrations/singer/bigquery/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestBigQueryDestination.java
@@ -24,6 +24,9 @@
 
 package io.dataline.integration_tests.destinations;
 
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
@@ -55,9 +58,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static java.util.stream.Collectors.toList;
-import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 
 class TestBigQueryDestination {
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,7 +18,7 @@ include 'dataline-tests'
 // include all integration subprojects
 def integrations = file(rootProject.projectDir.relativePath(file("dataline-integrations")))
 integrations.eachFileRecurse(FileType.FILES) { file ->
-  if (file.absolutePath.endsWith("build.gradle") && file.length() != 0) {
+  if (file.absolutePath.endsWith("build.gradle") && file.length() != 0 && !file.absolutePath.contains("/build/")) {
     def subproject = file.absolutePath.substring(integrations.absolutePath.length() + 1)
     subproject = subproject.substring(0, subproject.length() - "/build.gradle".length())
     subproject = ":dataline-integrations:" + subproject.split("/").join(":")


### PR DESCRIPTION
This sets up docker image building and credential usage (and documentation) for the build.

I'm using Gradle to build the image, which I think is the most self-contained way to represent an integration in our build.

Merging is blocked by adding a billing account to our GCP test account. 