### PR TITLE
template: Install pytest as a module in the venv to allow more flexible testing

### DIFF
--- a/airbyte-integrations/connector-templates/source-python/Dockerfile.test.hbs
+++ b/airbyte-integrations/connector-templates/source-python/Dockerfile.test.hbs
@@ -17,6 +17,6 @@ COPY secrets/* $CODE_PATH
 COPY source_{{snakeCase name}}/*.json $CODE_PATH
 COPY setup.py ./
 
-RUN pip install ".[integration_tests]"
+RUN pip install ".[tests]"
 
 WORKDIR /airbyte

--- a/airbyte-integrations/connector-templates/source-python/README.md.hbs
+++ b/airbyte-integrations/connector-templates/source-python/README.md.hbs
@@ -31,7 +31,7 @@ python main_dev.py read --config sample_files/test_config.json --catalog sample_
 ### Unit Tests
 To run unit tests locally, from the connector directory run:
 ```
-python setup.py test
+pytest unit_tests
 ```
 
 ### Locally running the connector docker image
@@ -47,6 +47,8 @@ docker run --rm -v $(pwd)/airbyte-integrations/connectors/source-{{dashCase name
 ### Integration Tests 
 1. Configure credentials as appropriate, described below.
 1. From the airbyte project root, run `./gradlew :airbyte-integrations:connectors:source-{{dashCase name}}:standardSourceTestPython` to run the standard integration test suite.
+1. To run additional integration tests, place your integration tests in the `integration_tests` directory and run them with `pytest integration_tests`.
+   Make sure to familiarize yourself with [pytest test discovery](https://docs.pytest.org/en/latest/goodpractices.html#test-discovery) to know how your test files and methods should be named.
 
 ## Dependency Management
 All of your dependencies should go in `setup.py`, NOT `requirements.txt`. The requirements file is only used to connect internal Airbyte dependencies in the monorepo for local development.

--- a/airbyte-integrations/connector-templates/source-python/build.gradle.hbs
+++ b/airbyte-integrations/connector-templates/source-python/build.gradle.hbs
@@ -13,10 +13,16 @@ standardSourceTestPython {
     }
 }
 
-task unitTest(type: PythonTask){
-    command = "setup.py test"
+task installTestDeps(type: PythonTask){
+    module = "pip"
+    command = "install ".[tests]"
 }
 
+task unitTest(type: PythonTask){
+    command = "pytest unit_tests"
+}
+
+unitTest.dependsOn(installTestDeps)
 build.dependsOn(unitTest)
 build.dependsOn ':airbyte-integrations:bases:base-python-test:build'
 buildImage.dependsOn ':airbyte-integrations:bases:base-python:buildImage'

--- a/airbyte-integrations/connector-templates/source-python/setup.cfg.hbs
+++ b/airbyte-integrations/connector-templates/source-python/setup.cfg.hbs
@@ -1,5 +1,0 @@
-[aliases]
-test='pytest'
-
-[tool:pytest]
-testpaths = unit_tests

--- a/airbyte-integrations/connector-templates/source-python/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/setup.py.hbs
@@ -42,6 +42,6 @@ setup(
         # integration tests but not the main package go in integration_tests. Deps required by both should go in
         # install_requires.
         "main":[],
-        "integration_tests": ["airbyte_python_test"],
+        "tests": ["airbyte_python_test", "pytest"],
     },
 )

--- a/airbyte-integrations/connector-templates/source-singer/Dockerfile.test.hbs
+++ b/airbyte-integrations/connector-templates/source-singer/Dockerfile.test.hbs
@@ -18,6 +18,6 @@ COPY secrets/* $CODE_PATH
 COPY $MODULE_NAME/*.json $CODE_PATH
 COPY setup.py ./
 
-RUN pip install ".[integration_tests]"
+RUN pip install ".[tests]"
 
 WORKDIR /airbyte

--- a/airbyte-integrations/connector-templates/source-singer/README.md.hbs
+++ b/airbyte-integrations/connector-templates/source-singer/README.md.hbs
@@ -48,6 +48,8 @@ docker run --rm -v $(pwd)/airbyte-integrations/connectors/source-{{dashCase name
 ### Integration Tests 
 1. Configure credentials as appropriate, described below.
 1. From the airbyte project root, run `./gradlew :airbyte-integrations:connectors:source-{{dashCase name}}-singer:standardSourceTestPython` to run the standard integration test suite.
+1. To run additional integration tests, place your integration tests in the `integration_tests` directory and run them with `pytest integration_tests`.
+   Make sure to familiarize yourself with [pytest test discovery](https://docs.pytest.org/en/latest/goodpractices.html#test-discovery) to know how your test files and methods should be named.
 
 ## Dependency Management
 All of your dependencies should go in `setup.py`, NOT `requirements.txt`. The requirements file is only used to connect internal Airbyte dependencies in the monorepo for local development.

--- a/airbyte-integrations/connector-templates/source-singer/README.md.hbs
+++ b/airbyte-integrations/connector-templates/source-singer/README.md.hbs
@@ -31,7 +31,7 @@ python main_dev.py read --config sample_files/test_config.json --catalog sample_
 ### Unit Tests
 To run unit tests locally, from the connector root run:
 ```
-python setup.py test
+pytest unit_tests
 ```
 
 

--- a/airbyte-integrations/connector-templates/source-singer/build.gradle.hbs
+++ b/airbyte-integrations/connector-templates/source-singer/build.gradle.hbs
@@ -13,10 +13,16 @@ standardSourceTestPython {
     }
 }
 
-task unitTest(type: PythonTask){
-    command = "setup.py test"
+task installTestDeps(type: PythonTask){
+module = "pip"
+command = "install ".[tests]"
 }
 
+task unitTest(type: PythonTask){
+command = "pytest unit_tests"
+}
+
+unitTest.dependsOn(installTestDeps)
 build.dependsOn(unitTest)
 build.dependsOn ':airbyte-integrations:bases:base-python-test:build'
 

--- a/airbyte-integrations/connector-templates/source-singer/build.gradle.hbs
+++ b/airbyte-integrations/connector-templates/source-singer/build.gradle.hbs
@@ -14,12 +14,12 @@ standardSourceTestPython {
 }
 
 task installTestDeps(type: PythonTask){
-module = "pip"
-command = "install ".[tests]"
+    module = "pip"
+    command = "install ".[tests]"
 }
 
 task unitTest(type: PythonTask){
-command = "pytest unit_tests"
+    command = "pytest unit_tests"
 }
 
 unitTest.dependsOn(installTestDeps)

--- a/airbyte-integrations/connector-templates/source-singer/setup.cfg.hbs
+++ b/airbyte-integrations/connector-templates/source-singer/setup.cfg.hbs
@@ -1,5 +1,0 @@
-[aliases]
-test='pytest'
-
-[tool:pytest]
-testpaths = unit_tests

--- a/airbyte-integrations/connector-templates/source-singer/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-singer/setup.py.hbs
@@ -39,6 +39,6 @@ setup(
         # integration tests but not the main package go in integration_tests. Deps required by both should go in
         # install_requires.
         "main":["base-singer", "base-python"],
-        "integration_tests": ["airbyte_python_test"],
+        "tests": ["airbyte_python_test", "pytest"],
     },
 )


### PR DESCRIPTION
## What
This allows more flexible use of pytest to run custom integration tests. See the updated READMEs for instructions. 
