### PR TITLE
check for image versions automatically in build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Ensure no file change
         run: git status --porcelain && test -z "$(git status --porcelain)"
 
+      - name: Check images exist
+        run: ./tools/bin/check_images_exist.sh
+
       - name: Check documentation
         if: success() && github.ref == 'refs/heads/master'
         run: ./tools/site/link_checker.sh check_docs

--- a/tools/bin/check_images_exist.sh
+++ b/tools/bin/check_images_exist.sh
@@ -8,6 +8,10 @@ function docker_tag_exists() {
     curl --silent -f -lSL "$URL" > /dev/null
 }
 
+echo "Checking core images exist..."
+docker-compose pull || exit 1
+
+echo "Checking integration images exist..."
 CONFIG_FILES=$(find airbyte-config/init | grep json | grep -v STANDARD_WORKSPACE | grep -v build)
 [ -z "$CONFIG_FILES" ] && echo "ERROR: Could not find any config files." && exit 1
 
@@ -23,3 +27,5 @@ while IFS= read -r file; do
         printf "\tERROR: not found!\n" && exit 1
     fi
 done <<< "$CONFIG_FILES"
+
+echo "Success! All images exist!"

--- a/tools/bin/check_integration_images_exist.sh
+++ b/tools/bin/check_integration_images_exist.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+function docker_tag_exists() {
+    URL=https://hub.docker.com/v2/repositories/"$1"/tags/"$2"
+    printf "\tURL: %s\n" "$URL"
+    curl --silent -f -lSL "$URL" > /dev/null
+}
+
+CONFIG_FILES=$(find airbyte-config/init | grep json | grep -v STANDARD_WORKSPACE | grep -v build)
+[ -z "$CONFIG_FILES" ] && echo "ERROR: Could not find any config files." && exit 1
+
+while IFS= read -r file; do
+    REPO=$(cat "$file" | jq -r .dockerRepository)
+    TAG=$(cat "$file" | jq -r .dockerImageTag)
+    echo "Checking $file..."
+    printf "\tREPO: %s\n" "$REPO"
+    printf "\tTAG: %s\n" "$TAG"
+    if docker_tag_exists "$REPO" "$TAG"; then
+        printf "\tSTATUS: found\n"
+    else
+        printf "\tERROR: not found!\n" && exit 1
+    fi
+done <<< "$CONFIG_FILES"
+

--- a/tools/bin/check_integration_images_exist.sh
+++ b/tools/bin/check_integration_images_exist.sh
@@ -23,4 +23,3 @@ while IFS= read -r file; do
         printf "\tERROR: not found!\n" && exit 1
     fi
 done <<< "$CONFIG_FILES"
-

--- a/tools/bin/check_integration_images_exist.sh
+++ b/tools/bin/check_integration_images_exist.sh
@@ -12,8 +12,8 @@ CONFIG_FILES=$(find airbyte-config/init | grep json | grep -v STANDARD_WORKSPACE
 [ -z "$CONFIG_FILES" ] && echo "ERROR: Could not find any config files." && exit 1
 
 while IFS= read -r file; do
-    REPO=$(cat "$file" | jq -r .dockerRepository)
-    TAG=$(cat "$file" | jq -r .dockerImageTag)
+    REPO=$(jq -r .dockerRepository < "$file")
+    TAG=$(jq -r .dockerImageTag < "$file")
     echo "Checking $file..."
     printf "\tREPO: %s\n" "$REPO"
     printf "\tTAG: %s\n" "$TAG"


### PR DESCRIPTION
Prevent the problem where we forget to push an image that's specified in the registry. The one downside is that we'll need to update this script when we reformat the registry.

Used to catch problems like https://github.com/airbytehq/airbyte/issues/648