### PR TITLE
tell users to deploy release instead of dev version

### DIFF
--- a/docs/deployment/deploying-airbyte/on-your-workstation.md
+++ b/docs/deployment/deploying-airbyte/on-your-workstation.md
@@ -13,7 +13,7 @@ These instructions have been tested on MacOS
 # In your workstation terminal
 git clone https://github.com/airbytehq/airbyte.git
 cd airbyte
-docker-compose up -d
+docker-compose up
 ```
 
 * In your browser, just visit [http://localhost:8000](http://localhost:8000)

--- a/docs/deployment/deploying-airbyte/on-your-workstation.md
+++ b/docs/deployment/deploying-airbyte/on-your-workstation.md
@@ -13,7 +13,7 @@ These instructions have been tested on MacOS
 # In your workstation terminal
 git clone https://github.com/airbytehq/airbyte.git
 cd airbyte
-VERSION=dev docker-compose up -d
+docker-compose up -d
 ```
 
 * In your browser, just visit [http://localhost:8000](http://localhost:8000)


### PR DESCRIPTION
Deploying airbyte instructions should always use the release version.