### PR TITLE
add spacing, casing, and characters tests

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/functional/CheckedFunction.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/functional/CheckedFunction.java
@@ -1,0 +1,32 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.commons.functional;
+
+@FunctionalInterface
+public interface CheckedFunction<T, R, E extends Throwable> {
+
+  R apply(T t) throws E;
+
+}

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
@@ -220,7 +220,8 @@ public abstract class TestDestination {
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
       return Stream.of(
-          Arguments.of("exchange_rate_messages.txt", "exchange_rate_catalog.json")
+          Arguments.of("exchange_rate_messages.txt", "exchange_rate_catalog.json"),
+          Arguments.of("edge_case_messages.txt", "edge_case_catalog.json")
       // todo - need to use the new protocol to capture this.
       // Arguments.of("stripe_messages.txt", "stripe_schema.json")
       );

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import io.airbyte.commons.functional.CheckedFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.commons.resources.MoreResources;
@@ -45,6 +46,7 @@ import io.airbyte.config.StandardTargetConfig;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
+import io.airbyte.protocol.models.AirbyteStream;
 import io.airbyte.workers.DefaultCheckConnectionWorker;
 import io.airbyte.workers.DefaultGetSpecWorker;
 import io.airbyte.workers.OutputAndStatus;
@@ -59,6 +61,7 @@ import io.airbyte.workers.protocols.airbyte.AirbyteDestination;
 import io.airbyte.workers.protocols.airbyte.DefaultAirbyteDestination;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -172,6 +175,7 @@ public abstract class TestDestination {
     jobRoot = Files.createDirectories(Path.of(workspaceRoot.toString(), "job"));
     localRoot = Files.createTempDirectory(testDir, "output");
     LOGGER.info("jobRoot: {}", jobRoot);
+    LOGGER.info("localRoot: {}", localRoot);
     testEnv = new TestDestinationEnv(localRoot);
 
     setup(testEnv);
@@ -241,7 +245,7 @@ public abstract class TestDestination {
         .map(record -> Jsons.deserialize(record, AirbyteMessage.class)).collect(Collectors.toList());
     runSync(getConfig(), messages, catalog);
 
-    assertSameMessages(messages, retrieveRecords(testEnv, catalog.getStreams().get(0).getName()));
+    assertSameMessages(messages, retrieveRecordsForCatalog(catalog));
   }
 
   /**
@@ -260,8 +264,8 @@ public abstract class TestDestination {
         .map(record -> Jsons.deserialize(record, AirbyteMessage.class)).collect(Collectors.toList());
     runSync(getConfigWithBasicNormalization(), messages, catalog);
 
-    assertSameMessages(messages, retrieveRecords(testEnv, catalog.getStreams().get(0).getName()));
-    assertSameMessagesPruneAirbyteInternalFields(messages, retrieveNormalizedRecords(testEnv, catalog.getStreams().get(0).getName()));
+    assertSameMessages(messages, retrieveRecordsForCatalog(catalog));
+    assertSameMessages(messages, retrieveNormalizedRecordsForCatalog(catalog), true);
   }
 
   /**
@@ -284,7 +288,7 @@ public abstract class TestDestination {
                 .put("NZD", 700)
                 .build()))));
     runSync(getConfig(), secondSyncMessages, catalog);
-    assertSameMessages(secondSyncMessages, retrieveRecords(testEnv, catalog.getStreams().get(0).getName()));
+    assertSameMessages(secondSyncMessages, retrieveRecordsForCatalog(catalog));
   }
 
   private OutputAndStatus<StandardGetSpecOutput> runSpec() {
@@ -329,29 +333,52 @@ public abstract class TestDestination {
     runner.close();
   }
 
-  private void assertSameMessages(List<AirbyteMessage> expected, List<JsonNode> actual) {
-    final List<JsonNode> expectedJson = expected.stream()
-        .filter(message -> message.getType() == AirbyteMessage.Type.RECORD)
-        .map(AirbyteMessage::getRecord)
-        .map(AirbyteRecordMessage::getData)
-        .collect(Collectors.toList());
-
-    assertSameData(expectedJson, actual);
+  private List<AirbyteRecordMessage> retrieveNormalizedRecordsForCatalog(AirbyteCatalog catalog) throws Exception {
+    return _retrieveRecordsForCatalog(streamName -> retrieveNormalizedRecords(testEnv, streamName), catalog);
   }
 
-  private void assertSameMessagesPruneAirbyteInternalFields(List<AirbyteMessage> expected, List<JsonNode> actual) {
-    final List<JsonNode> expectedPruned = expected.stream()
-        .filter(message -> message.getType() == AirbyteMessage.Type.RECORD)
-        .map(AirbyteMessage::getRecord)
-        .map(AirbyteRecordMessage::getData)
-        .map(this::safePrune)
-        .collect(Collectors.toList());
-
-    final List<JsonNode> actualPruned = actual.stream().map(this::safePrune).collect(Collectors.toList());
-    assertSameData(expectedPruned, actualPruned);
+  private List<AirbyteRecordMessage> retrieveRecordsForCatalog(AirbyteCatalog catalog) throws Exception {
+    return _retrieveRecordsForCatalog(streamName -> retrieveRecords(testEnv, streamName), catalog);
   }
 
-  private void assertSameData(List<JsonNode> expected, List<JsonNode> actual) {
+  private List<AirbyteRecordMessage> _retrieveRecordsForCatalog(CheckedFunction<String, List<JsonNode>, Exception> retriever, AirbyteCatalog catalog)
+      throws Exception {
+    final List<AirbyteRecordMessage> actualMessages = new ArrayList<>();
+    final List<String> streamNames = catalog.getStreams()
+        .stream()
+        .map(AirbyteStream::getName)
+        .collect(Collectors.toList());
+
+    for (final String streamName : streamNames) {
+      actualMessages.addAll(retriever.apply(streamName)
+          .stream()
+          .map(data -> new AirbyteRecordMessage().withStream(streamName).withData(data))
+          .collect(Collectors.toList()));
+    }
+
+    return actualMessages;
+  }
+
+  private void assertSameMessages(List<AirbyteMessage> expected, List<AirbyteRecordMessage> actual) {
+    assertSameMessages(expected, actual, false);
+  }
+
+  // ignores emitted at.
+  private void assertSameMessages(List<AirbyteMessage> expected, List<AirbyteRecordMessage> actual, boolean pruneAirbyteInternalFields) {
+    final List<AirbyteRecordMessage> expectedProcessed = expected.stream()
+        .filter(message -> message.getType() == AirbyteMessage.Type.RECORD)
+        .map(AirbyteMessage::getRecord)
+        .peek(recordMessage -> recordMessage.setEmittedAt(null))
+        .map(recordMessage -> pruneAirbyteInternalFields ? this.safePrune(recordMessage) : recordMessage)
+        .collect(Collectors.toList());
+
+    final List<AirbyteRecordMessage> actualProcessed = actual.stream()
+        .map(recordMessage -> pruneAirbyteInternalFields ? this.safePrune(recordMessage) : recordMessage)
+        .collect(Collectors.toList());
+    assertSameData(expectedProcessed, actualProcessed);
+  }
+
+  private void assertSameData(List<AirbyteRecordMessage> expected, List<AirbyteRecordMessage> actual) {
     LOGGER.info("expected: {}", expected);
     LOGGER.info("actual: {}", actual);
 
@@ -365,12 +392,12 @@ public abstract class TestDestination {
    * Same as {@link #pruneMutate(JsonNode)}, except does a defensive copy and returns a new json node
    * object instead of mutating in place.
    *
-   * @param json - json that will be pruned.
+   * @param record - record that will be pruned.
    * @return pruned json node.
    */
-  private JsonNode safePrune(JsonNode json) {
-    final JsonNode clone = Jsons.clone(json);
-    pruneMutate(clone);
+  private AirbyteRecordMessage safePrune(AirbyteRecordMessage record) {
+    final AirbyteRecordMessage clone = Jsons.clone(record);
+    pruneMutate(clone.getData());
     return clone;
   }
 

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
@@ -334,14 +334,14 @@ public abstract class TestDestination {
   }
 
   private List<AirbyteRecordMessage> retrieveNormalizedRecordsForCatalog(AirbyteCatalog catalog) throws Exception {
-    return _retrieveRecordsForCatalog(streamName -> retrieveNormalizedRecords(testEnv, streamName), catalog);
+    return retrieveRecordsForCatalog(streamName -> retrieveNormalizedRecords(testEnv, streamName), catalog);
   }
 
   private List<AirbyteRecordMessage> retrieveRecordsForCatalog(AirbyteCatalog catalog) throws Exception {
-    return _retrieveRecordsForCatalog(streamName -> retrieveRecords(testEnv, streamName), catalog);
+    return retrieveRecordsForCatalog(streamName -> retrieveRecords(testEnv, streamName), catalog);
   }
 
-  private List<AirbyteRecordMessage> _retrieveRecordsForCatalog(CheckedFunction<String, List<JsonNode>, Exception> retriever, AirbyteCatalog catalog)
+  private List<AirbyteRecordMessage> retrieveRecordsForCatalog(CheckedFunction<String, List<JsonNode>, Exception> retriever, AirbyteCatalog catalog)
       throws Exception {
     final List<AirbyteRecordMessage> actualMessages = new ArrayList<>();
     final List<String> streamNames = catalog.getStreams()

--- a/airbyte-integrations/bases/standard-destination-test/src/main/resources/edge_case_catalog.json
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/resources/edge_case_catalog.json
@@ -41,6 +41,16 @@
       }
     },
     {
+      "name": "STREAM_WITH_ALL_CAPS",
+      "json_schema": {
+        "properties": {
+          "data": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
       "name": "stream_with_edge_case_field_names",
       "json_schema": {
         "properties": {
@@ -54,6 +64,9 @@
             "type": "string"
           },
           "field*with*asterisk": {
+            "type": "string"
+          },
+          "FIELD_WITH_ALL_CAPS": {
             "type": "string"
           }
         }

--- a/airbyte-integrations/bases/standard-destination-test/src/main/resources/edge_case_catalog.json
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/resources/edge_case_catalog.json
@@ -1,0 +1,63 @@
+{
+  "streams": [
+    {
+      "name": "stream with spaces",
+      "json_schema": {
+        "properties": {
+          "data": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "name": "streamWithCamelCase",
+      "json_schema": {
+        "properties": {
+          "data": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "name": "stream_with_underscores",
+      "json_schema": {
+        "properties": {
+          "data": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "name": "stream*with*asterisk",
+      "json_schema": {
+        "properties": {
+          "data": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "name": "stream_with_edge_case_field_names",
+      "json_schema": {
+        "properties": {
+          "field with spaces": {
+            "type": "string"
+          },
+          "fieldWithCamelCase": {
+            "type": "string"
+          },
+          "field_with_underscore": {
+            "type": "string"
+          },
+          "field*with*asterisk": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/airbyte-integrations/bases/standard-destination-test/src/main/resources/edge_case_messages.txt
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/resources/edge_case_messages.txt
@@ -1,0 +1,8 @@
+{"type": "RECORD", "record": {"stream": "stream with spaces", "emitted_at": 1602637589, "data": { "data" : "one" }}}
+{"type": "RECORD", "record": {"stream": "streamWithCamelCase", "emitted_at": 1602637589, "data": { "data" : "one" }}}
+{"type": "RECORD", "record": {"stream": "stream_with_underscores", "emitted_at": 1602637589, "data": { "data" : "one" }}}
+{"type": "RECORD", "record": {"stream": "stream*with*asterisk", "emitted_at": 1602637589, "data": { "data" : "one" }}}
+{"type": "RECORD", "record": {"stream": "stream_with_edge_case_field_names", "emitted_at": 1602637589, "data": { "field with spaces" : "one" }}}
+{"type": "RECORD", "record": {"stream": "stream_with_edge_case_field_names", "emitted_at": 1602637589, "data": { "fieldWithCamelCase" : "one" }}}
+{"type": "RECORD", "record": {"stream": "stream_with_edge_case_field_names", "emitted_at": 1602637589, "data": { "field_with_underscore" : "one" }}}
+{"type": "RECORD", "record": {"stream": "stream_with_edge_case_field_names", "emitted_at": 1602637589, "data": { "field*with*asterisk" : "one" }}}

--- a/airbyte-integrations/connectors/destination-csv/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-csv/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationIntegrationTest.java
@@ -24,7 +24,7 @@
 
 package io.airbyte.integrations.destination.csv;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
@@ -34,6 +34,7 @@ import java.io.FileReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.commons.csv.CSVFormat;
@@ -73,11 +74,12 @@ public class CsvDestinationIntegrationTest extends TestDestination {
 
   @Override
   protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv, String streamName) throws Exception {
-    final List<Path> list = Files.list(testEnv.getLocalRoot().resolve(RELATIVE_PATH)).collect(Collectors.toList());
-    // todo (cgardens) - this should not be here. add a retrieve tables abstract method to verify this.
-    assertEquals(1, list.size());
+    final List<Path> allOutputs = Files.list(testEnv.getLocalRoot().resolve(RELATIVE_PATH)).collect(Collectors.toList());
+    final Optional<Path> streamOutput = allOutputs.stream().filter(path -> path.getFileName().toString().contains(streamName)).findFirst();
 
-    final FileReader in = new FileReader(list.get(0).toFile());
+    assertTrue(streamOutput.isPresent(), "could not find output file for stream: " + streamName);
+
+    final FileReader in = new FileReader(streamOutput.get().toFile());
     final Iterable<CSVRecord> records = CSVFormat.DEFAULT
         .withHeader(COLUMN_NAME)
         .withFirstRecordAsHeader()

--- a/airbyte-integrations/connectors/source-shopify-singer/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-shopify-singer/unit_tests/unit_test.py
@@ -22,6 +22,5 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-
 def test_example_method():
     assert True

--- a/airbyte-integrations/connectors/source-shopify-singer/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-shopify-singer/unit_tests/unit_test.py
@@ -22,5 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+
 def test_example_method():
     assert True


### PR DESCRIPTION
## What
* We discovered that many destinations do not gracefully handle various spacing, casing, and characters in stream and field names. This adds a test case to the standard destination tests to catch this.
* I have NOT gotten all destinations passing against these new tests yet. This is going to break the integration tests for all the destinations (except csv destination, tested it for that).
