### PR TITLE
Removed links from /docs/integrations/sources

### DIFF
--- a/docs/integrations/sources/README.md
+++ b/docs/integrations/sources/README.md
@@ -1,6 +1,2 @@
 # Sources
 
-* [Contributing Sources \(Python\)](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/python-source/README.md)
-* [Contributing Sources Based on Singer Taps \(Python\)](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/singer-source/README.md)
-* Please reach out to us for help developing sources in other languages.
-


### PR DESCRIPTION
## What
Links are broken on /integration/sources and it's the 3rd most visited page.
Removing the links will make Gitbook display a mosaic of all the subpages, which seems to be the best alternative right now. 