### PR TITLE
move labels to bottom of dockerfiles for better caching

### DIFF
--- a/dataline-integrations/singer/bigquery/destination/Dockerfile
+++ b/dataline-integrations/singer/bigquery/destination/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.7-alpine
 
-LABEL io.dataline.version=0.1.1
-
 WORKDIR /singer
 
 ENV VIRTUAL_ENV=/singer/env
@@ -18,3 +16,5 @@ RUN python -m pip install --upgrade pip && \
 COPY bigquery-destination.sh /singer/bigquery-destination.sh
 
 ENTRYPOINT ["sh", "/singer/bigquery-destination.sh"]
+
+LABEL io.dataline.version=0.1.1

--- a/dataline-integrations/singer/csv/destination/Dockerfile
+++ b/dataline-integrations/singer/csv/destination/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.7-slim
 
-LABEL io.dataline.version=0.1.1
-
 WORKDIR /singer
 
 ENV VIRTUAL_ENV=/singer/env
@@ -14,3 +12,5 @@ RUN python -m pip install --upgrade pip && \
   pip install -r requirements.txt
 
 ENTRYPOINT ["target-csv"]
+
+LABEL io.dataline.version=0.1.1

--- a/dataline-integrations/singer/exchangerateapi_io/source/Dockerfile
+++ b/dataline-integrations/singer/exchangerateapi_io/source/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.7-slim
 
-LABEL io.dataline.version=0.1.1
-
 WORKDIR /singer
 
 ENV VIRTUAL_ENV=/singer/env
@@ -14,3 +12,5 @@ RUN python -m pip install --upgrade pip && \
   pip install -r requirements.txt
 
 ENTRYPOINT ["tap-exchangeratesapi"]
+
+LABEL io.dataline.version=0.1.1

--- a/dataline-integrations/singer/postgres/destination/Dockerfile
+++ b/dataline-integrations/singer/postgres/destination/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.7-slim
 
-LABEL io.dataline.version=0.1.1
-
 WORKDIR /singer
 
 ENV VIRTUAL_ENV=/singer/env
@@ -22,3 +20,5 @@ RUN apt-get update && \
   pip install -r requirements.txt
 
 ENTRYPOINT ["/run.sh"]
+
+LABEL io.dataline.version=0.1.1

--- a/dataline-integrations/singer/postgres/source/Dockerfile
+++ b/dataline-integrations/singer/postgres/source/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.7-slim
 
-LABEL io.dataline.version=0.1.0
-
 WORKDIR /singer
 
 ENV VIRTUAL_ENV=/singer/env
@@ -20,3 +18,5 @@ RUN python -m pip install --upgrade pip && \
 RUN apt-get autoremove -y gcc
 
 ENTRYPOINT ["tap-postgres"]
+
+LABEL io.dataline.version=0.1.0

--- a/tools/build/Dockerfile.base
+++ b/tools/build/Dockerfile.base
@@ -3,9 +3,6 @@
 #####################
 FROM ubuntu:20.04
 
-LABEL io.dataline.image=dataline/build-base
-LABEL io.dataline.version=1.0.0
-
 WORKDIR /code
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -18,3 +15,7 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update && apt-get -y install \
   nodejs \
   openjdk-14-jdk
+
+
+LABEL io.dataline.image=dataline/build-base
+LABEL io.dataline.version=1.0.0


### PR DESCRIPTION
Changing a `LABEL` at the top of a `Dockerfile` for bumping a version causes all of the later steps to run again. 

This PR moves all existing labels to the bottom of the files. 