### PR TITLE
Fix Batching of Snowflake Inserts

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/424892c4-daac-4491-b35d-c6688ba547ba.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/424892c4-daac-4491-b35d-c6688ba547ba.json
@@ -2,6 +2,6 @@
   "destinationDefinitionId": "424892c4-daac-4491-b35d-c6688ba547ba",
   "name": "Snowflake",
   "dockerRepository": "airbyte/destination-snowflake",
-  "dockerImageTag": "0.1.5",
+  "dockerImageTag": "0.1.6",
   "documentationUrl": "https://docs.airbyte.io/integrations/destinations/snowflake"
 }

--- a/airbyte-integrations/connectors/destination-snowflake/Dockerfile
+++ b/airbyte-integrations/connectors/destination-snowflake/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.1.5
+LABEL io.airbyte.version=0.1.6
 LABEL io.airbyte.name=airbyte/destination-snowflake

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeRecordConsumer.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeRecordConsumer.java
@@ -107,36 +107,36 @@ public class SnowflakeRecordConsumer extends FailureTrackingConsumer<AirbyteMess
                                         int batchSize,
                                         CloseableQueue<byte[]> writeBuffer,
                                         String tmpTableName) {
-    try (Connection conn = connectionFactory.get()) {
-      final List<AirbyteRecordMessage> records = Lists.newArrayList();
-      for (int i = 0; i < batchSize; i++) {
-        final byte[] record = writeBuffer.poll();
-        if (record == null) {
-          break;
-        }
-        final AirbyteRecordMessage message = Jsons.deserialize(new String(record, Charsets.UTF_8), AirbyteRecordMessage.class);
-        records.add(message);
-      }
+    final List<AirbyteRecordMessage> records = accumulateRecordsFromBuffer(writeBuffer, batchSize);
 
-      LOGGER.info("max size of batch: {}", batchSize);
-      LOGGER.info("actual size of batch: {}", records.size());
+    LOGGER.info("max size of batch: {}", batchSize);
+    LOGGER.info("actual size of batch: {}", records.size());
 
-      if (records.isEmpty()) {
-        return;
-      }
+    if (records.isEmpty()) {
+      return;
+    }
 
+    try (final Connection conn = connectionFactory.get()) {
+      // Strategy: We want to use PreparedStatement because it handles binding values to the SQL query
+      // (e.g. handling formatting timestamps). A PreparedStatement statement is created by supplying the
+      // full SQL string at creation time. Then subsequently specifying which values are bound to the
+      // string. Thus there will be two loops below.
+      // 1) Loop over records to build the full string.
+      // 2) Loop over the records and bind the appropriate values to the string.
       final StringBuilder sql = new StringBuilder().append(String.format(
           "INSERT INTO \"%s\" (\"ab_id\", \"%s\", \"emitted_at\") SELECT column1, parse_json(column2), column3 FROM VALUES\n",
           tmpTableName,
           SnowflakeDestination.COLUMN_NAME));
 
+      // first loop: build SQL string.
       records.forEach(r -> sql.append("(?, ?, ?),\n"));
       final String s = sql.toString();
       final String s1 = s.substring(0, s.length() - 2) + ";";
 
-      try (PreparedStatement statement = conn.prepareStatement(s1)) {
+      try (final PreparedStatement statement = conn.prepareStatement(s1)) {
+        // second loop: bind values to the SQL string.
         int i = 1;
-        for (AirbyteRecordMessage message : records) {
+        for (final AirbyteRecordMessage message : records) {
           // 1-indexed
           statement.setString(i, UUID.randomUUID().toString());
           statement.setString(i + 1, Jsons.serialize(message.getData()));
@@ -149,6 +149,20 @@ public class SnowflakeRecordConsumer extends FailureTrackingConsumer<AirbyteMess
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private static List<AirbyteRecordMessage> accumulateRecordsFromBuffer(CloseableQueue<byte[]> writeBuffer, int maxRecords) {
+    final List<AirbyteRecordMessage> records = Lists.newArrayList();
+    for (int i = 0; i < maxRecords; i++) {
+      final byte[] record = writeBuffer.poll();
+      if (record == null) {
+        break;
+      }
+      final AirbyteRecordMessage message = Jsons.deserialize(new String(record, Charsets.UTF_8), AirbyteRecordMessage.class);
+      records.add(message);
+    }
+
+    return records;
   }
 
   @Override

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultSyncWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultSyncWorker.java
@@ -122,6 +122,8 @@ public class DefaultSyncWorker implements SyncWorker {
         .withStartTime(startTime)
         .withEndTime(System.currentTimeMillis());
 
+    LOGGER.info("sync summary: {}", summary);
+
     final StandardSyncOutput output = new StandardSyncOutput().withStandardSyncSummary(summary);
     messageTracker.getOutputState().ifPresent(capturedState -> {
       final State state = new State()


### PR DESCRIPTION
issue: https://github.com/airbytehq/airbyte/issues/1054
likely the culprit of this issue too: https://github.com/airbytehq/airbyte/issues/1056

## What
* snowflake destinations was doing one insert query per record. we need to have one insert query per batch.

## How
* change implementation of the query. code assumed that the `addBatch` functionality in the jdbc `PreparedStatment` handled consolidating this into one query, but it does not. [docs](https://docs.oracle.com/javase/tutorial/jdbc/basics/prepared.html) on `PrepararedStatement`.
* still using `PreparedStatement`'s functionality to handle binding values to the sql query for me. helps with formatting the timestamp. i had thought it was going to help with doing escape characters for json, but frankly i don't think it makes any difference for that part.