### PR TITLE
materialize normalized table not view

### DIFF
--- a/airbyte-integrations/bases/base-normalization/dbt-project-template/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template/dbt_project.yml
@@ -37,4 +37,4 @@ models:
   airbyte:
     # Schema (dataset) defined in profiles.yml is concatenated with schema below for dbt's final output
     +schema: NORMALIZED
-    +materialized: view
+    +materialized: table


### PR DESCRIPTION
## What
Replicate normalized data as tables, not views. This is how we'll get around issues with warehouses not allowing us to overwrite tables when they are depended upon by views. 

when we normalize, we create a view which depends on the raw table. But this means that we can’t drop the raw table (even if we rename another table to its name in the same transaction) without either:
cascading the delete to all dependent resources and views ( imo we definitely do not want to do this), or
manually rewiring all dependent views to depend on the new table

This has been tested on postgres but not snowflake or bigquery.