### PR TITLE
=> succeeded, => failed

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1430,8 +1430,8 @@ components:
         status:
           type: string
           enum:
-            - success
-            - fail
+            - succeeded
+            - failed
     # SCHEMA
     SourceSchema:
       description: describes the available schema.
@@ -1582,8 +1582,8 @@ components:
         status:
           type: string
           enum:
-            - success
-            - failure
+            - succeeded
+            - failed
         message:
           type: string
     # Web Backend

--- a/airbyte-config/models/src/main/resources/types/StandardCheckConnectionOutput.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardCheckConnectionOutput.yaml
@@ -11,7 +11,7 @@ properties:
   status:
     type: string
     enum:
-      - success
-      - failure
+      - succeeded
+      - failed
   message:
     type: string

--- a/airbyte-integrations/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunnerTest.java
+++ b/airbyte-integrations/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunnerTest.java
@@ -105,7 +105,7 @@ class IntegrationRunnerTest {
   @Test
   void testCheck() throws Exception {
     final IntegrationConfig intConfig = IntegrationConfig.check(Path.of(configPath.toString()));
-    final StandardCheckConnectionOutput output = new StandardCheckConnectionOutput().withStatus(Status.FAILURE).withMessage("it failed");
+    final StandardCheckConnectionOutput output = new StandardCheckConnectionOutput().withStatus(Status.FAILED).withMessage("it failed");
 
     when(cliParser.parse(ARGS)).thenReturn(intConfig);
     when(destination.check(CONFIG)).thenReturn(output);

--- a/airbyte-integrations/base-python/airbyte_protocol/models/airbyte_message.py
+++ b/airbyte-integrations/base-python/airbyte_protocol/models/airbyte_message.py
@@ -53,7 +53,7 @@ class AirbyteLogMessage(BaseModel):
 
 
 class Status(Enum):
-    SUCCESS = 'SUCCESS'
+    SUCCEEDED = 'SUCCEEDED'
     FAILED = 'FAILED'
 
 

--- a/airbyte-integrations/bigquery-destination/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
+++ b/airbyte-integrations/bigquery-destination/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
@@ -107,12 +107,12 @@ public class BigQueryDestination implements Destination {
 
       final ImmutablePair<Job, String> result = executeQuery(getBigQuery(config), queryConfig);
       if (result.getLeft() != null) {
-        return new StandardCheckConnectionOutput().withStatus(Status.SUCCESS);
+        return new StandardCheckConnectionOutput().withStatus(Status.SUCCEEDED);
       } else {
-        return new StandardCheckConnectionOutput().withStatus(Status.FAILURE).withMessage(result.getRight());
+        return new StandardCheckConnectionOutput().withStatus(Status.FAILED).withMessage(result.getRight());
       }
     } catch (Exception e) {
-      return new StandardCheckConnectionOutput().withStatus(Status.FAILURE).withMessage(e.getMessage());
+      return new StandardCheckConnectionOutput().withStatus(Status.FAILED).withMessage(e.getMessage());
     }
   }
 

--- a/airbyte-integrations/bigquery-destination/src/test/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTest.java
+++ b/airbyte-integrations/bigquery-destination/src/test/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTest.java
@@ -193,7 +193,7 @@ class BigQueryDestinationTest {
   // @Test
   void testCheckSuccess() {
     final StandardCheckConnectionOutput actual = new BigQueryDestination().check(config);
-    final StandardCheckConnectionOutput expected = new StandardCheckConnectionOutput().withStatus(Status.SUCCESS);
+    final StandardCheckConnectionOutput expected = new StandardCheckConnectionOutput().withStatus(Status.SUCCEEDED);
     assertEquals(expected, actual);
   }
 
@@ -201,7 +201,7 @@ class BigQueryDestinationTest {
   void testCheckFailure() {
     ((ObjectNode) config).put(BigQueryDestination.CONFIG_PROJECT_ID, "fake");
     final StandardCheckConnectionOutput actual = new BigQueryDestination().check(config);
-    final StandardCheckConnectionOutput expected = new StandardCheckConnectionOutput().withStatus(Status.FAILURE)
+    final StandardCheckConnectionOutput expected = new StandardCheckConnectionOutput().withStatus(Status.FAILED)
         .withMessage("Access Denied: Project fake: User does not have bigquery.jobs.create permission in project fake.");
     assertEquals(expected, actual);
   }

--- a/airbyte-integrations/csv-destination/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
+++ b/airbyte-integrations/csv-destination/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
@@ -73,9 +73,9 @@ public class CsvDestination implements Destination {
     try {
       FileUtils.forceMkdir(getDestinationPath(config).toFile());
     } catch (Exception e) {
-      return new StandardCheckConnectionOutput().withStatus(Status.FAILURE).withMessage(e.getMessage());
+      return new StandardCheckConnectionOutput().withStatus(Status.FAILED).withMessage(e.getMessage());
     }
-    return new StandardCheckConnectionOutput().withStatus(Status.SUCCESS);
+    return new StandardCheckConnectionOutput().withStatus(Status.SUCCEEDED);
   }
 
   /**

--- a/airbyte-integrations/csv-destination/src/test/java/io/airbyte/integrations/destination/csv/CsvDestinationTest.java
+++ b/airbyte-integrations/csv-destination/src/test/java/io/airbyte/integrations/destination/csv/CsvDestinationTest.java
@@ -114,7 +114,7 @@ class CsvDestinationTest {
   @Test
   void testCheckSuccess() {
     final StandardCheckConnectionOutput actual = new CsvDestination().check(config);
-    final StandardCheckConnectionOutput expected = new StandardCheckConnectionOutput().withStatus(Status.SUCCESS);
+    final StandardCheckConnectionOutput expected = new StandardCheckConnectionOutput().withStatus(Status.SUCCEEDED);
     assertEquals(expected, actual);
   }
 
@@ -124,7 +124,7 @@ class CsvDestinationTest {
     FileUtils.touch(looksLikeADirectoryButIsAFile.toFile());
     final JsonNode config = Jsons.jsonNode(ImmutableMap.of(CsvDestination.DESTINATION_PATH_FIELD, looksLikeADirectoryButIsAFile.toString()));
     final StandardCheckConnectionOutput actual = new CsvDestination().check(config);
-    final StandardCheckConnectionOutput expected = new StandardCheckConnectionOutput().withStatus(Status.FAILURE);
+    final StandardCheckConnectionOutput expected = new StandardCheckConnectionOutput().withStatus(Status.FAILED);
 
     // the message includes the random file path, so just verify it exists and then remove it when we do
     // rest of the comparison.

--- a/airbyte-integrations/java-template-destination/src/main/java/io/airbyte/integrations/destination/template/DestinationTemplate.java
+++ b/airbyte-integrations/java-template-destination/src/main/java/io/airbyte/integrations/destination/template/DestinationTemplate.java
@@ -61,9 +61,9 @@ public class DestinationTemplate implements Destination {
   @Override
   public StandardCheckConnectionOutput check(JsonNode config) {
     // if(success) {
-    // return new StandardCheckConnectionOutput().withStatus(Status.SUCCESS);
+    // return new StandardCheckConnectionOutput().withStatus(Status.SUCCEEDED);
     // } else {
-    // return new StandardCheckConnectionOutput().withStatus(Status.FAILURE).withMessage("(optional) the
+    // return new StandardCheckConnectionOutput().withStatus(Status.FAILED).withMessage("(optional) the
     // reason it failed");
     // }
     throw new RuntimeException("Not Implemented");

--- a/airbyte-integrations/postgres-destination/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
+++ b/airbyte-integrations/postgres-destination/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
@@ -81,10 +81,10 @@ public class PostgresDestination implements Destination {
               + "WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema' LIMIT 1;"));
 
       connectionPool.close();
-      return new StandardCheckConnectionOutput().withStatus(Status.SUCCESS);
+      return new StandardCheckConnectionOutput().withStatus(Status.SUCCEEDED);
     } catch (Exception e) {
       // todo (cgardens) - better error messaging for common cases. e.g. wrong password.
-      return new StandardCheckConnectionOutput().withStatus(Status.FAILURE).withMessage(e.getMessage());
+      return new StandardCheckConnectionOutput().withStatus(Status.FAILED).withMessage(e.getMessage());
     }
   }
 

--- a/airbyte-integrations/postgres-destination/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
+++ b/airbyte-integrations/postgres-destination/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
@@ -134,7 +134,7 @@ class PostgresDestinationTest {
   @Test
   void testCheckSuccess() {
     final StandardCheckConnectionOutput actual = new PostgresDestination().check(config);
-    final StandardCheckConnectionOutput expected = new StandardCheckConnectionOutput().withStatus(Status.SUCCESS);
+    final StandardCheckConnectionOutput expected = new StandardCheckConnectionOutput().withStatus(Status.SUCCEEDED);
     assertEquals(expected, actual);
   }
 
@@ -142,7 +142,7 @@ class PostgresDestinationTest {
   void testCheckFailure() {
     ((ObjectNode) config).put("password", "fake");
     final StandardCheckConnectionOutput actual = new PostgresDestination().check(config);
-    final StandardCheckConnectionOutput expected = new StandardCheckConnectionOutput().withStatus(Status.FAILURE)
+    final StandardCheckConnectionOutput expected = new StandardCheckConnectionOutput().withStatus(Status.FAILED)
         .withMessage("Cannot create PoolableConnectionFactory (FATAL: password authentication failed for user \"test\")");
     assertEquals(expected, actual);
   }

--- a/airbyte-integrations/singer/local_csv/destination/src/test-integration/java/io/airbyte/integration_tests/destinations/TestLocalCsvDestination.java
+++ b/airbyte-integrations/singer/local_csv/destination/src/test-integration/java/io/airbyte/integration_tests/destinations/TestLocalCsvDestination.java
@@ -158,9 +158,9 @@ class TestLocalCsvDestination {
     DefaultCheckConnectionWorker checkConnectionWorker = new DefaultCheckConnectionWorker(new DefaultDiscoverCatalogWorker(integrationLauncher));
     StandardCheckConnectionInput inputConfig = new StandardCheckConnectionInput().withConnectionConfiguration(Jsons.jsonNode(config));
     OutputAndStatus<StandardCheckConnectionOutput> run = checkConnectionWorker.run(inputConfig, jobRoot);
-    assertEquals(JobStatus.SUCCESSFUL, run.getStatus());
+    assertEquals(JobStatus.SUCCEEDED, run.getStatus());
     assertTrue(run.getOutput().isPresent());
-    assertEquals(StandardCheckConnectionOutput.Status.SUCCESS, run.getOutput().get().getStatus());
+    assertEquals(StandardCheckConnectionOutput.Status.SUCCEEDED, run.getOutput().get().getStatus());
   }
 
   private void assertProducesExpectedOutput(Map<String, Object> config, Path outputPathOnLocalFs)

--- a/airbyte-integrations/singer/postgres/destination/src/test-integration/java/io/airbyte/integration_tests/destinations/TestPostgresDestination.java
+++ b/airbyte-integrations/singer/postgres/destination/src/test-integration/java/io/airbyte/integration_tests/destinations/TestPostgresDestination.java
@@ -25,7 +25,7 @@
 package io.airbyte.integration_tests.destinations;
 
 import static io.airbyte.workers.JobStatus.FAILED;
-import static io.airbyte.workers.JobStatus.SUCCESSFUL;
+import static io.airbyte.workers.JobStatus.SUCCEEDED;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
@@ -132,9 +132,9 @@ class TestPostgresDestination {
     DefaultCheckConnectionWorker checkConnectionWorker = new DefaultCheckConnectionWorker(new DefaultDiscoverCatalogWorker(integrationLauncher));
     StandardCheckConnectionInput inputConfig = new StandardCheckConnectionInput().withConnectionConfiguration(Jsons.jsonNode(getDbConfig()));
     OutputAndStatus<StandardCheckConnectionOutput> run = checkConnectionWorker.run(inputConfig, jobRoot);
-    assertEquals(SUCCESSFUL, run.getStatus());
+    assertEquals(SUCCEEDED, run.getStatus());
     assertTrue(run.getOutput().isPresent());
-    assertEquals(StandardCheckConnectionOutput.Status.SUCCESS, run.getOutput().get().getStatus());
+    assertEquals(StandardCheckConnectionOutput.Status.SUCCEEDED, run.getOutput().get().getStatus());
   }
 
   @Test
@@ -147,7 +147,7 @@ class TestPostgresDestination {
     OutputAndStatus<StandardCheckConnectionOutput> run = checkConnectionWorker.run(inputConfig, jobRoot);
     assertEquals(FAILED, run.getStatus());
     assertTrue(run.getOutput().isPresent());
-    assertEquals(StandardCheckConnectionOutput.Status.FAILURE, run.getOutput().get().getStatus());
+    assertEquals(StandardCheckConnectionOutput.Status.FAILED, run.getOutput().get().getStatus());
   }
 
   private Process startTarget() throws IOException, WorkerException {

--- a/airbyte-integrations/singer/postgres/source/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SingerPostgresSourceTest.java
+++ b/airbyte-integrations/singer/postgres/source/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SingerPostgresSourceTest.java
@@ -213,7 +213,7 @@ public class SingerPostgresSourceTest {
     OutputAndStatus<StandardDiscoverCatalogOutput> run = new SingerDiscoverCatalogWorker(integrationLauncher).run(inputConfig, jobRoot);
 
     Schema expected = Jsons.deserialize(MoreResources.readResource("schema.json"), Schema.class);
-    assertEquals(JobStatus.SUCCESSFUL, run.getStatus());
+    assertEquals(JobStatus.SUCCEEDED, run.getStatus());
     assertTrue(run.getOutput().isPresent());
     assertEquals(expected, run.getOutput().get().getSchema());
   }
@@ -224,9 +224,9 @@ public class SingerPostgresSourceTest {
     OutputAndStatus<StandardCheckConnectionOutput> run =
         new DefaultCheckConnectionWorker(new SingerDiscoverCatalogWorker(integrationLauncher)).run(inputConfig, jobRoot);
 
-    assertEquals(JobStatus.SUCCESSFUL, run.getStatus());
+    assertEquals(JobStatus.SUCCEEDED, run.getStatus());
     assertTrue(run.getOutput().isPresent());
-    assertEquals(StandardCheckConnectionOutput.Status.SUCCESS, run.getOutput().get().getStatus());
+    assertEquals(StandardCheckConnectionOutput.Status.SUCCEEDED, run.getOutput().get().getStatus());
   }
 
   @Test
@@ -239,7 +239,7 @@ public class SingerPostgresSourceTest {
 
     assertEquals(JobStatus.FAILED, run.getStatus());
     assertTrue(run.getOutput().isPresent());
-    assertEquals(StandardCheckConnectionOutput.Status.FAILURE, run.getOutput().get().getStatus());
+    assertEquals(StandardCheckConnectionOutput.Status.FAILED, run.getOutput().get().getStatus());
   }
 
   private Map<String, Object> getDbConfig(PostgreSQLContainer containerDb) {

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_message.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_message.yaml
@@ -101,7 +101,7 @@ definitions:
       status:
         type: string
         enum:
-          - SUCCESS
+          - SUCCEEDED
           - FAILED
       message:
         type: string

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobSubmitter.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobSubmitter.java
@@ -91,7 +91,7 @@ public class JobSubmitter implements Runnable {
 
   private JobStatus getStatus(OutputAndStatus<?> output) {
     switch (output.getStatus()) {
-      case SUCCESSFUL:
+      case SUCCEEDED:
         return JobStatus.COMPLETED;
       case FAILED:
         return JobStatus.FAILED;

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobSubmitterTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobSubmitterTest.java
@@ -55,7 +55,7 @@ import org.slf4j.MDC;
 
 public class JobSubmitterTest {
 
-  public static final OutputAndStatus<JobOutput> SUCCESS_OUTPUT = new OutputAndStatus<>(JobStatus.SUCCESSFUL, new JobOutput());
+  public static final OutputAndStatus<JobOutput> SUCCESS_OUTPUT = new OutputAndStatus<>(JobStatus.SUCCEEDED, new JobOutput());
   public static final OutputAndStatus<JobOutput> FAILED_OUTPUT = new OutputAndStatus<>(JobStatus.FAILED);
 
   private SchedulerPersistence persistence;

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -29,6 +29,7 @@ import io.airbyte.analytics.TrackingClientSingleton;
 import io.airbyte.api.model.CheckConnectionRead;
 import io.airbyte.api.model.ConnectionIdRequestBody;
 import io.airbyte.api.model.ConnectionSyncRead;
+import io.airbyte.api.model.ConnectionSyncRead.StatusEnum;
 import io.airbyte.api.model.DestinationIdRequestBody;
 import io.airbyte.api.model.DestinationImplementationIdRequestBody;
 import io.airbyte.api.model.DestinationSpecificationRead;
@@ -231,7 +232,7 @@ public class SchedulerHandler {
         .build());
 
     return new ConnectionSyncRead()
-        .status(job.getStatus().equals(JobStatus.COMPLETED) ? ConnectionSyncRead.StatusEnum.SUCCESS : ConnectionSyncRead.StatusEnum.FAIL);
+        .status(job.getStatus().equals(JobStatus.COMPLETED) ? StatusEnum.SUCCEEDED : ConnectionSyncRead.StatusEnum.FAILED);
   }
 
   private Job waitUntilJobIsTerminalOrTimeout(final long jobId) throws IOException {
@@ -255,7 +256,7 @@ public class SchedulerHandler {
   private CheckConnectionRead reportConnectionStatus(final Job job) {
     final StandardCheckConnectionOutput output = job.getOutput().map(JobOutput::getCheckConnection)
         // the job should always produce an output, but if it does not, we assume a failure.
-        .orElse(new StandardCheckConnectionOutput().withStatus(StandardCheckConnectionOutput.Status.FAILURE));
+        .orElse(new StandardCheckConnectionOutput().withStatus(StandardCheckConnectionOutput.Status.FAILED));
 
     return new CheckConnectionRead()
         .status(Enums.convertTo(output.getStatus(), CheckConnectionRead.StatusEnum.class))

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendDestinationImplementationHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendDestinationImplementationHandler.java
@@ -24,9 +24,8 @@
 
 package io.airbyte.server.handlers;
 
-import static io.airbyte.api.model.CheckConnectionRead.StatusEnum.SUCCESS;
-
 import io.airbyte.api.model.CheckConnectionRead;
+import io.airbyte.api.model.CheckConnectionRead.StatusEnum;
 import io.airbyte.api.model.DestinationImplementationCreate;
 import io.airbyte.api.model.DestinationImplementationIdRequestBody;
 import io.airbyte.api.model.DestinationImplementationRead;
@@ -66,7 +65,7 @@ public class WebBackendDestinationImplementationHandler {
     try {
       CheckConnectionRead checkConnectionRead = schedulerHandler
           .checkDestinationImplementationConnection(destinationImplementationIdRequestBody);
-      if (checkConnectionRead.getStatus() == SUCCESS) {
+      if (checkConnectionRead.getStatus() == StatusEnum.SUCCEEDED) {
         return destinationImplementation;
       }
     } catch (Exception e) {
@@ -95,7 +94,7 @@ public class WebBackendDestinationImplementationHandler {
     try {
       CheckConnectionRead checkConnectionRead = schedulerHandler
           .checkDestinationImplementationConnection(destinationImplementationIdRequestBody);
-      if (checkConnectionRead.getStatus() == SUCCESS) {
+      if (checkConnectionRead.getStatus() == StatusEnum.SUCCEEDED) {
         final DestinationImplementationIdRequestBody destinationImplementationIdRequestBody1 = new DestinationImplementationIdRequestBody()
             .destinationImplementationId(destinationImplementationRecreate.getDestinationImplementationId());
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendSourceImplementationHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendSourceImplementationHandler.java
@@ -24,9 +24,8 @@
 
 package io.airbyte.server.handlers;
 
-import static io.airbyte.api.model.CheckConnectionRead.StatusEnum.SUCCESS;
-
 import io.airbyte.api.model.CheckConnectionRead;
+import io.airbyte.api.model.CheckConnectionRead.StatusEnum;
 import io.airbyte.api.model.SourceImplementationCreate;
 import io.airbyte.api.model.SourceImplementationIdRequestBody;
 import io.airbyte.api.model.SourceImplementationRead;
@@ -65,7 +64,7 @@ public class WebBackendSourceImplementationHandler {
     try {
       CheckConnectionRead checkConnectionRead = schedulerHandler
           .checkSourceImplementationConnection(sourceImplementationIdRequestBody);
-      if (checkConnectionRead.getStatus() == SUCCESS) {
+      if (checkConnectionRead.getStatus() == StatusEnum.SUCCEEDED) {
         return sourceImplementation;
       }
     } catch (Exception e) {
@@ -93,7 +92,7 @@ public class WebBackendSourceImplementationHandler {
     try {
       CheckConnectionRead checkConnectionRead = schedulerHandler
           .checkSourceImplementationConnection(sourceImplementationIdRequestBody);
-      if (checkConnectionRead.getStatus() == SUCCESS) {
+      if (checkConnectionRead.getStatus() == StatusEnum.SUCCEEDED) {
         final SourceImplementationIdRequestBody sourceImplementationIdRequestBody1 = new SourceImplementationIdRequestBody()
             .sourceImplementationId(sourceImplementationRecreate.getSourceImplementationId());
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendDestinationImplementationHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendDestinationImplementationHandlerTest.java
@@ -86,7 +86,7 @@ public class WebBackendDestinationImplementationHandlerTest {
     destinationImplementationIdRequestBody.setDestinationImplementationId(destinationImplementationRead.getDestinationImplementationId());
 
     CheckConnectionRead checkConnectionRead = new CheckConnectionRead();
-    checkConnectionRead.setStatus(StatusEnum.SUCCESS);
+    checkConnectionRead.setStatus(StatusEnum.SUCCEEDED);
 
     when(schedulerHandler.checkDestinationImplementationConnection(destinationImplementationIdRequestBody)).thenReturn(checkConnectionRead);
 
@@ -109,7 +109,7 @@ public class WebBackendDestinationImplementationHandlerTest {
         .thenReturn(destinationImplementationRead);
 
     CheckConnectionRead checkConnectionRead = new CheckConnectionRead();
-    checkConnectionRead.setStatus(StatusEnum.FAILURE);
+    checkConnectionRead.setStatus(StatusEnum.FAILED);
 
     DestinationImplementationIdRequestBody destinationImplementationIdRequestBody = new DestinationImplementationIdRequestBody();
     destinationImplementationIdRequestBody.setDestinationImplementationId(destinationImplementationRead.getDestinationImplementationId());
@@ -138,7 +138,7 @@ public class WebBackendDestinationImplementationHandlerTest {
     newDestinationId.setDestinationImplementationId(newDestinationImplementation.getDestinationImplementationId());
 
     CheckConnectionRead checkConnectionRead = new CheckConnectionRead();
-    checkConnectionRead.setStatus(StatusEnum.SUCCESS);
+    checkConnectionRead.setStatus(StatusEnum.SUCCEEDED);
 
     when(schedulerHandler.checkDestinationImplementationConnection(newDestinationId)).thenReturn(checkConnectionRead);
 
@@ -174,7 +174,7 @@ public class WebBackendDestinationImplementationHandlerTest {
     newDestinationId.setDestinationImplementationId(newDestinationImplementation.getDestinationImplementationId());
 
     CheckConnectionRead checkConnectionRead = new CheckConnectionRead();
-    checkConnectionRead.setStatus(StatusEnum.FAILURE);
+    checkConnectionRead.setStatus(StatusEnum.FAILED);
 
     when(schedulerHandler.checkDestinationImplementationConnection(newDestinationId)).thenReturn(checkConnectionRead);
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendSourceImplementationHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendSourceImplementationHandlerTest.java
@@ -84,7 +84,7 @@ public class WebBackendSourceImplementationHandlerTest {
     sourceImplementationIdRequestBody.setSourceImplementationId(sourceImplementationRead.getSourceImplementationId());
 
     CheckConnectionRead checkConnectionRead = new CheckConnectionRead();
-    checkConnectionRead.setStatus(StatusEnum.SUCCESS);
+    checkConnectionRead.setStatus(StatusEnum.SUCCEEDED);
 
     when(schedulerHandler.checkSourceImplementationConnection(sourceImplementationIdRequestBody)).thenReturn(checkConnectionRead);
 
@@ -103,7 +103,7 @@ public class WebBackendSourceImplementationHandlerTest {
     when(sourceImplementationsHandler.createSourceImplementation(sourceImplementationCreate)).thenReturn(sourceImplementationRead);
 
     CheckConnectionRead checkConnectionRead = new CheckConnectionRead();
-    checkConnectionRead.setStatus(StatusEnum.FAILURE);
+    checkConnectionRead.setStatus(StatusEnum.FAILED);
 
     SourceImplementationIdRequestBody sourceImplementationIdRequestBody = new SourceImplementationIdRequestBody();
     sourceImplementationIdRequestBody.setSourceImplementationId(sourceImplementationRead.getSourceImplementationId());
@@ -131,7 +131,7 @@ public class WebBackendSourceImplementationHandlerTest {
     newSourceId.setSourceImplementationId(newSourceImplementation.getSourceImplementationId());
 
     CheckConnectionRead checkConnectionRead = new CheckConnectionRead();
-    checkConnectionRead.setStatus(StatusEnum.SUCCESS);
+    checkConnectionRead.setStatus(StatusEnum.SUCCEEDED);
 
     when(schedulerHandler.checkSourceImplementationConnection(newSourceId)).thenReturn(checkConnectionRead);
 
@@ -167,7 +167,7 @@ public class WebBackendSourceImplementationHandlerTest {
     newSourceId.setSourceImplementationId(newSourceImplementation.getSourceImplementationId());
 
     CheckConnectionRead checkConnectionRead = new CheckConnectionRead();
-    checkConnectionRead.setStatus(StatusEnum.FAILURE);
+    checkConnectionRead.setStatus(StatusEnum.FAILED);
 
     when(schedulerHandler.checkSourceImplementationConnection(newSourceId)).thenReturn(checkConnectionRead);
 

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -33,6 +33,7 @@ import io.airbyte.api.client.AirbyteApiClient;
 import io.airbyte.api.client.invoker.ApiClient;
 import io.airbyte.api.client.invoker.ApiException;
 import io.airbyte.api.client.model.CheckConnectionRead;
+import io.airbyte.api.client.model.CheckConnectionRead.StatusEnum;
 import io.airbyte.api.client.model.ConnectionCreate;
 import io.airbyte.api.client.model.ConnectionIdRequestBody;
 import io.airbyte.api.client.model.ConnectionRead;
@@ -158,7 +159,7 @@ public class AcceptanceTests {
             new DestinationImplementationIdRequestBody().destinationImplementationId(destinationImplId))
         .getStatus();
 
-    assertEquals(CheckConnectionRead.StatusEnum.SUCCESS, checkOperationStatus);
+    assertEquals(StatusEnum.SUCCEEDED, checkOperationStatus);
   }
 
   @Test
@@ -189,7 +190,7 @@ public class AcceptanceTests {
     CheckConnectionRead checkConnectionRead = apiClient.getSourceImplementationApi()
         .checkConnectionToSourceImplementation(new SourceImplementationIdRequestBody().sourceImplementationId(sourceImplId));
 
-    assertEquals(CheckConnectionRead.StatusEnum.SUCCESS, checkConnectionRead.getStatus());
+    assertEquals(StatusEnum.SUCCEEDED, checkConnectionRead.getStatus());
   }
 
   @Test
@@ -238,7 +239,7 @@ public class AcceptanceTests {
 
     ConnectionSyncRead connectionSyncRead =
         apiClient.getConnectionApi().syncConnection(new ConnectionIdRequestBody().connectionId(createdConnection.getConnectionId()));
-    assertEquals(ConnectionSyncRead.StatusEnum.SUCCESS, connectionSyncRead.getStatus());
+    assertEquals(ConnectionSyncRead.StatusEnum.SUCCEEDED, connectionSyncRead.getStatus());
     assertSourceAndTargetDbInSync(sourcePsql, targetPsql);
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultCheckConnectionWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultCheckConnectionWorker.java
@@ -52,13 +52,13 @@ public class DefaultCheckConnectionWorker implements CheckConnectionWorker {
 
     final JobStatus jobStatus;
     final StandardCheckConnectionOutput output = new StandardCheckConnectionOutput();
-    if (outputAndStatus.getStatus() == JobStatus.SUCCESSFUL && outputAndStatus.getOutput().isPresent()) {
-      output.withStatus(StandardCheckConnectionOutput.Status.SUCCESS);
-      jobStatus = JobStatus.SUCCESSFUL;
+    if (outputAndStatus.getStatus() == JobStatus.SUCCEEDED && outputAndStatus.getOutput().isPresent()) {
+      output.withStatus(StandardCheckConnectionOutput.Status.SUCCEEDED);
+      jobStatus = JobStatus.SUCCEEDED;
     } else {
       LOGGER.info("Connection check unsuccessful. Discovery output: {}", outputAndStatus);
       jobStatus = JobStatus.FAILED;
-      output.withStatus(StandardCheckConnectionOutput.Status.FAILURE)
+      output.withStatus(StandardCheckConnectionOutput.Status.FAILED)
           // TODO add better error log parsing to specify the exact reason for failure as the message
           .withMessage("Failed to connect.");
     }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultDiscoverCatalogWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultDiscoverCatalogWorker.java
@@ -24,9 +24,6 @@
 
 package io.airbyte.workers;
 
-import static io.airbyte.workers.JobStatus.FAILED;
-import static io.airbyte.workers.JobStatus.SUCCEEDED;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.io.LineGobbler;
@@ -60,7 +57,7 @@ public class DefaultDiscoverCatalogWorker implements DiscoverCatalogWorker {
       return runInternal(discoverSchemaInput, jobRoot);
     } catch (final Exception e) {
       LOGGER.error("Error while discovering schema", e);
-      return new OutputAndStatus<>(FAILED);
+      return new OutputAndStatus<>(JobStatus.FAILED);
     }
   }
 
@@ -84,12 +81,12 @@ public class DefaultDiscoverCatalogWorker implements DiscoverCatalogWorker {
 
     if (exitCode == 0) {
       return new OutputAndStatus<>(
-          SUCCESSFUL,
+          JobStatus.SUCCEEDED,
           new StandardDiscoverCatalogOutput()
               .withCatalog(readCatalog(jobRoot)));
     } else {
       LOGGER.debug("Discovery job subprocess finished with exit code {}", exitCode);
-      return new OutputAndStatus<>(FAILED);
+      return new OutputAndStatus<>(JobStatus.FAILED);
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultDiscoverCatalogWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultDiscoverCatalogWorker.java
@@ -25,7 +25,7 @@
 package io.airbyte.workers;
 
 import static io.airbyte.workers.JobStatus.FAILED;
-import static io.airbyte.workers.JobStatus.SUCCESSFUL;
+import static io.airbyte.workers.JobStatus.SUCCEEDED;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.io.IOs;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultGetSpecWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultGetSpecWorker.java
@@ -62,7 +62,7 @@ public class DefaultGetSpecWorker implements GetSpecWorker {
         if (process.exitValue() == 0) {
           String specString = new String(stdout.readAllBytes());
           ConnectorSpecification spec = Jsons.deserialize(specString, ConnectorSpecification.class);
-          return new OutputAndStatus<>(JobStatus.SUCCESSFUL, new StandardGetSpecOutput().withSpecification(spec));
+          return new OutputAndStatus<>(JobStatus.SUCCEEDED, new StandardGetSpecOutput().withSpecification(spec));
         } else {
           return new OutputAndStatus<>(JobStatus.FAILED);
         }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultSyncWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultSyncWorker.java
@@ -101,7 +101,7 @@ public class DefaultSyncWorker<T> implements SyncWorker {
       output.withState(state);
     });
 
-    return new OutputAndStatus<>(cancelled.get() ? JobStatus.FAILED : JobStatus.SUCCESSFUL, output);
+    return new OutputAndStatus<>(cancelled.get() ? JobStatus.FAILED : JobStatus.SUCCEEDED, output);
   }
 
   @Override

--- a/airbyte-workers/src/main/java/io/airbyte/workers/EchoWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/EchoWorker.java
@@ -37,7 +37,7 @@ public class EchoWorker implements Worker<String, String> {
   @Override
   public OutputAndStatus<String> run(String string, Path jobRoot) {
     LOGGER.info("Hello World. input: {}, workspace root: {}", string, jobRoot);
-    return new OutputAndStatus<>(JobStatus.SUCCESSFUL, "echoed");
+    return new OutputAndStatus<>(JobStatus.SUCCEEDED, "echoed");
   }
 
   @Override

--- a/airbyte-workers/src/main/java/io/airbyte/workers/JobStatus.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/JobStatus.java
@@ -26,7 +26,7 @@ package io.airbyte.workers;
 
 /**
  * Indicates whether the worker's underlying process was successful. E.g this should return
- * SUCCESSFUL if a connection check succeeds, FAILED otherwise.
+ * SUCCEEDED if a connection check succeeds, FAILED otherwise.
  */
 public enum JobStatus {
   FAILED,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/JobStatus.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/JobStatus.java
@@ -30,5 +30,5 @@ package io.airbyte.workers;
  */
 public enum JobStatus {
   FAILED,
-  SUCCESSFUL
+  SUCCEEDED
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/singer/SingerDiscoverCatalogWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/singer/SingerDiscoverCatalogWorker.java
@@ -25,7 +25,7 @@
 package io.airbyte.workers.protocols.singer;
 
 import static io.airbyte.workers.JobStatus.FAILED;
-import static io.airbyte.workers.JobStatus.SUCCESSFUL;
+import static io.airbyte.workers.JobStatus.SUCCEEDED;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.io.IOs;
@@ -89,7 +89,7 @@ public class SingerDiscoverCatalogWorker implements DiscoverCatalogWorker {
 
     if (exitCode == 0) {
       return new OutputAndStatus<>(
-          SUCCESSFUL,
+          SUCCEEDED,
           new StandardDiscoverCatalogOutput()
               .withSchema(SingerCatalogConverters.toAirbyteSchema(readCatalog(jobRoot))));
     } else {

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultCheckConnectionWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultCheckConnectionWorkerTest.java
@@ -67,15 +67,15 @@ public class DefaultCheckConnectionWorkerTest {
   @Test
   public void testSuccessfulConnection() {
     OutputAndStatus<StandardDiscoverCatalogOutput> discoverOutput =
-        new OutputAndStatus<>(JobStatus.SUCCESSFUL, mock(StandardDiscoverCatalogOutput.class));
+        new OutputAndStatus<>(JobStatus.SUCCEEDED, mock(StandardDiscoverCatalogOutput.class));
     when(discoverCatalogWorker.run(discoverInput, jobRoot)).thenReturn(discoverOutput);
 
     final DefaultCheckConnectionWorker worker = new DefaultCheckConnectionWorker(discoverCatalogWorker);
     final OutputAndStatus<StandardCheckConnectionOutput> output = worker.run(input, jobRoot);
 
-    assertEquals(JobStatus.SUCCESSFUL, output.getStatus());
+    assertEquals(JobStatus.SUCCEEDED, output.getStatus());
     assertTrue(output.getOutput().isPresent());
-    assertEquals(StandardCheckConnectionOutput.Status.SUCCESS, output.getOutput().get().getStatus());
+    assertEquals(StandardCheckConnectionOutput.Status.SUCCEEDED, output.getOutput().get().getStatus());
     assertNull(output.getOutput().get().getMessage());
 
     verify(discoverCatalogWorker).run(discoverInput, jobRoot);
@@ -91,7 +91,7 @@ public class DefaultCheckConnectionWorkerTest {
 
     assertEquals(JobStatus.FAILED, output.getStatus());
     assertTrue(output.getOutput().isPresent());
-    assertEquals(StandardCheckConnectionOutput.Status.FAILURE, output.getOutput().get().getStatus());
+    assertEquals(StandardCheckConnectionOutput.Status.FAILED, output.getOutput().get().getStatus());
     assertEquals("Failed to connect.", output.getOutput().get().getMessage());
 
     verify(discoverCatalogWorker).run(discoverInput, jobRoot);
@@ -100,7 +100,7 @@ public class DefaultCheckConnectionWorkerTest {
   @Test
   public void testCancel() {
     OutputAndStatus<StandardDiscoverCatalogOutput> discoverOutput =
-        new OutputAndStatus<>(JobStatus.SUCCESSFUL, new StandardDiscoverCatalogOutput());
+        new OutputAndStatus<>(JobStatus.SUCCEEDED, new StandardDiscoverCatalogOutput());
     when(discoverCatalogWorker.run(discoverInput, jobRoot)).thenReturn(discoverOutput);
 
     final DefaultCheckConnectionWorker worker = new DefaultCheckConnectionWorker(discoverCatalogWorker);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultDiscoverCatalogWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultDiscoverCatalogWorkerTest.java
@@ -83,7 +83,7 @@ public class DefaultDiscoverCatalogWorkerTest {
 
     final OutputAndStatus<StandardDiscoverCatalogOutput> expectedOutput =
         new OutputAndStatus<>(
-            JobStatus.SUCCESSFUL,
+            JobStatus.SUCCEEDED,
             Jsons.deserialize(MoreResources.readResource("airbyte_discovered_postgres_catalog_output.json"), StandardDiscoverCatalogOutput.class));
 
     assertEquals(expectedOutput, output);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultGetSpecWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultGetSpecWorkerTest.java
@@ -75,7 +75,7 @@ class DefaultGetSpecWorkerTest {
 
     OutputAndStatus<StandardGetSpecOutput> actualOutput = worker.run(config, jobRoot);
     OutputAndStatus<StandardGetSpecOutput> expectedOutput =
-        new OutputAndStatus<>(JobStatus.SUCCESSFUL,
+        new OutputAndStatus<>(JobStatus.SUCCEEDED,
             new StandardGetSpecOutput().withSpecification(Jsons.deserialize(expectedSpecString, ConnectorSpecification.class)));
 
     assertEquals(expectedOutput, actualOutput);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/singer/DefaultSingerSourceTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/singer/DefaultSingerSourceTest.java
@@ -102,7 +102,7 @@ class DefaultSingerSourceTest {
               Files.writeString(
                   jobRoot.resolve(DefaultSingerSource.DISCOVERY_DIR).resolve(WorkerConstants.CATALOG_JSON_FILENAME),
                   Jsons.serialize(SINGER_CATALOG));
-              return new OutputAndStatus<>(JobStatus.SUCCESSFUL, new StandardDiscoverCatalogOutput());
+              return new OutputAndStatus<>(JobStatus.SUCCEEDED, new StandardDiscoverCatalogOutput());
             });
 
     integrationLauncher = mock(IntegrationLauncher.class, RETURNS_DEEP_STUBS);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/singer/SingerDiscoverCatalogWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/singer/SingerDiscoverCatalogWorkerTest.java
@@ -87,7 +87,7 @@ public class SingerDiscoverCatalogWorkerTest {
 
     final OutputAndStatus<StandardDiscoverCatalogOutput> expectedOutput =
         new OutputAndStatus<>(
-            JobStatus.SUCCESSFUL,
+            JobStatus.SUCCEEDED,
             Jsons.deserialize(MoreResources.readResource("singer_discovered_postgres_catalog_output.json"), StandardDiscoverCatalogOutput.class));
 
     assertEquals(expectedOutput, output);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/wrappers/JobOutputCheckConnectionWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/wrappers/JobOutputCheckConnectionWorkerTest.java
@@ -48,11 +48,11 @@ public class JobOutputCheckConnectionWorkerTest {
 
     StandardCheckConnectionOutput output = new StandardCheckConnectionOutput().withMessage("hello world");
 
-    when(checkConnectionWorker.run(input, jobRoot)).thenReturn(new OutputAndStatus<>(JobStatus.SUCCESSFUL, output));
+    when(checkConnectionWorker.run(input, jobRoot)).thenReturn(new OutputAndStatus<>(JobStatus.SUCCEEDED, output));
     OutputAndStatus<JobOutput> run = new JobOutputCheckConnectionWorker(checkConnectionWorker).run(input, jobRoot);
 
     JobOutput expected = new JobOutput().withOutputType(JobOutput.OutputType.CHECK_CONNECTION).withCheckConnection(output);
-    assertEquals(JobStatus.SUCCESSFUL, run.getStatus());
+    assertEquals(JobStatus.SUCCEEDED, run.getStatus());
     assertTrue(run.getOutput().isPresent());
     assertEquals(expected, run.getOutput().get());
   }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/wrappers/JobOutputDiscoveryWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/wrappers/JobOutputDiscoveryWorkerTest.java
@@ -52,11 +52,11 @@ public class JobOutputDiscoveryWorkerTest {
     StandardDiscoverCatalogOutput output = new StandardDiscoverCatalogOutput().withSchema(
         new Schema().withStreams(Lists.newArrayList(new Stream().withName("table"))));
 
-    when(discoverWorker.run(input, jobRoot)).thenReturn(new OutputAndStatus<>(JobStatus.SUCCESSFUL, output));
+    when(discoverWorker.run(input, jobRoot)).thenReturn(new OutputAndStatus<>(JobStatus.SUCCEEDED, output));
     OutputAndStatus<JobOutput> run = new JobOutputDiscoverSchemaWorker(discoverWorker).run(input, jobRoot);
 
     JobOutput expected = new JobOutput().withOutputType(JobOutput.OutputType.DISCOVER_CATALOG).withDiscoverCatalog(output);
-    assertEquals(JobStatus.SUCCESSFUL, run.getStatus());
+    assertEquals(JobStatus.SUCCEEDED, run.getStatus());
     assertTrue(run.getOutput().isPresent());
     assertEquals(expected, run.getOutput().get());
   }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/wrappers/JobOutputSyncWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/wrappers/JobOutputSyncWorkerTest.java
@@ -50,11 +50,11 @@ public class JobOutputSyncWorkerTest {
 
     StandardSyncOutput output = new StandardSyncOutput().withState(new State().withConnectionId(UUID.randomUUID()));
 
-    when(syncWorker.run(input, jobRoot)).thenReturn(new OutputAndStatus<>(JobStatus.SUCCESSFUL, output));
+    when(syncWorker.run(input, jobRoot)).thenReturn(new OutputAndStatus<>(JobStatus.SUCCEEDED, output));
     OutputAndStatus<JobOutput> run = new JobOutputSyncWorker(syncWorker).run(input, jobRoot);
 
     JobOutput expected = new JobOutput().withOutputType(JobOutput.OutputType.SYNC).withSync(output);
-    assertEquals(JobStatus.SUCCESSFUL, run.getStatus());
+    assertEquals(JobStatus.SUCCEEDED, run.getStatus());
     assertTrue(run.getOutput().isPresent());
     assertEquals(expected, run.getOutput().get());
   }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/wrappers/OutputConvertingWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/wrappers/OutputConvertingWorkerTest.java
@@ -45,7 +45,7 @@ public class OutputConvertingWorkerTest {
     String inputConfig = "input";
     int expectedOutput = 123;
     Path path = Path.of("fakepath");
-    when(worker.run(inputConfig, path)).thenReturn(new OutputAndStatus<>(JobStatus.SUCCESSFUL, String.valueOf(expectedOutput)));
+    when(worker.run(inputConfig, path)).thenReturn(new OutputAndStatus<>(JobStatus.SUCCEEDED, String.valueOf(expectedOutput)));
 
     OutputAndStatus<Integer> output = new OutputConvertingWorker<String, String, Integer>(worker, Integer::valueOf).run(inputConfig, path);
     assertTrue(output.getOutput().isPresent());


### PR DESCRIPTION
## What
* We are really inconsistent on how we use these words in enums. 
* This is frustrating because it makes it needless difficulty to convert between enums.

## How
* Now we are not inconsistent. All permutations of these words I could find as enums went to `succeeded` and `failed`.

It's a lot of files touched here, but it's all the same operation. 