### PR TITLE
introduce gradle format task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,6 +190,11 @@ task composeBuild {
 }
 build.dependsOn(composeBuild)
 
+task('format') {
+    dependsOn spotlessApply
+    dependsOn subprojects.collect { it.getTasksByName('blackFormat', true) }
+}
+
 // produce reproducible archives
 // (see https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives)
 tasks.withType(AbstractArchiveTask) {


### PR DESCRIPTION
Even after merging in https://github.com/airbytehq/airbyte/pull/910, it's possible to run into discrepancies in a normal iteration cycle because it's common to just run `./gradlew spotlessApply` before committing. 

I'm adding a task here `./gradlew format`. We should add any new formatters to it in the future. If you want to call something to make sure your code is formatted before committing, please call this instead of `./gradlew spotlessApply`.