### PR TITLE
read module attrs in main method instead of when loading source file

### DIFF
--- a/airbyte-integrations/bases/base-python-test/base_python_test/standard_test.py
+++ b/airbyte-integrations/bases/base-python-test/base_python_test/standard_test.py
@@ -93,14 +93,12 @@ def launch(source, args):
     StandardSourceTestRunner(source).start(args)
 
 
-impl_module = os.environ.get("AIRBYTE_TEST_MODULE")
-impl_class = os.environ.get("AIRBYTE_TEST_PATH")
-
-module = importlib.import_module(impl_module)
-impl = getattr(module, impl_class)
-
-
 def main():
+    impl_module = os.environ.get("AIRBYTE_TEST_MODULE")
+    impl_class = os.environ.get("AIRBYTE_TEST_PATH")
+    module = importlib.import_module(impl_module)
+    impl = getattr(module, impl_class)
+
     # set up and run test runner
     test = impl()
 

--- a/airbyte-integrations/bases/base-python/base_python/entrypoint.py
+++ b/airbyte-integrations/bases/base-python/base_python/entrypoint.py
@@ -33,11 +33,6 @@ from airbyte_protocol import AirbyteMessage, Status, Type
 from .integration import ConfigContainer, Source
 from .logger import AirbyteLogger
 
-impl_module = os.environ.get("AIRBYTE_IMPL_MODULE", Source.__module__)
-impl_class = os.environ.get("AIRBYTE_IMPL_PATH", Source.__name__)
-module = importlib.import_module(impl_module)
-impl = getattr(module, impl_class)
-
 logger = AirbyteLogger()
 
 
@@ -130,10 +125,16 @@ class AirbyteEntrypoint(object):
 
 
 def launch(source, args):
+
     AirbyteEntrypoint(source).start(args)
 
 
 def main():
+    impl_module = os.environ.get("AIRBYTE_IMPL_MODULE", Source.__module__)
+    impl_class = os.environ.get("AIRBYTE_IMPL_PATH", Source.__name__)
+    module = importlib.import_module(impl_module)
+    impl = getattr(module, impl_class)
+
     # set up and run entrypoint
     source = impl()
 


### PR DESCRIPTION
## What
* In our python entrypoints we are attempting to load module information from environment variables when a source python file is loaded. This worked previously because the only time these files were loaded was when we were going to invoke them. If these files are part of a lib that expose other functionality though and are not going to be invoked, we run into problems. The problem is that when someone includes this module, if they are not going to execute the entrypoint, then these environment variables are not going to be set properly causing errors. @sherifnada ran into effectively that issue when depending on both base_python and base_python_test. This PR makes it so that we never attempt to read the environment variables unless we are actually executing the code that would use them. This makes more sense anyway and closer to how we would approach this problem in java.
* @sherifnada - I think we should still retain the change you made in this [PR](https://github.com/airbytehq/airbyte/pull/734/files). Keeping the name spacing is good. But just wanted to highlight that I think this could have fixed your issues.
* @jrhizor - I wish I had seen this earlier, probably would have meant I wouldn't have needed to both splitting out airbyte_protocol structs from base_python(though I'm still happy I did it, it took forever).