### PR TITLE
Hook up Normalization Scripts and Run DBT

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -1,5 +1,8 @@
 FROM airbyte/base-airbyte-protocol-python:dev
 
+# dbt needs git in order to run.
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /airbyte
 COPY entrypoint.sh .
 

--- a/airbyte-integrations/bases/base-normalization/entrypoint.sh
+++ b/airbyte-integrations/bases/base-normalization/entrypoint.sh
@@ -2,8 +2,9 @@
 
 set -e
 
-TRANSFORMED_CONFIG=transformed_config.json
-DBT_MODEL=dbt_model.json
+# dbt looks specifically for files named profiles.yml and dbt_project.yml
+DBT_PROFILE=profiles.yml
+DBT_MODEL=dbt_project.yml
 
 function echo2() {
   echo >&2 "$@"
@@ -42,11 +43,12 @@ function main() {
 
   case "$CMD" in
   run)
-    transform-config --config "$CONFIG_FILE" --integration-type "$INTEGRATION_TYPE" --out "$TRANSFORMED_CONFIG"
-#    transform-catalog --catalog "$CATALOG_FILE" --out "$DBT_MODEL"
-    cat $TRANSFORMED_CONFIG
-#    cat $DBT_MODEL
-#    execute-dbt --config "$TRANSFORMED_CONFIG" --model "$DBT_MODEL"
+    transform-config --config "$CONFIG_FILE" --integration-type "$INTEGRATION_TYPE" --out "$DBT_PROFILE"
+    # todo (cgardens) - @ChristopheDuong adjust these args if necessary.
+    transform-catalog --catalog "$CATALOG_FILE" --integration-type "$INTEGRATION_TYPE" --out "$DBT_MODEL"
+
+    # todo (cgardens) - @ChristopheDuong this is my best guess at how we are supposed to invoke dbt. adjust when they are inevitably not quite right.
+    dbt run --profiles-dir $(pwd) --project-dir $(pwd) --full-refresh --fail-fast
     ;;
   dry-run)
     error "Not Implemented"


### PR DESCRIPTION
## What
* Hook up all of the dbt pre-processing scripts. 
* Run DBT
* @ChristopheDuong & @sherifnada - I got the point where I was able to run dbt (but it didn't anthing because it's still missing some inputs).
```
root@5bc35bd38953:/airbyte# dbt run --profiles-dir $(pwd) --project-dir $(pwd)
Running with dbt=0.18.1
[WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.airbyte

Found 0 models, 0 tests, 0 snapshots, 0 analyses, 155 macros, 0 operations, 0 seed files, 0 sources
WARNING: Nothing to do. Try checking your model configs and model specification args
root@5bc35bd38953:/airbyte# dbt ^C --help
root@5bc35bd38953:/airbyte# exit
```

I'd recommend merging this and then you guys can just work on top of it to get it working.