### PR TITLE
add guide to which currencies are allowed

### DIFF
--- a/dataline-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/37eb2ebf-0899-4b22-aba8-8537ec88b5a8.json
+++ b/dataline-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/37eb2ebf-0899-4b22-aba8-8537ec88b5a8.json
@@ -15,7 +15,7 @@
       },
       "base": {
         "type": "string",
-        "description": "Reference currency. This value must match exactly (including capitalization) one of the currency abbreviations found <a href=\"https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html\">here</a>."
+        "description": "ISO reference currency. See <a href=\"https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html\">here</a>"
       }
     }
   }

--- a/dataline-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/37eb2ebf-0899-4b22-aba8-8537ec88b5a8.json
+++ b/dataline-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/37eb2ebf-0899-4b22-aba8-8537ec88b5a8.json
@@ -15,7 +15,7 @@
       },
       "base": {
         "type": "string",
-        "description": "Reference currency."
+        "description": "Reference currency. This value must match exactly one of the currency abbreviations found <a href=\"https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html\">here</a>."
       }
     }
   }

--- a/dataline-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/37eb2ebf-0899-4b22-aba8-8537ec88b5a8.json
+++ b/dataline-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/37eb2ebf-0899-4b22-aba8-8537ec88b5a8.json
@@ -15,7 +15,7 @@
       },
       "base": {
         "type": "string",
-        "description": "Reference currency. This value must match exactly one of the currency abbreviations found <a href=\"https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html\">here</a>."
+        "description": "Reference currency. This value must match exactly (including capitalization) one of the currency abbreviations found <a href=\"https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html\">here</a>."
       }
     }
   }


### PR DESCRIPTION
## What
* My tap kept failing because I was guessing at currency abbreviations because neither we nor singer had documented the correct values. I was guessing "usd". The correct version was "USD". 

## How
* Found the supported values as documented by http://exchangeratesapi.io/ and added them to integration docs