### PR TITLE
Use redirect instead of the real link for the public slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ We love contributions to Airbyte, big or small. See our [Contributing Guide](htt
 
 For general help using Airbyte, please refer to the official Airbyte documentation. For additional help, you can use one of these channels to ask a question:
 
-* [Slack](https://join.slack.com/t/airbytehq/shared_invite/zt-h5m88w3a-twQ_6AF9e8SnAzOIkHu2VQ) \(For live discussion with the Community and Airbyte team\)
+* [Slack](https://slack.airbyte.io) \(For live discussion with the Community and Airbyte team\)
 * [GitHub](https://github.com/airbytehq/airbyte) \(Bug reports, Contributions\)
 * [Twitter](https://twitter.com/airbytehq) \(Get the news fast\)
 

--- a/docs/deployment/deploying-airbyte/on-aws-ec2.md
+++ b/docs/deployment/deploying-airbyte/on-aws-ec2.md
@@ -120,5 +120,5 @@ ssh -i $SSH_KEY -L 8000:localhost:8000 -L 8001:localhost:8001 -N -f ec2-user@$IN
 
 ## Troubleshooting
 
-If you encounter any issues, just connect to our [slack](https://join.slack.com/t/airbytehq/shared_invite/zt-h5m88w3a-twQ_6AF9e8SnAzOIkHu2VQ). Our community will help!
+If you encounter any issues, just connect to our [slack](https://slack.airbyte.io). Our community will help!
 

--- a/docs/deployment/deploying-airbyte/on-gcp-compute-engine.md
+++ b/docs/deployment/deploying-airbyte/on-gcp-compute-engine.md
@@ -127,5 +127,5 @@ gcloud --project=$PROJECT_ID beta compute ssh airbyte -- -L 8000:localhost:8000 
 
 ## Troubleshooting
 
-If you encounter any issues, just connect to our [slack](https://join.slack.com/t/airbytehq/shared_invite/zt-h5m88w3a-twQ_6AF9e8SnAzOIkHu2VQ). Our community will help!
+If you encounter any issues, just connect to our [slack](https://slack.airbyte.io). Our community will help!
 

--- a/docs/deployment/deploying-airbyte/with-docker.md
+++ b/docs/deployment/deploying-airbyte/with-docker.md
@@ -21,5 +21,5 @@ VERSION=dev docker-compose up -d
 
 ## Troubleshooting
 
-If you encounter any issues, just connect to our [slack](https://join.slack.com/t/airbytehq/shared_invite/zt-h5m88w3a-twQ_6AF9e8SnAzOIkHu2VQ). Our community will help!
+If you encounter any issues, just connect to our [slack](https://slack.airbyte.io). Our community will help!
 


### PR DESCRIPTION
## What
Use redirect instead of the real link for the public slack so we just need to change invite link on cloudflare

## How
redirect is configured on cloudflare
