### PR TITLE
Update descriptions for integration configuration

### DIFF
--- a/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/8442ee76-cc1d-419a-bd8b-859a090366d4.json
+++ b/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/8442ee76-cc1d-419a-bd8b-859a090366d4.json
@@ -15,12 +15,12 @@
         "examples": ["Default value: ,"]
       },
       "quotechar": {
-        "description": "The character used quote strings containing special characters in the CSV. Typically this will be '\"'. See <a href=\"https://docs.python.org/3/library/csv.html#csv.Dialect.quotechar\">python docs</a> for more details.",
+        "description": "The character used to quote strings containing special characters in the CSV. See <a href=\"https://docs.python.org/3/library/csv.html#csv.Dialect.quotechar\">python docs</a> for more details.",
         "type": "string",
         "examples": ["Default value: \""]
       },
       "destination_path": {
-        "description": "Path to write the data. This path will be concatenated onto the `LOCAL_ROOT`. e.g. If `LOCAL_ROOT = /tmp/airbyte_local` and destination_path is `cars/models`, then the directory `/tmp/airbyte_local/cars/models`. By default `LOCAL_ROOT` is `/tmp/airbyte_local`.",
+        "description": "Path to write the data. Check out the <a href=\"https://docs.airbyte.io/integrations/destinations/local-csv\">docs</a> for more details on the root of this path.",
         "type": "string",
         "examples": ["(Blank by default)"]
       }

--- a/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/e28a1a10-214a-4051-8cf4-79b6f88719cd.json
+++ b/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/e28a1a10-214a-4051-8cf4-79b6f88719cd.json
@@ -24,7 +24,7 @@
       },
       "credentials_json": {
         "type": "string",
-        "description": "The contents of the JSON service account key. The service account for this key must have BigQuery User access to the specified project and dataset."
+        "description": "The contents of the JSON service account key. Check out <a href\"https://docs.airbyte.io/integrations/destinations/bigquery\">docs</a> if you need help generating this key."
       }
     }
   }

--- a/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/e28a1a10-214a-4051-8cf4-79b6f88719cd.json
+++ b/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/e28a1a10-214a-4051-8cf4-79b6f88719cd.json
@@ -24,7 +24,7 @@
       },
       "credentials_json": {
         "type": "string",
-        "description": "The contents of the JSON service account key. This is the contents of the file path usually specified in GOOGLE_APPLICATION_CREDENTIALS. The service account for this key must have BigQuery User access to the specified project and dataset."
+        "description": "The contents of the JSON service account key. The service account for this key must have BigQuery User access to the specified project and dataset."
       }
     }
   }

--- a/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/e28a1a10-214a-4051-8cf4-79b6f88719cd.json
+++ b/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/e28a1a10-214a-4051-8cf4-79b6f88719cd.json
@@ -24,7 +24,7 @@
       },
       "credentials_json": {
         "type": "string",
-        "description": "The contents of the JSON service account key. Check out <a href\"https://docs.airbyte.io/integrations/destinations/bigquery\">docs</a> if you need help generating this key."
+        "description": "The contents of the JSON service account key. Check out the <a href\"https://docs.airbyte.io/integrations/destinations/bigquery\">docs</a> if you need help generating this key."
       }
     }
   }

--- a/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/37eb2ebf-0899-4b22-aba8-8537ec88b5a8.json
+++ b/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/37eb2ebf-0899-4b22-aba8-8537ec88b5a8.json
@@ -16,7 +16,7 @@
       },
       "base": {
         "type": "string",
-        "description": "ISO reference currency. See <a href=\"https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html\">here</a>"
+        "description": "ISO reference currency. See <a href=\"https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html\">here</a>."
       }
     }
   }

--- a/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/dd42e77b-24ce-485d-8146-ee6c96d5b454.json
+++ b/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/dd42e77b-24ce-485d-8146-ee6c96d5b454.json
@@ -17,7 +17,7 @@
       "account_id": {
         "type": "string",
         "pattern": "^acct_[a-zA-Z0-9]+$",
-        "description": "Your Stripe account ID (starts with 'acct_', find your <a href=\"https://dashboard.stripe.com/settings/account\">here</a>)."
+        "description": "Your Stripe account ID (starts with 'acct_', find yours <a href=\"https://dashboard.stripe.com/settings/account\">here</a>)."
       },
       "start_date": {
         "type": "string",

--- a/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/dd42e77b-24ce-485d-8146-ee6c96d5b454.json
+++ b/airbyte-config/init/src/main/resources/config/SOURCE_CONNECTION_SPECIFICATION/dd42e77b-24ce-485d-8146-ee6c96d5b454.json
@@ -12,18 +12,18 @@
       "client_secret": {
         "type": "string",
         "pattern": "^(s|r)k_(live|test)_[a-zA-Z0-9]+$",
-        "description": "Stripe API key (usually starts with 'rk_live_' in production, see https://dashboard.stripe.com/apikeys)."
+        "description": "Stripe API key (usually starts with 'sk_live_'; find yours <a href=\"https://dashboard.stripe.com/apikeys\">here</a>)."
       },
       "account_id": {
         "type": "string",
         "pattern": "^acct_[a-zA-Z0-9]+$",
-        "description": "Your Stripe account ID (starts with 'acct_', see https://stripe.com/docs/api/accounts)."
+        "description": "Your Stripe account ID (starts with 'acct_', find your <a href=\"https://dashboard.stripe.com/settings/account\">here</a>)."
       },
       "start_date": {
         "type": "string",
-        "default": "2009-01-01T00:00:00Z",
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
-        "description": "A UTC date and time in the format 2017-01-25T00:00:00Z. Any data before this date will not be replicated."
+        "description": "UTC date and time in the format 2017-01-25T00:00:00Z. Any data before this date will not be replicated.",
+        "examples": ["2017-01-25T00:00:00Z"]
       }
     }
   }


### PR DESCRIPTION
## What
* Now that we have docs for all the integrations in gitbook, we can make some of these inline descriptions more brief, in favor of sending the user to the docs where a more detailed description can be found.

closes https://github.com/airbytehq/airbyte/issues/324
