### PR TITLE
fix spelling of docker image.

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/9fed261d-d107-47fd-8c8b-323023db6e20.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/9fed261d-d107-47fd-8c8b-323023db6e20.json
@@ -1,7 +1,7 @@
 {
   "sourceId": "9fed261d-d107-47fd-8c8b-323023db6e20",
   "name": "exchangeratesapi.io",
-  "dockerRepository": "airbyte/integration-singer-exchangerateapi_io-source",
+  "dockerRepository": "airbyte/integration-singer-exchangeratesapi_io-source",
   "dockerImageTag": "0.1.3",
   "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-exchangeratesapi_io-source"
 }


### PR DESCRIPTION
```
airbyte-scheduler | 2020-10-15 15:26:58 INFO i.a.s.WorkerRun(call):58 - {job_id=2, job_log_filename=logs.log, job_root=/tmp/workspace/2/0} - Executing worker wrapper...
airbyte-scheduler | 2020-10-15 15:26:59 INFO i.a.c.i.LineGobbler(voidCall):69 - {job_id=2, job_log_filename=logs.log, job_root=/tmp/workspace/2/0} - Image does not exist.
airbyte-scheduler | 2020-10-15 15:26:59 ERROR i.a.w.DefaultGetSpecWorker(run):72 - {job_id=2, job_log_filename=logs.log, job_root=/tmp/workspace/2/0} - Error while getting spec from image airbyte/integration-singer-exchangerateapi_io-source:0.1.3: io.airbyte.workers.WorkerException: Could not find image: airbyte/integration-singer-exchangerateapi_io-source:0.1.3
airbyte-scheduler | 2020-10-15 15:26:59 INFO i.a.s.p.DefaultSchedulerPersistence(updateStatus):200 - {job_id=2, job_log_filename=logs.log, job_root=/tmp/workspace/2/0} - Setting job status to FAILED for job 2
airbyte-server | 2020-10-15 15:27:00 DEBUG i.a.s.e.UncaughtExceptionMapper(toResponse):42 - {} - Uncaught exception
airbyte-server | java.util.NoSuchElementException: No value present
```