### PR TITLE
Add (optional) documentation to source and dest specs

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -848,6 +848,8 @@ components:
           $ref: "#/components/schemas/SourceSpecificationId"
         sourceId:
           $ref: "#/components/schemas/SourceId"
+        documentation:
+          type: string
         connectionSpecification:
           $ref: "#/components/schemas/SourceSpecification"
     # SOURCE IMPLEMENTATION
@@ -982,6 +984,8 @@ components:
           $ref: "#/components/schemas/DestinationSpecificationId"
         destinationId:
           $ref: "#/components/schemas/DestinationId"
+        documentation:
+          type: string
         connectionSpecification:
           $ref: "#/components/schemas/DestinationSpecification"
     # DESTINATION IMPLEMENTATION

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -848,7 +848,7 @@ components:
           $ref: "#/components/schemas/SourceSpecificationId"
         sourceId:
           $ref: "#/components/schemas/SourceId"
-        documentation:
+        documentationUrl:
           type: string
         connectionSpecification:
           $ref: "#/components/schemas/SourceSpecification"
@@ -984,7 +984,7 @@ components:
           $ref: "#/components/schemas/DestinationSpecificationId"
         destinationId:
           $ref: "#/components/schemas/DestinationId"
-        documentation:
+        documentationUrl:
           type: string
         connectionSpecification:
           $ref: "#/components/schemas/DestinationSpecification"

--- a/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/8442ee76-cc1d-419a-bd8b-859a090366d4.json
+++ b/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/8442ee76-cc1d-419a-bd8b-859a090366d4.json
@@ -1,6 +1,8 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "destinationId": "8be1cf83-fde1-477f-a4ad-318d23c9f3c6",
   "destinationSpecificationId": "8442ee76-cc1d-419a-bd8b-859a090366d4",
+  "documentation": "https://docs.airbyte.io/integrations/destinations/local-csv",
   "specification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Singer CSV Target Spec",

--- a/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/8442ee76-cc1d-419a-bd8b-859a090366d4.json
+++ b/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/8442ee76-cc1d-419a-bd8b-859a090366d4.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "destinationId": "8be1cf83-fde1-477f-a4ad-318d23c9f3c6",
   "destinationSpecificationId": "8442ee76-cc1d-419a-bd8b-859a090366d4",
   "documentation": "https://docs.airbyte.io/integrations/destinations/local-csv",

