### PR TITLE
Remove filter_dbs configuration for postgrs source

### DIFF
--- a/dataline-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/2168516a-5c9a-4582-90dc-5e3a01e3f607.json
+++ b/dataline-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/2168516a-5c9a-4582-90dc-5e3a01e3f607.json
@@ -29,10 +29,6 @@
       "dbname": {
         "description": "Name of the database.",
         "type": "string"
-      },
-      "filter_dbs": {
-        "description": "This should be identical to dbname field.",
-        "type": "string"
       }
     }
   }

--- a/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
+++ b/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
@@ -63,7 +63,7 @@ class TestPostgresDestination {
 
   private static final String IMAGE_NAME = "dataline/integration-singer-postgres-destination:dev";
   private static final Path TESTS_PATH = Path.of("/tmp/dataline_integration_tests");
-  private static final String CONFIG_FILENAME = "target_config.json";
+  private static final String CONFIG_FILENAME = "config.json";
 
   protected Path jobRoot;
   protected Path workspaceRoot;
@@ -155,7 +155,7 @@ class TestPostgresDestination {
   }
 
   private void writeConfigFileToJobRoot(String fileContent) throws IOException {
-    Files.writeString(Path.of(jobRoot.toString(), CONFIG_FILENAME), fileContent);
+    Files.writeString(Path.of(jobRoot.toString(), "config.json"), fileContent);
   }
 
   private void writeResourceToStdIn(String resourceName, Process process) throws IOException {

--- a/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
+++ b/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
@@ -38,6 +38,7 @@ import io.dataline.db.DatabaseHelper;
 import io.dataline.workers.InvalidCatalogException;
 import io.dataline.workers.InvalidCredentialsException;
 import io.dataline.workers.OutputAndStatus;
+import io.dataline.workers.WorkerConstants;
 import io.dataline.workers.WorkerUtils;
 import io.dataline.workers.process.DockerProcessBuilderFactory;
 import io.dataline.workers.process.ProcessBuilderFactory;
@@ -63,7 +64,6 @@ class TestPostgresDestination {
 
   private static final String IMAGE_NAME = "dataline/integration-singer-postgres-destination:dev";
   private static final Path TESTS_PATH = Path.of("/tmp/dataline_integration_tests");
-  private static final String CONFIG_FILENAME = "config.json";
 
   protected Path jobRoot;
   protected Path workspaceRoot;
@@ -137,7 +137,7 @@ class TestPostgresDestination {
   }
 
   private Process startTarget() throws IOException {
-    return pbf.create(jobRoot, IMAGE_NAME, "--config", CONFIG_FILENAME)
+    return pbf.create(jobRoot, IMAGE_NAME, "--config", WorkerConstants.TARGET_CONFIG_JSON_FILENAME)
         .redirectOutput(ProcessBuilder.Redirect.INHERIT)
         .redirectError(ProcessBuilder.Redirect.INHERIT)
         .start();
@@ -155,7 +155,7 @@ class TestPostgresDestination {
   }
 
   private void writeConfigFileToJobRoot(String fileContent) throws IOException {
-    Files.writeString(Path.of(jobRoot.toString(), "config.json"), fileContent);
+    Files.writeString(Path.of(jobRoot.toString(), WorkerConstants.TARGET_CONFIG_JSON_FILENAME), fileContent);
   }
 
   private void writeResourceToStdIn(String resourceName, Process process) throws IOException {

--- a/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
+++ b/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
@@ -63,7 +63,7 @@ class TestPostgresDestination {
 
   private static final String IMAGE_NAME = "dataline/integration-singer-postgres-destination:dev";
   private static final Path TESTS_PATH = Path.of("/tmp/dataline_integration_tests");
-  private static final String CONFIG_FILENAME = "config.json";
+  private static final String CONFIG_FILENAME = "target_config.json";
 
   protected Path jobRoot;
   protected Path workspaceRoot;
@@ -155,7 +155,7 @@ class TestPostgresDestination {
   }
 
   private void writeConfigFileToJobRoot(String fileContent) throws IOException {
-    Files.writeString(Path.of(jobRoot.toString(), "config.json"), fileContent);
+    Files.writeString(Path.of(jobRoot.toString(), CONFIG_FILENAME), fileContent);
   }
 
   private void writeResourceToStdIn(String resourceName, Process process) throws IOException {

--- a/dataline-integrations/singer/postgres/source/.dockerignore
+++ b/dataline-integrations/singer/postgres/source/.dockerignore
@@ -1,3 +1,4 @@
 *
 !Dockerfile
 !requirements.txt
+!entrypoint.sh

--- a/dataline-integrations/singer/postgres/source/Dockerfile
+++ b/dataline-integrations/singer/postgres/source/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # need gcc to compile psycopg2
 RUN apt-get update && \
-  apt-get install -y libpq-dev gcc
+  apt-get install -y libpq-dev gcc jq
 
 # Install dependencies:
 COPY requirements.txt .
@@ -17,6 +17,8 @@ RUN python -m pip install --upgrade pip && \
 
 RUN apt-get autoremove -y gcc
 
-ENTRYPOINT ["tap-postgres"]
+COPY entrypoint.sh .
+
+ENTRYPOINT ["/singer/entrypoint.sh"]
 
 LABEL io.dataline.version=0.1.0

--- a/dataline-integrations/singer/postgres/source/entrypoint.sh
+++ b/dataline-integrations/singer/postgres/source/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+function echo2() {
+  echo >&2 "$@"
+}
+
+function error() {
+  echo2 "$@"
+  exit 1
+}
+
+function main() {
+  jq '.filter_dbs = .dbname' /data/job/config.json > /data/job/config_tmp.json
+  mv /data/job/config_tmp.json /data/job/config.json
+  tap-postgres "$@"
+}
+
+main "$@"

--- a/dataline-integrations/singer/postgres/source/entrypoint.sh
+++ b/dataline-integrations/singer/postgres/source/entrypoint.sh
@@ -12,8 +12,8 @@ function error() {
 }
 
 function main() {
-  jq '.filter_dbs = .dbname' /data/job/config.json > /data/job/config_tmp.json
-  mv /data/job/config_tmp.json /data/job/config.json
+  jq '.filter_dbs = .dbname' tap_config.json > tap_config_tmp.json
+  mv tap_config_tmp.json tap_config.json
   tap-postgres "$@"
 }
 

--- a/dataline-integrations/singer/postgres/source/entrypoint.sh
+++ b/dataline-integrations/singer/postgres/source/entrypoint.sh
@@ -12,8 +12,8 @@ function error() {
 }
 
 function main() {
-  jq '.filter_dbs = .dbname' /data/job/config.json > /data/job/config_tmp.json
-  mv /data/job/config_tmp.json /data/job/config.json
+  jq '.filter_dbs = .dbname' /data/job/tap_config.json > /data/job/tap_config_tmp.json
+  mv /data/job/tap_config_tmp.json /data/job/tap_config.json
   tap-postgres "$@"
 }
 

--- a/dataline-integrations/singer/postgres/source/entrypoint.sh
+++ b/dataline-integrations/singer/postgres/source/entrypoint.sh
@@ -12,8 +12,8 @@ function error() {
 }
 
 function main() {
-  jq '.filter_dbs = .dbname' /data/job/tap_config.json > /data/job/tap_config_tmp.json
-  mv /data/job/tap_config_tmp.json /data/job/tap_config.json
+  jq '.filter_dbs = .dbname' /data/job/config.json > /data/job/config_tmp.json
+  mv /data/job/config_tmp.json /data/job/config.json
   tap-postgres "$@"
 }
 

--- a/dataline-integrations/singer/postgres/source/entrypoint.sh
+++ b/dataline-integrations/singer/postgres/source/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+PROCESSED_CONFIG_FILE="processed_config.json"
+
 function echo2() {
   echo >&2 "$@"
 }
@@ -12,9 +14,34 @@ function error() {
 }
 
 function main() {
-  jq '.filter_dbs = .dbname' tap_config.json > tap_config_tmp.json
-  mv tap_config_tmp.json tap_config.json
-  tap-postgres "$@"
+  ARGS=
+  while [ $# -ne 0 ]; do
+    case "$1" in
+    --discover)
+      ARGS="$ARGS --discover"
+      shift 1
+      ;;
+    -b | --config)
+      jq '.filter_dbs = .dbname' $2 > $PROCESSED_CONFIG_FILE
+      ARGS="$ARGS --config $PROCESSED_CONFIG_FILE"
+      shift 2
+      ;;
+    -c | --state)
+      ARGS="$ARGS --state $2"
+      shift 2
+      ;;
+    --catalog | --properties)
+      # ignore
+      shift 2
+      ;;
+    *)
+      error "Unknown option: $1"
+      shift
+      ;;
+    esac
+  done
+
+  tap-postgres $ARGS
 }
 
 main "$@"

--- a/dataline-integrations/singer/postgres/source/src/test-integration/java/io/dataline/integrations/io/dataline/integration_tests/sources/SingerPostgresSourceTest.java
+++ b/dataline-integrations/singer/postgres/source/src/test-integration/java/io/dataline/integrations/io/dataline/integration_tests/sources/SingerPostgresSourceTest.java
@@ -230,7 +230,6 @@ public class SingerPostgresSourceTest {
     confMap.put("password", psqlDb.getPassword());
     confMap.put("port", psqlDb.getFirstMappedPort());
     confMap.put("host", psqlDb.getHost());
-    confMap.put("filter_dbs", psqlDb.getDatabaseName());
     return confMap;
   }
 

--- a/dataline-integrations/singer/postgres/source/src/test-integration/java/io/dataline/integrations/io/dataline/integration_tests/sources/SingerPostgresSourceTest.java
+++ b/dataline-integrations/singer/postgres/source/src/test-integration/java/io/dataline/integrations/io/dataline/integration_tests/sources/SingerPostgresSourceTest.java
@@ -73,7 +73,7 @@ import org.testcontainers.utility.MountableFile;
 public class SingerPostgresSourceTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SingerPostgresSourceTest.class);
-  private static final String IMAGE_NAME = "dataline/integration-singer-postgres-source:blah";
+  private static final String IMAGE_NAME = "dataline/integration-singer-postgres-source:dev";
   private static final Path TESTS_PATH = Path.of("/tmp/dataline_integration_tests");
 
   private PostgreSQLContainer psqlDb;

--- a/dataline-integrations/singer/postgres/source/src/test-integration/java/io/dataline/integrations/io/dataline/integration_tests/sources/SingerPostgresSourceTest.java
+++ b/dataline-integrations/singer/postgres/source/src/test-integration/java/io/dataline/integrations/io/dataline/integration_tests/sources/SingerPostgresSourceTest.java
@@ -73,7 +73,7 @@ import org.testcontainers.utility.MountableFile;
 public class SingerPostgresSourceTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SingerPostgresSourceTest.class);
-  private static final String IMAGE_NAME = "dataline/integration-singer-postgres-source";
+  private static final String IMAGE_NAME = "dataline/integration-singer-postgres-source:blah";
   private static final Path TESTS_PATH = Path.of("/tmp/dataline_integration_tests");
 
   private PostgreSQLContainer psqlDb;

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunFactory.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunFactory.java
@@ -74,7 +74,6 @@ public class WorkerRunFactory {
     LOGGER.info("job: {} {} {}", job.getId(), job.getScope(), job.getConfig().getConfigType());
 
     final Path jobRoot = workspaceRoot.resolve(String.valueOf(job.getId()));
-    LOGGER.info("job root: {}", jobRoot);
 
     switch (job.getConfig().getConfigType()) {
       case CHECK_CONNECTION_SOURCE:

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunFactory.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/WorkerRunFactory.java
@@ -74,6 +74,7 @@ public class WorkerRunFactory {
     LOGGER.info("job: {} {} {}", job.getId(), job.getScope(), job.getConfig().getConfigType());
 
     final Path jobRoot = workspaceRoot.resolve(String.valueOf(job.getId()));
+    LOGGER.info("job root: {}", jobRoot);
 
     switch (job.getConfig().getConfigType()) {
       case CHECK_CONNECTION_SOURCE:

--- a/dataline-workers/src/main/java/io/dataline/workers/WorkerConstants.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/WorkerConstants.java
@@ -1,2 +1,38 @@
-package io.dataline.workers;public class WorkerConstants {
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dataline
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.dataline.workers;
+
+public class WorkerConstants {
+
+  public static final String TAP_CONFIG_JSON_FILENAME = "tap_config.json";
+  public static final String TARGET_CONFIG_JSON_FILENAME = "target_config.json";
+
+  public static final String CATALOG_JSON_FILENAME = "catalog.json";
+  public static final String INPUT_STATE_JSON_FILENAME = "input_state.json";
+
+  public static final String TAP_ERR_LOG = "tap_err.log";
+  public static final String TARGET_ERR_LOG = "target_err.log";
+
 }

--- a/dataline-workers/src/main/java/io/dataline/workers/WorkerConstants.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/WorkerConstants.java
@@ -30,7 +30,6 @@ public class WorkerConstants {
   public static final String TARGET_CONFIG_JSON_FILENAME = "target_config.json";
 
   public static final String CATALOG_JSON_FILENAME = "catalog.json";
-  public static final String ORIGINAL_CATALOG_JSON_FILENAME = "catalog_original.json";
   public static final String INPUT_STATE_JSON_FILENAME = "input_state.json";
 
   public static final String TAP_ERR_LOG = "tap_err.log";

--- a/dataline-workers/src/main/java/io/dataline/workers/WorkerConstants.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/WorkerConstants.java
@@ -1,0 +1,2 @@
+package io.dataline.workers;public class WorkerConstants {
+}

--- a/dataline-workers/src/main/java/io/dataline/workers/WorkerConstants.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/WorkerConstants.java
@@ -30,6 +30,7 @@ public class WorkerConstants {
   public static final String TARGET_CONFIG_JSON_FILENAME = "target_config.json";
 
   public static final String CATALOG_JSON_FILENAME = "catalog.json";
+  public static final String ORIGINAL_CATALOG_JSON_FILENAME = "catalog_original.json";
   public static final String INPUT_STATE_JSON_FILENAME = "input_state.json";
 
   public static final String TAP_ERR_LOG = "tap_err.log";

--- a/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/DefaultSingerTap.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/DefaultSingerTap.java
@@ -35,6 +35,7 @@ import io.dataline.singer.SingerCatalog;
 import io.dataline.singer.SingerMessage;
 import io.dataline.workers.InvalidCredentialsException;
 import io.dataline.workers.StreamFactory;
+import io.dataline.workers.WorkerConstants;
 import io.dataline.workers.WorkerUtils;
 import io.dataline.workers.process.ProcessBuilderFactory;
 import java.io.IOException;
@@ -51,12 +52,6 @@ public class DefaultSingerTap implements SingerTap {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSingerTap.class);
 
-  @VisibleForTesting
-  static final String CONFIG_JSON_FILENAME = "tap_config.json";
-  @VisibleForTesting
-  static final String CATALOG_JSON_FILENAME = "catalog.json";
-  @VisibleForTesting
-  static final String STATE_JSON_FILENAME = "input_state.json";
   @VisibleForTesting
   static final String DISCOVERY_DIR = "discover";
 
@@ -96,25 +91,25 @@ public class DefaultSingerTap implements SingerTap {
     final SingerCatalog selectedCatalog = SingerCatalogConverters
         .applySchemaToDiscoveredCatalog(singerCatalog, input.getStandardSync().getSchema());
 
-    IOs.writeFile(jobRoot, CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
-    IOs.writeFile(jobRoot, CATALOG_JSON_FILENAME, Jsons.serialize(selectedCatalog));
-    IOs.writeFile(jobRoot, STATE_JSON_FILENAME, Jsons.serialize(input.getState()));
+    IOs.writeFile(jobRoot, WorkerConstants.TAP_CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
+    IOs.writeFile(jobRoot, WorkerConstants.CATALOG_JSON_FILENAME, Jsons.serialize(selectedCatalog));
+    IOs.writeFile(jobRoot, WorkerConstants.INPUT_STATE_JSON_FILENAME, Jsons.serialize(input.getState()));
 
     String[] cmd = {
       "--config",
-      CONFIG_JSON_FILENAME,
+      WorkerConstants.TAP_CONFIG_JSON_FILENAME,
       // TODO support both --properties and --catalog depending on integration
       "--properties",
-      CATALOG_JSON_FILENAME
+      WorkerConstants.CATALOG_JSON_FILENAME
     };
 
     if (input.getState() != null) {
-      cmd = ArrayUtils.addAll(cmd, "--state", STATE_JSON_FILENAME);
+      cmd = ArrayUtils.addAll(cmd, "--state", WorkerConstants.INPUT_STATE_JSON_FILENAME);
     }
 
     tapProcess =
         pbf.create(jobRoot, imageName, cmd)
-            .redirectError(jobRoot.resolve(SingerSyncWorker.TAP_ERR_LOG).toFile())
+            .redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile())
             .start();
 
     messageIterator = streamFactory.create(IOs.newBufferedReader(tapProcess.getInputStream())).iterator();

--- a/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/DefaultSingerTap.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/DefaultSingerTap.java
@@ -149,7 +149,8 @@ public class DefaultSingerTap implements SingerTap {
     Path discoverJobRoot = jobRoot.resolve(DISCOVERY_DIR);
     Files.createDirectory(discoverJobRoot);
 
-    return discoverSchemaWorker.runInternal(discoveryInput, discoverJobRoot).getOutput().get();
+    return discoverSchemaWorker.runInternal(discoveryInput, discoverJobRoot).getOutput()
+        .orElseThrow(() -> new IOException("Failed to discover schema."));
   }
 
 }

--- a/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/DefaultSingerTap.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/DefaultSingerTap.java
@@ -52,6 +52,9 @@ public class DefaultSingerTap implements SingerTap {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSingerTap.class);
 
+  @VisibleForTesting
+  static final String DISCOVERY_DIR = "discover";
+
   private final String imageName;
   private final ProcessBuilderFactory pbf;
   private final StreamFactory streamFactory;
@@ -143,15 +146,10 @@ public class DefaultSingerTap implements SingerTap {
     StandardDiscoverSchemaInput discoveryInput = new StandardDiscoverSchemaInput()
         .withConnectionConfiguration(input.getSourceConnectionImplementation().getConfiguration());
 
-    final Optional<SingerCatalog> output = discoverSchemaWorker.runInternal(discoveryInput, jobRoot).getOutput();
-    // We are going to write the catalog to be used in sync to this location. Instead of
-    // overwriting, retain the returned schema for debugging purposes.
-    final Path catalogPath = jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME);
-    if (Files.exists(catalogPath)) {
-      Files.move(catalogPath, jobRoot.resolve(WorkerConstants.ORIGINAL_CATALOG_JSON_FILENAME));
-    }
+    Path discoverJobRoot = jobRoot.resolve(DISCOVERY_DIR);
+    Files.createDirectory(discoverJobRoot);
 
-    return output.orElseThrow(() -> new IOException("Failed to discover schema."));
+    return discoverSchemaWorker.runInternal(discoveryInput, discoverJobRoot).getOutput().get();
   }
 
 }

--- a/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/DefaultSingerTarget.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/DefaultSingerTarget.java
@@ -25,13 +25,13 @@
 package io.dataline.workers.protocols.singer;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import io.dataline.commons.io.IOs;
 import io.dataline.commons.json.Jsons;
 import io.dataline.config.StandardTargetConfig;
 import io.dataline.singer.SingerMessage;
+import io.dataline.workers.WorkerConstants;
 import io.dataline.workers.WorkerUtils;
 import io.dataline.workers.process.ProcessBuilderFactory;
 import java.io.BufferedWriter;
@@ -45,9 +45,6 @@ import org.slf4j.LoggerFactory;
 public class DefaultSingerTarget implements SingerTarget {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSingerTarget.class);
-
-  @VisibleForTesting
-  static final String CONFIG_JSON_FILENAME = "target_config.json";
 
   private final String imageName;
   private final ProcessBuilderFactory pbf;
@@ -68,13 +65,13 @@ public class DefaultSingerTarget implements SingerTarget {
     final JsonNode configDotJson = targetConfig.getDestinationConnectionImplementation().getConfiguration();
 
     // write config.json to disk
-    IOs.writeFile(jobRoot, CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
+    IOs.writeFile(jobRoot, WorkerConstants.TARGET_CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
 
     try {
       LOGGER.info("Running Singer target...");
       targetProcess =
-          pbf.create(jobRoot, imageName, "--config", CONFIG_JSON_FILENAME)
-              .redirectError(jobRoot.resolve(SingerSyncWorker.TARGET_ERR_LOG).toFile())
+          pbf.create(jobRoot, imageName, "--config", WorkerConstants.TARGET_CONFIG_JSON_FILENAME)
+              .redirectError(jobRoot.resolve(WorkerConstants.TARGET_ERR_LOG).toFile())
               .start();
 
       writer = new BufferedWriter(new OutputStreamWriter(targetProcess.getOutputStream(), Charsets.UTF_8));

--- a/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorker.java
@@ -39,6 +39,7 @@ import io.dataline.workers.DiscoverSchemaWorker;
 import io.dataline.workers.InvalidCredentialsException;
 import io.dataline.workers.JobStatus;
 import io.dataline.workers.OutputAndStatus;
+import io.dataline.workers.WorkerConstants;
 import io.dataline.workers.WorkerUtils;
 import io.dataline.workers.process.ProcessBuilderFactory;
 import java.io.IOException;
@@ -53,10 +54,6 @@ public class SingerDiscoverSchemaWorker implements DiscoverSchemaWorker {
 
   // TODO log errors to specified file locations
   @VisibleForTesting
-  static final String CONFIG_JSON_FILENAME = "config.json";
-  static final String CATALOG_JSON_FILENAME = "catalog.json";
-  static final String ERROR_LOG_FILENAME = "err.log";
-
   private final String imageName;
   private final ProcessBuilderFactory pbf;
 
@@ -74,14 +71,14 @@ public class SingerDiscoverSchemaWorker implements DiscoverSchemaWorker {
     // reduced.
     final JsonNode configDotJson = discoverSchemaInput.getConnectionConfiguration();
 
-    IOs.writeFile(jobRoot, CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
+    IOs.writeFile(jobRoot, WorkerConstants.TAP_CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
 
     // exec
     try {
       workerProcess =
-          pbf.create(jobRoot, imageName, "--config", CONFIG_JSON_FILENAME, "--discover")
-              .redirectError(jobRoot.resolve(ERROR_LOG_FILENAME).toFile())
-              .redirectOutput(jobRoot.resolve(CATALOG_JSON_FILENAME).toFile())
+          pbf.create(jobRoot, imageName, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover")
+              .redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile())
+              .redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile())
               .start();
 
       while (!workerProcess.waitFor(1, TimeUnit.MINUTES)) {
@@ -90,11 +87,11 @@ public class SingerDiscoverSchemaWorker implements DiscoverSchemaWorker {
 
       int exitCode = workerProcess.exitValue();
       if (exitCode == 0) {
-        final String catalog = IOs.readFile(jobRoot, CATALOG_JSON_FILENAME);
+        final String catalog = IOs.readFile(jobRoot, WorkerConstants.CATALOG_JSON_FILENAME);
         return new OutputAndStatus<>(SUCCESSFUL, Jsons.deserialize(catalog, SingerCatalog.class));
       } else {
         // TODO throw invalid credentials exception where appropriate based on error log
-        String errLog = IOs.readFile(jobRoot, ERROR_LOG_FILENAME);
+        String errLog = IOs.readFile(jobRoot, WorkerConstants.TAP_ERR_LOG);
         LOGGER.debug(
             "Discovery job subprocess finished with exit code {}. Error log: {}", exitCode, errLog);
         return new OutputAndStatus<>(FAILED);

--- a/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorker.java
@@ -39,7 +39,6 @@ import io.dataline.workers.DiscoverSchemaWorker;
 import io.dataline.workers.InvalidCredentialsException;
 import io.dataline.workers.JobStatus;
 import io.dataline.workers.OutputAndStatus;
-import io.dataline.workers.WorkerConstants;
 import io.dataline.workers.WorkerUtils;
 import io.dataline.workers.process.ProcessBuilderFactory;
 import java.io.IOException;
@@ -54,6 +53,10 @@ public class SingerDiscoverSchemaWorker implements DiscoverSchemaWorker {
 
   // TODO log errors to specified file locations
   @VisibleForTesting
+  static final String CONFIG_JSON_FILENAME = "config.json";
+  static final String CATALOG_JSON_FILENAME = "catalog.json";
+  static final String ERROR_LOG_FILENAME = "err.log";
+
   private final String imageName;
   private final ProcessBuilderFactory pbf;
 
@@ -71,14 +74,14 @@ public class SingerDiscoverSchemaWorker implements DiscoverSchemaWorker {
     // reduced.
     final JsonNode configDotJson = discoverSchemaInput.getConnectionConfiguration();
 
-    IOs.writeFile(jobRoot, WorkerConstants.TAP_CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
+    IOs.writeFile(jobRoot, CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
 
     // exec
     try {
       workerProcess =
-          pbf.create(jobRoot, imageName, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover")
-              .redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile())
-              .redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile())
+          pbf.create(jobRoot, imageName, "--config", CONFIG_JSON_FILENAME, "--discover")
+              .redirectError(jobRoot.resolve(ERROR_LOG_FILENAME).toFile())
+              .redirectOutput(jobRoot.resolve(CATALOG_JSON_FILENAME).toFile())
               .start();
 
       while (!workerProcess.waitFor(1, TimeUnit.MINUTES)) {
@@ -87,11 +90,11 @@ public class SingerDiscoverSchemaWorker implements DiscoverSchemaWorker {
 
       int exitCode = workerProcess.exitValue();
       if (exitCode == 0) {
-        final String catalog = IOs.readFile(jobRoot, WorkerConstants.CATALOG_JSON_FILENAME);
+        final String catalog = IOs.readFile(jobRoot, CATALOG_JSON_FILENAME);
         return new OutputAndStatus<>(SUCCESSFUL, Jsons.deserialize(catalog, SingerCatalog.class));
       } else {
         // TODO throw invalid credentials exception where appropriate based on error log
-        String errLog = IOs.readFile(jobRoot, WorkerConstants.TAP_ERR_LOG);
+        String errLog = IOs.readFile(jobRoot, ERROR_LOG_FILENAME);
         LOGGER.debug(
             "Discovery job subprocess finished with exit code {}. Error log: {}", exitCode, errLog);
         return new OutputAndStatus<>(FAILED);

--- a/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/SingerSyncWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/SingerSyncWorker.java
@@ -35,6 +35,7 @@ import io.dataline.singer.SingerMessage;
 import io.dataline.workers.JobStatus;
 import io.dataline.workers.OutputAndStatus;
 import io.dataline.workers.SyncWorker;
+import io.dataline.workers.WorkerConstants;
 import io.dataline.workers.WorkerUtils;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -46,9 +47,6 @@ import org.slf4j.LoggerFactory;
 public class SingerSyncWorker implements SyncWorker {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SingerSyncWorker.class);
-
-  public static final String TAP_ERR_LOG = "tap_err.log";
-  public static final String TARGET_ERR_LOG = "target_err.log";
 
   private final SingerTap singerTap;
   private final SingerTarget singerTarget;
@@ -89,8 +87,8 @@ public class SingerSyncWorker implements SyncWorker {
 
     } catch (Exception e) {
       LOGGER.error("Sync worker failed. Tap error log: {}.\n Target error log: {}",
-          Files.exists(jobRoot.resolve(TAP_ERR_LOG)) ? IOs.readFile(jobRoot, TAP_ERR_LOG) : "<null>",
-          Files.exists(jobRoot.resolve(TARGET_ERR_LOG)) ? IOs.readFile(jobRoot, TARGET_ERR_LOG) : "<null>",
+          Files.exists(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG)) ? IOs.readFile(jobRoot, WorkerConstants.TAP_ERR_LOG) : "<null>",
+          Files.exists(jobRoot.resolve(WorkerConstants.TARGET_ERR_LOG)) ? IOs.readFile(jobRoot, WorkerConstants.TARGET_ERR_LOG) : "<null>",
           e);
 
       return new OutputAndStatus<>(JobStatus.FAILED, null);

--- a/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/DefaultSingerTapTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/DefaultSingerTapTest.java
@@ -81,11 +81,12 @@ class DefaultSingerTapTest {
 
     discoverSchemaWorker = mock(SingerDiscoverSchemaWorker.class);
     when(discoverSchemaWorker.runInternal(
-        new StandardDiscoverSchemaInput().withConnectionConfiguration(TAP_CONFIG.getSourceConnectionImplementation().getConfiguration()),
-        jobRoot)).thenReturn(new OutputAndStatus<>(JobStatus.SUCCESSFUL, SINGER_CATALOG));
+        new StandardDiscoverSchemaInput()
+            .withConnectionConfiguration(TAP_CONFIG.getSourceConnectionImplementation().getConfiguration()),
+        jobRoot.resolve(DefaultSingerTap.DISCOVERY_DIR)))
+            .thenReturn(new OutputAndStatus<>(JobStatus.SUCCESSFUL, SINGER_CATALOG));
   }
 
-  @SuppressWarnings("OptionalGetWithoutIsPresent")
   @Test
   public void test() throws InvalidCredentialsException, IOException {
     final List<SingerMessage> expectedMessages = Lists.newArrayList(

--- a/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/DefaultSingerTapTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/DefaultSingerTapTest.java
@@ -43,6 +43,7 @@ import io.dataline.workers.JobStatus;
 import io.dataline.workers.OutputAndStatus;
 import io.dataline.workers.StreamFactory;
 import io.dataline.workers.TestConfigHelpers;
+import io.dataline.workers.WorkerConstants;
 import io.dataline.workers.WorkerUtils;
 import io.dataline.workers.process.ProcessBuilderFactory;
 import java.io.IOException;
@@ -76,7 +77,7 @@ class DefaultSingerTapTest {
   @BeforeEach
   public void setup() throws IOException, InvalidCredentialsException {
     jobRoot = Files.createTempDirectory("test");
-    errorLogPath = jobRoot.resolve(SingerSyncWorker.TAP_ERR_LOG);
+    errorLogPath = jobRoot.resolve(WorkerConstants.TAP_ERR_LOG);
 
     discoverSchemaWorker = mock(SingerDiscoverSchemaWorker.class);
     when(discoverSchemaWorker.runInternal(
@@ -101,11 +102,11 @@ class DefaultSingerTapTest {
         jobRoot,
         IMAGE_NAME,
         "--config",
-        DefaultSingerTap.CONFIG_JSON_FILENAME,
+        WorkerConstants.TAP_CONFIG_JSON_FILENAME,
         "--properties",
-        DefaultSingerTap.CATALOG_JSON_FILENAME,
+        WorkerConstants.CATALOG_JSON_FILENAME,
         "--state",
-        DefaultSingerTap.STATE_JSON_FILENAME)
+        WorkerConstants.INPUT_STATE_JSON_FILENAME)
         .redirectError(errorLogPath.toFile())
         .start()).thenReturn(process);
     when(process.getInputStream()).thenReturn(inputStream);
@@ -115,15 +116,15 @@ class DefaultSingerTapTest {
 
     assertEquals(
         Jsons.jsonNode(TAP_CONFIG.getSourceConnectionImplementation().getConfiguration()),
-        Jsons.deserialize(IOs.readFile(jobRoot, DefaultSingerTap.CONFIG_JSON_FILENAME)));
+        Jsons.deserialize(IOs.readFile(jobRoot, WorkerConstants.TAP_CONFIG_JSON_FILENAME)));
 
     assertEquals(
         Jsons.jsonNode(SINGER_CATALOG),
-        Jsons.deserialize(IOs.readFile(jobRoot, DefaultSingerTap.CATALOG_JSON_FILENAME)));
+        Jsons.deserialize(IOs.readFile(jobRoot, WorkerConstants.CATALOG_JSON_FILENAME)));
 
     assertEquals(
         Jsons.jsonNode(TAP_CONFIG.getState()),
-        Jsons.deserialize(IOs.readFile(jobRoot, DefaultSingerTap.STATE_JSON_FILENAME)));
+        Jsons.deserialize(IOs.readFile(jobRoot, WorkerConstants.INPUT_STATE_JSON_FILENAME)));
 
     assertEquals(expectedMessages, Lists.newArrayList(tap.attemptRead().get(), tap.attemptRead().get()));
   }

--- a/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/DefaultSingerTapTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/DefaultSingerTapTest.java
@@ -81,12 +81,11 @@ class DefaultSingerTapTest {
 
     discoverSchemaWorker = mock(SingerDiscoverSchemaWorker.class);
     when(discoverSchemaWorker.runInternal(
-        new StandardDiscoverSchemaInput()
-            .withConnectionConfiguration(TAP_CONFIG.getSourceConnectionImplementation().getConfiguration()),
-        jobRoot.resolve(DefaultSingerTap.DISCOVERY_DIR)))
-            .thenReturn(new OutputAndStatus<>(JobStatus.SUCCESSFUL, SINGER_CATALOG));
+        new StandardDiscoverSchemaInput().withConnectionConfiguration(TAP_CONFIG.getSourceConnectionImplementation().getConfiguration()),
+        jobRoot)).thenReturn(new OutputAndStatus<>(JobStatus.SUCCESSFUL, SINGER_CATALOG));
   }
 
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
   @Test
   public void test() throws InvalidCredentialsException, IOException {
     final List<SingerMessage> expectedMessages = Lists.newArrayList(

--- a/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/DefaultSingerTargetTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/DefaultSingerTargetTest.java
@@ -33,6 +33,7 @@ import io.dataline.commons.json.Jsons;
 import io.dataline.config.StandardTargetConfig;
 import io.dataline.singer.SingerMessage;
 import io.dataline.workers.TestConfigHelpers;
+import io.dataline.workers.WorkerConstants;
 import io.dataline.workers.WorkerUtils;
 import io.dataline.workers.process.ProcessBuilderFactory;
 import java.io.ByteArrayOutputStream;
@@ -65,8 +66,8 @@ class DefaultSingerTargetTest {
 
   @Test
   public void test() throws Exception {
-    when(pbf.create(jobRoot, IMAGE_NAME, "--config", DefaultSingerTarget.CONFIG_JSON_FILENAME)
-        .redirectError(jobRoot.resolve(SingerSyncWorker.TARGET_ERR_LOG).toFile())
+    when(pbf.create(jobRoot, IMAGE_NAME, "--config", WorkerConstants.TARGET_CONFIG_JSON_FILENAME)
+        .redirectError(jobRoot.resolve(WorkerConstants.TARGET_ERR_LOG).toFile())
         .start()).thenReturn(process);
     when(process.getOutputStream()).thenReturn(outputStream);
 

--- a/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorkerTest.java
@@ -40,6 +40,7 @@ import io.dataline.config.StandardDiscoverSchemaOutput;
 import io.dataline.workers.InvalidCredentialsException;
 import io.dataline.workers.JobStatus;
 import io.dataline.workers.OutputAndStatus;
+import io.dataline.workers.WorkerConstants;
 import io.dataline.workers.process.ProcessBuilderFactory;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -68,9 +69,9 @@ public class SingerDiscoverSchemaWorkerTest {
 
     input = new StandardDiscoverSchemaInput().withConnectionConfiguration(CREDS);
 
-    when(pbf.create(jobRoot, IMAGE_NAME, "--config", SingerDiscoverSchemaWorker.CONFIG_JSON_FILENAME, "--discover")).thenReturn(processBuilder);
-    when(processBuilder.redirectError(jobRoot.resolve(SingerDiscoverSchemaWorker.ERROR_LOG_FILENAME).toFile())).thenReturn(processBuilder);
-    when(processBuilder.redirectOutput(jobRoot.resolve(SingerDiscoverSchemaWorker.CATALOG_JSON_FILENAME).toFile())).thenReturn(processBuilder);
+    when(pbf.create(jobRoot, IMAGE_NAME, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover")).thenReturn(processBuilder);
+    when(processBuilder.redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile())).thenReturn(processBuilder);
+    when(processBuilder.redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile())).thenReturn(processBuilder);
     when(processBuilder.start()).thenReturn(process);
     when(process.waitFor(1, TimeUnit.MINUTES)).thenReturn(true);
 
@@ -92,16 +93,16 @@ public class SingerDiscoverSchemaWorkerTest {
     assertTrue(run.getOutput().isPresent());
     assertEquals(expectedOutput, actualOutput);
 
-    assertTrue(Files.exists(jobRoot.resolve(SingerDiscoverSchemaWorker.CONFIG_JSON_FILENAME)));
-    assertTrue(Files.exists(jobRoot.resolve(SingerDiscoverSchemaWorker.CATALOG_JSON_FILENAME)));
+    assertTrue(Files.exists(jobRoot.resolve(WorkerConstants.TAP_CONFIG_JSON_FILENAME)));
+    assertTrue(Files.exists(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME)));
 
     final JsonNode expectedConfig = Jsons.jsonNode(input.getConnectionConfiguration());
-    final JsonNode actualConfig = Jsons.deserialize(IOs.readFile(jobRoot, SingerDiscoverSchemaWorker.CONFIG_JSON_FILENAME));
+    final JsonNode actualConfig = Jsons.deserialize(IOs.readFile(jobRoot, WorkerConstants.TAP_CONFIG_JSON_FILENAME));
     assertEquals(expectedConfig, actualConfig);
 
-    verify(pbf).create(jobRoot, IMAGE_NAME, "--config", SingerDiscoverSchemaWorker.CONFIG_JSON_FILENAME, "--discover");
-    verify(processBuilder).redirectError(jobRoot.resolve(SingerDiscoverSchemaWorker.ERROR_LOG_FILENAME).toFile());
-    verify(processBuilder).redirectOutput(jobRoot.resolve(SingerDiscoverSchemaWorker.CATALOG_JSON_FILENAME).toFile());
+    verify(pbf).create(jobRoot, IMAGE_NAME, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover");
+    verify(processBuilder).redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile());
+    verify(processBuilder).redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile());
     verify(processBuilder).start();
     verify(process).waitFor(1, TimeUnit.MINUTES);
   }

--- a/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorkerTest.java
@@ -40,7 +40,6 @@ import io.dataline.config.StandardDiscoverSchemaOutput;
 import io.dataline.workers.InvalidCredentialsException;
 import io.dataline.workers.JobStatus;
 import io.dataline.workers.OutputAndStatus;
-import io.dataline.workers.WorkerConstants;
 import io.dataline.workers.process.ProcessBuilderFactory;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -69,9 +68,9 @@ public class SingerDiscoverSchemaWorkerTest {
 
     input = new StandardDiscoverSchemaInput().withConnectionConfiguration(CREDS);
 
-    when(pbf.create(jobRoot, IMAGE_NAME, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover")).thenReturn(processBuilder);
-    when(processBuilder.redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile())).thenReturn(processBuilder);
-    when(processBuilder.redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile())).thenReturn(processBuilder);
+    when(pbf.create(jobRoot, IMAGE_NAME, "--config", SingerDiscoverSchemaWorker.CONFIG_JSON_FILENAME, "--discover")).thenReturn(processBuilder);
+    when(processBuilder.redirectError(jobRoot.resolve(SingerDiscoverSchemaWorker.ERROR_LOG_FILENAME).toFile())).thenReturn(processBuilder);
+    when(processBuilder.redirectOutput(jobRoot.resolve(SingerDiscoverSchemaWorker.CATALOG_JSON_FILENAME).toFile())).thenReturn(processBuilder);
     when(processBuilder.start()).thenReturn(process);
     when(process.waitFor(1, TimeUnit.MINUTES)).thenReturn(true);
 
@@ -93,16 +92,16 @@ public class SingerDiscoverSchemaWorkerTest {
     assertTrue(run.getOutput().isPresent());
     assertEquals(expectedOutput, actualOutput);
 
-    assertTrue(Files.exists(jobRoot.resolve(WorkerConstants.TAP_CONFIG_JSON_FILENAME)));
-    assertTrue(Files.exists(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME)));
+    assertTrue(Files.exists(jobRoot.resolve(SingerDiscoverSchemaWorker.CONFIG_JSON_FILENAME)));
+    assertTrue(Files.exists(jobRoot.resolve(SingerDiscoverSchemaWorker.CATALOG_JSON_FILENAME)));
 
     final JsonNode expectedConfig = Jsons.jsonNode(input.getConnectionConfiguration());
-    final JsonNode actualConfig = Jsons.deserialize(IOs.readFile(jobRoot, WorkerConstants.TAP_CONFIG_JSON_FILENAME));
+    final JsonNode actualConfig = Jsons.deserialize(IOs.readFile(jobRoot, SingerDiscoverSchemaWorker.CONFIG_JSON_FILENAME));
     assertEquals(expectedConfig, actualConfig);
 
-    verify(pbf).create(jobRoot, IMAGE_NAME, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover");
-    verify(processBuilder).redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile());
-    verify(processBuilder).redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile());
+    verify(pbf).create(jobRoot, IMAGE_NAME, "--config", SingerDiscoverSchemaWorker.CONFIG_JSON_FILENAME, "--discover");
+    verify(processBuilder).redirectError(jobRoot.resolve(SingerDiscoverSchemaWorker.ERROR_LOG_FILENAME).toFile());
+    verify(processBuilder).redirectOutput(jobRoot.resolve(SingerDiscoverSchemaWorker.CATALOG_JSON_FILENAME).toFile());
     verify(processBuilder).start();
     verify(process).waitFor(1, TimeUnit.MINUTES);
   }

--- a/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorkerTest.java
@@ -40,6 +40,7 @@ import io.dataline.config.StandardDiscoverSchemaOutput;
 import io.dataline.workers.InvalidCredentialsException;
 import io.dataline.workers.JobStatus;
 import io.dataline.workers.OutputAndStatus;
+import io.dataline.workers.WorkerConstants;
 import io.dataline.workers.process.ProcessBuilderFactory;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -68,14 +69,14 @@ public class SingerDiscoverSchemaWorkerTest {
 
     input = new StandardDiscoverSchemaInput().withConnectionConfiguration(CREDS);
 
-    when(pbf.create(jobRoot, IMAGE_NAME, "--config", SingerDiscoverSchemaWorker.CONFIG_JSON_FILENAME, "--discover")).thenReturn(processBuilder);
-    when(processBuilder.redirectError(jobRoot.resolve(SingerDiscoverSchemaWorker.ERROR_LOG_FILENAME).toFile())).thenReturn(processBuilder);
-    when(processBuilder.redirectOutput(jobRoot.resolve(SingerDiscoverSchemaWorker.CATALOG_JSON_FILENAME).toFile())).thenReturn(processBuilder);
+    when(pbf.create(jobRoot, IMAGE_NAME, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover")).thenReturn(processBuilder);
+    when(processBuilder.redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile())).thenReturn(processBuilder);
+    when(processBuilder.redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile())).thenReturn(processBuilder);
     when(processBuilder.start()).thenReturn(process);
     when(process.waitFor(1, TimeUnit.MINUTES)).thenReturn(true);
 
     // this would be written by the docker process.
-    IOs.writeFile(jobRoot, "catalog.json", MoreResources.readResource("simple_postgres_singer_catalog.json"));
+    IOs.writeFile(jobRoot, WorkerConstants.CATALOG_JSON_FILENAME, MoreResources.readResource("simple_postgres_singer_catalog.json"));
   }
 
   @Test
@@ -92,16 +93,16 @@ public class SingerDiscoverSchemaWorkerTest {
     assertTrue(run.getOutput().isPresent());
     assertEquals(expectedOutput, actualOutput);
 
-    assertTrue(Files.exists(jobRoot.resolve(SingerDiscoverSchemaWorker.CONFIG_JSON_FILENAME)));
-    assertTrue(Files.exists(jobRoot.resolve(SingerDiscoverSchemaWorker.CATALOG_JSON_FILENAME)));
+    assertTrue(Files.exists(jobRoot.resolve(WorkerConstants.TAP_CONFIG_JSON_FILENAME)));
+    assertTrue(Files.exists(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME)));
 
     final JsonNode expectedConfig = Jsons.jsonNode(input.getConnectionConfiguration());
-    final JsonNode actualConfig = Jsons.deserialize(IOs.readFile(jobRoot, SingerDiscoverSchemaWorker.CONFIG_JSON_FILENAME));
+    final JsonNode actualConfig = Jsons.deserialize(IOs.readFile(jobRoot, WorkerConstants.TAP_CONFIG_JSON_FILENAME));
     assertEquals(expectedConfig, actualConfig);
 
-    verify(pbf).create(jobRoot, IMAGE_NAME, "--config", SingerDiscoverSchemaWorker.CONFIG_JSON_FILENAME, "--discover");
-    verify(processBuilder).redirectError(jobRoot.resolve(SingerDiscoverSchemaWorker.ERROR_LOG_FILENAME).toFile());
-    verify(processBuilder).redirectOutput(jobRoot.resolve(SingerDiscoverSchemaWorker.CATALOG_JSON_FILENAME).toFile());
+    verify(pbf).create(jobRoot, IMAGE_NAME, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover");
+    verify(processBuilder).redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile());
+    verify(processBuilder).redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile());
     verify(processBuilder).start();
     verify(process).waitFor(1, TimeUnit.MINUTES);
   }


### PR DESCRIPTION
## What
* We should not expose the `filter_dbs` in the postgres singer tap (but we still need to set it internally).
  * It is confusing
  * If it includes databases other than just the dbname and the user selects tables / columns from it, things will fail.
  * If the user doesn't put in the dbname they get no schema back

## How
* In the docker image, fill out the `filter_dbs` fields with the contents of `dbname`
* Required _standardizing_ the name of a config for a tap. Standardize all of these files names (and put them in `WorkerConstants`).
* Required moving the discover schema process that happens in the tap to be moved into the main job root, instead of its own `discover` directory. I don't love this because it leads to more chance of these two messing each other up. If we do _not_ like this, the other option is to just add more complex logic in the integration to figure out where the config actually is. We may be able to make this problem go away as we make the interface for a docker integration clearer.

## Recommended reading order
1. `dataline-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/2168516a-5c9a-4582-90dc-5e3a01e3f607.json`
1. `dataline-integrations/singer/postgres/source/entrypoint.sh`
1. `dataline-workers/src/main/java/io/dataline/workers/protocols/singer/DefaultSingerTap.java`
1. the rest

## Other notes
Developing this was kinda annoying. Navigating the file paths was not super intuitive. I'm not sure that it's an actual problem with the design, so much as we could add some more documentation to help someone new to it navigate it faster. Will take a crack at that in gitbook.