### PR TITLE
increase gradle heap space

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.parallel=true
 org.gradle.vfs.watch=true
+org.gradle.jvmargs=-Xmx2g


### PR DESCRIPTION
Should fix intermittent `JVM heap space is exhausted` errors when building the project (see https://airbytehq.slack.com/archives/C019WEENQRM/p1603900395316800)

