### PR TITLE
Fix broken pipe issues in spec, check, discover

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultCheckConnectionWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultCheckConnectionWorker.java
@@ -82,9 +82,9 @@ public class DefaultCheckConnectionWorker implements CheckConnectionWorker {
         status = streamFactory.create(IOs.newBufferedReader(stdout))
             .filter(message -> message.getType() == Type.CONNECTION_STATUS)
             .map(AirbyteMessage::getConnectionStatus).findFirst();
-      }
 
-      WorkerUtils.gentleClose(process, 1, TimeUnit.MINUTES);
+        WorkerUtils.gentleClose(process, 1, TimeUnit.MINUTES);
+      }
 
       int exitCode = process.exitValue();
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultDiscoverCatalogWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultDiscoverCatalogWorker.java
@@ -81,9 +81,9 @@ public class DefaultDiscoverCatalogWorker implements DiscoverCatalogWorker {
             .filter(message -> message.getType() == Type.CATALOG)
             .map(AirbyteMessage::getCatalog)
             .findFirst();
-      }
 
-      WorkerUtils.gentleClose(process, 1, TimeUnit.MINUTES);
+        WorkerUtils.gentleClose(process, 1, TimeUnit.MINUTES);
+      }
 
       int exitCode = process.exitValue();
       if (exitCode == 0) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultGetSpecWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultGetSpecWorker.java
@@ -72,13 +72,13 @@ public class DefaultGetSpecWorker implements GetSpecWorker {
             .filter(message -> message.getType() == Type.SPEC)
             .map(AirbyteMessage::getSpec)
             .findFirst();
-      }
 
-      // todo (cgardens) - let's pre-fetch the images outside of the worker so we don't need account for
-      // this.
-      // retrieving spec should generally be instantaneous, but since docker images might not be pulled
-      // it could take a while longer depending on internet conditions as well.
-      WorkerUtils.gentleClose(process, 2, TimeUnit.MINUTES);
+        // todo (cgardens) - let's pre-fetch the images outside of the worker so we don't need account for
+        // this.
+        // retrieving spec should generally be instantaneous, but since docker images might not be pulled
+        // it could take a while longer depending on internet conditions as well.
+        WorkerUtils.gentleClose(process, 2, TimeUnit.MINUTES);
+      }
 
       int exitCode = process.exitValue();
       if (exitCode == 0) {


### PR DESCRIPTION
## What
* Transiently (but somewhat frequently), the spec, check, and discover workers would fail with a broken pipe. What I think was happening was that the worker was sometimes closing it's connection to the integration too early. This would cause the integration process to exit with a non-zero exit code (even though everything was working fine). This PR waits until after the integration process has ended to close the input stream. I have tested this alot of times and it seems to work, but it's a transient issue, so I can't be 100% sure.
