### PR TITLE
remove note that number of fields is limited to 100

### DIFF
--- a/docs/architecture/basic-normalization.md
+++ b/docs/architecture/basic-normalization.md
@@ -169,8 +169,3 @@ CREATE TABLE "powertrain_specs" (
     "transmission" VARCHAR
 );
 ```
-
-### Limitations
-
-Basic Normalization currently only works with streams that contain fewer than 100 fields.
-


### PR DESCRIPTION
## What
* Had added a note in the docs that basic normalization couldn't handle more than 100 fields. This is now no longer true with this fix: https://github.com/airbytehq/airbyte/commit/4a525158bf5992b8413f0681dab156d75ccb8254