### PR TITLE
Remove Salesforce integration tests from CI

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce-singer/build.gradle
+++ b/airbyte-integrations/connectors/source-salesforce-singer/build.gradle
@@ -9,14 +9,16 @@ apply from: rootProject.file('tools/gradle/commons/integrations/standard-source-
 dependencies {
 }
 
-standardSourceTest {
-    ext {
-        imageName = "${extractImageName(project.file('Dockerfile'))}:dev"
-        specPath = 'source_salesforce_singer/spec.json'
-        configPath ='secrets/config.json'
-        catalogPath = 'standard_test/catalog.json'
-    }
-}
+// We cannot run these tests with every build because it blows through the Salesforce quota. For now, turn this on as needed and run these tests locally; they will not be run in CI.
+// CRITICAL Salesforce has reported 13060/15000 (87.07%) total REST quota used across all Salesforce Applications. Terminating replication to not continue past configured percentage of 80% total quota.
+//standardSourceTest {
+//    ext {
+//        imageName = "${extractImageName(project.file('Dockerfile'))}:dev"
+//        specPath = 'source_salesforce_singer/spec.json'
+//        configPath ='secrets/config.json'
+//        catalogPath = 'standard_test/catalog.json'
+//    }
+//}
 
 buildImage.dependsOn ':airbyte-integrations:bases:base-singer:buildImage'
 integrationTest.dependsOn(buildImage)

--- a/airbyte-integrations/connectors/source-salesforce-singer/build.gradle
+++ b/airbyte-integrations/connectors/source-salesforce-singer/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 apply from: rootProject.file('tools/gradle/commons/integrations/image.gradle')
 apply from: rootProject.file('tools/gradle/commons/integrations/integration-test.gradle')
-apply from: rootProject.file('tools/gradle/commons/integrations/standard-source-test.gradle')
+//apply from: rootProject.file('tools/gradle/commons/integrations/standard-source-test.gradle')
 
 dependencies {
 }


### PR DESCRIPTION
* The Salesforce API call quota is such that we can't run these integration tests on every PR build.
* Each discover call, costs about 0.5% of the 24-hour API quota. In these tests that gets called at least 4 times in each run of the standard test suite so that's about 2% of the quota per build. Our options right now are to push less code or remove these tests for salesforce from the CI. 😉 