### PR TITLE
add rest api source to gitbook docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,6 +20,7 @@
     * [Hubspot](integrations/sources/hubspot.md)
     * [MySQL](integrations/sources/mysql.md)
     * [Postgres](integrations/sources/postgres.md)
+    * [Rest API](integrations/sources/rest-api.md)
     * [Salesforce](integrations/sources/salesforce.md)
     * [Stripe](integrations/sources/stripe.md)
   * [Destinations](integrations/destinations/README.md)


### PR DESCRIPTION
Forgot to add this as part of the original PR that added this source.