### PR TITLE
disable gradle caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.parallel=true
-org.gradle.caching=true
 org.gradle.vfs.watch=true


### PR DESCRIPTION
## What
I added caching under the assumption that gradle's `x.dependsOn(y)` would invalidate `x` if `y` was not found in the cache. This assumption is not true, which means we were skipping integration tests if their source code was not changed, even if their docker images (which are dependencies via `integrationTest.dependsOn(buildImage)` were rebuilt). 