### PR TITLE
remove ab protocol suffix

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION/22f6c74f-5699-40ff-833c-4a879ea40133.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION/22f6c74f-5699-40ff-833c-4a879ea40133.json
@@ -1,7 +1,7 @@
 {
   "destinationId": "22f6c74f-5699-40ff-833c-4a879ea40133",
   "name": "BigQuery",
-  "dockerRepository": "airbyte/airbyte-bigquery-destination-abprotocol",
+  "dockerRepository": "airbyte/airbyte-bigquery-destination",
   "dockerImageTag": "0.1.0",
   "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-bigquery-destination"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION/22f6c74f-5699-40ff-833c-4a879ea40133.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION/22f6c74f-5699-40ff-833c-4a879ea40133.json
@@ -1,7 +1,7 @@
 {
   "destinationId": "22f6c74f-5699-40ff-833c-4a879ea40133",
   "name": "BigQuery",
-  "dockerRepository": "airbyte/airbyte-bigquery-destination",
+  "dockerRepository": "airbyte/destination-bigquery",
   "dockerImageTag": "0.1.0",
   "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-bigquery-destination"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION/25c5221d-dce2-4163-ade9-739ef790f503.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION/25c5221d-dce2-4163-ade9-739ef790f503.json
@@ -1,7 +1,7 @@
 {
   "destinationId": "25c5221d-dce2-4163-ade9-739ef790f503",
   "name": "Postgres",
-  "dockerRepository": "airbyte/airbyte-postgres-destination-abprotocol",
+  "dockerRepository": "airbyte/airbyte-postgres-destination",
   "dockerImageTag": "0.1.0",
   "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-postgres-destination"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION/25c5221d-dce2-4163-ade9-739ef790f503.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION/25c5221d-dce2-4163-ade9-739ef790f503.json
@@ -1,7 +1,7 @@
 {
   "destinationId": "25c5221d-dce2-4163-ade9-739ef790f503",
   "name": "Postgres",
-  "dockerRepository": "airbyte/airbyte-postgres-destination",
+  "dockerRepository": "airbyte/destination-postgres",
   "dockerImageTag": "0.1.0",
   "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-postgres-destination"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION/8be1cf83-fde1-477f-a4ad-318d23c9f3c6.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION/8be1cf83-fde1-477f-a4ad-318d23c9f3c6.json
@@ -1,7 +1,7 @@
 {
   "destinationId": "8be1cf83-fde1-477f-a4ad-318d23c9f3c6",
   "name": "Local CSV",
-  "dockerRepository": "airbyte/airbyte-csv-destination",
+  "dockerRepository": "airbyte/destination-csv",
   "dockerImageTag": "0.1.0",
   "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-csv-destination"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION/8be1cf83-fde1-477f-a4ad-318d23c9f3c6.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION/8be1cf83-fde1-477f-a4ad-318d23c9f3c6.json
@@ -1,7 +1,7 @@
 {
   "destinationId": "8be1cf83-fde1-477f-a4ad-318d23c9f3c6",
   "name": "Local CSV",
-  "dockerRepository": "airbyte/airbyte-csv-destination-abprotocol",
+  "dockerRepository": "airbyte/airbyte-csv-destination",
   "dockerImageTag": "0.1.0",
   "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-csv-destination"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/9fed261d-d107-47fd-8c8b-323023db6e20.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/9fed261d-d107-47fd-8c8b-323023db6e20.json
@@ -1,7 +1,7 @@
 {
   "sourceId": "9fed261d-d107-47fd-8c8b-323023db6e20",
   "name": "exchangeratesapi.io",
-  "dockerRepository": "airbyte/source-exchangeratesapi-singer-abprotocol",
+  "dockerRepository": "airbyte/source-exchangeratesapi-singer",
   "dockerImageTag": "0.1.2",
   "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-exchangeratesapi_io-source"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/9fed261d-d107-47fd-8c8b-323023db6e20.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/9fed261d-d107-47fd-8c8b-323023db6e20.json
@@ -2,6 +2,6 @@
   "sourceId": "9fed261d-d107-47fd-8c8b-323023db6e20",
   "name": "exchangeratesapi.io",
   "dockerRepository": "airbyte/source-exchangeratesapi-singer",
-  "dockerImageTag": "0.1.2",
+  "dockerImageTag": "0.1.3",
   "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-exchangeratesapi_io-source"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/decd338e-5647-4c0b-adf4-da0e75f5a750.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/decd338e-5647-4c0b-adf4-da0e75f5a750.json
@@ -1,7 +1,7 @@
 {
   "sourceId": "decd338e-5647-4c0b-adf4-da0e75f5a750",
   "name": "Postgres",
-  "dockerRepository": "airbyte/postgres-singer-source",
-  "dockerImageTag": "0.1.0",
+  "dockerRepository": "airbyte/source-postgres-singer",
+  "dockerImageTag": "0.1.4",
   "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-postgres-source"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/decd338e-5647-4c0b-adf4-da0e75f5a750.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/decd338e-5647-4c0b-adf4-da0e75f5a750.json
@@ -1,7 +1,7 @@
 {
   "sourceId": "decd338e-5647-4c0b-adf4-da0e75f5a750",
   "name": "Postgres",
-  "dockerRepository": "airbyte/postgres-singer-source-abprotocol",
+  "dockerRepository": "airbyte/postgres-singer-source",
   "dockerImageTag": "0.1.0",
   "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-postgres-source"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/e094cb9a-26de-4645-8761-65c0c425d1de.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/e094cb9a-26de-4645-8761-65c0c425d1de.json
@@ -1,7 +1,7 @@
 {
   "sourceId": "e094cb9a-26de-4645-8761-65c0c425d1de",
   "name": "Stripe",
-  "dockerRepository": "airbyte/source-stripe-abprotocol-singer",
+  "dockerRepository": "airbyte/source-stripe-singer",
   "dockerImageTag": "0.1.3",
   "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-stripe-source"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/e094cb9a-26de-4645-8761-65c0c425d1de.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/e094cb9a-26de-4645-8761-65c0c425d1de.json
@@ -2,6 +2,6 @@
   "sourceId": "e094cb9a-26de-4645-8761-65c0c425d1de",
   "name": "Stripe",
   "dockerRepository": "airbyte/source-stripe-singer",
-  "dockerImageTag": "0.1.3",
+  "dockerImageTag": "0.1.4",
   "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-stripe-source"
 }

--- a/airbyte-integrations/connectors/destination-bigquery/Dockerfile
+++ b/airbyte-integrations/connectors/destination-bigquery/Dockerfile
@@ -9,4 +9,4 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
 LABEL io.airbyte.version=0.1.0
-LABEL io.airbyte.name=airbyte/airbyte-bigquery-destination-abprotocol
+LABEL io.airbyte.name=airbyte/airbyte-bigquery-destination

--- a/airbyte-integrations/connectors/destination-bigquery/Dockerfile
+++ b/airbyte-integrations/connectors/destination-bigquery/Dockerfile
@@ -9,4 +9,4 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
 LABEL io.airbyte.version=0.1.0
-LABEL io.airbyte.name=airbyte/airbyte-bigquery-destination
+LABEL io.airbyte.name=airbyte/destination-bigquery

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryIntegrationTest.java
@@ -69,7 +69,7 @@ public class BigQueryIntegrationTest extends TestDestination {
 
   @Override
   protected String getImageName() {
-    return "airbyte/airbyte-bigquery-destination-abprotocol:dev";
+    return "airbyte/airbyte-bigquery-destination:dev";
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryIntegrationTest.java
@@ -69,7 +69,7 @@ public class BigQueryIntegrationTest extends TestDestination {
 
   @Override
   protected String getImageName() {
-    return "airbyte/airbyte-bigquery-destination:dev";
+    return "airbyte/destination-bigquery:dev";
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-csv/Dockerfile
+++ b/airbyte-integrations/connectors/destination-csv/Dockerfile
@@ -8,4 +8,4 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
 LABEL io.airbyte.version=0.1.0
-LABEL io.airbyte.name=airbyte/airbyte-csv-destination
+LABEL io.airbyte.name=airbyte/destination-csv

--- a/airbyte-integrations/connectors/destination-csv/Dockerfile
+++ b/airbyte-integrations/connectors/destination-csv/Dockerfile
@@ -8,4 +8,4 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
 LABEL io.airbyte.version=0.1.0
-LABEL io.airbyte.name=airbyte/airbyte-csv-destination-abprotocol
+LABEL io.airbyte.name=airbyte/airbyte-csv-destination

--- a/airbyte-integrations/connectors/destination-csv/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-csv/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationIntegrationTest.java
@@ -46,7 +46,7 @@ public class CsvDestinationIntegrationTest extends TestDestination {
 
   @Override
   protected String getImageName() {
-    return "airbyte/airbyte-csv-destination-abprotocol:dev";
+    return "airbyte/airbyte-csv-destination:dev";
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-csv/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-csv/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationIntegrationTest.java
@@ -46,7 +46,7 @@ public class CsvDestinationIntegrationTest extends TestDestination {
 
   @Override
   protected String getImageName() {
-    return "airbyte/airbyte-csv-destination:dev";
+    return "airbyte/destination-csv:dev";
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-postgres/Dockerfile
+++ b/airbyte-integrations/connectors/destination-postgres/Dockerfile
@@ -10,4 +10,4 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
 LABEL io.airbyte.version=0.1.0
-LABEL io.airbyte.name=airbyte/airbyte-postgres-destination-abprotocol
+LABEL io.airbyte.name=airbyte/airbyte-postgres-destination

--- a/airbyte-integrations/connectors/destination-postgres/Dockerfile
+++ b/airbyte-integrations/connectors/destination-postgres/Dockerfile
@@ -10,4 +10,4 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
 LABEL io.airbyte.version=0.1.0
-LABEL io.airbyte.name=airbyte/airbyte-postgres-destination
+LABEL io.airbyte.name=airbyte/destination-postgres

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
@@ -43,7 +43,7 @@ public class PostgresIntegrationTest extends TestDestination {
 
   @Override
   protected String getImageName() {
-    return "airbyte/airbyte-postgres-destination:dev";
+    return "airbyte/destination-postgres:dev";
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
@@ -43,7 +43,7 @@ public class PostgresIntegrationTest extends TestDestination {
 
   @Override
   protected String getImageName() {
-    return "airbyte/airbyte-postgres-destination-abprotocol:dev";
+    return "airbyte/airbyte-postgres-destination:dev";
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-exchangeratesapi-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-exchangeratesapi-singer/Dockerfile
@@ -9,7 +9,7 @@ ENV AIRBYTE_IMPL_MODULE="source_exchangeratesapi_singer"
 ENV AIRBYTE_IMPL_PATH="SourceExchangeRatesApiSinger"
 
 LABEL io.airbyte.version=0.1.2
-LABEL io.airbyte.name=airbyte/source-exchangeratesapi-singer-abprotocol
+LABEL io.airbyte.name=airbyte/source-exchangeratesapi-singer
 
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH

--- a/airbyte-integrations/connectors/source-exchangeratesapi-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-exchangeratesapi-singer/Dockerfile
@@ -8,7 +8,7 @@ ENV CODE_PATH="source_exchangeratesapi_singer"
 ENV AIRBYTE_IMPL_MODULE="source_exchangeratesapi_singer"
 ENV AIRBYTE_IMPL_PATH="SourceExchangeRatesApiSinger"
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/source-exchangeratesapi-singer
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-exchangeratesapi-singer/src/test-integration/java/io/airbyte/integration_tests/sources/SingerExchangeRatesApiSourceTest.java
+++ b/airbyte-integrations/connectors/source-exchangeratesapi-singer/src/test-integration/java/io/airbyte/integration_tests/sources/SingerExchangeRatesApiSourceTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 public class SingerExchangeRatesApiSourceTest {
 
   private static final Path TESTS_PATH = Path.of("/tmp/airbyte_integration_tests");
-  private static final String IMAGE_NAME = "airbyte/source-exchangeratesapi-singer-abprotocol:dev";
+  private static final String IMAGE_NAME = "airbyte/source-exchangeratesapi-singer:dev";
 
   private static final String CATALOG = "catalog.json";
   private static final String CONFIG = "config.json";

--- a/airbyte-integrations/connectors/source-postgres-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres-singer/Dockerfile
@@ -8,8 +8,8 @@ ENV CODE_PATH="postgres_singer_source"
 ENV AIRBYTE_IMPL_MODULE="postgres_singer_source"
 ENV AIRBYTE_IMPL_PATH="PostgresSingerSource"
 
-LABEL io.airbyte.version=0.1.0
-LABEL io.airbyte.name=airbyte/postgres-singer-source
+LABEL io.airbyte.version=0.1.4
+LABEL io.airbyte.name=airbyte/source-postgres-singer
 
 WORKDIR /airbyte/integration_code
 

--- a/airbyte-integrations/connectors/source-postgres-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres-singer/Dockerfile
@@ -9,7 +9,7 @@ ENV AIRBYTE_IMPL_MODULE="postgres_singer_source"
 ENV AIRBYTE_IMPL_PATH="PostgresSingerSource"
 
 LABEL io.airbyte.version=0.1.0
-LABEL io.airbyte.name=airbyte/postgres-singer-source-abprotocol
+LABEL io.airbyte.name=airbyte/postgres-singer-source
 
 WORKDIR /airbyte/integration_code
 

--- a/airbyte-integrations/connectors/source-postgres-singer/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SingerPostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres-singer/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SingerPostgresSourceTest.java
@@ -78,7 +78,7 @@ import org.testcontainers.utility.MountableFile;
 @SuppressWarnings("rawtypes")
 public class SingerPostgresSourceTest {
 
-  private static final String IMAGE_NAME = "airbyte/postgres-singer-source-abprotocol:dev";
+  private static final String IMAGE_NAME = "airbyte/postgres-singer-source:dev";
   private static final Path TESTS_PATH = Path.of("/tmp/airbyte_integration_tests");
 
   private static final AirbyteCatalog CATALOG = CatalogHelpers.createAirbyteCatalog(

--- a/airbyte-integrations/connectors/source-postgres-singer/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SingerPostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres-singer/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SingerPostgresSourceTest.java
@@ -78,7 +78,7 @@ import org.testcontainers.utility.MountableFile;
 @SuppressWarnings("rawtypes")
 public class SingerPostgresSourceTest {
 
-  private static final String IMAGE_NAME = "airbyte/postgres-singer-source:dev";
+  private static final String IMAGE_NAME = "airbyte/source-postgres-singer:dev";
   private static final Path TESTS_PATH = Path.of("/tmp/airbyte_integration_tests");
 
   private static final AirbyteCatalog CATALOG = CatalogHelpers.createAirbyteCatalog(

--- a/airbyte-integrations/connectors/source-stripe-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe-singer/Dockerfile
@@ -10,7 +10,7 @@ ENV CODE_PATH="source_stripe_singer"
 ENV AIRBYTE_IMPL_MODULE="source_stripe_singer"
 ENV AIRBYTE_IMPL_PATH="SourceStripeSinger"
 
-LABEL io.airbyte.version=0.1.3
+LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/source-stripe-singer
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-stripe-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe-singer/Dockerfile
@@ -11,7 +11,7 @@ ENV AIRBYTE_IMPL_MODULE="source_stripe_singer"
 ENV AIRBYTE_IMPL_PATH="SourceStripeSinger"
 
 LABEL io.airbyte.version=0.1.3
-LABEL io.airbyte.name=airbyte/source-stripe-abprotocol-singer
+LABEL io.airbyte.name=airbyte/source-stripe-singer
 
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH

--- a/airbyte-integrations/connectors/source-stripe-singer/src/test-integration/java/io/airbyte/integration_tests/sources/SingerStripeSourceTest.java
+++ b/airbyte-integrations/connectors/source-stripe-singer/src/test-integration/java/io/airbyte/integration_tests/sources/SingerStripeSourceTest.java
@@ -68,7 +68,7 @@ import org.junit.jupiter.api.Test;
 public class SingerStripeSourceTest {
 
   private static final Path TESTS_PATH = Path.of("/tmp/airbyte_integration_tests");
-  private static final String IMAGE_NAME = "airbyte/source-stripe-abprotocol-singer:dev";
+  private static final String IMAGE_NAME = "airbyte/source-stripe-singer:dev";
 
   private static final String CATALOG = "catalog.json";
   private static final String CONFIG = "config.json";


### PR DESCRIPTION
## What
* remove the abprotocol suffix from docker image names. 
* Need to publish the new versions of these before merging this
* should i publish a new version of our core app for this or just overwrite the existing version? probably the right thing to do is go for 0.2.1-alpha