### PR TITLE
have compose build only depend on actual dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,17 @@ allprojects {
     apply plugin: 'base'
 
     afterEvaluate { project ->
-        composeBuild.dependsOn(project.tasks.assemble)
+        def composeDeps = [
+                "airbyte-config:init",
+                "airbyte-db",
+                "airbyte-scheduler",
+                "airbyte-server",
+                "airbyte-webapp",
+        ].toSet().asImmutable()
+
+        if (project.name in composeDeps) {
+            composeBuild.dependsOn(project.tasks.assemble)
+        }
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/958

## What
* `:composeBuild` depends on all integrations. It shouldn't. It only has a few real dependencies. Developing on the API or the webapp right now is really painful because of this.