### PR TITLE
add java version to gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,11 +92,6 @@ allprojects {
     tasks.withType(DockerBuildImage).all { task ->
         task.outputs.upToDateWhen { false }
     }
-
-    tasks.withType(JavaCompile) { 
-        sourceCompatibility = JavaVersion.VERSION_14
-        targetCompatibility = JavaVersion.VERSION_14 
-    }
 }
 
 allprojects {
@@ -114,6 +109,9 @@ subprojects {
 
     apply plugin: 'java'
     apply plugin: 'jacoco'
+
+    sourceCompatibility = JavaVersion.VERSION_14
+    targetCompatibility = JavaVersion.VERSION_14
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,11 @@ allprojects {
     tasks.withType(DockerBuildImage).all { task ->
         task.outputs.upToDateWhen { false }
     }
+
+    tasks.withType(JavaCompile) { 
+        sourceCompatibility = JavaVersion.VERSION_14
+        targetCompatibility = JavaVersion.VERSION_14 
+    }
 }
 
 allprojects {


### PR DESCRIPTION
I got easy to debug errors back when the fancy new case statements were added. Then I upgraded to Java 15 locally, which isn't supported by Gradle yet and got errors that were harder to debug. 

I'm setting the version to 14 which matches the docker images we're using so we can ensure everyone is working on the same version. 