### PR TITLE
test JSONB escaping and for reasonable emitted_at values

### DIFF
--- a/airbyte-integrations/postgres-destination/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
+++ b/airbyte-integrations/postgres-destination/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
@@ -86,9 +86,10 @@ class PostgresDestinationTest {
       .withRecord(new AirbyteRecordMessage().withStream(TASKS_STREAM_NAME)
           .withData(Jsons.jsonNode(ImmutableMap.builder().put("goal", "announce the game.").build()))
           .withEmittedAt(NOW.toEpochMilli()));
+  // also used for testing quote escaping
   private static final AirbyteMessage MESSAGE_TASKS2 = new AirbyteMessage().withType(AirbyteMessage.Type.RECORD)
       .withRecord(new AirbyteRecordMessage().withStream(TASKS_STREAM_NAME)
-          .withData(Jsons.jsonNode(ImmutableMap.builder().put("goal", "ship some code.").build()))
+          .withData(Jsons.jsonNode(ImmutableMap.builder().put("goal", "ship some 'code'.").build()))
           .withEmittedAt(NOW.toEpochMilli()));
   private static final AirbyteMessage MESSAGE_STATE = new AirbyteMessage().withType(AirbyteMessage.Type.STATE)
       .withState(new AirbyteStateMessage().withData(Jsons.jsonNode(ImmutableMap.builder().put("checkpoint", "now!").build())));

--- a/airbyte-integrations/postgres-destination/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
+++ b/airbyte-integrations/postgres-destination/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
@@ -24,6 +24,13 @@
 
 package io.airbyte.integrations.destination.postgres;
 
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
@@ -44,13 +51,6 @@ import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
-import org.apache.commons.dbcp2.BasicDataSource;
-import org.jooq.Record;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.PostgreSQLContainer;
-
 import java.io.IOException;
 import java.sql.SQLException;
 import java.time.Instant;
@@ -61,13 +61,12 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.toList;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.spy;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.jooq.Record;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
 
 class PostgresDestinationTest {
 


### PR DESCRIPTION
I checked that the emitted_at test failed before https://github.com/airbytehq/airbyte/pull/654.
I also checked that the addition of quotes was failing at commit https://github.com/airbytehq/airbyte/commit/0423578ed6156ff8ebec7c1241ef957f33636315 before using proper escaping.
