### PR TITLE
Hotfix: When no metadata is in the singer catalog conversion to our s…

### DIFF
--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/singer/SingerCatalogConvertersTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/singer/SingerCatalogConvertersTest.java
@@ -33,6 +33,7 @@ import io.airbyte.config.StandardDiscoverSchemaOutput;
 import io.airbyte.singer.SingerCatalog;
 import io.airbyte.singer.SingerMetadataChild;
 import java.io.IOException;
+import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 class SingerCatalogConvertersTest {
@@ -89,6 +90,23 @@ class SingerCatalogConvertersTest {
     expectedSchema.getStreams().get(0).withSelected(true);
     expectedSchema.getStreams().get(0).getFields().get(0).withSelected(true);
     expectedSchema.getStreams().get(0).getFields().get(1).withSelected(true);
+
+    final Schema actualSchema = SingerCatalogConverters.toAirbyteSchema(catalog);
+
+    assertEquals(expectedSchema, actualSchema);
+  }
+
+  @Test
+  void toAirbyteSchemaNoMetadataInSingerCatalog() throws IOException {
+    final SingerCatalog catalog =
+        Jsons.deserialize(MoreResources.readResource("simple_postgres_singer_catalog.json"), SingerCatalog.class);
+    // remove metadata from singer catalog
+    catalog.getStreams().forEach(stream -> stream.setMetadata(new ArrayList<>()));
+    final Schema expectedSchema =
+        Jsons.deserialize(MoreResources.readResource("simple_postgres_schema.json"), StandardDiscoverSchemaOutput.class).getSchema();
+    expectedSchema.getStreams().get(0).withSelected(false);
+    expectedSchema.getStreams().get(0).getFields().get(0).withSelected(false);
+    expectedSchema.getStreams().get(0).getFields().get(1).withSelected(false);
 
     final Schema actualSchema = SingerCatalogConverters.toAirbyteSchema(catalog);
 


### PR DESCRIPTION
…chema fails

* This was causing the exchange rate api integration to fail.

* This fix remedies this problem. We need to go and think a little bit more carefully about this, but for now we this fixes the exchangerate api integration.


* I am confused about why this started failing now. It's as if we were never managing to detect schema output from the exchange rate integration until now. And then now that we could we discovered yet another variant of the Singer Catalog which broke the converter between SingerCatalog and our Schema.

* This is gets us up and running again, but we need to go back and figure out what the right behavior should be.
