### PR TITLE
bump target timeout from 1 min => 5 min

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/singer/DefaultSingerTarget.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/singer/DefaultSingerTarget.java
@@ -104,7 +104,7 @@ public class DefaultSingerTarget implements SingerTarget {
     }
 
     LOGGER.debug("Closing target process");
-    WorkerUtils.gentleClose(targetProcess, 1, TimeUnit.MINUTES);
+    WorkerUtils.gentleClose(targetProcess, 5, TimeUnit.MINUTES);
     if (targetProcess.isAlive() || targetProcess.exitValue() != 0) {
       throw new WorkerException("target process wasn't successful");
     }


### PR DESCRIPTION
## What
* For postgres if there are a lot of columns, the first sync can take a long time, because each column is added one by one. For now just giving it more time so it can succeed. Saw this crop up when syncing stripe because those structs have a ton of columns.