--- a/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/8442ee76-cc1d-419a-bd8b-859a090366d4.json
+++ b/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/8442ee76-cc1d-419a-bd8b-859a090366d4.json
@@ -1,7 +1,7 @@
 {
   "destinationId": "8be1cf83-fde1-477f-a4ad-318d23c9f3c6",
   "destinationSpecificationId": "8442ee76-cc1d-419a-bd8b-859a090366d4",
-  "documentation": "https://docs.airbyte.io/integrations/destinations/local-csv",
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/local-csv",
   "specification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Singer CSV Target Spec",

--- a/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/a6655e6a-838c-4ecb-a28f-ffdcd27ec710.json
+++ b/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/a6655e6a-838c-4ecb-a28f-ffdcd27ec710.json
@@ -1,7 +1,7 @@
 {
   "destinationId": "25c5221d-dce2-4163-ade9-739ef790f503",
   "destinationSpecificationId": "a6655e6a-838c-4ecb-a28f-ffdcd27ec710",
-  "documentation": "https://docs.airbyte.io/integrations/destinations/postgres",
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/postgres",
   "specification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Postgres Destination Spec",

--- a/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/a6655e6a-838c-4ecb-a28f-ffdcd27ec710.json
+++ b/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/a6655e6a-838c-4ecb-a28f-ffdcd27ec710.json
@@ -1,6 +1,7 @@
 {
   "destinationId": "25c5221d-dce2-4163-ade9-739ef790f503",
   "destinationSpecificationId": "a6655e6a-838c-4ecb-a28f-ffdcd27ec710",
+  "documentation": "https://docs.airbyte.io/integrations/destinations/postgres",
   "specification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Postgres Destination Spec",

--- a/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/e28a1a10-214a-4051-8cf4-79b6f88719cd.json
+++ b/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/e28a1a10-214a-4051-8cf4-79b6f88719cd.json
@@ -1,6 +1,7 @@
 {
   "destinationId": "22f6c74f-5699-40ff-833c-4a879ea40133",
   "destinationSpecificationId": "e28a1a10-214a-4051-8cf4-79b6f88719cd",
+  "documentation": "https://docs.airbyte.io/integrations/destinations/bigquery",
   "specification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "BigQuery Destination Spec",

--- a/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/e28a1a10-214a-4051-8cf4-79b6f88719cd.json
+++ b/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/e28a1a10-214a-4051-8cf4-79b6f88719cd.json
@@ -1,7 +1,7 @@
 {
   "destinationId": "22f6c74f-5699-40ff-833c-4a879ea40133",
   "destinationSpecificationId": "e28a1a10-214a-4051-8cf4-79b6f88719cd",
-  "documentation": "https://docs.airbyte.io/integrations/destinations/bigquery",
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/bigquery",
   "specification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "BigQuery Destination Spec",

--- a/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/2168516a-5c9a-4582-90dc-5e3a01e3f607.json
+++ b/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/2168516a-5c9a-4582-90dc-5e3a01e3f607.json
@@ -1,7 +1,7 @@
 {
   "sourceId": "decd338e-5647-4c0b-adf4-da0e75f5a750",
   "sourceSpecificationId": "2168516a-5c9a-4582-90dc-5e3a01e3f607",
-  "documentation": "https://docs.airbyte.io/integrations/sources/postgres",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/postgres",
   "specification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Postgres Source Spec",

--- a/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/2168516a-5c9a-4582-90dc-5e3a01e3f607.json
+++ b/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/2168516a-5c9a-4582-90dc-5e3a01e3f607.json
@@ -1,6 +1,7 @@
 {
   "sourceId": "decd338e-5647-4c0b-adf4-da0e75f5a750",
   "sourceSpecificationId": "2168516a-5c9a-4582-90dc-5e3a01e3f607",
+  "documentation": "https://docs.airbyte.io/integrations/sources/postgres",
   "specification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Postgres Source Spec",

--- a/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/37eb2ebf-0899-4b22-aba8-8537ec88b5a8.json
+++ b/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/37eb2ebf-0899-4b22-aba8-8537ec88b5a8.json
@@ -1,7 +1,7 @@
 {
   "sourceId": "9fed261d-d107-47fd-8c8b-323023db6e20",
   "sourceSpecificationId": "37eb2ebf-0899-4b22-aba8-8537ec88b5a8",
-  "documentation": "https://docs.airbyte.io/integrations/sources/exchangerateapi-io",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/exchangerateapi-io",
   "specification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "exchangerateapi.io Source Spec",

--- a/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/37eb2ebf-0899-4b22-aba8-8537ec88b5a8.json
+++ b/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/37eb2ebf-0899-4b22-aba8-8537ec88b5a8.json
@@ -1,6 +1,7 @@
 {
   "sourceId": "9fed261d-d107-47fd-8c8b-323023db6e20",
   "sourceSpecificationId": "37eb2ebf-0899-4b22-aba8-8537ec88b5a8",
+  "documentation": "https://docs.airbyte.io/integrations/sources/exchangerateapi-io",
   "specification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "exchangerateapi.io Source Spec",

--- a/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/dd42e77b-24ce-485d-8146-ee6c96d5b454.json
+++ b/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/dd42e77b-24ce-485d-8146-ee6c96d5b454.json
@@ -1,6 +1,7 @@
 {
   "sourceId": "e094cb9a-26de-4645-8761-65c0c425d1de",
   "sourceSpecificationId": "dd42e77b-24ce-485d-8146-ee6c96d5b454",
+  "documentation": "https://docs.airbyte.io/integrations/sources/stripe",
   "specification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Stripe Source Spec",

--- a/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/dd42e77b-24ce-485d-8146-ee6c96d5b454.json
+++ b/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/dd42e77b-24ce-485d-8146-ee6c96d5b454.json
@@ -1,7 +1,7 @@
 {
   "sourceId": "e094cb9a-26de-4645-8761-65c0c425d1de",
   "sourceSpecificationId": "dd42e77b-24ce-485d-8146-ee6c96d5b454",
-  "documentation": "https://docs.airbyte.io/integrations/sources/stripe",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/stripe",
   "specification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Stripe Source Spec",

--- a/airbyte-config/models/src/main/resources/json/DestinationConnectionSpecification.json
+++ b/airbyte-config/models/src/main/resources/json/DestinationConnectionSpecification.json
@@ -15,6 +15,9 @@
       "type": "string",
       "format": "uuid"
     },
+    "documentation": {
+      "type": "string"
+    },
     "specification": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",

--- a/airbyte-config/models/src/main/resources/json/DestinationConnectionSpecification.json
+++ b/airbyte-config/models/src/main/resources/json/DestinationConnectionSpecification.json
@@ -15,7 +15,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "documentation": {
+    "documentationUrl": {
       "type": "string"
     },
     "specification": {

--- a/airbyte-config/models/src/main/resources/json/SourceConnectionSpecification.json
+++ b/airbyte-config/models/src/main/resources/json/SourceConnectionSpecification.json
@@ -15,6 +15,9 @@
       "type": "string",
       "format": "uuid"
     },
+    "documentation": {
+      "type": "string"
+    },
     "specification": {
       "description": "Integration specific blob. Must be a valid JSON string.",
       "type": "object",

--- a/airbyte-config/models/src/main/resources/json/SourceConnectionSpecification.json
+++ b/airbyte-config/models/src/main/resources/json/SourceConnectionSpecification.json
@@ -15,7 +15,7 @@
       "type": "string",
       "format": "uuid"
     },
-    "documentation": {
+    "documentationUrl": {
       "type": "string"
     },
     "specification": {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationSpecificationsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationSpecificationsHandler.java
@@ -64,6 +64,7 @@ public class DestinationSpecificationsHandler {
     return new DestinationSpecificationRead()
         .destinationId(dcs.getDestinationId())
         .destinationSpecificationId(dcs.getDestinationSpecificationId())
+        .documentation(dcs.getDocumentation())
         .connectionSpecification(dcs.getSpecification());
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationSpecificationsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationSpecificationsHandler.java
@@ -64,7 +64,7 @@ public class DestinationSpecificationsHandler {
     return new DestinationSpecificationRead()
         .destinationId(dcs.getDestinationId())
         .destinationSpecificationId(dcs.getDestinationSpecificationId())
-        .documentation(dcs.getDocumentation())
+        .documentationUrl(dcs.getDocumentationUrl())
         .connectionSpecification(dcs.getSpecification());
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceSpecificationsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceSpecificationsHandler.java
@@ -63,6 +63,7 @@ public class SourceSpecificationsHandler {
     return new SourceSpecificationRead()
         .sourceId(scs.getSourceId())
         .sourceSpecificationId(scs.getSourceSpecificationId())
+        .documentation(scs.getDocumentation())
         .connectionSpecification(scs.getSpecification());
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceSpecificationsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceSpecificationsHandler.java
@@ -63,7 +63,7 @@ public class SourceSpecificationsHandler {
     return new SourceSpecificationRead()
         .sourceId(scs.getSourceId())
         .sourceSpecificationId(scs.getSourceSpecificationId())
-        .documentation(scs.getDocumentation())
+        .documentationUrl(scs.getDocumentationUrl())
         .connectionSpecification(scs.getSpecification());
   }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationSpecificationsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationSpecificationsHandlerTest.java
@@ -44,13 +44,13 @@ class DestinationSpecificationsHandlerTest {
 
   private ConfigRepository configRepository;
   private DestinationConnectionSpecification destinationConnectionSpecification;
-  private DestinationSpecificationsHandler destinationSpecificationHandler;
+  private DestinationSpecificationsHandler handler;
 
   @BeforeEach
   void setUp() throws IOException {
     configRepository = mock(ConfigRepository.class);
     destinationConnectionSpecification = DestinationSpecificationHelpers.generateDestinationSpecification();
-    destinationSpecificationHandler = new DestinationSpecificationsHandler(configRepository);
+    handler = new DestinationSpecificationsHandler(configRepository);
   }
 
   @Test
@@ -58,18 +58,17 @@ class DestinationSpecificationsHandlerTest {
     when(configRepository.listDestinationConnectionSpecifications())
         .thenReturn(Lists.newArrayList(destinationConnectionSpecification));
 
-    DestinationSpecificationRead expectedDestinationSpecificationRead = new DestinationSpecificationRead();
-    expectedDestinationSpecificationRead.setDestinationId(destinationConnectionSpecification.getDestinationId());
-    expectedDestinationSpecificationRead.setDestinationSpecificationId(destinationConnectionSpecification.getDestinationSpecificationId());
-    expectedDestinationSpecificationRead.setConnectionSpecification(destinationConnectionSpecification.getSpecification());
+    DestinationSpecificationRead expected = new DestinationSpecificationRead()
+        .destinationId(destinationConnectionSpecification.getDestinationId())
+        .destinationSpecificationId(destinationConnectionSpecification.getDestinationSpecificationId())
+        .documentation(destinationConnectionSpecification.getDocumentation())
+        .connectionSpecification(destinationConnectionSpecification.getSpecification());
 
-    final DestinationIdRequestBody destinationIdRequestBody = new DestinationIdRequestBody();
-    destinationIdRequestBody.setDestinationId(expectedDestinationSpecificationRead.getDestinationId());
+    final DestinationIdRequestBody destinationIdRequestBody = new DestinationIdRequestBody().destinationId(expected.getDestinationId());
 
-    final DestinationSpecificationRead actualDestinationSpecificationRead =
-        destinationSpecificationHandler.getDestinationSpecification(destinationIdRequestBody);
+    final DestinationSpecificationRead actualDestinationSpecificationRead = handler.getDestinationSpecification(destinationIdRequestBody);
 
-    assertEquals(expectedDestinationSpecificationRead, actualDestinationSpecificationRead);
+    assertEquals(expected, actualDestinationSpecificationRead);
   }
 
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationSpecificationsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationSpecificationsHandlerTest.java
@@ -61,7 +61,7 @@ class DestinationSpecificationsHandlerTest {
     DestinationSpecificationRead expected = new DestinationSpecificationRead()
         .destinationId(destinationConnectionSpecification.getDestinationId())
         .destinationSpecificationId(destinationConnectionSpecification.getDestinationSpecificationId())
-        .documentation(destinationConnectionSpecification.getDocumentation())
+        .documentationUrl(destinationConnectionSpecification.getDocumentationUrl())
         .connectionSpecification(destinationConnectionSpecification.getSpecification());
 
     final DestinationIdRequestBody destinationIdRequestBody = new DestinationIdRequestBody().destinationId(expected.getDestinationId());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceSpecificationsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceSpecificationsHandlerTest.java
@@ -61,7 +61,7 @@ class SourceSpecificationsHandlerTest {
     SourceSpecificationRead expectedSourceSpecificationRead = new SourceSpecificationRead()
         .sourceId(sourceConnectionSpecification.getSourceId())
         .sourceSpecificationId(sourceConnectionSpecification.getSourceSpecificationId())
-        .documentation(sourceConnectionSpecification.getDocumentation())
+        .documentationUrl(sourceConnectionSpecification.getDocumentationUrl())
         .connectionSpecification(sourceConnectionSpecification.getSpecification());
 
     final SourceIdRequestBody sourceIdRequestBody = new SourceIdRequestBody().sourceId(expectedSourceSpecificationRead.getSourceId());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceSpecificationsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceSpecificationsHandlerTest.java
@@ -61,6 +61,7 @@ class SourceSpecificationsHandlerTest {
     SourceSpecificationRead expectedSourceSpecificationRead = new SourceSpecificationRead()
         .sourceId(sourceConnectionSpecification.getSourceId())
         .sourceSpecificationId(sourceConnectionSpecification.getSourceSpecificationId())
+        .documentation(sourceConnectionSpecification.getDocumentation())
         .connectionSpecification(sourceConnectionSpecification.getSpecification());
 
     final SourceIdRequestBody sourceIdRequestBody = new SourceIdRequestBody().sourceId(expectedSourceSpecificationRead.getSourceId());

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/DestinationSpecificationHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/DestinationSpecificationHelpers.java
@@ -48,7 +48,7 @@ public class DestinationSpecificationHelpers {
     return new DestinationConnectionSpecification()
         .withDestinationId(destinationId)
         .withDestinationSpecificationId(destinationSpecificationId)
-        .withDocumentation("https://airbyte.io")
+        .withDocumentationUrl("https://airbyte.io")
         .withSpecification(Jsons.deserialize(Files.readString(path)));
   }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/DestinationSpecificationHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/DestinationSpecificationHelpers.java
@@ -48,6 +48,7 @@ public class DestinationSpecificationHelpers {
     return new DestinationConnectionSpecification()
         .withDestinationId(destinationId)
         .withDestinationSpecificationId(destinationSpecificationId)
+        .withDocumentation("https://airbyte.io")
         .withSpecification(Jsons.deserialize(Files.readString(path)));
   }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/SourceSpecificationHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/SourceSpecificationHelpers.java
@@ -46,7 +46,7 @@ public class SourceSpecificationHelpers {
     return new SourceConnectionSpecification()
         .withSourceId(sourceId)
         .withSourceSpecificationId(sourceSpecificationId)
-        .withDocumentation("https://airbyte.io")
+        .withDocumentationUrl("https://airbyte.io")
         .withSpecification(Jsons.deserialize(Files.readString(path)));
   }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/SourceSpecificationHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/SourceSpecificationHelpers.java
@@ -46,6 +46,7 @@ public class SourceSpecificationHelpers {
     return new SourceConnectionSpecification()
         .withSourceId(sourceId)
         .withSourceSpecificationId(sourceSpecificationId)
+        .withDocumentation("https://airbyte.io")
         .withSpecification(Jsons.deserialize(Files.readString(path)));
   }
 

--- a/airbyte-webapp/src/components/ServiceForm/ServiceForm.tsx
+++ b/airbyte-webapp/src/components/ServiceForm/ServiceForm.tsx
@@ -32,6 +32,7 @@ type IProps = {
   errorMessage?: React.ReactNode;
   successMessage?: React.ReactNode;
   specifications?: specification;
+  documentationUrl?: string;
 };
 
 const FormContainer = styled(Form)`
@@ -47,7 +48,8 @@ const ServiceForm: React.FC<IProps> = ({
   hasSuccess,
   successMessage,
   errorMessage,
-  specifications
+  specifications,
+  documentationUrl
 }) => {
   const properties = Object.keys(specifications?.properties || {});
 
@@ -107,6 +109,7 @@ const ServiceForm: React.FC<IProps> = ({
             onDropDownSelect={onDropDownSelect}
             specifications={specifications}
             properties={properties}
+            documentationUrl={documentationUrl}
           />
 
           {isEditMode ? (

--- a/airbyte-webapp/src/components/ServiceForm/components/FormContent.tsx
+++ b/airbyte-webapp/src/components/ServiceForm/components/FormContent.tsx
@@ -20,6 +20,7 @@ type IProps = {
   values: { name: string; serviceType: string; frequency?: string };
   specifications?: specification;
   properties?: Array<string>;
+  documentationUrl?: string;
 };
 
 const FormItem = styled.div`
@@ -38,7 +39,8 @@ const FormContent: React.FC<IProps> = ({
   isEditMode,
   onDropDownSelect,
   specifications,
-  properties
+  properties,
+  documentationUrl
 }) => {
   const formatMessage = useIntl().formatMessage;
   const dropdownData = React.useMemo(
@@ -110,6 +112,7 @@ const FormContent: React.FC<IProps> = ({
           <Instruction
             serviceId={values.serviceType}
             dropDownData={dropDownData}
+            documentationUrl={documentationUrl}
           />
         )}
       </FormItem>

--- a/airbyte-webapp/src/components/ServiceForm/components/Instruction.tsx
+++ b/airbyte-webapp/src/components/ServiceForm/components/Instruction.tsx
@@ -7,6 +7,7 @@ import { IDataItem } from "../../DropDown/components/ListItem";
 type IProps = {
   serviceId: string;
   dropDownData?: Array<IDataItem>;
+  documentationUrl?: string;
 };
 
 const LinkToInstruction = styled.a`
@@ -19,12 +20,16 @@ const LinkToInstruction = styled.a`
   color: ${({ theme }) => theme.primaryColor};
 `;
 
-const Instruction: React.FC<IProps> = ({ dropDownData, serviceId }) => {
+const Instruction: React.FC<IProps> = ({
+  dropDownData,
+  serviceId,
+  documentationUrl
+}) => {
   const service =
     dropDownData && dropDownData.find(item => item.value === serviceId);
 
-  return service ? (
-    <LinkToInstruction href="https://docs.airbyte.io/" target="_blank">
+  return service && documentationUrl ? (
+    <LinkToInstruction href={documentationUrl} target="_blank">
       <FormattedMessage
         id="onboarding.instructionsLink"
         values={{ name: service.text }}

--- a/airbyte-webapp/src/core/resources/DestinationSpecification.ts
+++ b/airbyte-webapp/src/core/resources/DestinationSpecification.ts
@@ -8,6 +8,7 @@ export interface DestinationSpecification {
     properties: any;
     required: [string];
   };
+  documentationUrl: string;
 }
 
 export type specification = {
@@ -25,6 +26,7 @@ export default class DestinationSpecificationResource extends BaseResource
   implements DestinationSpecification {
   readonly destinationSpecificationId: string = "";
   readonly destinationId: string = "";
+  readonly documentationUrl: string = "";
   readonly connectionSpecification: specification = {
     properties: {},
     required: [""]

--- a/airbyte-webapp/src/core/resources/SourceSpecification.ts
+++ b/airbyte-webapp/src/core/resources/SourceSpecification.ts
@@ -13,6 +13,7 @@ export type specification = {
 export interface SourceSpecification {
   sourceSpecificationId: string;
   sourceId: string;
+  documentationUrl: string;
   connectionSpecification: specification;
 }
 
@@ -20,6 +21,7 @@ export default class SourceSpecificationResource extends BaseResource
   implements SourceSpecification {
   readonly sourceSpecificationId: string = "";
   readonly sourceId: string = "";
+  readonly documentationUrl: string = "";
   readonly connectionSpecification: specification = {
     properties: {},
     required: []

--- a/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
@@ -92,6 +92,7 @@ const DestinationStep: React.FC<IProps> = ({
           dropDownData={dropDownData}
           errorMessage={errorMessage}
           specifications={specification?.connectionSpecification}
+          documentationUrl={specification?.documentationUrl}
         />
       </ContentCard>
     </>

--- a/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
@@ -79,6 +79,7 @@ const SourceStep: React.FC<IProps> = ({
         hasSuccess={hasSuccess}
         errorMessage={errorMessage}
         specifications={specification?.connectionSpecification}
+        documentationUrl={specification?.documentationUrl}
       />
     </ContentCard>
   );


### PR DESCRIPTION
## What
* Part 1 of https://github.com/airbytehq/airbyte/issues/286. Persist and expose via API a link to the docs for an integration.

## Misc
* In the sync someone had mentioned just sticking this in the json schema. I thought about this a bit more, and I think explicitly adding it to our spec struct is a better choice: 1. It's now properly typed and validated, etc. 2. Putting non jsonschema stuff in a jsonschema object is pretty confusing. Ultimately this approach ended up being just as easy.