### PR TITLE
fix duplicate key exception in mssql

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b5ea17b1-f170-46dc-bc31-cc744ca984c1.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b5ea17b1-f170-46dc-bc31-cc744ca984c1.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "b5ea17b1-f170-46dc-bc31-cc744ca984c1",
   "name": "Microsoft SQL Server (MSSQL)",
   "dockerRepository": "airbyte/source-mssql",
-  "dockerImageTag": "0.1.3",
+  "dockerImageTag": "0.1.4",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-mssql"
 }

--- a/airbyte-integrations/connectors/source-mssql/Dockerfile
+++ b/airbyte-integrations/connectors/source-mssql/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.1.3
+LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/source-mssql

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
@@ -96,7 +96,11 @@ public class MssqlSource extends AbstractJdbcSource implements Source {
               final String dataType = r.get("data_type", String.class);
               final JsonSchemaPrimitive jsonType = getType(dataType);
               return Field.of(columnName, jsonType);
-            }).collect(Collectors.toList());
+            })
+            // this query can return duplicate columns if a column is used in multiple indexes or as a primary
+            // key.
+            .distinct()
+            .collect(Collectors.toList());
 
         return new TableInfo(tableName, fields);
       })

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -102,8 +102,7 @@ public class CatalogHelpers {
             .stream()
             .collect(Collectors.toMap(
                 Field::getName,
-                field -> ImmutableMap.of("type", field.getTypeAsJsonSchemaString()),
-                (a, b) -> a)))
+                field -> ImmutableMap.of("type", field.getTypeAsJsonSchemaString()))))
         .build());
   }
 

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/Field.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/Field.java
@@ -24,6 +24,8 @@
 
 package io.airbyte.protocol.models;
 
+import java.util.Objects;
+
 public class Field {
 
   public enum JsonSchemaPrimitive {
@@ -53,6 +55,24 @@ public class Field {
 
   public String getTypeAsJsonSchemaString() {
     return type.name().toLowerCase();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Field field = (Field) o;
+    return name.equals(field.name) &&
+        type == field.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type);
   }
 
 }


### PR DESCRIPTION
## What
* Removes temporary hack to unblock use of mssql source. (https://github.com/airbytehq/airbyte/pull/982)
* Enforce that the MSSQL does not return duplicate columns for any table.

## Checklist
- [x] *Write a test*
