### PR TITLE
move databind to top level dep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ subprojects {
         implementation(platform("com.fasterxml.jackson:jackson-bom:2.10.4"))
         implementation(platform("org.glassfish.jersey:jersey-bom:2.31"))
 
+        implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.2'
 
         implementation group: 'com.google.guava', name: 'guava', version: '29.0-jre'
 

--- a/build.gradle
+++ b/build.gradle
@@ -109,8 +109,8 @@ subprojects {
         implementation(platform("com.fasterxml.jackson:jackson-bom:2.10.4"))
         implementation(platform("org.glassfish.jersey:jersey-bom:2.31"))
 
-        implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.2'
-        implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.2'
+        implementation 'com.fasterxml.jackson.core:jackson-databind'
+        implementation 'com.fasterxml.jackson.core:jackson-annotations'
 
         implementation group: 'com.google.guava', name: 'guava', version: '29.0-jre'
 

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ subprojects {
         implementation(platform("com.fasterxml.jackson:jackson-bom:2.10.4"))
         implementation(platform("org.glassfish.jersey:jersey-bom:2.31"))
 
+        // version is handled by "com.fasterxml.jackson:jackson-bom:2.10.4", so we do not explicitly set it here.
         implementation 'com.fasterxml.jackson.core:jackson-databind'
         implementation 'com.fasterxml.jackson.core:jackson-annotations'
 

--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,7 @@ subprojects {
         implementation(platform("org.glassfish.jersey:jersey-bom:2.31"))
 
         implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.2'
+        implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.2'
 
         implementation group: 'com.google.guava', name: 'guava', version: '29.0-jre'
 

--- a/dataline-api/build.gradle
+++ b/dataline-api/build.gradle
@@ -59,7 +59,6 @@ task generateApiClient(type: GenerateTask) {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.2'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
     implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.2'

--- a/dataline-api/build.gradle
+++ b/dataline-api/build.gradle
@@ -59,8 +59,7 @@ task generateApiClient(type: GenerateTask) {
 }
 
 dependencies {
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.2'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
     implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.2'

--- a/dataline-commons/build.gradle
+++ b/dataline-commons/build.gradle
@@ -1,7 +1,3 @@
 plugins {
     id "java-library"
 }
-
-dependencies {
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
-}

--- a/dataline-config/models/build.gradle
+++ b/dataline-config/models/build.gradle
@@ -2,10 +2,6 @@ plugins {
     id "com.github.eirnym.js2p" version "1.0"
 }
 
-dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.2'
-}
-
 jsonSchema2Pojo {
     targetDirectory = new File(project.buildDir, 'generated/src/gen/java/')
 

--- a/dataline-config/models/build.gradle
+++ b/dataline-config/models/build.gradle
@@ -3,8 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation group: 'javax.validation', name: 'validation-api', version: '1.1.0.Final'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.2'
 }
 
 jsonSchema2Pojo {

--- a/dataline-config/persistence/build.gradle
+++ b/dataline-config/persistence/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: '2.7'
 
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
     implementation group: 'com.networknt', name: 'json-schema-validator', version: '1.0.42'
     // needed so that we can follow $ref when parsing json. jackson does not support this natively.
     implementation 'me.andrz.jackson:jackson-json-reference-core:0.3.2'

--- a/dataline-integrations/singer/bigquery/destination/build.gradle
+++ b/dataline-integrations/singer/bigquery/destination/build.gradle
@@ -21,7 +21,6 @@ configurations {
 dependencies {
     integrationTestImplementation 'org.apache.commons:commons-dbcp2:2.7.0'
     integrationTestImplementation 'com.google.cloud:google-cloud-bigquery:1.117.0'
-    integrationTestImplementation 'com.fasterxml.jackson.core:jackson-databind'
     integrationTestImplementation 'org.apache.commons:commons-text:1.9'
 
     integrationTestImplementation project(':dataline-workers')

--- a/dataline-scheduler/build.gradle
+++ b/dataline-scheduler/build.gradle
@@ -3,8 +3,6 @@ plugins {
 }
 
 dependencies {
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
-
     implementation project(':dataline-config:models')
     implementation project(':dataline-config:persistence')
     implementation project(':dataline-db')

--- a/dataline-server/build.gradle
+++ b/dataline-server/build.gradle
@@ -12,10 +12,6 @@ dependencies {
     implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson'
     implementation group: 'org.glassfish.jersey.ext', name: 'jersey-bean-validation'
 
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
-    implementation group: 'com.networknt', name: 'json-schema-validator', version: '1.0.42'
-
-
     implementation project(':dataline-analytics')
     implementation project(':dataline-api')
     implementation project(':dataline-config:models')

--- a/dataline-singer/build.gradle
+++ b/dataline-singer/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 dependencies {
     implementation group: 'javax.validation', name: 'validation-api', version: '1.1.0.Final'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
 }
 
 jsonSchema2Pojo {

--- a/dataline-workers/build.gradle
+++ b/dataline-workers/build.gradle
@@ -8,7 +8,6 @@ configurations {
 
 dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
 
     implementation project(":dataline-config:models")
     implementation project(":dataline-db")


### PR DESCRIPTION
## What
* JsonNode is part of our cross-module interfaces. This means that we declare the same dep in almost every package. It appears that haven't been specifying a version. This change declares the jackson data-bind dependency once at the top level with a specific version specified. The key thing here, is we want to keep the version of this dependency the same across all modules.

@michel-tricot - you had run into a version issue with jackson. wanted to double check that this change isn't reverting us back into the problem you ran into.