### PR TITLE
remove gsheets standard test from PRs

### DIFF
--- a/tools/bin/standard_test_pr.sh
+++ b/tools/bin/standard_test_pr.sh
@@ -7,5 +7,4 @@ set -e
 assert_root
 
 ./gradlew --no-daemon --scan -x generateProtocolClassFiles \
-  :airbyte-integrations:connectors:source-github-singer:standardSourceTestPython \
-  :airbyte-integrations:connectors:source-google-sheets:standardSourceTestPython
+  :airbyte-integrations:connectors:source-github-singer:standardSourceTestPython 


### PR DESCRIPTION
## What
Standard tests create, populate, and delete a gsheet for every test, so we hit API throttling limits. This PR removes it from being tested on every PR. 
