### PR TITLE
Upgrade standard source test to junit5

### DIFF
--- a/airbyte-integrations/bases/standard-source-test/build.gradle
+++ b/airbyte-integrations/bases/standard-source-test/build.gradle
@@ -9,11 +9,11 @@ dependencies {
     implementation project(':airbyte-protocol:models')
     implementation project(':airbyte-workers')
 
-    // todo (cgardens) - Using JUnit4 instead of five. See TestMain.java for more details.
-    implementation group: 'junit', name: 'junit', version: '4.12'
-
-
     implementation 'net.sourceforge.argparse4j:argparse4j:0.8.1'
+
+    runtimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
+    implementation 'org.junit.platform:junit-platform-launcher:1.7.0'
+    implementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
 }
 
 application {

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/base/TestPythonSourceMain.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/base/TestPythonSourceMain.java
@@ -28,9 +28,6 @@ import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
-import org.junit.internal.TextListener;
-import org.junit.runner.JUnitCore;
-import org.junit.runner.Result;
 
 /**
  * Parse command line arguments and inject them into the test class before running the test. Then
@@ -63,13 +60,7 @@ public class TestPythonSourceMain {
     PythonTestSource.IMAGE_NAME = imageName;
     PythonTestSource.PYTHON_CONTAINER_NAME = pythonContainerName;
 
-    JUnitCore junit = new JUnitCore();
-    junit.addListener(new TextListener(System.out));
-    final Result result = junit.run(PythonTestSource.class);
-
-    if (result.getFailureCount() > 0) {
-      System.exit(1);
-    }
+    TestRunner.runTestClass(PythonTestSource.class);
   }
 
 }

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/base/TestRunner.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/base/TestRunner.java
@@ -1,0 +1,35 @@
+package io.airbyte.integrations.base;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import java.io.PrintWriter;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.TestPlan;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+
+public class TestRunner {
+  public static void runTestClass(Class<?> testClass) {
+    final LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+        .selectors(selectClass(testClass))
+        .build();
+
+    final TestPlan plan = LauncherFactory.create().discover(request);
+    final Launcher launcher = LauncherFactory.create();
+
+    // Register a listener of your choice
+    final SummaryGeneratingListener listener = new SummaryGeneratingListener();
+    launcher.registerTestExecutionListeners(listener);
+
+    launcher.execute(plan, listener);
+
+    listener.getSummary().printFailuresTo(new PrintWriter(System.out));
+    listener.getSummary().printTo(new PrintWriter(System.out));
+
+    if (listener.getSummary().getTestsFailedCount() > 0) {
+      System.exit(1);
+    }
+  }
+}

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/base/TestRunner.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/base/TestRunner.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.airbyte.integrations.base;
 
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
@@ -11,6 +35,7 @@ import org.junit.platform.launcher.core.LauncherFactory;
 import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 
 public class TestRunner {
+
   public static void runTestClass(Class<?> testClass) {
     final LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
         .selectors(selectClass(testClass))
@@ -32,4 +57,5 @@ public class TestRunner {
       System.exit(1);
     }
   }
+
 }

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/base/TestSource.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/base/TestSource.java
@@ -24,10 +24,10 @@
 
 package io.airbyte.integrations.base;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.config.JobGetSpecConfig;
@@ -58,9 +58,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class TestSource {
 
@@ -120,7 +120,7 @@ public abstract class TestSource {
    */
   protected abstract void tearDown(TestDestinationEnv testEnv) throws Exception;
 
-  @Before
+  @BeforeEach
   public void setUpInternal() throws Exception {
     Path testDir = Path.of("/tmp/airbyte_tests/");
     Files.createDirectories(testDir);
@@ -138,7 +138,7 @@ public abstract class TestSource {
         "host");
   }
 
-  @After
+  @AfterEach
   public void tearDownInternal() throws Exception {
     tearDown(testEnv);
   }

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/base/TestSourceMain.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/base/TestSourceMain.java
@@ -34,9 +34,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Parse command line arguments and inject them into the test class before running the test. Then runs the tests.
+ * Parse command line arguments and inject them into the test class before running the test. Then
+ * runs the tests.
  */
 public class TestSourceMain {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(TestSourceMain.class);
 
   public static void main(String[] args) {

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/base/TestSourceMain.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/base/TestSourceMain.java
@@ -30,15 +30,14 @@ import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
-import org.junit.internal.TextListener;
-import org.junit.runner.JUnitCore;
-import org.junit.runner.Result;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Parse command line arguments and inject them into the test class before running the test. Then
- * runs the tests.
+ * Parse command line arguments and inject them into the test class before running the test. Then runs the tests.
  */
 public class TestSourceMain {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestSourceMain.class);
 
   public static void main(String[] args) {
     ArgumentParser parser = ArgumentParsers.newFor(TestSourceMain.class.getName()).build()
@@ -71,40 +70,7 @@ public class TestSourceMain {
     final String catalogFile = ns.getString("catalog");
     ExecutableTestSource.TEST_CONFIG = new TestConfig(imageName, Path.of(specFile), Path.of(configFile), Path.of(catalogFile));
 
-    // todo (cgardens) - using JUnit4 (instead of 5) here for two reasons: 1) Cannot get JUnit5 to print
-    // output nearly as nicely as 4. 2) JUnit5 was running all tests twice. Likely there are workarounds
-    // to both, but I cut my losses and went for something that worked.
-    JUnitCore junit = new JUnitCore();
-    junit.addListener(new TextListener(System.out));
-    final Result result = junit.run(ExecutableTestSource.class);
-
-    if (result.getFailureCount() > 0) {
-      System.exit(1);
-    }
-
-    // this is how you you are supposed to do it in JUnit5
-    // LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
-    // .selectors(
-    // selectPackage("io.airbyte.integrations.base"),
-    // selectClass(TestBasicTest.class)
-    // selectClass(TestBasicTest.class, ExecutableTestSource.class)
-    // )
-    // .filters(includeClassNamePatterns(".*Test"))
-    // .build();
-    //
-    // TestPlan plan = LauncherFactory.create().discover(request);
-    // Launcher launcher = LauncherFactory.create();
-    //
-    //
-    //
-    // // Register a listener of your choice
-    // SummaryGeneratingListener listener = new SummaryGeneratingListener();
-    // launcher.registerTestExecutionListeners(listener);
-    //
-    // launcher.execute(plan, listener);
-    //
-    // listener.getSummary().printFailuresTo(new PrintWriter(System.out));
-    // listener.getSummary().printTo(new PrintWriter(System.out));
+    TestRunner.runTestClass(ExecutableTestSource.class);
   }
 
 }


### PR DESCRIPTION
## What
* It was on junit 4 because "1) Cannot get JUnit5 to print output nearly as nicely as 4. 2) JUnit5 was running all tests twice."
* Unfortunately both of these things are still true. The printing isn't nearly as pretty and at least in intellij it seems like tests run twice. Junit4 is blocking java sources using these tests though so it needs to upgrade. Will try to figure out why the double test thing is happening before I merge.

**UPDATE: the tests are _not_ being run twice. they are just being reported twice in the summary. this is annoying but i'm not going to block on it. i've seen a couple people report this online, but i haven't found a solution yet. going to work on this as a background job nice to have. Issue to track it: https://github.com/airbytehq/airbyte/issues/763**
