### PR TITLE
push python / singer base across finish line for airbyte protocol (aka charles tries to write python)

### DIFF
--- a/airbyte-integrations/base-python/airbyte_protocol/__init__.py
+++ b/airbyte-integrations/base-python/airbyte_protocol/__init__.py
@@ -7,6 +7,7 @@ from .models import AirbyteMessage
 from .models import AirbyteRecordMessage
 from .models import AirbyteStateMessage
 from .models import AirbyteStream
+from .models import ConnectorSpecification
 
 # Must be the last one because the way we load the connector module creates a circular
 # dependency and models might not have been loaded yet

--- a/airbyte-integrations/base-python/airbyte_protocol/entrypoint.py
+++ b/airbyte-integrations/base-python/airbyte_protocol/entrypoint.py
@@ -6,6 +6,7 @@ import tempfile
 
 from .integration import ConfigContainer, Source
 from .logger import AirbyteLogger
+from airbyte_protocol import AirbyteMessage, AirbyteConnectionStatus
 
 impl_module = os.environ.get('AIRBYTE_IMPL_MODULE', Source.__module__)
 impl_class = os.environ.get('AIRBYTE_IMPL_PATH', Source.__name__)
@@ -65,8 +66,8 @@ class AirbyteEntrypoint(object):
 
         with tempfile.TemporaryDirectory() as temp_dir:
             if cmd == "spec":
-                # todo: output this as a JSON formatted message
-                print(self.source.spec(logger).spec_string)
+                message = AirbyteMessage(type='SPEC', spec=self.source.spec(logger))
+                print(message.json(exclude_unset=True))
                 sys.exit(0)
 
             raw_config = self.source.read_config(parsed_args.config)
@@ -83,15 +84,20 @@ class AirbyteEntrypoint(object):
 
             if cmd == "check":
                 check_result = self.source.check(logger, config_container)
+
                 if check_result.successful:
                     logger.info("Check succeeded")
-                    sys.exit(0)
+                    status = AirbyteConnectionStatus(status='SUCCEEDED')
                 else:
                     logger.error("Check failed")
-                    sys.exit(1)
+                    status = AirbyteConnectionStatus(status='FAILED')
+                message = AirbyteMessage(type='CONNECTION_STATUS', connectionStatus=status)
+                print(message.json(exclude_unset=True))
+                sys.exit(0)
             elif cmd == "discover":
                 catalog = self.source.discover(logger, config_container)
-                print(catalog.json(exclude_unset=True))
+                message = AirbyteMessage(type='CATALOG', catalog=catalog)
+                print(message.json(exclude_unset=True))
                 sys.exit(0)
             elif cmd == "read":
                 generator = self.source.read(logger, config_container, parsed_args.catalog, parsed_args.state)

--- a/airbyte-integrations/base-python/airbyte_protocol/integration.py
+++ b/airbyte-integrations/base-python/airbyte_protocol/integration.py
@@ -3,8 +3,7 @@ import pkgutil
 from dataclasses import dataclass
 from typing import Generator
 
-from .models import AirbyteCatalog, AirbyteMessage
-
+from .models import AirbyteCatalog, AirbyteMessage, ConnectorSpecification
 
 class AirbyteSpec(object):
     @staticmethod
@@ -35,11 +34,9 @@ class Integration(object):
     def __init__(self):
         pass
 
-    def spec(self, logger) -> AirbyteSpec:
+    def spec(self, logger) -> ConnectorSpecification:
         raw_spec = pkgutil.get_data(self.__class__.__module__.split('.')[0], 'spec.json')
-        # we need to output a spec on a single line
-        flattened_json = json.dumps(json.loads(raw_spec))
-        return AirbyteSpec(flattened_json)
+        return ConnectorSpecification.parse_obj(json.loads(raw_spec))
 
     def read_config(self, config_path):
         with open(config_path, 'r') as file:

--- a/airbyte-integrations/base-python/airbyte_protocol/models/airbyte_message.py
+++ b/airbyte-integrations/base-python/airbyte_protocol/models/airbyte_message.py
@@ -64,8 +64,8 @@ class AirbyteConnectionStatus(BaseModel):
 
 class AirbyteStream(BaseModel):
     name: str = Field(..., description="Stream's name.")
