### PR TITLE
Always push the latest master images to dockerhub

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,33 +35,37 @@ jobs:
         with:
           node-version: '14.7'
 
-      - name: Build
-        run: ./gradlew build --no-daemon -g ${{ env.GRADLE_PATH }}
+#      - name: Build
+#        run: ./gradlew build --no-daemon -g ${{ env.GRADLE_PATH }}
 
-      - name: Ensure no file change
-        run: git diff-index --quiet HEAD
+#      - name: Ensure no file change
+#        run: git diff-index --quiet HEAD
 
-      - name: Build Integration Docker Images (Master branch only)
-        if: success() && github.ref == 'refs/heads/master'
-        run: ./gradlew buildImage --no-daemon -g ${{ env.GRADLE_PATH }}
-
-      - name: Write BigQuery Integration Test Credentials (Master branch only)
-        if: success() && github.ref == 'refs/heads/master'
-        run: 'mkdir dataline-integrations/singer/bigquery/destination/config && echo "$BIGQUERY_INTEGRATION_TEST_CREDS" > dataline-integrations/singer/bigquery/destination/config/credentials.json'
-        env:
-          BIGQUERY_INTEGRATION_TEST_CREDS: ${{secrets.BIGQUERY_INTEGRATION_TEST_CREDS}}
-
-      - name: Run Integration Tests (Master branch only)
-        if: success() && github.ref == 'refs/heads/master'
-        run: ./gradlew integrationTest --no-daemon -g ${{ env.GRADLE_PATH }}
+#      - name: Build Integration Docker Images (Master branch only)
+#        if: success() && github.ref == 'refs/heads/master'
+#        run: ./gradlew buildImage --no-daemon -g ${{ env.GRADLE_PATH }}
+#
+#      - name: Write BigQuery Integration Test Credentials (Master branch only)
+#        if: success() && github.ref == 'refs/heads/master'
+#        run: 'mkdir dataline-integrations/singer/bigquery/destination/config && echo "$BIGQUERY_INTEGRATION_TEST_CREDS" > dataline-integrations/singer/bigquery/destination/config/credentials.json'
+#        env:
+#          BIGQUERY_INTEGRATION_TEST_CREDS: ${{ secrets.BIGQUERY_INTEGRATION_TEST_CREDS }}
+#
+#      - name: Run Integration Tests (Master branch only)
+#        if: success() && github.ref == 'refs/heads/master'
+#        run: ./gradlew integrationTest --no-daemon -g ${{ env.GRADLE_PATH }}
 
       - name: Build Core Docker Images (Master branch only)
-        if: success() && github.ref == 'refs/heads/master'
+        if: success() #&& github.ref == 'refs/heads/master'
         run: docker-compose -f docker-compose.build.yaml build
 
-      - name: Run End-to-End Acceptance Tests (Master branch only)
-        if: success() && github.ref == 'refs/heads/master'
-        run: ./tools/bin/acceptance_test.sh
+#      - name: Run End-to-End Acceptance Tests (Master branch only)
+#        if: success() && github.ref == 'refs/heads/master'
+#        run: ./tools/bin/acceptance_test.sh
+
+      - name: Push Dev Images (Master branch only)
+        if: success() #&& github.ref == 'refs/heads/master'
+        run: docker-compose -f docker-compose.build.yaml push
 
       - name: Slack Notification (Master branch only)
         if: failure() && github.ref == 'refs/heads/master'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -59,7 +59,7 @@ jobs:
         if: success() #&& github.ref == 'refs/heads/master'
         run: docker-compose -e GIT_REVISION=${GIT_REVISION} -f docker-compose.build.yaml build
         env:
-          - GIT_REVISION: ${{ github.sha }}
+          GIT_REVISION: ${{ github.sha }}
 
 #      - name: Run End-to-End Acceptance Tests (Master branch only)
 #        if: success() && github.ref == 'refs/heads/master'
@@ -71,7 +71,7 @@ jobs:
           docker login -u datalinebot -p ${DOCKER_PASSWORD}
           docker-compose -f docker-compose.build.yaml push
         env:
