### PR TITLE
add restricted key support for stripe integration spec

### DIFF
--- a/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/dd42e77b-24ce-485d-8146-ee6c96d5b454.json
+++ b/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/dd42e77b-24ce-485d-8146-ee6c96d5b454.json
@@ -11,8 +11,8 @@
     "properties": {
       "client_secret": {
         "type": "string",
-        "pattern": "^sk_(live|test)_[a-zA-Z0-9]+$",
-        "description": "Stripe API key (starts with 'sk_live_' in production, see https://dashboard.stripe.com/apikeys)."
+        "pattern": "^(s|r)k_(live|test)_[a-zA-Z0-9]+$",
+        "description": "Stripe API key (usually starts with 'rk_live_' in production, see https://dashboard.stripe.com/apikeys)."
       },
       "account_id": {
         "type": "string",


### PR DESCRIPTION
While adding documentation for Stripe I realized that it'd be better for us to allow and encourage the use of restricted API keys with read only access. This PR updates the spec to allow `rk_live_` and `rk_test_` keys.  