### PR TITLE
hotfix: duplicate column in discover of mssql

### DIFF
--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -59,7 +59,8 @@ public class CatalogHelpers {
             .stream()
             .collect(Collectors.toMap(
                 Field::getName,
-                field -> ImmutableMap.of("type", field.getTypeAsJsonSchemaString()))))
+                field -> ImmutableMap.of("type", field.getTypeAsJsonSchemaString()),
+                (a, b) -> a)))
         .build());
   }
 


### PR DESCRIPTION
## What
In working with cody, we ran into this bug. This PR was the hotfix that I pushed to the production image (mssql 0.1.0) unblock him. PR with a non hacked fix coming momentarily. (update: better fix https://github.com/airbytehq/airbyte/pull/983/files)

![image (2)](https://user-images.githubusercontent.com/9092207/99200048-fde1be00-2757-11eb-8173-6e572c68ae3c.png)
