### PR TITLE
Add check connection to Singer postgres target

### DIFF
--- a/dataline-integrations/singer/postgres/destination/build.gradle
+++ b/dataline-integrations/singer/postgres/destination/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     integrationTestImplementation "org.testcontainers:postgresql:1.14.3"
     integrationTestImplementation "org.postgresql:postgresql:42.2.16"
 
+    integrationTestImplementation project(':dataline-config:models')
     integrationTestImplementation project(':dataline-workers')
     integrationTestImplementation project(':dataline-db')
 }

--- a/dataline-integrations/singer/postgres/destination/docker/Dockerfile
+++ b/dataline-integrations/singer/postgres/destination/docker/Dockerfile
@@ -8,6 +8,8 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Install dependencies:
 COPY requirements.txt .
+COPY ./run.sh /run.sh
+COPY ./check_connection.py /check_connection.py
 
 RUN apt-get update && \
   # https://github.com/datamill-co/target-postgres/issues/186
@@ -17,4 +19,4 @@ RUN apt-get update && \
   python -m pip install --upgrade pip && \
   pip install -r requirements.txt
 
-ENTRYPOINT ["target-postgres"]
+ENTRYPOINT ["/run.sh"]

--- a/dataline-integrations/singer/postgres/destination/docker/check_connection.py
+++ b/dataline-integrations/singer/postgres/destination/docker/check_connection.py
@@ -4,16 +4,23 @@ import json
 import argparse
 
 parser = argparse.ArgumentParser(description='Check if the provided creds can be used to successfully connect to the target postgres DB')
-parser.add_argument("config_path")
+parser.add_argument("--config", "-c", help="Path to the config.json file containing the DB creds")
+parser.add_argument("--discover", nargs='?', const='')
+
 try:
     args = parser.parse_args()
-    config_path = args.config_path
+    config_path = args.config
     with open(config_path, 'r') as config_string:
         config_json = json.loads(config_string.read())
         conn = psycopg2.connect(
-            "dbname='{postgres_database}' user='{postgres_username}' host='{postgres_host}' password='{postgres_password}' port='{postgres_port}'".format(**config_json))
+            "dbname='{postgres_database}' user='{postgres_username}' host='{postgres_host}' password='{postgres_password}' port='{postgres_port}'".format(
+                **config_json))
 except Exception as e:
     print(e)
     sys.exit(1)
+
+# If connection check is successful write a fake catalog for the discovery worker to find
+with open("catalog.json", "w") as catalog:
+    catalog.write('{"streams":[]}')
 
 sys.exit(0)

--- a/dataline-integrations/singer/postgres/destination/docker/check_connection.py
+++ b/dataline-integrations/singer/postgres/destination/docker/check_connection.py
@@ -1,0 +1,19 @@
+import psycopg2
+import sys
+import json
+import argparse
+
+parser = argparse.ArgumentParser(description='Check if the provided creds can be used to successfully connect to the target postgres DB')
+parser.add_argument("config_path")
+try:
+    args = parser.parse_args()
+    config_path = args.config_path
+    with open(config_path, 'r') as config_string:
+        config_json = json.loads(config_string.read())
+        conn = psycopg2.connect(
+            "dbname='{postgres_database}' user='{postgres_username}' host='{postgres_host}' password='{postgres_password}' port='{postgres_port}'".format(**config_json))
+except Exception as e:
+    print(e)
+    sys.exit(1)
+
+sys.exit(0)

--- a/dataline-integrations/singer/postgres/destination/docker/config.json
+++ b/dataline-integrations/singer/postgres/destination/docker/config.json
@@ -1,0 +1,8 @@
+{
+  "postgres_host": "localhost",
+  "postgres_username": "test",
+  "postgres_password": "test",
+  "postgres_schema": "public",
+  "postgres_port": 32854,
+  "postgres_database": "test"
+}

