### PR TITLE
Support string and array in singer schema

### DIFF
--- a/dataline-commons/src/main/java/io/dataline/commons/json/Jsons.java
+++ b/dataline-commons/src/main/java/io/dataline/commons/json/Jsons.java
@@ -25,6 +25,7 @@
 package io.dataline.commons.json;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -77,6 +78,14 @@ public class Jsons {
 
   public static <T> JsonNode jsonNode(final T object) {
     return OBJECT_MAPPER.valueToTree(object);
+  }
+
+  public static <T> T object(final JsonNode jsonNode, final Class<T> klass) {
+    return OBJECT_MAPPER.convertValue(jsonNode, klass);
+  }
+
+  public static <T> T object(final JsonNode jsonNode, final TypeReference<T> typeReference) {
+    return OBJECT_MAPPER.convertValue(jsonNode, typeReference);
   }
 
   @SuppressWarnings("unchecked")

--- a/dataline-commons/src/test/java/io/dataline/commons/json/JsonsTest.java
+++ b/dataline-commons/src/test/java/io/dataline/commons/json/JsonsTest.java
@@ -25,7 +25,10 @@
 package io.dataline.commons.json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
@@ -125,6 +128,18 @@ class JsonsTest {
     Assertions.assertEquals(
         Jsons.jsonNode(new ToClass("abc", 999, 888L)),
         Jsons.jsonNode(Jsons.jsonNode(new ToClass("abc", 999, 888L))));
+  }
+
+  @Test
+  void testToObject() {
+    final ToClass expected = new ToClass("abc", 999, 888L);
+    Assertions.assertEquals(
+        expected,
+        Jsons.object(Jsons.jsonNode(expected), ToClass.class));
+
+    Assertions.assertEquals(
+        Lists.newArrayList(expected),
+        Jsons.object(Jsons.jsonNode(Lists.newArrayList(expected)), new TypeReference<List<ToClass>>() {}));
   }
 
   @Test

--- a/dataline-config/models/build.gradle
+++ b/dataline-config/models/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 jsonSchema2Pojo {
+    source = files("${sourceSets.main.output.resourcesDir}/json")
     targetDirectory = new File(project.buildDir, 'generated/src/gen/java/')
 
     targetPackage = 'io.dataline.config'

--- a/dataline-singer/build.gradle
+++ b/dataline-singer/build.gradle
@@ -23,3 +23,22 @@ jsonSchema2Pojo {
     includeConstructors = false
     includeSetters = true
 }
+
+task postprocess {
+    doFirst {
+        def original = new File(project.buildDir, 'generated/src/gen/java/io/dataline/singer/SingerColumn.java')
+        def lines = original.readLines()
+
+        original.withWriter('utf-8') { writer ->
+            lines.each {
+                if (it.contains("private List<SingerType> type"))
+                    writer.writeLine("    @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = io.dataline.singer.SingerTypeDeserializer.class)")
+                writer.writeLine(it)
+            }
+        }
+    }
+}
+
+afterEvaluate { project ->
+    project.tasks.generateJsonSchema2Pojo.finalizedBy postprocess
+}

--- a/dataline-singer/src/main/java/io/dataline/singer/SingerTypeDeserializer.java
+++ b/dataline-singer/src/main/java/io/dataline/singer/SingerTypeDeserializer.java
@@ -1,0 +1,59 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.singer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.fasterxml.jackson.databind.type.ArrayType;
+import com.fasterxml.jackson.databind.type.SimpleType;
+import io.dataline.commons.json.Jsons;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SingerTypeDeserializer extends JsonDeserializer<List<SingerType>> {
+
+  private final static Logger LOGGER = LoggerFactory.getLogger(SingerTypeDeserializer.class);
+
+  @Override
+  public List<SingerType> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    ObjectCodec oc = p.getCodec();
+    JsonNode node = oc.readTree(p);
+    if (node.isArray()) {
+      return Jsons.object(node, new TypeReference<>() {});
+    } else if (node.isTextual()) {
+      return Collections.singletonList(Jsons.object(node, SingerType.class));
+    }
+    throw MismatchedInputException.from(p, ArrayType.construct(SimpleType.constructUnsafe(SingerType.class), null), "Cannot decode field");
+  }
+
+}

--- a/dataline-singer/src/main/java/io/dataline/singer/SingerTypeDeserializer.java
+++ b/dataline-singer/src/main/java/io/dataline/singer/SingerTypeDeserializer.java
@@ -37,12 +37,8 @@ import io.dataline.commons.json.Jsons;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SingerTypeDeserializer extends JsonDeserializer<List<SingerType>> {
-
-  private final static Logger LOGGER = LoggerFactory.getLogger(SingerTypeDeserializer.class);
 
   @Override
   public List<SingerType> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
@@ -53,7 +49,10 @@ public class SingerTypeDeserializer extends JsonDeserializer<List<SingerType>> {
     } else if (node.isTextual()) {
       return Collections.singletonList(Jsons.object(node, SingerType.class));
     }
-    throw MismatchedInputException.from(p, ArrayType.construct(SimpleType.constructUnsafe(SingerType.class), null), "Cannot decode field");
+    throw MismatchedInputException.from(
+        p,
+        ArrayType.construct(SimpleType.constructUnsafe(SingerType.class), null),
+        String.format("Cannot deserialize instance of `%s` out of %s token", "List<SingerType>", node.getNodeType()));
   }
 
 }

--- a/dataline-singer/src/test/java/io/dataline/singer/SingerTypeDeserializerTest.java
+++ b/dataline-singer/src/test/java/io/dataline/singer/SingerTypeDeserializerTest.java
@@ -47,4 +47,10 @@ class SingerTypeDeserializerTest {
         Jsons.deserialize("{\"type\":[\"string\",\"null\"]}", SingerColumn.class));
   }
 
+  @Test
+  void testBadType() {
+    Assertions.assertThrows(RuntimeException.class,
+        () -> Jsons.deserialize("{\"type\":1}", SingerColumn.class));
+  }
+
 }

--- a/dataline-singer/src/test/java/io/dataline/singer/SingerTypeDeserializerTest.java
+++ b/dataline-singer/src/test/java/io/dataline/singer/SingerTypeDeserializerTest.java
@@ -1,0 +1,50 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.singer;
+
+import com.google.common.collect.Lists;
+import io.dataline.commons.json.Jsons;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class SingerTypeDeserializerTest {
+
+  @Test
+  void testDeserializationString() {
+    Assertions.assertEquals(
+        new SingerColumn()
+            .withType(Lists.newArrayList(SingerType.STRING)),
+        Jsons.deserialize("{\"type\":\"string\"}", SingerColumn.class));
+  }
+
+  @Test
+  void testDeserializationArray() {
+    Assertions.assertEquals(
+        new SingerColumn()
+            .withType(Lists.newArrayList(SingerType.STRING, SingerType.NULL)),
+        Jsons.deserialize("{\"type\":[\"string\",\"null\"]}", SingerColumn.class));
+  }
+
+}


### PR DESCRIPTION
## What
Support string and array in singer schema.

## How
Inject a custom deserialization on the type field. The library we use doesn't support it so we just add a post-processing step after the code generation
