### PR TITLE
default to object when getting data type from jsonschema

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteProtocolConverters.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteProtocolConverters.java
@@ -81,7 +81,7 @@ public class AirbyteProtocolConverters {
           .withName(airbyteStream.getName())
           .withFields(list.stream().map(item -> new Field()
               .withName(item.getKey())
-              .withDataType(jsonSchemaTypesToDataType(item.getValue().get("type")))
+              .withDataType(getDataType(item.getValue()))
               .withSelected(true)).collect(Collectors.toList()));
     }).collect(Collectors.toList()));
   }
@@ -107,6 +107,18 @@ public class AirbyteProtocolConverters {
           .orElse(DataType.STRING);
     } else {
       throw new IllegalArgumentException("Unknown jsonschema type:" + Jsons.serialize(node));
+    }
+  }
+
+  // TODO HACK: this defaults to OBJECT in the case of anyOf. May fail with anyOf: [int or string],
+  // for example.
+  private static DataType getDataType(JsonNode node) {
+    JsonNode type = node.get("type");
+
+    if (type == null) {
+      return DataType.OBJECT;
+    } else {
+      return jsonSchemaTypesToDataType(type);
     }
   }
 

--- a/airbyte-config/models/src/test/java/io/airbyte/config/AirbyteProtocolConvertersTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/AirbyteProtocolConvertersTest.java
@@ -95,4 +95,22 @@ class AirbyteProtocolConvertersTest {
     assertEquals(schema, AirbyteProtocolConverters.toSchema(message.getCatalog()));
   }
 
+  @Test
+  void testAnyOfAsObject() {
+    final String testString =
+        "{\"type\":\"CATALOG\",\"catalog\":{\"streams\":[{\"name\":\"users\",\"json_schema\":{\"properties\":{\"date\":{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"object\"}]}}}}]}}";
+
+    Schema schema = new Schema()
+        .withStreams(Lists.newArrayList(new Stream()
+            .withName(STREAM)
+            .withFields(Lists.newArrayList(
+                new io.airbyte.config.Field()
+                    .withName("date")
+                    .withDataType(DataType.OBJECT)
+                    .withSelected(true)))));
+
+    final AirbyteMessage message = Jsons.deserialize(testString, AirbyteMessage.class);
+    assertEquals(schema, AirbyteProtocolConverters.toSchema(message.getCatalog()));
+  }
+
 }


### PR DESCRIPTION
Handles a case in `stripe_abprotocol` where we get a node like `{"anyOf":[{"type":["null","array"],"items":{"type":["null","object"],"p...` which doesn't have a `type` property.