### PR TITLE
add health check endpoint to config api

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -50,6 +50,8 @@ tags:
     description: Connection between sources and destinations.
   - name: web_backend
     description: Connection between sources and destinations.
+  - name: health
+    description: Healthchecks
 
 paths:
   /v1/workspaces/get:
@@ -914,7 +916,21 @@ paths:
                 $ref: "#/components/schemas/DebugRead"
         "404":
           description: Debug info not found
-
+  /v1/health:
+    get:
+      tags:
+        - health
+      summary: Health Check
+      operationId: getHealthCheck
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthCheckRead"
+        "404":
+          description: Debug info not found
 components:
   securitySchemes:
     bearerAuth:
@@ -1618,6 +1634,14 @@ components:
           type: array
           items:
             type: string
+    # Health
+    HealthCheckRead:
+      type: object
+      required:
+        - db
+      properties:
+        db:
+          type: boolean
     # General
     CheckConnectionRead:
       type: object

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -76,6 +76,7 @@ import io.airbyte.server.handlers.ConnectionsHandler;
 import io.airbyte.server.handlers.DebugInfoHandler;
 import io.airbyte.server.handlers.DestinationDefinitionsHandler;
 import io.airbyte.server.handlers.DestinationHandler;
+import io.airbyte.server.handlers.HealthCheckHandler;
 import io.airbyte.server.handlers.JobHistoryHandler;
 import io.airbyte.server.handlers.SchedulerHandler;
 import io.airbyte.server.handlers.SourceDefinitionsHandler;
@@ -106,6 +107,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   private final WebBackendConnectionsHandler webBackendConnectionsHandler;
   private final WebBackendSourceHandler webBackendSourceHandler;
   private final WebBackendDestinationHandler webBackendDestinationHandler;
+  private final HealthCheckHandler healthCheckHandler;
 
   public ConfigurationApi(final ConfigRepository configRepository, final SchedulerPersistence schedulerPersistence, final SpecCache specCache) {
     final JsonSchemaValidator schemaValidator = new JsonSchemaValidator();
@@ -122,6 +124,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
     webBackendSourceHandler = new WebBackendSourceHandler(sourceHandler, schedulerHandler);
     webBackendDestinationHandler = new WebBackendDestinationHandler(destinationHandler, schedulerHandler);
     debugInfoHandler = new DebugInfoHandler(configRepository);
+    healthCheckHandler = new HealthCheckHandler(configRepository);
   }
 
   // WORKSPACE
@@ -336,9 +339,8 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   // HEALTH
   @Override
   public HealthCheckRead getHealthCheck() {
-    return null;
+    return healthCheckHandler.health();
   }
-
 
   // WEB BACKEND
 

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -43,6 +43,7 @@ import io.airbyte.api.model.DestinationRead;
 import io.airbyte.api.model.DestinationReadList;
 import io.airbyte.api.model.DestinationRecreate;
 import io.airbyte.api.model.DestinationUpdate;
+import io.airbyte.api.model.HealthCheckRead;
 import io.airbyte.api.model.JobIdRequestBody;
 import io.airbyte.api.model.JobInfoRead;
 import io.airbyte.api.model.JobListRequestBody;
@@ -331,6 +332,13 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   public DebugRead getDebuggingInfo() {
     return execute(debugInfoHandler::getInfo);
   }
+
+  // HEALTH
+  @Override
+  public HealthCheckRead getHealthCheck() {
+    return null;
+  }
+
 
   // WEB BACKEND
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/HealthCheckHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/HealthCheckHandler.java
@@ -1,13 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.airbyte.server.handlers;
 
 import io.airbyte.api.model.HealthCheckRead;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.PersistenceConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HealthCheckHandler {
 
-  public HealthCheckHandler() {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckHandler.class);
+
+  private final ConfigRepository configRepository;
+
+  public HealthCheckHandler(ConfigRepository configRepository) {
+    this.configRepository = configRepository;
   }
 
   public HealthCheckRead health() {
-    return null;
+    boolean databaseHealth = false;
+    try {
+      databaseHealth = configRepository.getStandardWorkspace(PersistenceConstants.DEFAULT_WORKSPACE_ID) != null;
+    } catch (Exception e) {
+      LOGGER.error("database health check failed.");
+    }
+
+    return new HealthCheckRead().db(databaseHealth);
   }
+
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/HealthCheckHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/HealthCheckHandler.java
@@ -1,0 +1,13 @@
+package io.airbyte.server.handlers;
+
+import io.airbyte.api.model.HealthCheckRead;
+
+public class HealthCheckHandler {
+
+  public HealthCheckHandler() {
+  }
+
+  public HealthCheckRead health() {
+    return null;
+  }
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/HealthCheckHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/HealthCheckHandler.java
@@ -40,6 +40,7 @@ public class HealthCheckHandler {
     this.configRepository = configRepository;
   }
 
+  // todo (cgardens) - add more checks as we go.
   public HealthCheckRead health() {
     boolean databaseHealth = false;
     try {

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/HealthCheckHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/HealthCheckHandlerTest.java
@@ -1,0 +1,60 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.server.handlers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.airbyte.api.model.HealthCheckRead;
+import io.airbyte.config.StandardWorkspace;
+import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.PersistenceConstants;
+import io.airbyte.validation.json.JsonValidationException;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class HealthCheckHandlerTest {
+
+  @Test
+  void testDbHealth() throws ConfigNotFoundException, IOException, JsonValidationException {
+    final ConfigRepository configRepository = mock(ConfigRepository.class);
+    final HealthCheckHandler healthCheckHandler = new HealthCheckHandler(configRepository);
+
+    // check db healthy
+    when(configRepository.getStandardWorkspace(PersistenceConstants.DEFAULT_WORKSPACE_ID)).thenReturn(new StandardWorkspace());
+    assertEquals(new HealthCheckRead().db(true), healthCheckHandler.health());
+
+    // check db unhealthy
+    when(configRepository.getStandardWorkspace(PersistenceConstants.DEFAULT_WORKSPACE_ID)).thenReturn(null);
+    assertEquals(new HealthCheckRead().db(false), healthCheckHandler.health());
+
+    doThrow(IOException.class).when(configRepository.getStandardWorkspace(PersistenceConstants.DEFAULT_WORKSPACE_ID));
+    assertEquals(new HealthCheckRead().db(false), healthCheckHandler.health());
+  }
+
+}

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/HealthCheckHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/HealthCheckHandlerTest.java
@@ -53,7 +53,7 @@ class HealthCheckHandlerTest {
     when(configRepository.getStandardWorkspace(PersistenceConstants.DEFAULT_WORKSPACE_ID)).thenReturn(null);
     assertEquals(new HealthCheckRead().db(false), healthCheckHandler.health());
 
-    doThrow(IOException.class).when(configRepository.getStandardWorkspace(PersistenceConstants.DEFAULT_WORKSPACE_ID));
+    doThrow(IOException.class).when(configRepository).getStandardWorkspace(PersistenceConstants.DEFAULT_WORKSPACE_ID);
     assertEquals(new HealthCheckRead().db(false), healthCheckHandler.health());
   }
 


### PR DESCRIPTION
For K8s, our API needs to have a GET endpoint that can be used as a health check. Goal of this PR is to get something up for a health check. We should add more things we test in the health check as we go.

https://github.com/airbytehq/airbyte/issues/835
https://github.com/airbytehq/airbyte/issues/1102