### PR TITLE
fix postgres table name quoting

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
@@ -268,9 +268,9 @@ public class PostgresDestination implements Destination {
         database.transaction(ctx -> {
           final StringBuilder query = new StringBuilder();
           for (final WriteConfig writeConfig : writeConfigs.values()) {
-            query.append(String.format("DROP TABLE IF EXISTS %s;\n", writeConfig.getTableName()));
+            query.append(String.format("DROP TABLE IF EXISTS \"%s\";\n", writeConfig.getTableName()));
 
-            query.append(String.format("ALTER TABLE %s RENAME TO %s;\n", writeConfig.getTmpTableName(), writeConfig.getTableName()));
+            query.append(String.format("ALTER TABLE \"%s\" RENAME TO \"%s\";\n", writeConfig.getTmpTableName(), writeConfig.getTableName()));
           }
           return ctx.execute(query.toString());
         });


### PR DESCRIPTION
I think this is actually quite simple on the destination side compared to what we thought. `CREATE TABLE` is already quoted and inserts are quoted via JOOQ with `ctx.insertInto(table(tmpTableName), ...)`. These seem to be the only exceptions, but we will need the test cases @cgardens is adding.

Also, as far as I can tell CSV/BigQuery/Snowflake all don't have this problem, but we should use the new test cases ofc.