### PR TITLE
cleanup StandardTapConfig

### DIFF
--- a/dataline-config/models/src/main/resources/json/StandardTapConfig.json
+++ b/dataline-config/models/src/main/resources/json/StandardTapConfig.json
@@ -7,7 +7,6 @@
   "additionalProperties": false,
   "required": [
     "sourceConnectionImplementation",
-    "destinationConnectionImplementation",
     "standardSync"
   ],
   "properties": {
@@ -19,10 +18,6 @@
     },
     "state": {
       "$ref": "State.json"
-    },
-    "standardSyncSummary": {
-      "description": "optional state of the previous run. this object is standard for any sync run.",
-      "$ref": "StandardSyncSummary.json"
     }
   }
 }

--- a/dataline-config/models/src/main/resources/json/StandardTapConfig.json
+++ b/dataline-config/models/src/main/resources/json/StandardTapConfig.json
@@ -5,10 +5,7 @@
   "description": "StandardTapConfig",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "sourceConnectionImplementation",
-    "standardSync"
-  ],
+  "required": ["sourceConnectionImplementation", "standardSync"],
   "properties": {
     "sourceConnectionImplementation": {
       "$ref": "SourceConnectionImplementation.json"


### PR DESCRIPTION
## What
remove unneeded fields from `StandardTapConfig`

## Reading Order
1. Everything