### PR TITLE
improve exception logging in bq destination

### DIFF
--- a/airbyte-integrations/bigquery-destination/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
+++ b/airbyte-integrations/bigquery-destination/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
@@ -121,7 +121,8 @@ public class BigQueryDestination implements Destination {
     final String projectId = config.get(CONFIG_PROJECT_ID).asText();
     final String credentialsString = config.get(CONFIG_CREDS).asText();
     try {
-      final ServiceAccountCredentials credentials = ServiceAccountCredentials.fromStream(new ByteArrayInputStream(credentialsString.getBytes(Charsets.UTF_8)));
+      final ServiceAccountCredentials credentials =
+          ServiceAccountCredentials.fromStream(new ByteArrayInputStream(credentialsString.getBytes(Charsets.UTF_8)));
 
       return BigQueryOptions.newBuilder()
           .setProjectId(projectId)

--- a/airbyte-integrations/bigquery-destination/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
+++ b/airbyte-integrations/bigquery-destination/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
@@ -112,7 +112,8 @@ public class BigQueryDestination implements Destination {
         return new AirbyteConnectionStatus().withStatus(Status.FAILED).withMessage(result.getRight());
       }
     } catch (Exception e) {
-      return new AirbyteConnectionStatus().withStatus(Status.FAILED).withMessage(e.getMessage());
+      LOGGER.info("Check failed.", e);
+      return new AirbyteConnectionStatus().withStatus(Status.FAILED).withMessage(e.getMessage() != null ? e.getMessage() : e.toString());
     }
   }
 
@@ -120,7 +121,7 @@ public class BigQueryDestination implements Destination {
     final String projectId = config.get(CONFIG_PROJECT_ID).asText();
     final String credentialsString = config.get(CONFIG_CREDS).asText();
     try {
-      final ServiceAccountCredentials credentials = ServiceAccountCredentials.fromStream(new ByteArrayInputStream(credentialsString.getBytes()));
+      final ServiceAccountCredentials credentials = ServiceAccountCredentials.fromStream(new ByteArrayInputStream(credentialsString.getBytes(Charsets.UTF_8)));
 
       return BigQueryOptions.newBuilder()
           .setProjectId(projectId)


### PR DESCRIPTION
It was a pain to debug an exception here because most of the exception text was being swallowed.