### PR TITLE
add debugging endpoint that shows versions of images

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -776,7 +776,7 @@ paths:
     get:
       tags:
         - debugging
-      summary: Get miscellanious information for debugging
+      summary: Get miscellaneous information for debugging
       operationId: getDebuggingInfo
       responses:
         "200":

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -772,6 +772,22 @@ paths:
           description: Job not found
         "422":
           $ref: "#/components/responses/InvalidInput"
+  /v1/debug:
+    get:
+      tags:
+        - debugging
+      summary: Get miscellanious information for debugging
+      operationId: getDebuggingInfo
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DebugRead"
+        "404":
+          description: Debug info not found
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1362,6 +1378,13 @@ components:
           $ref: "#/components/schemas/JobRead"
         logs:
           $ref: "#/components/schemas/LogRead"
+    DebugRead:
+      type: object
+      required:
+        - info
+      properties:
+        info:
+          type: object
     LogRead:
       type: object
       required:

--- a/airbyte-integrations/src/main/java/io/airbyte/integrations/Integrations.java
+++ b/airbyte-integrations/src/main/java/io/airbyte/integrations/Integrations.java
@@ -30,22 +30,22 @@ public enum Integrations {
 
   POSTGRES_TAP(
       UUID.fromString("2168516a-5c9a-4582-90dc-5e3a01e3f607"),
-      new IntegrationMapping("airbyte/integration-singer-postgres-source:0.1.2")),
+      new IntegrationMapping("airbyte/integration-singer-postgres-source", "0.1.2")),
   EXCHANGERATESAPI_IO_TAP(
       UUID.fromString("37eb2ebf-0899-4b22-aba8-8537ec88b5a8"),
-      new IntegrationMapping("airbyte/integration-singer-exchangeratesapi_io-source:0.1.2")),
+      new IntegrationMapping("airbyte/integration-singer-exchangeratesapi_io-source", "0.1.2")),
   STRIPE_TAP(
       UUID.fromString("dd42e77b-24ce-485d-8146-ee6c96d5b454"),
-      new IntegrationMapping("airbyte/integration-singer-stripe-source:0.1.1")),
+      new IntegrationMapping("airbyte/integration-singer-stripe-source", "0.1.1")),
   POSTGRES_TARGET(
       UUID.fromString("a6655e6a-838c-4ecb-a28f-ffdcd27ec710"),
-      new IntegrationMapping("airbyte/integration-singer-postgres-destination:0.1.1")),
+      new IntegrationMapping("airbyte/integration-singer-postgres-destination", "0.1.1")),
   BIGQUERY_TARGET(
       UUID.fromString("e28a1a10-214a-4051-8cf4-79b6f88719cd"),
-      new IntegrationMapping("airbyte/integration-singer-bigquery-destination:0.1.3")),
+      new IntegrationMapping("airbyte/integration-singer-bigquery-destination", "0.1.3")),
   CSV_TARGET(
       UUID.fromString("8442ee76-cc1d-419a-bd8b-859a090366d4"),
-      new IntegrationMapping("airbyte/integration-singer-csv-destination:0.1.0"));
+      new IntegrationMapping("airbyte/integration-singer-csv-destination", "0.1.0"));
 
   private final UUID specId;
   private final IntegrationMapping integrationMapping;
@@ -70,44 +70,30 @@ public enum Integrations {
     return specId;
   }
 
