### PR TITLE
reintroduce docker check

### DIFF
--- a/airbyte-scheduler/Dockerfile
+++ b/airbyte-scheduler/Dockerfile
@@ -14,7 +14,7 @@ RUN add-apt-repository \
        "deb [arch=amd64] https://download.docker.com/linux/debian \
        $(lsb_release -cs) \
        stable"
-RUN apt-get update && apt-get install -y docker-ce-cli
+RUN apt-get update && apt-get install -y docker-ce-cli jq
 
 ENV WAIT_VERSION=2.7.2
 ENV APPLICATION airbyte-scheduler

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessBuilderFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessBuilderFactory.java
@@ -24,9 +24,11 @@
 
 package io.airbyte.workers.process;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.io.IOs;
+import io.airbyte.commons.io.LineGobbler;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.workers.WorkerException;
 import java.io.IOException;
@@ -77,9 +79,9 @@ public class DockerProcessBuilderFactory implements ProcessBuilderFactory {
   @Override
   public ProcessBuilder create(final Path jobRoot, final String imageName, final String... args) throws WorkerException {
 
-    // if (!checkImageExists(imageName)) {
-    // throw new WorkerException("Could not find image: " + imageName);
-    // }
+    if (!checkImageExists(imageName)) {
+      throw new WorkerException("Could not find image: \"" + imageName + "\"");
+    }
 
     final List<String> cmd =
         Lists.newArrayList(
@@ -108,10 +110,15 @@ public class DockerProcessBuilderFactory implements ProcessBuilderFactory {
     return DATA_MOUNT_DESTINATION.resolve(relativePath);
   }
 
-  private boolean checkImageExists(String imageName) {
+  @VisibleForTesting
+  boolean checkImageExists(String imageName) {
     try {
       final Process process = new ProcessBuilder(imageExistsScriptPath.toString(), imageName).start();
+      LineGobbler.gobble(process.getErrorStream(), LOGGER::error);
+      LineGobbler.gobble(process.getInputStream(), LOGGER::info);
+
       process.waitFor(1, TimeUnit.MINUTES);
+
       return process.exitValue() == 0;
 
     } catch (IOException | InterruptedException e) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessBuilderFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessBuilderFactory.java
@@ -80,7 +80,7 @@ public class DockerProcessBuilderFactory implements ProcessBuilderFactory {
   public ProcessBuilder create(final Path jobRoot, final String imageName, final String... args) throws WorkerException {
 
     if (!checkImageExists(imageName)) {
-      throw new WorkerException("Could not find image: \"" + imageName + "\"");
+      throw new WorkerException("Could not find image: " + imageName);
     }
 
     final List<String> cmd =

--- a/airbyte-workers/src/main/resources/image_exists.sh
+++ b/airbyte-workers/src/main/resources/image_exists.sh
@@ -24,7 +24,7 @@ main() {
   if [[ $LOCAL -eq 0 ]]; then
     # handle the case where the image exists in the remote and either has never been pulled or has already been pulled
     # and is already up to date.
-    RESULT=$(docker pull $imageName 2> /dev/null | awk '/Image is up to date/ || /Status: Downloaded newer image/')
+    RESULT=$(docker pull $imageName 2> /dev/null | awk '/Status: Image is up to date/ || /Status: Downloaded newer image/')
     [ -z "$RESULT" ] && _error "Image does not exist."
   fi
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessBuilderFactoryTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessBuilderFactoryTest.java
@@ -40,4 +40,13 @@ class DockerProcessBuilderFactoryTest {
     final DockerProcessBuilderFactory pbf = new DockerProcessBuilderFactory(workspaceRoot, "", "", "");
     assertTrue(pbf.checkImageExists("airbyte/scheduler:dev"));
   }
+
+  @Test
+  public void testImageDoesNotExist() throws IOException {
+    Path workspaceRoot = Files.createTempDirectory("pbf");
+
+    final DockerProcessBuilderFactory pbf = new DockerProcessBuilderFactory(workspaceRoot, "", "", "");
+    assertFalse(pbf.checkImageExists("airbyte/fake:0.1.2"));
+  }
+
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessBuilderFactoryTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessBuilderFactoryTest.java
@@ -1,0 +1,60 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.workers.process;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class DockerProcessBuilderFactoryTest {
+
+  @Test
+  public void testImageExists() throws IOException {
+    Path workspaceRoot = Files.createTempDirectory("pbf");
+
+    final DockerProcessBuilderFactory pbf = new DockerProcessBuilderFactory(workspaceRoot, "", "", "");
+    assertTrue(pbf.checkImageExists("airbyte/integration-singer-exchangeratesapi_io-source:0.1.2"));
+  }
+
+  @Test
+  public void testImageExistsOnlyLocally() throws IOException {
+    Path workspaceRoot = Files.createTempDirectory("pbf");
+
+    final DockerProcessBuilderFactory pbf = new DockerProcessBuilderFactory(workspaceRoot, "", "", "");
+    assertTrue(pbf.checkImageExists("cg/sched:blah"));
+  }
+
+  @Test
+  public void testImageDoesNotExist() throws IOException {
+    Path workspaceRoot = Files.createTempDirectory("pbf");
+
+    final DockerProcessBuilderFactory pbf = new DockerProcessBuilderFactory(workspaceRoot, "", "", "");
+    assertFalse(pbf.checkImageExists("airbyte/fake:0.1.2"));
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessBuilderFactoryTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessBuilderFactoryTest.java
@@ -31,6 +31,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
+// todo (cgardens) - these are not truly "unit" tests as they are check resources on the internet.
+// we should move them to "integration" tests, when we have facility to do so.
 class DockerProcessBuilderFactoryTest {
 
   @Test

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessBuilderFactoryTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessBuilderFactoryTest.java
@@ -38,23 +38,6 @@ class DockerProcessBuilderFactoryTest {
     Path workspaceRoot = Files.createTempDirectory("pbf");
 
     final DockerProcessBuilderFactory pbf = new DockerProcessBuilderFactory(workspaceRoot, "", "", "");
-    assertTrue(pbf.checkImageExists("airbyte/integration-singer-exchangeratesapi_io-source:0.1.2"));
+    assertTrue(pbf.checkImageExists("airbyte/scheduler:dev"));
   }
-
-  @Test
-  public void testImageExistsOnlyLocally() throws IOException {
-    Path workspaceRoot = Files.createTempDirectory("pbf");
-
-    final DockerProcessBuilderFactory pbf = new DockerProcessBuilderFactory(workspaceRoot, "", "", "");
-    assertTrue(pbf.checkImageExists("cg/sched:blah"));
-  }
-
-  @Test
-  public void testImageDoesNotExist() throws IOException {
-    Path workspaceRoot = Files.createTempDirectory("pbf");
-
-    final DockerProcessBuilderFactory pbf = new DockerProcessBuilderFactory(workspaceRoot, "", "", "");
-    assertFalse(pbf.checkImageExists("airbyte/fake:0.1.2"));
-  }
-
 }


### PR DESCRIPTION
## What
* Solves the last issue in this PR https://github.com/airbytehq/airbyte/pull/391. Container needed access to `jq`. It had been removed in an intermediate iteration. This was hard to debug because it worked on my machine (because I have `jq`) and the logs from the `image_exists.sh` script were not piped out to the scheduler logs. 

## How
* added `jq` to scheduler dockerfile
* pipe stdout and sterr from `image_exists.sh` script to scheduler logs
* add tests to test functionality of the script. these are _not_ proper unit tests in that they interact directly with the internet. these should be integration tests, but we don't have a good facility for that. options for right now:
  1. I can remove them entirely
  1. I can leave them as is 
  1. I can leave them there but add the ignore annotation so that they can be used for manual testing
