### PR TITLE
Create data volume with configuration seed data

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,6 @@ DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_DB=dataline
 DATABASE_URL=jdbc:postgresql://db:5432/dataline
-CONFIG_ROOT=/data/config
+CONFIG_ROOT=/data
 WORKSPACE_ROOT=/tmp/workspace
 WORKSPACE_DOCKER_MOUNT=workspace

--- a/.env
+++ b/.env
@@ -4,6 +4,6 @@ DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_DB=dataline
 DATABASE_URL=jdbc:postgresql://db:5432/dataline
-CONFIG_ROOT=data/config
+CONFIG_ROOT=/data/config
 WORKSPACE_ROOT=/tmp/workspace
 WORKSPACE_DOCKER_MOUNT=workspace

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -53,7 +53,7 @@ COPY --from=build /code/dataline-webapp/build /usr/share/nginx/html
 ####################
 # Build seed image #
 ####################
-FROM ubuntu:20.04 AS seed
+FROM alpine:3.4 AS seed
 
 WORKDIR /app
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -61,9 +61,6 @@ WORKDIR /app
 # that the app should have when it is first installed.
 COPY --from=build /code/dataline-config/init/src/main/resources/config seed/config
 
-# uncomment, if you need to explore this container for some reason.
-# ENTRYPOINT sleep 86400
-
 ######################
 # Build server image #
 ######################

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -50,6 +50,20 @@ EXPOSE 80
 
 COPY --from=build /code/dataline-webapp/build /usr/share/nginx/html
 
+####################
+# Build seed image #
+####################
+FROM ubuntu:20.04 AS seed
+
+WORKDIR /app
+
+# the sole purpose of this image is to seed the data volume with the default data
+# that the app should have when it is first installed.
+COPY --from=build /code/dataline-config/init/src/main/resources/config seed/config
+
+# uncomment, if you need to explore this container for some reason.
+# ENTRYPOINT sleep 86400
+
 ######################
 # Build server image #
 ######################
@@ -66,7 +80,6 @@ WORKDIR /app
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/${WAIT_VERSION}/wait wait
 RUN chmod +x wait
 
-COPY --from=build /code/dataline-config/init/src/main/resources/config data/config
 COPY --from=build /code/${APPLICATION}/build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
@@ -88,7 +101,6 @@ WORKDIR /app
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/${WAIT_VERSION}/wait wait
 RUN chmod +x wait
 
-COPY --from=build /code/dataline-config/init/src/main/resources/config data/config
 COPY --from=build /code/${APPLICATION}/build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1

--- a/dataline-config/persistence/src/main/java/io/dataline/config/persistence/DefaultConfigPersistence.java
+++ b/dataline-config/persistence/src/main/java/io/dataline/config/persistence/DefaultConfigPersistence.java
@@ -51,7 +51,7 @@ public class DefaultConfigPersistence implements ConfigPersistence {
   }
 
   public DefaultConfigPersistence(final Path storageRoot, final JsonSchemaValidator schemaValidator) {
-    this.storageRoot = storageRoot;
+    this.storageRoot = storageRoot.resolve("config");
     jsonSchemaValidator = schemaValidator;
   }
 

