### PR TITLE
pass tracking strategy as env variable to server and webapp

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,6 +64,7 @@ services:
       - WAIT_BEFORE_HOSTS=5
       - WAIT_HOSTS=db:5432
       - CONFIG_ROOT=${CONFIG_ROOT}
+      - TRACKING_STRATEGY=${TRACKING_STRATEGY}
     ports:
       - 8001:8001
     volumes:
@@ -78,6 +79,8 @@ services:
       - 8000:80
     depends_on:
       - server
+    environment:
+      - TRACKING_STRATEGY=${TRACKING_STRATEGY}
 
 volumes:
   workspace:


### PR DESCRIPTION
## What
* `TRACKING_STRATEGY` env variable was not getting set for the server

## How
* Added it in the docker-compose file. 
* Did the same for the webapp. Currently the web app is always going to to report to segment (a compromise to get out the door), but we should change it so that the webapp, based on the env variable can just log instead of reporting to segment.