### PR TITLE
prevent untracked files

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,7 +39,7 @@ jobs:
         run: ./gradlew build --no-daemon -g ${{ env.GRADLE_PATH }}
 
       - name: Ensure no file change
-        run: git diff-index --exit-code HEAD
+        run: test -z "$(git status --porcelain)"
 
       - name: Write Integration Test Credentials
         run: ./tools/bin/ci_credentials.sh


### PR DESCRIPTION
Our current check doesn't fail on untracked files. This new version does.