### PR TITLE
Stop build from re-building the whole gradle project 3 times.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,5 @@
 **/node_modules
 Dockerfile.*
 docker-compose*.yaml
+dataline-db/pg_data/*
+data


### PR DESCRIPTION
## What
* The master build and `docker-compose -f docker-compose.build.yaml build` were doing the equivalent of gradle clean and gradle build 3 times. This is because as test ran, they were editing files in the fs causing docker to think that the cached layer had expired. 

## How
* `.dockerignore` data dirs

## Checklist
- [ ] Double check that this still detects changes to the _initial data_ as a chance to the layer (requiring a rebuild)
