### PR TITLE
add output converter

### DIFF
--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/JobSubmitter.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/JobSubmitter.java
@@ -25,9 +25,11 @@
 package io.dataline.scheduler;
 
 import io.dataline.commons.concurrency.LifecycledCallable;
+import io.dataline.config.JobOutput;
 import io.dataline.scheduler.persistence.SchedulerPersistence;
 import io.dataline.workers.OutputAndStatus;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +64,7 @@ public class JobSubmitter implements Runnable {
   }
 
   private void submitJob(Job job) {
-    threadPool.submit(new LifecycledCallable.Builder<>(workerRunFactory.create(job))
+    threadPool.submit(new LifecycledCallable.Builder<>((Callable<OutputAndStatus<JobOutput>>) workerRunFactory.create(job))
         .setOnStart(() -> persistence.updateStatus(job.getId(), JobStatus.RUNNING))
         .setOnSuccess(output -> {
           if (output.getOutput().isPresent()) {

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunFactory.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunFactory.java
@@ -41,7 +41,6 @@ import io.dataline.workers.singer.SingerTapFactory;
 import io.dataline.workers.singer.SingerTargetFactory;
 import java.nio.file.Path;
 import java.util.function.Function;
-import javax.swing.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/dataline-scheduler/src/test/java/io/dataline/scheduler/JobSubmitterTest.java
+++ b/dataline-scheduler/src/test/java/io/dataline/scheduler/JobSubmitterTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.util.concurrent.MoreExecutors;
+import io.dataline.config.JobOutput;
 import io.dataline.scheduler.persistence.SchedulerPersistence;
 import io.dataline.workers.JobStatus;
 import io.dataline.workers.OutputAndStatus;
@@ -45,8 +46,8 @@ import org.mockito.InOrder;
 
 public class JobSubmitterTest {
 
-  public static final OutputAndStatus<Integer> SUCCESS_OUTPUT = new OutputAndStatus<>(JobStatus.SUCCESSFUL, 1);
-  public static final OutputAndStatus<Integer> FAILED_OUTPUT = new OutputAndStatus<>(JobStatus.FAILED);
+  public static final OutputAndStatus<JobOutput> SUCCESS_OUTPUT = new OutputAndStatus<>(JobStatus.SUCCESSFUL, new JobOutput());
+  public static final OutputAndStatus<JobOutput> FAILED_OUTPUT = new OutputAndStatus<>(JobStatus.FAILED);
 
   private SchedulerPersistence persistence;
   private WorkerRunFactory workerRunFactory;
@@ -88,7 +89,7 @@ public class JobSubmitterTest {
 
     InOrder inOrder = inOrder(persistence);
     inOrder.verify(persistence).updateStatus(1L, io.dataline.scheduler.JobStatus.RUNNING);
-    inOrder.verify(persistence).writeOutput(1L, 1);
+    inOrder.verify(persistence).writeOutput(1L, new JobOutput());
     inOrder.verify(persistence).updateStatus(1L, io.dataline.scheduler.JobStatus.COMPLETED);
     inOrder.verifyNoMoreInteractions();
   }

--- a/dataline-scheduler/src/test/java/io/dataline/scheduler/WorkerRunFactoryTest.java
+++ b/dataline-scheduler/src/test/java/io/dataline/scheduler/WorkerRunFactoryTest.java
@@ -24,6 +24,8 @@
 
 package io.dataline.scheduler;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -44,7 +46,6 @@ import io.dataline.workers.process.ProcessBuilderFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -84,8 +85,8 @@ class WorkerRunFactoryTest {
 
     StandardCheckConnectionInput expectedInput = new StandardCheckConnectionInput().withConnectionConfiguration(CONFIG);
     ArgumentCaptor<Worker<StandardCheckConnectionInput, ?>> argument = ArgumentCaptor.forClass(Worker.class);
-    verify(creator).create(eq(rootPath.resolve("1")), eq(expectedInput), argument.capture());
-    Assertions.assertTrue(argument.getValue() instanceof CheckConnectionWorker);
+    verify(creator).create(eq(rootPath.resolve("1")), eq(expectedInput), argument.capture(), any());
+    assertTrue(argument.getValue() instanceof CheckConnectionWorker);
   }
 
   @SuppressWarnings("unchecked")
@@ -97,9 +98,9 @@ class WorkerRunFactoryTest {
     factory.create(job);
 
     StandardDiscoverSchemaInput expectedInput = new StandardDiscoverSchemaInput().withConnectionConfiguration(CONFIG);
-    ArgumentCaptor<Worker<StandardDiscoverSchemaInput, ?>> argument = ArgumentCaptor.forClass(Worker.class);
-    verify(creator).create(eq(rootPath.resolve("1")), eq(expectedInput), argument.capture());
-    Assertions.assertTrue(argument.getValue() instanceof DiscoverSchemaWorker);
+    ArgumentCaptor<Worker<StandardDiscoverSchemaInput, ?>> workerArg = ArgumentCaptor.forClass(Worker.class);
+    verify(creator).create(eq(rootPath.resolve("1")), eq(expectedInput), workerArg.capture(), any());
+    assertTrue(workerArg.getValue() instanceof DiscoverSchemaWorker);
   }
 
   @SuppressWarnings("unchecked")
@@ -115,8 +116,8 @@ class WorkerRunFactoryTest {
         .withStandardSync(job.getConfig().getSync().getStandardSync());
 
     ArgumentCaptor<Worker<StandardSyncInput, ?>> argument = ArgumentCaptor.forClass(Worker.class);
-    verify(creator).create(eq(rootPath.resolve("1")), eq(expectedInput), argument.capture());
-    Assertions.assertTrue(argument.getValue() instanceof SyncWorker);
+    verify(creator).create(eq(rootPath.resolve("1")), eq(expectedInput), argument.capture(), any());
+    assertTrue(argument.getValue() instanceof SyncWorker);
   }
 
 }

--- a/dataline-scheduler/src/test/java/io/dataline/scheduler/WorkerRunTest.java
+++ b/dataline-scheduler/src/test/java/io/dataline/scheduler/WorkerRunTest.java
@@ -38,7 +38,7 @@ import org.mockito.Mockito;
 class WorkerRunTest {
 
   private Path path;
-  private Worker<Integer, ?> worker;
+  private Worker<Integer, String> worker;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
@@ -49,7 +49,7 @@ class WorkerRunTest {
 
   @Test
   void name() throws Exception {
-    new WorkerRun(path, 1, worker).call();
+    new WorkerRun<>(path, 1, worker, Mockito.mock(WorkerRunFactory.OutputConverter.class)).call();
 
     assertTrue(Files.exists(path));
     verify(worker).run(1, path);


### PR DESCRIPTION
Choosing between this, #184 , and #182 

## What
Right now, we persist the string representation of the worker's output (e.g: `StandardDiscoverSchemaOutput` in JSON format). This causes the app failure because `DefaultSchedulerPersistence` deserializes expecting `JobOutput` but the worker serializes its own task-specific output format. This PR fixes this by adding functionality to `WorkerRun` and `WorkerRunFactory` that converts the task-specific output format to `JobOutput`. 

## Reading order
1. `WorkerRunFactory`
1. `WorkerRun`
1. other classes

