### PR TITLE
template fixes

### DIFF
--- a/airbyte-integrations/connector-templates/source-python/build.gradle.hbs
+++ b/airbyte-integrations/connector-templates/source-python/build.gradle.hbs
@@ -15,11 +15,12 @@ standardSourceTestPython {
 
 task installTestDeps(type: PythonTask){
     module = "pip"
-    command = "install ".[tests]"
+    command = "install .[tests]"
 }
 
 task unitTest(type: PythonTask){
-    command = "pytest unit_tests"
+    module = "pytest"
+    command = "unit_tests"
 }
 
 unitTest.dependsOn(installTestDeps)

--- a/airbyte-integrations/connector-templates/source-singer/build.gradle.hbs
+++ b/airbyte-integrations/connector-templates/source-singer/build.gradle.hbs
@@ -15,11 +15,12 @@ standardSourceTestPython {
 
 task installTestDeps(type: PythonTask){
     module = "pip"
-    command = "install ".[tests]"
+    command = "install .[tests]"
 }
 
 task unitTest(type: PythonTask){
-    command = "pytest unit_tests"
+    module = "pytest"
+    command = "unit_tests"
 }
 
 unitTest.dependsOn(installTestDeps)


### PR DESCRIPTION
## What
* Fixes two bugs in the python / singer templates
* One is a syntax error with a quotation mark in the install command.
* The other i'm a little less sure of. AFter I ran the template script (after fixing the above error) the module wouldn't compile with the error below. I think the correct structure should be `.venv/bin/pytest unit_tests` instead of `.venv/bin/python pytest unit_tests`. tried to fix it by setting the `module` to `pytest`. that seems to have worked. 🤷‍♀️ @sherifnada lmk if i'm missing something on this one.

```
> Task :airbyte-integrations:connectors:source-rest-api:unitTest FAILED
[python] .venv/bin/python pytest unit_tests
         .venv/bin/python: can't open file 'pytest': [Errno 2] No such file or directory

FAILURE: Build failed with an exception.
```


