### PR TITLE
ensure input configurations match specs, error otherwise

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
@@ -182,7 +182,7 @@ public class DestinationHandler {
       throws JsonValidationException, IOException, ConfigNotFoundException {
     DestinationDefinitionSpecificationRead dcs =
         schedulerHandler.getDestinationSpecification(new DestinationDefinitionIdRequestBody().destinationDefinitionId(destinationId));
-    validator.validate(dcs.getConnectionSpecification(), implementationJson);
+    validator.ensure(dcs.getConnectionSpecification(), implementationJson);
   }
 
   private void persistDestinationConnection(final String name,

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -191,7 +191,7 @@ public class SourceHandler {
     SourceDefinitionSpecificationRead sds =
         schedulerHandler.getSourceDefinitionSpecification(new SourceDefinitionIdRequestBody().sourceDefinitionId(sourceDefinitionId));
 
-    validator.validate(sds.getConnectionSpecification(), implementationJson);
+    validator.ensure(sds.getConnectionSpecification(), implementationJson);
   }
 
   private void persistSourceConnection(final String name,

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
@@ -134,11 +134,7 @@ class DestinationHandlerTest {
 
     assertEquals(expectedDestinationRead, actualDestinationRead);
 
-    verify(validator)
-        .validate(
-            destinationDefinitionSpecificationRead.getConnectionSpecification(),
-            destinationConnection.getConfiguration());
-
+    verify(validator).ensure(destinationDefinitionSpecificationRead.getConnectionSpecification(), destinationConnection.getConfiguration());
     verify(configRepository).writeDestinationConnection(destinationConnection);
   }
 
@@ -224,6 +220,7 @@ class DestinationHandlerTest {
     assertEquals(expectedDestinationRead, actualDestinationRead);
 
     verify(configRepository).writeDestinationConnection(expectedDestinationConnection);
+    verify(validator).ensure(destinationDefinitionSpecificationRead.getConnectionSpecification(), destinationConnection.getConfiguration());
   }
 
   @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
@@ -118,23 +118,19 @@ class SourceHandlerTest {
         .name(sourceConnection.getName())
         .workspaceId(sourceConnection.getWorkspaceId())
         .sourceDefinitionId(standardSourceDefinition.getSourceDefinitionId())
-        .connectionConfiguration(SourceHelpers.getTestImplementationJson());
+        .connectionConfiguration(sourceConnection.getConfiguration());
 
     final SourceRead actualSourceRead =
         sourceHandler.createSource(sourceCreate);
 
     final SourceRead expectedSourceRead =
         SourceHelpers.getSourceRead(sourceConnection, standardSourceDefinition)
-            .connectionConfiguration(SourceHelpers.getTestImplementationJson());
+            .connectionConfiguration(sourceConnection.getConfiguration());
 
     assertEquals(expectedSourceRead, actualSourceRead);
 
-    verify(validator)
-        .validate(
-            sourceDefinitionSpecificationRead.getConnectionSpecification(),
-            sourceConnection.getConfiguration());
-
     verify(configRepository).writeSourceConnection(sourceConnection);
+    verify(validator).ensure(sourceDefinitionSpecificationRead.getConnectionSpecification(), sourceConnection.getConfiguration());
   }
 
   @Test
@@ -170,6 +166,7 @@ class SourceHandlerTest {
     assertEquals(expectedSourceRead, actualSourceRead);
 
     verify(configRepository).writeSourceConnection(expectedSourceConnection);
+    verify(validator).ensure(sourceDefinitionSpecificationRead.getConnectionSpecification(), newConfiguration);
   }
 
   @Test


### PR DESCRIPTION
## What
`JsonSchemaValidator::validate` doesn't throw an exception when the input configuration to creating or updating a connector doesn't match the spec, it only returns a set containing validation errors. However it was being used in the server to "validate" that the input config matched the spec. But nothing was done with the result of the validation. This PR uses `ensure` instead of `validate` to ascertain that we throw an exception if a non-compliant config was passed in. 