### PR TITLE
Narrow JobSyncConfig and StandardSyncInput

### DIFF
--- a/airbyte-config/models/src/main/resources/types/JobSyncConfig.yaml
+++ b/airbyte-config/models/src/main/resources/types/JobSyncConfig.yaml
@@ -6,18 +6,24 @@ description: job sync config
 type: object
 additionalProperties: false
 required:
-  - sourceConnection
-  - destinationConnection
-  - standardSync
+  - sourceConfiguration
+  - destinationConfiguration
+  - configuredAirbyteCatalog
   - sourceDockerImage
   - destinationDockerImage
 properties:
-  sourceConnection:
-    "$ref": SourceConnection.yaml
-  destinationConnection:
-    "$ref": DestinationConnection.yaml
-  standardSync:
-    "$ref": StandardSync.yaml
+  sourceConfiguration:
+    description: Integration specific blob. Must be a valid JSON string.
+    type: object
+    existingJavaType: com.fasterxml.jackson.databind.JsonNode
+  destinationConfiguration:
+    description: Integration specific blob. Must be a valid JSON string.
+    type: object
+    existingJavaType: com.fasterxml.jackson.databind.JsonNode
+  configuredAirbyteCatalog:
+    description: the configured airbyte catalog
+    type: object
+    existingJavaType: io.airbyte.protocol.models.ConfiguredAirbyteCatalog
   sourceDockerImage:
     type: string
   destinationDockerImage:

--- a/airbyte-config/models/src/main/resources/types/StandardCheckConnectionInput.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardCheckConnectionInput.yaml
@@ -1,7 +1,7 @@
 ---
 "$schema": http://json-schema.org/draft-07/schema#
-"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/PublicCheckConnection.yaml
-title: PublicCheckConnection
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardCheckConnectionInput.yaml
+title: StandardCheckConnectionInput
 description: information required for connection.
 type: object
 required:

--- a/airbyte-config/models/src/main/resources/types/StandardSync.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSync.yaml
@@ -23,7 +23,8 @@ properties:
     format: uuid
   name:
     type: string
-  # deprecated.
+  # todo (cgardens) - this is deprecated. we should remove it.
+  # https://github.com/airbytehq/airbyte/issues/1224
   syncMode:
     "$ref": SyncMode.yaml
   schema:

--- a/airbyte-config/models/src/main/resources/types/StandardSync.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSync.yaml
@@ -23,6 +23,7 @@ properties:
     format: uuid
   name:
     type: string
+  # deprecated.
   syncMode:
     "$ref": SyncMode.yaml
   schema:

--- a/airbyte-config/models/src/main/resources/types/StandardSyncInput.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSyncInput.yaml
@@ -1,7 +1,7 @@
 ---
 "$schema": http://json-schema.org/draft-07/schema#
-"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/JobSyncConfig.yaml
-title: JobSyncConfig
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSyncInput.yaml
+title: StandardSyncInput
 description: job sync config
 type: object
 additionalProperties: false

--- a/airbyte-config/models/src/main/resources/types/StandardSyncInput.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSyncInput.yaml
@@ -6,22 +6,22 @@ description: job sync config
 type: object
 additionalProperties: false
 required:
-  - sourceConnection
-  - destinationConnection
-  - standardSync
-  - connectionId
+  - sourceConfiguration
+  - destinationConfiguration
+  - configuredAirbyteCatalog
 properties:
-  sourceConnection:
-    "$ref": SourceConnection.yaml
-  destinationConnection:
-    "$ref": DestinationConnection.yaml
-  syncMode:
-    "$ref": SyncMode.yaml
+  sourceConfiguration:
+    description: Integration specific blob. Must be a valid JSON string.
+    type: object
+    existingJavaType: com.fasterxml.jackson.databind.JsonNode
+  destinationConfiguration:
+    description: Integration specific blob. Must be a valid JSON string.
+    type: object
+    existingJavaType: com.fasterxml.jackson.databind.JsonNode
   catalog:
+    description: the configured airbyte catalog
     type: object
     existingJavaType: io.airbyte.protocol.models.ConfiguredAirbyteCatalog
-  connectionId:
-    type: string
-    format: uuid
   state:
+    description: optional state of the previous run. this object is defined per integration.
     "$ref": State.yaml

--- a/airbyte-config/models/src/main/resources/types/StandardTapConfig.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardTapConfig.yaml
@@ -8,8 +8,6 @@ additionalProperties: false
 required:
   - sourceConnectionConfiguration
   - catalog
