### PR TITLE
add Catalog to DefaultAirbyteDestination

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteProtocolConverters.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteProtocolConverters.java
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.protocol.models.AirbyteCatalog;
+import io.airbyte.protocol.models.AirbyteStream;
+import java.util.List;
+import java.util.stream.Collectors;
+
+// todo (cgardens) - hack, remove after we've gotten rid of Schema object.
+public class AirbyteProtocolConverters {
+
+  public static AirbyteCatalog toCatalog(Schema schema) {
+    return new AirbyteCatalog()
+        .withStreams(schema.getStreams().stream().map(s -> new AirbyteStream().withName(s.getName())
+            .withSchema(toJson(s.getFields()))).collect(Collectors.toList()));
+  }
+
+  // todo (cgardens) - this will only work with table / column schemas. it's hack to get us through
+  // migration.
+  public static JsonNode toJson(List<Field> fields) {
+    // assumes this shape.
+    // type: object,
+    // property: {
+    // <fieldName>: {
+    // "type" : <fieldType>
+    // }
+    // }
+    return Jsons.jsonNode(ImmutableMap.builder()
+        .put("type", "object")
+        .put("properties", fields
+            .stream()
+            .filter(Field::getSelected)
+            .collect(Collectors.toMap(Field::getName, field -> ImmutableMap.of("type", field.getDataType().toString())))));
+  }
+
+}

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.protocol.models;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class CatalogHelpers {
+
+  public static AirbyteStream createAirbyteStream(String streamName, Field... fields) {
+    return new AirbyteStream().withName(streamName).withSchema(fieldsToJsonSchema(fields));
+  }
+
+  public static JsonNode fieldsToJsonSchema(Field... fields) {
+    return Jsons.jsonNode(ImmutableMap.builder()
+        .put("type", "object")
+        .put("properties", Arrays.stream(fields).collect(Collectors.toMap(Field::getName, field -> ImmutableMap.of("type", field.getType())))));
+  }
+}

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -39,7 +39,8 @@ public class CatalogHelpers {
   public static JsonNode fieldsToJsonSchema(Field... fields) {
     return Jsons.jsonNode(ImmutableMap.builder()
         .put("type", "object")
-        .put("properties", Arrays.stream(fields).collect(Collectors.toMap(Field::getName, field -> ImmutableMap.of("type", field.getType())))));
+        .put("properties", Arrays.stream(fields)
+            .collect(Collectors.toMap(Field::getName, field -> ImmutableMap.of("type", field.getTypeAsJsonSchemaString())))));
   }
 
 }

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -41,4 +41,5 @@ public class CatalogHelpers {
         .put("type", "object")
         .put("properties", Arrays.stream(fields).collect(Collectors.toMap(Field::getName, field -> ImmutableMap.of("type", field.getType())))));
   }
+
 }

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/Field.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/Field.java
@@ -24,39 +24,39 @@
 
 package io.airbyte.protocol.models;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
