### PR TITLE
Frequently run build to avoid stale build info

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,9 @@
 name: Airbyte CI
 
-on: push
+on:
+  schedule:
+    - cron: '0 13 * * *'
+  push:
 
 jobs:
   build:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,7 +2,7 @@ name: Airbyte CI
 
 on:
   schedule:
-    - cron: '0 13 * * *'
+    - cron: '0 */6 * * *'
   push:
 
 jobs:


### PR DESCRIPTION
## What
Run the build once a day to make sure we always have up-to-date build information. 