### PR TITLE
Refeshing on the webapp was returning 404

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -29,6 +29,7 @@ FROM nginx:1.19-alpine as webapp
 
 EXPOSE 80
 
+COPY  /code/dataline-webapp/nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /code/dataline-webapp/build /usr/share/nginx/html
 
 ####################

--- a/dataline-webapp/nginx/default.conf
+++ b/dataline-webapp/nginx/default.conf
@@ -1,0 +1,45 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}


### PR DESCRIPTION
## What
Refeshing on the webapp was returning 404

## How
Because the path in not interpreted by the server but by the webapp, let's default to index.html when the server cannot find the path.
