### PR TITLE
suppress unchecked warnings

### DIFF
--- a/dataline-config/models/src/test/java/io/dataline/config/EnvConfigsTest.java
+++ b/dataline-config/models/src/test/java/io/dataline/config/EnvConfigsTest.java
@@ -38,6 +38,7 @@ class EnvConfigsTest {
   private Function<String, String> function;
   private EnvConfigs config;
 
+  @SuppressWarnings("unchecked")
   @BeforeEach
   void setUp() {
     function = Mockito.mock(Function.class);

--- a/dataline-tests/src/acceptanceTests/java/io/dataline/tests/acceptance/AcceptanceTests.java
+++ b/dataline-tests/src/acceptanceTests/java/io/dataline/tests/acceptance/AcceptanceTests.java
@@ -70,6 +70,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.MountableFile;
 
+@SuppressWarnings("rawtypes")
 public class AcceptanceTests {
 
   static final Logger LOGGER = LoggerFactory.getLogger(AcceptanceTests.class);
@@ -181,6 +182,7 @@ public class AcceptanceTests {
    * Verifies that a record in the target table and database exists with the same (and potentially
    * more) fields.
    */
+  @SuppressWarnings("unchecked")
   private void assertRecordInTable(Record record, BasicDataSource connectionPool, String tableName)
       throws SQLException {
 

--- a/dataline-workers/src/test/java/io/dataline/workers/wrappers/OutputConvertingWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/wrappers/OutputConvertingWorkerTest.java
@@ -40,6 +40,7 @@ import org.mockito.Mockito;
 
 public class OutputConvertingWorkerTest {
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testRun() throws InvalidCredentialsException, InvalidCatalogException {
     Worker<String, String> worker = Mockito.mock(Worker.class);
@@ -53,6 +54,7 @@ public class OutputConvertingWorkerTest {
     assertEquals(expectedOutput, output.getOutput().get());
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testCancel() {
     Worker<String, String> worker = Mockito.mock(Worker.class);


### PR DESCRIPTION
## What
* suppressed uncheck warnings in tests. we are intentionally doing unchecked operations in these cases. by suppressing them, we remove a bunch of warnings form the build logs.