### PR TITLE
(java) postgres destination

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -107,6 +108,10 @@ public class Jsons {
   @SuppressWarnings("unchecked")
   public static <T> T clone(final T object) {
     return (T) deserialize(serialize(object), object.getClass());
+  }
+
+  public static byte[] toBytes(JsonNode jsonNode) {
+    return serialize(jsonNode).getBytes(Charsets.UTF_8);
   }
 
 }

--- a/airbyte-commons/src/test/java/io/airbyte/commons/concurrency/GracefulShutdownHandlerTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/concurrency/GracefulShutdownHandlerTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class GracefulShutdownHandlerTest {

--- a/airbyte-commons/src/test/java/io/airbyte/commons/concurrency/GracefulShutdownHandlerTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/concurrency/GracefulShutdownHandlerTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class GracefulShutdownHandlerTest {

--- a/airbyte-commons/src/test/java/io/airbyte/commons/json/JsonsTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/json/JsonsTest.java
@@ -27,6 +27,7 @@ package io.airbyte.commons.json;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.util.List;
@@ -191,6 +192,12 @@ class JsonsTest {
     final JsonNode actualWithStringType = Jsons.deserialize("{\"test\":\"abc\", \"type\":\"object\"}");
     JsonSchemas.mutateTypeToArrayStandard(actualWithStringType);
     Assertions.assertEquals(expectedWithoutArrayType, actualWithStringType);
+  }
+
+  @Test
+  void testToBytes() {
+    final String jsonString = "{\"test\":\"abc\",\"type\":[\"object\"]}";
+    Assertions.assertArrayEquals(jsonString.getBytes(Charsets.UTF_8), Jsons.toBytes(Jsons.deserialize(jsonString)));
   }
 
   private static class ToClass {

--- a/airbyte-integrations/csv-destination/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationIntegrationTest.java
+++ b/airbyte-integrations/csv-destination/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationIntegrationTest.java
@@ -60,7 +60,7 @@ public class CsvDestinationIntegrationTest extends TestDestination {
   }
 
   @Override
-  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv) throws Exception {
+  protected List<JsonNode> recordRetriever(TestDestinationEnv testEnv, String streamName) throws Exception {
     final List<Path> list = Files.list(testEnv.getLocalRoot().resolve(RELATIVE_PATH)).collect(Collectors.toList());
     // todo (cgardens) - this should be here. add a retrieve tables abstract method to verify this.
     assertEquals(1, list.size());

--- a/airbyte-integrations/csv-destination/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationIntegrationTest.java
+++ b/airbyte-integrations/csv-destination/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationIntegrationTest.java
@@ -60,7 +60,7 @@ public class CsvDestinationIntegrationTest extends TestDestination {
   }
 
   @Override
-  protected List<JsonNode> recordRetriever(TestDestinationEnv testEnv, String streamName) throws Exception {
+  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv, String streamName) throws Exception {
     final List<Path> list = Files.list(testEnv.getLocalRoot().resolve(RELATIVE_PATH)).collect(Collectors.toList());
     // todo (cgardens) - this should be here. add a retrieve tables abstract method to verify this.
     assertEquals(1, list.size());

--- a/airbyte-integrations/integration-test-lib/src/main/java/io/airbyte/integrations/base/TestDestination.java
+++ b/airbyte-integrations/integration-test-lib/src/main/java/io/airbyte/integrations/base/TestDestination.java
@@ -100,7 +100,7 @@ public abstract class TestDestination {
    * @return All of the records in the destination at the time this method is invoked.
    * @throws Exception - can throw any exception, test framework will handle.
    */
-  protected abstract List<JsonNode> recordRetriever(TestDestinationEnv testEnv, String streamName) throws Exception;
+  protected abstract List<JsonNode> retrieveRecords(TestDestinationEnv testEnv, String streamName) throws Exception;
 
   /**
    * Function that performs any setup of external resources required for the test. e.g. instantiate a
@@ -181,7 +181,7 @@ public abstract class TestDestination {
         .map(record -> Jsons.deserialize(record, SingerMessage.class)).collect(Collectors.toList());
     runSync(messages, catalog);
 
-    assertSameMessages(messages, recordRetriever(testEnv, catalog.getStreams().get(0).getName()));
+    assertSameMessages(messages, retrieveRecords(testEnv, catalog.getStreams().get(0).getName()));
   }
 
   /**
@@ -202,7 +202,7 @@ public abstract class TestDestination {
             .put("NZD", 700)
             .build())));
     runSync(secondSyncMessages, catalog);
-    assertSameMessages(secondSyncMessages, recordRetriever(testEnv, catalog.getStreams().get(0).getName()));
+    assertSameMessages(secondSyncMessages, retrieveRecords(testEnv, catalog.getStreams().get(0).getName()));
   }
 
   private void runSync(List<SingerMessage> messages, Schema catalog) throws IOException, WorkerException {

--- a/airbyte-integrations/java-template-destination/readme.md
+++ b/airbyte-integrations/java-template-destination/readme.md
@@ -5,8 +5,8 @@
     1. e.g. 
         ```
        mkdir -p airbyte-integrations/bigquery-destination/src/main/java/io/airbyte/integrations/destination/bigquery
-       mv airbyte-integrations/java-template-destination/src/main/java/io/airbyte/integrations/destination/template/DestinationTemplate.java airbyte-integrations/bigquery-destination/src/main/java/io/airbyte/integrations/destination/bigquery/DestinationTemplate.java
-       rm -r airbyte-integrations/java-template-destination/src/main/java/io/airbyte/integrations/destination/template
+       mv airbyte-integrations/bigquery-destination/src/main/java/io/airbyte/integrations/destination/template/DestinationTemplate.java airbyte-integrations/bigquery-destination/src/main/java/io/airbyte/integrations/destination/bigquery/DestinationTemplate.java
+       rm -r airbyte-integrations/bigquery-destination/src/main/java/io/airbyte/integrations/destination/template
         ``` 
 1. Rename the template class to an appropriate name for your integration. 
     1. e.g. `DestinationTemplate.java` to `BigQueryDestination.java`.

--- a/airbyte-integrations/postgres-destination/.dockerignore
+++ b/airbyte-integrations/postgres-destination/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!build

--- a/airbyte-integrations/postgres-destination/Dockerfile
+++ b/airbyte-integrations/postgres-destination/Dockerfile
@@ -1,0 +1,10 @@
+FROM airbyte/base-java:dev
+
+WORKDIR /airbyte
+
+# fixme - replace java-template with the name of directory that this file is in.
+ENV APPLICATION postgres-destination
+
+COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
+
+RUN tar xf ${APPLICATION}.tar --strip-components=1

--- a/airbyte-integrations/postgres-destination/build.gradle
+++ b/airbyte-integrations/postgres-destination/build.gradle
@@ -1,0 +1,70 @@
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+plugins {
+    id 'com.bmuschko.docker-remote-api'
+    id 'application'
+}
+
+sourceSets {
+    integrationTest {
+        java {
+            srcDir 'src/test-integration/java'
+        }
+        resources {
+            srcDir 'src/test-integration/resources'
+        }
+    }
+}
+test.dependsOn('compileIntegrationTestJava')
+
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
+dependencies {
+    implementation project(':airbyte-config:models')
+    implementation project(':airbyte-db')
+    implementation project(':airbyte-integrations:base-java')
+    implementation project(':airbyte-queue')
+    implementation project(':airbyte-singer')
+
+    integrationTestImplementation project(':airbyte-integrations:integration-test-lib')
+    integrationTestImplementation project(':airbyte-integrations:postgres-destination')
+
+    testImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+    integrationTestImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+}
+
+application {
+    mainClass = 'io.airbyte.integrations.destination.postgres.PostgresDestination'
+}
+
+
+def image = 'airbyte/airbyte-postgres-destination:dev'
+
+task imageName {
+    doLast {
+        println "IMAGE $image"
+    }
+}
+
+task buildImage(type: DockerBuildImage) {
+    inputDir = projectDir
+    images.add(image)
+    dependsOn ':airbyte-integrations:base-java:buildImage'
+}
+
+task integrationTest(type: Test) {
+    testClassesDirs += sourceSets.integrationTest.output.classesDirs
+    classpath += sourceSets.integrationTest.runtimeClasspath
+
+    useJUnitPlatform()
+    testLogging() {
+        events "passed", "failed"
+        exceptionFormat "full"
+    }
+
+    mustRunAfter test
+    dependsOn(buildImage)
+}
+

--- a/airbyte-integrations/postgres-destination/build.gradle
+++ b/airbyte-integrations/postgres-destination/build.gradle
@@ -28,10 +28,10 @@ dependencies {
     implementation project(':airbyte-queue')
     implementation project(':airbyte-singer')
 
+    testImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+
     integrationTestImplementation project(':airbyte-integrations:integration-test-lib')
     integrationTestImplementation project(':airbyte-integrations:postgres-destination')
-
-    testImplementation "org.testcontainers:postgresql:1.15.0-rc2"
     integrationTestImplementation "org.testcontainers:postgresql:1.15.0-rc2"
 }
 

--- a/airbyte-integrations/postgres-destination/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
+++ b/airbyte-integrations/postgres-destination/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
@@ -30,11 +30,11 @@ import io.airbyte.commons.concurrency.GracefulShutdownHandler;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.CloseableQueue;
 import io.airbyte.commons.resources.MoreResources;
-import io.airbyte.config.DestinationConnectionSpecification;
+import io.airbyte.config.ConnectorSpecification;
 import io.airbyte.config.Schema;
 import io.airbyte.config.StandardCheckConnectionOutput;
 import io.airbyte.config.StandardCheckConnectionOutput.Status;
-import io.airbyte.config.StandardDiscoverSchemaOutput;
+import io.airbyte.config.StandardDiscoverCatalogOutput;
 import io.airbyte.config.Stream;
 import io.airbyte.db.DatabaseHelper;
 import io.airbyte.integrations.base.Destination;
@@ -64,10 +64,10 @@ public class PostgresDestination implements Destination {
   static final String COLUMN_NAME = "data";
 
   @Override
-  public DestinationConnectionSpecification spec() throws IOException {
+  public ConnectorSpecification spec() throws IOException {
     // return a jsonschema representation of the spec for the integration.
     final String resourceString = MoreResources.readResource("spec.json");
-    return Jsons.deserialize(resourceString, DestinationConnectionSpecification.class);
+    return Jsons.deserialize(resourceString, ConnectorSpecification.class);
   }
 
   @Override
@@ -89,7 +89,7 @@ public class PostgresDestination implements Destination {
   }
 
   @Override
-  public StandardDiscoverSchemaOutput discover(JsonNode config) {
+  public StandardDiscoverCatalogOutput discover(JsonNode config) {
     throw new RuntimeException("Not Implemented");
   }
 

--- a/airbyte-integrations/postgres-destination/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
+++ b/airbyte-integrations/postgres-destination/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
@@ -133,7 +133,7 @@ public class PostgresDestination implements Destination {
       final String tmpTableName = stream.getName() + "_" + Instant.now().toEpochMilli();
       DatabaseHelper.query(connectionPool, ctx -> ctx.execute(String.format(
           "CREATE TABLE \"%s\" ( \n"
-              + "\"ab_id\" VARCHAR PRIMARY KEY DEFAULT uuid_generate_v4(),\n"
+              + "\"ab_id\" VARCHAR PRIMARY KEY,\n"
               + "\"%s\" JSONB,\n"
               + "\"ab_inserted_at\" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP\n"
               + ");",

--- a/airbyte-integrations/postgres-destination/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
+++ b/airbyte-integrations/postgres-destination/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
@@ -1,0 +1,341 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.integrations.destination.postgres;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Charsets;
+import io.airbyte.commons.concurrency.GracefulShutdownHandler;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.lang.CloseableQueue;
+import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.config.DestinationConnectionSpecification;
+import io.airbyte.config.Schema;
+import io.airbyte.config.StandardCheckConnectionOutput;
+import io.airbyte.config.StandardCheckConnectionOutput.Status;
+import io.airbyte.config.StandardDiscoverSchemaOutput;
+import io.airbyte.config.Stream;
+import io.airbyte.db.DatabaseHelper;
+import io.airbyte.integrations.base.Destination;
+import io.airbyte.integrations.base.DestinationConsumer;
+import io.airbyte.integrations.base.FailureTrackingConsumer;
+import io.airbyte.integrations.base.IntegrationRunner;
+import io.airbyte.queue.BigQueue;
+import io.airbyte.singer.SingerMessage;
+import io.airbyte.singer.SingerMessage.Type;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PostgresDestination implements Destination {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PostgresDestination.class);
+  static final String COLUMN_NAME = "data";
+
+  @Override
+  public DestinationConnectionSpecification spec() throws IOException {
+    // return a jsonschema representation of the spec for the integration.
+    final String resourceString = MoreResources.readResource("spec.json");
+    return Jsons.deserialize(resourceString, DestinationConnectionSpecification.class);
+  }
+
+  @Override
+  public StandardCheckConnectionOutput check(JsonNode config) {
+    try {
+      final BasicDataSource connectionPool = getConnectionPool(config);
+      DatabaseHelper.query(connectionPool, ctx -> ctx.execute(
+          "SELECT *\n"
+              + "FROM pg_catalog.pg_tables\n"
+              + "WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema';"));
+
+      connectionPool.close();
+    } catch (Exception e) {
+      // todo (cgardens) - better error messaging for common cases. e.g. wrong password.
+      return new StandardCheckConnectionOutput().withStatus(Status.FAILURE).withMessage(e.getMessage());
+    }
+
+    return new StandardCheckConnectionOutput().withStatus(Status.SUCCESS);
+  }
+
+  @Override
+  public StandardDiscoverSchemaOutput discover(JsonNode config) {
+    throw new RuntimeException("Not Implemented");
+  }
+
+  /**
+   * Strategy:
+   * <p>
+   * 1. Create a temporary table for each stream
+   * </p>
+   * <p>
+   * 2. Accumulate records in a buffer. One buffer per stream.
+   * </p>
+   * <p>
+   * 3. As records accumulate write them in batch to the database. We set a minimum numbers of records
+   * before writing to avoid wasteful record-wise writes.
+   * </p>
+   * <p>
+   * 4. Once all records have been written to buffer, flush the buffer and write any remaining records
+   * to the database (regardless of how few are left).
+   * </p>
+   * <p>
+   * 5. In a single transaction, delete the target tables if they exist and rename the temp tables to
+   * the final table name.
+   * </p>
+   *
+   * @param config - integration-specific configuration object as json. e.g. { "username": "airbyte",
+   *        "password": "super secure" }
+   * @param schema - schema of the incoming messages.
+   * @return consumer that writes singer messages to the database.
+   * @throws Exception - anything could happen!
+   */
+  @Override
+  public DestinationConsumer<SingerMessage> write(JsonNode config, Schema schema) throws Exception {
+    // connect to db.
+    final BasicDataSource connectionPool = getConnectionPool(config);
+    Map<String, WriteConfig> writeBuffers = new HashMap<>();
+
+    // create tmp tables if not exist
+    for (final Stream stream : schema.getStreams()) {
+      final String tableName = stream.getName();
+      final String tmpTableName = stream.getName() + "_" + Instant.now().toEpochMilli();
+      DatabaseHelper.query(connectionPool, ctx -> ctx.execute(String.format(
+          "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";\n"
+              + "CREATE TABLE \"%s\" ( \n"
+              + "\"ab_id\" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),\n"
+              + "\"%s\" jsonb,\n"
+              + "\"ab_inserted_at\" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP\n"
+              + ");",
+          tmpTableName, COLUMN_NAME)));
+
+      final Path queueRoot = Files.createTempDirectory("queues");
+      final BigQueue writeBuffer = new BigQueue(queueRoot.resolve(stream.getName()), stream.getName());
+      writeBuffers.put(stream.getName(), new WriteConfig(tableName, tmpTableName, writeBuffer));
+    }
+
+    // write to tmp tables
+    // if success copy delete main table if exists. rename tmp tables to real tables.
+    return new RecordConsumer(connectionPool, writeBuffers, schema);
+  }
+
+  public static class RecordConsumer extends FailureTrackingConsumer<SingerMessage> implements DestinationConsumer<SingerMessage> {
+
+    private static final long THREAD_DELAY_MILLIS = 500L;
+
+    private static final long GRACEFUL_SHUTDOWN_MINUTES = 5L;
+    private static final int MIN_RECORDS = 500;
+    private static final int BATCH_SIZE = 500;
+
+    private final ScheduledExecutorService writerPool;
+    private final BasicDataSource connectionPool;
+    private final Map<String, WriteConfig> writeConfigs;
+    private final Schema schema;
+
+    public RecordConsumer(BasicDataSource connectionPool, Map<String, WriteConfig> writeConfigs, Schema schema) {
+      this.connectionPool = connectionPool;
+      this.writeConfigs = writeConfigs;
+      this.schema = schema;
+      this.writerPool = Executors.newSingleThreadScheduledExecutor();
+      // todo (cgardens) - how long? boh.
+      Runtime.getRuntime().addShutdownHook(new GracefulShutdownHandler(GRACEFUL_SHUTDOWN_MINUTES, TimeUnit.MINUTES, writerPool));
+
+      writerPool.scheduleWithFixedDelay(
+          () -> writeStreamsWithNRecords(MIN_RECORDS, BATCH_SIZE, writeConfigs, connectionPool),
+          THREAD_DELAY_MILLIS,
+          THREAD_DELAY_MILLIS,
+          TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Write records from buffer to postgres in batch.
+     *
+     * @param minRecords - the minimum number of records in the buffer before writing. helps avoid
+     *        wastefully writing one record at a time.
+     * @param batchSize - the maximum number of records to write in a single insert.
+     * @param writeBuffers - map of stream name to its respective buffer.
+     * @param connectionPool - connection to the db.
+     */
+    private static void writeStreamsWithNRecords(int minRecords,
+                                                 int batchSize,
+                                                 Map<String, WriteConfig> writeBuffers,
+                                                 BasicDataSource connectionPool) {
+      for (final Map.Entry<String, WriteConfig> entry : writeBuffers.entrySet()) {
+        final String tmpTableName = entry.getValue().getTmpTableName();
+        final CloseableQueue<byte[]> writeBuffer = entry.getValue().getWriteBuffer();
+        while (writeBuffer.size() > minRecords) {
+          try {
+            DatabaseHelper.query(connectionPool, ctx -> ctx.execute(buildWriteQuery(batchSize, writeBuffer, tmpTableName)));
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      }
+    }
+
+    // build the following query:
+    // INSERT INTO <tableName>(data)
+    // VALUES
+    // ({ "my": "data" }),
+    // ({ "my": "data" });
+    private static String buildWriteQuery(int batchSize, CloseableQueue<byte[]> writeBuffer, String tmpTableName) {
+      final StringBuilder query = new StringBuilder(String.format("INSERT INTO %s(%s)\n", tmpTableName, COLUMN_NAME))
+          .append("VALUES \n");
+      boolean firstRecordInQuery = true;
+      for (int i = 0; i < batchSize; i++) {
+        final byte[] record = writeBuffer.poll();
+        if (record == null) {
+          break;
+        }
+
+        // don't write comma before the first record.
+        if (firstRecordInQuery) {
+          firstRecordInQuery = false;
+        } else {
+          query.append(", \n");
+        }
+        query.append(String.format("('%s')", new String(record, Charsets.UTF_8)));
+      }
+      query.append(";");
+
+      return query.toString();
+    }
+
+    @Override
+    public void acceptTracked(SingerMessage singerMessage) {
+      // ignore other message types.
+      if (singerMessage.getType() == Type.RECORD) {
+        if (!writeConfigs.containsKey(singerMessage.getStream())) {
+          throw new IllegalArgumentException(
+              String.format("Message contained record from a stream that was not in the catalog. \ncatalog: %s , \nmessage: %s",
+                  Jsons.serialize(schema), Jsons.serialize(singerMessage)));
+        }
+
+        writeConfigs.get(singerMessage.getStream()).getWriteBuffer().offer(Jsons.toBytes(singerMessage.getRecord()));
+      }
+    }
+
+    @Override
+    public void close(boolean hasFailed) throws Exception {
+      if (hasFailed) {
+        LOGGER.error("executing on failed close procedure.");
+
+        // kill executor pool fast.
+        writerPool.shutdown();
+        writerPool.awaitTermination(1, TimeUnit.SECONDS);
+      } else {
+        LOGGER.error("executing on success close procedure.");
+
+        // shutdown executor pool with time to complete writes.
+        writerPool.shutdown();
+        writerPool.awaitTermination(GRACEFUL_SHUTDOWN_MINUTES, TimeUnit.MINUTES);
+
+        // write anything that is left in the buffers.
+        writeStreamsWithNRecords(0, 500, writeConfigs, connectionPool);
+
+        // delete tables if already exist. copy new tables into their place.
+        DatabaseHelper.transaction(connectionPool, ctx -> {
+          final StringBuilder query = new StringBuilder();
+          for (final WriteConfig writeConfig : writeConfigs.values()) {
+            query.append(String.format("DROP TABLE IF EXISTS %s;\n", writeConfig.getTableName()));
+
+            query.append(String.format("ALTER TABLE %s RENAME TO %s;\n", writeConfig.getTmpTableName(), writeConfig.getTableName()));
+          }
+          return ctx.execute(query.toString());
+        });
+
+      }
+
+      // close buffers.
+      for (final WriteConfig writeConfig : writeConfigs.values()) {
+        writeConfig.getWriteBuffer().close();
+      }
+      cleanupTmpTables(connectionPool, writeConfigs);
+    }
+
+    private static void cleanupTmpTables(BasicDataSource connectionPool, Map<String, WriteConfig> writeConfigs) {
+      for (WriteConfig writeConfig : writeConfigs.values()) {
+        try {
+          DatabaseHelper.query(connectionPool, ctx -> ctx.execute(String.format("DROP TABLE IF EXISTS %s;", writeConfig.getTmpTableName())));
+        } catch (SQLException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+
+  }
+
+  private static class WriteConfig {
+
+    private final String tableName;
+    private final String tmpTableName;
+    private final CloseableQueue<byte[]> writeBuffer;
+
+    private WriteConfig(String tableName, String tmpTableName, CloseableQueue<byte[]> writeBuffer) {
+      this.tableName = tableName;
+      this.tmpTableName = tmpTableName;
+      this.writeBuffer = writeBuffer;
+    }
+
+    public String getTableName() {
+      return tableName;
+    }
+
+    public String getTmpTableName() {
+      return tmpTableName;
+    }
+
+    public CloseableQueue<byte[]> getWriteBuffer() {
+      return writeBuffer;
+    }
+
+  }
+
+  private BasicDataSource getConnectionPool(JsonNode config) {
+    return DatabaseHelper.getConnectionPool(
+        config.get("username").asText(),
+        config.get("password").asText(),
+        String.format("jdbc:postgresql://%s:%s/%s",
+            config.get("host").asText(),
+            config.get("port").asText(),
+            config.get("database").asText()));
+  }
+
+  public static void main(String[] args) throws Exception {
+    final Destination destination = new PostgresDestination();
+    LOGGER.info("starting destination: {}", PostgresDestination.class);
+    new IntegrationRunner(destination).run(args);
+    LOGGER.info("completed destination: {}", PostgresDestination.class);
+  }
+
+}

--- a/airbyte-integrations/postgres-destination/src/main/resources/spec.json
+++ b/airbyte-integrations/postgres-destination/src/main/resources/spec.json
@@ -1,0 +1,44 @@
+{
+  "destinationId": "",
+  "destinationSpecificationId": "",
+  "documentationUrl": "<url to where the docs are>",
+  "specification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Postgres Destination Spec",
+    "type": "object",
+    "required": ["host", "port", "username", "database", "schema"],
+    "additionalProperties": false,
+    "properties": {
+      "host": {
+        "description": "Hostname of the database.",
+        "type": "string"
+      },
+      "port": {
+        "description": "Port of the database.",
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 65536,
+        "default": 5432,
+        "examples": ["5432"]
+      },
+      "username": {
+        "description": "Username to use to access the database.",
+        "type": "string"
+      },
+      "password": {
+        "description": "Password associated with the username.",
+        "type": "string"
+      },
+      "database": {
+        "description": "Name of the database.",
+        "type": "string"
+      },
+      "schema": {
+        "description": "Unless specifically configured, the usual value for this field is \"public\".",
+        "type": "string",
+        "examples": ["public"],
+        "default": "public"
+      }
+    }
+  }
+}

--- a/airbyte-integrations/postgres-destination/src/main/resources/spec.json
+++ b/airbyte-integrations/postgres-destination/src/main/resources/spec.json
@@ -1,8 +1,7 @@
 {
-  "destinationId": "",
-  "destinationSpecificationId": "",
-  "documentationUrl": "<url to where the docs are>",
-  "specification": {
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/postgres",
+  "changelogUrl": "https://docs.airbyte.io/integrations/destinations/postgres",
+  "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Postgres Destination Spec",
     "type": "object",

--- a/airbyte-integrations/postgres-destination/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
+++ b/airbyte-integrations/postgres-destination/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
@@ -1,0 +1,104 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.integrations.destination.postgres;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.db.DatabaseHelper;
+import io.airbyte.integrations.base.TestDestination;
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.jooq.Record;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class PostgresIntegrationTest extends TestDestination {
+
+  private PostgreSQLContainer<?> db;
+
+  @Override
+  protected String getImageName() {
+    return "airbyte/airbyte-postgres-destination:dev";
+  }
+
+  @Override
+  protected JsonNode getConfig() {
+    return Jsons.jsonNode(ImmutableMap.builder()
+        .put("host", db.getHost())
+        .put("username", db.getUsername())
+        .put("password", db.getPassword())
+        .put("schema", "public")
+        .put("port", db.getFirstMappedPort())
+        .put("database", db.getDatabaseName())
+        .build());
+  }
+
+  @Override
+  protected JsonNode getInvalidConfig() {
+    return Jsons.jsonNode(ImmutableMap.builder()
+        .put("host", db.getHost())
+        .put("username", db.getUsername())
+        .put("password", "wrong password")
+        .put("schema", "public")
+        .put("port", db.getFirstMappedPort())
+        .put("database", db.getDatabaseName())
+        .build());
+  }
+
+  @Override
+  protected List<JsonNode> recordRetriever(TestDestinationEnv env, String streamName) throws Exception {
+
+    return DatabaseHelper.query(
+        DatabaseHelper.getConnectionPool(db.getUsername(), db.getPassword(), db.getJdbcUrl()),
+        ctx -> ctx
+            .fetch(String.format("SELECT * FROM %s ORDER BY ab_inserted_at ASC;", streamName))
+            .stream()
+            .map(Record::intoMap)
+            .map(r -> r.entrySet().stream().map(e -> {
+              if (e.getValue().getClass().equals(org.jooq.JSONB.class)) {
+                return new AbstractMap.SimpleImmutableEntry<>(e.getKey(), e.getValue().toString());
+              }
+              return e;
+            }).collect(Collectors.toMap(Entry::getKey, Entry::getValue)))
+            .map(r -> (String) r.get(PostgresDestination.COLUMN_NAME))
+            .map(Jsons::deserialize)
+            .collect(Collectors.toList()));
+  }
+
+  @Override
+  protected void setup(TestDestinationEnv testEnv) {
+    db = new PostgreSQLContainer<>("postgres:13-alpine");
+    db.start();
+  }
+
+  @Override
+  protected void tearDown(TestDestinationEnv testEnv) {
+    db.stop();
+    db.close();
+  }
+
+}

--- a/airbyte-integrations/postgres-destination/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
+++ b/airbyte-integrations/postgres-destination/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
@@ -58,7 +58,7 @@ public class PostgresIntegrationTest extends TestDestination {
   }
 
   @Override
-  protected JsonNode getInvalidConfig() {
+  protected JsonNode getFailCheckConfig() {
     return Jsons.jsonNode(ImmutableMap.builder()
         .put("host", db.getHost())
         .put("username", db.getUsername())
@@ -70,7 +70,7 @@ public class PostgresIntegrationTest extends TestDestination {
   }
 
   @Override
-  protected List<JsonNode> recordRetriever(TestDestinationEnv env, String streamName) throws Exception {
+  protected List<JsonNode> retrieveRecords(TestDestinationEnv env, String streamName) throws Exception {
 
     return DatabaseHelper.query(
         DatabaseHelper.getConnectionPool(db.getUsername(), db.getPassword(), db.getJdbcUrl()),
@@ -79,6 +79,8 @@ public class PostgresIntegrationTest extends TestDestination {
             .stream()
             .map(Record::intoMap)
             .map(r -> r.entrySet().stream().map(e -> {
+              // jooq needs more configuration to handle jsonb natively. coerce it to a string for now and handle
+              // deserializing later.
               if (e.getValue().getClass().equals(org.jooq.JSONB.class)) {
                 return new AbstractMap.SimpleImmutableEntry<>(e.getKey(), e.getValue().toString());
               }

--- a/airbyte-integrations/postgres-destination/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
+++ b/airbyte-integrations/postgres-destination/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
@@ -1,0 +1,219 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.integrations.destination.postgres;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.config.DataType;
+import io.airbyte.config.DestinationConnectionSpecification;
+import io.airbyte.config.Field;
+import io.airbyte.config.Schema;
+import io.airbyte.config.StandardCheckConnectionOutput;
+import io.airbyte.config.StandardCheckConnectionOutput.Status;
+import io.airbyte.config.Stream;
+import io.airbyte.db.DatabaseHelper;
+import io.airbyte.integrations.base.DestinationConsumer;
+import io.airbyte.singer.SingerMessage;
+import io.airbyte.singer.SingerMessage.Type;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.jooq.Record;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+class PostgresDestinationTest {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  private static final String USERS_STREAM_NAME = "users";
+  private static final String TASKS_STREAM_NAME = "tasks";
+  private static final SingerMessage SINGER_MESSAGE_USERS1 = new SingerMessage().withType(Type.RECORD).withStream(USERS_STREAM_NAME)
+      .withRecord(objectMapper.createObjectNode().put("name", "john").put("id", "10"));
+  private static final SingerMessage SINGER_MESSAGE_USERS2 = new SingerMessage().withType(Type.RECORD).withStream(USERS_STREAM_NAME)
+      .withRecord(objectMapper.createObjectNode().put("name", "susan").put("id", "30"));
+  private static final SingerMessage SINGER_MESSAGE_TASKS1 = new SingerMessage().withType(Type.RECORD).withStream(TASKS_STREAM_NAME)
+      .withRecord(objectMapper.createObjectNode().put("goal", "announce the game."));
+  private static final SingerMessage SINGER_MESSAGE_TASKS2 = new SingerMessage().withType(Type.RECORD).withStream(TASKS_STREAM_NAME)
+      .withRecord(objectMapper.createObjectNode().put("goal", "ship some code."));
+  private static final SingerMessage SINGER_MESSAGE_RECORD = new SingerMessage().withType(Type.STATE)
+      .withValue(objectMapper.createObjectNode().put("checkpoint", "now!"));
+
+  private static final Schema CATALOG = new Schema().withStreams(Lists.newArrayList(
+      new Stream().withName(USERS_STREAM_NAME)
+          .withFields(Lists.newArrayList(new Field().withName("name").withDataType(DataType.STRING).withSelected(true),
+              new Field().withName("id").withDataType(DataType.STRING).withSelected(true))),
+      new Stream().withName(TASKS_STREAM_NAME)
+          .withFields(Lists.newArrayList(new Field().withName("goal").withDataType(DataType.STRING).withSelected(true)))));
+
+  private JsonNode config;
+
+  private PostgreSQLContainer<?> db;
+
+  @BeforeEach
+  void setup() {
+    db = new PostgreSQLContainer<>("postgres:13-alpine");
+    db.start();
+
+    config = Jsons.jsonNode(ImmutableMap.builder()
+        .put("host", db.getHost())
+        .put("username", db.getUsername())
+        .put("password", db.getPassword())
+        .put("schema", "public")
+        .put("port", db.getFirstMappedPort())
+        .put("database", db.getDatabaseName())
+        .build());
+  }
+
+  @AfterEach
+  void tearDown() {
+    db.stop();
+    db.close();
+  }
+
+  // todo - same test as csv destination
+  @Test
+  void testSpec() throws IOException {
+    final DestinationConnectionSpecification actual = new PostgresDestination().spec();
+    final String resourceString = MoreResources.readResource("spec.json");
+    final DestinationConnectionSpecification expected = Jsons.deserialize(resourceString, DestinationConnectionSpecification.class);
+
+    assertEquals(expected, actual);
+  }
+
+  // todo - same test as csv destination
+  @Test
+  void testCheckSuccess() {
+    final StandardCheckConnectionOutput actual = new PostgresDestination().check(config);
+    final StandardCheckConnectionOutput expected = new StandardCheckConnectionOutput().withStatus(Status.SUCCESS);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testCheckFailure() {
+    ((ObjectNode) config).put("password", "fake");
+    final StandardCheckConnectionOutput actual = new PostgresDestination().check(config);
+    final StandardCheckConnectionOutput expected = new StandardCheckConnectionOutput().withStatus(Status.FAILURE)
+        .withMessage("Cannot create PoolableConnectionFactory (FATAL: password authentication failed for user \"test\")");
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testWriteSuccess() throws Exception {
+    final DestinationConsumer<SingerMessage> consumer = new PostgresDestination().write(config, CATALOG);
+
+    consumer.accept(SINGER_MESSAGE_USERS1);
+    consumer.accept(SINGER_MESSAGE_TASKS1);
+    consumer.accept(SINGER_MESSAGE_USERS2);
+    consumer.accept(SINGER_MESSAGE_TASKS2);
+    consumer.accept(SINGER_MESSAGE_RECORD);
+    consumer.close();
+
+    Set<JsonNode> usersActual = recordRetriever(USERS_STREAM_NAME);
+    final Set<JsonNode> expectedUsersJson = Sets.newHashSet(SINGER_MESSAGE_USERS1.getRecord(), SINGER_MESSAGE_USERS2.getRecord());
+    assertEquals(expectedUsersJson, usersActual);
+
+    Set<JsonNode> tasksActual = recordRetriever(TASKS_STREAM_NAME);
+    final Set<JsonNode> expectedTasksJson = Sets.newHashSet(SINGER_MESSAGE_TASKS1.getRecord(), SINGER_MESSAGE_TASKS2.getRecord());
+    assertEquals(expectedTasksJson, tasksActual);
+
+    assertTmpTablesNotPresent(CATALOG.getStreams().stream().map(Stream::getName).collect(Collectors.toList()));
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test
+  void testWriteFailure() throws Exception {
+    // hack to force an exception to be thrown from within the consumer.
+    final SingerMessage spiedMessage = spy(SINGER_MESSAGE_USERS1);
+    doThrow(new RuntimeException()).when(spiedMessage).getStream();
+
+    final DestinationConsumer<SingerMessage> consumer = spy(new PostgresDestination().write(config, CATALOG));
+
+    assertThrows(RuntimeException.class, () -> consumer.accept(spiedMessage));
+    consumer.accept(SINGER_MESSAGE_USERS2);
+    consumer.close();
+
+    final List<String> tableNames = CATALOG.getStreams().stream().map(Stream::getName).collect(toList());
+    assertTmpTablesNotPresent(CATALOG.getStreams().stream().map(Stream::getName).collect(Collectors.toList()));
+    // assert that no tables were created.
+    assertTrue(fetchNamesOfTablesInDb().stream().noneMatch(tableName -> tableNames.stream().anyMatch(tableName::startsWith)));
+  }
+
+  private List<String> fetchNamesOfTablesInDb() throws SQLException {
+    return DatabaseHelper.query(getDatabasePool(),
+        ctx -> ctx.fetch("SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_type='BASE TABLE';"))
+        .stream()
+        .map(record -> (String) record.get("table_name")).collect(Collectors.toList());
+  }
+
+  private void assertTmpTablesNotPresent(List<String> tableNames) throws SQLException {
+    Set<String> tmpTableNamePrefixes = tableNames.stream().map(name -> name + "_").collect(Collectors.toSet());
+    assertTrue(fetchNamesOfTablesInDb().stream().noneMatch(tableName -> tmpTableNamePrefixes.stream().anyMatch(tableName::startsWith)));
+  }
+
+  private BasicDataSource getDatabasePool() {
+    return DatabaseHelper.getConnectionPool(db.getUsername(), db.getPassword(), db.getJdbcUrl());
+  }
+
+  private Set<JsonNode> recordRetriever(String streamName) throws Exception {
+
+    return DatabaseHelper.query(
+        getDatabasePool(),
+        ctx -> ctx
+            .fetch(String.format("SELECT * FROM %s ORDER BY ab_inserted_at ASC;", streamName))
+            .stream()
+            .map(Record::intoMap)
+            .map(r -> r.entrySet().stream().map(e -> {
+              if (e.getValue().getClass().equals(org.jooq.JSONB.class)) {
+                return new AbstractMap.SimpleImmutableEntry<>(e.getKey(), e.getValue().toString());
+              }
+              return e;
+            }).collect(Collectors.toMap(Entry::getKey, Entry::getValue)))
+            .map(r -> (String) r.get(PostgresDestination.COLUMN_NAME))
+            .map(Jsons::deserialize)
+            .collect(Collectors.toSet()));
+  }
+
+}

--- a/airbyte-integrations/postgres-destination/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
+++ b/airbyte-integrations/postgres-destination/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
@@ -39,8 +39,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.config.ConnectorSpecification;
 import io.airbyte.config.DataType;
-import io.airbyte.config.DestinationConnectionSpecification;
 import io.airbyte.config.Field;
 import io.airbyte.config.Schema;
 import io.airbyte.config.StandardCheckConnectionOutput;
@@ -116,9 +116,9 @@ class PostgresDestinationTest {
   // todo - same test as csv destination
   @Test
   void testSpec() throws IOException {
-    final DestinationConnectionSpecification actual = new PostgresDestination().spec();
+    final ConnectorSpecification actual = new PostgresDestination().spec();
     final String resourceString = MoreResources.readResource("spec.json");
-    final DestinationConnectionSpecification expected = Jsons.deserialize(resourceString, DestinationConnectionSpecification.class);
+    final ConnectorSpecification expected = Jsons.deserialize(resourceString, ConnectorSpecification.class);
 
     assertEquals(expected, actual);
   }

--- a/airbyte-integrations/postgres-destination/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
+++ b/airbyte-integrations/postgres-destination/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
@@ -207,6 +207,8 @@ class PostgresDestinationTest {
             .map(Record::intoMap)
             .map(r -> r.entrySet().stream().map(e -> {
               if (e.getValue().getClass().equals(org.jooq.JSONB.class)) {
+                // jooq needs more configuration to handle jsonb natively. coerce it to a string for now and handle
+                // deserializing later.
                 return new AbstractMap.SimpleImmutableEntry<>(e.getKey(), e.getValue().toString());
               }
               return e;

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/SchedulerApp.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/SchedulerApp.java
@@ -58,6 +58,7 @@ public class SchedulerApp {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerApp.class);
 
+  private static final long GRACEFUL_SHUTDOWN_SECONDS = 30;
   private static final int MAX_WORKERS = 4;
   private static final long JOB_SUBMITTER_DELAY_MILLIS = 5000L;
   private static final ThreadFactory THREAD_FACTORY = new ThreadFactoryBuilder().setNameFormat("worker-%d").build();
@@ -100,7 +101,7 @@ public class SchedulerApp {
         JOB_SUBMITTER_DELAY_MILLIS,
         TimeUnit.MILLISECONDS);
 
-    Runtime.getRuntime().addShutdownHook(new GracefulShutdownHandler(Duration.ofSeconds(30), workerThreadPool, scheduledPool));
+    Runtime.getRuntime().addShutdownHook(new GracefulShutdownHandler(Duration.ofSeconds(GRACEFUL_SHUTDOWN_SECONDS), workerThreadPool, scheduledPool));
   }
 
   public static void main(String[] args) {


### PR DESCRIPTION
## What
* Move `GracefulShutdownHandler` for `ExecutorService`s to commons.
* Remove tests that rely on ordering from the sync test suite.
* Add `transaction` method to DatabaseHelper. 
* Oh yeah, and add the java impl of the postgres-destination. 😉 

closes https://github.com/airbytehq/airbyte/issues/540


## First Impressions
* It really didn't feel too hard to write this integration. The simplifying assumptions that we are doing full refresh and writing a singe object column makes life much easier. Feeling optimistic that we can bang out a couple other warehouses quickly. Having the test suite to run again made developing go faster too. The most time-consumnig part was writing the buffering logic (presented in separate PR)

## Checklist
- [ ] *Add / update docs*
- [ ] *Manual testing with the app*

## Recommended reading order
I recommend focusing on the postgres-destination code and then the little updates to commons and utility methods will make sense from there. 
1. `PostgresDestination.java`, `PostgresDestinationTest.java`, `PostgresDestinationIntegrationTest.java`
1. the rest
