### PR TITLE
add override version for dev integration testing

### DIFF
--- a/airbyte-integrations/src/main/java/io/airbyte/integrations/Integrations.java
+++ b/airbyte-integrations/src/main/java/io/airbyte/integrations/Integrations.java
@@ -47,6 +47,8 @@ public enum Integrations {
       UUID.fromString("8442ee76-cc1d-419a-bd8b-859a090366d4"),
       new IntegrationMapping("airbyte/integration-singer-csv-destination", "0.1.0"));
 
+  private static final String INTEGRATION_OVERRIDE_VERSION = "INTEGRATION_OVERRIDE_VERSION";
+
   private final UUID specId;
   private final IntegrationMapping integrationMapping;
 
@@ -81,7 +83,14 @@ public enum Integrations {
 
     public IntegrationMapping(String image, String tag) {
       this.image = image;
-      this.tag = tag;
+
+      String overrideVersion = System.getenv(INTEGRATION_OVERRIDE_VERSION);
+
+      if (overrideVersion == null) {
+        this.tag = tag;
+      } else {
+        this.tag = overrideVersion;
+      }
     }
 
     public String getTaggedImage() {

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -24,7 +24,11 @@ services:
     ports:
       - 5432:5432
   scheduler:
+    environment:
+      - INTEGRATION_OVERRIDE_VERSION=${INTEGRATION_OVERRIDE_VERSION}
   server:
+    environment:
+      - INTEGRATION_OVERRIDE_VERSION=${INTEGRATION_OVERRIDE_VERSION}
   webapp:
 # Allow us to access the volume content on the local filesystem
 volumes:


### PR DESCRIPTION
We should be able to easily test latest versions of integrations locally before bumping and tagging.

The expected workflow for this is:
```
./gradlew build
./gradlew buildImage
INTEGRATION_OVERRIDE_VERSION=dev docker-compose --env-file .env.dev -f docker-compose.yaml -f docker-compose.dev.yaml up
```

I tried adding it to `EnvConfigs` but that felt clunky and required dependency changes. Let me know if you'd prefer for every ENV var to go through there.

I also thought about just using `VERSION`, but I think it's also probably common to want to try running the non-integration code at DEV with production integrations. Defaulting to `dev` integrations while allowing the opposite as an override is another option that seems fine to me. 