### PR TITLE
Hotfix: Fix Hubspot Env Variables

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot-singer/Dockerfile.test
+++ b/airbyte-integrations/connectors/source-hubspot-singer/Dockerfile.test
@@ -6,8 +6,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 ENV CODE_PATH="standardtest"
-ENV AIRBYTE_IMPL_MODULE="standardtest"
-ENV AIRBYTE_IMPL_PATH="HubspotStandardSourceTest"
+ENV AIRBYTE_TEST_MODULE="standardtest"
+ENV AIRBYTE_TEST_PATH="HubspotStandardSourceTest"
 
 LABEL io.airbyte.version=0.1.0
 LABEL io.airbyte.name=airbyte/source-hubspot-singer-standard-test


### PR DESCRIPTION
## What
* In between the last time I ran the tests and merging the env variables names changed. is here.