### PR TITLE
use hyphen instead of underscore in template

### DIFF
--- a/airbyte-integrations/connector-templates/source-python/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/setup.py.hbs
@@ -42,6 +42,6 @@ setup(
         # integration tests but not the main package go in integration_tests. Deps required by both should go in
         # install_requires.
         "main": [],
-        "tests": ["airbyte_python_test", "pytest"],
+        "tests": ["airbyte-python-test", "pytest"],
     },
 )

--- a/airbyte-integrations/connector-templates/source-singer/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-singer/setup.py.hbs
@@ -39,6 +39,6 @@ setup(
         # integration tests but not the main package go in integration_tests. Deps required by both should go in
         # install_requires.
         "main": ["base-singer", "base-python"],
-        "tests": ["airbyte_python_test", "pytest"],
+        "tests": ["airbyte-python-test", "pytest"],
     },
 )


### PR DESCRIPTION
## What
* match our preferred style in the template.