### PR TITLE
remove rest-api from docs so it can be added in a commit by itself

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,7 +20,6 @@
     * [Hubspot](integrations/sources/hubspot.md)
     * [MySQL](integrations/sources/mysql.md)
     * [Postgres](integrations/sources/postgres.md)
-    * [Rest API](integrations/sources/rest-api.md)
     * [Salesforce](integrations/sources/salesforce.md)
     * [Stripe](integrations/sources/stripe.md)
   * [Destinations](integrations/destinations/README.md)


### PR DESCRIPTION
## What
* We want to link to adding the docs from the original PR. We want the commit that does this to just add rest api source. so reverting it out and then adding it back in its own commit. 🧀 