-import java.util.Set;
-
 public class Field {
 
-  private static final Set<String> JSON_SCHEMA_PRIMITIVES = Sets.newHashSet(
-      "string",
-      "number",
-      "object",
-      "array",
-      "boolean",
-      "null");
+  private enum JsonSchemaPrimitives {
+    STRING,
+    NUMBER,
+    OBJECT,
+    ARRAY,
+    BOOLEAN,
+    NULL;
+  }
 
   private final String name;
-  private final String type;
+  private final JsonSchemaPrimitives type;
 
-  public Field(String name, String type) {
-    Preconditions.checkState(JSON_SCHEMA_PRIMITIVES.contains(type));
+  public Field(String name, JsonSchemaPrimitives type) {
     this.name = name;
     this.type = type;
   }
 
-  public static Field of(String name, String type) {
+  public static Field of(String name, JsonSchemaPrimitives type) {
     return new Field(name, type);
+  }
+
+  public static Field of(String name, String type) {
+    return new Field(name, JsonSchemaPrimitives.valueOf(type));
   }
 
   public String getName() {
     return name;
   }
 
-  public String getType() {
-    return type;
+  public String getTypeAsJsonSchemaString() {
+    return type.name().toLowerCase();
   }
 
 }

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/Field.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/Field.java
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.protocol.models;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import java.util.Set;
+
+public class Field {
+
+  private static final Set<String> JSON_SCHEMA_PRIMITIVES = Sets.newHashSet(
+      "string",
+      "number",
+      "object",
+      "array",
+      "boolean",
+      "null");
+
+  private final String name;
+  private final String type;
+
+  public Field(String name, String type) {
+    Preconditions.checkState(JSON_SCHEMA_PRIMITIVES.contains(type));
+    this.name = name;
+    this.type = type;
+  }
+
+  public static Field of(String name, String type) {
+    return new Field(name, type);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -66,12 +66,11 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
 
     final JsonNode configDotJson = targetConfig.getDestinationConnectionImplementation().getConfiguration();
     final AirbyteCatalog catalog = AirbyteProtocolConverters.toCatalog(targetConfig.getStandardSync().getSchema());
-    
     IOs.writeFile(jobRoot, WorkerConstants.TARGET_CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
     IOs.writeFile(jobRoot, WorkerConstants.CATALOG_JSON_FILENAME, Jsons.serialize(catalog));
 
     LOGGER.info("Running target...");
-    targetProcess = integrationLauncher.write(jobRoot, WorkerConstants.TARGET_CONFIG_JSON_FILENAME).start();
+    targetProcess = integrationLauncher.write(jobRoot, WorkerConstants.TARGET_CONFIG_JSON_FILENAME, WorkerConstants.CATALOG_JSON_FILENAME).start();
     LineGobbler.gobble(targetProcess.getInputStream(), LOGGER::info);
     LineGobbler.gobble(targetProcess.getErrorStream(), LOGGER::error);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -30,7 +30,9 @@ import com.google.common.base.Preconditions;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.io.LineGobbler;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.AirbyteProtocolConverters;
 import io.airbyte.config.StandardTargetConfig;
+import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.workers.WorkerConstants;
 import io.airbyte.workers.WorkerException;
@@ -63,8 +65,10 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
     Preconditions.checkState(targetProcess == null);
 
     final JsonNode configDotJson = targetConfig.getDestinationConnectionImplementation().getConfiguration();
-
+    final AirbyteCatalog catalog = AirbyteProtocolConverters.toCatalog(targetConfig.getStandardSync().getSchema());
+    
     IOs.writeFile(jobRoot, WorkerConstants.TARGET_CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
+    IOs.writeFile(jobRoot, WorkerConstants.CATALOG_JSON_FILENAME, Jsons.serialize(catalog));
 
     LOGGER.info("Running target...");
     targetProcess = integrationLauncher.write(jobRoot, WorkerConstants.TARGET_CONFIG_JSON_FILENAME).start();

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
@@ -77,7 +77,8 @@ class DefaultAirbyteDestinationTest {
     when(process.getErrorStream()).thenReturn(new ByteArrayInputStream("error".getBytes(StandardCharsets.UTF_8)));
 
     integrationLauncher = mock(IntegrationLauncher.class, RETURNS_DEEP_STUBS);
-    when(integrationLauncher.write(jobRoot, WorkerConstants.TARGET_CONFIG_JSON_FILENAME).start()).thenReturn(process);
+    when(integrationLauncher.write(jobRoot, WorkerConstants.TARGET_CONFIG_JSON_FILENAME, WorkerConstants.CATALOG_JSON_FILENAME).start())
+        .thenReturn(process);
   }
 
   @SuppressWarnings("BusyWait")


### PR DESCRIPTION
## What
* Does not change the interface on `DefaultAirbyteDestination`. Just internally converts the Schema object to an `AirbyteCatalog`. This is a shim until we can totally get rid of the Schema object. It unblocks switching destinations to use `DefaultAirbyteDestination`
* Add helpers for converting between `Schema` and `AirbyteCatalog`
* Add helpers for making a schema by hand (i.e. for tests)
