### PR TITLE
Eagerly validate created/updated docker images

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -104,11 +104,11 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
 
   public ConfigurationApi(final ConfigRepository configRepository, final SchedulerPersistence schedulerPersistence) {
     final JsonSchemaValidator schemaValidator = new JsonSchemaValidator();
-    workspacesHandler = new WorkspacesHandler(configRepository);
-    sourcesHandler = new SourcesHandler(configRepository);
-    connectionsHandler = new ConnectionsHandler(configRepository);
-    destinationsHandler = new DestinationsHandler(configRepository);
     schedulerHandler = new SchedulerHandler(configRepository, schedulerPersistence);
+    workspacesHandler = new WorkspacesHandler(configRepository);
+    sourcesHandler = new SourcesHandler(configRepository, schedulerHandler);
+    connectionsHandler = new ConnectionsHandler(configRepository);
+    destinationsHandler = new DestinationsHandler(configRepository, schedulerHandler);
     destinationImplementationsHandler =
         new DestinationImplementationsHandler(configRepository, schemaValidator, schedulerHandler, connectionsHandler);
     sourceImplementationsHandler = new SourceImplementationsHandler(configRepository, schemaValidator, schedulerHandler, connectionsHandler);

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -82,10 +82,9 @@ import io.airbyte.server.handlers.WebBackendConnectionsHandler;
 import io.airbyte.server.handlers.WebBackendDestinationImplementationHandler;
 import io.airbyte.server.handlers.WebBackendSourceImplementationHandler;
 import io.airbyte.server.handlers.WorkspacesHandler;
+import io.airbyte.server.validators.DockerImageValidator;
 import java.io.IOException;
 import javax.validation.Valid;
-
-import io.airbyte.server.validators.DockerImageValidator;
 import org.eclipse.jetty.http.HttpStatus;
 
 @javax.ws.rs.Path("/v1")

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -84,6 +84,8 @@ import io.airbyte.server.handlers.WebBackendSourceImplementationHandler;
 import io.airbyte.server.handlers.WorkspacesHandler;
 import java.io.IOException;
 import javax.validation.Valid;
+
+import io.airbyte.server.validators.DockerImageValidator;
 import org.eclipse.jetty.http.HttpStatus;
 
 @javax.ws.rs.Path("/v1")
@@ -106,9 +108,10 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
     final JsonSchemaValidator schemaValidator = new JsonSchemaValidator();
     schedulerHandler = new SchedulerHandler(configRepository, schedulerPersistence);
     workspacesHandler = new WorkspacesHandler(configRepository);
-    sourcesHandler = new SourcesHandler(configRepository, schedulerHandler);
+    DockerImageValidator dockerImageValidator = new DockerImageValidator(schedulerHandler);
+    sourcesHandler = new SourcesHandler(configRepository, dockerImageValidator);
     connectionsHandler = new ConnectionsHandler(configRepository);
-    destinationsHandler = new DestinationsHandler(configRepository, schedulerHandler);
+    destinationsHandler = new DestinationsHandler(configRepository, dockerImageValidator);
     destinationImplementationsHandler =
         new DestinationImplementationsHandler(configRepository, schemaValidator, schedulerHandler, connectionsHandler);
     sourceImplementationsHandler = new SourceImplementationsHandler(configRepository, schemaValidator, schedulerHandler, connectionsHandler);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationsHandler.java
@@ -28,14 +28,11 @@ import io.airbyte.api.model.DestinationIdRequestBody;
 import io.airbyte.api.model.DestinationRead;
 import io.airbyte.api.model.DestinationReadList;
 import io.airbyte.api.model.DestinationUpdate;
-import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.JsonValidationException;
 import io.airbyte.config.StandardDestination;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.server.errors.KnownException;
 import io.airbyte.server.validators.DockerImageValidator;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -94,4 +91,5 @@ public class DestinationsHandler {
       throw new RuntimeException(e);
     }
   }
