### PR TITLE
Add Basic Normalization Test to Standard Destination Test

### DIFF
--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -47,6 +48,7 @@ import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.workers.DefaultCheckConnectionWorker;
 import io.airbyte.workers.DefaultGetSpecWorker;
 import io.airbyte.workers.OutputAndStatus;
+import io.airbyte.workers.WorkerConstants;
 import io.airbyte.workers.process.AirbyteIntegrationLauncher;
 import io.airbyte.workers.process.DockerProcessBuilderFactory;
 import io.airbyte.workers.process.ProcessBuilderFactory;
@@ -57,7 +59,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
@@ -115,6 +116,14 @@ public abstract class TestDestination {
    */
   protected abstract List<JsonNode> retrieveRecords(TestDestinationEnv testEnv, String streamName) throws Exception;
 
+  protected boolean implementsBasicNormalization() {
+    return false;
+  }
+
+  protected List<JsonNode> retrieveNormalizedRecords(TestDestinationEnv testEnv, String streamName)  throws Exception {
+    throw new IllegalStateException("Not implemented");
+  }
+
   /**
    * Function that performs any setup of external resources required for the test. e.g. instantiate a
    * postgres database. This function will be called before EACH test.
@@ -133,23 +142,6 @@ public abstract class TestDestination {
    * @throws Exception - can throw any exception, test framework will handle.
    */
   protected abstract void tearDown(TestDestinationEnv testEnv) throws Exception;
-
-  /**
-   * Function that is applied to stream names in destination tests before emitting records/schemas.
-   * This is useful if there's a non-trivial amount of setup involved for the integration or it isn't
-   * easy to namespace.
-   *
-   * @return - function to transform resource (usually the identity function)
-   */
-  protected Function<String, String> streamRenamer() {
-    return Function.identity();
-  }
-
-  protected Set<String> getAllStreamNames() {
-    return ALL_RAW_STREAM_NAMES.stream()
-        .map(x -> streamRenamer().apply(x))
-        .collect(Collectors.toSet());
-  }
 
   @BeforeEach
   void setUpInternal() throws Exception {
@@ -221,12 +213,29 @@ public abstract class TestDestination {
   @ParameterizedTest
   @ArgumentsSource(DataArgumentsProvider.class)
   public void testSync(String messagesFilename, String catalogFilename) throws Exception {
-    final AirbyteCatalog catalog = Jsons.deserialize(renameAllStreams(MoreResources.readResource(catalogFilename)), AirbyteCatalog.class);
-    final List<AirbyteMessage> messages = renameAllStreams(MoreResources.readResource(messagesFilename)).lines()
+    final AirbyteCatalog catalog = Jsons.deserialize(MoreResources.readResource(catalogFilename), AirbyteCatalog.class);
+    final List<AirbyteMessage> messages = MoreResources.readResource(messagesFilename).lines()
         .map(record -> Jsons.deserialize(record, AirbyteMessage.class)).collect(Collectors.toList());
-    runSync(messages, catalog);
+    runSync(getConfig(), messages, catalog);
 
     assertSameMessages(messages, retrieveRecords(testEnv, catalog.getStreams().get(0).getName()));
+  }
+
+  /**
+   * Verify that the integration successfully writes records. Tests a wide variety of messages and
+   * schemas (aspirationally, anyway).
+   */
+  @ParameterizedTest
+  @ArgumentsSource(DataArgumentsProvider.class)
+  public void testSyncWithNormalization(String messagesFilename, String catalogFilename) throws Exception {
+    if(!implementsBasicNormalization()) return;
+
+    final AirbyteCatalog catalog = Jsons.deserialize(MoreResources.readResource(catalogFilename), AirbyteCatalog.class);
+    final List<AirbyteMessage> messages = MoreResources.readResource(messagesFilename).lines()
+        .map(record -> Jsons.deserialize(record, AirbyteMessage.class)).collect(Collectors.toList());
+    runSync(getConfigWithBasicNormalization(), messages, catalog);
+
+    assertSameMessages(messages, retrieveNormalizedRecords(testEnv, catalog.getStreams().get(0).getName()));
   }
 
   /**
@@ -235,12 +244,12 @@ public abstract class TestDestination {
   @Test
   public void testSecondSync() throws Exception {
     final AirbyteCatalog catalog =
-        Jsons.deserialize(renameAllStreams(MoreResources.readResource("exchange_rate_catalog.json")), AirbyteCatalog.class);
-    final List<AirbyteMessage> firstSyncMessages = renameAllStreams(MoreResources.readResource("exchange_rate_messages.txt")).lines()
+        Jsons.deserialize(MoreResources.readResource("exchange_rate_catalog.json"), AirbyteCatalog.class);
+    final List<AirbyteMessage> firstSyncMessages = MoreResources.readResource("exchange_rate_messages.txt").lines()
         .map(record -> Jsons.deserialize(record, AirbyteMessage.class)).collect(Collectors.toList());
-    runSync(firstSyncMessages, catalog);
+    runSync(getConfig(), firstSyncMessages, catalog);
 
-    List<AirbyteMessage> secondSyncMessages = Lists.newArrayList(new AirbyteMessage()
+    final List<AirbyteMessage> secondSyncMessages = Lists.newArrayList(new AirbyteMessage()
         .withRecord(new AirbyteRecordMessage()
             .withStream(catalog.getStreams().get(0).getName())
             .withData(Jsons.jsonNode(ImmutableMap.builder()
@@ -248,7 +257,7 @@ public abstract class TestDestination {
                 .put("HKD", 10)
                 .put("NZD", 700)
                 .build()))));
-    runSync(secondSyncMessages, catalog);
+    runSync(getConfig(), secondSyncMessages, catalog);
     assertSameMessages(secondSyncMessages, retrieveRecords(testEnv, catalog.getStreams().get(0).getName()));
   }
 
@@ -263,12 +272,12 @@ public abstract class TestDestination {
   }
 
   // todo (cgardens) - still uses the old schema.
-  private void runSync(List<AirbyteMessage> messages, AirbyteCatalog catalog) throws Exception {
+  private void runSync(JsonNode config, List<AirbyteMessage> messages, AirbyteCatalog catalog) throws Exception {
     final StandardTargetConfig targetConfig = new StandardTargetConfig()
         .withConnectionId(UUID.randomUUID())
         .withSyncMode(SyncMode.FULL_REFRESH)
         .withCatalog(catalog)
-        .withDestinationConnectionConfiguration(getConfig());
+        .withDestinationConnectionConfiguration(config);
 
     final AirbyteDestination target = new DefaultAirbyteDestination(new AirbyteIntegrationLauncher(getImageName(), pbf));
 
@@ -291,17 +300,11 @@ public abstract class TestDestination {
     assertTrue(actual.containsAll(expectedJson));
   }
 
-  private String renameAllStreams(String input) {
-    String output = input;
-
-    for (String streamName : ALL_RAW_STREAM_NAMES) {
-      final String newStreamName = streamRenamer().apply(streamName);
-      output = output.replace(streamName, newStreamName);
-    }
-
-    return output;
+  private JsonNode getConfigWithBasicNormalization() throws Exception {
+    final JsonNode config = getConfig();
+    ((ObjectNode)config).put(WorkerConstants.BASIC_NORMALIZATION_KEY, true);
+    return config;
   }
-
   public static class TestDestinationEnv {
 
     private final Path localRoot;

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
@@ -83,10 +83,25 @@ public class PostgresIntegrationTest extends TestDestination {
             .collect(Collectors.toList()));
   }
 
-  @Override
-  protected List<JsonNode> retrieveNormalizedRecords(TestDestinationEnv env, String streamName) throws Exception {
-    return retrieveRecords(env, streamName);
-  }
+  // todo (cgardens) - Example of what this should look like for postgres once normalization is added.
+  // Keep in mind `retrieveRecords` will also need to be updated once we have `_raw`
+  // @Override
+  // protected boolean implementsBasicNormalization() {
+  // return true;
+  // }
+  //
+  // @Override
+  // protected List<JsonNode> retrieveNormalizedRecords(TestDestinationEnv env, String streamName)
+  // throws Exception {
+  // return Databases.createPostgresDatabase(db.getUsername(), db.getPassword(),
+  // db.getJdbcUrl()).query(
+  // ctx -> ctx
+  // .fetch(String.format("SELECT * FROM %s ORDER BY emitted_at ASC;", streamName))
+  // .stream()
+  // .map(r -> r.formatJSON(JSON_FORMAT))
+  // .map(Jsons::deserialize)
+  // .collect(Collectors.toList()));
+  // }
 
   @Override
   protected void setup(TestDestinationEnv testEnv) {

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
@@ -84,6 +84,11 @@ public class PostgresIntegrationTest extends TestDestination {
   }
 
   @Override
+  protected List<JsonNode> retrieveNormalizedRecords(TestDestinationEnv env, String streamName) throws Exception {
+    return retrieveRecords(env, streamName);
+  }
+
+  @Override
   protected void setup(TestDestinationEnv testEnv) {
     db = new PostgreSQLContainer<>("postgres:13-alpine");
     db.start();

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeIntegrationTest.java
@@ -66,11 +66,6 @@ public class SnowflakeIntegrationTest extends TestDestination {
     return invalidConfig;
   }
 
-  @Test
-  public void testIt() {
-    assertTrue(true);
-  }
-
   @Override
   protected List<JsonNode> retrieveRecords(TestDestinationEnv env, String streamName) throws Exception {
     return SnowflakeDatabase.executeSync(

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeIntegrationTest.java
@@ -24,8 +24,6 @@
 
 package io.airbyte.integrations.destination.snowflake;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.airbyte.commons.io.IOs;
@@ -35,7 +33,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.Test;
 
 public class SnowflakeIntegrationTest extends TestDestination {
 


### PR DESCRIPTION
## What
* Add a test for Basic Normalization.
  * This kind of a stub until @sherifnada finishes up the change to make it saw that we write to `_raw` for non-normalized tables.
* Example of how this will be used
* Remove renamer functionality in standard test
  * Blows away the snowflake integration tests for now. I'm still fighting them in a separate [PR](https://github.com/airbytehq/airbyte/pull/866), so this PR just deletes them for now until I get them fixed. Basically they use the renamer feature. I have a way of getting around needing to do that, but I'm fighting permission administrivia in snowflake.

## How
* Added more methods to be overwritten to the existing `TestDestination` class. I tested out subclassing it and doing a `TestDestinationWithBasicNormalization`. It ended up being a lot more code and was hard to reason about for figuring out the inheritance logic across the different classes.