### PR TITLE
add stream name support in AirbyteRecordMessage

### DIFF
--- a/airbyte-integrations/singer/base-singer/base_singer/singer_helpers.py
+++ b/airbyte-integrations/singer/base-singer/base_singer/singer_helpers.py
@@ -67,16 +67,15 @@ class SingerHelper:
                             if transformed_json.get('type') == "SCHEMA":
                                 pass
                             elif transformed_json.get('type') == "STATE":
-                                del transformed_json['type']
-                                out_record = AirbyteStateMessage(data=transformed_json)
+                                out_record = AirbyteStateMessage(data=transformed_json["value"])
                                 out_message = AirbyteMessage(type="STATE", state=out_record)
                                 yield transform(out_message)
                             else:
                                 # todo: remove type from record
                                 # todo: handle stream designation
                                 # todo: check that messages match the discovered schema
-                                stream_name = transformed_json['stream']
-                                out_record = AirbyteRecordMessage(stream=stream_name, data=transformed_json['record'], emitted_at=str(datetime.now()))
+                                stream_name = transformed_json["stream"]
+                                out_record = AirbyteRecordMessage(stream=stream_name, data=transformed_json["record"], emitted_at=str(datetime.now()))
                                 out_message = AirbyteMessage(type="RECORD", record=out_record)
                                 yield transform(out_message)
                     elif out_line:

--- a/airbyte-integrations/singer/base-singer/base_singer/singer_helpers.py
+++ b/airbyte-integrations/singer/base-singer/base_singer/singer_helpers.py
@@ -75,8 +75,10 @@ class SingerHelper:
                                 # todo: remove type from record
                                 # todo: handle stream designation
                                 # todo: check that messages match the discovered schema
+                                stream_name = transformed_json['stream']
                                 del transformed_json['type']
-                                out_record = AirbyteRecordMessage(data=transformed_json, emitted_at=str(datetime.now()))
+                                del transformed_json['stream']
+                                out_record = AirbyteRecordMessage(stream=stream_name, data=transformed_json['record'], emitted_at=str(datetime.now()))
                                 out_message = AirbyteMessage(type="RECORD", record=out_record)
                                 yield transform(out_message)
                     elif out_line:

--- a/airbyte-integrations/singer/base-singer/base_singer/singer_helpers.py
+++ b/airbyte-integrations/singer/base-singer/base_singer/singer_helpers.py
@@ -76,8 +76,6 @@ class SingerHelper:
                                 # todo: handle stream designation
                                 # todo: check that messages match the discovered schema
                                 stream_name = transformed_json['stream']
-                                del transformed_json['type']
-                                del transformed_json['stream']
                                 out_record = AirbyteRecordMessage(stream=stream_name, data=transformed_json['record'], emitted_at=str(datetime.now()))
                                 out_message = AirbyteMessage(type="RECORD", record=out_record)
                                 yield transform(out_message)

