### PR TITLE
install generator dependencies as part of the build

### DIFF
--- a/airbyte-integrations/README.md
+++ b/airbyte-integrations/README.md
@@ -1,8 +1,9 @@
 ## Creating a new Integration
 
-From the `airbyte-integrations/connector-templates/generator` directory, run: 
+First, make sure you built the project by running `./gradlew build` from the project root directory. 
+
+Then, from the `airbyte-integrations/connector-templates/generator` directory, run: 
 ```
-npm install
 npm run generate
 ```
 and follow the interactive prompt. This will generate a new integration in the `airbyte-integrations/connectors/<your-integration>` directory. 

--- a/airbyte-integrations/README.md
+++ b/airbyte-integrations/README.md
@@ -2,6 +2,7 @@
 
 From the `airbyte-integrations/connector-templates/generator` directory, run: 
 ```
+npm install
 npm run generate
 ```
 and follow the interactive prompt. This will generate a new integration in the `airbyte-integrations/connectors/<your-integration>` directory. 
@@ -21,7 +22,7 @@ to tell Airbyte to use the latest version of your integration.
     ```
     ./tools/integrations/manage.sh publish airbyte-integrations/connectors/source-postgres-singer
     ```
-1. Update the connector version inside the `STANDARD_SOURCE` (or `STANDARD_DESTINATION` directory) to the one you just published. 
+1. Update the connector version inside the `STANDARD_SOURCE_DEFINITION` (or `STANDARD_DESTINATION_DEFINITION` directory) to the one you just published. 
 This will update Airbyte to use this new version by default. 
 1. Merge the PR containing the changes you made.
 

--- a/airbyte-integrations/connector-templates/generator/build.gradle
+++ b/airbyte-integrations/connector-templates/generator/build.gradle
@@ -8,4 +8,6 @@ node {
     version = "14.11.0"
 }
 
+assemble.dependsOn(npmInstall)
+
 // TODO add gradle tasks which generate one module for each generator we support and tests that the resulting code is valid.

--- a/airbyte-integrations/connector-templates/generator/package-lock.json
+++ b/airbyte-integrations/connector-templates/generator/package-lock.json
@@ -93,9 +93,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.2.tgz",
-      "integrity": "sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg==",
+      "version": "14.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==",
       "dev": true
     },
     "@types/through": {
@@ -814,9 +814,9 @@
       }
     },
     "fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -2145,9 +2145,9 @@
       "dev": true
     },
     "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
     },
     "rxjs": {
@@ -2523,9 +2523,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.3.tgz",
-      "integrity": "sha512-wDRziHG94mNj2n3R864CvYw/+pc9y/RNImiTyrrf8BzgWn75JgFSwYvXrtZQMnMnOp/4UTrf3iCSQxSStPiByA==",
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.5.tgz",
+      "integrity": "sha512-btvv/baMqe7HxP7zJSF7Uc16h1mSfuuSplT0/qdjxseesDU+yYzH33eHBH+eMdeRXwujXspaCTooWHQVVBh09w==",
       "dev": true,
       "optional": true
     },


### PR DESCRIPTION
## What
title. Either `npm install` or `./gradlew :airbyte-integrations:connector-templates:generator:build` is an acceptable way of installing deps (latter calls the former), but the latter will be more convenient for automated template testing. 