### PR TITLE
GitBook: [john_specs_suggestion] 5 pages modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ Here is a [step-by-step guide](docs/getting-started-tutorial.md) showing you how
 
 [See more on our website.](https://airbyte.io/features/)
 
-
-
 ## Contributing
 
 Before you can contribute, you need to understand the [**specification of Airbyte's data protocol**](https://docs.airbyte.io/architecture/airbyte-specification)**.** 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Here is a [step-by-step guide](docs/getting-started-tutorial.md) showing you how
 ## Features
 
 * **Built for extensibility**: Adapt an existing integration to your needs or build a new one with ease.
-* **Normalized schemas**: Elegant, entirely customizable and a fully extensible admin panel.
+* **Optional normalized schemas**: Entirely customizable, start with raw data or from some suggestion of normalized data.
 * **Full-grade scheduler**: Automate your replications with the frequency you need.
 * **Real-time monitoring**: We log all errors in full detail to help you understand.
 * **Incremental updates**: Automated replications are based on incremental updates to reduce your data transfer costs.
@@ -45,7 +45,11 @@ Here is a [step-by-step guide](docs/getting-started-tutorial.md) showing you how
 
 [See more on our website.](https://airbyte.io/features/)
 
+
+
 ## Contributing
+
+Before you can contribute, you need to understand the [**specification of Airbyte's data protocol**](https://docs.airbyte.io/architecture/airbyte-specification)**.** 
 
 We love contributions to Airbyte, big or small. See our [Contributing Guide](https://docs.airbyte.io/contributing/contributing-to-airbyte) on how to get started. Not sure where to start? We’ve listed some [good first issues](https://github.com/airbytehq/airbyte/labels/good%20first%20issue) to start with. You can also [book a free, no-pressure pairing session](https://drift.me/micheltricot/meeting) with one of our core contributors.
 

--- a/docs/architecture/airbyte-specification.md
+++ b/docs/architecture/airbyte-specification.md
@@ -1,56 +1,65 @@
+---
+description: This page will describe the Airbyte Specification.
+---
+
 # The Airbyte Specification
 
-## Summary
-This page will describe the Airbyte Specification.
+## Key Takeaways
 
-### Key Takeaways
-* The specification is docker-based; this allows a developer to write an integration in any language they want. All they have to do is put that code in a docker container that adheres to the interface and protocol described below.
-    * We currently provide templates to make this even easier for those who prefer to work in python or java. These templates allow the developer skip any docker setup so that they can just implement code against well-defined interfaces in their language of choice.
+* The specification is Docker-based; this allows a developer to write an integration in any language they want. All they have to do is put that code in a Docker container that adheres to the interface and protocol described below.
+  * We currently provide templates to make this even easier for those who prefer to work in Python or Java. These templates allow the developer skip any Docker setup so that they can just implement code against well-defined interfaces in their language of choice.
 * The specification is designed to work as a CLI. The Airbyte app is built on top of this CLI.
 * The specification defines a standard interface for implementing data integrations: Sources and Destinations.
 * The specification provides a structured stdout / stdin message passing standard for data transport.
 * While this specification works with Airbyte, it is an independent standard.
 
 #### Contents:
-1. [General information about the specification](#general)
-1. [Integration primitives](#primitives)
-1. [Details of the protocol to pass information between integrations](#the-airbyte-protocol)
+
+1. [General information about the specification](airbyte-specification.md#General)
+2. [Integration primitives](airbyte-specification.md#Primitives)
+3. [Details of the protocol to pass information between integrations](airbyte-specification.md#The-Airbyte-Protocol)
 
 This document is focused on the interfaces and primitives around integrations. You can better understand how that fits into the bigger picture by checking out the [Airbyte Architecture](high-level-overview.md).
 
 ## General
-* All structs described in this article are defined using JsonSchema.
+
+* All structs described in this article are defined using JSONSchema.
 * Airbyte uses JSON representations of these structs for all inter-process communication.
 
 ### Definitions
-* **Airbyte Worker** - This is a core piece of the Airbyte stack that is responsible for 1) initializing a Source and a Destinations and 2) passing data from Source to Destination.
-    * Someone implementing an integration need not ever touch this code, but in this article we mention it to contextualize how data is flowing through Airbyte.
-* **Integration** - An integration is code that allows Airbyte to interact with a specific underlying data source (e.g. Postgres). In Airbyte, an integration is either a Source or a Destination.
-* **Source** - An integration that _pulls_ data from an underlying data source. (e.g. A Postgres Source reads data from a Postgres database. A Stripe Source reads data from the Stripe API)
-* **Destination** - An integration that _pushes_ data to an underlying data source. (e.g. A Postgres Destination writes data to a Postgres database)
+
+* **Airbyte Worker** - This is a core piece of the Airbyte stack that is responsible for 1\) initializing a Source and a Destination and 2\) passing data from Source to Destination.
+  * Someone implementing an integration need not ever touch this code, but in this article we mention it to contextualize how data is flowing through Airbyte.
+* **Integration** - An integration is code that allows Airbyte to interact with a specific underlying data source \(e.g. Postgres\). In Airbyte, an integration is either a Source or a Destination.
+* **Source** - An integration that _pulls_ data from an underlying data source. \(e.g. A Postgres Source reads data from a Postgres database. A Stripe Source reads data from the Stripe API\)
+* **Destination** - An integration that _pushes_ data to an underlying data source. \(e.g. A Postgres Destination writes data to a Postgres database\)
 * **AirbyteSpecification** - the specification that describes how to implement integrations using a standard interface.
 * **AirbyteProtocol** - the protocol used for inter-process communication.
-* **Integration Commands** - the commands that an integration container implements (e.g. `spec`, `check`, `discover`, `read`/`write`). We describe these commands in more detail below.
+* **Integration Commands** - the commands that an integration container implements \(e.g. `spec`, `check`, `discover`, `read`/`write`\). We describe these commands in more detail below.
 * **Sync** - the act of moving data from a Source to a Destination.
 
 ## Primitives
 
 ### Source
-A source is implemented as a docker container. The container must adhere to the interface described below.
 
-##### How the container will be called:
-The first argument passed to the image must be the command (e.g. `spec`, `check`, `discover`, `read`). Additional arguments can be passed after the command.
-Note: The system running the container will handle mounting the appropriate paths so that the config files are available to the container. This code snippet does not include that logic.
-```
+A source is implemented as a Docker container. The container must adhere to the interface described below.
+
+**How the container will be called:**
+
+The first argument passed to the image must be the command \(e.g. `spec`, `check`, `discover`, `read`\). Additional arguments can be passed after the command. Note: The system running the container will handle mounting the appropriate paths so that the config files are available to the container. This code snippet does not include that logic.
+
+```text
 docker run --rm -i <source-image-name> spec
 docker run --rm -i <source-image-name> check --config <config-file-path>
 docker run --rm -i <source-image-name> discover --config <config-file-path>
 docker run --rm -i <source-image-name> read --config <config-file-path> --catalog <catalog-file-path> [--state <state-file-path>] > message_stream.json
 ```
+
 The `read` command will emit a stream records to stdout.
 
-##### Interface Pseudocode:
-```
+**Interface Pseudocode:**
+
+```text
 spec() -> ConnectorSpecification
 check(Config) -> AirbyteConnectionStatus
 discover(Config) -> AirbyteCatalog
@@ -58,125 +67,135 @@ read(Config, AirbyteCatalog, State) -> Stream<AirbyteMessage>
 ```
 
 #### Spec
+
 * Input:
-    1. none.
+  1. none.
 * Output:
-    1. `spec` - a [ConnectorSpecification](https://github.com/airbytehq/airbyte/blob/master/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_message.yaml#L133-L149) wrapped in an `AirbyteMessage` of type `spec`.
+  1. `spec` - a [ConnectorSpecification](https://github.com/airbytehq/airbyte/blob/master/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_message.yaml#L133-L149) wrapped in an `AirbyteMessage` of type `spec`.
 * The objective of the spec command is to pull information about how to use a source. The `ConnectorSpecification` contains this information.
-* The `connectionSpecification` of the `ConnectorSpecification` must be valid JsonSchema. It describes what inputs are needed in order for the source to interact with the underlying data source.
-    * e.g. If using a postgres source, the `ConnectorSpecification` would specify that a `hostname`, `port`, and `password` are required in order for the integration to function.
-    * The UI reads the JsonSchema in this field in order to render the input fields for a user to fill in.
-    * This JsonSchema is also used to validate that the provided inputs are valid. e.g. If `port` is one of the fields and the JsonSchema in the `connectorSpecification` specifies that this filed should be a number, if a user inputs "airbyte", they will receive an error. Airbyte adheres to JsonSchema validation rules.
+* The `connectionSpecification` of the `ConnectorSpecification` must be valid JSONSchema. It describes what inputs are needed in order for the source to interact with the underlying data source.
+  * e.g. If using a Postgres source, the `ConnectorSpecification` would specify that a `hostname`, `port`, and `password` are required in order for the integration to function.
+  * The UI reads the JSONSchema in this field in order to render the input fields for a user to fill in.
+  * This JSONSchema is also used to validate that the provided inputs are valid. e.g. If `port` is one of the fields and the JSONSchema in the `connectorSpecification` specifies that this filed should be a number, if a user inputs "airbyte", they will receive an error. Airbyte adheres to JSONSchema validation rules.
 
 #### Check
+
 * Input:
-    1. `config` - A configuration json object that has been validated using the `ConnectorSpecification`.
+  * `config` - A configuration JSON object that has been validated using the `ConnectorSpecification`.
 * Output:
-    1. `connectionStatus` - an [AirbyteConnectionStatus](https://github.com/airbytehq/airbyte/blob/master/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_message.yaml#L94-L107) wrapped in an `AirbyteMessage` of type `connection_status`.
+  * `connectionStatus` - an [AirbyteConnectionStatus](https://github.com/airbytehq/airbyte/blob/master/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_message.yaml#L94-L107) wrapped in an `AirbyteMessage` of type `connection_status`.
 * The `check` command attempts to connect to the underlying data source in order to verify that the provided credentials are usable.
-    * e.g. If the given the credentials, it can connect to the postgres database, it will return a success response. If it fails (perhaps the password is incorrect), it will return a failed response and (when possible) a helpful error message.
+  * e.g. If the given the credentials, it can connect to the Postgres database, it will return a success response. If it fails \(perhaps the password is incorrect\), it will return a failed response and \(when possible\) a helpful error message.
 
 #### Discover
+
 * Input:
-    1. `config` - A configuration json object that has been validated using the `ConnectorSpecification`.
+  1. `config` - A configuration JSON object that has been validated using the `ConnectorSpecification`.
 * Output:
-    1. `catalog` - an [AirbyteCatalog](https://github.com/airbytehq/airbyte/blob/master/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_message.yaml#L108-L132) wrapped in an `AirbyteMessage` of type `catalog`.
+  1. `catalog` - an [AirbyteCatalog](https://github.com/airbytehq/airbyte/blob/master/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_message.yaml#L108-L132) wrapped in an `AirbyteMessage` of type `catalog`.
 * This command detects the _structure_ of the data in the data source.
-* An `AirbyteCatalog` describes the structure of data in a data source. It has a single field called `streams` that contains a list of `AirbyteStream`s. Each of these contain a `name` and `json_schema` field. The `json_schema` field accepts any valid JsonSchema and describes the structure of a stream. This data model is intentionally flexible. That can make it a little hard at first to mentally map onto your own data, so we provide some example below:
-    * If we are using a data source that is a traditional relational database, each table in that database would map to an `AirbyteStream`. Each column in the table would be a key in the `properties` field of the `json_schema` field.
-        * e.g. If we have a table called `users` which had the columns `name` and `age` (the age column is optional) the `AirbyteCatalog` would look like this:
-            ```
+* An `AirbyteCatalog` describes the structure of data in a data source. It has a single field called `streams` that contains a list of `AirbyteStream`s. Each of these contain a `name` and `json_schema` field. The `json_schema` field accepts any valid JSONSchema and describes the structure of a stream. This data model is intentionally flexible. That can make it a little hard at first to mentally map onto your own data, so we provide some example below:
+  * If we are using a data source that is a traditional relational database, each table in that database would map to an `AirbyteStream`. Each column in the table would be a key in the `properties` field of the `json_schema` field.
+    * e.g. If we have a table called `users` which had the columns `name` and `age` \(the age column is optional\) the `AirbyteCatalog` would look like this:
+
+      ```text
+        {
+          "streams": [
             {
-              "streams": [
-                {
-                  "name": "users",
-                  "schema": {
-                    "type": "object",
-                    "required": ["name"],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "age": {
-                        "type": {
-                          "number"
-                        }
+              "name": "users",
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "age": {
+                    "type": {
+                      "number"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ```
+  * If we are using a data source that wraps an API with multiple different resources \(e.g. `api/customers` and `api/products`\) each route would correspond to a stream. The JSON object returned by each route would be described in the `json_schema` field.
+    * e.g. In the case where the API has two endpoints `api/customers` and `api/products` and each returns a list of JSON objects, the `AirbyteCatalog` might look like this. \(Note: using the JSON schema standard for defining a stream allows us to describe nested objects. We are not constrained to a classic "table/columns" structure\)
+
+      ```text
+        {
+          "streams": [
+            {
+              "name": "customers",
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            {
+              "name": "products",
+              "schema": {
+                "type": "object",
+                "required": ["name", "features"],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "features": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": ["name", "productId"],
+                      "properties": {
+                        "name": "string",
+                        "productId": "number"
                       }
                     }
                   }
                 }
-              ]
+              }
             }
-            ```
-    * If we are using a data source that wraps an API with multiple different resources (e.g. `api/customers` and `api/products`) each route would correspond to a stream. The json object returned by each route would be described in the `json_schema` field.
-        * e.g. In the case where the API has two endpoints `api/customers` and `api/products` and each returns a list of json objects, the `AirbyteCatalog` might look like this. (Note: using the json schema standard for defining a stream allows us to describe nested objects. We are not constrained to a classic "table/columns" structure)
-            ```
-            {
-              "streams": [
-                {
-                  "name": "customers",
-                  "schema": {
-                    "type": "object",
-                    "required": ["name"],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                {
-                  "name": "products",
-                  "schema": {
-                    "type": "object",
-                    "required": ["name", "features"],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "features": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "required": ["name", "productId"],
-                          "properties": {
-                            "name": "string",
-                            "productId": "number"
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-            ```
-#### Read
+          ]
+        }
+      ```
+
+      **Read**
 * Input:
-    1. `config` - A configuration json object that has been validated using the `ConnectorSpecification`.
-    1. `catalog` - An `AirbyteCatalog`. This `catalog` should be a subset of the `catalog` returned by the `discover` command. It is what will be used in the `read` command to select what data to transfer.
-    1. `state` - A json object. This object is only ever written or read by the source, so it is a json blob with whatever information is necessary to keep track of how much of the data source has already been read. Because Airbyte currently only supports [Full Refresh](full-refresh.md), this state object is purely cosmetic. It will become more important when Airbyte beings to support incremental syncs.
+  1. `config` - A configuration JSON object that has been validated using the `ConnectorSpecification`.
+  2. `catalog` - An `AirbyteCatalog`. This `catalog` should be a subset of the `catalog` returned by the `discover` command. It is what will be used in the `read` command to select what data to transfer.
+  3. `state` - A JSON object. This object is only ever written or read by the source, so it is a JSON blob with whatever information is necessary to keep track of how much of the data source has already been read. Because Airbyte currently only supports [Full Refresh](full-refresh.md), this state object is purely cosmetic. It will become more important when Airbyte beings to support incremental syncs.
 * Output:
-    1. `message stream` - A stream of `AirbyteRecordMessage`s and `AirbyteStateMessage`s piped to stdout.
+  1. `message stream` - A stream of `AirbyteRecordMessage`s and `AirbyteStateMessage`s piped to stdout.
 * This command reads data from the underlying data source and converts it into `AirbyteRecordMessage`.
 * Outputting `AirbyteStateMessages` is optional. It can be used to track how much of the data source has been synced.
 * The integration ideally will only pull the data described in the `catalog` argument. It is permissible for the integration, however, to ignore the `catalog` and pull data from any stream it can find. If it follows this second behavior, the extra data will be pruned in the worker. We prefer the former behavior because it reduces the amount of data that is transferred and allows control over not sending sensitive data. There are some sources for which this is simply not possible.
 
 ### Destination
-* A source is implemented as a docker container. The container must adhere to the following interface.
 
-##### How the container will be called:
-The first argument passed to the image must be the command (e.g. `spec`, `check`, `write`). Additional arguments can be passed after the command.
-Note: The system running the container will handle mounting the appropriate paths so that the config files are available to the container. This code snippet does not include that logic.
-```
+* A source is implemented as a Docker container. The container must adhere to the following interface.
+
+**How the container will be called:**
+
+The first argument passed to the image must be the command \(e.g. `spec`, `check`, `write`\). Additional arguments can be passed after the command. Note: The system running the container will handle mounting the appropriate paths so that the config files are available to the container. This code snippet does not include that logic.
+
+```text
 docker run --rm -i <source-image-name> spec
 docker run --rm -i <source-image-name> check --config <config-file-path>
 cat <&0 | docker run --rm -i <source-image-name> write --config <config-file-path> --catalog <catalog-file-path>
 ```
+
 The `write` command will consume `AirbyteMessage`s from stdin.
 
-##### Interface Pseudocode:
-```
+**Interface Pseudocode:**
+
+```text
 spec() -> ConnectorSpecification
 check(Config) -> AirbyteConnectionStatus
 write(Config, AirbyteCatalog, Stream<AirbyteMessage>(stdin)) -> void
@@ -185,26 +204,26 @@ write(Config, AirbyteCatalog, Stream<AirbyteMessage>(stdin)) -> void
 For the sake of brevity, we will not re-describe `spec` and `check`. They are exactly the same as those commands described for the Source.
 
 #### Write
+
 * Input:
-    1. `config` - A configuration json object that has been validated using the `ConnectorSpecification`.
-    1. `catalog` - An `AirbyteCatalog`. This `catalog` should be a subset of the `catalog` returned by the `discover` command. Any `AirbyteRecordMessages`s that the destination receives that do _not_ match the structure described in the `catalog` will fail.
-    1. `message stream` - (this stream is consumed on stdin--it is not passed as an arg). It will receive a stream of json-serialized `AirbyteMesssage`.
+  1. `config` - A configuration JSON object that has been validated using the `ConnectorSpecification`.
+  2. `catalog` - An `AirbyteCatalog`. This `catalog` should be a subset of the `catalog` returned by the `discover` command. Any `AirbyteRecordMessages`s that the destination receives that do _not_ match the structure described in the `catalog` will fail.
+  3. `message stream` - \(this stream is consumed on stdin--it is not passed as an arg\). It will receive a stream of JSON-serialized `AirbyteMesssage`.
 * Output:
-    1. none.
+  1. none.
 * The destination should read in the `AirbyteMessages` and write any that are of type `AirbyteRecordMessage` to the underlying data store.
 * The destination should fail if any of the messages it receives do not match the structure described in the `catalog`.
 
 ## The Airbyte Protocol
-* All messages passed to and from integrations must be wrapped in an `AirbyteMesage` envelope and serialized as json. The JsonSchema specification for these messages can be found [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_message.yaml).
+
+* All messages passed to and from integrations must be wrapped in an `AirbyteMesage` envelope and serialized as JSON. The JSONSchema specification for these messages can be found [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_message.yaml).
 * Even if a record is wrapped in an `AirbyteMessage` it will only be processed if it appropriate for the given command. e.g. If a source `read` action includes AirbyteMessages in its stream of type Catalog for instance, these messages will be ignored as the `read` interface only expects `AirbyteRecordMessage`s and `AirbyteStateMessage`s. The appropriate `AirbyteMessage` types have been described in each command above.
 * **ALL** actions are allowed to return `AirbyteLogMessage`s on stdout. For brevity, we have not mentioned these log messages in the description of each action, but they are always allowed. An `AirbyteLogMessage` wraps any useful logging that the integration wants to provide. These logs will written to Airbyte's log files and output to the console.
 * I/O:
-    * Integrations receive arguments on the command line via json files. `e.g. --catalog catalog.json`
-    * They read `AirbyteMessage`s from stdin. The destination `write` action is the only command that consumes `AirbyteMessage`s.
-    * They emit `AirbyteMessage`s on stdout. All commands that output messages use this approach (even `write` emits `AirbyteLogMessage`s). e.g. `discover` outputs the `catalog` wrapped in an AirbyteMessage on stdout.
+  * Integrations receive arguments on the command line via JSON files. `e.g. --catalog catalog.json`
+  * They read `AirbyteMessage`s from stdin. The destination `write` action is the only command that consumes `AirbyteMessage`s.
+  * They emit `AirbyteMessage`s on stdout. All commands that output messages use this approach \(even `write` emits `AirbyteLogMessage`s\). e.g. `discover` outputs the `catalog` wrapped in an AirbyteMessage on stdout.
 * Messages not wrapped in the `AirbyteMessage` will be ignored.
 * Each message must be on its own line. Multiple messages _cannot_ be sent on the same line.
-* Each message must but serialize to a json object that is exactly 1 line. The json objects cannot be serialized across multiple lines.
+* Each message must but serialize to a JSON object that is exactly 1 line. The JSON objects cannot be serialized across multiple lines.
 
-## Recognition
-We have been heavily inspired by Singer.io's [specification](https://github.com/singer-io/getting-started/blob/master/docs/SPEC.md#singer-specification) and would like to acknowledge how some of their choices have helped us bootstrap.

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -17,6 +17,7 @@ This BigQuery destination is based on the [PipelineWise BigQuery Target](https:/
 #### Output schema
 
 Each stream will be output into its own table in BigQuery. Each table will contain 3 columns:
+
 * `ab_id`: a uuid assigned by Airbyte to each event that is processed. The column type in BigQuery is `String`.
 * `emitted_at`: a timestamp representing when the event was pulled from the data source. The column type in BigQuery is `Timestamp`.
 * `data`: a json blob representing with the event data. The column type in BigQuery is `String`.

--- a/docs/integrations/destinations/local-csv.md
+++ b/docs/integrations/destinations/local-csv.md
@@ -9,6 +9,7 @@ This destination writes data to a directory on the _local_ filesystem on the hos
 #### Output schema
 
 Each stream will be output into its own file. Each file will contain 3 columns:
+
 * `ab_id`: a uuid assigned by Airbyte to each event that is processed.
 * `emitted_at`: a timestamp representing when the event was pulled from the data source.
 * `data`: a json blob representing with the event data.

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -11,6 +11,7 @@ This Postgres destination is based on the [Singer Postgres Target](https://githu
 #### Output schema
 
 Each stream will be output into its own table in Postgres. Each table will contain 3 columns:
+
 * `ab_id`: a uuid assigned by Airbyte to each event that is processed. The column type in Postgres is `VARCHAR`.
 * `emitted_at`: a timestamp representing when the event was pulled from the data source. The column type in Postgres is `TIMESTAMP WITH TIME ZONE`.
 * `data`: a json blob representing with the event data. The column type in BigQuery is `JSONB`.


### PR DESCRIPTION
in OVERVIEW: 
- Added a sentence about the Airbyte Specifications in the Overview page (displayed in the README) to get more visibility

in SPECIFICATIONS PAGE: 
- Removed "Summary" part at the top of the Airbyte specification, as seemingly useless
- Fixed the links within the Specifications in Content as they didn't work
- Replaced docker by Docker
- Replaced json by JSON
- Replaced postgres by Postgres