-  - syncMode
-  - connectionId
 properties:
   sourceConnectionConfiguration:
     description: Integration specific blob. Must be a valid JSON string.
@@ -18,10 +16,5 @@ properties:
   catalog:
     type: object
     existingJavaType: io.airbyte.protocol.models.ConfiguredAirbyteCatalog
-  syncMode:
-    "$ref": SyncMode.yaml
-  connectionId:
-    type: string
-    format: uuid
   state:
     "$ref": State.yaml

--- a/airbyte-config/models/src/main/resources/types/State.yaml
+++ b/airbyte-config/models/src/main/resources/types/State.yaml
@@ -5,13 +5,9 @@ title: State
 description: information output by the connection.
 type: object
 required:
-  - connectionId
   - state
 additionalProperties: false
 properties:
-  connectionId:
-    type: string
-    format: uuid
   state:
     description: Integration specific blob. Must be a valid JSON string.
     type: object

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/TestSource.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/TestSource.java
@@ -40,7 +40,6 @@ import io.airbyte.config.StandardCheckConnectionOutput.Status;
 import io.airbyte.config.StandardDiscoverCatalogInput;
 import io.airbyte.config.StandardDiscoverCatalogOutput;
 import io.airbyte.config.StandardGetSpecOutput;
-import io.airbyte.config.StandardSync.SyncMode;
 import io.airbyte.config.StandardTapConfig;
 import io.airbyte.config.State;
 import io.airbyte.protocol.models.AirbyteMessage;
