### PR TITLE
fix the invalid link about create new connectors in the documentation

### DIFF
--- a/docs/integrations/adding-your-own-connectors.md
+++ b/docs/integrations/adding-your-own-connectors.md
@@ -18,14 +18,7 @@ Before you can start building your own connector, you need to understand [Airbyt
 
 It's easy to code your own integrations on Airbyte. Here are some links to instruct on how to code new sources and destinations.
 
-#### **Coding new source connectors:**
-
-* [In Python](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/python-source/README.md)
-* [Based on Singer Taps in Python](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/singer-source/README.md)
-
-#### **Coding new destination connectors:**
-
-* [In Java](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/java-destination/README.md)
+* [Creating a new Integration](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/README.md)
 
 While the guides above are specific to the languages used most frequently to write integrations, **Airbyte integrations can be written in any language**. Please reach out to us if you'd like help developing integrations in other languages.
 


### PR DESCRIPTION
I just found there has no README file in the sub-folder of the connector-templates folder.

After search from the project, I thought it was one guide for how to create a new connector now. 

So, I fix the invalid link to that README file in the documentation.