### PR TITLE
bump singer postgres source to version 0.1.1

### DIFF
--- a/dataline-integrations/singer/postgres/source/Dockerfile
+++ b/dataline-integrations/singer/postgres/source/Dockerfile
@@ -21,4 +21,4 @@ COPY entrypoint.sh .
 
 ENTRYPOINT ["/singer/entrypoint.sh"]
 
-LABEL io.dataline.version=0.1.0
+LABEL io.dataline.version=0.1.1

--- a/dataline-integrations/src/main/java/io/dataline/integrations/Integrations.java
+++ b/dataline-integrations/src/main/java/io/dataline/integrations/Integrations.java
@@ -30,7 +30,7 @@ public enum Integrations {
 
   POSTGRES_TAP(
       UUID.fromString("2168516a-5c9a-4582-90dc-5e3a01e3f607"),
-      new IntegrationMapping("dataline/integration-singer-postgres-source:0.1.0")),
+      new IntegrationMapping("dataline/integration-singer-postgres-source:0.1.1")),
   EXCHANGERATEAPI_IO_TAP(
       UUID.fromString("37eb2ebf-0899-4b22-aba8-8537ec88b5a8"),
       new IntegrationMapping("dataline/integration-singer-exchangerateapi_io-source:0.1.2")),


### PR DESCRIPTION
Closes https://github.com/datalineio/dataline/issues/339
## What
* The configuration for the postgres source was changed to remove a property, but I did not bump the image, so we effectively weren't passing the `filter_dbs` property anymore. This led to timeouts on any operation that we tried to perform on a heroku db.

## How
* Bump the version. 
* I have run publish so this image is available on dockerhub.

