### PR TITLE
Add Docker CLI to scheduler image

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -14,8 +14,7 @@ RUN apt-get update && apt-get -y install curl
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update && apt-get -y install \
   nodejs \
-  openjdk-14-jdk \
-  docker.io
+  openjdk-14-jdk
 
 #######################
 # Prepare project env #
@@ -44,11 +43,11 @@ RUN ./gradlew clean distTar build -x test --no-daemon -g /home/gradle/.gradle
 ######################
 # Build webapp image #
 ######################
-FROM nginx:1.19-alpine as webapp
+#FROM nginx:1.19-alpine as webapp
 
-EXPOSE 80
+#EXPOSE 80
 
-COPY --from=build /code/dataline-webapp/build /usr/share/nginx/html
+#COPY --from=build /code/dataline-webapp/build /usr/share/nginx/html
 
 ######################
 # Build server image #
@@ -78,6 +77,23 @@ ENTRYPOINT ["/bin/bash", "-c", "./wait && bin/${APPLICATION}"]
 # Build scheduler image #
 #########################
 FROM openjdk:14.0.2-slim AS scheduler
+
+
+# Install Docker to launch worker images. Eventually should be replaced with Docker-java.
+# See https://gitter.im/docker-java/docker-java?at=5f3eb87ba8c1780176603f4e for more information on why we are not currently using Docker-java
+RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y \
+                          apt-transport-https \
+                          ca-certificates \
+                          curl \
+                          gnupg-agent \
+                          software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/debian \
+       $(lsb_release -cs) \
+       stable"
+RUN apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io
 
 ENV WAIT_VERSION=2.7.2
 ENV APPLICATION dataline-scheduler

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -81,7 +81,6 @@ FROM openjdk:14.0.2-slim AS scheduler
 
 # Install Docker to launch worker images. Eventually should be replaced with Docker-java.
 # See https://gitter.im/docker-java/docker-java?at=5f3eb87ba8c1780176603f4e for more information on why we are not currently using Docker-java
-RUN apt-get update && apt-get install -y curl
 RUN apt-get update && apt-get install -y \
                           apt-transport-https \
                           ca-certificates \
@@ -93,7 +92,7 @@ RUN add-apt-repository \
        "deb [arch=amd64] https://download.docker.com/linux/debian \
        $(lsb_release -cs) \
        stable"
-RUN apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io
+RUN apt-get update && apt-get install -y docker-ce-cli
 
 ENV WAIT_VERSION=2.7.2
 ENV APPLICATION dataline-scheduler

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -43,11 +43,11 @@ RUN ./gradlew clean distTar build -x test --no-daemon -g /home/gradle/.gradle
 ######################
 # Build webapp image #
 ######################
-#FROM nginx:1.19-alpine as webapp
+FROM nginx:1.19-alpine as webapp
 
-#EXPOSE 80
+EXPOSE 80
 
-#COPY --from=build /code/dataline-webapp/build /usr/share/nginx/html
+COPY --from=build /code/dataline-webapp/build /usr/share/nginx/html
 
 ######################
 # Build server image #

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,11 +39,10 @@ services:
       - 8001:8001
     depends_on:
       - db
-
-#  webapp:
-#    image: dataline/webapp:${VERSION}
-#    container_name: dataline-webapp
-#    ports:
-#      - 8000:80
-#    depends_on:
-#      - server
+  webapp:
+    image: dataline/webapp:${VERSION}
+    container_name: dataline-webapp
+    ports:
+      - 8000:80
+    depends_on:
+      - server

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,8 @@ services:
       - WAIT_HOSTS=db:5432
       - WORKSPACE_ROOT=${WORKSPACE_ROOT}
       - CONFIG_ROOT=${CONFIG_ROOT}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - db
   server:
@@ -37,10 +39,11 @@ services:
       - 8001:8001
     depends_on:
       - db
-  webapp:
-    image: dataline/webapp:${VERSION}
-    container_name: dataline-webapp
-    ports:
-      - 8000:80
-    depends_on:
-      - server
+
+#  webapp:
+#    image: dataline/webapp:${VERSION}
+#    container_name: dataline-webapp
+#    ports:
+#      - 8000:80
+#    depends_on:
+#      - server


### PR DESCRIPTION
## What
Workers fail to launch with the exception
```
java.lang.RuntimeException: java.io.IOException: Cannot run program "docker": error=2, No such file or directory
dataline-scheduler | 	at io.dataline.workers.singer.SingerDiscoverSchemaWorker.runInternal(SingerDiscoverSchemaWorker.java:104) ~[dataline-workers-0.1.0.jar:?]
```

This PR adds Docker to the scheduler image and mounts the host's docker daemon into the scheduler. 