### PR TITLE
prevent libpq5 and libpq-dev version mismatches

### DIFF
--- a/airbyte-integrations/singer/postgres/destination/Dockerfile
+++ b/airbyte-integrations/singer/postgres/destination/Dockerfile
@@ -14,6 +14,7 @@ COPY ./check_connection.py /check_connection.py
 RUN apt-get update && \
   # https://github.com/datamill-co/target-postgres/issues/186
   # Need to install libpq and gcc since they're not listed in pip requirements
+  apt-get -y install libpq5=11.9-0+deb10u1 && \
   apt-get -y install libpq-dev=11.9-0+deb10u1 && \
   apt-get -y install gcc=4:8.3.0-1 && \
   python -m pip install --upgrade pip && \


### PR DESCRIPTION
While https://github.com/airbytehq/airbyte/pull/463 fixed the build, we would still run into this issue if the versions get out of sync for `libpq5` and `libpq-dev`, which is the underlying problem.

Adding this install fixes the problem and should prevent the issue from recurring. 

This also passes the build:
```
  apt-get -y install libpq5=11.7-0+deb10u1 && \
  apt-get -y install libpq-dev=11.7-0+deb10u1
```

I figured that we should just leave it upgraded. 