### PR TITLE
index workspace path by attempt

### DIFF
--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunFactory.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunFactory.java
@@ -42,7 +42,6 @@ import io.dataline.workers.wrappers.JobOutputCheckConnectionWorker;
 import io.dataline.workers.wrappers.JobOutputDiscoverSchemaWorker;
 import io.dataline.workers.wrappers.JobOutputSyncWorker;
 import java.nio.file.Path;
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,9 +71,10 @@ public class WorkerRunFactory {
   }
 
   public WorkerRun create(final Job job) {
-    LOGGER.info("job id: {} attempt: {} scope: {} type: {}", job.getId(), job.getAttempts(), job.getScope(), job.getConfig().getConfigType());
+    final int currentAttempt = job.getAttempts();
+    LOGGER.info("job id: {} attempt: {} scope: {} type: {}", job.getId(), currentAttempt, job.getScope(), job.getConfig().getConfigType());
 
-    final Path jobRoot = workspaceRoot.resolve(String.valueOf(job.getId())).resolve(String.valueOf(job.getAttempts()));
+    final Path jobRoot = workspaceRoot.resolve(String.valueOf(job.getId())).resolve(String.valueOf(currentAttempt));
     LOGGER.info("job root: {}", jobRoot);
 
     switch (job.getConfig().getConfigType()) {

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunFactory.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunFactory.java
@@ -42,6 +42,7 @@ import io.dataline.workers.wrappers.JobOutputCheckConnectionWorker;
 import io.dataline.workers.wrappers.JobOutputDiscoverSchemaWorker;
 import io.dataline.workers.wrappers.JobOutputSyncWorker;
 import java.nio.file.Path;
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,9 +72,9 @@ public class WorkerRunFactory {
   }
 
   public WorkerRun create(final Job job) {
-    LOGGER.info("job: {} {} {}", job.getId(), job.getScope(), job.getConfig().getConfigType());
+    LOGGER.info("job id: {} attempt: {} scope: {} type: {}", job.getId(), job.getAttempts(), job.getScope(), job.getConfig().getConfigType());
 
-    final Path jobRoot = workspaceRoot.resolve(String.valueOf(job.getId()));
+    final Path jobRoot = workspaceRoot.resolve(String.valueOf(job.getId())).resolve(String.valueOf(job.getAttempts()));
     LOGGER.info("job root: {}", jobRoot);
 
     switch (job.getConfig().getConfigType()) {

--- a/dataline-scheduler/src/test/java/io/dataline/scheduler/WorkerRunFactoryTest.java
+++ b/dataline-scheduler/src/test/java/io/dataline/scheduler/WorkerRunFactoryTest.java
@@ -66,7 +66,7 @@ class WorkerRunFactoryTest {
   void setUp() throws IOException {
     job = mock(Job.class, RETURNS_DEEP_STUBS);
     when(job.getId()).thenReturn(1L);
-    when(job.getAttempts()).thenReturn(0);
+    when(job.getAttempts()).thenReturn(2);
 
     creator = mock(WorkerRunFactory.Creator.class);
     rootPath = Files.createTempDirectory("test");
@@ -86,7 +86,7 @@ class WorkerRunFactoryTest {
 
     StandardCheckConnectionInput expectedInput = new StandardCheckConnectionInput().withConnectionConfiguration(CONFIG);
     ArgumentCaptor<Worker<StandardCheckConnectionInput, JobOutput>> argument = ArgumentCaptor.forClass(Worker.class);
-    verify(creator).create(eq(rootPath.resolve("1").resolve("0")), eq(expectedInput), argument.capture());
+    verify(creator).create(eq(rootPath.resolve("1").resolve("2")), eq(expectedInput), argument.capture());
     Assertions.assertTrue(argument.getValue() instanceof JobOutputCheckConnectionWorker);
   }
 
@@ -100,7 +100,7 @@ class WorkerRunFactoryTest {
 
     StandardDiscoverSchemaInput expectedInput = new StandardDiscoverSchemaInput().withConnectionConfiguration(CONFIG);
     ArgumentCaptor<Worker<StandardDiscoverSchemaInput, JobOutput>> argument = ArgumentCaptor.forClass(Worker.class);
-    verify(creator).create(eq(rootPath.resolve("1").resolve("0")), eq(expectedInput), argument.capture());
+    verify(creator).create(eq(rootPath.resolve("1").resolve("2")), eq(expectedInput), argument.capture());
     Assertions.assertTrue(argument.getValue() instanceof JobOutputDiscoverSchemaWorker);
   }
 
@@ -117,7 +117,7 @@ class WorkerRunFactoryTest {
         .withStandardSync(job.getConfig().getSync().getStandardSync());
 
     ArgumentCaptor<Worker<StandardSyncInput, JobOutput>> argument = ArgumentCaptor.forClass(Worker.class);
-    verify(creator).create(eq(rootPath.resolve("1").resolve("0")), eq(expectedInput), argument.capture());
+    verify(creator).create(eq(rootPath.resolve("1").resolve("2")), eq(expectedInput), argument.capture());
     Assertions.assertTrue(argument.getValue() instanceof JobOutputSyncWorker);
   }
 

--- a/dataline-scheduler/src/test/java/io/dataline/scheduler/WorkerRunFactoryTest.java
+++ b/dataline-scheduler/src/test/java/io/dataline/scheduler/WorkerRunFactoryTest.java
@@ -66,6 +66,7 @@ class WorkerRunFactoryTest {
   void setUp() throws IOException {
     job = mock(Job.class, RETURNS_DEEP_STUBS);
     when(job.getId()).thenReturn(1L);
+    when(job.getAttempts()).thenReturn(0);
 
     creator = mock(WorkerRunFactory.Creator.class);
     rootPath = Files.createTempDirectory("test");
@@ -85,7 +86,7 @@ class WorkerRunFactoryTest {
 
     StandardCheckConnectionInput expectedInput = new StandardCheckConnectionInput().withConnectionConfiguration(CONFIG);
     ArgumentCaptor<Worker<StandardCheckConnectionInput, JobOutput>> argument = ArgumentCaptor.forClass(Worker.class);
-    verify(creator).create(eq(rootPath.resolve("1")), eq(expectedInput), argument.capture());
+    verify(creator).create(eq(rootPath.resolve("1").resolve("0")), eq(expectedInput), argument.capture());
     Assertions.assertTrue(argument.getValue() instanceof JobOutputCheckConnectionWorker);
   }
 
@@ -99,7 +100,7 @@ class WorkerRunFactoryTest {
 
     StandardDiscoverSchemaInput expectedInput = new StandardDiscoverSchemaInput().withConnectionConfiguration(CONFIG);
     ArgumentCaptor<Worker<StandardDiscoverSchemaInput, JobOutput>> argument = ArgumentCaptor.forClass(Worker.class);
-    verify(creator).create(eq(rootPath.resolve("1")), eq(expectedInput), argument.capture());
+    verify(creator).create(eq(rootPath.resolve("1").resolve("0")), eq(expectedInput), argument.capture());
     Assertions.assertTrue(argument.getValue() instanceof JobOutputDiscoverSchemaWorker);
   }
 
@@ -116,7 +117,7 @@ class WorkerRunFactoryTest {
         .withStandardSync(job.getConfig().getSync().getStandardSync());
 
     ArgumentCaptor<Worker<StandardSyncInput, JobOutput>> argument = ArgumentCaptor.forClass(Worker.class);
-    verify(creator).create(eq(rootPath.resolve("1")), eq(expectedInput), argument.capture());
+    verify(creator).create(eq(rootPath.resolve("1").resolve("0")), eq(expectedInput), argument.capture());
     Assertions.assertTrue(argument.getValue() instanceof JobOutputSyncWorker);
   }
 


### PR DESCRIPTION
## What
* Now that we allow workers to retry, they were attempting to retry in the same workspace over and over again. This is bad because it means each attempt isn't happening in a hermetic environment. It also in some cases could cause `FileAlreadyExists` errors.

## How
* Instead of the workspace path just being `.../<job_id>`, this pr makes it `.../<job_id>/<attempt>`. This avoids us ever having workers running in the same workspace path and keeps that paths human readable.
* Also explicitly blows away any workspace that is in the path that the worker wants to use before it launches. In normal operation this should never need to be used, but if you manually retry an attempt (by fiddling in the db), then this protects you. It's another guarantee that workers are running in a hermetic workspace.