--- a/airbyte-integrations/singer/exchangeratesapi/source/src/test-integration/java/io/airbyte/integration_tests/sources/SingerExchangeRatesApiSourceTest.java
+++ b/airbyte-integrations/singer/exchangeratesapi/source/src/test-integration/java/io/airbyte/integration_tests/sources/SingerExchangeRatesApiSourceTest.java
@@ -24,14 +24,14 @@
 
 package io.airbyte.integration_tests.sources;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.workers.WorkerException;
 import io.airbyte.workers.process.DockerProcessBuilderFactory;
 import io.airbyte.workers.process.ProcessBuilderFactory;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -40,9 +40,8 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SingerExchangeRatesApiSourceTest {
 

--- a/airbyte-integrations/singer/exchangeratesapi/source/src/test-integration/java/io/airbyte/integration_tests/sources/SingerExchangeRatesApiSourceTest.java
+++ b/airbyte-integrations/singer/exchangeratesapi/source/src/test-integration/java/io/airbyte/integration_tests/sources/SingerExchangeRatesApiSourceTest.java
@@ -24,14 +24,14 @@
 
 package io.airbyte.integration_tests.sources;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.workers.WorkerException;
 import io.airbyte.workers.process.DockerProcessBuilderFactory;
 import io.airbyte.workers.process.ProcessBuilderFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -40,8 +40,9 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SingerExchangeRatesApiSourceTest {
 
@@ -107,7 +108,6 @@ public class SingerExchangeRatesApiSourceTest {
     assertTrue(Jsons.deserialize(record.get())
         .get("record")
         .get("data")
-        .get("record")
         .get("CAD").asDouble() > 0);
   }
 

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_message.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_message.yaml
@@ -29,9 +29,13 @@ definitions:
     type: object
     additionalProperties: false
     required:
+      - stream
       - data
       - emitted_at
     properties:
+      stream:
+        description: "the name of the stream for this record"
+        type: string
       data:
         description: "the record data"
         type: object


### PR DESCRIPTION
We need the stream name to know where to map the record to within the schema.

After this PR (in contrast to https://github.com/airbytehq/airbyte/pull/520#issuecomment-706248508) for config:
```
{
  "base": "AUD",
  "start_date": "2020-10-02"
}
```

We get:
```
{"type": "LOG", "log": {"level": "INFO", "message": "Replicating exchange rate data from 2020-10-02 using base AUD"}}
{"type": "RECORD", "record": {"stream": "exchange_rate", "data": {"CAD": 0.9530295627, "HKD": 5.5527730271, "ISK": 99.071585634, "PHP": 34.7324700709, "DKK": 4.5451991204, "HUF": 219.2035182018, "CZK": 16.5037869533, "GBP": 0.5538297093, "RON": 2.9755069631, "SEK": 6.3675787931, "IDR": 10655.5888101637, "INR": 52.5516125092, "BRL": 4.0336550208, "RUB": 56.2438920108, "HRK": 4.6188614708, "JPY": 75.3725873442, "THB": 22.5940630344, "CHF": 0.6590520401, "EUR": 0.610798925, "MYR": 2.9837527486, "BGN": 1.1946005375, "TRY": 5.5452602003, "CNY": 4.8653799169, "NOK": 6.6601514781, "NZD": 1.07952602, "ZAR": 11.8496213047, "USD": 0.716467139, "MXN": 15.6720009773, "SGD": 0.9765453213, "AUD": 1.0, "ILS": 2.4580991937, "KRW": 833.5450769607, "PLN": 2.7451746885, "date": "2020-10-02T00:00:00Z"}, "emitted_at": "2020-10-09 16:24:22.789844"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Replicating exchange rate data from 2020-10-03 using base AUD"}}
{"type": "RECORD", "record": {"stream": "exchange_rate", "data": {"CAD": 0.9532938519, "HKD": 5.5682886623, "ISK": 99.1513523414, "PHP": 34.7768484034, "DKK": 4.542401856, "HUF": 218.6763538678, "CZK": 16.5431345015, "GBP": 0.5544294523, "RON": 2.975761646, "SEK": 6.3889736858, "IDR": 10577.3307283717, "INR": 52.5593748092, "BRL": 4.0642285854, "RUB": 56.4963062458, "HRK": 4.6205507052, "JPY": 75.8593320716, "THB": 22.4958788693, "CHF": 0.6582208926, "EUR": 0.6105378839, "MYR": 2.9835154771, "BGN": 1.1940899933, "TRY": 5.5933817693, "CNY": 4.8921179559, "NOK": 6.6460101349, "NZD": 1.0808352158, "ZAR": 11.8106722022, "USD": 0.7184809817, "MXN": 15.4191953111, "SGD": 0.9772879907, "AUD": 1.0, "ILS": 2.4569876061, "KRW": 832.602722999, "PLN": 2.7461994017, "date": "2020-10-05T00:00:00Z"}, "emitted_at": "2020-10-09 16:24:23.065615"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Replicating exchange rate data from 2020-10-04 using base AUD"}}
{"type": "RECORD", "record": {"stream": "exchange_rate", "data": {"CAD": 0.9488829529, "HKD": 5.549538611, "ISK": 98.8343856241, "PHP": 34.6873482273, "DKK": 4.5172413793, "HUF": 218.3827100534, "CZK": 16.41270034, "GBP": 0.5528047596, "RON": 2.9601748422, "SEK": 6.3828314716, "IDR": 10551.195968917, "INR": 52.5567629917, "BRL": 3.9681277319, "RUB": 55.7139388052, "HRK": 4.5949490044, "JPY": 75.6313744536, "THB": 22.3379067508, "CHF": 0.6545046139, "EUR": 0.6070908208, "MYR": 2.9741986401, "BGN": 1.1873482273, "TRY": 5.5624696455, "CNY": 4.8634652744, "NOK": 6.593188441, "NZD": 1.0765541525, "ZAR": 11.8097377368, "USD": 0.7160636231, "MXN": 15.2762870325, "SGD": 0.9732880039, "AUD": 1.0, "ILS": 2.440080136, "KRW": 830.7977173385, "PLN": 2.724137931, "date": "2020-10-06T00:00:00Z"}, "emitted_at": "2020-10-09 16:24:23.144218"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Replicating exchange rate data from 2020-10-05 using base AUD"}}
{"type": "RECORD", "record": {"stream": "exchange_rate", "data": {"CAD": 0.9478787879, "HKD": 5.5284242424, "ISK": 98.6666666667, "PHP": 34.5327272727, "DKK": 4.5103636364, "HUF": 217.7272727273, "CZK": 16.4024242424, "GBP": 0.5540181818, "RON": 2.9544242424, "SEK": 6.3533333333, "IDR": 10520.9151515152, "INR": 52.2806060606, "BRL": 3.9665454545, "RUB": 55.7403030303, "HRK": 4.586969697, "JPY": 75.5939393939, "THB": 22.2775757576, "CHF": 0.6537575758, "EUR": 0.6060606061, "MYR": 2.9646666667, "BGN": 1.1853333333, "TRY": 5.6195151515, "CNY": 4.8444848485, "NOK": 6.625030303, "NZD": 1.0825454545, "ZAR": 11.8662424242, "USD": 0.7133333333, "MXN": 15.3096363636, "SGD": 0.9693939394, "AUD": 1.0, "ILS": 2.4269090909, "KRW": 825.8787878788, "PLN": 2.7189090909, "date": "2020-10-07T00:00:00Z"}, "emitted_at": "2020-10-09 16:24:23.240117"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Replicating exchange rate data from 2020-10-06 using base AUD"}}
{"type": "RECORD", "record": {"stream": "exchange_rate", "data": {"CAD": 0.9489677852, "HKD": 5.5527068997, "ISK": 99.1413434017, "PHP": 34.7140856221, "DKK": 4.532184398, "HUF": 217.6968515925, "CZK": 16.4983862128, "GBP": 0.5543815846, "RON": 2.9692466963, "SEK": 6.3618537239, "IDR": 10573.1685037452, "INR": 52.4852323245, "BRL": 4.0090128494, "RUB": 55.4579501857, "HRK": 4.6087327203, "JPY": 75.9332561963, "THB": 22.3640460386, "CHF": 0.6576335181, "EUR": 0.6089763108, "MYR": 2.9750928689, "BGN": 1.1910358687, "TRY": 5.6819925705, "CNY": 4.8653553377, "NOK": 6.6401558979, "NZD": 1.0873881006, "ZAR": 11.8747335729, "USD": 0.7164606297, "MXN": 15.3107606114, "SGD": 0.9730832471, "AUD": 1.0, "ILS": 2.4303635589, "KRW": 825.4552097923, "PLN": 2.7308324706, "date": "2020-10-08T00:00:00Z"}, "emitted_at": "2020-10-09 16:24:23.316307"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Replicating exchange rate data from 2020-10-07 using base AUD"}}
{"type": "RECORD", "record": {"stream": "exchange_rate", "data": {"CAD": 0.9473940872, "HKD": 5.5722035965, "ISK": 99.2380371838, "PHP": 34.7960987504, "DKK": 4.5365437367, "HUF": 217.1776897287, "CZK": 16.5254495581, "GBP": 0.5557269125, "RON": 2.9695214874, "SEK": 6.351722036, "IDR": 10569.954282231, "INR": 52.5440414508, "BRL": 4.0107284365, "RUB": 55.4351112466, "HRK": 4.6184090216, "JPY": 76.1658031088, "THB": 22.3279487961, "CHF": 0.6566900335, "EUR": 0.609570253, "MYR": 2.9751904907, "BGN": 1.1921975008, "TRY": 5.6860103627, "CNY": 4.8184699787, "NOK": 6.6213349589, "NZD": 1.0863151478, "ZAR": 11.8448643706, "USD": 0.7189881134, "MXN": 15.2900335264, "SGD": 0.9744590064, "AUD": 1.0, "ILS": 2.4296860713, "KRW": 823.2368180433, "PLN": 2.7249009448, "date": "2020-10-09T00:00:00Z"}, "emitted_at": "2020-10-09 16:24:23.459728"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Replicating exchange rate data from 2020-10-08 using base AUD"}}
{"type": "STATE", "state": {"data": {"start_date": "2020-10-09"}}}
{"type": "LOG", "log": {"level": "INFO", "message": "Replicating exchange rate data from 2020-10-09 using base AUD"}}
```

Which is (I believe) our desired final form, except for the lack of a schema message at the start.