### PR TITLE
Limit computation of surrogate_keys (#913)

### DIFF
--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
@@ -298,7 +298,7 @@ def process_node(
         prefix = previous + ","
     node_properties = extract_node_properties(path=path, json_col=json_col, properties=properties)
     node_columns = ",\n    ".join([sql for sql in node_properties.values()])
-    hash_node_columns = ",\n        ".join([f"adapter.quote_as_configured('{column}', 'identifier')" for column in node_properties.keys()])
+    hash_node_columns = ",\n        ".join([f"adapter.quote_as_configured('{column}', 'identifier')" for column in node_properties.keys()][:50])
     hash_node_columns = jinja_call(f"dbt_utils.surrogate_key([\n        {hash_node_columns}\n    ])")
     hash_id = jinja_call(f"adapter.quote_as_configured('_{name}_hashid', 'identifier')")
     foreign_hash_id = jinja_call(f"adapter.quote_as_configured('_{name}_foreign_hashid', 'identifier')")

--- a/docs/architecture/basic-normalization.md
+++ b/docs/architecture/basic-normalization.md
@@ -29,6 +29,7 @@ CREATE TABLE "cars" (
 ```
 
 You'll notice that we add some metadata to keep track of important information about each record.
+One of these is a column computed from the hash of up to the first 50 columns in case the source doesn't provide any primary keys to use as an ID for joining tables back together.
 
 The [normalization rules](basic-normalization.md#Rules) are _not_ configurable. They are designed to pick a reasonable set of defaults to hit the 80/20 rule of data normalization. We respect that normalization is a detail-oriented problem and that with a fixed set of rules, we cannot normalize your data in such a way that covers all use cases. If this feature does not meet your normalization needs, we always put the full json blob in destination as well, so that you can parse that object however best meets your use case. We will be adding more advanced normalization functionality shortly. Airbyte is focused on the EL of ELT. If you need a really featureful tool for the transformations then, we suggest trying out DBT.
 


### PR DESCRIPTION
Use only 50 columns to compute hash in case tables has too many columns (which has a higher probability of containing a proper primary key already so the hashid column wouldn't be as useful in that case...)

closes #913