### PR TITLE
RFC: skinny singer catalog

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -7,13 +7,8 @@
         {
           "breadcrumb": [],
           "metadata": {
-            "table-key-properties": [
-              "id"
-            ],
             "schema-name": "public",
             "database-name": "df2398b8h9cmec",
-            "row-count": 3,
-            "is-view": false,
             "selected": true,
             "replication-method": "FULL_TABLE"
           }
@@ -25,8 +20,7 @@
           ],
           "metadata": {
             "sql-datatype": "integer",
-            "inclusion": "automatic",
-            "selected-by-default": true
+            "_sql-datatype": "is required?!?!?!"
           }
         },
         {
@@ -35,9 +29,7 @@
             "name"
           ],
           "metadata": {
-            "sql-datatype": "character varying",
-            "inclusion": "available",
-            "selected-by-default": true
+            "sql-datatype": "character varying"
           }
         },
         {
@@ -46,9 +38,7 @@
             "active"
           ],
           "metadata": {
-            "sql-datatype": "boolean",
-            "inclusion": "available",
-            "selected-by-default": true
+            "sql-datatype": "boolean"
           }
         },
         {
@@ -57,9 +47,7 @@
             "length"
           ],
           "metadata": {
-            "sql-datatype": "integer",
-            "inclusion": "available",
-            "selected-by-default": true
+            "sql-datatype": "integer"
           }
         }
       ],
@@ -70,16 +58,13 @@
           "id": {
             "type": [
               "integer"
-            ],
-            "minimum": -2147483648,
-            "maximum": 2147483647
+            ]
           },
           "name": {
             "type": [
               "null",
               "string"
-            ],
-            "maxLength": 255
+            ]
           },
           "active": {
             "type": [
@@ -91,72 +76,7 @@
             "type": [
               "null",
               "integer"
-            ],
-            "minimum": -2147483648,
-            "maximum": 2147483647
-          }
-        },
-        "definitions": {
-          "sdc_recursive_integer_array": {
-            "type": [
-              "null",
-              "integer",
-              "array"
-            ],
-            "items": {
-              "$ref": "#/definitions/sdc_recursive_integer_array"
-            }
-          },
-          "sdc_recursive_number_array": {
-            "type": [
-              "null",
-              "number",
-              "array"
-            ],
-            "items": {
-              "$ref": "#/definitions/sdc_recursive_number_array"
-            }
-          },
-          "sdc_recursive_string_array": {
-            "type": [
-              "null",
-              "string",
-              "array"
-            ],
-            "items": {
-              "$ref": "#/definitions/sdc_recursive_string_array"
-            }
-          },
-          "sdc_recursive_boolean_array": {
-            "type": [
-              "null",
-              "boolean",
-              "array"
-            ],
-            "items": {
-              "$ref": "#/definitions/sdc_recursive_boolean_array"
-            }
-          },
-          "sdc_recursive_timestamp_array": {
-            "type": [
-              "null",
-              "string",
-              "array"
-            ],
-            "format": "date-time",
-            "items": {
-              "$ref": "#/definitions/sdc_recursive_timestamp_array"
-            }
-          },
-          "sdc_recursive_object_array": {
-            "type": [
-              "null",
-              "object",
-              "array"
-            ],
-            "items": {
-              "$ref": "#/definitions/sdc_recursive_object_array"
-            }
+            ]
           }
         }
       }


### PR DESCRIPTION
_This PR is meant for discussion. It will NOT be merged._

## What
* Per a discussion I had with @michel-tricot, I took a look at whether or not we could generate a singer catalog from scratch (as opposed to what we do now, which is generate one from whatever catalog singer gives us in the discover process).
* This PR is a diff from the catalog that singer gives us as the base and the skinniest version of the catalog I could use to still perform a successful sync.

## Conclusion
* Maybe... The skinny version seems doable relative to our data model **EXCEPT**...
* `sql-datatype` is a required field for the postgres tap. The issues I outline here will apply to any other unique, required metdata.
  * We might be able to figure out a mapping between our data type and the `sql-datatype`, this isn't the backbreaking part.
  * It's that this piece of metadata is integration specific. So if we wanted to generate singer catalogs from our schema, I think we have two options:
    1. add a ton of cruft to our core app and live in fear of a new integration with some other critical piece of metadata. In my mind this isn't a real option.
    1.  Add more complex mappings to each integration. This might be doable. I probably need a wider sample set of taps to decide on this. Stopping here so that this investigation doesn't become too big a rabbit hole. 

## Open Question
1. Do we try to generate singer catalogs ourselves?
1. If yes, when?
