### PR TITLE
Make schedule a member of standard sync

### DIFF
--- a/dataline-config/models/src/main/resources/json/StandardSync.json
+++ b/dataline-config/models/src/main/resources/json/StandardSync.json
@@ -32,6 +32,9 @@
       "type": "string",
       "enum": ["full_refresh", "append"]
     },
+    "syncSchedule": {
+      "$ref": "StandardSyncSchedule.json"
+    },
     "schema": {
       "$ref": "StandardDataSchema.json#/definitions/schema"
     },

--- a/dataline-config/models/src/main/resources/json/StandardSyncSchedule.json
+++ b/dataline-config/models/src/main/resources/json/StandardSyncSchedule.json
@@ -2,15 +2,11 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/datalineio/dataline/blob/master/dataline-config/src/main/resources/json/StandardSyncSchedule.json",
   "description": "ideally this should be a union but java codegen does not handle the union type properly.",
-  "title": "StandardScheduleConfiguration",
+  "title": "StandardSyncSchedule",
   "type": "object",
-  "required": ["manual", "connectionId"],
+  "required": ["manual"],
   "additionalProperties": false,
   "properties": {
-    "connectionId": {
-      "type": "string",
-      "format": "uuid"
-    },
     "schedule": {
       "type": "object",
       "required": ["timeUnit", "units"],

--- a/dataline-config/persistence/src/main/java/io/dataline/config/persistence/ConfigRepository.java
+++ b/dataline-config/persistence/src/main/java/io/dataline/config/persistence/ConfigRepository.java
@@ -32,7 +32,6 @@ import io.dataline.config.SourceConnectionSpecification;
 import io.dataline.config.StandardDestination;
 import io.dataline.config.StandardSource;
 import io.dataline.config.StandardSync;
-import io.dataline.config.StandardSyncSchedule;
 import io.dataline.config.StandardWorkspace;
 import java.io.IOException;
 import java.util.List;
@@ -185,23 +184,6 @@ public class ConfigRepository {
   public List<StandardSync> listStandardSyncs()
       throws ConfigNotFoundException, IOException, JsonValidationException {
     return persistence.listConfigs(ConfigSchema.STANDARD_SYNC, StandardSync.class);
-  }
-
-  public StandardSyncSchedule getStandardSyncSchedule(final UUID connectionId)
-      throws JsonValidationException, IOException, ConfigNotFoundException {
-    return persistence.getConfig(
-        ConfigSchema.STANDARD_SYNC_SCHEDULE,
-        connectionId.toString(),
-        StandardSyncSchedule.class);
-  }
-
-  public void writeStandardSchedule(final StandardSyncSchedule schedule)
-      throws JsonValidationException, IOException {
-    // todo (cgardens) - stored on sync id (there is no schedule id concept). this is non-intuitive.
-    persistence.writeConfig(
-        ConfigSchema.STANDARD_SYNC_SCHEDULE,
-        schedule.getConnectionId().toString(),
-        schedule);
   }
 
 }

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/JobScheduler.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/JobScheduler.java
@@ -85,19 +85,10 @@ public class JobScheduler implements Runnable {
   private void scheduleSyncJobs() throws IOException {
     for (StandardSync connection : getAllActiveConnections()) {
       Optional<Job> previousJobOptional = schedulerPersistence.getLastSyncJob(connection.getConnectionId());
-      final StandardSyncSchedule standardSyncSchedule = getStandardSyncSchedule(connection);
 
-      if (scheduleJobPredicate.test(previousJobOptional, standardSyncSchedule)) {
+      if (scheduleJobPredicate.test(previousJobOptional, connection.getSyncSchedule())) {
         jobFactory.create(connection.getConnectionId());
       }
-    }
-  }
-
-  private StandardSyncSchedule getStandardSyncSchedule(StandardSync connection) {
-    try {
-      return configRepository.getStandardSyncSchedule(connection.getConnectionId());
-    } catch (JsonValidationException | IOException | ConfigNotFoundException e) {
-      throw new RuntimeException(e.getMessage(), e);
     }
   }
 

--- a/dataline-server/src/test/java/io/dataline/server/helpers/ConnectionHelpers.java
+++ b/dataline-server/src/test/java/io/dataline/server/helpers/ConnectionHelpers.java
@@ -45,11 +45,16 @@ public class ConnectionHelpers {
   public static StandardSync generateSync(UUID sourceImplementationId) {
     final UUID connectionId = UUID.randomUUID();
 
+    final Schedule schedule = new Schedule()
+        .withTimeUnit(Schedule.TimeUnit.DAYS)
+        .withUnits(1L);
+
     return new StandardSync()
         .withConnectionId(connectionId)
         .withName("presto to hudi")
         .withStatus(StandardSync.Status.ACTIVE)
         .withSchema(generateBasicPersistenceSchema())
+        .withSyncSchedule(new StandardSyncSchedule().withSchedule(schedule).withManual(false))
         .withSourceImplementationId(sourceImplementationId)
         .withDestinationImplementationId(UUID.randomUUID())
         .withSyncMode(StandardSync.SyncMode.APPEND);
@@ -109,17 +114,6 @@ public class ConnectionHelpers {
         standardSync.getConnectionId(),
         standardSync.getSourceImplementationId(),
         standardSync.getDestinationImplementationId());
-  }
-
-  public static StandardSyncSchedule generateSchedule(UUID connectionId) {
-    final Schedule schedule = new Schedule()
-        .withTimeUnit(Schedule.TimeUnit.DAYS)
-        .withUnits(1L);
-
-    return new StandardSyncSchedule()
-        .withConnectionId(connectionId)
-        .withSchedule(schedule)
-        .withManual(false);
   }
 
 }


### PR DESCRIPTION
## What
Make standard sync schedule part of the connection (https://github.com/datalineio/dataline/issues/188)

## How
Add it to the standard sync instead of an object that lives by itself. Their lifecycles are the same so there is no reason why they should be separate. It fixes Charles comment about indexing schedules based on connection ids.
Makes the consumer code a bit cleaner

## Recommended reading order
1. `dataline-config/models/src/main/resources/json/StandardSync.json`
1. the rest
