### PR TITLE
Fix networking issues in Integration Tests

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,3 +1,5 @@
+# DEV_ROOT must be in a directory that can be mounted by docker
+# we highly recommend a directory in /tmp
 DEV_ROOT=/tmp/dev_root
 VERSION=dev
 DATABASE_USER=docker

--- a/.env.dev
+++ b/.env.dev
@@ -1,5 +1,3 @@
-# DEV_ROOT must be in a directory that can be mounted by docker
-# we highly recommend a directory in /tmp
 DEV_ROOT=/tmp/dev_root
 VERSION=dev
 DATABASE_USER=docker

--- a/dataline-config/models/src/main/java/io/dataline/config/Configs.java
+++ b/dataline-config/models/src/main/java/io/dataline/config/Configs.java
@@ -40,6 +40,8 @@ public interface Configs {
 
   String getWorkspaceDockerMount();
 
+  String getDockerNetwork();
+
   TrackingStrategy getTrackingStrategy();
 
   enum TrackingStrategy {

--- a/dataline-config/models/src/main/java/io/dataline/config/EnvConfigs.java
+++ b/dataline-config/models/src/main/java/io/dataline/config/EnvConfigs.java
@@ -37,10 +37,13 @@ public class EnvConfigs implements Configs {
   public static final String WORKSPACE_ROOT = "WORKSPACE_ROOT";
   public static final String WORKSPACE_DOCKER_MOUNT = "WORKSPACE_DOCKER_MOUNT";
   public static final String CONFIG_ROOT = "CONFIG_ROOT";
+  public static final String DOCKER_NETWORK = "DOCKER_NETWORK";
   public static final String TRACKING_STRATEGY = "TRACKING_STRATEGY";
   public static final String DATABASE_USER = "DATABASE_USER";
   public static final String DATABASE_PASSWORD = "DATABASE_PASSWORD";
   public static final String DATABASE_URL = "DATABASE_URL";
+
+  public static final String DEFAULT_NETWORK = "host";
 
   private final Function<String, String> getEnv;
 
@@ -86,6 +89,17 @@ public class EnvConfigs implements Configs {
 
     LOGGER.info(WORKSPACE_DOCKER_MOUNT + " not found, defaulting to " + WORKSPACE_ROOT);
     return getWorkspaceRoot().toString();
+  }
+
+  @Override
+  public String getDockerNetwork() {
+    final String network = getEnv.apply(DOCKER_NETWORK);
+    if (network != null) {
+      return network;
+    }
+
+    LOGGER.info(DOCKER_NETWORK + " not found, defaulting to " + DEFAULT_NETWORK);
+    return DEFAULT_NETWORK;
   }
 
   @Override

--- a/dataline-config/models/src/test/java/io/dataline/config/EnvConfigsTest.java
+++ b/dataline-config/models/src/test/java/io/dataline/config/EnvConfigsTest.java
@@ -111,6 +111,15 @@ class EnvConfigsTest {
   }
 
   @Test
+  void testDockerNetwork() {
+    when(function.apply(EnvConfigs.DOCKER_NETWORK)).thenReturn(null);
+    Assertions.assertEquals("host", config.getDockerNetwork());
+
+    when(function.apply(EnvConfigs.DOCKER_NETWORK)).thenReturn("abc");
+    Assertions.assertEquals("abc", config.getDockerNetwork());
+  }
+
+  @Test
   void testTrackingStrategy() {
     when(function.apply(EnvConfigs.TRACKING_STRATEGY)).thenReturn(null);
     Assertions.assertEquals(Configs.TrackingStrategy.LOGGING, config.getTrackingStrategy());

--- a/dataline-integrations/singer/bigquery/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestBigQueryDestination.java
+++ b/dataline-integrations/singer/bigquery/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestBigQueryDestination.java
@@ -85,7 +85,7 @@ class TestBigQueryDestination {
     jobRoot = Path.of(workspaceRoot.toString(), "job");
     Files.createDirectories(jobRoot);
 
-    pbf = new DockerProcessBuilderFactory(workspaceRoot, workspaceRoot.toString());
+    pbf = new DockerProcessBuilderFactory(workspaceRoot, workspaceRoot.toString(), "host");
 
     datasetName = "dataline_tests_" + RandomStringUtils.randomAlphanumeric(8);
     DatasetInfo datasetInfo = DatasetInfo.newBuilder(datasetName).build();

--- a/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
+++ b/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
@@ -76,6 +76,9 @@ class TestPostgresDestination {
   @BeforeEach
   public void setUp() throws IOException {
     PSQL = new PostgreSQLContainer<>();
+    if(!System.getProperty("os.name").equals("Mac OS X")) {
+      PSQL.withNetworkMode("host");
+    }
     PSQL.start();
 
     Files.createDirectories(TESTS_PATH);

--- a/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
+++ b/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
@@ -76,9 +76,6 @@ class TestPostgresDestination {
   @BeforeEach
   public void setUp() throws IOException {
     PSQL = new PostgreSQLContainer<>();
-    if(!System.getProperty("os.name").equals("Mac OS X")) {
-      PSQL.withNetworkMode("host");
-    }
     PSQL.start();
 
     Files.createDirectories(TESTS_PATH);
@@ -149,7 +146,7 @@ class TestPostgresDestination {
   private Map<String, Object> getDbConfig() {
     Map<String, Object> fullConfig = new HashMap<>();
 
-    fullConfig.put("postgres_host", System.getProperty("os.name").equals("Mac OS X") ? "host.docker.internal" : "localhost");
+    fullConfig.put("postgres_host", PSQL.getHost());
     fullConfig.put("postgres_port", PSQL.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT));
     fullConfig.put("postgres_username", PSQL.getUsername());
     fullConfig.put("postgres_password", PSQL.getPassword());

--- a/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
+++ b/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
@@ -146,7 +146,7 @@ class TestPostgresDestination {
   private Map<String, Object> getDbConfig() {
     Map<String, Object> fullConfig = new HashMap<>();
 
-    fullConfig.put("postgres_host", PSQL.getHost());
+    fullConfig.put("postgres_host", System.getProperty("os.name").equals("Mac OS X") ? "host.docker.internal" : "localhost");
     fullConfig.put("postgres_port", PSQL.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT));
     fullConfig.put("postgres_username", PSQL.getUsername());
     fullConfig.put("postgres_password", PSQL.getPassword());

--- a/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
+++ b/dataline-integrations/singer/postgres/destination/src/test-integration/java/io/dataline/integration_tests/destinations/TestPostgresDestination.java
@@ -86,7 +86,7 @@ class TestPostgresDestination {
     jobRoot = Path.of(workspaceRoot.toString(), "job");
     Files.createDirectories(jobRoot);
 
-    pbf = new DockerProcessBuilderFactory(workspaceRoot, workspaceRoot.toString());
+    pbf = new DockerProcessBuilderFactory(workspaceRoot, workspaceRoot.toString(), "host");
   }
 
   @AfterEach

--- a/dataline-integrations/singer/postgres/source/src/test-integration/java/io/dataline/integrations/io/dataline/integration_tests/sources/SingerPostgresSourceTest.java
+++ b/dataline-integrations/singer/postgres/source/src/test-integration/java/io/dataline/integrations/io/dataline/integration_tests/sources/SingerPostgresSourceTest.java
@@ -92,7 +92,7 @@ public class SingerPostgresSourceTest {
     jobRoot = workspaceRoot.resolve("job");
     Files.createDirectories(jobRoot);
 
-    pbf = new DockerProcessBuilderFactory(workspaceRoot, workspaceRoot.toString());
+    pbf = new DockerProcessBuilderFactory(workspaceRoot, workspaceRoot.toString(), "host");
   }
 
   @AfterEach

--- a/dataline-scheduler/src/main/java/io/dataline/scheduler/SchedulerApp.java
+++ b/dataline-scheduler/src/main/java/io/dataline/scheduler/SchedulerApp.java
@@ -116,7 +116,7 @@ public class SchedulerApp {
         configs.getDatabasePassword(),
         configs.getDatabaseUrl());
 
-    final ProcessBuilderFactory pbf = new DockerProcessBuilderFactory(workspaceRoot, configs.getWorkspaceDockerMount());
+    final ProcessBuilderFactory pbf = new DockerProcessBuilderFactory(workspaceRoot, configs.getWorkspaceDockerMount(), configs.getDockerNetwork());
 
     LOGGER.info("Launching scheduler...");
     new SchedulerApp(connectionPool, configRoot, workspaceRoot, pbf).start();

--- a/dataline-workers/src/main/java/io/dataline/workers/process/DockerProcessBuilderFactory.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/process/DockerProcessBuilderFactory.java
@@ -40,10 +40,12 @@ public class DockerProcessBuilderFactory implements ProcessBuilderFactory {
 
   private final String mountSource;
   private final Path workspaceRoot;
+  private final String networkName;
 
-  public DockerProcessBuilderFactory(final Path workspaceRoot, final String mountSource) {
+  public DockerProcessBuilderFactory(Path workspaceRoot, String mountSource, String networkName) {
     this.mountSource = mountSource;
     this.workspaceRoot = workspaceRoot;
+    this.networkName = networkName;
   }
 
   @Override
@@ -52,12 +54,13 @@ public class DockerProcessBuilderFactory implements ProcessBuilderFactory {
         Lists.newArrayList(
             "docker",
             "run",
-            "--rm",
             "-i",
             "-v",
             String.format("%s:%s", mountSource, MOUNT_DESTINATION),
             "-w",
             rebasePath(jobRoot).toString(),
+            "--network",
+            networkName,
             imageName);
     cmd.addAll(Arrays.asList(args));
 

--- a/dataline-workers/src/main/java/io/dataline/workers/process/DockerProcessBuilderFactory.java
+++ b/dataline-workers/src/main/java/io/dataline/workers/process/DockerProcessBuilderFactory.java
@@ -54,6 +54,7 @@ public class DockerProcessBuilderFactory implements ProcessBuilderFactory {
         Lists.newArrayList(
             "docker",
             "run",
+            "--rm",
             "-i",
             "-v",
             String.format("%s:%s", mountSource, MOUNT_DESTINATION),

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -6,12 +6,15 @@ services:
     image: busybox
     container_name: init
     command: /bin/sh -c "
-      mkdir -p /tmp/workspace;
-      mkdir -p /tmp/data;
-      mkdir -p /tmp/db;
+      echo ${DEV_ROOT};
+      mkdir -p ${DEV_ROOT}/workspace;
+      mkdir -p ${DEV_ROOT}/data;
+      mkdir -p ${DEV_ROOT}/db;
       "
+    environment:
+      - DEV_ROOT=${DEV_ROOT}
     volumes:
-      - root:/tmp
+      - ${DEV_ROOT}/..:/tmp
   seed:
   db:
     ports:
@@ -19,16 +22,8 @@ services:
   scheduler:
   server:
   webapp:
-
 # Allow us to access the volume content on the local filesystem
 volumes:
-  root:
-    name: dev-root
-    driver: local
-    driver_opts:
-      o: bind
-      type: none
-      device: ${DEV_ROOT}
   workspace:
     name: dev-workspace
     driver: local

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -6,15 +6,12 @@ services:
     image: busybox
     container_name: init
     command: /bin/sh -c "
-      echo ${DEV_ROOT};
-      mkdir -p ${DEV_ROOT}/workspace;
-      mkdir -p ${DEV_ROOT}/data;
-      mkdir -p ${DEV_ROOT}/db;
+      mkdir -p /tmp/workspace;
+      mkdir -p /tmp/data;
+      mkdir -p /tmp/db;
       "
-    environment:
-      - DEV_ROOT=${DEV_ROOT}
     volumes:
-      - ${DEV_ROOT}/..:/tmp
+      - root:/tmp
   seed:
   db:
     ports:
@@ -25,6 +22,13 @@ services:
 
 # Allow us to access the volume content on the local filesystem
 volumes:
+  root:
+    name: dev-root
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: ${DEV_ROOT}
   workspace:
     name: dev-workspace
     driver: local


### PR DESCRIPTION
## What
* Switching the application to not run on the host network by default (in this [pr](https://github.com/datalineio/dataline/pull/302)), broke the integration tests, because the tap can no longer find the source database. Issue to follow up: https://github.com/datalineio/dataline/issues/311

## How
* This PR reverts the networking parts of that PR so that the app once again, by default, runs on the host network.