### PR TITLE
Fix fetching of previous state for a connection

### DIFF
--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobScheduler.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobScheduler.java
@@ -86,7 +86,7 @@ public class JobScheduler implements Runnable {
 
   private void scheduleSyncJobs() throws IOException {
     for (StandardSync connection : getAllActiveConnections()) {
-      Optional<Job> previousJobOptional = jobPersistence.getLastSyncJob(connection.getConnectionId());
+      final Optional<Job> previousJobOptional = jobPersistence.getLastSyncJob(connection.getConnectionId());
       final StandardSyncSchedule standardSyncSchedule = getStandardSyncSchedule(connection);
 
       if (scheduleJobPredicate.test(previousJobOptional, standardSyncSchedule)) {

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
@@ -158,10 +158,7 @@ public class DefaultJobCreator implements JobCreator {
         .withConfiguredAirbyteCatalog(configuredAirbyteCatalog)
         .withState(null);
 
-    // todo (cgardens) - this will not have the intended behavior if the last job failed. then the next
-    // job will assume there is no state and re-sync everything! this is already wrong, so i'm not going
-    // to increase the scope of the current project.
-    final Optional<Job> previousJobOptional = jobPersistence.getLastSyncJob(connectionId);
+    final Optional<State> previousJobOptional = jobPersistence.getCurrentState(connectionId);
 
     final Optional<State> stateOptional = previousJobOptional.flatMap(j -> {
       final List<Attempt> attempts = j.getAttempts() != null ? j.getAttempts() : Lists.newArrayList();

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/DefaultJobPersistence.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/DefaultJobPersistence.java
@@ -28,7 +28,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.JobConfig;
 import io.airbyte.config.JobOutput;
-import io.airbyte.config.JobSyncConfig;
+import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.State;
 import io.airbyte.db.Database;
 import io.airbyte.db.ExceptionWrappingDatabase;
@@ -277,18 +277,13 @@ public class DefaultJobPersistence implements JobPersistence {
 
   @Override
   public Optional<State> getCurrentState(UUID connectionId) throws IOException {
-    // if a job does not succeed, we assume that it synced nothing. that is the most conservative
-    // assumption we can make. as long as all destinations write the final data output in a
-    // transactional way, this will be true. if this changes, then we may end up writing duplicate data
-    // with our incremental append only. this is preferable to failing to send data at all. our
-    // incremental append only most closely resembles a deliver at least once strategy anyway.
     return database.query(ctx -> getJobFromResult(ctx
-        .fetch(BASE_JOB_SELECT_AND_JOIN + "WHERE scope = ? AND CAST(jobs.status AS VARCHAR) = ? ORDER BY jobs.created_at DESC LIMIT 1",
+        .fetch(BASE_JOB_SELECT_AND_JOIN + "WHERE scope = ? AND CAST(jobs.status AS VARCHAR) = ? ORDER BY attempts.created_at DESC LIMIT 1",
             ScopeHelper.createScope(JobConfig.ConfigType.SYNC, connectionId.toString()),
             JobStatus.SUCCEEDED.toString().toLowerCase())))
-        .map(Job::getConfig)
-        .map(JobConfig::getSync)
-        .map(JobSyncConfig::getState);
+        .flatMap(Job::getSuccessOutput)
+        .map(JobOutput::getSync)
+        .map(StandardSyncOutput::getState);
   }
 
   @Override

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/JobPersistence.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/JobPersistence.java
@@ -25,6 +25,7 @@
 package io.airbyte.scheduler.persistence;
 
 import io.airbyte.config.JobConfig;
+import io.airbyte.config.State;
 import io.airbyte.scheduler.Job;
 import io.airbyte.scheduler.JobStatus;
 import java.io.IOException;
@@ -129,6 +130,8 @@ public interface JobPersistence {
   List<Job> listJobsWithStatus(JobConfig.ConfigType configType, JobStatus status) throws IOException;
 
   Optional<Job> getLastSyncJob(UUID connectionId) throws IOException;
+
+  Optional<State> getCurrentState(UUID connectionId) throws IOException;
 
   Optional<Job> getOldestPendingJob() throws IOException;
 

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/JobPersistence.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/JobPersistence.java
@@ -65,7 +65,6 @@ public interface JobPersistence {
    * Set job status from current status to CANCELLED. If already in a terminal status, no op.
    *
    * @param jobId job to cancel
-   * @param cancellationReason rest that the job is being cancelled.
    * @throws IOException exception due to interaction with persistence
    */
   void cancelJob(long jobId) throws IOException;
@@ -131,6 +130,17 @@ public interface JobPersistence {
 
   Optional<Job> getLastSyncJob(UUID connectionId) throws IOException;
 
+  /**
+   * if a job does not succeed, we assume that it synced nothing. that is the most conservative
+   * assumption we can make. as long as all destinations write the final data output in a
+   * transactional way, this will be true. if this changes, then we may end up writing duplicate data
+   * with our incremental append only. this is preferable to failing to send data at all. our
+   * incremental append only most closely resembles a deliver at least once strategy anyway.
+   *
+   * @param connectionId - id of the connection whose state we want to fetch.
+   * @return the current state, if any of, the connection
+   * @throws IOException exception due to interaction with persistence
+   */
   Optional<State> getCurrentState(UUID connectionId) throws IOException;
 
   Optional<Job> getOldestPendingJob() throws IOException;

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobPersistenceTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobPersistenceTest.java
@@ -31,12 +31,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.JobConfig;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.JobOutput;
 import io.airbyte.config.JobSyncConfig;
+import io.airbyte.config.StandardSyncOutput;
+import io.airbyte.config.State;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
 import io.airbyte.scheduler.Attempt;
@@ -368,6 +372,72 @@ class DefaultJobPersistenceTest {
     final Optional<Job> actual = jobPersistence.getLastSyncJob(CONNECTION_ID);
 
     assertTrue(actual.isEmpty());
+  }
+
+  @Test
+  public void testGetCurrentStateForConnectionIdNoState() throws IOException {
+    // no state when the connection has never had a job.
+    checkCurrentState(null, jobPersistence);
+
+    final long jobId = jobPersistence.createJob(SCOPE, JOB_CONFIG);
+    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
+
+    // no state when connection has a job but it has not completed that has not completed
+    checkCurrentState(null, jobPersistence);
+
+    jobPersistence.failJob(jobId);
+
+    // no state when connection has a job but it is failed.
+    checkCurrentState(null, jobPersistence);
+
+    jobPersistence.cancelJob(jobId);
+
+    // no state when connection has a job but it is cancelled.
+    checkCurrentState(null, jobPersistence);
+
+    final JobOutput jobOutput1 = new JobOutput()
+        .withSync(new StandardSyncOutput().withState(new State().withState(Jsons.jsonNode(ImmutableMap.of("checkpoint", "1")))));
+    jobPersistence.writeOutput(jobId, attemptNumber, jobOutput1);
+    jobPersistence.succeedAttempt(jobId, attemptNumber);
+
+    // job 1 state, after first success.
+    checkCurrentState(jobOutput1.getSync().getState(), jobPersistence);
+
+    when(timeSupplier.get()).thenReturn(NOW.plusSeconds(1000));
+    final long jobId2 = jobPersistence.createJob(SCOPE, JOB_CONFIG);
+    final int attemptNumber2 = jobPersistence.createAttempt(jobId2, LOG_PATH);
+
+    // job 1 state, second job created.
+    checkCurrentState(jobOutput1.getSync().getState(), jobPersistence);
+
+    jobPersistence.failJob(jobId2);
+
+    // job 1 state, second job failed.
+    checkCurrentState(jobOutput1.getSync().getState(), jobPersistence);
+
+    jobPersistence.cancelJob(jobId2);
+
+    // job 1 state, second job cancelled
+    checkCurrentState(jobOutput1.getSync().getState(), jobPersistence);
+
+    final JobOutput jobOutput2 = new JobOutput()
+        .withSync(new StandardSyncOutput().withState(new State().withState(Jsons.jsonNode(ImmutableMap.of("checkpoint", "2")))));
+    jobPersistence.writeOutput(jobId2, attemptNumber2, jobOutput2);
+    jobPersistence.succeedAttempt(jobId2, attemptNumber2);
+
+    // job 2 state, after second job success.
+    checkCurrentState(jobOutput2.getSync().getState(), jobPersistence);
+  }
+
+  private static void checkCurrentState(State expectedState, JobPersistence jobPersistence) throws IOException {
+    final Optional<State> currentState = jobPersistence.getCurrentState(CONNECTION_ID);
+
+    if (expectedState != null) {
+      assertTrue(currentState.isPresent());
+      assertEquals(expectedState, currentState.get());
+    } else {
+      assertTrue(currentState.isEmpty());
+    }
   }
 
   @Test


### PR DESCRIPTION
The issue and the resolution are both explained in the issue: https://github.com/airbytehq/airbyte/issues/1154.

## Checklist
- [x] - write a test for the job persistence
- [x] - write a test for the scheduler that tests that would have caught the bad behavior reported in the issue (wrote it as part of the job persistence test)
