### PR TITLE
document allowable characters in airbyte protocol and gsheets 

### DIFF
--- a/docs/architecture/airbyte-specification.md
+++ b/docs/architecture/airbyte-specification.md
@@ -162,7 +162,10 @@ read(Config, AirbyteCatalog, State) -> Stream<AirbyteMessage>
         }
       ```
 
-      **Read**
+Airbyte only supports stream and field names which are alphanumeric or contain underscores, as identified by the regex `[a-zA-Z0-9_]*"`. Syncs may fail 
+if they attempt to sync streams or fields whose names contain disallowed characters.
+
+#### Read
 * Input:
   1. `config` - A configuration JSON object that has been validated using the `ConnectorSpecification`.
   2. `catalog` - An `AirbyteCatalog`. This `catalog` should be a subset of the `catalog` returned by the `discover` command. It is what will be used in the `read` command to select what data to transfer.

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -10,6 +10,8 @@ Each sheet in the selected spreadsheet will be output as a separate stream. Each
 
 Airbyte only supports replicating Grid sheets. See the [Google Sheets API docs](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/sheets#SheetType) for more info on all available sheet types.
 
+**Note: Sheet names and column headers must contain only alphanumeric characters or `_`, as specified in the [Airbyte Protocol](../../architecture/airbyte-specification.md)**. If your sheet or column header is named e.g: "the data", you'll need to change it to "the_data" for it to be synced by Airbyte. This restriction does not apply to non-header cell values: those can contain any unicode characters.
+
 ### Data type mapping
 
 | Integration Type | Airbyte Type | Notes |

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -10,7 +10,7 @@ Each sheet in the selected spreadsheet will be output as a separate stream. Each
 
 Airbyte only supports replicating Grid sheets. See the [Google Sheets API docs](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/sheets#SheetType) for more info on all available sheet types.
 
-**Note: Sheet names and column headers must contain only alphanumeric characters or `_`, as specified in the [Airbyte Protocol](../../architecture/airbyte-specification.md)**. If your sheet or column header is named e.g: "the data", you'll need to change it to "the_data" for it to be synced by Airbyte. This restriction does not apply to non-header cell values: those can contain any unicode characters.
+**Note: Sheet names and column headers must contain only alphanumeric characters or `_`, as specified in the [Airbyte Protocol](../../architecture/airbyte-specification.md)**. If your sheet or column header is named e.g: "the data", you'll need to change it to "the_data" for it to be synced by Airbyte. This restriction does not apply to non-header cell values: those can contain any unicode characters. This limitation is temporary and future versions of Airbyte will support more permissive naming patterns. 
 
 ### Data type mapping
 


### PR DESCRIPTION
## What
Title -- added a note specifically to gsheets since it's very easy to make this naming mistake in it. 