### PR TITLE
set acceptanceTests.sh to not use a daemon

### DIFF
--- a/tools/bin/acceptance_test.sh
+++ b/tools/bin/acceptance_test.sh
@@ -16,4 +16,4 @@ echo "Waiting for services to begin"
 sleep 10 # TODO need a better way to wait
 
 echo "Running e2e tests via gradle"
-./gradlew :dataline-tests:acceptanceTests
+./gradlew --no-daemon :dataline-tests:acceptanceTests


### PR DESCRIPTION
## What
* In the CI we always use the no-daemon form of gradle. Any reason why it is different here? Just happened to notice as I was debugging something else.