-          - DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Slack Notification (Master branch only)
         if: failure() && github.ref == 'refs/heads/master'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,38 +35,38 @@ jobs:
         with:
           node-version: '14.7'
 
-#      - name: Build
-#        run: ./gradlew build --no-daemon -g ${{ env.GRADLE_PATH }}
+      - name: Build
+        run: ./gradlew build --no-daemon -g ${{ env.GRADLE_PATH }}
 
-#      - name: Ensure no file change
-#        run: git diff-index --quiet HEAD
+      - name: Ensure no file change
+        run: git diff-index --quiet HEAD
 
-#      - name: Build Integration Docker Images
-#        if: success() && github.ref == 'refs/heads/master'
-#        run: ./gradlew buildImage --no-daemon -g ${{ env.GRADLE_PATH }}
-#
-#      - name: Write BigQuery Integration Test Credentials
-#        if: success() && github.ref == 'refs/heads/master'
-#        run: 'mkdir dataline-integrations/singer/bigquery/destination/config && echo "$BIGQUERY_INTEGRATION_TEST_CREDS" > dataline-integrations/singer/bigquery/destination/config/credentials.json'
-#        env:
-#          BIGQUERY_INTEGRATION_TEST_CREDS: ${{ secrets.BIGQUERY_INTEGRATION_TEST_CREDS }}
-#
-#      - name: Run Integration Tests
-#        if: success() && github.ref == 'refs/heads/master'
-#        run: ./gradlew integrationTest --no-daemon -g ${{ env.GRADLE_PATH }}
+      - name: Build Integration Docker Images
+        if: success() && github.ref == 'refs/heads/master'
+        run: ./gradlew buildImage --no-daemon -g ${{ env.GRADLE_PATH }}
+
+      - name: Write BigQuery Integration Test Credentials
+        if: success() && github.ref == 'refs/heads/master'
+        run: 'mkdir dataline-integrations/singer/bigquery/destination/config && echo "$BIGQUERY_INTEGRATION_TEST_CREDS" > dataline-integrations/singer/bigquery/destination/config/credentials.json'
+        env:
+          BIGQUERY_INTEGRATION_TEST_CREDS: ${{ secrets.BIGQUERY_INTEGRATION_TEST_CREDS }}
+
+      - name: Run Integration Tests
+        if: success() && github.ref == 'refs/heads/master'
+        run: ./gradlew integrationTest --no-daemon -g ${{ env.GRADLE_PATH }}
 
       - name: Build Core Docker Images
-        if: success() #&& github.ref == 'refs/heads/master'
+        if: success() && github.ref == 'refs/heads/master'
         run: docker-compose -f docker-compose.build.yaml build
         env:
           GIT_REVISION: ${{ github.sha }}
 
-#      - name: Run End-to-End Acceptance Tests (Master branch only)
-#        if: success() && github.ref == 'refs/heads/master'
-#        run: ./tools/bin/acceptance_test.sh
+      - name: Run End-to-End Acceptance Tests (Master branch only)
+        if: success() && github.ref == 'refs/heads/master'
+        run: ./tools/bin/acceptance_test.sh
 
       - name: Push Core Docker Images
-        if: success() #&& github.ref == 'refs/heads/master'
+        if: success() && github.ref == 'refs/heads/master'
         run: |
           docker login -u datalinebot -p ${DOCKER_PASSWORD}
           docker-compose -f docker-compose.build.yaml push

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,21 +41,21 @@ jobs:
 #      - name: Ensure no file change
 #        run: git diff-index --quiet HEAD
 
-#      - name: Build Integration Docker Images (Master branch only)
+#      - name: Build Integration Docker Images
 #        if: success() && github.ref == 'refs/heads/master'
 #        run: ./gradlew buildImage --no-daemon -g ${{ env.GRADLE_PATH }}
 #
