### PR TITLE
force black to run after spotless

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -29,6 +29,7 @@ class AirbytePythonPlugin implements Plugin<Project> {
             module = "black"
             // the line length should match .isort.cfg
             command = ". --line-length 140"
+            dependsOn project.rootProject.spotlessPythonApply
         }
 
         project.task('isortFormat', type: PythonTask) {


### PR DESCRIPTION
It looks like in the Shopify integration there's a transient build file change failure where `spotlessPythonApply` treats newlines differently in `unit_test.py` because the ordering isn't enforced between these two steps. 