### PR TITLE
report state to kvdb for master builds

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -60,6 +60,9 @@ jobs:
           AWS_S3_INTEGRATION_TEST_CREDS: ${{ secrets.AWS_S3_INTEGRATION_TEST_CREDS }}
           AWS_REDSHIFT_INTEGRATION_TEST_CREDS: ${{ secrets.AWS_REDSHIFT_INTEGRATION_TEST_CREDS }}
           MAILCHIMP_TEST_CREDS: ${{ secrets.MAILCHIMP_TEST_CREDS }}
+          ACTION_RUN_ID: ${{github.run_id}}
+          BUILD_STAT_WRITE_KEY: ${{ secrets.BUILD_STAT_WRITE_KEY }}
+          BUILD_STAT_BUCKET: ${{ secrets.BUILD_STAT_BUCKET }}
       - run: |
           ./tools/bin/ci_integration_test.sh ${{ github.event.inputs.connector }}
       - name: Add Success Comment


### PR DESCRIPTION
We need to store state of builds somewhere and have the ability to link to the build history since the `workflow_dispatch` events are hard to parse in the Github UI (and if we didn't do it that way we'd have to edit several more files and have custom workflows for each integration build, which is a pretty significant downside).

This uses the free plan on kvdb.io and is also in Github Secrets and LastPass already. The script I'm making for the dashboard will read from this.