### PR TITLE
Fix java-destination template name

### DIFF
--- a/airbyte-integrations/template/java-destination/Dockerfile
+++ b/airbyte-integrations/template/java-destination/Dockerfile
@@ -3,7 +3,7 @@ FROM airbyte/integration-base-java:dev
 WORKDIR /airbyte
 
 # fixme - replace java-template with the name of directory that this file is in.
-ENV APPLICATION java-template-destination
+ENV APPLICATION java-destination
 
 COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 


### PR DESCRIPTION
## What
* directory housing the template changed, which changes the name of the distribution. in order to be able to build this image the Dockerfile needs to be looking for the correct name.