### PR TITLE
remove filter_dbs from AcceptanceTests

### DIFF
--- a/dataline-tests/src/acceptanceTests/java/io/dataline/test/acceptance/AcceptanceTests.java
+++ b/dataline-tests/src/acceptanceTests/java/io/dataline/test/acceptance/AcceptanceTests.java
@@ -318,7 +318,6 @@ public class AcceptanceTests {
         .put("password", SOURCE_PSQL.getPassword())
         .put("port", SOURCE_PSQL.getFirstMappedPort())
         .put("dbname", SOURCE_PSQL.getDatabaseName())
-        .put("filter_dbs", SOURCE_PSQL.getDatabaseName())
         .put("user", SOURCE_PSQL.getUsername()).build());
 
     UUID defaultWorkspaceId = PersistenceConstants.DEFAULT_WORKSPACE_ID;


### PR DESCRIPTION
## What
* Remove filter_dbs from pg source is breaking AcceptanceTests (and the master build), because the AcceptanceTests still pass `filter_dbs` as part of the config. The API correctly validates that the extra field `filter_dbs` should not be there.

## How
* Remove `filter_dbs` field from AcceptanceTests.
