### PR TITLE
exit early if there is an error in the run script

### DIFF
--- a/airbyte-integrations/singer/postgres/destination/run.sh
+++ b/airbyte-integrations/singer/postgres/destination/run.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 function echo_err() {
   echo >&2 "$@"
 }


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/408

## What
* Missing a `set -e` in one of our entrypoint scripts which causes us to fail later than we should and with less clear behavior.