-    json_schema: Optional[Dict[str, Any]] = Field(
-        None, description='Stream schema using Json Schema specs.'
+    json_schema: Dict[str, Any] = Field(
+        ..., description='Stream schema using Json Schema specs.'
     )
 
 

--- a/airbyte-integrations/base-singer/base_singer/singer_helpers.py
+++ b/airbyte-integrations/base-singer/base_singer/singer_helpers.py
@@ -47,7 +47,7 @@ class SingerHelper:
 
         for stream in singer_catalog.get("streams"):
             name = stream.get("stream")
-            schema = stream.get("schema").get("properties")
+            schema = stream.get("schema")
             airbyte_streams += [AirbyteStream(name=name, json_schema=schema)]
 
         airbyte_catalog = airbyte_transform(AirbyteCatalog(streams=airbyte_streams))
@@ -104,14 +104,15 @@ class SingerHelper:
         for singer_stream in discovered_singer_catalog.get("streams"):
             if singer_stream.get("stream") in stream_to_airbyte_schema:
                 new_metadatas = []
-                metadatas = singer_stream.get("metadata")
-                for metadata in metadatas:
-                    new_metadata = metadata
-                    new_metadata["metadata"]["selected"] = True
-                    if not is_field_metadata(new_metadata):
-                        new_metadata["metadata"]["forced-replication-method"] = "FULL_TABLE"
-                    new_metadatas += [new_metadata]
-                singer_stream["metadata"] = new_metadatas
+                if singer_stream.get("metadata"):
+                    metadatas = singer_stream.get("metadata")
+                    for metadata in metadatas:
+                        new_metadata = metadata
+                        new_metadata["metadata"]["selected"] = True
+                        if not is_field_metadata(new_metadata):
+                            new_metadata["metadata"]["forced-replication-method"] = "FULL_TABLE"
+                        new_metadatas += [new_metadata]
+                    singer_stream["metadata"] = new_metadatas
 
             masked_singer_streams += [singer_stream]
 

--- a/airbyte-integrations/base-singer/requirements.txt
+++ b/airbyte-integrations/base-singer/requirements.txt
@@ -1,2 +1,2 @@
--e ../../base-python
+-e ../base-python
 -e .

--- a/airbyte-integrations/singer/exchangeratesapi/source/Dockerfile
+++ b/airbyte-integrations/singer/exchangeratesapi/source/Dockerfile
@@ -9,7 +9,7 @@ ENV AIRBYTE_IMPL_MODULE="source_exchangeratesapi_singer"
 ENV AIRBYTE_IMPL_PATH="SourceExchangeRatesApiSinger"
 
 LABEL io.airbyte.version=0.1.2
-LABEL io.airbyte.name=airbyte/source-exchangeratesapi-singer
+LABEL io.airbyte.name=airbyte/source-exchangeratesapi-singer-abprotocol
 
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH

--- a/airbyte-integrations/singer/exchangeratesapi/source/src/test-integration/java/io/airbyte/integration_tests/sources/SingerExchangeRatesApiSourceTest.java
+++ b/airbyte-integrations/singer/exchangeratesapi/source/src/test-integration/java/io/airbyte/integration_tests/sources/SingerExchangeRatesApiSourceTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 public class SingerExchangeRatesApiSourceTest {
 
   private static final Path TESTS_PATH = Path.of("/tmp/airbyte_integration_tests");
-  private static final String IMAGE_NAME = "airbyte/source-exchangeratesapi-singer:dev";
+  private static final String IMAGE_NAME = "airbyte/source-exchangeratesapi-singer-abprotocol:dev";
 
   private static final String CATALOG = "catalog.json";
   private static final String CONFIG = "config.json";

--- a/airbyte-integrations/singer/exchangeratesapi/source/src/test-integration/java/io/airbyte/integration_tests/sources/SingerExchangeRatesApiSourceTest.java
+++ b/airbyte-integrations/singer/exchangeratesapi/source/src/test-integration/java/io/airbyte/integration_tests/sources/SingerExchangeRatesApiSourceTest.java
@@ -41,9 +41,7 @@ import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -119,9 +117,8 @@ public class SingerExchangeRatesApiSourceTest {
     final Date date = Date.from(Instant.now().minus(2, ChronoUnit.DAYS));
     final SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
 
-    IOs.writeFile(jobRoot, CONFIG, String.format("{\"start_date\":\"%s\", \"base\":\"USD\"}", fmt.format(date)));
+    IOs.writeFile(jobRoot, CONFIG, String.format("{\"start_date\":\"%s\"}", fmt.format(date)));
     IOs.writeFile(jobRoot, CATALOG, MoreResources.readResource("catalog.json"));
-    System.out.println("MoreResources.readResource(\"catalog.json\") = " + MoreResources.readResource("catalog.json"));
 
     final Path syncOutputPath = jobRoot.resolve("sync_output.txt");
     final Process process = createSyncProcess(syncOutputPath);
@@ -129,9 +126,6 @@ public class SingerExchangeRatesApiSourceTest {
 
     assertEquals(0, process.exitValue());
 
-    final List<String> list = IOs.readFile(syncOutputPath).lines().collect(Collectors.toList());
-    System.out.println("list.size() = " + list.size());
-    System.out.println("list = " + list);
     final Optional<String> record = IOs.readFile(syncOutputPath).lines().filter(s -> s.contains("RECORD")).findFirst();
     assertTrue(record.isPresent());
 
@@ -163,7 +157,7 @@ public class SingerExchangeRatesApiSourceTest {
   }
 
   private Process createSyncProcess(Path syncOutputPath) throws IOException, WorkerException {
-    return launcher.read(jobRoot, CONFIG, CATALOG)
+    return launcher.read(jobRoot, CONFIG, "catalog.json")
         .redirectOutput(syncOutputPath.toFile())
         .redirectError(ProcessBuilder.Redirect.INHERIT)
         .start();

--- a/airbyte-integrations/singer/exchangeratesapi/source/src/test-integration/java/io/airbyte/integration_tests/sources/SingerExchangeRatesApiSourceTest.java
+++ b/airbyte-integrations/singer/exchangeratesapi/source/src/test-integration/java/io/airbyte/integration_tests/sources/SingerExchangeRatesApiSourceTest.java
@@ -41,7 +41,9 @@ import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -117,8 +119,9 @@ public class SingerExchangeRatesApiSourceTest {
     final Date date = Date.from(Instant.now().minus(2, ChronoUnit.DAYS));
     final SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
 
-    IOs.writeFile(jobRoot, CONFIG, String.format("{\"start_date\":\"%s\"}", fmt.format(date)));
+    IOs.writeFile(jobRoot, CONFIG, String.format("{\"start_date\":\"%s\", \"base\":\"USD\"}", fmt.format(date)));
     IOs.writeFile(jobRoot, CATALOG, MoreResources.readResource("catalog.json"));
+    System.out.println("MoreResources.readResource(\"catalog.json\") = " + MoreResources.readResource("catalog.json"));
 
     final Path syncOutputPath = jobRoot.resolve("sync_output.txt");
     final Process process = createSyncProcess(syncOutputPath);
@@ -126,6 +129,9 @@ public class SingerExchangeRatesApiSourceTest {
 
     assertEquals(0, process.exitValue());
 
+    final List<String> list = IOs.readFile(syncOutputPath).lines().collect(Collectors.toList());
+    System.out.println("list.size() = " + list.size());
+    System.out.println("list = " + list);
     final Optional<String> record = IOs.readFile(syncOutputPath).lines().filter(s -> s.contains("RECORD")).findFirst();
     assertTrue(record.isPresent());
 
@@ -157,7 +163,7 @@ public class SingerExchangeRatesApiSourceTest {
   }
 
   private Process createSyncProcess(Path syncOutputPath) throws IOException, WorkerException {
-    return launcher.read(jobRoot, CONFIG, "catalog.json")
+    return launcher.read(jobRoot, CONFIG, CATALOG)
         .redirectOutput(syncOutputPath.toFile())
         .redirectError(ProcessBuilder.Redirect.INHERIT)
         .start();

--- a/airbyte-integrations/singer/stripe_abprotocol/source/build.gradle
+++ b/airbyte-integrations/singer/stripe_abprotocol/source/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     integrationTestImplementation project(':airbyte-workers')
     integrationTestImplementation project(':airbyte-config:models')
+    integrationTestImplementation project(':airbyte-protocol:models')
 }
 
 buildImage.dependsOn ':airbyte-integrations:base-singer:buildImage'

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_message.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_message.yaml
@@ -121,7 +121,7 @@ definitions:
     additionalProperties: false
     required:
       - name
-      - schema
+      - json_schema
     properties:
       name:
         type: string


### PR DESCRIPTION
## What
* Migrate python base to use AirbyteMessage as envelope for everything.
* Fix issue where singer base was not returning valid json schema for the catalog to the worker on the discover action
* Fix issue where python converters could not valid handle singer catalogs that do not contain metadata
* fix pathing issue in requirements.txt for base-singer

This is the first of 2 PRs that gets us to a state where we can successfully run integrations fully using the airbyte protocol. 