### PR TITLE
prevent NPEs when password isn't set for jdbc integrations

### DIFF
--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -176,9 +176,10 @@ public abstract class AbstractJdbcSource implements Source {
 
   private Database createDatabase(JsonNode config) {
     final JsonNode jdbcConfig = toJdbcConfig(config);
+
     return Databases.createDatabase(
         jdbcConfig.get("username").asText(),
-        jdbcConfig.get("password").asText(),
+        jdbcConfig.has("password") ? jdbcConfig.get("password").asText() : null,
         jdbcConfig.get("jdbc_url").asText(),
         driverClass,
         dialect);

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
@@ -43,15 +43,19 @@ public class MySqlSource extends AbstractJdbcSource implements Source {
   }
 
   @Override
-  public JsonNode toJdbcConfig(JsonNode mySqlConfig) {
-    return Jsons.jsonNode(ImmutableMap.builder()
-        .put("username", mySqlConfig.get("username").asText())
-        .put("password", mySqlConfig.get("password").asText())
+  public JsonNode toJdbcConfig(JsonNode config) {
+    ImmutableMap.Builder<Object, Object> configBuilder = ImmutableMap.builder()
+        .put("username", config.get("username").asText())
         .put("jdbc_url", String.format("jdbc:mysql://%s:%s/%s",
-            mySqlConfig.get("host").asText(),
-            mySqlConfig.get("port").asText(),
-            mySqlConfig.get("database").asText()))
-        .build());
+            config.get("host").asText(),
+            config.get("port").asText(),
+            config.get("database").asText()));
+
+    if (config.has("password")) {
+      configBuilder.put("password", config.get("password").asText());
+    }
+
+    return Jsons.jsonNode(configBuilder.build());
   }
 
   public static void main(String[] args) throws Exception {

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -44,14 +44,18 @@ public class PostgresSource extends AbstractJdbcSource implements Source {
 
   @Override
   public JsonNode toJdbcConfig(JsonNode config) {
-    return Jsons.jsonNode(ImmutableMap.builder()
+    ImmutableMap.Builder<Object, Object> configBuilder = ImmutableMap.builder()
         .put("username", config.get("username").asText())
-        .put("password", config.get("password").asText())
         .put("jdbc_url", String.format("jdbc:postgresql://%s:%s/%s",
             config.get("host").asText(),
             config.get("port").asText(),
-            config.get("database").asText()))
-        .build());
+            config.get("database").asText()));
+
+    if (config.has("password")) {
+      configBuilder.put("password", config.get("password").asText());
+    }
+
+    return Jsons.jsonNode(configBuilder.build());
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
The specs for `source-mysql` and `source-postgres` have an optional `password` but the sources fail midway through. This fixes the NPEs that show up when the source isn't specified. 