### PR TITLE
Notify build status on every push to master

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -68,7 +68,7 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Slack Notification - Failure
-        if: failure() #&& github.ref == 'refs/heads/master'
+        if: failure() 
         uses: rtCamp/action-slack-notify@master
         env:
           SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}
@@ -79,7 +79,7 @@ jobs:
           SLACK_FOOTER: ""
 
       - name: Slack Notification - Success
-          if: success() #&& github.ref == 'refs/heads/master'
+          if: success()
           uses: rtCamp/action-slack-notify@master
           env:
             SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -67,13 +67,23 @@ jobs:
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Slack Notification (Master branch only)
-        if: github.ref == 'refs/heads/master'
+      - name: Slack Notification - Failure
+        if: failure() #&& github.ref == 'refs/heads/master'
         uses: rtCamp/action-slack-notify@master
         env:
           SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}
           SLACK_USERNAME: Buildozer
           SLACK_ICON: https://avatars.slack-edge.com/temp/2020-09-01/1342729352468_209b10acd6ff13a649a1.jpg
-          SLACK_COLOR: ${{ failure() ? "DC143C" : "good" }}
+          SLACK_COLOR: DC143C
           SLACK_TITLE: "Build failure"
           SLACK_FOOTER: ""
+
+      - name: Slack Notification - Success
+          if: success() #&& github.ref == 'refs/heads/master'
+          uses: rtCamp/action-slack-notify@master
+          env:
+            SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}
+            SLACK_USERNAME: Buildbot
+            SLACK_TITLE: "Build Success"
+            SLACK_FOOTER: ""
+

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -68,12 +68,12 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Slack Notification (Master branch only)
-        if: failure() && github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         uses: rtCamp/action-slack-notify@master
         env:
           SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}
           SLACK_USERNAME: Buildozer
           SLACK_ICON: https://avatars.slack-edge.com/temp/2020-09-01/1342729352468_209b10acd6ff13a649a1.jpg
-          SLACK_COLOR: DC143C
+          SLACK_COLOR: ${{ failure() ? "DC143C" : "good" }}
           SLACK_TITLE: "Build failure"
           SLACK_FOOTER: ""

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -68,7 +68,7 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Slack Notification - Failure
-        if: failure()
+        if: failure() && github.ref == 'refs/heads/master'
         uses: rtCamp/action-slack-notify@master
         env:
           SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}
@@ -79,7 +79,7 @@ jobs:
           SLACK_FOOTER: ""
 
       - name: Slack Notification - Success
-        if: success()
+        if: success() && github.ref == 'refs/heads/master'
         uses: rtCamp/action-slack-notify@master
         env:
           SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -68,7 +68,7 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Slack Notification - Failure
-        if: failure() 
+        if: failure()
         uses: rtCamp/action-slack-notify@master
         env:
           SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}
@@ -77,13 +77,4 @@ jobs:
           SLACK_COLOR: DC143C
           SLACK_TITLE: "Build failure"
           SLACK_FOOTER: ""
-
-      - name: Slack Notification - Success
-          if: success()
-          uses: rtCamp/action-slack-notify@master
-          env:
-            SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}
-            SLACK_USERNAME: Buildbot
-            SLACK_TITLE: "Build Success"
-            SLACK_FOOTER: ""
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -78,3 +78,11 @@ jobs:
           SLACK_TITLE: "Build failure"
           SLACK_FOOTER: ""
 
+      - name: Slack Notification - Success
+        if: success()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}
+          SLACK_USERNAME: Buildbot
+          SLACK_TITLE: "Build Success"
+          SLACK_FOOTER: ""


### PR DESCRIPTION
## What
Right now we only know when master has failed, but not when it is fixed. This change makes Slack notify us of the build status of every push to master. 