### PR TITLE
add version tag to integrations docker images

### DIFF
--- a/dataline-integrations/readme.md
+++ b/dataline-integrations/readme.md
@@ -1,0 +1,12 @@
+### Upgrading an Integration
+1. Make sure you can build the integration locally
+
+    ```
+    ./tools/integrations/manage.sh build <path to integration>
+    # e.g.
+    # ./tools/integrations/manage.sh build dataline-integrations/singer/postgres/source
+    ```
+1. Update the version in the dockerfile of the integration `LABEL io.dataline.version=0.1.0`
+1. (If you want Dataline to use this new integration) Update the version of the integration in `Integrations.java`
+1. Publish it to docker hub. `./tools/integrations/manage.sh build <path to integration>`
+1. Merge you changes. (Make sure you've done the previous step first, otherwise the application will look for the wrong integration!!!)

--- a/dataline-integrations/singer/bigquery/destination/Dockerfile
+++ b/dataline-integrations/singer/bigquery/destination/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-alpine
 
-LABEL io.dataline.version=1.0.0
+LABEL io.dataline.version=0.1.1
 
 WORKDIR /singer
 

--- a/dataline-integrations/singer/csv/destination/Dockerfile
+++ b/dataline-integrations/singer/csv/destination/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-slim
 
-LABEL io.dataline.version=1.0.0
+LABEL io.dataline.version=0.1.1
 
 WORKDIR /singer
 

--- a/dataline-integrations/singer/exchangerateapi_io/source/Dockerfile
+++ b/dataline-integrations/singer/exchangerateapi_io/source/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-slim
 
-LABEL io.dataline.version=1.0.0
+LABEL io.dataline.version=0.1.1
 
 WORKDIR /singer
 

--- a/dataline-integrations/singer/postgres/destination/Dockerfile
+++ b/dataline-integrations/singer/postgres/destination/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-slim
 
-LABEL io.dataline.version=1.0.0
+LABEL io.dataline.version=0.1.1
 
 WORKDIR /singer
 

--- a/dataline-integrations/singer/postgres/source/Dockerfile
+++ b/dataline-integrations/singer/postgres/source/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-slim
 
-LABEL io.dataline.version=0.1.1
+LABEL io.dataline.version=0.1.0
 
 WORKDIR /singer
 

--- a/dataline-integrations/singer/postgres/source/Dockerfile
+++ b/dataline-integrations/singer/postgres/source/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-slim
 
-LABEL io.dataline.version=1.0.0
+LABEL io.dataline.version=0.1.1
 
 WORKDIR /singer
 

--- a/dataline-integrations/src/main/java/io/dataline/integrations/Integrations.java
+++ b/dataline-integrations/src/main/java/io/dataline/integrations/Integrations.java
@@ -30,16 +30,16 @@ public enum Integrations {
 
   POSTGRES_TAP(
       UUID.fromString("2168516a-5c9a-4582-90dc-5e3a01e3f607"),
-      new IntegrationMapping("dataline/integration-singer-postgres-source")),
+      new IntegrationMapping("dataline/integration-singer-postgres-source:0.1.1")),
   EXCHANGERATEAPI_IO_TAP(
       UUID.fromString("37eb2ebf-0899-4b22-aba8-8537ec88b5a8"),
-      new IntegrationMapping("dataline/integration-singer-exchangerateapi_io-source")),
+      new IntegrationMapping("dataline/integration-singer-exchangerateapi_io-source:0.1.1")),
   POSTGRES_TARGET(
       UUID.fromString("a6655e6a-838c-4ecb-a28f-ffdcd27ec710"),
-      new IntegrationMapping("dataline/integration-singer-postgres-destination")),
+      new IntegrationMapping("dataline/integration-singer-postgres-destination:0.1.1")),
   BIGQUERY_TARGET(
       UUID.fromString("e28a1a10-214a-4051-8cf4-79b6f88719cd"),
-      new IntegrationMapping("dataline/integration-singer-bigquery-destination"));
+      new IntegrationMapping("dataline/integration-singer-bigquery-destination:0.1.1"));
 
   private final UUID specId;
   private final IntegrationMapping integrationMapping;

--- a/dataline-integrations/src/main/java/io/dataline/integrations/Integrations.java
+++ b/dataline-integrations/src/main/java/io/dataline/integrations/Integrations.java
@@ -30,7 +30,7 @@ public enum Integrations {
 
   POSTGRES_TAP(
       UUID.fromString("2168516a-5c9a-4582-90dc-5e3a01e3f607"),
-      new IntegrationMapping("dataline/integration-singer-postgres-source:0.1.1")),
+      new IntegrationMapping("dataline/integration-singer-postgres-source:0.1.0")),
   EXCHANGERATEAPI_IO_TAP(
       UUID.fromString("37eb2ebf-0899-4b22-aba8-8537ec88b5a8"),
       new IntegrationMapping("dataline/integration-singer-exchangerateapi_io-source:0.1.1")),


### PR DESCRIPTION
## What
* we want to use a version if the image that we know works.
* right now, if you have an old version of any integration on your laptop, that old version will be used.