@@ -65,7 +64,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -153,7 +151,7 @@ public abstract class TestSource {
 
   @BeforeEach
   public void setUpInternal() throws Exception {
-    Path testDir = Path.of("/tmp/airbyte_tests/");
+    final Path testDir = Path.of("/tmp/airbyte_tests/");
     Files.createDirectories(testDir);
     final Path workspaceRoot = Files.createTempDirectory(testDir, "test");
     jobRoot = Files.createDirectories(Path.of(workspaceRoot.toString(), "job"));
@@ -244,12 +242,12 @@ public abstract class TestSource {
 
   @Test
   public void testIdenticalFullRefreshes() throws Exception {
-    ConfiguredAirbyteCatalog configuredCatalog = withFullRefreshSyncModes(getConfiguredCatalog());
+    final ConfiguredAirbyteCatalog configuredCatalog = withFullRefreshSyncModes(getConfiguredCatalog());
     final List<AirbyteRecordMessage> recordMessagesFirstRun = filterRecords(runRead(configuredCatalog));
     final List<AirbyteRecordMessage> recordMessagesSecondRun = filterRecords(runRead(configuredCatalog));
     // the worker validates the messages, so we just validate the message, so we do not need to validate
     // again (as long as we use the worker, which we will not want to do long term).
-    String assertionMessage = "Expected two full refresh syncs to produce the same records";
+    final String assertionMessage = "Expected two full refresh syncs to produce the same records";
     assertFalse(recordMessagesFirstRun.isEmpty(), assertionMessage);
     assertFalse(recordMessagesSecondRun.isEmpty(), assertionMessage);
 
@@ -265,10 +263,10 @@ public abstract class TestSource {
       return;
     }
 
-    ConfiguredAirbyteCatalog configuredAirbyteCatalog = withSourceDefinedCursors(getConfiguredCatalog());
-    List<AirbyteMessage> airbyteMessages = runRead(configuredAirbyteCatalog, getState());
-    List<AirbyteRecordMessage> recordMessages = filterRecords(airbyteMessages);
-    List<AirbyteStateMessage> stateMessages = airbyteMessages
+    final ConfiguredAirbyteCatalog configuredAirbyteCatalog = withSourceDefinedCursors(getConfiguredCatalog());
+    final List<AirbyteMessage> airbyteMessages = runRead(configuredAirbyteCatalog, getState());
+    final List<AirbyteRecordMessage> recordMessages = filterRecords(airbyteMessages);
+    final List<AirbyteStateMessage> stateMessages = airbyteMessages
         .stream()
         .filter(m -> m.getType() == Type.STATE)
         .map(AirbyteMessage::getState)
@@ -280,8 +278,8 @@ public abstract class TestSource {
 
     // when we run incremental sync again there should be no new records. Run a sync with the latest
     // state message and assert no records were emitted.
-    JsonNode latestState = stateMessages.get(stateMessages.size() - 1).getData();
-    List<AirbyteRecordMessage> secondSyncRecords = filterRecords(runRead(configuredAirbyteCatalog, latestState));
+    final JsonNode latestState = stateMessages.get(stateMessages.size() - 1).getData();
+    final List<AirbyteRecordMessage> secondSyncRecords = filterRecords(runRead(configuredAirbyteCatalog, latestState));
     assertTrue(
         secondSyncRecords.isEmpty(),
         "Expected the second incremental sync to produce no records when given the first sync's output state.");
@@ -293,12 +291,12 @@ public abstract class TestSource {
       return;
     }
 
-    ConfiguredAirbyteCatalog configuredCatalog = getConfiguredCatalog();
-    ConfiguredAirbyteCatalog fullRefreshCatalog = withFullRefreshSyncModes(configuredCatalog);
+    final ConfiguredAirbyteCatalog configuredCatalog = getConfiguredCatalog();
+    final ConfiguredAirbyteCatalog fullRefreshCatalog = withFullRefreshSyncModes(configuredCatalog);
 
     final List<AirbyteRecordMessage> fullRefreshRecords = filterRecords(runRead(fullRefreshCatalog));
     final List<AirbyteRecordMessage> emptyStateRecords = filterRecords(runRead(configuredCatalog, Jsons.jsonNode(new HashMap<>())));
-    String assertionMessage = "Expected a full refresh sync and incremental sync with no input state to produce identical records";
+    final String assertionMessage = "Expected a full refresh sync and incremental sync with no input state to produce identical records";
     assertFalse(fullRefreshRecords.isEmpty(), assertionMessage);
     assertFalse(emptyStateRecords.isEmpty(), assertionMessage);
     assertSameRecords(fullRefreshRecords, emptyStateRecords, assertionMessage);
@@ -312,7 +310,7 @@ public abstract class TestSource {
   }
 
   private ConfiguredAirbyteCatalog withSourceDefinedCursors(ConfiguredAirbyteCatalog catalog) {
-    ConfiguredAirbyteCatalog clone = Jsons.clone(catalog);
+    final ConfiguredAirbyteCatalog clone = Jsons.clone(catalog);
     for (ConfiguredAirbyteStream configuredStream : clone.getStreams()) {
       if (configuredStream.getSyncMode() == INCREMENTAL
           && configuredStream.getStream().getSourceDefinedCursor() != null
@@ -324,7 +322,7 @@ public abstract class TestSource {
   }
 
   private ConfiguredAirbyteCatalog withFullRefreshSyncModes(ConfiguredAirbyteCatalog catalog) {
-    ConfiguredAirbyteCatalog clone = Jsons.clone(catalog);
+    final ConfiguredAirbyteCatalog clone = Jsons.clone(catalog);
     for (ConfiguredAirbyteStream configuredStream : clone.getStreams()) {
       if (configuredStream.getStream().getSupportedSyncModes().contains(FULL_REFRESH)) {
         configuredStream.setSyncMode(FULL_REFRESH);
@@ -334,7 +332,7 @@ public abstract class TestSource {
   }
 
   private boolean sourceSupportsIncremental() throws Exception {
-    ConfiguredAirbyteCatalog catalog = getConfiguredCatalog();
+    final ConfiguredAirbyteCatalog catalog = getConfiguredCatalog();
     for (ConfiguredAirbyteStream stream : catalog.getStreams()) {
       if (stream.getStream().getSupportedSyncModes().contains(INCREMENTAL)) {
         return true;
@@ -365,10 +363,8 @@ public abstract class TestSource {
   // todo (cgardens) - assume no state since we are all full refresh right now.
   private List<AirbyteMessage> runRead(ConfiguredAirbyteCatalog catalog, JsonNode state) throws Exception {
     final StandardTapConfig tapConfig = new StandardTapConfig()
-        .withConnectionId(UUID.randomUUID())
         .withSourceConnectionConfiguration(getConfig())
-        .withSyncMode(SyncMode.FULL_REFRESH)
-        .withState(state == null ? null : new State().withState(state).withConnectionId(UUID.randomUUID()))
+        .withState(state == null ? null : new State().withState(state))
         .withCatalog(catalog);
 
     final AirbyteSource source = new DefaultAirbyteSource(new AirbyteIntegrationLauncher(getImageName(), pbf));
@@ -384,8 +380,8 @@ public abstract class TestSource {
   }
 
   private void assertSameRecords(List<AirbyteRecordMessage> expected, List<AirbyteRecordMessage> actual, String message) {
-    List<AirbyteRecordMessage> prunedExpected = expected.stream().map(this::pruneEmittedAt).collect(Collectors.toList());
-    List<AirbyteRecordMessage> prunedActual = actual.stream().map(this::pruneEmittedAt).collect(Collectors.toList());
+    final List<AirbyteRecordMessage> prunedExpected = expected.stream().map(this::pruneEmittedAt).collect(Collectors.toList());
+    final List<AirbyteRecordMessage> prunedActual = actual.stream().map(this::pruneEmittedAt).collect(Collectors.toList());
     assertEquals(prunedExpected.size(), prunedActual.size(), message);
     assertTrue(prunedExpected.containsAll(prunedActual), message);
     assertTrue(prunedActual.containsAll(prunedExpected), message);

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/WorkerRunFactory.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/WorkerRunFactory.java
@@ -25,7 +25,6 @@
 package io.airbyte.scheduler;
 
 import com.google.common.base.Preconditions;
-import io.airbyte.config.AirbyteProtocolConverters;
 import io.airbyte.config.JobCheckConnectionConfig;
 import io.airbyte.config.JobDiscoverCatalogConfig;
 import io.airbyte.config.JobGetSpecConfig;
@@ -116,7 +115,7 @@ public class WorkerRunFactory {
   private WorkerRun createDiscoverCatalogWorker(JobDiscoverCatalogConfig config, Path jobRoot) {
     final StandardDiscoverCatalogInput discoverSchemaInput = getDiscoverCatalogInput(config);
 
-    IntegrationLauncher launcher = createLauncher(config.getDockerImage());
+    final IntegrationLauncher launcher = createLauncher(config.getDockerImage());
 
     return creator.create(
         jobRoot,
@@ -127,8 +126,8 @@ public class WorkerRunFactory {
   private WorkerRun createSyncWorker(JobSyncConfig config, Path jobRoot) {
     final StandardSyncInput syncInput = getSyncInput(config);
 
-    IntegrationLauncher sourceLauncher = createLauncher(config.getSourceDockerImage());
-    IntegrationLauncher destinationLauncher = createLauncher(config.getDestinationDockerImage());
+    final IntegrationLauncher sourceLauncher = createLauncher(config.getSourceDockerImage());
+    final IntegrationLauncher destinationLauncher = createLauncher(config.getDestinationDockerImage());
 
     Preconditions.checkArgument(sourceLauncher.getClass().equals(destinationLauncher.getClass()),
         "Source and Destination must be using the same protocol");
@@ -144,7 +143,7 @@ public class WorkerRunFactory {
                 NormalizationRunnerFactory.create(
                     config.getDestinationDockerImage(),
                     pbf,
-                    syncInput.getDestinationConnection().getConfiguration()))));
+                    syncInput.getDestinationConfiguration()))));
   }
 
   private IntegrationLauncher createLauncher(final String image) {
@@ -161,11 +160,9 @@ public class WorkerRunFactory {
 
   private static StandardSyncInput getSyncInput(JobSyncConfig config) {
     return new StandardSyncInput()
-        .withSourceConnection(config.getSourceConnection())
-        .withDestinationConnection(config.getDestinationConnection())
-        .withConnectionId(config.getStandardSync().getConnectionId())
-        .withCatalog(AirbyteProtocolConverters.toConfiguredCatalog(config.getStandardSync().getSchema()))
-        .withSyncMode(config.getStandardSync().getSyncMode())
+        .withSourceConfiguration(config.getSourceConfiguration())
+        .withDestinationConfiguration(config.getDestinationConfiguration())
+        .withCatalog(config.getConfiguredAirbyteCatalog())
         .withState(config.getState());
   }
 

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
@@ -26,7 +26,6 @@ package io.airbyte.scheduler.persistence;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
-import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.AirbyteProtocolConverters;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.JobCheckConnectionConfig;

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.AirbyteProtocolConverters;
 import io.airbyte.config.DataType;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.Field;
@@ -192,11 +193,11 @@ public class DefaultJobCreatorTest {
   @Test
   void testCreateSyncJob() throws IOException {
     final JobSyncConfig jobSyncConfig = new JobSyncConfig()
-        .withSourceConnection(SOURCE_CONNECTION)
+        .withSourceConfiguration(SOURCE_CONNECTION.getConfiguration())
         .withSourceDockerImage(SOURCE_IMAGE_NAME)
-        .withDestinationConnection(DESTINATION_CONNECTION)
+        .withDestinationConfiguration(DESTINATION_CONNECTION.getConfiguration())
         .withDestinationDockerImage(DESTINATION_IMAGE_NAME)
-        .withStandardSync(STANDARD_SYNC);
+        .withConfiguredAirbyteCatalog(AirbyteProtocolConverters.toConfiguredCatalog(STANDARD_SYNC.getSchema()));
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(JobConfig.ConfigType.SYNC)

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobPersistenceTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobPersistenceTest.java
@@ -37,7 +37,6 @@ import io.airbyte.config.JobConfig;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.JobOutput;
 import io.airbyte.config.JobSyncConfig;
-import io.airbyte.config.StandardSync;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
 import io.airbyte.scheduler.Attempt;
@@ -73,8 +72,7 @@ class DefaultJobPersistenceTest {
   private static final Instant NOW = Instant.now();
   private static final UUID CONNECTION_ID = UUID.randomUUID();
   private static final String SCOPE = ScopeHelper.createScope(ConfigType.SYNC, CONNECTION_ID.toString());
-  private static final JobConfig JOB_CONFIG =
-      new JobConfig().withSync(new JobSyncConfig().withStandardSync(new StandardSync().withConnectionId(CONNECTION_ID)));
+  private static final JobConfig JOB_CONFIG = new JobConfig().withSync(new JobSyncConfig());
   private static final Path LOG_PATH = Path.of("/tmp/logs/all/the/way/down");
 
   private JobPersistence jobPersistence;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultSyncWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultSyncWorker.java
@@ -105,7 +105,7 @@ public class DefaultSyncWorker implements SyncWorker {
       LOGGER.info("Running normalization.");
       normalizationRunner.start();
       final Path normalizationRoot = Files.createDirectories(jobRoot.resolve("normalize"));
-      if (!normalizationRunner.normalize(normalizationRoot, syncInput.getDestinationConnection().getConfiguration(), syncInput.getCatalog())) {
+      if (!normalizationRunner.normalize(normalizationRoot, syncInput.getDestinationConfiguration(), syncInput.getCatalog())) {
         throw new WorkerException("Normalization Failed.");
       }
     } catch (Exception e) {
@@ -125,7 +125,6 @@ public class DefaultSyncWorker implements SyncWorker {
     final StandardSyncOutput output = new StandardSyncOutput().withStandardSyncSummary(summary);
     messageTracker.getOutputState().ifPresent(capturedState -> {
       final State state = new State()
-          .withConnectionId(tapConfig.getConnectionId())
           .withState(capturedState);
       output.withState(state);
     });

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -96,10 +96,8 @@ public class WorkerUtils {
    */
   public static StandardTapConfig syncToTapConfig(StandardSyncInput sync) {
     return new StandardTapConfig()
-        .withConnectionId(sync.getConnectionId())
-        .withSourceConnectionConfiguration(sync.getSourceConnection().getConfiguration())
+        .withSourceConnectionConfiguration(sync.getSourceConfiguration())
         .withCatalog(sync.getCatalog())
-        .withSyncMode(sync.getSyncMode())
         .withState(sync.getState());
   }
 
@@ -109,9 +107,8 @@ public class WorkerUtils {
    */
   public static StandardTargetConfig syncToTargetConfig(StandardSyncInput sync) {
     return new StandardTargetConfig()
-        .withDestinationConnectionConfiguration(sync.getDestinationConnection().getConfiguration())
+        .withDestinationConnectionConfiguration(sync.getDestinationConfiguration())
         .withCatalog(sync.getCatalog())
-        .withSyncMode(sync.getSyncMode())
         .withState(sync.getState());
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultSyncWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultSyncWorkerTest.java
@@ -129,9 +129,7 @@ class DefaultSyncWorkerTest {
             .withRecordsSynced(12L)
             .withBytesSynced(100L)
             .withStatus(Status.COMPLETED))
-        .withState(new State()
-            .withConnectionId(syncInput.getConnectionId())
-            .withState(expectedState));
+        .withState(new State().withState(expectedState));
     final OutputAndStatus<StandardSyncOutput> expected = new OutputAndStatus<>(JobStatus.SUCCEEDED, expectedSyncOutput);
 
     // good enough to verify that times are present.

--- a/airbyte-workers/src/test/java/io/airbyte/workers/TestConfigHelpers.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/TestConfigHelpers.java
@@ -95,7 +95,7 @@ public class TestConfigHelpers {
 
     final Schema schema = new Schema().withStreams(Collections.singletonList(stream));
 
-    StandardSync standardSync = new StandardSync()
+    final StandardSync standardSync = new StandardSync()
         .withConnectionId(connectionId)
         .withDestinationId(destinationId)
         .withSourceId(sourceId)
@@ -106,16 +106,12 @@ public class TestConfigHelpers {
 
     final String stateValue = Jsons.serialize(Map.of("lastSync", String.valueOf(LAST_SYNC_TIME)));
 
-    State state = new State()
-        .withConnectionId(connectionId)
-        .withState(Jsons.jsonNode(stateValue));
+    final State state = new State().withState(Jsons.jsonNode(stateValue));
 
-    StandardSyncInput syncInput = new StandardSyncInput()
-        .withDestinationConnection(destinationConnectionConfig)
-        .withSyncMode(standardSync.getSyncMode())
+    final StandardSyncInput syncInput = new StandardSyncInput()
+        .withDestinationConfiguration(destinationConnectionConfig.getConfiguration())
         .withCatalog(AirbyteProtocolConverters.toConfiguredCatalog(standardSync.getSchema()))
-        .withConnectionId(standardSync.getConnectionId())
-        .withSourceConnection(sourceConnectionConfig)
+        .withSourceConfiguration(sourceConnectionConfig.getConfiguration())
         .withState(state);
 
     return new ImmutablePair<>(standardSync, syncInput);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/wrappers/JobOutputSyncWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/wrappers/JobOutputSyncWorkerTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.JobOutput;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardSyncOutput;
@@ -37,23 +38,23 @@ import io.airbyte.workers.JobStatus;
 import io.airbyte.workers.OutputAndStatus;
 import io.airbyte.workers.SyncWorker;
 import java.nio.file.Path;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 public class JobOutputSyncWorkerTest {
 
   @Test
   public void test() {
-    StandardSyncInput input = mock(StandardSyncInput.class);
-    Path jobRoot = Path.of("fakeroot");
-    SyncWorker syncWorker = mock(SyncWorker.class);
+    final StandardSyncInput input = mock(StandardSyncInput.class);
+    final Path jobRoot = Path.of("fakeroot");
+    final SyncWorker syncWorker = mock(SyncWorker.class);
 
-    StandardSyncOutput output = new StandardSyncOutput().withState(new State().withConnectionId(UUID.randomUUID()));
+    final StandardSyncOutput output = new StandardSyncOutput().withState(new State().withState(Jsons.jsonNode(ImmutableMap.of("checkpoint", "10"))));
 
     when(syncWorker.run(input, jobRoot)).thenReturn(new OutputAndStatus<>(JobStatus.SUCCEEDED, output));
-    OutputAndStatus<JobOutput> run = new JobOutputSyncWorker(syncWorker).run(input, jobRoot);
+    final OutputAndStatus<JobOutput> run = new JobOutputSyncWorker(syncWorker).run(input, jobRoot);
 
-    JobOutput expected = new JobOutput().withOutputType(JobOutput.OutputType.SYNC).withSync(output);
+    final JobOutput expected = new JobOutput().withOutputType(JobOutput.OutputType.SYNC).withSync(output);
     assertEquals(JobStatus.SUCCEEDED, run.getStatus());
     assertTrue(run.getOutput().isPresent());
     assertEquals(expected, run.getOutput().get());


### PR DESCRIPTION
## What
* JobSyncConfig and StandardSyncInput relied on the config models used in the API. This meant that they were passing extra information to the Scheduler / Worker.
* While this extra information wasn't really a problem until now, it was complicating adding a reset data in destination job. So I narrowed these objects down to the data they actually needed to make that task easier.
* All of the job configs for the other work types already follow the model that this PR enforces for sync jobs.

## How
* The process of narrowing these objects was mostly just only passing the values we needed in these structs instead of passing the broader structs used in the API. In practice this is mostly stripping out ids that were not needed.

## Recommended reading order
1. `JobSyncConfig.yaml`
1. `StandardSyncInput.yaml`
1. the rest (all effectively name changes)
