### PR TITLE
bump timeout in spec worker

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultGetSpecWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultGetSpecWorker.java
@@ -56,8 +56,9 @@ public class DefaultGetSpecWorker implements GetSpecWorker {
       LineGobbler.gobble(process.getErrorStream(), LOGGER::error);
 
       try (InputStream stdout = process.getInputStream()) {
-        // retrieving spec should generally be instantaneous
-        WorkerUtils.gentleClose(process, 10, TimeUnit.SECONDS);
+        // retrieving spec should generally be instantaneous, but since docker images might not be pulled
+        // it could take a while longer depending on internet conditions as well.
+        WorkerUtils.gentleClose(process, 2, TimeUnit.MINUTES);
 
         if (process.exitValue() == 0) {
           String specString = new String(stdout.readAllBytes());


### PR DESCRIPTION
## What
10 seconds is too short of a timeout for the spec worker in the case that docker images need to be pulled, so this PR bumps the timeout to 2 minutes. 