-#      - name: Write BigQuery Integration Test Credentials (Master branch only)
+#      - name: Write BigQuery Integration Test Credentials
 #        if: success() && github.ref == 'refs/heads/master'
 #        run: 'mkdir dataline-integrations/singer/bigquery/destination/config && echo "$BIGQUERY_INTEGRATION_TEST_CREDS" > dataline-integrations/singer/bigquery/destination/config/credentials.json'
 #        env:
 #          BIGQUERY_INTEGRATION_TEST_CREDS: ${{ secrets.BIGQUERY_INTEGRATION_TEST_CREDS }}
 #
-#      - name: Run Integration Tests (Master branch only)
+#      - name: Run Integration Tests
 #        if: success() && github.ref == 'refs/heads/master'
 #        run: ./gradlew integrationTest --no-daemon -g ${{ env.GRADLE_PATH }}
 
-      - name: Build Core Docker Images (Master branch only)
+      - name: Build Core Docker Images
         if: success() #&& github.ref == 'refs/heads/master'
         run: docker-compose -f docker-compose.build.yaml build
         env:
@@ -65,7 +65,7 @@ jobs:
 #        if: success() && github.ref == 'refs/heads/master'
 #        run: ./tools/bin/acceptance_test.sh
 
-      - name: Push Dev Images (Master branch only)
+      - name: Push Core Docker Images
         if: success() #&& github.ref == 'refs/heads/master'
         run: |
           docker login -u datalinebot -p ${DOCKER_PASSWORD}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Build Core Docker Images (Master branch only)
         if: success() #&& github.ref == 'refs/heads/master'
-        run: docker-compose -f docker-compose.build.yaml build
+        run: docker-compose -e GIT_REVISION=${{ github.sha }} -f docker-compose.build.yaml build
 
 #      - name: Run End-to-End Acceptance Tests (Master branch only)
 #        if: success() && github.ref == 'refs/heads/master'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -57,7 +57,9 @@ jobs:
 
       - name: Build Core Docker Images (Master branch only)
         if: success() #&& github.ref == 'refs/heads/master'
-        run: docker-compose -e GIT_REVISION=${{ github.sha }} -f docker-compose.build.yaml build
+        run: docker-compose -e GIT_REVISION=${GIT_REVISION} -f docker-compose.build.yaml build
+        env:
+          - GIT_REVISION: ${{ github.sha }}
 
 #      - name: Run End-to-End Acceptance Tests (Master branch only)
 #        if: success() && github.ref == 'refs/heads/master'
@@ -66,8 +68,10 @@ jobs:
       - name: Push Dev Images (Master branch only)
         if: success() #&& github.ref == 'refs/heads/master'
         run: |
-          docker login -u datalinebot -p ${{ secret.DOCKER_PASSWORD }}
+          docker login -u datalinebot -p ${DOCKER_PASSWORD}
           docker-compose -f docker-compose.build.yaml push
+        env:
+          - DOCKER_PASSWORD: ${{ secret.DOCKER_PASSWORD }}
 
       - name: Slack Notification (Master branch only)
         if: failure() && github.ref == 'refs/heads/master'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Build Core Docker Images (Master branch only)
         if: success() #&& github.ref == 'refs/heads/master'
-        run: docker-compose -e GIT_REVISION=${GIT_REVISION} -f docker-compose.build.yaml build
+        run: docker-compose -f docker-compose.build.yaml build
         env:
           GIT_REVISION: ${{ github.sha }}
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -65,9 +65,9 @@ jobs:
 
       - name: Push Dev Images (Master branch only)
         if: success() #&& github.ref == 'refs/heads/master'
-        run:
-          - docker login -u datalinebot -p ${{ secret.DOCKER_PASSWORD }}
-          - docker-compose -f docker-compose.build.yaml push
+        run: |
+          docker login -u datalinebot -p ${{ secret.DOCKER_PASSWORD }}
+          docker-compose -f docker-compose.build.yaml push
 
       - name: Slack Notification (Master branch only)
         if: failure() && github.ref == 'refs/heads/master'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -71,7 +71,7 @@ jobs:
           docker login -u datalinebot -p ${DOCKER_PASSWORD}
           docker-compose -f docker-compose.build.yaml push
         env:
