### PR TITLE
Normalization integration test

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/NamingHelper.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/NamingHelper.java
@@ -1,7 +1,33 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.airbyte.integrations.base;
 
 public class NamingHelper {
+
   public static String getRawTableName(String streamName) {
     return streamName + "_raw";
   }
+
 }

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template/dbt_project.yml
@@ -35,6 +35,4 @@ quoting:
 # are materialized, and more!
 models:
   airbyte:
-    # Schema (dataset) defined in profiles.yml is concatenated with schema below for dbt's final output
-    +schema: NORMALIZED
     +materialized: table

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
@@ -81,8 +81,8 @@ python3 main_dev_transform_catalog.py \
             if not os.path.exists(output):
                 os.makedirs(output)
             for file, sql in result.items():
-                print(f"  Generating {file.lower()}.sql in {output}")
-                with open(os.path.join(output, f"{file}.sql").lower(), "w") as f:
+                print(f"  Generating {file.lower()}_normalized.sql in {output}")
+                with open(os.path.join(output, f"{file}_normalized.sql").lower(), "w") as f:
                     f.write(sql)
 
     @staticmethod
@@ -302,11 +302,10 @@ def process_node(
     hash_node_columns = jinja_call(f"dbt_utils.surrogate_key([\n        {hash_node_columns}\n    ])")
     hash_id = jinja_call(f"adapter.quote_as_configured('_{name}_hashid', 'identifier')")
     foreign_hash_id = jinja_call(f"adapter.quote_as_configured('_{name}_foreign_hashid', 'identifier')")
-    emitted_col = "{} as {},\n    {} as {}".format(
+    emitted_col = "{},\n    {} as {}".format(
         jinja_call("adapter.quote_as_configured('emitted_at', 'identifier')"),
-        jinja_call("adapter.quote_as_configured('_emitted_at', 'identifier')"),
         jinja_call("dbt_utils.current_timestamp_in_utc()"),
-        jinja_call("adapter.quote_as_configured('_loaded_at', 'identifier')"),
+        jinja_call("adapter.quote_as_configured('normalized_at', 'identifier')"),
     )
     node_sql = f"""{prefix}
 {name}_node as (

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
@@ -182,7 +182,7 @@ def json_extract_base_property(path: List[str], json_col: str, name: str, defini
     elif is_number(definition["type"]):
         return "cast({} as {}) as {}".format(
             jinja_call(f"json_extract_scalar('{json_col}', {current})"),
-            jinja_call("dbt_utils.type_numeric()"),
+            jinja_call("dbt_utils.type_float()"),
             jinja_call(f"adapter.quote_as_configured('{name}', 'identifier')"),
         )
     elif is_boolean(definition["type"]):

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
@@ -29,9 +29,6 @@ from typing import List, Optional, Set, Tuple, Union
 
 import yaml
 
-MACRO_START = "{{"
-MACRO_END = "}}"
-
 
 class TransformCatalog:
     """
@@ -162,29 +159,36 @@ def find_combining_schema(properties: dict) -> set:
     return set(properties).intersection({"anyOf", "oneOf", "allOf"})
 
 
+def jinja_call(command: str) -> str:
+    return "{{ " + command + "  }}"
+
+
 def json_extract_base_property(path: List[str], json_col: str, name: str, definition: dict) -> Optional[str]:
     current = path + [name]
     if "type" not in definition:
         return None
     elif is_string(definition["type"]):
-        return (
-            f"cast({MACRO_START} json_extract_scalar('{json_col}', {current}) {MACRO_END} as {MACRO_START} dbt_utils.type_string()"
-            + f" {MACRO_END}) as {MACRO_START} adapter.quote_as_configured('{name}', 'identifier') {MACRO_END}"
+        return "cast({} as {}) as {}".format(
+            jinja_call(f"json_extract('{json_col}', {current})"),
+            jinja_call("dbt_utils.type_string()"),
+            jinja_call(f"adapter.quote_as_configured('{name}', 'identifier')"),
         )
     elif is_integer(definition["type"]):
-        return (
-            f"cast({MACRO_START} json_extract_scalar('{json_col}', {current}) {MACRO_END} as {MACRO_START} dbt_utils.type_int()"
-            + f" {MACRO_END}) as {MACRO_START} adapter.quote_as_configured('{name}', 'identifier') {MACRO_END}"
+        return "cast({} as {}) as {}".format(
+            jinja_call(f"json_extract_scalar('{json_col}', {current})"),
+            jinja_call("dbt_utils.type_int()"),
+            jinja_call(f"adapter.quote_as_configured('{name}', 'identifier')"),
         )
     elif is_number(definition["type"]):
-        return (
-            f"cast({MACRO_START} json_extract_scalar('{json_col}', {current}) {MACRO_END} as {MACRO_START} dbt_utils.type_numeric()"
-            + f" {MACRO_END}) as {MACRO_START} adapter.quote_as_configured('{name}', 'identifier') {MACRO_END}"
+        return "cast({} as {}) as {}".format(
+            jinja_call(f"json_extract_scalar('{json_col}', {current})"),
+            jinja_call("dbt_utils.type_numeric()"),
+            jinja_call(f"adapter.quote_as_configured('{name}', 'identifier')"),
         )
     elif is_boolean(definition["type"]):
-        return (
-            f"cast({MACRO_START} json_extract_scalar('{json_col}', {current}) {MACRO_END} as boolean"
-            + f") as {MACRO_START} adapter.quote_as_configured('{name}', 'identifier') {MACRO_END}"
+        return "cast({} as boolean) as {}".format(
+            jinja_call(f"json_extract_scalar('{json_col}', {current})"),
+            jinja_call(f"adapter.quote_as_configured('{name}', 'identifier')"),
         )
     else:
         return None
@@ -196,15 +200,20 @@ def json_extract_nested_property(path: List[str], json_col: str, name: str, defi
         return None, None
     elif is_array(definition["type"]):
         return (
-            f"{MACRO_START} json_extract_array('{json_col}', {current}) {MACRO_END} as "
-            + f"{MACRO_START} adapter.quote_as_configured('{name}', 'identifier') {MACRO_END}",
-            f"cross join {MACRO_START} unnest('{name}') {MACRO_END} as "
-            + f"{MACRO_START} adapter.quote_as_configured('{name}', 'identifier') {MACRO_END}",
+            "{} as {}".format(
+                jinja_call(f"json_extract_array('{json_col}', {current})"),
+                jinja_call(f"adapter.quote_as_configured('{name}', 'identifier')"),
+            ),
+            "cross join {} as {}".format(
+                jinja_call(f"unnest('{name}')"), jinja_call(f"adapter.quote_as_configured('{name}', 'identifier')")
+            ),
         )
     elif is_object(definition["type"]):
         return (
-            f"{MACRO_START} json_extract('{json_col}', {current}) {MACRO_END} as "
-            + f"{MACRO_START} adapter.quote_as_configured('{name}', 'identifier') {MACRO_END}",
+            "{} as {}".format(
+                jinja_call(f"json_extract('{json_col}', {current})"),
+                jinja_call(f"adapter.quote_as_configured('{name}', 'identifier')"),
+            ),
             "",
         )
     else:
@@ -290,17 +299,26 @@ def process_node(
     node_properties = extract_node_properties(path=path, json_col=json_col, properties=properties)
     node_columns = ",\n    ".join([sql for sql in node_properties.values()])
     hash_node_columns = ",\n        ".join([f"adapter.quote_as_configured('{column}', 'identifier')" for column in node_properties.keys()])
-    hash_node_columns = f"{MACRO_START} dbt_utils.surrogate_key([\n        {hash_node_columns}\n    ]) {MACRO_END}"
+    hash_node_columns = jinja_call(f"dbt_utils.surrogate_key([\n        {hash_node_columns}\n    ])")
+    hash_id = jinja_call(f"adapter.quote_as_configured('_{name}_hashid', 'identifier')")
+    foreign_hash_id = jinja_call(f"adapter.quote_as_configured('_{name}_foreign_hashid', 'identifier')")
+    emitted_col = "{} as {},\n    {} as {}".format(
+        jinja_call("adapter.quote_as_configured('emitted_at', 'identifier')"),
+        jinja_call("adapter.quote_as_configured('_emitted_at', 'identifier')"),
+        jinja_call("dbt_utils.current_timestamp_in_utc()"),
+        jinja_call("adapter.quote_as_configured('_loaded_at', 'identifier')"),
+    )
     node_sql = f"""{prefix}
 {name}_node as (
   select {inject_cols}
+    {emitted_col},
     {node_columns}
   from {from_table}
 ),
 {name}_with_id as (
   select
     *,
-    {hash_node_columns} as {MACRO_START} adapter.quote_as_configured('_{name}_hashid', 'identifier') {MACRO_END}
+    {hash_node_columns} as {hash_id}
   from {name}_node
 )"""
     # SQL Query for current node's basic properties
@@ -310,17 +328,19 @@ def process_node(
     if children_columns:
         for col in children_columns.keys():
             child_col, join_child_table = json_extract_nested_property(path=path, json_col=json_col, name=col, definition=properties[col])
+            column_name = jinja_call(f"adapter.quote_as_configured('{col}', 'identifier')")
             child_sql = f"""{prefix}
 {name}_node as (
   select
+    {emitted_col},
     {child_col},
     {node_columns}
   from {from_table}
 ),
 {name}_with_id as (
   select
-    {hash_node_columns} as {MACRO_START} adapter.quote_as_configured('_{name}_hashid', 'identifier') {MACRO_END},
-    {MACRO_START} adapter.quote_as_configured('{col}', 'identifier') {MACRO_END}
+    {hash_node_columns} as {hash_id},
+    {column_name}
   from {name}_node
   {join_child_table}
 )"""
@@ -332,7 +352,7 @@ def process_node(
                     properties=children_columns[col],
                     from_table=f"{name}_with_id",
                     previous=child_sql,
-                    inject_cols=f"\n    {MACRO_START} adapter.quote_as_configured('_{name}_hashid', 'identifier') {MACRO_END} as _{name}_foreign_hashid,",
+                    inject_cols=f"\n    {hash_id} as {foreign_hash_id},",
                 )
                 result.update(children)
             else:
@@ -340,7 +360,7 @@ def process_node(
                 result[f"{name}_{col}"] = child_sql + select_table(
                     f"{name}_with_id",
                     columns=f"""
-  {MACRO_START} adapter.quote_as_configured('_{name}_hashid', 'identifier') {MACRO_END} as _{name}_foreign_hashid,
+  {hash_id} as {foreign_hash_id},
   {col}
 """,
                 )
@@ -359,7 +379,7 @@ def generate_dbt_model(catalog: dict, json_col: str, schema: str) -> Tuple[dict,
             properties = obj["json_schema"]["properties"]
         else:
             properties = {}
-        table = f"{MACRO_START} source('{schema}','{name}') {MACRO_END}"
+        table = jinja_call(f"source('{schema}','{name}')")
         result.update(process_node(path=[], json_col=json_col, name=name, properties=properties, from_table=table))
         source_tables.add(name)
     return result, source_tables

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
@@ -81,8 +81,8 @@ python3 main_dev_transform_catalog.py \
             if not os.path.exists(output):
                 os.makedirs(output)
             for file, sql in result.items():
-                print(f"  Generating {file.lower()}_normalized.sql in {output}")
-                with open(os.path.join(output, f"{file}_normalized.sql").lower(), "w") as f:
+                print(f"  Generating {file.lower()}.sql in {output}")
+                with open(os.path.join(output, f"{file}.sql").lower(), "w") as f:
                     f.write(sql)
 
     @staticmethod

--- a/airbyte-integrations/bases/standard-destination-test/src/main/resources/exchange_rate_catalog.json
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/resources/exchange_rate_catalog.json
@@ -5,13 +5,13 @@
       "json_schema": {
         "properties": {
           "date": {
-            "dataType": "string"
+            "type": "string"
           },
           "HKD": {
-            "dataType": "number"
+            "type": "number"
           },
           "NZD": {
-            "dataType": "number"
+            "type": "number"
           }
         }
       }

--- a/airbyte-integrations/bases/standard-destination-test/src/main/resources/exchange_rate_catalog.json
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/resources/exchange_rate_catalog.json
@@ -12,6 +12,9 @@
           },
           "NZD": {
             "type": "number"
+          },
+          "USD": {
+            "type": "number"
           }
         }
       }

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryIntegrationTest.java
@@ -88,7 +88,8 @@ public class BigQueryIntegrationTest extends TestDestination {
   protected List<JsonNode> retrieveRecords(TestDestinationEnv env, String streamName) throws Exception {
     final QueryJobConfiguration queryConfig =
         QueryJobConfiguration
-            .newBuilder(String.format("SELECT * FROM %s.%s;", dataset.getDatasetId().getDataset(), NamingHelper.getRawTableName(streamName.toLowerCase())))
+            .newBuilder(
+                String.format("SELECT * FROM %s.%s;", dataset.getDatasetId().getDataset(), NamingHelper.getRawTableName(streamName.toLowerCase())))
             .setUseLegacySql(false).build();
 
     return StreamSupport
@@ -102,7 +103,8 @@ public class BigQueryIntegrationTest extends TestDestination {
   protected void setup(TestDestinationEnv testEnv) throws Exception {
     if (!Files.exists(CREDENTIALS_PATH)) {
       throw new IllegalStateException(
-          "Must provide path to a big query credentials file. By default {module-root}/" + CREDENTIALS_PATH + ". Override by setting setting path with the CREDENTIALS_PATH constant.");
+          "Must provide path to a big query credentials file. By default {module-root}/" + CREDENTIALS_PATH
+              + ". Override by setting setting path with the CREDENTIALS_PATH constant.");
     }
 
     final String credentialsJsonString = new String(Files.readAllBytes(CREDENTIALS_PATH));

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
@@ -29,7 +29,6 @@ import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.Databases;
 import io.airbyte.integrations.standardtest.destination.TestDestination;
-import io.airbyte.protocol.models.AirbyteMessage;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.jooq.JSONFormat;

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.Databases;
 import io.airbyte.integrations.standardtest.destination.TestDestination;
+import io.airbyte.protocol.models.AirbyteMessage;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.jooq.JSONFormat;
@@ -85,23 +86,23 @@ public class PostgresIntegrationTest extends TestDestination {
 
   // todo (cgardens) - Example of what this should look like for postgres once normalization is added.
   // Keep in mind `retrieveRecords` will also need to be updated once we have `_raw`
-  // @Override
-  // protected boolean implementsBasicNormalization() {
-  // return true;
-  // }
-  //
-  // @Override
-  // protected List<JsonNode> retrieveNormalizedRecords(TestDestinationEnv env, String streamName)
-  // throws Exception {
-  // return Databases.createPostgresDatabase(db.getUsername(), db.getPassword(),
-  // db.getJdbcUrl()).query(
-  // ctx -> ctx
-  // .fetch(String.format("SELECT * FROM %s ORDER BY emitted_at ASC;", streamName))
-  // .stream()
-  // .map(r -> r.formatJSON(JSON_FORMAT))
-  // .map(Jsons::deserialize)
-  // .collect(Collectors.toList()));
-  // }
+  @Override
+  protected boolean implementsBasicNormalization() {
+    return true;
+  }
+
+  @Override
+  protected List<JsonNode> retrieveNormalizedRecords(TestDestinationEnv env, String streamName)
+      throws Exception {
+    return Databases.createPostgresDatabase(db.getUsername(), db.getPassword(),
+        db.getJdbcUrl()).query(
+            ctx -> ctx
+                .fetch(String.format("SELECT * FROM %s_normalized ORDER BY emitted_at ASC;", streamName))
+                .stream()
+                .map(r -> r.formatJSON(JSON_FORMAT))
+                .map(Jsons::deserialize)
+                .collect(Collectors.toList()));
+  }
 
   @Override
   protected void setup(TestDestinationEnv testEnv) {

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
@@ -97,7 +97,7 @@ public class PostgresIntegrationTest extends TestDestination {
     return Databases.createPostgresDatabase(db.getUsername(), db.getPassword(),
         db.getJdbcUrl()).query(
             ctx -> ctx
-                .fetch(String.format("SELECT * FROM %s_normalized ORDER BY emitted_at ASC;", streamName))
+                .fetch(String.format("SELECT * FROM %s ORDER BY emitted_at ASC;", streamName))
                 .stream()
                 .map(r -> r.formatJSON(JSON_FORMAT))
                 .map(Jsons::deserialize)


### PR DESCRIPTION
## What
Enable normalization in destination integration tests

Here i remove the `_normalized` schema suffix but add it to the table name suffix instead until #845 defines proper `_raw` naming for tables produced before  normalization.
There is also a method in `TestDestination.assertEquivalentMessages` that needs to be better implemented since I didn't know how to properly compare expected messages and actual ones...

(Messages from normalized tables contains a few extra metadata columns that fails the tests with `assertSameMessages)`

`{HKD: 13,2, date: 2020-11-01}`
vs
`{emitted_at: 2020-11-01, HKD: 13,2, date: 2020-11-01, normalized_at: 2020-11-01, _exchange_hashid: 2141sfas21aaz2}`

