### PR TITLE
improve shopify sync speed by increasing date window

### DIFF
--- a/airbyte-integrations/connectors/source-shopify-singer/source_shopify_singer/source.py
+++ b/airbyte-integrations/connectors/source-shopify-singer/source_shopify_singer/source.py
@@ -35,7 +35,12 @@ class SourceShopifySinger(SingerSource):
         super().__init__()
 
     def transform_config(self, raw_config):
-        return {"start_date": raw_config["start_date"], "api_key": raw_config["api_password"], "shop": raw_config["shop"]}
+        return {
+            "start_date": raw_config["start_date"],
+            "api_key": raw_config["api_password"],
+            "shop": raw_config["shop"],
+            "date_window_size": 7,
+        }
 
     def check(self, logger: AirbyteLogger, config_container: ConfigContainer) -> AirbyteConnectionStatus:
         try:


### PR DESCRIPTION
Add `tap-shopify` option for looking at 7 days of API history instead of 1. https://github.com/singer-io/tap-shopify/blob/master/tap_shopify/streams/base.py#L18.

This allows the standard test to execute in under a minute and doesn't hit the problems the comment linked is discussing. I'm thinking we can leave it here as is and make it configurable in the future if needed. I'd like to lean towards ease of configurability for now. 