### PR TITLE
validate schema messages (instead of always allowing them through)

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonSchemas.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonSchemas.java
@@ -1,0 +1,46 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.commons.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class JsonSchemas {
+
+  /**
+   * JsonSchema supports to ways of declaring type. `type: "string"` and `type: ["null", "string"]`.
+   * This method will mutate a JsonNode with a type field so that the output type is the array
+   * version.
+   *
+   * @param jsonNode - a json object with children that contain types.
+   */
+  public static void mutateTypeToArrayStandard(final JsonNode jsonNode) {
+    if (jsonNode.get("type") != null && !jsonNode.get("type").isArray()) {
+      final JsonNode type = jsonNode.get("type");
+      ((ObjectNode) jsonNode).putArray("type").add(type);
+    }
+  }
+
+}

--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -107,6 +108,20 @@ public class Jsons {
   @SuppressWarnings("unchecked")
   public static <T> T clone(final T object) {
     return (T) deserialize(serialize(object), object.getClass());
+  }
+
+  /**
+   * JsonSchema supports to ways of declaring type. `type: "string"` and `type: ["null", "string"]`.
+   * This method will mutate a JsonNode with a type field so that the output type is the array
+   * version.
+   *
+   * @param jsonNode - a json object with children that contain types.
+   */
+  public static void mutateTypeToArrayStandard(final JsonNode jsonNode) {
+    if (jsonNode.get("type") != null && !jsonNode.get("type").isArray()) {
+      final JsonNode type = jsonNode.get("type");
+      ((ObjectNode) jsonNode).putArray("type").add(type);
+    }
   }
 
 }

--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -108,20 +107,6 @@ public class Jsons {
   @SuppressWarnings("unchecked")
   public static <T> T clone(final T object) {
     return (T) deserialize(serialize(object), object.getClass());
-  }
-
-  /**
-   * JsonSchema supports to ways of declaring type. `type: "string"` and `type: ["null", "string"]`.
-   * This method will mutate a JsonNode with a type field so that the output type is the array
-   * version.
-   *
-   * @param jsonNode - a json object with children that contain types.
-   */
-  public static void mutateTypeToArrayStandard(final JsonNode jsonNode) {
-    if (jsonNode.get("type") != null && !jsonNode.get("type").isArray()) {
-      final JsonNode type = jsonNode.get("type");
-      ((ObjectNode) jsonNode).putArray("type").add(type);
-    }
   }
 
 }

--- a/airbyte-commons/src/test/java/io/airbyte/commons/json/JsonsTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/json/JsonsTest.java
@@ -26,6 +26,7 @@ package io.airbyte.commons.json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.util.List;
@@ -167,11 +168,29 @@ class JsonsTest {
   }
 
   @Test
