### PR TITLE
Bugfix: Upgrade test_containers version

### DIFF
--- a/airbyte-db/build.gradle
+++ b/airbyte-db/build.gradle
@@ -8,5 +8,5 @@ dependencies {
     api 'org.jooq:jooq:3.13.4'
     api 'org.postgresql:postgresql:42.2.16'
 
-    testImplementation "org.testcontainers:postgresql:1.14.3"
+    testImplementation "org.testcontainers:postgresql:1.15.0-rc2"
 }

--- a/airbyte-integrations/singer/postgres/destination/build.gradle
+++ b/airbyte-integrations/singer/postgres/destination/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     integrationTestImplementation 'org.apache.commons:commons-dbcp2:2.7.0'
     integrationTestImplementation 'com.fasterxml.jackson.core:jackson-databind'
     integrationTestImplementation 'org.apache.commons:commons-text:1.9'
-    integrationTestImplementation "org.testcontainers:postgresql:1.14.3"
+    integrationTestImplementation "org.testcontainers:postgresql:1.15.0-rc2"
     integrationTestImplementation "org.postgresql:postgresql:42.2.16"
 
     integrationTestImplementation project(':airbyte-config:models')

--- a/airbyte-integrations/singer/postgres/source/build.gradle
+++ b/airbyte-integrations/singer/postgres/source/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     integrationTestImplementation 'org.apache.commons:commons-dbcp2:2.7.0'
     integrationTestImplementation 'com.fasterxml.jackson.core:jackson-databind'
     integrationTestImplementation 'org.apache.commons:commons-text:1.9'
-    integrationTestImplementation "org.testcontainers:postgresql:1.14.3"
+    integrationTestImplementation "org.testcontainers:postgresql:1.15.0-rc2"
     integrationTestImplementation "org.postgresql:postgresql:42.2.16"
 
     integrationTestImplementation project(':airbyte-config:models')

--- a/airbyte-scheduler/build.gradle
+++ b/airbyte-scheduler/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(':airbyte-integrations')
     implementation project(':airbyte-workers')
 
-    testImplementation "org.testcontainers:postgresql:1.14.3"
+    testImplementation "org.testcontainers:postgresql:1.15.0-rc2"
 }
 
 application {

--- a/airbyte-test-utils/build.gradle
+++ b/airbyte-test-utils/build.gradle
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-    implementation 'org.testcontainers:postgresql:1.14.3'
+    implementation 'org.testcontainers:postgresql:1.15.0-rc2'
 }

--- a/airbyte-tests/build.gradle
+++ b/airbyte-tests/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     acceptanceTestsImplementation project(':airbyte-db')
     acceptanceTestsImplementation project(':airbyte-test-utils')
 
-    acceptanceTestsImplementation "org.testcontainers:postgresql:1.14.3"
+    acceptanceTestsImplementation "org.testcontainers:postgresql:1.15.0-rc2"
     acceptanceTestsImplementation "org.postgresql:postgresql:42.2.16"
     acceptanceTestsImplementation "com.fasterxml.jackson.core:jackson-databind"
 }

--- a/airbyte-workers/build.gradle
+++ b/airbyte-workers/build.gradle
@@ -16,6 +16,6 @@ dependencies {
 
     testImplementation "org.mockito:mockito-inline:2.13.0"
     testImplementation "org.testcontainers:testcontainers:1.14.3"
-    testImplementation "org.testcontainers:postgresql:1.14.3"
+    testImplementation "org.testcontainers:postgresql:1.15.0-rc2"
     testImplementation "org.postgresql:postgresql:42.2.16"
 }


### PR DESCRIPTION
## What
* The newest stable version of docker for mac triggers an issue in test containers (see [issue](https://github.com/testcontainers/testcontainers-java/issues/3166)). The test containers maintainers have a fix but it is currently only in `1.15.0-rc2`. This PR upgrades that for now. Without this fix, if you are on the newest version of docker for mac, you can't build our project.
* Issue to upgrade to `1.15` when it becomes stable so we don't stay on the RC forever: https://github.com/airbytehq/airbyte/issues/493

## Error
```
DefaultSchedulerPersistenceTest > initializationError FAILED
    org.testcontainers.containers.ContainerLaunchException: Container startup failed
        at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:330)
        at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:311)
        at io.airbyte.scheduler.persistence.DefaultSchedulerPersistenceTest.dbSetup(DefaultSchedulerPersistenceTest.java:150)

        Caused by:
        org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=postgres:13-alpine, imagePullPolicy=DefaultPullPolicy())
            at org.testcontainers.containers.GenericContainer.getDockerImageName(GenericContainer.java:1279)
            at org.testcontainers.containers.GenericContainer.logger(GenericContainer.java:613)
            at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:320)
            ... 2 more

            Caused by:
            java.lang.IllegalStateException: Can not connect to Ryuk at localhost:32774
                at org.testcontainers.utility.ResourceReaper.start(ResourceReaper.java:176)
                at org.testcontainers.DockerClientFactory.client(DockerClientFactory.java:168)
                at org.testcontainers.LazyDockerClient.getDockerClient(LazyDockerClient.java:14)
                at org.testcontainers.LazyDockerClient.listImagesCmd(LazyDockerClient.java:12)
                at org.testcontainers.images.LocalImagesCache.maybeInitCache(LocalImagesCache.java:68)
                at org.testcontainers.images.LocalImagesCache.get(LocalImagesCache.java:32)
                at org.testcontainers.images.AbstractImagePullPolicy.shouldPull(AbstractImagePullPolicy.java:18)
                at org.testcontainers.images.RemoteDockerImage.resolve(RemoteDockerImage.java:59)
                at org.testcontainers.images.RemoteDockerImage.resolve(RemoteDockerImage.java:26)
                at org.testcontainers.utility.LazyFuture.getResolvedValue(LazyFuture.java:20)
                at org.testcontainers.utility.LazyFuture.get(LazyFuture.java:27)
                at org.testcontainers.containers.GenericContainer.getDockerImageName(GenericContainer.java:1277)
                ... 4 more
```