### PR TITLE
add catalog to airbyte source

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteProtocolConverters.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteProtocolConverters.java
@@ -37,7 +37,8 @@ public class AirbyteProtocolConverters {
 
   public static AirbyteCatalog toCatalog(Schema schema) {
     return new AirbyteCatalog()
-        .withStreams(schema.getStreams().stream().map(s -> new AirbyteStream().withName(s.getName())
+        .withStreams(schema.getStreams().stream().map(s -> new AirbyteStream()
+            .withName(s.getName())
             .withSchema(toJson(s.getFields()))).collect(Collectors.toList()));
   }
 

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/WorkerRunFactory.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/WorkerRunFactory.java
@@ -157,14 +157,12 @@ public class WorkerRunFactory {
                   new SingerMessageTracker())));
 
     } else {
-      final DefaultDiscoverCatalogWorker discoverSchemaWorker = new DefaultDiscoverCatalogWorker(createLauncher(config.getSourceDockerImage()));
-
       return creator.create(
           jobRoot,
           syncInput,
           new JobOutputSyncWorker(
               new DefaultSyncWorker<>(
-                  new DefaultAirbyteSource(sourceLauncher, discoverSchemaWorker),
+                  new DefaultAirbyteSource(sourceLauncher),
                   new DefaultAirbyteDestination(destinationLauncher),
                   new AirbyteMessageTracker())));
     }


### PR DESCRIPTION
## What
* `DefaultAirbyteSource` was sending the old Schema object. This PR switches to so that it still takes in the Schema object but it converts it to an `AirbyteCatalog` before sending it to the integrations.
