### PR TITLE
avoid overloading env variable names

### DIFF
--- a/airbyte-integrations/bases/base-python-test/base_python_test/standard_test.py
+++ b/airbyte-integrations/bases/base-python-test/base_python_test/standard_test.py
@@ -93,8 +93,8 @@ def launch(source, args):
     StandardSourceTestRunner(source).start(args)
 
 
-impl_module = os.environ.get("AIRBYTE_IMPL_MODULE")
-impl_class = os.environ.get("AIRBYTE_IMPL_PATH")
+impl_module = os.environ.get("AIRBYTE_TEST_MODULE")
+impl_class = os.environ.get("AIRBYTE_TEST_PATH")
 
 module = importlib.import_module(impl_module)
 impl = getattr(module, impl_class)

--- a/airbyte-integrations/connectors/source-github-singer/Dockerfile.test
+++ b/airbyte-integrations/connectors/source-github-singer/Dockerfile.test
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 ENV CODE_PATH="standardtest"
-ENV AIRBYTE_IMPL_MODULE="standardtest"
-ENV AIRBYTE_IMPL_PATH="GithubStandardSourceTest"
+ENV AIRBYTE_TEST_MODULE="standardtest"
+ENV AIRBYTE_TEST_PATH="GithubStandardSourceTest"
 ENV AIRBYTE_TEST_CASE=true
 
 LABEL io.airbyte.version=0.1.0


### PR DESCRIPTION
## What
Integration tests that transitively or directly depend on python_base run into a circular dependency:

* `python_base_test` tries to import the integration test. 
* The integration test tries to import `python_base`.
* `python_base`  reads the `AIRBYTE_IMPL_MODULE` environment variable and tries to import `AIRBYTE_IMPL_PATH` from it. 
* Since this is an integration test environment, `AIRBYTE_IMPL_MODULE` is the integration test module. 
* `python_base` tries to import the integration test module which hasn't been initialized. 
* kaboom

This PR fixes this issue by using a different env variable. 
