### PR TITLE
use non-deprecated constructor for PostgreSQLContainer

### DIFF
--- a/airbyte-integrations/connectors/source-postgres-singer/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SingerPostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres-singer/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SingerPostgresSourceTest.java
@@ -92,7 +92,7 @@ public class SingerPostgresSourceTest {
 
   @BeforeEach
   public void init() throws IOException {
-    psqlDb = new PostgreSQLContainer();
+    psqlDb = new PostgreSQLContainer("postgres:13-alpine");
     psqlDb.start();
 
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forClasspathResource("init_ascii.sql"), psqlDb);
@@ -150,7 +150,7 @@ public class SingerPostgresSourceTest {
   public void testCanReadUtf8() throws IOException, InterruptedException, WorkerException {
     // force the db server to start with sql_ascii encoding to verify the tap can read UTF8 even when
     // default settings are in another encoding
-    PostgreSQLContainer db = (PostgreSQLContainer) new PostgreSQLContainer().withCommand("postgres -c client_encoding=sql_ascii");
+    PostgreSQLContainer db = (PostgreSQLContainer) new PostgreSQLContainer("postgres:13-alpine").withCommand("postgres -c client_encoding=sql_ascii");
     db.start();
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forClasspathResource("init_utf8.sql"), db);
 

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -104,8 +104,8 @@ public class AcceptanceTests {
     connectionIds = Lists.newArrayList();
     destinationImplIds = Lists.newArrayList();
 
-    sourcePsql = new PostgreSQLContainer();
-    targetPsql = new PostgreSQLContainer();
+    sourcePsql = new PostgreSQLContainer("postgres:13-alpine");
+    targetPsql = new PostgreSQLContainer("postgres:13-alpine");
     sourcePsql.start();
     targetPsql.start();
 


### PR DESCRIPTION
## What
* default `PostgreSQLContainer()` constructor is deprecated. you now have to pass in the image name. did this for all usages in our codebase.