### PR TITLE
upgrade libpq-dev version

### DIFF
--- a/airbyte-integrations/singer/postgres/destination/Dockerfile
+++ b/airbyte-integrations/singer/postgres/destination/Dockerfile
@@ -14,7 +14,7 @@ COPY ./check_connection.py /check_connection.py
 RUN apt-get update && \
   # https://github.com/datamill-co/target-postgres/issues/186
   # Need to install libpq and gcc since they're not listed in pip requirements
-  apt-get -y install libpq-dev=11.7-0+deb10u1 && \
+  apt-get -y install libpq-dev=11.9-0+deb10u1 && \
   apt-get -y install gcc=4:8.3.0-1 && \
   python -m pip install --upgrade pip && \
   pip install -r requirements.txt


### PR DESCRIPTION
This will fix the issue in runs like https://github.com/airbytehq/airbyte/runs/1177495054 where we're getting an error:
```
* What went wrong:
Execution failed for task ':airbyte-integrations:singer:postgres:destination:buildImage'.
> Could not build image: The command '/bin/sh -c apt-get update &&   apt-get -y install libpq-dev=11.7-0+deb10u1 &&   apt-get -y install gcc=4:8.3.0-1 &&   python -m pip install --upgrade pip &&   pip install -r requirements.txt' returned a non-zero code: 100
```

This is caused by the `apt-get -y install libpq-dev=11.7-0+deb10u1` part, which by itself is giving the error:
```
The following packages have unmet dependencies:
 libpq-dev : Depends: libpq5 (= 11.7-0+deb10u1) but 11.9-0+deb10u1 is to be installed
E: Unable to correct problems, you have held broken packages.
```

I'm looking into why this version is mismatched, but this change fixes the build and passes integration tests.