### PR TITLE
Hot fix: wait for gobbler thread to finish

### DIFF
--- a/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/DefaultSingerTapTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/DefaultSingerTapTest.java
@@ -58,6 +58,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
@@ -156,7 +157,11 @@ class DefaultSingerTapTest {
 
     assertEquals(MESSAGES, messages);
 
-    assertEquals(0, process.getErrorStream().available());
+    Assertions.assertTimeout(Duration.ofSeconds(5), () -> {
+      while (process.getErrorStream().available() != 0) {
+        Thread.sleep(50);
+      }
+    });
 
     verify(process).waitFor(anyLong(), any());
   }

--- a/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/DefaultSingerTargetTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/DefaultSingerTargetTest.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -100,8 +101,16 @@ class DefaultSingerTargetTest {
     final String actualOutput = new String(outputStream.toByteArray());
     assertEquals(Jsons.serialize(recordMessage) + "\n", actualOutput);
 
-    assertEquals(0, process.getErrorStream().available());
-    assertEquals(0, process.getInputStream().available());
+    Assertions.assertTimeout(Duration.ofSeconds(5), () -> {
+      while (process.getErrorStream().available() != 0) {
+        Thread.sleep(50);
+      }
+    });
+    Assertions.assertTimeout(Duration.ofSeconds(5), () -> {
+      while (process.getInputStream().available() != 0) {
+        Thread.sleep(50);
+      }
+    });
 
     verify(process).waitFor(anyLong(), any());
   }

--- a/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorkerTest.java
+++ b/dataline-workers/src/test/java/io/dataline/workers/protocols/singer/SingerDiscoverSchemaWorkerTest.java
@@ -48,6 +48,8 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -95,7 +97,11 @@ public class SingerDiscoverSchemaWorkerTest {
         Jsons.jsonNode(input.getConnectionConfiguration()),
         Jsons.deserialize(IOs.readFile(jobRoot, WorkerConstants.TAP_CONFIG_JSON_FILENAME)));
 
-    assertEquals(process.getErrorStream().available(), 0);
+    Assertions.assertTimeout(Duration.ofSeconds(5), () -> {
+      while (process.getErrorStream().available() != 0) {
+        Thread.sleep(50);
+      }
+    });
 
     verify(process).waitFor(anyLong(), any());
   }
@@ -111,7 +117,11 @@ public class SingerDiscoverSchemaWorkerTest {
 
     assertEquals(expectedOutput, output);
 
-    assertEquals(process.getErrorStream().available(), 0);
+    Assertions.assertTimeout(Duration.ofSeconds(5), () -> {
+      while (process.getErrorStream().available() != 0) {
+        Thread.sleep(50);
+      }
+    });
 
     verify(process).waitFor(anyLong(), any());
   }


### PR DESCRIPTION
## What
Tests are failing because the gobbler isn't done reading when we check the buffer state. 
Waiting for it to finish before asserting

Not super happy about the busy loop but it is time bounded. 

Another solution would be to inject the gobbler but that's a bit heavy.