### PR TITLE
Fix schema discovery state machine

### DIFF
--- a/dataline-integrations/singer/postgres/source/src/test-integration/java/io/dataline/integrations/io/dataline/integration_tests/sources/SingerPostgresSourceTest.java
+++ b/dataline-integrations/singer/postgres/source/src/test-integration/java/io/dataline/integrations/io/dataline/integration_tests/sources/SingerPostgresSourceTest.java
@@ -101,7 +101,7 @@ public class SingerPostgresSourceTest {
   }
 
   @Test
-  public void testReadFirstTime() throws IOException, InvalidCredentialsException {
+  public void testReadFirstTime() throws Exception {
     Schema schema = Jsons.deserialize(MoreResources.readResource("simple_postgres_source_schema.json"), Schema.class);
 
     // select all tables and all columns

--- a/dataline-workers/src/main/java/io/dataline/workers/OutputAndStatus.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/OutputAndStatus.java
@@ -24,6 +24,7 @@
 
 package io.dataline.workers;
 
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
@@ -53,6 +54,24 @@ public class OutputAndStatus<OutputType> {
 
   public JobStatus getStatus() {
     return status;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    OutputAndStatus<?> that = (OutputAndStatus<?>) o;
+    return Objects.equals(output, that.output) &&
+        status == that.status;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(output, status);
   }
 
 }

--- a/dataline-workers/src/main/java/io/dataline/workers/WorkerException.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/WorkerException.java
@@ -22,22 +22,12 @@
  * SOFTWARE.
  */
 
-package io.dataline.workers.protocols.singer;
+package io.dataline.workers;
 
-import io.dataline.config.StandardTapConfig;
-import io.dataline.singer.SingerMessage;
-import java.nio.file.Path;
-import java.util.Optional;
+public class WorkerException extends Exception {
 
-public interface SingerTap extends AutoCloseable {
-
-  void start(StandardTapConfig input, Path jobRoot) throws Exception;
-
-  boolean isFinished();
-
-  Optional<SingerMessage> attemptRead();
-
-  @Override
-  void close() throws Exception;
+  public WorkerException(String message) {
+    super(message);
+  }
 
 }

--- a/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorker.java
@@ -30,13 +30,10 @@ import static io.dataline.workers.JobStatus.SUCCESSFUL;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.dataline.commons.io.IOs;
 import io.dataline.commons.json.Jsons;
-import io.dataline.config.Schema;
 import io.dataline.config.StandardDiscoverSchemaInput;
 import io.dataline.config.StandardDiscoverSchemaOutput;
 import io.dataline.singer.SingerCatalog;
 import io.dataline.workers.DiscoverSchemaWorker;
-import io.dataline.workers.InvalidCredentialsException;
-import io.dataline.workers.JobStatus;
 import io.dataline.workers.OutputAndStatus;
 import io.dataline.workers.WorkerConstants;
 import io.dataline.workers.WorkerUtils;
@@ -54,73 +51,59 @@ public class SingerDiscoverSchemaWorker implements DiscoverSchemaWorker {
   private final String imageName;
   private final ProcessBuilderFactory pbf;
 
-  private volatile Process workerProcess;
+  private volatile Process process;
 
   public SingerDiscoverSchemaWorker(final String imageName, final ProcessBuilderFactory pbf) {
     this.imageName = imageName;
     this.pbf = pbf;
   }
 
-  // package private since package-local classes need direct access to singer catalog, and the
-  // conversion from SingerSchema to Dataline schema is lossy
-  OutputAndStatus<SingerCatalog> runInternal(StandardDiscoverSchemaInput discoverSchemaInput, Path jobRoot) throws InvalidCredentialsException {
-    // todo (cgardens) - just getting original impl to line up with new iface for now. this can be
-    // reduced.
+  @Override
+  public OutputAndStatus<StandardDiscoverSchemaOutput> run(final StandardDiscoverSchemaInput discoverSchemaInput,
+                                                           final Path jobRoot) {
+    try {
+      return runInternal(discoverSchemaInput, jobRoot);
+    } catch (final Exception e) {
+      LOGGER.error("Error while discovering schema", e);
+      return new OutputAndStatus<>(FAILED);
+    }
+  }
+
+  private OutputAndStatus<StandardDiscoverSchemaOutput> runInternal(final StandardDiscoverSchemaInput discoverSchemaInput,
+                                                                    final Path jobRoot)
+      throws IOException {
     final JsonNode configDotJson = discoverSchemaInput.getConnectionConfiguration();
 
     IOs.writeFile(jobRoot, WorkerConstants.TAP_CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
 
-    // exec
-    try {
-      workerProcess =
-          pbf.create(jobRoot, imageName, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover")
-              .redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile())
-              .redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile())
-              .start();
+    process = pbf.create(jobRoot, imageName, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover")
+        // TODO: we shouldn't trust the tap not not pollute stdout
+        .redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile())
+        .start();
 
-      while (!workerProcess.waitFor(1, TimeUnit.MINUTES)) {
-        LOGGER.info("Waiting for discovery job.");
-      }
+    WorkerUtils.gentleClose(process, 1, TimeUnit.MINUTES);
 
-      int exitCode = workerProcess.exitValue();
-      if (exitCode == 0) {
-        final String catalog = IOs.readFile(jobRoot, WorkerConstants.CATALOG_JSON_FILENAME);
-        return new OutputAndStatus<>(SUCCESSFUL, Jsons.deserialize(catalog, SingerCatalog.class));
-      } else {
-        // TODO throw invalid credentials exception where appropriate based on error log
-        String errLog = IOs.readFile(jobRoot, WorkerConstants.TAP_ERR_LOG);
-        LOGGER.debug(
-            "Discovery job subprocess finished with exit code {}. Error log: {}", exitCode, errLog);
-        return new OutputAndStatus<>(FAILED);
-      }
-    } catch (IOException | InterruptedException e) {
-      LOGGER.error("Exception running discovery: ", e);
-      throw new RuntimeException(e);
-    }
-  }
+    int exitCode = process.exitValue();
 
-  @Override
-  public OutputAndStatus<StandardDiscoverSchemaOutput> run(StandardDiscoverSchemaInput discoverSchemaInput, Path jobRoot)
-      throws InvalidCredentialsException {
-    OutputAndStatus<SingerCatalog> output = runInternal(discoverSchemaInput, jobRoot);
-    JobStatus status = output.getStatus();
-
-    if (output.getOutput().isPresent()) {
-      return new OutputAndStatus<>(status, toDiscoveryOutput(output.getOutput().get()));
+    if (exitCode == 0) {
+      final SingerCatalog catalog = readCatalog(jobRoot);
+      return new OutputAndStatus<>(
+          SUCCESSFUL,
+          new StandardDiscoverSchemaOutput()
+              .withSchema(SingerCatalogConverters.toDatalineSchema(catalog)));
     } else {
-      return new OutputAndStatus<>(status);
+      LOGGER.debug("Discovery job subprocess finished with exit code {}", exitCode);
+      return new OutputAndStatus<>(FAILED);
     }
-  }
-
-  private static StandardDiscoverSchemaOutput toDiscoveryOutput(SingerCatalog catalog) {
-    final Schema schema = SingerCatalogConverters.toDatalineSchema(catalog);
-
-    return new StandardDiscoverSchemaOutput().withSchema(schema);
   }
 
   @Override
   public void cancel() {
-    WorkerUtils.cancelProcess(workerProcess);
+    WorkerUtils.cancelProcess(process);
+  }
+
+  public static SingerCatalog readCatalog(Path jobRoot) {
+    return Jsons.deserialize(IOs.readFile(jobRoot, WorkerConstants.CATALOG_JSON_FILENAME), SingerCatalog.class);
   }
 
 }

--- a/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorker.java
@@ -78,6 +78,7 @@ public class SingerDiscoverSchemaWorker implements DiscoverSchemaWorker {
 
     process = pbf.create(jobRoot, imageName, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover")
         // TODO: we shouldn't trust the tap not not pollute stdout
+        .redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile())
         .redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile())
         .start();
 

--- a/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorker.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorker.java
@@ -77,7 +77,7 @@ public class SingerDiscoverSchemaWorker implements DiscoverSchemaWorker {
     IOs.writeFile(jobRoot, WorkerConstants.TAP_CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
 
     process = pbf.create(jobRoot, imageName, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover")
-        // TODO: we shouldn't trust the tap not not pollute stdout
+        // TODO: we shouldn't trust the tap does not pollute stdout
         .redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile())
         .redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile())
         .start();

--- a/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/DefaultSingerTapTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/DefaultSingerTapTest.java
@@ -25,25 +25,31 @@
 package io.dataline.workers.protocols.singer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
 import io.dataline.commons.io.IOs;
 import io.dataline.commons.json.Jsons;
 import io.dataline.config.StandardDiscoverSchemaInput;
+import io.dataline.config.StandardDiscoverSchemaOutput;
 import io.dataline.config.StandardTapConfig;
 import io.dataline.singer.SingerCatalog;
 import io.dataline.singer.SingerMessage;
 import io.dataline.singer.SingerStream;
 import io.dataline.singer.SingerTableSchema;
-import io.dataline.workers.InvalidCredentialsException;
 import io.dataline.workers.JobStatus;
 import io.dataline.workers.OutputAndStatus;
 import io.dataline.workers.StreamFactory;
 import io.dataline.workers.TestConfigHelpers;
 import io.dataline.workers.WorkerConstants;
+import io.dataline.workers.WorkerException;
 import io.dataline.workers.WorkerUtils;
 import io.dataline.workers.process.ProcessBuilderFactory;
 import java.io.IOException;
@@ -52,6 +58,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -69,35 +76,37 @@ class DefaultSingerTapTest {
           .withSchema(new SingerTableSchema())));
 
   private static final StandardTapConfig TAP_CONFIG = WorkerUtils.syncToTapConfig(TestConfigHelpers.createSyncConfig().getValue());
+  private static final StandardDiscoverSchemaInput DISCOVER_SCHEMA_INPUT = new StandardDiscoverSchemaInput()
+      .withConnectionConfiguration(TAP_CONFIG.getSourceConnectionImplementation().getConfiguration());
+
+  final List<SingerMessage> MESSAGES = Lists.newArrayList(
+      SingerMessageUtils.createRecordMessage(TABLE_NAME, COLUMN_NAME, "blue"),
+      SingerMessageUtils.createRecordMessage(TABLE_NAME, COLUMN_NAME, "yellow"));
 
   private Path jobRoot;
-  private Path errorLogPath;
   private SingerDiscoverSchemaWorker discoverSchemaWorker;
+  private ProcessBuilderFactory pbf;
+  private Process process;
+  private StreamFactory streamFactory;
 
   @BeforeEach
-  public void setup() throws IOException, InvalidCredentialsException {
+  public void setup() throws IOException {
     jobRoot = Files.createTempDirectory("test");
-    errorLogPath = jobRoot.resolve(WorkerConstants.TAP_ERR_LOG);
 
     discoverSchemaWorker = mock(SingerDiscoverSchemaWorker.class);
-    when(discoverSchemaWorker.runInternal(
-        new StandardDiscoverSchemaInput()
-            .withConnectionConfiguration(TAP_CONFIG.getSourceConnectionImplementation().getConfiguration()),
+    when(discoverSchemaWorker.run(
+        DISCOVER_SCHEMA_INPUT,
         jobRoot.resolve(DefaultSingerTap.DISCOVERY_DIR)))
-            .thenReturn(new OutputAndStatus<>(JobStatus.SUCCESSFUL, SINGER_CATALOG));
-  }
+            .thenAnswer(invocation -> {
+              Files.writeString(
+                  jobRoot.resolve(DefaultSingerTap.DISCOVERY_DIR).resolve(WorkerConstants.CATALOG_JSON_FILENAME),
+                  Jsons.serialize(SINGER_CATALOG));
+              return new OutputAndStatus<>(JobStatus.SUCCESSFUL, new StandardDiscoverSchemaOutput());
+            });
 
-  @Test
-  public void test() throws InvalidCredentialsException, IOException {
-    final List<SingerMessage> expectedMessages = Lists.newArrayList(
-        SingerMessageUtils.createRecordMessage(TABLE_NAME, COLUMN_NAME, "blue"),
-        SingerMessageUtils.createRecordMessage(TABLE_NAME, COLUMN_NAME, "yellow"));
-    StreamFactory streamFactory = noop -> expectedMessages.stream();
-
-    final ProcessBuilderFactory pbf = mock(ProcessBuilderFactory.class, RETURNS_DEEP_STUBS);
-    final Process process = mock(Process.class);
+    pbf = mock(ProcessBuilderFactory.class, RETURNS_DEEP_STUBS);
+    process = mock(Process.class, RETURNS_DEEP_STUBS);
     final InputStream inputStream = mock(InputStream.class);
-
     when(pbf.create(
         jobRoot,
         IMAGE_NAME,
@@ -107,26 +116,67 @@ class DefaultSingerTapTest {
         WorkerConstants.CATALOG_JSON_FILENAME,
         "--state",
         WorkerConstants.INPUT_STATE_JSON_FILENAME)
-        .redirectError(errorLogPath.toFile())
+        .redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile())
         .start()).thenReturn(process);
+    when(process.isAlive()).thenReturn(true);
     when(process.getInputStream()).thenReturn(inputStream);
 
+    streamFactory = noop -> MESSAGES.stream();
+  }
+
+  @Test
+  public void testSuccessfulLifecycle() throws Exception {
     final SingerTap tap = new DefaultSingerTap(IMAGE_NAME, pbf, streamFactory, discoverSchemaWorker);
     tap.start(TAP_CONFIG, jobRoot);
+
+    final List<SingerMessage> messages = Lists.newArrayList();
+
+    assertFalse(tap.isFinished());
+    messages.add(tap.attemptRead().get());
+    assertFalse(tap.isFinished());
+    messages.add(tap.attemptRead().get());
+    assertFalse(tap.isFinished());
+
+    when(process.isAlive()).thenReturn(false);
+    assertTrue(tap.isFinished());
+
+    tap.close();
 
     assertEquals(
         Jsons.jsonNode(TAP_CONFIG.getSourceConnectionImplementation().getConfiguration()),
         Jsons.deserialize(IOs.readFile(jobRoot, WorkerConstants.TAP_CONFIG_JSON_FILENAME)));
-
+    assertEquals(
+        Jsons.jsonNode(TAP_CONFIG.getState()),
+        Jsons.deserialize(IOs.readFile(jobRoot, WorkerConstants.INPUT_STATE_JSON_FILENAME)));
     assertEquals(
         Jsons.jsonNode(SINGER_CATALOG),
         Jsons.deserialize(IOs.readFile(jobRoot, WorkerConstants.CATALOG_JSON_FILENAME)));
 
-    assertEquals(
-        Jsons.jsonNode(TAP_CONFIG.getState()),
-        Jsons.deserialize(IOs.readFile(jobRoot, WorkerConstants.INPUT_STATE_JSON_FILENAME)));
+    assertEquals(MESSAGES, messages);
 
-    assertEquals(expectedMessages, Lists.newArrayList(tap.attemptRead().get(), tap.attemptRead().get()));
+    verify(process).waitFor(anyLong(), any());
+  }
+
+  @Test
+  public void testProcessFail() throws Exception {
+    final SingerTap tap = new DefaultSingerTap(IMAGE_NAME, pbf, streamFactory, discoverSchemaWorker);
+    tap.start(TAP_CONFIG, jobRoot);
+
+    when(process.exitValue()).thenReturn(1);
+
+    Assertions.assertThrows(WorkerException.class, tap::close);
+  }
+
+  @Test
+  public void testSchemaDiscoveryFail() {
+    when(discoverSchemaWorker.run(any(), any())).thenReturn(new OutputAndStatus<>(JobStatus.FAILED));
+
+    final SingerTap tap = new DefaultSingerTap(IMAGE_NAME, pbf, streamFactory, discoverSchemaWorker);
+    Assertions.assertThrows(WorkerException.class, () -> tap.start(TAP_CONFIG, jobRoot));
+
+    assertFalse(Files.exists(jobRoot.resolve(WorkerConstants.TAP_CONFIG_JSON_FILENAME)));
+    assertFalse(Files.exists(jobRoot.resolve(WorkerConstants.INPUT_STATE_JSON_FILENAME)));
+    assertFalse(Files.exists(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME)));
   }
 
 }

--- a/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorkerTest.java
@@ -68,6 +68,7 @@ public class SingerDiscoverSchemaWorkerTest {
     input = new StandardDiscoverSchemaInput().withConnectionConfiguration(CREDENTIALS);
 
     when(pbf.create(jobRoot, IMAGE_NAME, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover")
+        .redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile())
         .redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile())
         .start())
             .thenReturn(process);

--- a/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorkerTest.java
@@ -26,6 +26,9 @@ package io.dataline.workers.protocols.singer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -37,78 +40,89 @@ import io.dataline.commons.json.Jsons;
 import io.dataline.commons.resources.MoreResources;
 import io.dataline.config.StandardDiscoverSchemaInput;
 import io.dataline.config.StandardDiscoverSchemaOutput;
-import io.dataline.workers.InvalidCredentialsException;
 import io.dataline.workers.JobStatus;
 import io.dataline.workers.OutputAndStatus;
 import io.dataline.workers.WorkerConstants;
 import io.dataline.workers.process.ProcessBuilderFactory;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class SingerDiscoverSchemaWorkerTest {
 
   private static final String IMAGE_NAME = "selfie:latest";
-  private static final JsonNode CREDS = Jsons.jsonNode(ImmutableMap.builder().put("apiKey", "123").build());
+  private static final JsonNode CREDENTIALS = Jsons.jsonNode(ImmutableMap.builder().put("apiKey", "123").build());
 
   private Path jobRoot;
   private ProcessBuilderFactory pbf;
-  private ProcessBuilder processBuilder;
   private Process process;
   private StandardDiscoverSchemaInput input;
 
   @BeforeEach
-  public void setup() throws IOException, InterruptedException {
+  public void setup() throws Exception {
     jobRoot = Files.createTempDirectory("");
-    pbf = mock(ProcessBuilderFactory.class);
-    processBuilder = mock(ProcessBuilder.class);
+    pbf = mock(ProcessBuilderFactory.class, RETURNS_DEEP_STUBS);
     process = mock(Process.class);
 
-    input = new StandardDiscoverSchemaInput().withConnectionConfiguration(CREDS);
+    input = new StandardDiscoverSchemaInput().withConnectionConfiguration(CREDENTIALS);
 
-    when(pbf.create(jobRoot, IMAGE_NAME, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover")).thenReturn(processBuilder);
-    when(processBuilder.redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile())).thenReturn(processBuilder);
-    when(processBuilder.redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile())).thenReturn(processBuilder);
-    when(processBuilder.start()).thenReturn(process);
-    when(process.waitFor(1, TimeUnit.MINUTES)).thenReturn(true);
-
-    // this would be written by the docker process.
+    when(pbf.create(jobRoot, IMAGE_NAME, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover")
+        .redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile())
+        .start())
+            .thenReturn(process);
     IOs.writeFile(jobRoot, WorkerConstants.CATALOG_JSON_FILENAME, MoreResources.readResource("simple_postgres_singer_catalog.json"));
   }
 
   @Test
-  public void testDiscoverSchema() throws IOException, InterruptedException, InvalidCredentialsException {
-    SingerDiscoverSchemaWorker worker = new SingerDiscoverSchemaWorker(IMAGE_NAME, pbf);
-    OutputAndStatus<StandardDiscoverSchemaOutput> run = worker.run(input, jobRoot);
+  public void testDiscoverSchema() throws Exception {
+    final SingerDiscoverSchemaWorker worker = new SingerDiscoverSchemaWorker(IMAGE_NAME, pbf);
+    final OutputAndStatus<StandardDiscoverSchemaOutput> output = worker.run(input, jobRoot);
 
-    assertEquals(JobStatus.SUCCESSFUL, run.getStatus());
+    final OutputAndStatus<StandardDiscoverSchemaOutput> expectedOutput =
+        new OutputAndStatus<>(
+            JobStatus.SUCCESSFUL,
+            Jsons.deserialize(MoreResources.readResource("simple_discovered_postgres_schema.json"), StandardDiscoverSchemaOutput.class));
 
-    final StandardDiscoverSchemaOutput expectedOutput =
-        Jsons.deserialize(MoreResources.readResource("simple_discovered_postgres_schema.json"), StandardDiscoverSchemaOutput.class);
-    final StandardDiscoverSchemaOutput actualOutput = run.getOutput().get();
+    assertEquals(expectedOutput, output);
 
-    assertTrue(run.getOutput().isPresent());
-    assertEquals(expectedOutput, actualOutput);
-
-    assertTrue(Files.exists(jobRoot.resolve(WorkerConstants.TAP_CONFIG_JSON_FILENAME)));
     assertTrue(Files.exists(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME)));
 
-    final JsonNode expectedConfig = Jsons.jsonNode(input.getConnectionConfiguration());
-    final JsonNode actualConfig = Jsons.deserialize(IOs.readFile(jobRoot, WorkerConstants.TAP_CONFIG_JSON_FILENAME));
-    assertEquals(expectedConfig, actualConfig);
+    assertEquals(
+        Jsons.jsonNode(input.getConnectionConfiguration()),
+        Jsons.deserialize(IOs.readFile(jobRoot, WorkerConstants.TAP_CONFIG_JSON_FILENAME)));
 
-    verify(pbf).create(jobRoot, IMAGE_NAME, "--config", WorkerConstants.TAP_CONFIG_JSON_FILENAME, "--discover");
-    verify(processBuilder).redirectError(jobRoot.resolve(WorkerConstants.TAP_ERR_LOG).toFile());
-    verify(processBuilder).redirectOutput(jobRoot.resolve(WorkerConstants.CATALOG_JSON_FILENAME).toFile());
-    verify(processBuilder).start();
-    verify(process).waitFor(1, TimeUnit.MINUTES);
+    verify(process).waitFor(anyLong(), any());
   }
 
   @Test
-  public void testCancel() throws InvalidCredentialsException {
+  public void testDiscoverSchemaProcessFail() throws Exception {
+    when(process.exitValue()).thenReturn(1);
+
+    final SingerDiscoverSchemaWorker worker = new SingerDiscoverSchemaWorker(IMAGE_NAME, pbf);
+    final OutputAndStatus<StandardDiscoverSchemaOutput> output = worker.run(input, jobRoot);
+
+    final OutputAndStatus<StandardDiscoverSchemaOutput> expectedOutput = new OutputAndStatus<>(JobStatus.FAILED);
+
+    assertEquals(expectedOutput, output);
+
+    verify(process).waitFor(anyLong(), any());
+  }
+
+  @Test
+  public void testDiscoverSchemaException() {
+    when(pbf.create(any(), any(), any())).thenThrow(new RuntimeException());
+
+    final SingerDiscoverSchemaWorker worker = new SingerDiscoverSchemaWorker(IMAGE_NAME, pbf);
+    final OutputAndStatus<StandardDiscoverSchemaOutput> output = worker.run(input, jobRoot);
+
+    final OutputAndStatus<StandardDiscoverSchemaOutput> expectedOutput = new OutputAndStatus<>(JobStatus.FAILED);
+
+    assertEquals(expectedOutput, output);
+  }
+
+  @Test
+  public void testCancel() {
     SingerDiscoverSchemaWorker worker = new SingerDiscoverSchemaWorker(IMAGE_NAME, pbf);
     worker.run(input, jobRoot);
 


### PR DESCRIPTION
## What
Fix schema discovery state machine

## How
Make sure it always returns an output
Remove the call to `runInternal`
Improve `SingerDiscoverSchemaWorker` test coverage
Update `DefaultSingerTap` tests

## Recommended reading order
1. `SingerDiscoverSchemaWorker.java`
1. `SingerDiscoverSchemaWorkerTest.java`
1. `DefaultSingerTap.java`
1. `DefaultSingerTapTest.java`
1. the rest
