### PR TITLE
improve get_stream_level_metadata error handling

### DIFF
--- a/airbyte-integrations/bases/base-singer/base_singer/singer_helpers.py
+++ b/airbyte-integrations/bases/base-singer/base_singer/singer_helpers.py
@@ -66,8 +66,8 @@ def configured_for_incremental(configured_stream: ConfiguredAirbyteStream):
 
 def get_stream_level_metadata(metadatas: List[Dict[str, any]]) -> Optional[Dict[str, any]]:
     for metadata in metadatas:
-        if not is_field_metadata(metadata):
-            return metadata
+        if not is_field_metadata(metadata) and "metadata" in metadata:
+            return metadata.get("metadata")
     return None
 
 
@@ -92,8 +92,7 @@ class SingerHelper:
             schema = stream.get("schema")
             airbyte_stream = AirbyteStream(name=name, json_schema=schema)
             metadatas = stream.get("metadata")
-            stream_metadata_container = get_stream_level_metadata(metadatas) if metadatas else None
-            stream_metadata = stream_metadata_container.get("metadata")
+            stream_metadata = get_stream_level_metadata(metadatas)
             if stream_metadata:
                 # TODO unclear from the singer spec what behavior should be if there are no valid replication keys, but forced-replication-method is INCREMENTAL.
                 #  For now requiring replication keys for a stream to be considered incremental.

--- a/airbyte-integrations/bases/base-singer/base_singer/singer_helpers.py
+++ b/airbyte-integrations/bases/base-singer/base_singer/singer_helpers.py
@@ -91,8 +91,8 @@ class SingerHelper:
             name = stream.get("stream")
             schema = stream.get("schema")
             airbyte_stream = AirbyteStream(name=name, json_schema=schema)
-            metadatas = stream.get("metadata")
-            stream_metadata = get_stream_level_metadata(metadatas) if metadatas else {}
+            metadatas = stream.get("metadata", [])
+            stream_metadata = get_stream_level_metadata(metadatas)
             if stream_metadata:
                 # TODO unclear from the singer spec what behavior should be if there are no valid replication keys, but forced-replication-method is INCREMENTAL.
                 #  For now requiring replication keys for a stream to be considered incremental.

--- a/airbyte-integrations/bases/base-singer/base_singer/singer_helpers.py
+++ b/airbyte-integrations/bases/base-singer/base_singer/singer_helpers.py
@@ -92,7 +92,7 @@ class SingerHelper:
             schema = stream.get("schema")
             airbyte_stream = AirbyteStream(name=name, json_schema=schema)
             metadatas = stream.get("metadata")
-            stream_metadata = get_stream_level_metadata(metadatas)
+            stream_metadata = get_stream_level_metadata(metadatas) if metadatas else {}
             if stream_metadata:
                 # TODO unclear from the singer spec what behavior should be if there are no valid replication keys, but forced-replication-method is INCREMENTAL.
                 #  For now requiring replication keys for a stream to be considered incremental.


### PR DESCRIPTION
Slight refactor to prevent 

```

Traceback (most recent call last): |  
-- | --
  | File "/usr/local/bin/base-python", line 8, in <module> |  
  | sys.exit(main()) |  
  | File "/usr/local/lib/python3.7/site-packages/base_python/entrypoint.py", line 144, in main |  
  | launch(source, sys.argv[1:]) |  
  | File "/usr/local/lib/python3.7/site-packages/base_python/entrypoint.py", line 129, in launch |  
  | AirbyteEntrypoint(source).start(args) |  
  | File "/usr/local/lib/python3.7/site-packages/base_python/entrypoint.py", line 115, in start |  
  | catalog = self.source.discover(logger, config_container) |  
  | File "/usr/local/lib/python3.7/site-packages/base_singer/source.py", line 54, in discover |  
  | catalogs = SingerHelper.get_catalogs(logger, cmd) |  
  | File "/usr/local/lib/python3.7/site-packages/base_singer/singer_helpers.py", line 120, in get_catalogs |  
  | airbyte_catalog = SingerHelper.singer_catalog_to_airbyte_catalog(singer_catalog) |  
  | File "/usr/local/lib/python3.7/site-packages/base_singer/singer_helpers.py", line 96, in singer_catalog_to_airbyte_catalog |  
  | stream_metadata = stream_metadata_container.get("metadata") |  
  | AttributeError: 'NoneType' object has no attribute 'get'


```