### PR TITLE
Register the google sheets integration in airbyte core

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/71607ba1-c0ac-4799-8049-7f4b90dd50f7.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE/71607ba1-c0ac-4799-8049-7f4b90dd50f7.json
@@ -1,0 +1,7 @@
+{
+  "sourceId": "71607ba1-c0ac-4799-8049-7f4b90dd50f7",
+  "name": "Google Sheets",
+  "dockerRepository": "airbyte/source-google-sheets",
+  "dockerImageTag": "0.1.0",
+  "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-google-sheets"
+}


### PR DESCRIPTION
## What
#695 added the google sheets connector definition. This PR registers it with Airbyte core so that it is usable from the UI. 

The connector has been published to dockerhub here: https://hub.docker.com/repository/docker/airbyte/source-google-sheets