### PR TITLE
Fix name conflict in gradle dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,6 @@ if (!env.containsKey('VERSION')) {
     throw new Exception('Version not specified in .env file...')
 }
 
-allprojects {
-    group = "io.airbyte.${rootProject.name}"
-    version = env.VERSION
-}
-
 def createLicenseWith = { licence ->
     def tmp = File.createTempFile('tmp', '.tmp')
     tmp.withWriter {
@@ -97,6 +92,12 @@ allprojects {
     tasks.withType(DockerBuildImage).all { task ->
         task.outputs.upToDateWhen { false }
     }
+}
+
+allprojects {
+    def sub = rootDir.relativePath(projectDir.parentFile).replace('/', '.')
+    group = "io.airbyte${sub.isEmpty() ? '' : ".$sub"}"
+    version = env.VERSION
 }
 
 // Java projects common configurations

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ allprojects {
 
 allprojects {
     def sub = rootDir.relativePath(projectDir.parentFile).replace('/', '.')
-    group = "io.airbyte${sub.isEmpty() ? '' : ".$sub"}"
+    group = "io.${rootProject.name}${sub.isEmpty() ? '' : ".$sub"}"
     version = env.VERSION
 }
 


### PR DESCRIPTION
## What
Gradle uses group and project name to import dependencies into project, not sub-project path.
It causes `project :airbyte-protocol:models` and  `project :airbyte-config:models` to conflicts when imported in the same project.

## How
The automatically generated group now takes sub>sub>sub directories into account.
`project :airbyte-protocol:models` was `io.airbyte.airbyte:models` now: `io.airbyte.airbyte-protocol:models`
`project :airbyte-config:models` was `io.airbyte.airbyte:models` now: `io.airbyte.airbyte-config:models`