### PR TITLE
save emitted_at as milliseconds in BQ

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
@@ -270,7 +270,7 @@ public class BigQueryDestination implements Destination {
         final JsonNode data = Jsons.jsonNode(ImmutableMap.of(
             COLUMN_AB_ID, UUID.randomUUID().toString(),
             COLUMN_DATA, Jsons.serialize(message.getRecord().getData()),
-            COLUMN_EMITTED_AT, Instants.toSeconds(message.getRecord().getEmittedAt())));
+            COLUMN_EMITTED_AT, message.getRecord().getEmittedAt()));
         try {
           writeConfigs.get(message.getRecord().getStream()).getWriter()
               .write(ByteBuffer.wrap((Jsons.serialize(data) + "\n").getBytes(Charsets.UTF_8)));


### PR DESCRIPTION
## What
This corrects the emitted_at timestamps we persist in bigquery. Currently they are persisted as a date in 1970.