### PR TITLE
turn on gradle flags for reproducible archives

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,3 +197,10 @@ task composeBuild {
     }
 }
 build.dependsOn(composeBuild)
+
+// produce reproducible archives
+// (see https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives)
+tasks.withType(AbstractArchiveTask) {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}


### PR DESCRIPTION
@cgardens just testing to see if there is a difference in build times. 