### PR TITLE
Use integration specific url in setup help link

### DIFF
--- a/airbyte-webapp/src/components/ServiceForm/ServiceForm.tsx
+++ b/airbyte-webapp/src/components/ServiceForm/ServiceForm.tsx
@@ -32,6 +32,7 @@ type IProps = {
   errorMessage?: React.ReactNode;
   successMessage?: React.ReactNode;
   specifications?: specification;
+  documentation?: string;
 };
 
 const FormContainer = styled(Form)`
@@ -47,7 +48,8 @@ const ServiceForm: React.FC<IProps> = ({
   hasSuccess,
   successMessage,
   errorMessage,
-  specifications
+  specifications,
+  documentation
 }) => {
   const properties = Object.keys(specifications?.properties || {});
 
@@ -107,6 +109,7 @@ const ServiceForm: React.FC<IProps> = ({
             onDropDownSelect={onDropDownSelect}
             specifications={specifications}
             properties={properties}
+            documentation={documentation}
           />
 
           {isEditMode ? (

--- a/airbyte-webapp/src/components/ServiceForm/ServiceForm.tsx
+++ b/airbyte-webapp/src/components/ServiceForm/ServiceForm.tsx
@@ -32,7 +32,7 @@ type IProps = {
   errorMessage?: React.ReactNode;
   successMessage?: React.ReactNode;
   specifications?: specification;
-  documentation?: string;
+  documentationUrl?: string;
 };
 
 const FormContainer = styled(Form)`
