### PR TITLE
JSON InputStreamReader

### DIFF
--- a/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/JsonNodeIterator.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/JsonNodeIterator.java
@@ -1,0 +1,45 @@
+package io.dataline.workers.protocols.singer;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.AbstractIterator;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Iterator to consume input stream from a SingerTap. Rules:
+ * 1. JSON objects should be new line delimited.
+ * 2. Some lines will not be JSON and should be ignored.
+ * 3. No guarantee that there are not new lines within a JSON object.
+ */
+public class JsonNodeIterator extends AbstractIterator<JsonNode> {
+
+  private final JsonParser parser;
+  private final ObjectMapper objectMapper;
+
+  public JsonNodeIterator(InputStream is) throws IOException {
+    parser = new JsonFactory().createParser(is);
+    objectMapper = new ObjectMapper();
+  }
+
+  @Override
+  protected JsonNode computeNext() {
+    while (true) {
+      try {
+        final JsonNode treeNode = objectMapper.readTree(parser);
+        if (treeNode == null) {
+          return endOfData();
+        } else {
+          return treeNode;
+        }
+      } catch (JsonParseException e) {
+        // no op.
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/JsonNodeIterator.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/JsonNodeIterator.java
@@ -35,6 +35,9 @@ public class JsonNodeIterator extends AbstractIterator<JsonNode> {
         } else {
           return treeNode;
         }
+        // When no object can be parsed, the mapper throws a JsonParseException. This is our cue to move on to the
+        // next token. This could be come a performance problem because it means for each word it finds, it throws
+        // an exception.
       } catch (JsonParseException e) {
         // no op.
       } catch (IOException e) {

--- a/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/JsonNodeIteratorTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/JsonNodeIteratorTest.java
@@ -1,0 +1,51 @@
+package io.dataline.workers.protocols.singer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
+import io.dataline.commons.json.Jsons;
+import org.junit.jupiter.api.Test;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JsonNodeIteratorTest {
+
+  private static final List<JsonNode> EXPECTED = Lists.newArrayList(
+      Jsons.deserialize("{ \"a\": \"a\"}"),
+      Jsons.deserialize("{ \"a\": \"b\"}"),
+      Jsons.deserialize("{ \"a\": \"c\"}"));
+
+  @Test
+  void testNewLineDelimitedJsonStream() throws IOException {
+    assertEquals(EXPECTED, run("{ \"a\": \"a\"}\n{ \"a\": \"b\"}\n{ \"a\": \"c\"}"));
+  }
+
+  @Test
+  void testNoDelimiterJsonStream() throws IOException {
+    assertEquals(EXPECTED, run("{ \"a\": \"a\"}{ \"a\": \"b\"}\n{ \"a\": \"c\"}"));
+  }
+
+  @Test
+  void testNewLineDelimitedJsonStreamWithExtraNewLines() throws IOException {
+    assertEquals(EXPECTED, run("{ \"a\":\n \"a\"}\n{\n \"a\":\n \"b\"\n}\n{ \"a\": \"c\"}"));
+  }
+
+  @Test
+  void testInputStreamWithNonJsonLines() throws IOException {
+    assertEquals(EXPECTED, run("{ \"a\": \"a\"}\nHe's dead, Jim!\n{ \"a\": \"b\"}\nResistance is futile.\n{ \"a\": \"c\"}"));
+  }
+
+  @Test
+  void testCommaDelimitedJsonStream() throws IOException {
+    assertEquals(EXPECTED, run("{ \"a\": \"a\"},{ \"a\": \"b\"},{ \"a\": \"c\"}"));
+  }
+
+  private static List<JsonNode> run(String testString) throws IOException {
+    final InputStream targetStream = new ByteArrayInputStream(testString.getBytes());
+    return Lists.newArrayList(new JsonNodeIterator(targetStream));
+  }
+
+}


### PR DESCRIPTION
## What
* Currently we read from a singer tap by using `lines()`. If a json object is split across multiple lines, we will not be able to parse it.

## How
* Use jackson parser to parse the InputStream. It handles this cross line issue. One downside is that it throws a lot of exceptions for any non json in the InputStream (on per word). ~My inclination is to use this implementation instead of trying to go lower level because I think doing so will be more prone to error. Curious to hear other people's opinions on this.~ It's the jackson json parser that throws all of these errors. If we want to use the jackson parser then we're going to have to deal with it.

@michel-tricot - this is branch is off of your branch, but I did not hook it up since you're still changing things.