### PR TITLE
add instructions to checkout the correct tag

### DIFF
--- a/docs/getting-started-tutorial.md
+++ b/docs/getting-started-tutorial.md
@@ -15,6 +15,8 @@ First of all, make sure you have Docker and Docker Compose installed. Then run t
 ```text
 git clone https://github.com/airbytehq/airbyte.git
 cd airbyte
+git fetch --tags
+git checkout tags/v0.5.1-alpha
 docker-compose up
 ```
 


### PR DESCRIPTION
## What
* `docker-compose up` leads to a broken state right now. 
* issue described here: https://github.com/airbytehq/airbyte/issues/1049
* versions of connectors have been updates. but docker-compose up runs whatever the core containers were when the last release happened. the issue is that the new connector versions aren't compatible with those old version anymore (catalog updates and secrets changes).

## How
* this is a stop gap until we decide how we want to resolve the issue mentioned above. this is enough to get us to a non-broken state. The alternative can be found in this draft pr: https://github.com/airbytehq/airbyte/pull/1050, but i think it is a worse hack to get this fixed. I am going to merge this as soon as the build passes as a hotfix. 