### PR TITLE
fix include_deleted option for fb marketing api

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing-api-singer/source_facebook_marketing_api_singer/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing-api-singer/source_facebook_marketing_api_singer/source.py
@@ -33,6 +33,15 @@ class SourceFacebookMarketingApiSinger(SingerSource):
     def __init__(self):
         super().__init__()
 
+    def transform_config(self, raw_config):
+        return {
+            "start_date": raw_config["start_date"],
+            "account_id": raw_config["account_id"],
+            "access_token": raw_config["access_token"],
+            # tap-singer expects a string not a boolean
+            "include_deleted": str(raw_config.get("include_deleted", False)),
+        }
+
     def check(self, logger: AirbyteLogger, config_container: ConfigContainer) -> AirbyteConnectionStatus:
         try:
             self.discover(logger, config_container)


### PR DESCRIPTION
Now that `include_deleted` is able to be toggled, we run into an issue that our correct type of `boolean` isn't compatible with `tap-facebook`'s expected type of `string`. 