-  public String getCheckConnectionImage() {
-    return integrationMapping.getCheckConnection();
-  }
-
-  public String getDiscoverSchemaImage() {
-    return integrationMapping.getDiscoverSchema();
-  }
-
-  public String getSyncImage() {
-    return integrationMapping.getSync();
+  public String getTaggedImage() {
+    return integrationMapping.getTaggedImage();
   }
 
   public static class IntegrationMapping {
 
-    private final String checkConnection;
-    private final String discoverSchema;
-    private final String sync;
+    private final String image;
+    private final String tag;
 
-    public IntegrationMapping(String checkConnection, String discoverSchema, String sync) {
-      this.checkConnection = checkConnection;
-      this.discoverSchema = discoverSchema;
-      this.sync = sync;
+    public IntegrationMapping(String image, String tag) {
+      this.image = image;
+      this.tag = tag;
     }
 
-    public IntegrationMapping(String image) {
-      this(image, image, image);
+    public String getTaggedImage() {
+      return image + ":" + tag;
     }
 
-    public String getCheckConnection() {
-      return checkConnection;
+    public String getImage() {
+      return image;
     }
 
-    public String getDiscoverSchema() {
-      return discoverSchema;
-    }
-
-    public String getSync() {
-      return sync;
+    public String getTag() {
+      return tag;
     }
 
   }

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/WorkerRunFactory.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/WorkerRunFactory.java
@@ -41,9 +41,10 @@ import io.airbyte.workers.protocols.singer.SingerSyncWorker;
 import io.airbyte.workers.wrappers.JobOutputCheckConnectionWorker;
 import io.airbyte.workers.wrappers.JobOutputDiscoverSchemaWorker;
 import io.airbyte.workers.wrappers.JobOutputSyncWorker;
-import java.nio.file.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
 
 /**
  * This class is a runnable that give a job id and db connection figures out how to run the

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/WorkerRunFactory.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/WorkerRunFactory.java
@@ -41,10 +41,9 @@ import io.airbyte.workers.protocols.singer.SingerSyncWorker;
 import io.airbyte.workers.wrappers.JobOutputCheckConnectionWorker;
 import io.airbyte.workers.wrappers.JobOutputDiscoverSchemaWorker;
 import io.airbyte.workers.wrappers.JobOutputSyncWorker;
+import java.nio.file.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.nio.file.Path;
 
 /**
  * This class is a runnable that give a job id and db connection figures out how to run the

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/DefaultSchedulerPersistence.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/DefaultSchedulerPersistence.java
@@ -82,7 +82,7 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
     final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig()
         .withConnectionConfiguration(sourceImplementation.getConfiguration())
         .withDockerImage(Integrations.findBySpecId(sourceImplementation.getSourceSpecificationId())
-            .getCheckConnectionImage());
+            .getTaggedImage());
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(JobConfig.ConfigType.CHECK_CONNECTION_SOURCE)
@@ -101,7 +101,7 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
     final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig()
         .withConnectionConfiguration(destinationImplementation.getConfiguration())
         .withDockerImage(Integrations.findBySpecId(destinationImplementation.getDestinationSpecificationId())
-            .getCheckConnectionImage());
+            .getTaggedImage());
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(JobConfig.ConfigType.CHECK_CONNECTION_DESTINATION)
@@ -118,7 +118,7 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
         sourceImplementation.getSourceImplementationId().toString());
 
     final String imageName = Integrations.findBySpecId(sourceImplementation.getSourceSpecificationId())
-        .getDiscoverSchemaImage();
+        .getTaggedImage();
     final JobDiscoverSchemaConfig jobDiscoverSchemaConfig = new JobDiscoverSchemaConfig()
         .withConnectionConfiguration(sourceImplementation.getConfiguration())
         .withDockerImage(imageName);
@@ -139,8 +139,8 @@ public class DefaultSchedulerPersistence implements SchedulerPersistence {
 
     final String scope = ScopeHelper.createScope(JobConfig.ConfigType.SYNC, connectionId.toString());
 
-    final String sourceImageName = Integrations.findBySpecId(sourceImplementation.getSourceSpecificationId()).getSyncImage();
-    final String destinationImageName = Integrations.findBySpecId(destinationImplementation.getDestinationSpecificationId()).getSyncImage();
+    final String sourceImageName = Integrations.findBySpecId(sourceImplementation.getSourceSpecificationId()).getTaggedImage();
+    final String destinationImageName = Integrations.findBySpecId(destinationImplementation.getDestinationSpecificationId()).getTaggedImage();
     final JobSyncConfig jobSyncConfig = new JobSyncConfig()
         .withSourceConnectionImplementation(sourceImplementation)
         .withSourceDockerImage(sourceImageName)

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultSchedulerPersistenceTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultSchedulerPersistenceTest.java
@@ -190,7 +190,7 @@ class DefaultSchedulerPersistenceTest {
 
     final Record jobEntry = getJobRecord(jobId);
 
-    final String imageName = Integrations.findBySpecId(SOURCE_CONNECTION_IMPLEMENTATION.getSourceSpecificationId()).getDiscoverSchemaImage();
+    final String imageName = Integrations.findBySpecId(SOURCE_CONNECTION_IMPLEMENTATION.getSourceSpecificationId()).getTaggedImage();
     final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig()
         .withConnectionConfiguration(SOURCE_CONNECTION_IMPLEMENTATION.getConfiguration())
         .withDockerImage(imageName);
@@ -209,7 +209,7 @@ class DefaultSchedulerPersistenceTest {
     final Record jobEntry = getJobRecord(jobId);
 
     final String imageName = Integrations.findBySpecId(DESTINATION_CONNECTION_IMPLEMENTATION.getDestinationSpecificationId())
-        .getDiscoverSchemaImage();
+        .getTaggedImage();
     final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig()
         .withConnectionConfiguration(DESTINATION_CONNECTION_IMPLEMENTATION.getConfiguration())
         .withDockerImage(imageName);
@@ -227,7 +227,7 @@ class DefaultSchedulerPersistenceTest {
 
     final Record jobEntry = getJobRecord(jobId);
 
-    final String imageName = Integrations.findBySpecId(SOURCE_CONNECTION_IMPLEMENTATION.getSourceSpecificationId()).getDiscoverSchemaImage();
+    final String imageName = Integrations.findBySpecId(SOURCE_CONNECTION_IMPLEMENTATION.getSourceSpecificationId()).getTaggedImage();
     final JobDiscoverSchemaConfig jobDiscoverSchemaConfig = new JobDiscoverSchemaConfig()
         .withConnectionConfiguration(SOURCE_CONNECTION_IMPLEMENTATION.getConfiguration())
         .withDockerImage(imageName);
@@ -248,9 +248,9 @@ class DefaultSchedulerPersistenceTest {
 
     final Record jobEntry = getJobRecord(jobId);
 
-    final String sourceImageName = Integrations.findBySpecId(SOURCE_CONNECTION_IMPLEMENTATION.getSourceSpecificationId()).getSyncImage();
+    final String sourceImageName = Integrations.findBySpecId(SOURCE_CONNECTION_IMPLEMENTATION.getSourceSpecificationId()).getTaggedImage();
     final String destinationImageName = Integrations.findBySpecId(DESTINATION_CONNECTION_IMPLEMENTATION.getDestinationSpecificationId())
-        .getSyncImage();
+        .getTaggedImage();
     final JobSyncConfig jobSyncConfig = new JobSyncConfig()
         .withSourceConnectionImplementation(SOURCE_CONNECTION_IMPLEMENTATION)
         .withSourceDockerImage(sourceImageName)
@@ -388,9 +388,9 @@ class DefaultSchedulerPersistenceTest {
 
     final Optional<Job> actual = schedulerPersistence.getLastSyncJob(STANDARD_SYNC.getConnectionId());
 
-    final String sourceImageName = Integrations.findBySpecId(SOURCE_CONNECTION_IMPLEMENTATION.getSourceSpecificationId()).getSyncImage();
+    final String sourceImageName = Integrations.findBySpecId(SOURCE_CONNECTION_IMPLEMENTATION.getSourceSpecificationId()).getTaggedImage();
     final String destinationImageName =
-        Integrations.findBySpecId(DESTINATION_CONNECTION_IMPLEMENTATION.getDestinationSpecificationId()).getSyncImage();
+        Integrations.findBySpecId(DESTINATION_CONNECTION_IMPLEMENTATION.getDestinationSpecificationId()).getTaggedImage();
     final JobSyncConfig jobSyncConfig = new JobSyncConfig()
         .withSourceConnectionImplementation(SOURCE_CONNECTION_IMPLEMENTATION)
         .withSourceDockerImage(sourceImageName)
@@ -491,9 +491,9 @@ class DefaultSchedulerPersistenceTest {
 
   private Job getExpectedJob(long jobId, JobStatus jobStatus) {
     final String sourceImageName = Integrations.findBySpecId(SOURCE_CONNECTION_IMPLEMENTATION.getSourceSpecificationId())
-        .getDiscoverSchemaImage();
+        .getTaggedImage();
     final String destinationImageName = Integrations.findBySpecId(DESTINATION_CONNECTION_IMPLEMENTATION.getDestinationSpecificationId())
-        .getDiscoverSchemaImage();
+        .getTaggedImage();
 
     final JobSyncConfig jobSyncConfig = new JobSyncConfig()
         .withSourceDockerImage(sourceImageName)

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation project(':airbyte-config:persistence')
     implementation project(':airbyte-config:init')
     implementation project(':airbyte-db')
+    implementation project(':airbyte-integrations')
     implementation project(':airbyte-scheduler')
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -31,6 +31,7 @@ import io.airbyte.api.model.ConnectionRead;
 import io.airbyte.api.model.ConnectionReadList;
 import io.airbyte.api.model.ConnectionSyncRead;
 import io.airbyte.api.model.ConnectionUpdate;
+import io.airbyte.api.model.DebugRead;
 import io.airbyte.api.model.DestinationIdRequestBody;
 import io.airbyte.api.model.DestinationImplementationCreate;
 import io.airbyte.api.model.DestinationImplementationIdRequestBody;
@@ -66,6 +67,7 @@ import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.scheduler.persistence.SchedulerPersistence;
 import io.airbyte.server.errors.KnownException;
 import io.airbyte.server.handlers.ConnectionsHandler;
+import io.airbyte.server.handlers.DebugInfoHandler;
 import io.airbyte.server.handlers.DestinationImplementationsHandler;
 import io.airbyte.server.handlers.DestinationSpecificationsHandler;
 import io.airbyte.server.handlers.DestinationsHandler;
@@ -94,6 +96,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   private final DestinationSpecificationsHandler destinationSpecificationsHandler;
   private final DestinationImplementationsHandler destinationImplementationsHandler;
   private final ConnectionsHandler connectionsHandler;
+  private final DebugInfoHandler debugInfoHandler;
   private final SchedulerHandler schedulerHandler;
   private final JobHistoryHandler jobHistoryHandler;
   private final WebBackendConnectionsHandler webBackendConnectionsHandler;
@@ -115,6 +118,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
     webBackendConnectionsHandler = new WebBackendConnectionsHandler(connectionsHandler, sourceImplementationsHandler, jobHistoryHandler);
     webBackendSourceImplementationHandler = new WebBackendSourceImplementationHandler(sourceImplementationsHandler, schedulerHandler);
     webBackendDestinationImplementationHandler = new WebBackendDestinationImplementationHandler(destinationImplementationsHandler, schedulerHandler);
+    debugInfoHandler = new DebugInfoHandler();
   }
 
   // WORKSPACE
@@ -275,6 +279,11 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   @Override
   public ConnectionRead getConnection(@Valid ConnectionIdRequestBody connectionIdRequestBody) {
     return execute(() -> connectionsHandler.getConnection(connectionIdRequestBody));
+  }
+
+  @Override
+  public DebugRead getDebuggingInfo() {
+    return execute(debugInfoHandler::getInfo);
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DebugInfoHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DebugInfoHandler.java
@@ -1,0 +1,130 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.server.handlers;
+
+import com.google.common.collect.Lists;
+import io.airbyte.api.model.DebugRead;
+import io.airbyte.integrations.Integrations;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+
+public class DebugInfoHandler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DebugInfoHandler.class);
+
+  public DebugRead getInfo() {
+    try {
+      List<Map<String, String>> integrationImages = Arrays.stream(Integrations.values())
+          .map(Integrations::getTaggedImage)
+          .map(image -> {
+            try {
+              String hash = getOutput(Lists.newArrayList("docker", "images", "--no-trunc", "--quiet", image));
+              Map<String, String> result = new HashMap<>();
+              result.put("hash", hash.isEmpty() ? null : hash.split(":")[1].substring(0, 12));
+              result.put("image", image);
+              return result;
+            } catch (IOException | InterruptedException e) {
+              throw new RuntimeException(e);
+            }
+          })
+          .collect(toList());
+
+      String runningContainers = getOutput(
+          Lists.newArrayList(
+              "docker",
+              "ps",
+              "-f",
+              "name=airbyte",
+              "-q"));
+
+      List<String> outputCommand = Lists.newArrayList(
+          "docker",
+          "inspect",
+          "--format='{{.Image}} {{.Config.Image}}'");
+
+      outputCommand.addAll(Lists.newArrayList(runningContainers.split("\n")));
+
+      LOGGER.error("outputCommand = " + outputCommand);
+
+      String output = getOutput(outputCommand).replaceAll("'", "");
+
+      LOGGER.error("output = " + output);
+
+      List<String> coreOutput = Lists.newArrayList(output.split("\n"));
+
+      LOGGER.error("coreOutput = " + coreOutput);
+
+      List<Map<String, String>> coreImages = coreOutput.stream().map(x -> {
+        LOGGER.error("x = " + x);
+
+        String[] s = x.split(" ");
+        String shortHash = s[0].split(":")[1].substring(0, 12);
+        String taggedImage = s[1];
+
+        return Map.of(
+            "image", taggedImage,
+            "hash", shortHash);
+      }).collect(toList());
+
+      // todo: split into lines
+      // todo:get columns
+      // todo: format into map
+
+      // todo: list airbyte local images with docker
+
+      DebugRead result = new DebugRead();
+      result.info(Map.of(
+          "images",
+          Map.of("running", coreImages,
+              "integrations", integrationImages)));
+      return result;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static String getOutput(List<String> cmd) throws IOException, InterruptedException {
+    ProcessBuilder processBuilder = new ProcessBuilder(cmd);
+    Process process = processBuilder.start();
+    process.waitFor();
+
+    String output = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
+
+    process.destroy();
+
+    return output;
+  }
+
+}

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DebugInfoHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DebugInfoHandlerTest.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.server.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class DebugInfoHandlerTest {
+
+  @Test
+  public void testNoFailures() {
+    new DebugInfoHandler().getInfo();
+  }
+
+  @Test
+  public void testRunAndGetOutput() throws IOException, InterruptedException {
+    final String expected = "hi";
+    final String actual = DebugInfoHandler.runAndGetOutput(Lists.newArrayList("echo", "-n", "hi"));
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testShortHash() {
+    final String expected = "1326d8641577";
+    final String actual = DebugInfoHandler.getShortHash("sha256:1326d864157731c10724e5a407cf227e14e147a11dc4ba64157ebe8689a28d84");
+    assertEquals(expected, actual);
+  }
+
+}


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/421

- stop allow separate images for discovery/check connection/etc (our thinking on this changed when we went to single-image and self-contained integrations)
- separates image name and tags (so we can run `VERSION=dev` with dev integrations in the future)
- add a flexible debug endpoint to the API
- add show all of the relevant images and hashes

Example usage on running with `VERSION=dev`:
```
→ curl http://localhost:8001/api/v1/debug | jq .
{
  "info": {
    "images": {
      "integrations": [
        {
          "image": "airbyte/integration-singer-postgres-source:0.1.2",
          "hash": "1326d8641577"
        },
        {
          "image": "airbyte/integration-singer-exchangeratesapi_io-source:0.1.2",
          "hash": "90cd8448bc87"
        },
        {
          "image": "airbyte/integration-singer-stripe-source:0.1.1",
          "hash": "66c2157baa0e"
        },
        {
          "image": "airbyte/integration-singer-postgres-destination:0.1.1",
          "hash": "18c2f838fb2d"
        },
        {
          "image": "airbyte/integration-singer-bigquery-destination:0.1.3",
          "hash": null
        },
        {
          "image": "airbyte/integration-singer-csv-destination:0.1.0",
          "hash": "3496a3c8d990"
        }
      ],
      "running": [
        {
          "image": "airbyte/webapp:dev",
          "hash": "e2cc56f0a11e"
        },
        {
          "image": "airbyte/scheduler:dev",
          "hash": "e64c4d735db1"
        },
        {
          "image": "airbyte/db:dev",
          "hash": "872d56996ccb"
        }
      ]
    }
  }
}
```

Notice that the running images are all `dev` scoped. Also, it's important to note that for images that have not been pulled at the latest version, like `airbyte/integration-singer-bigquery-destination:0.1.3`, the hash will be null.