### PR TITLE
depend on main dependency installation for python tests

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -87,6 +87,7 @@ class AirbytePythonPlugin implements Plugin<Project> {
 
 
         project.task('airbytePythonTest', type: DefaultTask) {
+            dependsOn project.airbytePythonApply
             dependsOn project.installTestReqs
             dependsOn project.unitTest
         }


### PR DESCRIPTION
Resolves https://airbytehq.slack.com/archives/C019WEENQRM/p1605857519497100?thread_ts=1605851398.489300&cid=C019WEENQRM

You can run `./gradlew :airbyte-integrations:connectors:source-facebook-marketing-api-singer:build` in a fresh repo to see that it works.