### PR TITLE
hotfix: use non-named mount for local mount

### DIFF
--- a/.env
+++ b/.env
@@ -6,5 +6,5 @@ CONFIG_ROOT=/data
 WORKSPACE_ROOT=/tmp/workspace
 WORKSPACE_DOCKER_MOUNT=workspace
 LOCAL_ROOT=/tmp/airbyte_local
-LOCAL_DOCKER_MOUNT=local
+LOCAL_DOCKER_MOUNT=/tmp/airbyte_local
 TRACKING_STRATEGY=segment

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,13 +6,8 @@ services:
   init:
     image: alpine
     command: /bin/sh -c "
-      echo ${LOCAL_ROOT};
-      mkdir -p ${LOCAL_ROOT};
+      echo hello;
       "
-    environment:
-      - LOCAL_ROOT=${LOCAL_ROOT}
-    volumes:
-      - ${LOCAL_ROOT}/..:/tmp
   db:
     image: airbyte/db:${VERSION}
     container_name: airbyte-db
@@ -49,7 +44,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - workspace:${WORKSPACE_ROOT}
-      - local:${LOCAL_ROOT}
+      - ${LOCAL_ROOT}:${LOCAL_ROOT}
       - data:${CONFIG_ROOT}
     depends_on:
       - db
@@ -85,12 +80,5 @@ services:
 volumes:
   workspace:
     name: ${WORKSPACE_DOCKER_MOUNT}
-  local:
-    name: local
-    driver: local
-    driver_opts:
-      o: bind
-      type: none
-      device: ${LOCAL_ROOT}
   data:
   db:


### PR DESCRIPTION
## What
* An update in docker-compose has made named local volumes unusable on mac. This means `docker-compose up` on our app will work the _first_ time, but will fail on subsequent attempts.
* We use named local volumes for all volumes in our dev version and for the local mount in the prod version of the app. This PR converts the prod local mount to use a non named mount to get us to a state where the app will reliably start. 
* ~~Todo, need to publish this as a new version.~~ nvm, no publishing necessary since these changes are just in env file and compose.yaml.

This PR is just to get us in a non-broken state. By no means is this how I want to leave this.