### PR TITLE
remove snowflake use of renamer in standard tests

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeDatabase.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeDatabase.java
@@ -102,17 +102,27 @@ public class SnowflakeDatabase {
    */
   public static <T> T executeSync(Supplier<Connection> connectionFactory, String query, boolean multipleStatements, Function<ResultSet, T> transform)
       throws SQLException, InterruptedException {
-    try (Connection conn = connectionFactory.get()) {
-      Statement statement = conn.createStatement();
-      SnowflakeStatement snowflakeStatement = statement.unwrap(SnowflakeStatement.class);
+    final ResultSet results = execute(connectionFactory, query, multipleStatements);
+    return transform.apply(waitForQuery(results));
+  }
+
+  private static ResultSet execute(Supplier<Connection> connectionFactory, String query, boolean multipleStatements)
+      throws SQLException, InterruptedException {
+    try (final Connection conn = connectionFactory.get()) {
+      final Statement statement = conn.createStatement();
+      final SnowflakeStatement snowflakeStatement = statement.unwrap(SnowflakeStatement.class);
 
       if (multipleStatements) {
         snowflakeStatement.setParameter("MULTI_STATEMENT_COUNT", 0);
       }
 
-      ResultSet resultSet = snowflakeStatement.executeAsyncQuery(query);
-      return transform.apply(waitForQuery(resultSet));
+      return snowflakeStatement.executeAsyncQuery(query);
     }
+  }
+
+  public static void executeVoid(Supplier<Connection> connectionFactory, String query, boolean multipleStatements)
+      throws SQLException, InterruptedException {
+    execute(connectionFactory, query, multipleStatements);
   }
 
   /**
@@ -122,7 +132,7 @@ public class SnowflakeDatabase {
   public static Supplier<Connection> getConnectionFactory(JsonNode config) {
     final String connectUrl = String.format("jdbc:snowflake://%s", config.get("host").asText());
 
-    Properties properties = new Properties();
+    final Properties properties = new Properties();
 
     properties.put("user", config.get("username").asText());
     properties.put("password", config.get("password").asText());

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeIntegrationTest.java
@@ -99,7 +99,7 @@ public class SnowflakeIntegrationTest extends TestDestination {
     final String createSchemaQuery = String.format("CREATE SCHEMA %s", schemaName);
 
     baseConfig = getStaticConfig();
-    SnowflakeDatabase.executeVoid(SnowflakeDatabase.getConnectionFactory(baseConfig), createSchemaQuery, false);
+    SnowflakeDatabase.executeSync(SnowflakeDatabase.getConnectionFactory(baseConfig), createSchemaQuery, false);
 
     final JsonNode configForSchema = Jsons.clone(baseConfig);
     ((ObjectNode) configForSchema).put("schema", schemaName);
@@ -108,8 +108,8 @@ public class SnowflakeIntegrationTest extends TestDestination {
 
   @Override
   protected void tearDown(TestDestinationEnv testEnv) throws Exception {
-     final String createSchemaQuery = String.format("DROP SCHEMA IF EXISTS %s", config.get("schema").asText());
-     SnowflakeDatabase.executeVoid(SnowflakeDatabase.getConnectionFactory(baseConfig), createSchemaQuery, false);
+    final String createSchemaQuery = String.format("DROP SCHEMA IF EXISTS %s", config.get("schema").asText());
+    SnowflakeDatabase.executeSync(SnowflakeDatabase.getConnectionFactory(baseConfig), createSchemaQuery, false);
   }
 
 }

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeIntegrationTest.java
@@ -34,19 +34,16 @@ import io.airbyte.integrations.standardtest.destination.TestDestination;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 
 public class SnowflakeIntegrationTest extends TestDestination {
 
   private static final String COLUMN_NAME = "data";
-  private static final String STREAM_SUFFIX = "_" + RandomStringUtils.randomAlphanumeric(5);
-
-  @Override
-  protected Function<String, String> streamRenamer() {
-    return x -> x + STREAM_SUFFIX;
-  }
+  // config from which to create / delete schemas.
+  private JsonNode baseConfig;
+  // config which refers to the schema that the test is being run in.
+  private JsonNode config;
 
   @Override
   protected String getImageName() {
@@ -55,7 +52,7 @@ public class SnowflakeIntegrationTest extends TestDestination {
 
   @Override
   protected JsonNode getConfig() {
-    return getStaticConfig();
+    return config;
   }
 
   private static JsonNode getStaticConfig() {
@@ -64,9 +61,9 @@ public class SnowflakeIntegrationTest extends TestDestination {
 
   @Override
   protected JsonNode getFailCheckConfig() {
-    ObjectNode node = (ObjectNode) getConfig();
-    node.put("password", "wrong password");
-    return node;
+    final JsonNode invalidConfig = Jsons.clone(config);
+    ((ObjectNode) invalidConfig).put("password", "wrong password");
+    return invalidConfig;
   }
 
   @Test
@@ -95,18 +92,24 @@ public class SnowflakeIntegrationTest extends TestDestination {
         });
   }
 
+  // for each test we create a new schema in the database. run the test in there and then remove it.
   @Override
   protected void setup(TestDestinationEnv testEnv) throws Exception {
-    // no-op
+    final String schemaName = "integration_test_" + RandomStringUtils.randomAlphanumeric(5);
+    final String createSchemaQuery = String.format("CREATE SCHEMA %s", schemaName);
+
+    baseConfig = getStaticConfig();
+    SnowflakeDatabase.executeVoid(SnowflakeDatabase.getConnectionFactory(baseConfig), createSchemaQuery, false);
+
+    final JsonNode configForSchema = Jsons.clone(baseConfig);
+    ((ObjectNode) configForSchema).put("schema", schemaName);
+    config = configForSchema;
   }
 
   @Override
   protected void tearDown(TestDestinationEnv testEnv) throws Exception {
-    for (String stream : getAllStreamNames()) {
-      SnowflakeDatabase.executeSync(
-          SnowflakeDatabase.getConnectionFactory(getStaticConfig()),
-          String.format("DROP TABLE IF EXISTS \"%s\";", stream));
-    }
+     final String createSchemaQuery = String.format("DROP SCHEMA IF EXISTS %s", config.get("schema").asText());
+     SnowflakeDatabase.executeVoid(SnowflakeDatabase.getConnectionFactory(baseConfig), createSchemaQuery, false);
   }
 
 }

--- a/docs/integrations/destinations/snowflake.md
+++ b/docs/integrations/destinations/snowflake.md
@@ -84,7 +84,7 @@ begin;
 USE DATABASE identifier($airbyte_database);
 
 -- create schema for Airbyte data
-CREATE SCHEMA identifier($airbyte_schema);
+CREATE SCHEMA IF NOT EXISTS identifier($airbyte_schema);
 
 commit;
 ```


### PR DESCRIPTION
## What
* `streamRenamer` was added to accommodate the permission that the integration test user had in snowflake. 
* We have a workaround now, where instead of writing data to the same namespace, we write it to a different schema for each test. This allows us to get ride of `streamRenamer` and gives us better test isolation env isolation.