-  void testCopy() {
+  void testClone() {
     final ToClass expected = new ToClass("abc", 999, 888L);
     final ToClass actual = Jsons.clone(expected);
     Assertions.assertNotSame(expected, actual);
     Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  void testMutateTypeToArrayStandard() {
+    final JsonNode expectedWithoutType = Jsons.deserialize("{\"test\":\"abc\"}");
+    final JsonNode actualWithoutType = Jsons.clone(expectedWithoutType);
+    Jsons.mutateTypeToArrayStandard(expectedWithoutType);
+    Assertions.assertEquals(expectedWithoutType, actualWithoutType);
+
+    final JsonNode expectedWithArrayType = Jsons.deserialize("{\"test\":\"abc\", \"type\":[\"object\"]}");
+    final JsonNode actualWithArrayType = Jsons.clone(expectedWithArrayType);
+    Jsons.mutateTypeToArrayStandard(actualWithArrayType);
+    Assertions.assertEquals(expectedWithoutType, actualWithoutType);
+
+    final JsonNode expectedWithoutArrayType = Jsons.deserialize("{\"test\":\"abc\", \"type\":[\"object\"]}");
+    final JsonNode actualWithStringType = Jsons.deserialize("{\"test\":\"abc\", \"type\":\"object\"}");
+    Jsons.mutateTypeToArrayStandard(actualWithStringType);
+    Assertions.assertEquals(expectedWithoutArrayType, actualWithStringType);
   }
 
   private static class ToClass {

--- a/airbyte-commons/src/test/java/io/airbyte/commons/json/JsonsTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/json/JsonsTest.java
@@ -179,17 +179,17 @@ class JsonsTest {
   void testMutateTypeToArrayStandard() {
     final JsonNode expectedWithoutType = Jsons.deserialize("{\"test\":\"abc\"}");
     final JsonNode actualWithoutType = Jsons.clone(expectedWithoutType);
-    Jsons.mutateTypeToArrayStandard(expectedWithoutType);
+    JsonSchemas.mutateTypeToArrayStandard(expectedWithoutType);
     Assertions.assertEquals(expectedWithoutType, actualWithoutType);
 
     final JsonNode expectedWithArrayType = Jsons.deserialize("{\"test\":\"abc\", \"type\":[\"object\"]}");
     final JsonNode actualWithArrayType = Jsons.clone(expectedWithArrayType);
-    Jsons.mutateTypeToArrayStandard(actualWithArrayType);
+    JsonSchemas.mutateTypeToArrayStandard(actualWithArrayType);
     Assertions.assertEquals(expectedWithoutType, actualWithoutType);
 
     final JsonNode expectedWithoutArrayType = Jsons.deserialize("{\"test\":\"abc\", \"type\":[\"object\"]}");
     final JsonNode actualWithStringType = Jsons.deserialize("{\"test\":\"abc\", \"type\":\"object\"}");
-    Jsons.mutateTypeToArrayStandard(actualWithStringType);
+    JsonSchemas.mutateTypeToArrayStandard(actualWithStringType);
     Assertions.assertEquals(expectedWithoutArrayType, actualWithStringType);
   }
 

--- a/airbyte-integrations/singer/exchangeratesapi_io/source/src/test-integration/java/io/airbyte/integration_tests/sources/SingerExchangeRatesApiSourceDataModelTest.java
+++ b/airbyte-integrations/singer/exchangeratesapi_io/source/src/test-integration/java/io/airbyte/integration_tests/sources/SingerExchangeRatesApiSourceDataModelTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.airbyte.commons.json.JsonSchemas;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.config.Schema;
@@ -46,12 +47,12 @@ public class SingerExchangeRatesApiSourceDataModelTest {
 
     final JsonNode expected = Jsons.deserialize(input);
     // our deserializer converts `type: "object"` => `type: ["object"]`. both are valid jsonschema.
-    Jsons.mutateTypeToArrayStandard(expected.get("streams").get(0).get("schema"));
+    JsonSchemas.mutateTypeToArrayStandard(expected.get("streams").get(0).get("schema"));
     expected.get("streams")
         .get(0)
         .get("schema")
         .get("properties")
-        .forEach(Jsons::mutateTypeToArrayStandard);
+        .forEach(JsonSchemas::mutateTypeToArrayStandard);
 
     final SingerCatalog catalog = Jsons.deserialize(input, SingerCatalog.class);
 

--- a/airbyte-integrations/singer/exchangeratesapi_io/source/src/test-integration/resources/schema_message.json
+++ b/airbyte-integrations/singer/exchangeratesapi_io/source/src/test-integration/resources/schema_message.json
@@ -1,0 +1,113 @@
+{
+  "type": "SCHEMA",
+  "stream": "exchange_rate",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "date": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "CAD": {
+        "type": ["null", "number"]
+      },
+      "HKD": {
+        "type": ["null", "number"]
+      },
+      "ISK": {
+        "type": ["null", "number"]
+      },
+      "PHP": {
+        "type": ["null", "number"]
+      },
+      "DKK": {
+        "type": ["null", "number"]
+      },
+      "HUF": {
+        "type": ["null", "number"]
+      },
+      "CZK": {
+        "type": ["null", "number"]
+      },
+      "GBP": {
+        "type": ["null", "number"]
+      },
+      "RON": {
+        "type": ["null", "number"]
+      },
+      "SEK": {
+        "type": ["null", "number"]
+      },
+      "IDR": {
+        "type": ["null", "number"]
+      },
+      "INR": {
+        "type": ["null", "number"]
+      },
+      "BRL": {
+        "type": ["null", "number"]
+      },
+      "RUB": {
+        "type": ["null", "number"]
+      },
+      "HRK": {
+        "type": ["null", "number"]
+      },
+      "JPY": {
+        "type": ["null", "number"]
+      },
+      "THB": {
+        "type": ["null", "number"]
+      },
+      "CHF": {
+        "type": ["null", "number"]
+      },
+      "EUR": {
+        "type": ["null", "number"]
+      },
+      "MYR": {
+        "type": ["null", "number"]
+      },
+      "BGN": {
+        "type": ["null", "number"]
+      },
+      "TRY": {
+        "type": ["null", "number"]
+      },
+      "CNY": {
+        "type": ["null", "number"]
+      },
+      "NOK": {
+        "type": ["null", "number"]
+      },
+      "NZD": {
+        "type": ["null", "number"]
+      },
+      "ZAR": {
+        "type": ["null", "number"]
+      },
+      "USD": {
+        "type": ["null", "number"]
+      },
+      "MXN": {
+        "type": ["null", "number"]
+      },
+      "SGD": {
+        "type": ["null", "number"]
+      },
+      "AUD": {
+        "type": ["null", "number"]
+      },
+      "ILS": {
+        "type": ["null", "number"]
+      },
+      "KRW": {
+        "type": ["null", "number"]
+      },
+      "PLN": {
+        "type": ["null", "number"]
+      }
+    }
+  },
+  "key_properties": ["date"]
+}

--- a/airbyte-integrations/singer/postgres/source/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SingerPostgresSourceDataModelTest.java
+++ b/airbyte-integrations/singer/postgres/source/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SingerPostgresSourceDataModelTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.commons.json.JsonSchemas;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.singer.SingerCatalog;
@@ -45,12 +46,12 @@ public class SingerPostgresSourceDataModelTest {
 
     final JsonNode expected = Jsons.deserialize(catalogString);
     final JsonNode actual = Jsons.deserialize(reserialized);
-    Jsons.mutateTypeToArrayStandard(expected.get("streams").get(0).get("schema"));
+    JsonSchemas.mutateTypeToArrayStandard(expected.get("streams").get(0).get("schema"));
     expected.get("streams")
         .get(0)
         .get("schema")
         .get("properties")
-        .forEach(Jsons::mutateTypeToArrayStandard);
+        .forEach(JsonSchemas::mutateTypeToArrayStandard);
 
     assertEquals(expected, actual);
   }

--- a/airbyte-integrations/singer/postgres/source/src/test-integration/resources/schema_message.json
+++ b/airbyte-integrations/singer/postgres/source/src/test-integration/resources/schema_message.json
@@ -1,0 +1,42 @@
+{
+  "type": "SCHEMA",
+  "stream": "id_and_name",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "name": { "type": ["null", "string"], "maxLength": 200 },
+      "id": {
+        "type": ["null", "integer"],
+        "minimum": -2147483648,
+        "maximum": 2147483647
+      }
+    },
+    "definitions": {
+      "sdc_recursive_integer_array": {
+        "type": ["null", "integer", "array"],
+        "items": { "$ref": "#/definitions/sdc_recursive_integer_array" }
+      },
+      "sdc_recursive_number_array": {
+        "type": ["null", "number", "array"],
+        "items": { "$ref": "#/definitions/sdc_recursive_number_array" }
+      },
+      "sdc_recursive_string_array": {
+        "type": ["null", "string", "array"],
+        "items": { "$ref": "#/definitions/sdc_recursive_string_array" }
+      },
+      "sdc_recursive_boolean_array": {
+        "type": ["null", "boolean", "array"],
+        "items": { "$ref": "#/definitions/sdc_recursive_boolean_array" }
+      },
+      "sdc_recursive_timestamp_array": {
+        "type": ["null", "string", "array"],
+        "format": "date-time",
+        "items": { "$ref": "#/definitions/sdc_recursive_timestamp_array" }
+      },
+      "sdc_recursive_object_array": {
+        "type": ["null", "object", "array"],
+        "items": { "$ref": "#/definitions/sdc_recursive_object_array" }
+      }
+    }
+  }
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/singer/DefaultSingerStreamFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/singer/DefaultSingerStreamFactory.java
@@ -75,13 +75,6 @@ public class DefaultSingerStreamFactory implements SingerStreamFactory {
         .filter(Optional::isPresent)
         .map(Optional::get)
         .filter(j -> {
-          // todo (cgardens) - hack. seems like the validation in the worker does not play well with
-          // the custom deserializer. it marks the type as object when really it is going to be an
-          // array. while the generate pojo is correct (using the custom serializer) the validator
-          // doesn't understand this annotation and fails because these fields are not objects.
-          if (j.get("type") != null && j.get("type").asText().equals("SCHEMA")) {
-            return true;
-          }
           boolean res = singerProtocolValidator.test(j);
           if (!res) {
             logger.error("Validation failed: {}", Jsons.serialize(j));


### PR DESCRIPTION
## What
* Yesterday we were having issues where all schema messages were not passing validation. 
* I actually cannot recreate the issue anymore. I think it's possible that some of the adjustments that we made to converters and catalog schema have fixed them. 
* here's the original note i made of the issue:
```
  // todo (cgardens) - WIP, seems like the validation in the worker does not play well with the custom
  // deserializer. it marks the type as object when really it is going to be an array. while the
  // generate pojo is correct (using the custom serializer) the validator doesn't understand this
  // annotation and fails because these fields are not objects.
  // $.schema.type: array found, object expected
  // $.schema.properties.sources.anyOf: array found, object expected
```

## How
* Added tests for a schema message from each of our sources to make sure it passes validation.
* Ran data from each source into local csv and verified there were no validation failed messages for schema messages.
