### PR TITLE
Install python deps declared in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ __pycache__
 .eggs
 .venv
 .mypy_cache
-dist
 
 # dbt
 profiles.yml

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__
 .eggs
 .venv
 .mypy_cache
+dist
 
 # dbt
 profiles.yml

--- a/airbyte-integrations/bases/base-normalization/requirements.txt
+++ b/airbyte-integrations/bases/base-normalization/requirements.txt
@@ -1,3 +1,2 @@
 -e ../airbyte-protocol
 -e .
-dbt==0.18.1

--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -42,10 +42,20 @@ class AirbytePythonPlugin implements Plugin<Project> {
             command = ". --config ${project.rootProject.file('tools/python/.flake8').absolutePath}"
         }
 
-        project.task('installReqs', type: PythonTask) {
+        project.task('installReqs1', type: PythonTask) {
             module = "pip"
             command = "install -r requirements.txt"
+//            command = "install .[main]"
             inputs.file('requirements.txt')
+            outputs.file('build/installedreqs.txt')
+            outputs.cacheIf { true }
+        }
+
+        project.task('installReqs', type: PythonTask, dependsOn: project.installReqs1) {
+            module = "pip"
+//            command = "install -r requirements.txt"
+            command = "install .[main]"
+            inputs.file('setup.py')
             outputs.file('build/installedreqs.txt')
             outputs.cacheIf { true }
         }
@@ -78,7 +88,13 @@ class AirbytePythonPlugin implements Plugin<Project> {
             project.check.dependsOn mypyCheck
         }
 
+//        project.task('publish', type: PythonTask, dependsOn: project.installReqs) {
+//            module = "python"
+//            command = "setup.py bdist_egg"
+//        }
+
         project.task('airbytePythonApply', type: DefaultTask) {
+//            dependsOn project.publish
             dependsOn project.installReqs
             dependsOn project.blackFormat
             dependsOn project.isortFormat

--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -42,18 +42,17 @@ class AirbytePythonPlugin implements Plugin<Project> {
             command = ". --config ${project.rootProject.file('tools/python/.flake8').absolutePath}"
         }
 
-        project.task('installReqs1', type: PythonTask) {
+        // attempt to install anything in requirements.txt. by convention this should only be dependencies whose source is located in the project.
+        project.task('installLocalReqs', type: PythonTask) {
             module = "pip"
             command = "install -r requirements.txt"
-//            command = "install .[main]"
             inputs.file('requirements.txt')
-            outputs.file('build/installedreqs.txt')
+            outputs.file('build/installedlocalreqs.txt')
             outputs.cacheIf { true }
         }
 
-        project.task('installReqs', type: PythonTask, dependsOn: project.installReqs1) {
+        project.task('installReqs', type: PythonTask, dependsOn: project.installLocalReqs) {
             module = "pip"
-//            command = "install -r requirements.txt"
             command = "install .[main]"
             inputs.file('setup.py')
             outputs.file('build/installedreqs.txt')
@@ -88,13 +87,7 @@ class AirbytePythonPlugin implements Plugin<Project> {
             project.check.dependsOn mypyCheck
         }
 
-//        project.task('publish', type: PythonTask, dependsOn: project.installReqs) {
-//            module = "python"
-//            command = "setup.py bdist_egg"
-//        }
-
         project.task('airbytePythonApply', type: DefaultTask) {
-//            dependsOn project.publish
             dependsOn project.installReqs
             dependsOn project.blackFormat
             dependsOn project.isortFormat


### PR DESCRIPTION
Relates to https://github.com/airbytehq/airbyte/issues/1110
Relates to https://github.com/airbytehq/airbyte/issues/1031

## What
* I have not been able to run `./gradlew clean build` successfully on my local machine for the last 2 weeks due to the error described here: https://github.com/airbytehq/airbyte/issues/1031. It seems to be a race condition-y sort of thing that happens when building the whole project.
* It seems like we don't ever install deps declared in setup.py. We just install what's in requirements.txt. Not 100% sure if this is a separate problem from the previous bullet point or related. The fix for this seems to have fixed the previous bullet point as well, but I'm not totally clear on why.
* I think this got confused because of our need to install local python deps that are located in the project

## How
* Keeps step to install our own local deps in each project that depends on them
* Add step that installs deps in setup.py
* Not sure this is the right way to do this... I was trying to figure out how to move the local dep installation into setup.py but wasn't successful. 

## Next Steps
* It seems like the way this should work is that each library produces a self-contained artifact. I think this should be doable as python eggs. Then each module that depends on the library can just consume the egg and we don't need to rely on requirements.txt at all.