+
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationsHandler.java
@@ -34,12 +34,10 @@ import io.airbyte.config.StandardDestination;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.server.errors.KnownException;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class DestinationsHandler {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationsHandler.java
@@ -70,7 +70,7 @@ public class DestinationsHandler {
   public DestinationRead updateDestination(DestinationUpdate destinationUpdate) throws ConfigNotFoundException, IOException, JsonValidationException {
     StandardDestination currentDestination = configRepository.getStandardDestination(destinationUpdate.getDestinationId());
     assertDockerImageIsValidIntegration(currentDestination.getDockerRepository(), destinationUpdate.getDockerImageTag());
-    
+
     StandardDestination newDestination = new StandardDestination()
         .withDestinationId(currentDestination.getDestinationId())
         .withDockerImageTag(destinationUpdate.getDockerImageTag())

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -167,7 +167,7 @@ public class SchedulerHandler {
         .sourceId(sourceId);
   }
 
-  ConnectorSpecification getConnectorSpecification(String imageName) throws IOException {
+  public ConnectorSpecification getConnectorSpecification(String imageName) throws IOException {
     final long jobId = schedulerPersistence.createGetSpecJob(imageName);
     LOGGER.debug("getSourceSpec jobId = {}", jobId);
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourcesHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourcesHandler.java
@@ -35,9 +35,6 @@ import io.airbyte.config.StandardSource;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.server.errors.KnownException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -45,6 +42,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SourcesHandler {
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourcesHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourcesHandler.java
@@ -29,12 +29,11 @@ import io.airbyte.api.model.SourceIdRequestBody;
 import io.airbyte.api.model.SourceRead;
 import io.airbyte.api.model.SourceReadList;
 import io.airbyte.api.model.SourceUpdate;
-import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.JsonValidationException;
 import io.airbyte.config.StandardSource;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.server.errors.KnownException;
+import io.airbyte.server.validators.DockerImageValidator;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -42,8 +41,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import io.airbyte.server.validators.DockerImageValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourcesHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourcesHandler.java
@@ -35,19 +35,16 @@ import io.airbyte.config.StandardSource;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.server.errors.KnownException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.swing.*;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SourcesHandler {
 

--- a/airbyte-server/src/main/java/io/airbyte/server/validators/DockerImageValidator.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/validators/DockerImageValidator.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.airbyte.server.validators;
 
 import io.airbyte.commons.docker.DockerUtils;
@@ -8,12 +32,13 @@ public class DockerImageValidator {
 
   private SchedulerHandler schedulerHandler;
 
-  public DockerImageValidator (SchedulerHandler schedulerHandler){
+  public DockerImageValidator(SchedulerHandler schedulerHandler) {
     this.schedulerHandler = schedulerHandler;
   }
 
   /**
-   * @throws KnownException if it is unable to verify that the input image is a valid connector definition image.
+   * @throws KnownException if it is unable to verify that the input image is a valid connector
+   *         definition image.
    */
   public void assertValidIntegrationImage(String dockerRepository, String imageTag) throws KnownException {
     // Validates that the docker image exists and can generate a compatible spec by running a getSpec
@@ -25,4 +50,5 @@ public class DockerImageValidator {
       throw new KnownException(422, "Encountered an issue while validating input docker image: " + e.getMessage());
     }
   }
+
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/validators/DockerImageValidator.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/validators/DockerImageValidator.java
@@ -1,0 +1,28 @@
+package io.airbyte.server.validators;
+
+import io.airbyte.commons.docker.DockerUtils;
+import io.airbyte.server.errors.KnownException;
+import io.airbyte.server.handlers.SchedulerHandler;
+
+public class DockerImageValidator {
+
+  private SchedulerHandler schedulerHandler;
+
+  public DockerImageValidator (SchedulerHandler schedulerHandler){
+    this.schedulerHandler = schedulerHandler;
+  }
+
+  /**
+   * @throws KnownException if it is unable to verify that the input image is a valid connector definition image.
+   */
+  public void assertValidIntegrationImage(String dockerRepository, String imageTag) throws KnownException {
+    // Validates that the docker image exists and can generate a compatible spec by running a getSpec
+    // job on the provided image.
+    String imageName = DockerUtils.getTaggedImageName(dockerRepository, imageTag);
+    try {
+      schedulerHandler.getConnectorSpecification(imageName);
+    } catch (Exception e) {
+      throw new KnownException(422, "Encountered an issue while validating input docker image: " + e.getMessage());
+    }
+  }
+}

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationsHandlerTest.java
@@ -26,9 +26,6 @@ package io.airbyte.server.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,20 +35,15 @@ import io.airbyte.api.model.DestinationIdRequestBody;
 import io.airbyte.api.model.DestinationRead;
 import io.airbyte.api.model.DestinationReadList;
 import io.airbyte.api.model.DestinationUpdate;
-import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.JsonValidationException;
-import io.airbyte.config.ConnectorSpecification;
 import io.airbyte.config.StandardDestination;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
-
+import io.airbyte.server.validators.DockerImageValidator;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.UUID;
-
-import io.airbyte.server.errors.KnownException;
-import io.airbyte.server.validators.DockerImageValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -144,4 +136,5 @@ class DestinationsHandlerTest {
     assertEquals(newDockerImageTag, sourceRead.getDockerImageTag());
     verify(dockerImageValidator).assertValidIntegrationImage(currentRepo, newDockerImageTag);
   }
+
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
@@ -124,6 +124,7 @@ class SchedulerHandlerTest {
     SourceIdRequestBody sourceIdRequestBody = new SourceIdRequestBody().sourceId(UUID.randomUUID());
     when(configRepository.getStandardSource(sourceIdRequestBody.getSourceId()))
         .thenReturn(new StandardSource()
+            .withName("name")
             .withDockerRepository(SOURCE_DOCKER_REPO)
             .withDockerImageTag(SOURCE_DOCKER_TAG)
             .withSourceId(sourceIdRequestBody.getSourceId()));
@@ -153,6 +154,7 @@ class SchedulerHandlerTest {
 
     when(configRepository.getStandardDestination(destinationIdRequestBody.getDestinationId()))
         .thenReturn(new StandardDestination()
+            .withName("name")
             .withDockerRepository(DESTINATION_DOCKER_REPO)
             .withDockerImageTag(DESTINATION_DOCKER_TAG)
             .withDestinationId(destinationIdRequestBody.getDestinationId()));

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
@@ -178,6 +178,25 @@ class SchedulerHandlerTest {
   }
 
   @Test
+  public void testGetConnectorSpec() throws IOException, URISyntaxException {
+    when(schedulerPersistence.createGetSpecJob(SOURCE_DOCKER_IMAGE)).thenReturn(JOB_ID);
+    when(schedulerPersistence.getJob(JOB_ID)).thenReturn(inProgressJob).thenReturn(completedJob);
+    StandardGetSpecOutput specOutput = new StandardGetSpecOutput().withSpecification(
+        new ConnectorSpecification()
+            .withDocumentationUrl(new URI("https://google.com"))
+            .withChangelogUrl(new URI("https://google.com"))
+            .withConnectionSpecification(Jsons.jsonNode(new HashMap<>())));
+    JobOutput jobOutput = mock(JobOutput.class);
+    when(jobOutput.getGetSpec()).thenReturn(specOutput);
+    when(completedJob.getOutput()).thenReturn(Optional.of(jobOutput));
+
+    schedulerHandler.getConnectorSpecification(SOURCE_DOCKER_IMAGE);
+
+    verify(schedulerPersistence).createGetSpecJob(SOURCE_DOCKER_IMAGE);
+    verify(schedulerPersistence, atLeast(2)).getJob(JOB_ID);
+  }
+
+  @Test
   void testCheckDestinationImplementationConnection() throws IOException, JsonValidationException, ConfigNotFoundException {
     DestinationConnectionImplementation destinationImpl = DestinationImplementationHelpers.generateDestinationImplementation(UUID.randomUUID());
     final DestinationImplementationIdRequestBody request =

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourcesHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourcesHandlerTest.java
@@ -36,7 +36,6 @@ import io.airbyte.api.model.SourceIdRequestBody;
 import io.airbyte.api.model.SourceRead;
 import io.airbyte.api.model.SourceReadList;
 import io.airbyte.api.model.SourceUpdate;
-import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.JsonValidationException;
 import io.airbyte.config.StandardSource;
 import io.airbyte.config.persistence.ConfigNotFoundException;

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourcesHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourcesHandlerTest.java
@@ -26,8 +26,6 @@ package io.airbyte.server.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,15 +41,12 @@ import io.airbyte.commons.json.JsonValidationException;
 import io.airbyte.config.StandardSource;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
-
+import io.airbyte.server.validators.DockerImageValidator;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.UUID;
 import java.util.function.Supplier;
-
-import io.airbyte.server.errors.KnownException;
-import io.airbyte.server.validators.DockerImageValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -156,14 +151,13 @@ class SourcesHandlerTest {
   void testUpdateSource() throws ConfigNotFoundException, IOException, JsonValidationException {
     when(configRepository.getStandardSource(source.getSourceId())).thenReturn(source);
     final String newDockerImageTag = "averydifferenttag";
-    final String newDockerImage = DockerUtils.getTaggedImageName(source.getDockerRepository(), newDockerImageTag);
     final String currentTag = sourceHandler.getSource(new SourceIdRequestBody().sourceId(source.getSourceId())).getDockerImageTag();
     assertNotEquals(newDockerImageTag, currentTag);
 
     SourceRead sourceRead = sourceHandler.updateSource(new SourceUpdate().sourceId(source.getSourceId()).dockerImageTag(newDockerImageTag));
 
     assertEquals(newDockerImageTag, sourceRead.getDockerImageTag());
-    verify(dockerImageValidator).assertValidIntegrationImage(source.getDockerRepository(), source.getDockerImageTag());
+    verify(dockerImageValidator).assertValidIntegrationImage(source.getDockerRepository(), newDockerImageTag);
   }
 
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/validators/DockerImageValidatorTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/validators/DockerImageValidatorTest.java
@@ -1,30 +1,53 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.airbyte.server.validators;
-
-import io.airbyte.commons.docker.DockerUtils;
-import io.airbyte.commons.json.Jsons;
-import io.airbyte.config.ConnectorSpecification;
-import io.airbyte.server.errors.KnownException;
-import io.airbyte.server.handlers.SchedulerHandler;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.airbyte.commons.docker.DockerUtils;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ConnectorSpecification;
+import io.airbyte.server.errors.KnownException;
+import io.airbyte.server.handlers.SchedulerHandler;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 class DockerImageValidatorTest {
+
   private SchedulerHandler schedulerHandler;
   private DockerImageValidator validator;
 
   @BeforeEach
-  public void init(){
+  public void init() {
     schedulerHandler = mock(SchedulerHandler.class);
     validator = new DockerImageValidator(schedulerHandler);
   }
@@ -51,4 +74,5 @@ class DockerImageValidatorTest {
 
     assertThrows(KnownException.class, () -> validator.assertValidIntegrationImage(repo, tag));
   }
+
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/validators/DockerImageValidatorTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/validators/DockerImageValidatorTest.java
@@ -1,0 +1,54 @@
+package io.airbyte.server.validators;
+
+import io.airbyte.commons.docker.DockerUtils;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ConnectorSpecification;
+import io.airbyte.server.errors.KnownException;
+import io.airbyte.server.handlers.SchedulerHandler;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DockerImageValidatorTest {
+  private SchedulerHandler schedulerHandler;
+  private DockerImageValidator validator;
+
+  @BeforeEach
+  public void init(){
+    schedulerHandler = mock(SchedulerHandler.class);
+    validator = new DockerImageValidator(schedulerHandler);
+  }
+
+  @Test
+  public void testAssertImageIsValid() throws URISyntaxException, IOException {
+    final String repo = "repo";
+    final String tag = "tag";
+    final String imageName = DockerUtils.getTaggedImageName(repo, tag);
+    when(schedulerHandler.getConnectorSpecification(imageName)).thenReturn(new ConnectorSpecification()
+        .withDocumentationUrl(new URI("https://google.com"))
+        .withChangelogUrl(new URI("https://google.com"))
+        .withConnectionSpecification(Jsons.jsonNode(new HashMap<>())));
+
+    assertDoesNotThrow(() -> validator.assertValidIntegrationImage(repo, tag));
+  }
+
+  @Test
+  public void testThrowsOnInvalidImage() throws IOException {
+    final String repo = "repo";
+    final String tag = "tag";
+    final String imageName = DockerUtils.getTaggedImageName(repo, tag);
+    when(schedulerHandler.getConnectorSpecification(imageName)).thenThrow(new IllegalArgumentException());
+
+    assertThrows(KnownException.class, () -> validator.assertValidIntegrationImage(repo, tag));
+  }
+}


### PR DESCRIPTION
## What
Adds eager validation of docker images supplied when creating/updating sources/destinations. 

## How
Runs a `getSpec` operation on the provided docker image in the relevant endpoints. 

## Reading order
1. `SourcesHandler.java`
1. `SchedulerHandler.java`
1. `DestinationsHandler.java`
1. `SourcesHandlerTest.java`
1. `SchedulerHandlerTest.java`
1. `DestinationsHandlerTest.java`
