### PR TITLE
use normal dep

### DIFF
--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -14136,6 +14136,28 @@
         "classnames": "^2.2.5",
         "react": "^16.3.2",
         "react-dom": "^16.3.2"
+      },
+      "dependencies": {
+        "react-dom": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+          "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
+          }
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-component-managers": {
@@ -14284,14 +14306,14 @@
       }
     },
     "react-dom": {
-      "version": "16.13.0",
-      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-16.13.0.tgz",
-      "integrity": "sha512-lJZrmkucz2MrQJTQtJobx5MICXcfQvKihszqv655p557HPi0hMOWxrNpiHv3DWD8ugNWjtWcVWqRnFvwsHq1mQ==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.19.0"
+        "scheduler": "^0.19.1"
       },
       "dependencies": {
         "scheduler": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -22,7 +22,7 @@
     "react-checkbox-tree": "^1.6.0",
     "react-code-input": "^3.9.0",
     "react-copy-to-clipboard": "^5.0.2",
-    "react-dom": "npm:@hot-loader/react-dom",
+    "react-dom": "16.13.1",
     "react-helmet": "^5.2.1",
     "react-intl": "^3.12.0",
     "react-pose": "^4.0.10",


### PR DESCRIPTION
We are seeing build failures:
```
> Task :airbyte-webapp:npm_run_build
Creating an optimized production build...
npm ERR! code ELIFECYCLE
Failed to compile.
npm ERR! errno 1

./src/index.tsx
Cannot find module: 'react-dom'. Make sure this package is installed.

You can install this package by running: npm install react-dom.


npm ERR! airbyte-webapp@0.1.0 build: `react-app-rewired build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the airbyte-webapp@0.1.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2020-09-22T16_44_52_287Z-debug.log
```
I took a guess that the the hot loader was the thing causing it. Switching to a normal style dependency seems to fix it. Don't know if this is the "right" thing to do though. Not familiar with npm hot loader.
