### PR TITLE
fix stream level selection

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteProtocolConverters.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteProtocolConverters.java
@@ -41,10 +41,14 @@ import java.util.stream.StreamSupport;
 public class AirbyteProtocolConverters {
 
   public static AirbyteCatalog toCatalog(Schema schema) {
-    return new AirbyteCatalog()
-        .withStreams(schema.getStreams().stream().map(s -> new AirbyteStream()
+    List<AirbyteStream> airbyteStreams = schema.getStreams().stream()
+        .map(s -> new AirbyteStream()
             .withName(s.getName())
-            .withJsonSchema(toJson(s.getFields()))).collect(Collectors.toList()));
+            .withJsonSchema(toJson(s.getFields())))
+        // perform selection based on the output of toJson, which keeps properties if selected=true
+        .filter(s -> !s.getJsonSchema().get("properties").isEmpty())
+        .collect(Collectors.toList());
+    return new AirbyteCatalog().withStreams(airbyteStreams);
   }
 
   // todo (cgardens) - this will only work with table / column schemas. it's hack to get us through

--- a/airbyte-config/models/src/test/java/io/airbyte/config/AirbyteProtocolConvertersTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/AirbyteProtocolConvertersTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
 class AirbyteProtocolConvertersTest {
 
   private static final String STREAM = "users";
+  private static final String STREAM_2 = "users2";
   private static final String COLUMN_NAME = "name";
   private static final String COLUMN_AGE = "age";
   private static final AirbyteCatalog CATALOG = new AirbyteCatalog()
@@ -61,9 +62,38 @@ class AirbyteProtocolConvertersTest {
                   .withDataType(DataType.NUMBER)
                   .withSelected(true)))));
 
+  private static final Schema SCHEMA_WITH_UNSELECTED = new Schema()
+      .withStreams(Lists.newArrayList(new Stream()
+          .withName(STREAM)
+          .withFields(Lists.newArrayList(
+              new io.airbyte.config.Field()
+                  .withName(COLUMN_NAME)
+                  .withDataType(DataType.STRING)
+                  .withSelected(true),
+              new io.airbyte.config.Field()
+                  .withName(COLUMN_AGE)
+                  .withDataType(DataType.NUMBER)
+                  .withSelected(true))),
+          new Stream()
+              .withName(STREAM_2)
+              .withFields(Lists.newArrayList(
+                  new io.airbyte.config.Field()
+                      .withName(COLUMN_NAME)
+                      .withDataType(DataType.STRING)
+                      .withSelected(false),
+                  new io.airbyte.config.Field()
+                      .withName(COLUMN_AGE)
+                      .withDataType(DataType.NUMBER)
+                      .withSelected(false)))));
+
   @Test
   void testToCatalog() {
     assertEquals(CATALOG, AirbyteProtocolConverters.toCatalog(SCHEMA));
+  }
+
+  @Test
+  void testToCatalogWithUnselected() {
+    assertEquals(CATALOG, AirbyteProtocolConverters.toCatalog(SCHEMA_WITH_UNSELECTED));
   }
 
   @Test

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
@@ -38,9 +38,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.DataType;
 import io.airbyte.config.Schema;
 import io.airbyte.config.SourceConnectionImplementation;
-import io.airbyte.config.StandardDiscoverCatalogInput;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardTapConfig;
 import io.airbyte.config.State;
@@ -49,6 +49,7 @@ import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteStream;
 import io.airbyte.protocol.models.CatalogHelpers;
+import io.airbyte.protocol.models.Field;
 import io.airbyte.workers.WorkerConstants;
 import io.airbyte.workers.WorkerException;
 import io.airbyte.workers.process.IntegrationLauncher;
@@ -75,7 +76,7 @@ class DefaultAirbyteSourceTest {
       .withStreams(Collections.singletonList(
           new AirbyteStream()
               .withName("hudi:latest")
-              .withJsonSchema(CatalogHelpers.fieldsToJsonSchema())));
+              .withJsonSchema(CatalogHelpers.fieldsToJsonSchema(new Field(FIELD_NAME, Field.JsonSchemaPrimitive.STRING)))));
 
   private static final StandardTapConfig TAP_CONFIG = new StandardTapConfig()
       .withState(new State().withState(Jsons.jsonNode(ImmutableMap.of("checkpoint", "the future."))))
@@ -83,9 +84,9 @@ class DefaultAirbyteSourceTest {
           .withConfiguration(Jsons.jsonNode(Map.of(
               "apiKey", "123",
               "region", "us-east"))))
-      .withStandardSync(new StandardSync().withSchema(new Schema().withStreams(Lists.newArrayList(new Stream().withName("hudi:latest")))));
-  private static final StandardDiscoverCatalogInput DISCOVER_SCHEMA_INPUT = new StandardDiscoverCatalogInput()
-      .withConnectionConfiguration(TAP_CONFIG.getSourceConnectionImplementation().getConfiguration());
+      .withStandardSync(new StandardSync().withSchema(new Schema().withStreams(Lists.newArrayList(new Stream().withName("hudi:latest")
+          .withFields(Lists.newArrayList(new io.airbyte.config.Field().withDataType(DataType.STRING).withName(FIELD_NAME).withSelected(true)))
+          .withSelected(true)))));
 
   private static final List<AirbyteMessage> MESSAGES = Lists.newArrayList(
       AirbyteMessageUtils.createRecordMessage(STREAM_NAME, FIELD_NAME, "blue"),


### PR DESCRIPTION
For table-level selection, the Python Singer shim was not expecting an empty properties map from the catalog provided by the API for an unselected table.

After this discussion, the API will not emit an empty `AirbyteStream` at all for an unselected stream.