### PR TITLE
add unit tests for all usages of Enums.convertTo(...)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,7 +39,7 @@ jobs:
         run: ./gradlew build --no-daemon -g ${{ env.GRADLE_PATH }}
 
       - name: Ensure no file change
-        run: git diff-index --quiet HEAD
+        run: git diff-index --exit-code HEAD
 
       - name: Write BigQuery Integration Test Credentials
         if: success() && github.ref == 'refs/heads/master'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,7 +39,7 @@ jobs:
         run: ./gradlew build --no-daemon -g ${{ env.GRADLE_PATH }}
 
       - name: Ensure no file change
-        run: git diff-index --exit-code HEAD
+        run: git diff-index --quiet HEAD
 
       - name: Write BigQuery Integration Test Credentials
         if: success() && github.ref == 'refs/heads/master'

--- a/dataline-server/src/test/java/io/dataline/server/converters/SchemaConverterTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/converters/SchemaConverterTest.java
@@ -1,0 +1,40 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.server.converters;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.dataline.commons.enums.Enums;
+import io.dataline.config.DataType;
+import org.junit.jupiter.api.Test;
+
+class SchemaConverterTest {
+
+  @Test
+  void testEnumConversion() {
+    assertTrue(Enums.isCompatible(io.dataline.api.model.DataType.class, DataType.class));
+  }
+
+}

--- a/dataline-server/src/test/java/io/dataline/server/handlers/JobHistoryHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/JobHistoryHandlerTest.java
@@ -25,6 +25,7 @@
 package io.dataline.server.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -35,6 +36,7 @@ import io.dataline.api.model.JobListRequestBody;
 import io.dataline.api.model.JobRead;
 import io.dataline.api.model.JobReadList;
 import io.dataline.api.model.LogRead;
+import io.dataline.commons.enums.Enums;
 import io.dataline.config.JobCheckConnectionConfig;
 import io.dataline.config.JobConfig;
 import io.dataline.scheduler.Job;
@@ -126,6 +128,12 @@ public class JobHistoryHandlerTest {
   public void testGetJobRead() {
     JobRead jobReadActual = JobHistoryHandler.getJobRead(JOB);
     assertEquals(JOB_INFO.getJob(), jobReadActual);
+  }
+
+  @Test
+  public void testEnumConversion() {
+    assertTrue(Enums.isCompatible(JobConfig.ConfigType.class, JobConfigType.class));
+    assertTrue(Enums.isCompatible(JobStatus.class, JobRead.StatusEnum.class));
   }
 
 }

--- a/dataline-server/src/test/java/io/dataline/server/handlers/SchedulerHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/SchedulerHandlerTest.java
@@ -1,0 +1,41 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.server.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.dataline.api.model.CheckConnectionRead;
+import io.dataline.commons.enums.Enums;
+import io.dataline.config.StandardCheckConnectionOutput;
+import org.junit.jupiter.api.Test;
+
+class SchedulerHandlerTest {
+
+  @Test
+  public void testEnumConversion() {
+    assertTrue(Enums.isCompatible(StandardCheckConnectionOutput.Status.class, CheckConnectionRead.StatusEnum.class));
+  }
+
+}

--- a/dataline-server/src/test/java/io/dataline/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/dataline-server/src/test/java/io/dataline/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -139,4 +139,9 @@ class WebBackendConnectionsHandlerTest {
     assertEquals(expected, wbConnectionRead);
   }
 
+  @Test
+  public void testEnumConversion() {
+    assertTrue(Enums.isCompatible(ConnectionRead.SyncModeEnum.class, WbConnectionRead.SyncModeEnum.class));
+  }
+
 }


### PR DESCRIPTION
## What
* Anytime we use `Enums.convertTo()` on a pair of enums, we should have a unit test that verifies that they're compatible.

## How
* Add this test for all usages.