--- a/dataline-config/persistence/src/main/java/io/dataline/config/persistence/DefaultConfigPersistence.java
+++ b/dataline-config/persistence/src/main/java/io/dataline/config/persistence/DefaultConfigPersistence.java
@@ -40,6 +40,7 @@ import me.andrz.jackson.JsonReferenceProcessor;
 
 // we force all interaction with disk storage to be effectively single threaded.
 public class DefaultConfigPersistence implements ConfigPersistence {
+  private static final String CONFIG_DIR = "config";
 
   private static final Object lock = new Object();
 
@@ -51,7 +52,7 @@ public class DefaultConfigPersistence implements ConfigPersistence {
   }
 
   public DefaultConfigPersistence(final Path storageRoot, final JsonSchemaValidator schemaValidator) {
-    this.storageRoot = storageRoot.resolve("config");
+    this.storageRoot = storageRoot.resolve(CONFIG_DIR);
     jsonSchemaValidator = schemaValidator;
   }
 

--- a/dataline-config/persistence/src/main/java/io/dataline/config/persistence/DefaultConfigPersistence.java
+++ b/dataline-config/persistence/src/main/java/io/dataline/config/persistence/DefaultConfigPersistence.java
@@ -40,6 +40,7 @@ import me.andrz.jackson.JsonReferenceProcessor;
 
 // we force all interaction with disk storage to be effectively single threaded.
 public class DefaultConfigPersistence implements ConfigPersistence {
+
   private static final String CONFIG_DIR = "config";
 
   private static final Object lock = new Object();

--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -24,12 +24,12 @@ services:
       dockerfile: Dockerfile.build
       target: server
       context: .
-#  webapp:
-#    image: dataline/webapp:dev
-#    build:
-#      dockerfile: Dockerfile.build
-#      target: webapp
-#      context: .
+  webapp:
+    image: dataline/webapp:dev
+    build:
+      dockerfile: Dockerfile.build
+      target: webapp
+      context: .
 
 networks:
   dataline:

--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -6,6 +6,12 @@ services:
     build:
       dockerfile: Dockerfile.database
       context: .
+  seed:
+    image: dataline/seed:dev
+    build:
+      dockerfile: Dockerfile.build
+      target: seed
+      context: .
   scheduler:
     image: dataline/scheduler:dev
     build:
@@ -18,15 +24,12 @@ services:
       dockerfile: Dockerfile.build
       target: server
       context: .
-  webapp:
-    image: dataline/webapp:dev
-    build:
-      dockerfile: Dockerfile.build
-      target: webapp
-      context: .
-
-volumes:
-  workspace:
+#  webapp:
+#    image: dataline/webapp:dev
+#    build:
+#      dockerfile: Dockerfile.build
+#      target: webapp
+#      context: .
 
 networks:
   dataline:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - "${WORKSPACE_DOCKER_MOUNT}:${WORKSPACE_ROOT}"
-      - "data:/data"
+      - "data:${CONFIG_ROOT}"
     depends_on:
       - db
       - seed
@@ -59,7 +59,7 @@ services:
     ports:
       - 8001:8001
     volumes:
-      - "data:/data"
+      - "data:${CONFIG_ROOT}"
     depends_on:
       - db
   webapp:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,23 @@ services:
       - POSTGRES_USER=${DATABASE_USER}
       - POSTGRES_PASSWORD=${DATABASE_PASSWORD}
       - POSTGRES_DB=db-${DATABASE_DB}
+  seed:
+    image: dataline/seed:${VERSION}
+    container_name: dataline-data-seed
+    environment:
+      - ENV=${ENV}
+    # When the volume is created for the first time it will be populated with the contents of /app/seed,
+    # which is prepopulated with the configs that we want config persistence to have access to upon
+    # installation. On subsequent compose up / down, this will get mounted, but not copy any data.
+    # Effectively it'll be a no-op on subsequent runs, though we may be able to use it to add new data
+    # to the volume if we need to as we release updates.
+    # reference:
+    # https://docs.docker.com/storage/volumes/#populate-a-volume-using-a-container
+    # https://docs.docker.com/compose/compose-file/#long-syntax-3
+    volumes:
+      - type: volume
+        source: data
+        target: /app/seed
   scheduler:
     image: dataline/scheduler:${VERSION}
     container_name: dataline-scheduler
@@ -24,8 +41,10 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - "${WORKSPACE_DOCKER_MOUNT}:${WORKSPACE_ROOT}"
+      - "data:/data"
     depends_on:
       - db
+      - seed
   server:
     image: dataline/server:${VERSION}
     container_name: dataline-server
@@ -39,6 +58,8 @@ services:
       - CONFIG_ROOT=${CONFIG_ROOT}
     ports:
       - 8001:8001
+    volumes:
+      - "data:/data"
     depends_on:
       - db
   webapp:
@@ -52,3 +73,5 @@ services:
 volumes:
   workspace:
     name: ${WORKSPACE_DOCKER_MOUNT}
+  data:
+    name: data


### PR DESCRIPTION
## What
* Seed config data into a docker volume that all images that need to (server and scheduler) can access.
* Currently when we run `docker-compose -f docker-compose.build.yaml build`, gradle build gets called 3 times (which should not happen; it should be once). This PR also fixes this issue by moving the data dir into its own volume (which fixes the docker caching issue that was causing the rebuilds).

## How
* Adds a seed container that we copy the default configurations onto. Then we mount a volume (data) onto the path where the seed data has been copied on this image. When the volume is created, this mount configuration will copy the contents from the seed container into the volume. On subsequent start ups it will be a no-op, which is exactly what we want.
  * Note: There is probably a way to do this by just copying the data from one of the existing images, but all of the permutations of that version seemed less clear to me.

## Recommended reading order
1. `Dockerfile.build`
1. `docker-compose.yaml`
1. the rest
