### PR TITLE
API spec v0.2.0

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -121,6 +121,43 @@ paths:
           description: Workspace not found
         "422":
           $ref: "#/components/responses/InvalidInput"
+  /v1/sources/create:
+    post:
+      tags:
+        - source
+      summary: List all of the sources that Airbyte supports
+      operationId: listSources
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SourceRead"
+        "422":
+          $ref: "#/components/responses/InvalidInput"
+  /v1/sources/update:
+    post:
+      tags:
+        - source
+      summary: Update a source
+      operationId: updateSource
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SourceUpdate"
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SourceRead"
+        "404":
+          description: Source not found
+        "422":
+          $ref: "#/components/responses/InvalidInput"
   /v1/sources/list:
     post:
       tags:
@@ -178,7 +215,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SourceSpecificationRead"
         "404":
-          description: Source Specification not found
+          description: Source not found
         "422":
           $ref: "#/components/responses/InvalidInput"
   /v1/source_implementations/create:
@@ -875,15 +912,45 @@ components:
       properties:
         sourceId:
           $ref: "#/components/schemas/SourceId"
+    SourceCreate:
+      type: object
+      required:
+        - name
+        - defaultDockerRepository
+        - defaultDockerImageVersion
+      properties:
+        name:
+          type: string
+        defaultDockerRepository:
+          type: string
+        defaultDockerImageVersion:
+          type: string
+    SourceUpdate:
+      type: object
+      description: Update the source. Currently, the only allowed attribute to update is the default docker image version.
+      required:
+        - sourceId
+        - defaultDockerImageVersion
+      properties:
+        sourceId:
+          $ref: "#/components/schemas/SourceId"
+        defaultDockerImageVersion:
+          type: string
     SourceRead:
       type: object
       required:
         - sourceId
         - name
+        - defaultDockerRepository
+        - defaultDockerImageVersion
       properties:
         sourceId:
           $ref: "#/components/schemas/SourceId"
         name:
+          type: string
+        defaultDockerRepository:
+          type: string
+        defaultDockerImageVersion:
           type: string
     SourceReadList:
       type: object
@@ -1440,4 +1507,4 @@ components:
     InvalidInput:
       description: Invalid Input
 security:
-  - {}
+  - { }

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -379,6 +379,29 @@ paths:
           description: Source Implementation not found
         "422":
           $ref: "#/components/responses/InvalidInput"
+  /v1/destinations/update:
+    post:
+      tags:
+        - destination
+      summary: Update destination
+      operationId: updateDestination
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DestinationUpdate"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DestinationRead"
+        "404":
+          description: Destination not found
+        "422":
+          $ref: "#/components/responses/InvalidInput"
   /v1/destinations/list:
     post:
       tags:
@@ -1074,15 +1097,31 @@ components:
       properties:
         destinationId:
           $ref: "#/components/schemas/DestinationId"
+    DestinationUpdate:
+      type: object
+      required:
+        - destinationId
+        - destinationImageVersion
+      properties:
+        destinationId:
+          $ref: "#/components/schemas/DestinationId"
+        defaultDockerImageVersion:
+          type: string
     DestinationRead:
       type: object
       required:
         - destinationId
         - name
+        - defaultDockerRepository
+        - defaultDockerImageVersion
       properties:
         destinationId:
           $ref: "#/components/schemas/DestinationId"
         name:
+          type: string
+        defaultDockerRepository:
+          type: string
+        defaultDockerImageVersion:
           type: string
     DestinationReadList:
       type: object

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -895,21 +895,15 @@ components:
           items:
             $ref: "#/components/schemas/SourceRead"
     # SOURCE SPECIFICATION
-    SourceSpecificationId:
-      type: string
-      format: uuid
     SourceSpecification:
       description: The specification for what values are required to configure the source.
       example: { user: { type: string } }
     SourceSpecificationRead:
       type: object
       required:
-        - sourceSpecificationId
         - sourceId
         - specification
       properties:
