### PR TITLE
add jacoco to measure test coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,10 @@ subprojects {
     }
 
     apply plugin: 'java'
+    apply plugin: 'jacoco'
+    test {
+
+    }
 
     repositories {
         mavenCentral()
@@ -115,6 +119,11 @@ subprojects {
             exceptionFormat 'full'
             // showStandardStreams = true
         }
+        finalizedBy jacocoTestReport
+    }
+
+    jacocoTestReport {
+        dependsOn test
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -96,9 +96,6 @@ subprojects {
 
     apply plugin: 'java'
     apply plugin: 'jacoco'
-    test {
-
-    }
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## What
Add Jacoco to get test coverage numbers. Jacoco reports will be under `${projectName}/build/reports/jacoco`.