--- a/dataline-integrations/singer/postgres/destination/docker/config.json
+++ b/dataline-integrations/singer/postgres/destination/docker/config.json
@@ -1,8 +1,0 @@
-{
-  "postgres_host": "localhost",
-  "postgres_username": "test",
-  "postgres_password": "test",
-  "postgres_schema": "public",
-  "postgres_port": 32854,
-  "postgres_database": "test"
-}

--- a/dataline-integrations/singer/postgres/destination/docker/requirements.txt
+++ b/dataline-integrations/singer/postgres/destination/docker/requirements.txt
@@ -1,2 +1,2 @@
 psycopg2-binary == 2.8.5
-singer-target-postgres === 0.2.4
+singer-target-postgres == 0.2.4

--- a/dataline-integrations/singer/postgres/destination/docker/run.sh
+++ b/dataline-integrations/singer/postgres/destination/docker/run.sh
@@ -12,7 +12,7 @@ function check_connection() {
         exit 1
       else
         # If connection check is successful write a fake catalog for the discovery worker to find
-        echo '{"streams":[]}' > catalog.json
+        echo '{"streams":[]}' >catalog.json
       fi
       ;;
     esac
@@ -20,14 +20,14 @@ function check_connection() {
   done
 }
 
-function echo_err(){
-  >&2 echo "$@"
+function echo_err() {
+  echo >&2 "$@"
 }
 
 function main() {
   # Singer's discovery is what we currently use to check connection
   if [[ "$*" =~ .*"--discover".* ]]; then
-   echo_err "Checking connection..."
+    echo_err "Checking connection..."
     check_connection "$@"
   else
     echo_err "Running sync..."

--- a/dataline-integrations/singer/postgres/destination/docker/run.sh
+++ b/dataline-integrations/singer/postgres/destination/docker/run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+function check_connection() {
+  local CONFIG_FILE_PATH=
+  while test $# -gt 0; do
+    case "$1" in
+    --config)
+      shift
+      CONFIG_FILE_PATH="$1"
+      python3 /check_connection.py "$CONFIG_FILE_PATH"
+      if [ $? -gt 0 ]; then
+        exit 1
+      else
+        # If connection check is successful write a fake catalog for the discovery worker to find
+        echo '{"streams":[]}' > catalog.json
+      fi
+      ;;
+    esac
+    shift
+  done
+}
+
+function main() {
+  # Singer's discovery is what we currently use to check connection
+  if [[ "$*" =~ .*"--discover".* ]]; then
+    echo "Checking connection..."
+    check_connection "$@"
+  else
+    echo "Running sync..."
+    target-postgres "$@"
+  fi
+}
+
+main "$@"

--- a/dataline-integrations/singer/postgres/destination/docker/run.sh
+++ b/dataline-integrations/singer/postgres/destination/docker/run.sh
@@ -20,13 +20,17 @@ function check_connection() {
   done
 }
 
+function echo_err(){
+  >&2 echo "$@"
+}
+
 function main() {
   # Singer's discovery is what we currently use to check connection
   if [[ "$*" =~ .*"--discover".* ]]; then
-    echo "Checking connection..."
+   echo_err "Checking connection..."
     check_connection "$@"
   else
-    echo "Running sync..."
+    echo_err "Running sync..."
     target-postgres "$@"
   fi
 }

--- a/dataline-integrations/singer/postgres/destination/docker/run.sh
+++ b/dataline-integrations/singer/postgres/destination/docker/run.sh
@@ -1,25 +1,4 @@
 #!/bin/bash
-
-function check_connection() {
-  local CONFIG_FILE_PATH=
-  while test $# -gt 0; do
-    case "$1" in
-    --config)
-      shift
-      CONFIG_FILE_PATH="$1"
-      python3 /check_connection.py "$CONFIG_FILE_PATH"
-      if [ $? -gt 0 ]; then
-        exit 1
-      else
-        # If connection check is successful write a fake catalog for the discovery worker to find
-        echo '{"streams":[]}' >catalog.json
-      fi
-      ;;
-    esac
-    shift
-  done
-}
-
 function echo_err() {
   echo >&2 "$@"
 }
@@ -28,7 +7,7 @@ function main() {
   # Singer's discovery is what we currently use to check connection
   if [[ "$*" =~ .*"--discover".* ]]; then
     echo_err "Checking connection..."
-    check_connection "$@"
+    python3 /check_connection.py "$@"
   else
     echo_err "Running sync..."
     target-postgres "$@"

--- a/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
+++ b/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
@@ -31,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.dataline.commons.json.Jsons;
 import io.dataline.config.StandardCheckConnectionInput;
 import io.dataline.config.StandardCheckConnectionOutput;

--- a/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
+++ b/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
@@ -65,7 +65,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 class TestPostgresDestination {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TestPostgresDestination.class);
-  private static final String IMAGE_NAME = "dataline/integration-singer-postgres-destination-docker";
+  private static final String IMAGE_NAME = "dataline/integration-singer-postgres-destination";
   private static final Path TESTS_PATH = Path.of("/tmp/dataline_integration_tests");
   private static final String CONFIG_FILENAME = "config.json";
 

--- a/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
+++ b/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
@@ -120,7 +120,7 @@ class TestPostgresDestination {
   @Test
   public void testConnectionSuccessful() throws InvalidCredentialsException, InvalidCatalogException {
     SingerCheckConnectionWorker checkConnectionWorker = new SingerCheckConnectionWorker(new SingerDiscoverSchemaWorker(IMAGE_NAME, pbf));
-    StandardCheckConnectionInput inputConfig = new StandardCheckConnectionInput().withConnectionConfiguration(getDbConfig());
+    StandardCheckConnectionInput inputConfig = new StandardCheckConnectionInput().withConnectionConfiguration(Jsons.jsonNode(getDbConfig()));
     OutputAndStatus<StandardCheckConnectionOutput> run = checkConnectionWorker.run(inputConfig, jobRoot);
     assertEquals(SUCCESSFUL, run.getStatus());
     assertTrue(run.getOutput().isPresent());
@@ -130,9 +130,9 @@ class TestPostgresDestination {
   @Test
   public void testConnectionUnsuccessfulInvalidCreds() throws InvalidCredentialsException, InvalidCatalogException {
     SingerCheckConnectionWorker checkConnectionWorker = new SingerCheckConnectionWorker(new SingerDiscoverSchemaWorker(IMAGE_NAME, pbf));
-    ObjectNode dbConfig = getDbConfig();
+    Map<String, Object> dbConfig = getDbConfig();
     dbConfig.put("postgres_password", "superfakepassword_nowaythisworks");
-    StandardCheckConnectionInput inputConfig = new StandardCheckConnectionInput().withConnectionConfiguration(dbConfig);
+    StandardCheckConnectionInput inputConfig = new StandardCheckConnectionInput().withConnectionConfiguration(Jsons.jsonNode(dbConfig));
 
     OutputAndStatus<StandardCheckConnectionOutput> run = checkConnectionWorker.run(inputConfig, jobRoot);
     assertEquals(FAILED, run.getStatus());
@@ -147,7 +147,7 @@ class TestPostgresDestination {
         .start();
   }
 
-  private ObjectNode getDbConfig() {
+  private Map<String, Object> getDbConfig() {
     Map<String, Object> fullConfig = new HashMap<>();
 
     fullConfig.put("postgres_host", PSQL.getHost());
@@ -155,7 +155,7 @@ class TestPostgresDestination {
     fullConfig.put("postgres_username", PSQL.getUsername());
     fullConfig.put("postgres_password", PSQL.getPassword());
     fullConfig.put("postgres_database", PSQL.getDatabaseName());
-    return (ObjectNode) Jsons.jsonNode(fullConfig);
+    return fullConfig;
   }
 
   private void writeConfigFileToJobRoot(String fileContent) throws IOException {

--- a/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
+++ b/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
@@ -24,14 +24,26 @@
 
 package io.dataline.integration_tests.destinations;
 
+import static io.dataline.workers.JobStatus.FAILED;
+import static io.dataline.workers.JobStatus.SUCCESSFUL;
 import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.dataline.commons.json.Jsons;
+import io.dataline.config.StandardCheckConnectionInput;
+import io.dataline.config.StandardCheckConnectionOutput;
 import io.dataline.db.DatabaseHelper;
+import io.dataline.workers.InvalidCatalogException;
+import io.dataline.workers.InvalidCredentialsException;
+import io.dataline.workers.OutputAndStatus;
 import io.dataline.workers.WorkerUtils;
 import io.dataline.workers.process.DockerProcessBuilderFactory;
 import io.dataline.workers.process.ProcessBuilderFactory;
+import io.dataline.workers.singer.SingerCheckConnectionWorker;
+import io.dataline.workers.singer.SingerDiscoverSchemaWorker;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -53,8 +65,9 @@ import org.testcontainers.containers.PostgreSQLContainer;
 class TestPostgresDestination {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TestPostgresDestination.class);
-
+  private static final String IMAGE_NAME = "dataline/integration-singer-postgres-destination-docker";
   private static final Path TESTS_PATH = Path.of("/tmp/dataline_integration_tests");
+  private static final String CONFIG_FILENAME = "config.json";
 
   protected Path jobRoot;
   protected Path workspaceRoot;
@@ -75,9 +88,6 @@ class TestPostgresDestination {
     Files.createDirectories(jobRoot);
 
     pbf = new DockerProcessBuilderFactory(workspaceRoot, workspaceRoot.toString(), "host");
-
-    writeConfigFileToJobRoot();
-    process = startTarget();
   }
 
   @AfterEach
@@ -88,6 +98,9 @@ class TestPostgresDestination {
 
   @Test
   public void runTest() throws IOException, InterruptedException, SQLException {
+    writeConfigFileToJobRoot(Jsons.serialize(getDbConfig()));
+    process = startTarget();
+
     List<String> expectedList =
         Arrays.asList(
             "('1598659200', '2.12999999999999989', '0.119999999999999996', null)",
@@ -104,15 +117,37 @@ class TestPostgresDestination {
     assertLinesMatch(expectedList, actualList);
   }
 
+  @Test
+  public void testConnectionSuccessful() throws InvalidCredentialsException, InvalidCatalogException {
+    SingerCheckConnectionWorker checkConnectionWorker = new SingerCheckConnectionWorker(new SingerDiscoverSchemaWorker(IMAGE_NAME, pbf));
+    StandardCheckConnectionInput inputConfig = new StandardCheckConnectionInput().withConnectionConfiguration(getDbConfig());
+    OutputAndStatus<StandardCheckConnectionOutput> run = checkConnectionWorker.run(inputConfig, jobRoot);
+    assertEquals(SUCCESSFUL, run.getStatus());
+    assertTrue(run.getOutput().isPresent());
+    assertEquals(StandardCheckConnectionOutput.Status.SUCCESS, run.getOutput().get().getStatus());
+  }
+
+  @Test
+  public void testConnectionUnsuccessfulInvalidCreds() throws InvalidCredentialsException, InvalidCatalogException {
+    SingerCheckConnectionWorker checkConnectionWorker = new SingerCheckConnectionWorker(new SingerDiscoverSchemaWorker(IMAGE_NAME, pbf));
+    ObjectNode dbConfig = getDbConfig();
+    dbConfig.put("postgres_password", "superfakepassword_nowaythisworks");
+    StandardCheckConnectionInput inputConfig = new StandardCheckConnectionInput().withConnectionConfiguration(dbConfig);
+
+    OutputAndStatus<StandardCheckConnectionOutput> run = checkConnectionWorker.run(inputConfig, jobRoot);
+    assertEquals(FAILED, run.getStatus());
+    assertTrue(run.getOutput().isPresent());
+    assertEquals(StandardCheckConnectionOutput.Status.FAILURE, run.getOutput().get().getStatus());
+  }
+
   private Process startTarget() throws IOException {
-    return pbf.create(
-        jobRoot, "dataline/integration-singer-postgres-destination", "--config", "config.json")
+    return pbf.create(jobRoot, IMAGE_NAME, "--config", CONFIG_FILENAME)
         .redirectOutput(ProcessBuilder.Redirect.INHERIT)
         .redirectError(ProcessBuilder.Redirect.INHERIT)
         .start();
   }
 
-  private void writeConfigFileToJobRoot() throws IOException {
+  private ObjectNode getDbConfig() {
     Map<String, Object> fullConfig = new HashMap<>();
 
     fullConfig.put("postgres_host", PSQL.getHost());
@@ -120,8 +155,11 @@ class TestPostgresDestination {
     fullConfig.put("postgres_username", PSQL.getUsername());
     fullConfig.put("postgres_password", PSQL.getPassword());
     fullConfig.put("postgres_database", PSQL.getDatabaseName());
+    return (ObjectNode) Jsons.jsonNode(fullConfig);
+  }
 
-    Files.writeString(Path.of(jobRoot.toString(), "config.json"), Jsons.serialize(fullConfig));
+  private void writeConfigFileToJobRoot(String fileContent) throws IOException {
+    Files.writeString(Path.of(jobRoot.toString(), "config.json"), fileContent);
   }
 
   private void writeResourceToStdIn(String resourceName, Process process) throws IOException {

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunFactory.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunFactory.java
@@ -78,7 +78,6 @@ public class WorkerRunFactory {
     switch (job.getConfig().getConfigType()) {
       case CHECK_CONNECTION_SOURCE:
       case CHECK_CONNECTION_DESTINATION:
-
         final StandardCheckConnectionInput checkConnectionInput = getCheckConnectionInput(job.getConfig().getCheckConnection());
         return creator.create(
             jobRoot,

--- a/dataline-workers/src/test/java/io/dataline/workers/wrappers/OutputConvertingWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/wrappers/OutputConvertingWorkerTest.java
@@ -54,9 +54,10 @@ public class OutputConvertingWorkerTest {
   }
 
   @Test
-  public void testCancel(){
+  public void testCancel() {
     Worker<String, String> worker = Mockito.mock(Worker.class);
     new OutputConvertingWorker<>(worker, Integer::valueOf).cancel();
     verify(worker).cancel();
   }
+
 }

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -32,13 +32,18 @@ cmd_publish() {
   cmd_push "$path"
 }
 
+USAGE="
+
+Usage: $(basename $0) <build|push|publish> <integration_root_path | all> 
+"
+
 main() {
   assert_root
 
   local cmd=$1
-  shift || error "Missing cmd"
+  shift || error "Missing cmd $USAGE"
   local path=$1
-  shift || error "Missing target (root path of integration or 'all')"
+  shift || error "Missing target (root path of integration or 'all') $USAGE"
 
   if [ "$path" == "all" ]; then
     for path in $(find dataline-integrations -iname "Dockerfile" -type f); do


### PR DESCRIPTION
## What
Singer targets do not support `--discover`, which is the underlying operation we currently use to verify connectivity to a Singer tap or target. This means our taps currently cannot check credentials against a target. This PR fixes this issue for the Postgres destination by adding a shim to the Docker container that, if the `--discover` flag is provided, runs a small python script (instead of the singer tap) to check connectivity. 

## Reading Order
1. `Dockerfile`
1. `run.sh`
1. `check_connection`
1. `TestPostgresDestination`