-        sourceSpecificationId:
-          $ref: "#/components/schemas/SourceSpecificationId"
         sourceId:
           $ref: "#/components/schemas/SourceId"
         documentationUrl:
@@ -934,14 +928,14 @@ components:
       type: object
       required:
         - workspaceId
-        - sourceSpecificationId
+        - sourceId
         - connectionConfiguration
         - name
       properties:
         workspaceId:
           $ref: "#/components/schemas/WorkspaceId"
-        sourceSpecificationId:
-          $ref: "#/components/schemas/SourceSpecificationId"
+        sourceId:
+          $ref: "#/components/schemas/SourceId"
         connectionConfiguration:
           $ref: "#/components/schemas/SourceConfiguration"
         name:
@@ -965,7 +959,6 @@ components:
         - sourceId
         - sourceImplementationId
         - workspaceId
-        - sourceSpecificationId
         - connectionConfiguration
         - name
         - sourceName
@@ -976,8 +969,6 @@ components:
           $ref: "#/components/schemas/SourceImplementationId"
         workspaceId:
           $ref: "#/components/schemas/WorkspaceId"
-        sourceSpecificationId:
-          $ref: "#/components/schemas/SourceSpecificationId"
         connectionConfiguration:
           $ref: "#/components/schemas/SourceConfiguration"
         name:
@@ -1031,21 +1022,15 @@ components:
           items:
             $ref: "#/components/schemas/DestinationRead"
     # DESTINATION SPECIFICATION
-    DestinationSpecificationId:
-      type: string
-      format: uuid
     DestinationSpecification:
       description: The specification for what values are required to configure the destination.
       example: { user: { type: string } }
     DestinationSpecificationRead:
       type: object
       required:
-        - destinationSpecificationId
         - destinationId
         - specification
       properties:
-        destinationSpecificationId:
-          $ref: "#/components/schemas/DestinationSpecificationId"
         destinationId:
           $ref: "#/components/schemas/DestinationId"
         documentationUrl:
@@ -1070,13 +1055,13 @@ components:
       type: object
       required:
         - workspaceId
-        - destinationSpecificationId
+        - destinationId
         - connectionConfiguration
       properties:
         workspaceId:
           $ref: "#/components/schemas/WorkspaceId"
-        destinationSpecificationId:
-          $ref: "#/components/schemas/DestinationSpecificationId"
+        destinationId:
+          $ref: "#/components/schemas/DestinationId"
         connectionConfiguration:
           $ref: "#/components/schemas/DestinationConfiguration"
         name:
@@ -1100,7 +1085,6 @@ components:
         - destinationId
         - destinationImplementationId
         - workspaceId
-        - destinationSpecificationId
         - connectionConfiguration
         - name
         - destinationName
@@ -1111,8 +1095,6 @@ components:
           $ref: "#/components/schemas/DestinationImplementationId"
         workspaceId:
           $ref: "#/components/schemas/WorkspaceId"
-        destinationSpecificationId:
-          $ref: "#/components/schemas/DestinationSpecificationId"
         connectionConfiguration:
           $ref: "#/components/schemas/DestinationConfiguration"
         name:

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -125,8 +125,13 @@ paths:
     post:
       tags:
         - source
-      summary: List all of the sources that Airbyte supports
-      operationId: listSources
+      summary: Creates a source
+      operationId: createSource
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SourceCreate"
       responses:
         "200":
           description: Successful operation

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1551,4 +1551,4 @@ components:
     InvalidInput:
       description: Invalid Input
 security:
-  - { }
+  - {}


### PR DESCRIPTION
## What
* Attaches a default DockerRepository and imageVersion to source/destination
* keys SourceSpec/DestinationSpec on Source/Destination instead of having its own primary key
* Adds the ability to create sources, and update a source or destination's default imageVersion

in the future, specs will be retrieved based on a (source/dest ID, source/dest version) tuple or a dedicated ID representing that tuple. But right now since there is no explicit versioning registry, we always use the source/destination's default image version. 

If this looks good I'll go ahead and start editing the "inner" schemas behind the scenes