### PR TITLE
Revert "Clearer CSV placeholders (#369)"

### DIFF
--- a/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/8442ee76-cc1d-419a-bd8b-859a090366d4.json
+++ b/airbyte-config/init/src/main/resources/config/DESTINATION_CONNECTION_SPECIFICATION/8442ee76-cc1d-419a-bd8b-859a090366d4.json
@@ -12,17 +12,16 @@
       "delimiter": {
         "description": "Delimiter used to separate fields.",
         "type": "string",
-        "examples": ["Default value: ,"]
+        "examples": [","]
       },
       "quotechar": {
         "description": "The character used to quote strings containing special characters in the CSV. See <a href=\"https://docs.python.org/3/library/csv.html#csv.Dialect.quotechar\">python docs</a> for more details.",
         "type": "string",
-        "examples": ["Default value: \""]
+        "examples": ["\""]
       },
       "destination_path": {
         "description": "Path to write the data. Check out the <a href=\"https://docs.airbyte.io/integrations/destinations/local-csv\">docs</a> for more details on the root of this path.",
-        "type": "string",
-        "examples": ["(Blank by default)"]
+        "type": "string"
       }
     }
   }


### PR DESCRIPTION
This reverts commit 3868a3eda7665018cff0aed213fdb4f63ca2cd99.

Reverting this PR https://github.com/airbytehq/airbyte/pull/369. It implies that we set defaults and that values do not need to be set. If you do not set these values the integration fails. @sherifnada - heads up.

```
airbyte-scheduler | 2020-09-23 03:03:22 DEBUG i.a.w.p.s.DefaultSingerTap(close):140 - {job_id=2, job_log_filename=logs.log, job_root=/tmp/workspace/2/1} - Closing tap process
airbyte-scheduler | 2020-09-23 03:03:22 DEBUG i.a.w.p.s.DefaultSingerTarget(close):106 - {job_id=2, job_log_filename=logs.log, job_root=/tmp/workspace/2/1} - Closing target process
airbyte-scheduler | 2020-09-23 03:03:22 ERROR i.a.c.i.LineGobbler(voidCall):60 - {} - Traceback (most recent call last):
airbyte-scheduler | 2020-09-23 03:03:22 ERROR i.a.c.i.LineGobbler(voidCall):60 - {} -   File "/singer/env/bin/target-csv", line 11, in <module>
airbyte-scheduler | 2020-09-23 03:03:22 ERROR i.a.c.i.LineGobbler(voidCall):60 - {} -     load_entry_point('target-csv==0.3.0', 'console_scripts', 'target-csv')()
airbyte-scheduler | 2020-09-23 03:03:22 ERROR i.a.c.i.LineGobbler(voidCall):60 - {} -   File "/singer/env/lib/python3.7/site-packages/target_csv.py", line 144, in main
airbyte-scheduler | 2020-09-23 03:03:22 ERROR i.a.c.i.LineGobbler(voidCall):60 - {} -     config.get('destination_path', ''))
airbyte-scheduler | 2020-09-23 03:03:22 ERROR i.a.c.i.LineGobbler(voidCall):60 - {} -   File "/singer/env/lib/python3.7/site-packages/target_csv.py", line 82, in persist_messages
airbyte-scheduler | 2020-09-23 03:03:22 ERROR i.a.c.i.LineGobbler(voidCall):60 - {} -     quotechar=quotechar)
airbyte-scheduler | 2020-09-23 03:03:22 ERROR i.a.c.i.LineGobbler(voidCall):60 - {} -   File "/usr/local/lib/python3.7/csv.py", line 140, in __init__
airbyte-scheduler | 2020-09-23 03:03:22 ERROR i.a.c.i.LineGobbler(voidCall):60 - {} -     self.writer = writer(f, dialect, *args, **kwds)
airbyte-scheduler | 2020-09-23 03:03:22 ERROR i.a.c.i.LineGobbler(voidCall):60 - {} - TypeError: "delimiter" must be a 1-character string
airbyte-scheduler | 2020-09-23 03:03:22 ERROR i.a.w.p.s.SingerSyncWorker(run):86 - {job_id=2, job_log_filename=logs.log, job_root=/tmp/workspace/2/1} - Sync worker failed.
airbyte-scheduler | io.airbyte.workers.WorkerException: target process wasn't successful
airbyte-scheduler | 	at io.airbyte.workers.protocols.singer.DefaultSingerTarget.close(DefaultSingerTarget.java:109) ~[airbyte-workers-0.1.0.jar:?]
airbyte-scheduler | 	at io.airbyte.workers.protocols.singer.SingerSyncWorker.run(SingerSyncWorker.java:85) [airbyte-workers-0.1.0.jar:?]
airbyte-scheduler | 	at io.airbyte.workers.protocols.singer.SingerSyncWorker.run(SingerSyncWorker.java:44) [airbyte-workers-0.1.0.jar:?]
airbyte-scheduler | 	at io.airbyte.workers.wrappers.OutputConvertingWorker.run(OutputConvertingWorker.java:44) [airbyte-workers-0.1.0.jar:?]
airbyte-scheduler | 	at io.airbyte.workers.wrappers.JobOutputSyncWorker.run(JobOutputSyncWorker.java:32) [airbyte-workers-0.1.0.jar:?]
airbyte-scheduler | 	at io.airbyte.scheduler.WorkerRun.lambda$new$0(WorkerRun.java:53) [airbyte-scheduler-0.1.0.jar:?]
airbyte-scheduler | 	at io.airbyte.scheduler.WorkerRun.call(WorkerRun.java:61) [airbyte-scheduler-0.1.0.jar:?]
airbyte-scheduler | 	at io.airbyte.scheduler.WorkerRun.call(WorkerRun.java:42) [airbyte-scheduler-0.1.0.jar:?]
airbyte-scheduler | 	at io.airbyte.commons.concurrency.LifecycledCallable.execute(LifecycledCallable.java:114) [airbyte-commons-0.1.0.jar:?]
airbyte-scheduler | 	at io.airbyte.commons.concurrency.LifecycledCallable.call(LifecycledCallable.java:98) [airbyte-commons-0.1.0.jar:?]
airbyte-scheduler | 	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
airbyte-scheduler | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) [?:?]
airbyte-scheduler | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) [?:?]
airbyte-scheduler | 	at java.lang.Thread.run(Thread.java:832) [?:?]
airbyte-scheduler | 2020-09-23 03:03:22 INFO i.a.s.p.DefaultSchedulerPersistence(updateStatus):190 - {job_id=2, job_log_filename=logs.log, job_root=/tmp/workspace/2/1} - Setting job status to FAILED for job 2
```