### PR TITLE
Have open api code generation respect to gradle Up-To-Date

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ subprojects {
 
     spotless {
         java {
+            targetExclude "build/generated/**/*.*"
+
             importOrder()
 
             eclipse('4.16.0').configFile(rootProject.file('tools/gradle/codestyle/java-google-style.xml'))
@@ -86,6 +88,7 @@ subprojects {
         }
         format 'styling', {
             target '**/*.json', '**/*.yaml'
+            targetExclude "build/generated/**/*.*"
 
             prettier()
         }

--- a/dataline-api/build.gradle
+++ b/dataline-api/build.gradle
@@ -1,14 +1,13 @@
 plugins {
-    id "org.openapi.generator" version "4.3.1"
+    id "org.openapi.generator" version "5.0.0-beta2"
     id "java-library"
 }
 
 def specFile = "$projectDir/src/main/openapi/config.yaml".toString()
 openApiGenerate {
-
     generatorName = "jaxrs-spec"
     inputSpec = specFile
-    outputDir = "$buildDir/generated"
+    outputDir = "$buildDir/generated/api/server"
 
     apiPackage = "io.dataline.api"
     invokerPackage = "io.dataline.api.invoker"
@@ -34,7 +33,7 @@ import org.openapitools.generator.gradle.plugin.tasks.GenerateTask;
 task generateApiClient(type: GenerateTask) {
     generatorName = "java"
     inputSpec = specFile
-    outputDir = "$buildDir/generated"
+    outputDir = "$buildDir/generated/api/client"
 
     apiPackage = "io.dataline.api.client"
     invokerPackage = "io.dataline.api.client.invoker"
@@ -73,7 +72,7 @@ dependencies {
 sourceSets {
     main {
         java {
-            srcDirs "$buildDir/generated/src/gen/java", "$buildDir/generated/src/main/java", "$projectDir/src/main/java"
+            srcDirs "$buildDir/generated/api/server/src/gen/java", "$buildDir/generated/api/client/src/main/java", "$projectDir/src/main/java"
         }
         resources {
             srcDir "$projectDir/src/main/openapi/"

--- a/dataline-api/build.gradle
+++ b/dataline-api/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.openapi.generator" version "5.0.0-beta2"
+    id "org.openapi.generator" version "5.0.0-beta"
     id "java-library"
 }
 


### PR DESCRIPTION
## What
* We re-run the open api generators on every build. This is because gradle cannot properly detect that it does not need to re-run the generator even though nothing has changed (as it does with other modules)

## How
* Upgrade to newest plugin does support for working with up-to-date (though it is in beta)
* Stop spotless from reformatting the generated code (which causes gradle to think something has changed between builds, when it hasn't).