-          - DOCKER_PASSWORD: ${{ secret.DOCKER_PASSWORD }}
+          - DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Slack Notification (Master branch only)
         if: failure() && github.ref == 'refs/heads/master'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -65,7 +65,9 @@ jobs:
 
       - name: Push Dev Images (Master branch only)
         if: success() #&& github.ref == 'refs/heads/master'
-        run: docker-compose -f docker-compose.build.yaml push
+        run:
+          - docker login -u datalinebot -p ${{ secret.DOCKER_PASSWORD }}
+          - docker-compose -f docker-compose.build.yaml push
 
       - name: Slack Notification (Master branch only)
         if: failure() && github.ref == 'refs/heads/master'

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle
 .idea
 build
+!tools/build
 .DS_Store
 dataline-db/pg_data/*
 data

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,25 +1,7 @@
-#####################
-# Setup build image #
-#####################
-FROM ubuntu:20.04 AS build-base
-
-WORKDIR /code
-
-ENV DEBIAN_FRONTEND noninteractive
-
-# Install tools
-RUN apt-get update && apt-get -y install curl
-
-# Setup Node & Java
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get update && apt-get -y install \
-  nodejs \
-  openjdk-14-jdk
-
 #######################
 # Prepare project env #
 #######################
-FROM build-base AS build-project
+FROM dataline/build-base:1.0.0 AS build-project
 
 WORKDIR /code
 

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ subprojects {
             dbeaver().configFile(rootProject.file('tools/gradle/codestyle/sql-dbeaver.properties'))
         }
         format 'styling', {
-            target '**/*.json', '**/*.yaml', '**/*.yml'
+            target '**/*.json', '**/*.yaml'
 
             prettier()
         }

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ subprojects {
             dbeaver().configFile(rootProject.file('tools/gradle/codestyle/sql-dbeaver.properties'))
         }
         format 'styling', {
-            target '**/*.json', '**/*.yaml'
+            target '**/*.json', '**/*.yaml', '**/*.yml'
 
             prettier()
         }

--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -6,31 +6,37 @@ services:
     build:
       dockerfile: Dockerfile.database
       context: .
+      labels:
+        io.dataline.git-revision: ${GIT_REVISION}
   seed:
     image: dataline/seed:dev
     build:
       dockerfile: Dockerfile.build
       target: seed
       context: .
+      labels:
+        io.dataline.git-revision: ${GIT_REVISION}
   scheduler:
     image: dataline/scheduler:dev
     build:
       dockerfile: Dockerfile.build
       target: scheduler
       context: .
+      labels:
+        io.dataline.git-revision: ${GIT_REVISION}
   server:
     image: dataline/server:dev
     build:
       dockerfile: Dockerfile.build
       target: server
       context: .
+      labels:
+        io.dataline.git-revision: ${GIT_REVISION}
   webapp:
     image: dataline/webapp:dev
     build:
       dockerfile: Dockerfile.build
       target: webapp
       context: .
-
-networks:
-  dataline:
-    driver: "bridge"
+      labels:
+        io.dataline.git-revision: ${GIT_REVISION}

--- a/tools/build/Dockerfile.base
+++ b/tools/build/Dockerfile.base
@@ -1,0 +1,20 @@
+#####################
+# Setup build image #
+#####################
+FROM ubuntu:20.04
+
+LABEL io.dataline.image=datalineio/build-base
+LABEL io.dataline.version=1.0.0
+
+WORKDIR /code
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install tools
+RUN apt-get update && apt-get -y install curl
+
+# Setup Node & Java
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt-get update && apt-get -y install \
+  nodejs \
+  openjdk-14-jdk

--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -1,0 +1,6 @@
+This docker image contains the build environment used to generate all our artifacts.
+
+If you need to do some changes the environment:
+1. Bump up the version in the docker file (`io.dataline.version`).
+1. Build and push the image (with the new tag).
+1. Update the consumers to use the most recent build image.


### PR DESCRIPTION
## What
Always push the latest master images to dockerhub (https://github.com/datalineio/dataline/issues/208)

## How
Github action pushes to dockerhub.
These images are tagged with `dev`.
Speed up build by precomputing the build image.
Label all our images with the git hash when built from github
