### PR TITLE
Remove "default_target_schema" option from bigquery integration

### DIFF
--- a/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/e28a1a10-214a-4051-8cf4-79b6f88719cd.json
+++ b/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/e28a1a10-214a-4051-8cf4-79b6f88719cd.json
@@ -25,10 +25,6 @@
       "credentials_json": {
         "type": "string",
         "description": "The contents of the JSON service account key. This is the contents of the file path usually specified in GOOGLE_APPLICATION_CREDENTIALS. The service account for this key must have BigQuery User access to the specified project and dataset."
-      },
-      "default_target_schema": {
-        "type": "string",
-        "description": "Name of the schema where the tables will be created. In most cases this should match the dataset_id."
       }
     }
   }

--- a/airbyte-integrations/singer/bigquery/destination/Dockerfile
+++ b/airbyte-integrations/singer/bigquery/destination/Dockerfile
@@ -17,4 +17,4 @@ COPY bigquery-destination.sh /singer/bigquery-destination.sh
 
 ENTRYPOINT ["sh", "/singer/bigquery-destination.sh"]
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2

--- a/airbyte-integrations/singer/bigquery/destination/bigquery-destination.sh
+++ b/airbyte-integrations/singer/bigquery/destination/bigquery-destination.sh
@@ -8,9 +8,9 @@ case "$1" in
 esac
 
 # Set default_target_schema to the value of dataset_id
-PRE_PROCESSED_CONFIG="preprocessed_config.json"
-mv "$CONFIG_FILE" "$PRE_PROCESSED_CONFIG"
-jq '.default_target_schema = .dataset_id' "$PRE_PROCESSED_CONFIG" > "$CONFIG_FILE"
+ORIGINAL_CONFIG_FILE="original_config.json"
+mv "$CONFIG_FILE" "$ORIGINAL_CONFIG_FILE"
+jq '.default_target_schema = .dataset_id' "$ORIGINAL_CONFIG_FILE" > "$CONFIG_FILE"
 
 cat "$CONFIG_FILE" | jq '.credentials_json | fromjson' > credentials.json
 GOOGLE_APPLICATION_CREDENTIALS=credentials.json target-bigquery "$@"

--- a/airbyte-integrations/singer/bigquery/destination/bigquery-destination.sh
+++ b/airbyte-integrations/singer/bigquery/destination/bigquery-destination.sh
@@ -7,5 +7,10 @@ case "$1" in
   *)                 shift; break             ;;
 esac
 
-cat $CONFIG_FILE | jq '.credentials_json | fromjson' > credentials.json
+# Set default_target_schema to the value of dataset_id
+PRE_PROCESSED_CONFIG="preprocessed_config.json"
+mv "$CONFIG_FILE" "$PRE_PROCESSED_CONFIG"
+jq '.default_target_schema = .dataset_id' "$PRE_PROCESSED_CONFIG" > "$CONFIG_FILE"
+
+cat "$CONFIG_FILE" | jq '.credentials_json | fromjson' > credentials.json
 GOOGLE_APPLICATION_CREDENTIALS=credentials.json target-bigquery "$@"

--- a/airbyte-integrations/singer/bigquery/destination/src/test-integration/java/io/airbyte/integration_tests/destinations/TestBigQueryDestination.java
+++ b/airbyte-integrations/singer/bigquery/destination/src/test-integration/java/io/airbyte/integration_tests/destinations/TestBigQueryDestination.java
@@ -171,7 +171,6 @@ class TestBigQueryDestination {
     fullConfig.put("project_id", credentials.get("project_id").textValue());
     fullConfig.put("dataset_id", datasetName);
     fullConfig.put("credentials_json", credentialsJsonString);
-    fullConfig.put("default_target_schema", datasetName);
 
     Files.writeString(
         Path.of(jobRoot.toString(), "rendered_bigquery.json"), Jsons.serialize(fullConfig));

--- a/airbyte-integrations/src/main/java/io/airbyte/integrations/Integrations.java
+++ b/airbyte-integrations/src/main/java/io/airbyte/integrations/Integrations.java
@@ -42,7 +42,7 @@ public enum Integrations {
       new IntegrationMapping("airbyte/integration-singer-postgres-destination:0.1.1")),
   BIGQUERY_TARGET(
       UUID.fromString("e28a1a10-214a-4051-8cf4-79b6f88719cd"),
-      new IntegrationMapping("airbyte/integration-singer-bigquery-destination:0.1.1")),
+      new IntegrationMapping("airbyte/integration-singer-bigquery-destination:0.1.2")),
   CSV_TARGET(
       UUID.fromString("8442ee76-cc1d-419a-bd8b-859a090366d4"),
       new IntegrationMapping("airbyte/integration-singer-csv-destination:0.1.0"));


### PR DESCRIPTION
## What
The value of this option should always be the same as dataset_id, so we copy that value inside the integration container. 