@@ -49,7 +49,7 @@ const ServiceForm: React.FC<IProps> = ({
   successMessage,
   errorMessage,
   specifications,
-  documentation
+  documentationUrl
 }) => {
   const properties = Object.keys(specifications?.properties || {});
 
@@ -109,7 +109,7 @@ const ServiceForm: React.FC<IProps> = ({
             onDropDownSelect={onDropDownSelect}
             specifications={specifications}
             properties={properties}
-            documentation={documentation}
+            documentationUrl={documentationUrl}
           />
 
           {isEditMode ? (

--- a/airbyte-webapp/src/components/ServiceForm/components/FormContent.tsx
+++ b/airbyte-webapp/src/components/ServiceForm/components/FormContent.tsx
@@ -20,6 +20,7 @@ type IProps = {
   values: { name: string; serviceType: string; frequency?: string };
   specifications?: specification;
   properties?: Array<string>;
+  documentation?: string;
 };
 
 const FormItem = styled.div`
@@ -38,7 +39,8 @@ const FormContent: React.FC<IProps> = ({
   isEditMode,
   onDropDownSelect,
   specifications,
-  properties
+  properties,
+  documentation
 }) => {
   const formatMessage = useIntl().formatMessage;
   const dropdownData = React.useMemo(
@@ -110,6 +112,7 @@ const FormContent: React.FC<IProps> = ({
           <Instruction
             serviceId={values.serviceType}
             dropDownData={dropDownData}
+            url={documentation}
           />
         )}
       </FormItem>

--- a/airbyte-webapp/src/components/ServiceForm/components/FormContent.tsx
+++ b/airbyte-webapp/src/components/ServiceForm/components/FormContent.tsx
@@ -20,7 +20,7 @@ type IProps = {
   values: { name: string; serviceType: string; frequency?: string };
   specifications?: specification;
   properties?: Array<string>;
-  documentation?: string;
+  documentationUrl?: string;
 };
 
 const FormItem = styled.div`
@@ -40,7 +40,7 @@ const FormContent: React.FC<IProps> = ({
   onDropDownSelect,
   specifications,
   properties,
-  documentation
+  documentationUrl
 }) => {
   const formatMessage = useIntl().formatMessage;
   const dropdownData = React.useMemo(
@@ -112,7 +112,7 @@ const FormContent: React.FC<IProps> = ({
           <Instruction
             serviceId={values.serviceType}
             dropDownData={dropDownData}
-            url={documentation}
+            documentationUrl={documentationUrl}
           />
         )}
       </FormItem>

--- a/airbyte-webapp/src/components/ServiceForm/components/Instruction.tsx
+++ b/airbyte-webapp/src/components/ServiceForm/components/Instruction.tsx
@@ -7,6 +7,7 @@ import { IDataItem } from "../../DropDown/components/ListItem";
 type IProps = {
   serviceId: string;
   dropDownData?: Array<IDataItem>;
+  url?: string;
 };
 
 const LinkToInstruction = styled.a`
@@ -19,12 +20,15 @@ const LinkToInstruction = styled.a`
   color: ${({ theme }) => theme.primaryColor};
 `;
 
-const Instruction: React.FC<IProps> = ({ dropDownData, serviceId }) => {
+const Instruction: React.FC<IProps> = ({ dropDownData, serviceId, url }) => {
   const service =
     dropDownData && dropDownData.find(item => item.value === serviceId);
 
   return service ? (
-    <LinkToInstruction href="https://docs.airbyte.io/" target="_blank">
+    <LinkToInstruction
+      href={url ? url : "https://docs.airbyte.io/"}
+      target="_blank"
+    >
       <FormattedMessage
         id="onboarding.instructionsLink"
         values={{ name: service.text }}

--- a/airbyte-webapp/src/components/ServiceForm/components/Instruction.tsx
+++ b/airbyte-webapp/src/components/ServiceForm/components/Instruction.tsx
@@ -29,10 +29,7 @@ const Instruction: React.FC<IProps> = ({
     dropDownData && dropDownData.find(item => item.value === serviceId);
 
   return service && documentationUrl ? (
-    <LinkToInstruction
-      href={documentationUrl ? documentationUrl : "https://docs.airbyte.io/"}
-      target="_blank"
-    >
+    <LinkToInstruction href={documentationUrl} target="_blank">
       <FormattedMessage
         id="onboarding.instructionsLink"
         values={{ name: service.text }}

--- a/airbyte-webapp/src/components/ServiceForm/components/Instruction.tsx
+++ b/airbyte-webapp/src/components/ServiceForm/components/Instruction.tsx
@@ -7,7 +7,7 @@ import { IDataItem } from "../../DropDown/components/ListItem";
 type IProps = {
   serviceId: string;
   dropDownData?: Array<IDataItem>;
-  url?: string;
+  documentationUrl?: string;
 };
 
 const LinkToInstruction = styled.a`
@@ -20,13 +20,17 @@ const LinkToInstruction = styled.a`
   color: ${({ theme }) => theme.primaryColor};
 `;
 
-const Instruction: React.FC<IProps> = ({ dropDownData, serviceId, url }) => {
+const Instruction: React.FC<IProps> = ({
+  dropDownData,
+  serviceId,
+  documentationUrl
+}) => {
   const service =
     dropDownData && dropDownData.find(item => item.value === serviceId);
 
-  return service ? (
+  return service && documentationUrl ? (
     <LinkToInstruction
-      href={url ? url : "https://docs.airbyte.io/"}
+      href={documentationUrl ? documentationUrl : "https://docs.airbyte.io/"}
       target="_blank"
     >
       <FormattedMessage

--- a/airbyte-webapp/src/core/resources/DestinationSpecification.ts
+++ b/airbyte-webapp/src/core/resources/DestinationSpecification.ts
@@ -8,6 +8,7 @@ export interface DestinationSpecification {
     properties: any;
     required: [string];
   };
+  documentation: string;
 }
 
 export type specification = {
@@ -25,6 +26,7 @@ export default class DestinationSpecificationResource extends BaseResource
   implements DestinationSpecification {
   readonly destinationSpecificationId: string = "";
   readonly destinationId: string = "";
+  readonly documentation: string = "";
   readonly connectionSpecification: specification = {
     properties: {},
     required: [""]

--- a/airbyte-webapp/src/core/resources/DestinationSpecification.ts
+++ b/airbyte-webapp/src/core/resources/DestinationSpecification.ts
@@ -8,7 +8,7 @@ export interface DestinationSpecification {
     properties: any;
     required: [string];
   };
-  documentation: string;
+  documentationUrl: string;
 }
 
 export type specification = {
@@ -26,7 +26,7 @@ export default class DestinationSpecificationResource extends BaseResource
   implements DestinationSpecification {
   readonly destinationSpecificationId: string = "";
   readonly destinationId: string = "";
-  readonly documentation: string = "";
+  readonly documentationUrl: string = "";
   readonly connectionSpecification: specification = {
     properties: {},
     required: [""]

--- a/airbyte-webapp/src/core/resources/SourceSpecification.ts
+++ b/airbyte-webapp/src/core/resources/SourceSpecification.ts
@@ -13,6 +13,7 @@ export type specification = {
 export interface SourceSpecification {
   sourceSpecificationId: string;
   sourceId: string;
+  documentation: string;
   connectionSpecification: specification;
 }
 
@@ -20,6 +21,7 @@ export default class SourceSpecificationResource extends BaseResource
   implements SourceSpecification {
   readonly sourceSpecificationId: string = "";
   readonly sourceId: string = "";
+  readonly documentation: string = "";
   readonly connectionSpecification: specification = {
     properties: {},
     required: []

--- a/airbyte-webapp/src/core/resources/SourceSpecification.ts
+++ b/airbyte-webapp/src/core/resources/SourceSpecification.ts
@@ -13,7 +13,7 @@ export type specification = {
 export interface SourceSpecification {
   sourceSpecificationId: string;
   sourceId: string;
-  documentation: string;
+  documentationUrl: string;
   connectionSpecification: specification;
 }
 
@@ -21,7 +21,7 @@ export default class SourceSpecificationResource extends BaseResource
   implements SourceSpecification {
   readonly sourceSpecificationId: string = "";
   readonly sourceId: string = "";
-  readonly documentation: string = "";
+  readonly documentationUrl: string = "";
   readonly connectionSpecification: specification = {
     properties: {},
     required: []

--- a/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
@@ -92,6 +92,7 @@ const DestinationStep: React.FC<IProps> = ({
           dropDownData={dropDownData}
           errorMessage={errorMessage}
           specifications={specification?.connectionSpecification}
+          documentation={specification?.documentation}
         />
       </ContentCard>
     </>

--- a/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
@@ -92,7 +92,7 @@ const DestinationStep: React.FC<IProps> = ({
           dropDownData={dropDownData}
           errorMessage={errorMessage}
           specifications={specification?.connectionSpecification}
-          documentation={specification?.documentation}
+          documentationUrl={specification?.documentationUrl}
         />
       </ContentCard>
     </>

--- a/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
@@ -79,6 +79,7 @@ const SourceStep: React.FC<IProps> = ({
         hasSuccess={hasSuccess}
         errorMessage={errorMessage}
         specifications={specification?.connectionSpecification}
+        documentation={specification?.documentation}
       />
     </ContentCard>
   );

--- a/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
@@ -79,7 +79,7 @@ const SourceStep: React.FC<IProps> = ({
         hasSuccess={hasSuccess}
         errorMessage={errorMessage}
         specifications={specification?.connectionSpecification}
-        documentation={specification?.documentation}
+        documentationUrl={specification?.documentationUrl}
       />
     </ContentCard>
   );


### PR DESCRIPTION
## What
* Part 2 of https://github.com/airbytehq/airbyte/issues/286
* Depends on https://github.com/airbytehq/airbyte/pull/361
* In the UI, when configuring an integration, have the help url bring the user to the integration specific page in the docs.

### How
* Pipe the `documentation` field that is newly exposed in the API all the way through to the wizard.