### PR TITLE
Normalization use pinned version

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -16,5 +16,5 @@ WORKDIR /airbyte
 
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
@@ -43,7 +43,7 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNormalizationRunner.class);
 
-  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:dev";
+  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.2";
 
   private final DestinationType destinationType;
   private final ProcessBuilderFactory pbf;


### PR DESCRIPTION
## What
* I'm hating this PR: https://github.com/airbytehq/airbyte/pull/1208. It is spiraling out of control. The number of dependency related hacks is too big. We're going to mess it up. The straw that broke the camel's back was needing to depend on `composeBuild` ([example](https://github.com/airbytehq/airbyte/pull/1208/files#r536457042)). That is really ugly.
* Proposing we do what @sherifnada said in the first place and just pin the version. The single, but big, downside of this is when we change normalization we need to remember to bump the version AND to change the version in `DefaultNormalizationRunner`.
