### PR TITLE
auto assign issues to airbyte github project

### DIFF
--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -16,5 +16,5 @@ jobs:
         uses: srggrs/assign-one-project-github-action@1.2.0
         if: github.event.action == 'opened'
         with:
-          project: 'https://github.com/airbytehq/airbyte/projects/1'
-          column_name: 'backlog'
+          project: "https://github.com/airbytehq/airbyte/projects/1"
+          column_name: "backlog"

--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -1,0 +1,20 @@
+# https://github.com/marketplace/actions/assign-to-one-project#:~:text=GitHub%20Action%20for%20Assign%20to,columns%20in%20your%20project%20dashboard.
+name: Auto Assign to Airbyte Github Project
+
+on:
+  issues:
+    types: [opened]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to Airbyte Github Project
+    steps:
+      - name: Assign NEW issues and NEW pull requests to airbyte github project
+        uses: srggrs/assign-one-project-github-action@1.2.0
+        if: github.event.action == 'opened'
+        with:
+          project: 'https://github.com/airbytehq/airbyte/projects/1'
+          column_name: 'backlog'


### PR DESCRIPTION
## What
* For the kanban board to work properly, we need to assign our issues to the airbyte github project. it is not automatic, so no one remembers to do it. This makes it automatic.

## To do
* We still need to go back and add all preexisting issues to the project.
