### PR TITLE
bring back failed check test

### DIFF
--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
@@ -174,7 +174,7 @@ public abstract class TestDestination {
    * Verify that when the integrations returns a valid spec.
    */
   @Test
-  void testGetSpec() throws Exception {
+  public void testGetSpec() {
     final OutputAndStatus<StandardGetSpecOutput> output = runSpec();
     assertTrue(output.getOutput().isPresent());
   }
@@ -184,24 +184,22 @@ public abstract class TestDestination {
    * Assume that the {@link TestDestination#getConfig()} is valid.
    */
   @Test
-  void testCheckConnection() throws Exception {
+  public void testCheckConnection() throws Exception {
     final OutputAndStatus<StandardCheckConnectionOutput> output = runCheck(getConfig());
     assertTrue(output.getOutput().isPresent());
     assertEquals(Status.SUCCEEDED, output.getOutput().get().getStatus());
   }
 
-  // todo (cgardens) - fix issue where CsvDestination cannot be induced to fail this pass this test
-  // (cannot find credentials that are actually invalid).
   /**
    * Verify that when given invalid credentials, that check connection returns a failed response.
    * Assume that the {@link TestDestination#getFailCheckConfig()} is invalid.
    */
-  // @Test
-  // void testCheckConnectionInvalidCredentials() throws Exception {
-  // final OutputAndStatus<StandardCheckConnectionOutput> output = runCheck(getFailCheckConfig());
-  // assertTrue(output.getOutput().isPresent());
-  // assertEquals(Status.FAILED, output.getOutput().get().getStatus());
-  // }
+  @Test
+  public void testCheckConnectionInvalidCredentials() throws Exception {
+    final OutputAndStatus<StandardCheckConnectionOutput> output = runCheck(getFailCheckConfig());
+    assertTrue(output.getOutput().isPresent());
+    assertEquals(Status.FAILED, output.getOutput().get().getStatus());
+  }
 
   private static class DataArgumentsProvider implements ArgumentsProvider {
 
@@ -222,7 +220,7 @@ public abstract class TestDestination {
    */
   @ParameterizedTest
   @ArgumentsSource(DataArgumentsProvider.class)
-  void testSync(String messagesFilename, String catalogFilename) throws Exception {
+  public void testSync(String messagesFilename, String catalogFilename) throws Exception {
     final AirbyteCatalog catalog = Jsons.deserialize(renameAllStreams(MoreResources.readResource(catalogFilename)), AirbyteCatalog.class);
     final List<AirbyteMessage> messages = renameAllStreams(MoreResources.readResource(messagesFilename)).lines()
         .map(record -> Jsons.deserialize(record, AirbyteMessage.class)).collect(Collectors.toList());
@@ -235,7 +233,7 @@ public abstract class TestDestination {
    * Verify that the integration overwrites the first sync with the second sync.
    */
   @Test
-  void testSecondSync() throws Exception {
+  public void testSecondSync() throws Exception {
     final AirbyteCatalog catalog =
         Jsons.deserialize(renameAllStreams(MoreResources.readResource("exchange_rate_catalog.json")), AirbyteCatalog.class);
     final List<AirbyteMessage> firstSyncMessages = renameAllStreams(MoreResources.readResource("exchange_rate_messages.txt")).lines()
@@ -259,7 +257,7 @@ public abstract class TestDestination {
         .run(new JobGetSpecConfig().withDockerImage(getImageName()), jobRoot);
   }
 
-  private OutputAndStatus<StandardCheckConnectionOutput> runCheck(JsonNode config) throws Exception {
+  private OutputAndStatus<StandardCheckConnectionOutput> runCheck(JsonNode config) {
     return new DefaultCheckConnectionWorker(new AirbyteIntegrationLauncher(getImageName(), pbf))
         .run(new StandardCheckConnectionInput().withConnectionConfiguration(config), jobRoot);
   }

--- a/airbyte-integrations/connectors/destination-csv/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-csv/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationIntegrationTest.java
@@ -44,8 +44,6 @@ public class CsvDestinationIntegrationTest extends TestDestination {
   private static final String COLUMN_NAME = "data";
   private static final Path RELATIVE_PATH = Path.of("integration_test/test");
 
-  private Path localRoot;
-
   @Override
   protected String getImageName() {
     return "airbyte/destination-csv:dev";
@@ -56,19 +54,27 @@ public class CsvDestinationIntegrationTest extends TestDestination {
     return Jsons.jsonNode(ImmutableMap.of("destination_path", Path.of("/local").resolve(RELATIVE_PATH).toString()));
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
+  // todo (cgardens) - it would be great if we could find a configuration here that failed. the
+  // commented out one fails in mac but not on the linux box that the github action runs in. instead
+  // we override the test here so it never runs.
   @Override
   protected JsonNode getFailCheckConfig() {
     // set the directory to which the integration will try to write to to read only.
-    localRoot.toFile().setReadOnly();
+    // localRoot.toFile().setReadOnly();
 
-    return Jsons.jsonNode(ImmutableMap.of("destination_path", Path.of("/local").resolve(RELATIVE_PATH).toString()));
+    // return Jsons.jsonNode(ImmutableMap.of("destination_path",
+    // Path.of("/local").resolve(RELATIVE_PATH).toString()));
+    return null;
   }
+
+  // override test that this integration cannot pass.
+  @Override
+  public void testCheckConnectionInvalidCredentials() {}
 
   @Override
   protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv, String streamName) throws Exception {
     final List<Path> list = Files.list(testEnv.getLocalRoot().resolve(RELATIVE_PATH)).collect(Collectors.toList());
-    // todo (cgardens) - this should be here. add a retrieve tables abstract method to verify this.
+    // todo (cgardens) - this should not be here. add a retrieve tables abstract method to verify this.
     assertEquals(1, list.size());
 
     final FileReader in = new FileReader(list.get(0).toFile());
@@ -83,13 +89,12 @@ public class CsvDestinationIntegrationTest extends TestDestination {
   }
 
   @Override
-  protected void setup(TestDestinationEnv testEnv) throws Exception {
-    localRoot = testEnv.getLocalRoot();
+  protected void setup(TestDestinationEnv testEnv) {
     // no op
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv) throws Exception {
+  protected void tearDown(TestDestinationEnv testEnv) {
     // no op
   }
 


### PR DESCRIPTION
## What
* Bring back test in standard destination that checks that a destination fails check connection when it should.
* Have csv destination skip this test as it is quasi-impossible to get that destination to fail check connection.