### PR TITLE
fix postgres emittedat

### DIFF
--- a/airbyte-integrations/postgres-destination/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
+++ b/airbyte-integrations/postgres-destination/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
@@ -227,7 +227,7 @@ public class PostgresDestination implements Destination {
         final AirbyteRecordMessage message = Jsons.deserialize(new String(record, Charsets.UTF_8), AirbyteRecordMessage.class);
 
         step = step.values(UUID.randomUUID().toString(), JSONB.valueOf(Jsons.serialize(message.getData())),
-            OffsetDateTime.of(LocalDateTime.ofEpochSecond(message.getEmittedAt(), 0, ZoneOffset.UTC), ZoneOffset.UTC));
+            OffsetDateTime.of(LocalDateTime.ofEpochSecond(message.getEmittedAt() / 1000, 0, ZoneOffset.UTC), ZoneOffset.UTC));
       }
 
       return step;


### PR DESCRIPTION
It's using the millis instead of seconds to construct the `emitted_at` value, which is in the distant future. 🤖 