### PR TITLE
hotfix: docker-compose 1.27.3 volume issue

### DIFF
--- a/docs/deployment/deploying-airbyte/on-your-workstation.md
+++ b/docs/deployment/deploying-airbyte/on-your-workstation.md
@@ -6,7 +6,7 @@ These instructions have been tested on MacOS
 
 ## Setup & launch Airbyte
 
-* Install Docker on your workstation \(see [instructions](https://www.docker.com/products/docker-desktop)\)
+* Install Docker on your workstation \(see [instructions](https://www.docker.com/products/docker-desktop)\). Note: There is a known issue with docker-compose 1.27.3. If you are using that version, please upgrade to 1.27.4.
 * Clone Airbyte's repository and run `docker compose`
 
 ```bash

--- a/tools/bin/acceptance_test.sh
+++ b/tools/bin/acceptance_test.sh
@@ -8,7 +8,10 @@ assert_root
 
 echo "Starting app..."
 
-# todo (cgardens) - docker-compose 1.27.3 contained a bug that causes a failure if the volume path does not exist when the volume is created. It was fixed in 1.27.4. Github actions virtual envs, however, new ubuntu release upgraded to 1.27.3 on 09/24/20. Once github actions virtual envs upgrades to 1.27.4, we can stop manually making the directory.
+# todo (cgardens) - docker-compose 1.27.3 contained a bug that causes a failure if the volume path
+#  does not exist when the volume is created. It was fixed in 1.27.4. Github actions virtual envs,
+#  however, new ubuntu release upgraded to 1.27.3 on 09/24/20. Once github actions virtual envs
+#  upgrades to 1.27.4, we can stop manually making the directory.
 mkdir -p /tmp/airbyte_local
 
 # Detach so we can run subsequent commands

--- a/tools/bin/acceptance_test.sh
+++ b/tools/bin/acceptance_test.sh
@@ -8,6 +8,9 @@ assert_root
 
 echo "Starting app..."
 
+# todo (cgardens) - docker-compose 1.27.3 contained a bug that causes a failure if the volume path does not exist when the volume is created. It was fixed in 1.27.4. Github actions virtual envs, however, new ubuntu release upgraded to 1.27.3 on 09/24/20. Once github actions virtual envs upgrades to 1.27.4, we can stop manually making the directory.
+mkdir -p /tmp/airbyte_local
+
 # Detach so we can run subsequent commands
 VERSION=dev docker-compose up -d
 trap "echo 'docker-compose logs:' && docker-compose logs -t --tail 150 && docker-compose down" EXIT


### PR DESCRIPTION
## What
* closes https://github.com/airbytehq/airbyte/issues/451
* Fix build by, temporarily, manually creating /tmp/airbyte_local (until github actions upgrades to docker-compose 1.27.4)
* Document that docker-compose version 1.27.3 has known issues.
