### PR TITLE
output spec on a single line

### DIFF
--- a/airbyte-integrations/singer/base-singer/base_singer/singer_helpers.py
+++ b/airbyte-integrations/singer/base-singer/base_singer/singer_helpers.py
@@ -40,7 +40,9 @@ class SingerHelper:
     def spec_from_file(spec_path) -> AirbyteSpec:
         with open(spec_path) as file:
             spec_text = file.read()
-        return AirbyteSpec(spec_text)
+        # we need to output a spec on a single line
+        flattened_json = json.dumps(json.loads(spec_text))
+        return AirbyteSpec(flattened_json)
 
     @staticmethod
     def get_catalogs(logger, shell_command, singer_transform=(lambda catalog: catalog), airbyte_transform=(lambda catalog: catalog)) -> Catalogs:


### PR DESCRIPTION
After the change:
```
→ docker run -v $(pwd):/mount --rm airbyte/source-exchangeratesapi-singer:dev spec
{"documentationUrl": "https://docs.airbyte.io/integrations/sources/exchangeratesapi-io", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "title": "exchangeratesapi.io Source Spec", "type": "object", "required": ["start_date", "base"], "additionalProperties": false, "properties": {"start_date": {"type": "string", "description": "Start getting data from that date.", "examples": ["YYYY-MM-DD"]}, "base": {"type": "string", "description": "ISO reference currency. See <a href=\"https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html\">here</a>."}}}}
```