### PR TITLE
add spec cache

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigurationApiFactory.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigurationApiFactory.java
@@ -27,12 +27,14 @@ package io.airbyte.server;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.scheduler.persistence.SchedulerPersistence;
 import io.airbyte.server.apis.ConfigurationApi;
+import io.airbyte.server.cache.SpecCache;
 import org.glassfish.hk2.api.Factory;
 
 public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
 
   private static ConfigRepository configRepository;
   private static SchedulerPersistence schedulerPersistence;
+  private static SpecCache specCache;
 
   public static void setConfigRepository(final ConfigRepository configRepository) {
     ConfigurationApiFactory.configRepository = configRepository;
@@ -42,9 +44,16 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
     ConfigurationApiFactory.schedulerPersistence = schedulerPersistence;
   }
 
+  public static void setSpecCache(final SpecCache specCache) {
+    ConfigurationApiFactory.specCache = specCache;
+  }
+
   @Override
   public ConfigurationApi provide() {
-    return new ConfigurationApi(ConfigurationApiFactory.configRepository, ConfigurationApiFactory.schedulerPersistence);
+    return new ConfigurationApi(
+        ConfigurationApiFactory.configRepository,
+        ConfigurationApiFactory.schedulerPersistence,
+        ConfigurationApiFactory.specCache);
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -37,6 +37,7 @@ import io.airbyte.db.Databases;
 import io.airbyte.scheduler.persistence.DefaultSchedulerPersistence;
 import io.airbyte.scheduler.persistence.SchedulerPersistence;
 import io.airbyte.server.apis.ConfigurationApi;
+import io.airbyte.server.cache.DefaultSpecCache;
 import io.airbyte.server.errors.InvalidInputExceptionMapper;
 import io.airbyte.server.errors.InvalidJsonExceptionMapper;
 import io.airbyte.server.errors.InvalidJsonInputExceptionMapper;
@@ -79,6 +80,7 @@ public class ServerApp {
 
     ServletContextHandler handler = new ServletContextHandler();
 
+    ConfigurationApiFactory.setSpecCache(new DefaultSpecCache());
     ConfigurationApiFactory.setConfigRepository(configRepository);
     ConfigurationApiFactory.setSchedulerPersistence(schedulerPersistence);
 

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -106,10 +106,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   private final WebBackendSourceHandler webBackendSourceHandler;
   private final WebBackendDestinationHandler webBackendDestinationHandler;
 
-  public ConfigurationApi(
-                          final ConfigRepository configRepository,
-                          final SchedulerPersistence schedulerPersistence,
-                          final SpecCache specCache) {
+  public ConfigurationApi(final ConfigRepository configRepository, final SchedulerPersistence schedulerPersistence, final SpecCache specCache) {
     final JsonSchemaValidator schemaValidator = new JsonSchemaValidator();
     schedulerHandler = new SchedulerHandler(configRepository, schedulerPersistence, specCache);
     workspacesHandler = new WorkspacesHandler(configRepository);

--- a/airbyte-server/src/main/java/io/airbyte/server/cache/DefaultSpecCache.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/cache/DefaultSpecCache.java
@@ -1,0 +1,55 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.server.cache;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import io.airbyte.protocol.models.ConnectorSpecification;
+import java.util.Optional;
+
+public class DefaultSpecCache implements SpecCache {
+
+  private final Cache<String, ConnectorSpecification> cache;
+
+  public DefaultSpecCache() {
+    cache = CacheBuilder.newBuilder().build();
+  }
+
+  @Override
+  public Optional<ConnectorSpecification> get(String imageName) {
+    return Optional.ofNullable(cache.getIfPresent(imageName));
+  }
+
+  @Override
+  public void put(String imageName, ConnectorSpecification spec) {
+    cache.put(imageName, spec);
+  }
+
+  @Override
+  public void evict(String imageName) {
+    cache.invalidate(imageName);
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/cache/SpecCache.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/cache/SpecCache.java
@@ -1,0 +1,57 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.server.cache;
+
+import io.airbyte.protocol.models.ConnectorSpecification;
+import java.util.Optional;
+
+public interface SpecCache {
+
+  Optional<ConnectorSpecification> get(String imageName);
+
+  void put(String imageName, ConnectorSpecification spec);
+
+  void evict(String imageName);
+
+  public static class AlwaysMissCache implements SpecCache {
+
+    @Override
+    public Optional<ConnectorSpecification> get(String imageName) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void put(String imageName, ConnectorSpecification spec) {
+      // no op.
+    }
+
+    @Override
+    public void evict(String imageName) {
+      // no op.
+    }
+
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -82,7 +82,7 @@ public class DestinationDefinitionsHandler {
 
     configRepository.writeStandardDestinationDefinition(newDestination);
     // we want to re-fetch the spec for updated definitions.
-    specCache.evict(destinationDefinitionUpdate.getDockerImageTag());
+    specCache.evict(currentDestination.getDockerRepository() + ":" + destinationDefinitionUpdate.getDockerImageTag());
     return buildDestinationDefinitionRead(newDestination);
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -31,6 +31,7 @@ import io.airbyte.api.model.DestinationDefinitionUpdate;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.server.cache.SpecCache;
 import io.airbyte.server.validators.DockerImageValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
@@ -42,15 +43,16 @@ import java.util.stream.Collectors;
 public class DestinationDefinitionsHandler {
 
   private final ConfigRepository configRepository;
-  private DockerImageValidator dockerImageValidator;
+  private final DockerImageValidator dockerImageValidator;
+  private final SpecCache specCache;
 
-  public DestinationDefinitionsHandler(final ConfigRepository configRepository, DockerImageValidator dockerImageValidator) {
+  public DestinationDefinitionsHandler(final ConfigRepository configRepository, DockerImageValidator dockerImageValidator, SpecCache specCache) {
     this.configRepository = configRepository;
     this.dockerImageValidator = dockerImageValidator;
+    this.specCache = specCache;
   }
 
-  public DestinationDefinitionReadList listDestinationDefinitions()
-      throws ConfigNotFoundException, IOException, JsonValidationException {
+  public DestinationDefinitionReadList listDestinationDefinitions() throws ConfigNotFoundException, IOException, JsonValidationException {
     final List<DestinationDefinitionRead> reads = configRepository.listStandardDestinationDefinitions()
         .stream()
         .map(DestinationDefinitionsHandler::buildDestinationDefinitionRead)
@@ -71,7 +73,7 @@ public class DestinationDefinitionsHandler {
         configRepository.getStandardDestinationDefinition(destinationDefinitionUpdate.getDestinationDefinitionId());
     dockerImageValidator.assertValidIntegrationImage(currentDestination.getDockerRepository(), destinationDefinitionUpdate.getDockerImageTag());
 
-    StandardDestinationDefinition newDestination = new StandardDestinationDefinition()
+    final StandardDestinationDefinition newDestination = new StandardDestinationDefinition()
         .withDestinationDefinitionId(currentDestination.getDestinationDefinitionId())
         .withDockerImageTag(destinationDefinitionUpdate.getDockerImageTag())
         .withDockerRepository(currentDestination.getDockerRepository())
@@ -79,6 +81,8 @@ public class DestinationDefinitionsHandler {
         .withDocumentationUrl(currentDestination.getDocumentationUrl());
 
     configRepository.writeStandardDestinationDefinition(newDestination);
+    // we want to re-fetch the spec for updated definitions.
+    specCache.evict(destinationDefinitionUpdate.getDockerImageTag());
     return buildDestinationDefinitionRead(newDestination);
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -69,7 +69,7 @@ public class SchedulerHandler {
 
   private final ConfigRepository configRepository;
   private final SchedulerPersistence schedulerPersistence;
-  private SpecCache specCache;
+  private final SpecCache specCache;
 
   public SchedulerHandler(final ConfigRepository configRepository, final SchedulerPersistence schedulerPersistence, final SpecCache specCache) {
     this.specCache = specCache;

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -71,10 +71,7 @@ public class SchedulerHandler {
   private final SchedulerPersistence schedulerPersistence;
   private SpecCache specCache;
 
-  public SchedulerHandler(
-                          final ConfigRepository configRepository,
-                          final SchedulerPersistence schedulerPersistence,
-                          final SpecCache specCache) {
+  public SchedulerHandler(final ConfigRepository configRepository, final SchedulerPersistence schedulerPersistence, final SpecCache specCache) {
     this.specCache = specCache;
     this.configRepository = configRepository;
     this.schedulerPersistence = schedulerPersistence;

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -32,6 +32,7 @@ import io.airbyte.api.model.SourceDefinitionUpdate;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.server.cache.SpecCache;
 import io.airbyte.server.validators.DockerImageValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
@@ -51,15 +52,24 @@ public class SourceDefinitionsHandler {
   private final DockerImageValidator imageValidator;
   private final ConfigRepository configRepository;
   private final Supplier<UUID> uuidSupplier;
+  private final SpecCache specCache;
 
-  public SourceDefinitionsHandler(final ConfigRepository configRepository, DockerImageValidator imageValidator) {
-    this(configRepository, imageValidator, UUID::randomUUID);
+  public SourceDefinitionsHandler(
+                                  final ConfigRepository configRepository,
+                                  final DockerImageValidator imageValidator,
+                                  final SpecCache specCache) {
+    this(configRepository, imageValidator, UUID::randomUUID, specCache);
   }
 
-  public SourceDefinitionsHandler(final ConfigRepository configRepository, DockerImageValidator imageValidator, Supplier<UUID> uuidSupplier) {
+  public SourceDefinitionsHandler(
+                                  final ConfigRepository configRepository,
+                                  final DockerImageValidator imageValidator,
+                                  final Supplier<UUID> uuidSupplier,
+                                  final SpecCache specCache) {
     this.configRepository = configRepository;
     this.uuidSupplier = uuidSupplier;
     this.imageValidator = imageValidator;
+    this.specCache = specCache;
   }
 
   public SourceDefinitionReadList listSourceDefinitions() throws ConfigNotFoundException, IOException, JsonValidationException {
@@ -104,6 +114,8 @@ public class SourceDefinitionsHandler {
         .withName(currentSourceDefinition.getName());
 
     configRepository.writeStandardSource(newSource);
+    // we want to re-fetch the spec for updated definitions.
+    specCache.evict(sourceDefinitionUpdate.getDockerImageTag());
     return buildSourceDefinitionRead(newSource);
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -115,7 +115,7 @@ public class SourceDefinitionsHandler {
 
     configRepository.writeStandardSource(newSource);
     // we want to re-fetch the spec for updated definitions.
-    specCache.evict(sourceDefinitionUpdate.getDockerImageTag());
+    specCache.evict(currentSourceDefinition.getDockerRepository() + ":" + sourceDefinitionUpdate.getDockerImageTag());
     return buildSourceDefinitionRead(newSource);
   }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
@@ -38,6 +38,7 @@ import io.airbyte.api.model.DestinationDefinitionUpdate;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.server.cache.SpecCache.AlwaysMissCache;
 import io.airbyte.server.validators.DockerImageValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
@@ -59,7 +60,7 @@ class DestinationDefinitionsHandlerTest {
     configRepository = mock(ConfigRepository.class);
     dockerImageValidator = mock(DockerImageValidator.class);
     destination = generateDestination();
-    destinationHandler = new DestinationDefinitionsHandler(configRepository, dockerImageValidator);
+    destinationHandler = new DestinationDefinitionsHandler(configRepository, dockerImageValidator, new AlwaysMissCache());
   }
 
   private StandardDestinationDefinition generateDestination() {

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
@@ -54,6 +54,7 @@ import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.Job;
 import io.airbyte.scheduler.JobStatus;
 import io.airbyte.scheduler.persistence.SchedulerPersistence;
+import io.airbyte.server.cache.SpecCache.AlwaysMissCache;
 import io.airbyte.server.helpers.ConnectionHelpers;
 import io.airbyte.server.helpers.DestinationHelpers;
 import io.airbyte.server.helpers.SourceHelpers;
@@ -94,7 +95,7 @@ class SchedulerHandlerTest {
 
     configRepository = mock(ConfigRepository.class);
     schedulerPersistence = mock(SchedulerPersistence.class);
-    schedulerHandler = new SchedulerHandler(configRepository, schedulerPersistence);
+    schedulerHandler = new SchedulerHandler(configRepository, schedulerPersistence, new AlwaysMissCache());
   }
 
   @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -39,6 +39,7 @@ import io.airbyte.api.model.SourceDefinitionUpdate;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.server.cache.SpecCache.AlwaysMissCache;
 import io.airbyte.server.validators.DockerImageValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
@@ -65,7 +66,7 @@ class SourceDefinitionsHandlerTest {
     dockerImageValidator = mock(DockerImageValidator.class);
 
     source = generateSource();
-    sourceHandler = new SourceDefinitionsHandler(configRepository, dockerImageValidator, uuidSupplier);
+    sourceHandler = new SourceDefinitionsHandler(configRepository, dockerImageValidator, uuidSupplier, new AlwaysMissCache());
   }
 
   private StandardSourceDefinition generateSource() {

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -27,6 +27,7 @@ package io.airbyte.server.handlers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -57,6 +58,7 @@ class SourceDefinitionsHandlerTest {
   private StandardSourceDefinition source;
   private SourceDefinitionsHandler sourceHandler;
   private Supplier<UUID> uuidSupplier;
+  private AlwaysMissCache specCache;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
@@ -64,9 +66,10 @@ class SourceDefinitionsHandlerTest {
     configRepository = mock(ConfigRepository.class);
     uuidSupplier = mock(Supplier.class);
     dockerImageValidator = mock(DockerImageValidator.class);
+    specCache = spy(new AlwaysMissCache());
 
     source = generateSource();
-    sourceHandler = new SourceDefinitionsHandler(configRepository, dockerImageValidator, uuidSupplier, new AlwaysMissCache());
+    sourceHandler = new SourceDefinitionsHandler(configRepository, dockerImageValidator, uuidSupplier, specCache);
   }
 
   private StandardSourceDefinition generateSource() {
@@ -153,16 +156,18 @@ class SourceDefinitionsHandlerTest {
   void testUpdateSourceDefinition() throws ConfigNotFoundException, IOException, JsonValidationException {
     when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId())).thenReturn(source);
     final String newDockerImageTag = "averydifferenttag";
-    final String currentTag =
-        sourceHandler.getSourceDefinition(new SourceDefinitionIdRequestBody().sourceDefinitionId(source.getSourceDefinitionId())).getDockerImageTag();
+    final SourceDefinitionRead sourceDefinition = sourceHandler
+        .getSourceDefinition(new SourceDefinitionIdRequestBody().sourceDefinitionId(source.getSourceDefinitionId()));
+    final String dockerRepository = sourceDefinition.getDockerRepository();
+    final String currentTag = sourceDefinition.getDockerImageTag();
     assertNotEquals(newDockerImageTag, currentTag);
 
-    SourceDefinitionRead sourceDefinitionRead =
-        sourceHandler.updateSourceDefinition(
-            new SourceDefinitionUpdate().sourceDefinitionId(source.getSourceDefinitionId()).dockerImageTag(newDockerImageTag));
+    final SourceDefinitionRead sourceDefinitionRead = sourceHandler
+        .updateSourceDefinition(new SourceDefinitionUpdate().sourceDefinitionId(source.getSourceDefinitionId()).dockerImageTag(newDockerImageTag));
 
     assertEquals(newDockerImageTag, sourceDefinitionRead.getDockerImageTag());
-    verify(dockerImageValidator).assertValidIntegrationImage(source.getDockerRepository(), newDockerImageTag);
+    verify(dockerImageValidator).assertValidIntegrationImage(dockerRepository, newDockerImageTag);
+    verify(specCache).evict(dockerRepository + ":" + newDockerImageTag);
   }
 
 }

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -114,6 +114,16 @@ docker-compose stop scheduler
 
 * Happy Hacking!
 
+### Connector Specification Caching
+
+The Configuration API caches connector specifications. This is done to avoid needing to run docker everytime one is needed in the UI. Without this caching, the UI crawls. If you update the specification of a connector and you need to clear this cache so the API / UI pick up the change. You have two options:
+1. Go to the Admin page in the UI and update the version of the connector. Updating to the same version will for the cache to clear for that connector.
+1. Restart the server
+     ```bash
+        docker-compose --env-file .env.dev -f docker-compose.yaml -f docker-compose.dev.yaml down -v
+        docker-compose --env-file .env.dev -f docker-compose.yaml -f docker-compose.dev.yaml up
+      ```
+
 ### Resetting the Airbyte developer environment
 
 Sometimes you'll want to reset the data in your local environment. One common case for this is if you are updating an connector's entry in the database \(`airbyte-config/init/src/main/resources/config`\), often the easiest thing to do, is wipe the local database and start it from scratch. To reset your data back to a clean install of Airbyte, follow these steps:


### PR DESCRIPTION
## What
* The UI is becoming unusable because it is so slow. I was getting frustrated trying to debug the snowflake issues today because UI couldn't keep up. The slowness is because we are always fetching specs (especially now with multiple destinations there are even more specs to fetch). 

## How
* Cache calls to get spec.
* If you need to invalidate the cache for dev purposes restart the server.
* Cache entries are re set when using the admin UI