### PR TITLE
remove discover action from the destination interface

### DIFF
--- a/airbyte-integrations/base-java/src/main/java/io/airbyte/integrations/base/Destination.java
+++ b/airbyte-integrations/base-java/src/main/java/io/airbyte/integrations/base/Destination.java
@@ -27,7 +27,6 @@ package io.airbyte.integrations.base;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.config.ConnectorSpecification;
 import io.airbyte.config.StandardCheckConnectionOutput;
-import io.airbyte.config.StandardDiscoverCatalogOutput;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.AirbyteMessage;
 
@@ -51,16 +50,6 @@ public interface Destination {
    * @throws Exception - any exception.
    */
   StandardCheckConnectionOutput check(JsonNode config) throws Exception;
-
-  /**
-   * Discover the current schema in the destination.
-   *
-   * @param config - integration-specific configuration object as json. e.g. { "username": "airbyte",
-   *        "password": "super secure" }
-   * @return Description of the schema.
-   * @throws Exception - any exception.
-   */
-  StandardDiscoverCatalogOutput discover(JsonNode config) throws Exception;
 
   /**
    * Return a consumer that writes messages to the destination.

--- a/airbyte-integrations/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
+++ b/airbyte-integrations/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
@@ -71,8 +71,7 @@ public class IntegrationRunner {
         stdoutConsumer.accept(Jsons.serialize(destination.check(config)));
       }
       case DISCOVER -> {
-        final JsonNode config = parseConfig(parsed.getConfigPath());
-        stdoutConsumer.accept(Jsons.serialize(destination.discover(config)));
+        throw new IllegalStateException("Discover is not implemented for destinations");
       }
       case READ ->
         // final JsonNode config = parseConfig(parsed.getConfig());

--- a/airbyte-integrations/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunnerTest.java
+++ b/airbyte-integrations/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunnerTest.java
@@ -116,21 +116,6 @@ class IntegrationRunnerTest {
     verify(stdoutConsumer).accept(Jsons.serialize(output));
   }
 
-  // @Test
-  // void testDiscover() throws Exception {
-  // final IntegrationConfig intConfig = IntegrationConfig.discover(Path.of(configPath.toString()));
-  // final StandardDiscoverCatalogOutput output = new
-  // StandardDiscoverCatalogOutput().withSchema(CATALOG);
-  //
-  // when(cliParser.parse(ARGS)).thenReturn(intConfig);
-  // when(destination.discover(CONFIG)).thenReturn(output);
-  //
-  // new IntegrationRunner(cliParser, stdoutConsumer, destination).run(ARGS);
-  //
-  // verify(destination).discover(CONFIG);
-  // verify(stdoutConsumer).accept(Jsons.serialize(output));
-  // }
-
   @SuppressWarnings("unchecked")
   @Test
   void testWrite() throws Exception {

--- a/airbyte-integrations/bigquery-destination/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
+++ b/airbyte-integrations/bigquery-destination/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
@@ -54,7 +54,6 @@ import io.airbyte.commons.time.Instants;
 import io.airbyte.config.ConnectorSpecification;
 import io.airbyte.config.StandardCheckConnectionOutput;
 import io.airbyte.config.StandardCheckConnectionOutput.Status;
-import io.airbyte.config.StandardDiscoverCatalogOutput;
 import io.airbyte.integrations.base.Destination;
 import io.airbyte.integrations.base.DestinationConsumer;
 import io.airbyte.integrations.base.FailureTrackingConsumer;
@@ -158,11 +157,6 @@ public class BigQueryDestination implements Destination {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-  }
-
-  @Override
-  public StandardDiscoverCatalogOutput discover(JsonNode config) {
-    throw new RuntimeException("Not Implemented");
   }
 
   /**

--- a/airbyte-integrations/csv-destination/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
+++ b/airbyte-integrations/csv-destination/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
@@ -31,7 +31,6 @@ import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.config.ConnectorSpecification;
 import io.airbyte.config.StandardCheckConnectionOutput;
 import io.airbyte.config.StandardCheckConnectionOutput.Status;
-import io.airbyte.config.StandardDiscoverCatalogOutput;
 import io.airbyte.integrations.base.Destination;
 import io.airbyte.integrations.base.DestinationConsumer;
 import io.airbyte.integrations.base.FailureTrackingConsumer;
@@ -77,13 +76,6 @@ public class CsvDestination implements Destination {
       return new StandardCheckConnectionOutput().withStatus(Status.FAILURE).withMessage(e.getMessage());
     }
     return new StandardCheckConnectionOutput().withStatus(Status.SUCCESS);
-  }
-
-  // todo (cgardens) - we currently don't leverage discover in our destinations, so skipping
-  // implementing it... for now.
-  @Override
-  public StandardDiscoverCatalogOutput discover(JsonNode config) {
-    throw new RuntimeException("Not Implemented");
   }
 
   /**

--- a/airbyte-integrations/java-template-destination/src/main/java/io/airbyte/integrations/destination/template/DestinationTemplate.java
+++ b/airbyte-integrations/java-template-destination/src/main/java/io/airbyte/integrations/destination/template/DestinationTemplate.java
@@ -29,7 +29,6 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.config.ConnectorSpecification;
 import io.airbyte.config.StandardCheckConnectionOutput;
-import io.airbyte.config.StandardDiscoverCatalogOutput;
 import io.airbyte.integrations.base.Destination;
 import io.airbyte.integrations.base.DestinationConsumer;
 import io.airbyte.integrations.base.IntegrationRunner;
@@ -67,12 +66,6 @@ public class DestinationTemplate implements Destination {
     // return new StandardCheckConnectionOutput().withStatus(Status.FAILURE).withMessage("(optional) the
     // reason it failed");
     // }
-    throw new RuntimeException("Not Implemented");
-  }
-
-  // fixme - implement this method such that it returns the current schema found in the destination.
-  @Override
-  public StandardDiscoverCatalogOutput discover(JsonNode config) {
     throw new RuntimeException("Not Implemented");
   }
 

--- a/airbyte-integrations/postgres-destination/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
+++ b/airbyte-integrations/postgres-destination/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
@@ -33,7 +33,6 @@ import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.config.ConnectorSpecification;
 import io.airbyte.config.StandardCheckConnectionOutput;
 import io.airbyte.config.StandardCheckConnectionOutput.Status;
-import io.airbyte.config.StandardDiscoverCatalogOutput;
 import io.airbyte.db.DatabaseHelper;
 import io.airbyte.integrations.base.Destination;
 import io.airbyte.integrations.base.DestinationConsumer;
@@ -87,11 +86,6 @@ public class PostgresDestination implements Destination {
       // todo (cgardens) - better error messaging for common cases. e.g. wrong password.
       return new StandardCheckConnectionOutput().withStatus(Status.FAILURE).withMessage(e.getMessage());
     }
-  }
-
-  @Override
-  public StandardDiscoverCatalogOutput discover(JsonNode config) {
-    throw new RuntimeException("Not Implemented");
   }
 
   /**


### PR DESCRIPTION
## What
* We don't ever call discover on destinations and we have not been implementing it. At such time that we have a plan for this, we can re-add. For now we will remove so that people do not need to think about something that's dead code.