### PR TITLE
put all integration test tasks under integrationTest 

### DIFF
--- a/airbyte-integrations/connector-templates/java-destination/build.gradle.hbs
+++ b/airbyte-integrations/connector-templates/java-destination/build.gradle.hbs
@@ -14,5 +14,5 @@ dependencies {
     implementation project(':airbyte-integrations:bases:base-java')
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 
-    integrationTestImplementation project(':airbyte-integrations:bases:standard-destination-test')
+    integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
 }

--- a/airbyte-integrations/connectors/destination-bigquery/build.gradle
+++ b/airbyte-integrations/connectors/destination-bigquery/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     implementation project(':airbyte-protocol:models')
     implementation project(':airbyte-queue')
 
-    integrationTestImplementation project(':airbyte-integrations:bases:standard-destination-test')
-    integrationTestImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
+    integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
+    integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/destination-csv/build.gradle
+++ b/airbyte-integrations/connectors/destination-csv/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     implementation project(':airbyte-integrations:bases:base-java')
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 
-    integrationTestImplementation project(':airbyte-integrations:bases:standard-destination-test')
+    integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
 }

--- a/airbyte-integrations/connectors/destination-jdbc/build.gradle
+++ b/airbyte-integrations/connectors/destination-jdbc/build.gradle
@@ -16,9 +16,9 @@ dependencies {
 
     testImplementation "org.testcontainers:postgresql:1.15.0-rc2"
 
-    integrationTestImplementation project(':airbyte-integrations:bases:standard-destination-test')
-    integrationTestImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+    integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
+    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.0-rc2"
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
-    integrationTestImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
+    integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/destination-postgres/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres/build.gradle
@@ -17,9 +17,9 @@ dependencies {
 
     testImplementation "org.testcontainers:postgresql:1.15.0-rc2"
 
-    integrationTestImplementation project(':airbyte-integrations:bases:standard-destination-test')
-    integrationTestImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+    integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
+    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.0-rc2"
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
-    integrationTestImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
+    integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/destination-redshift/build.gradle
+++ b/airbyte-integrations/connectors/destination-redshift/build.gradle
@@ -29,8 +29,8 @@ dependencies {
 
     testImplementation project(':airbyte-test-utils')
 
-    integrationTestImplementation project(':airbyte-integrations:bases:standard-destination-test')
+    integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
-    integrationTestImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
+    integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/destination-snowflake/build.gradle
+++ b/airbyte-integrations/connectors/destination-snowflake/build.gradle
@@ -15,10 +15,10 @@ dependencies {
     implementation project(':airbyte-integrations:bases:base-java')
     implementation project(':airbyte-protocol:models')
 
-    integrationTestImplementation project(':airbyte-integrations:bases:standard-destination-test')
-    integrationTestImplementation project(':airbyte-integrations:connectors:destination-snowflake')
-    integrationTestImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
-    integrationTestImplementation 'org.apache.commons:commons-lang3:3.11'
+    integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
+    integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-snowflake')
+    integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
+    integrationTestJavaImplementation 'org.apache.commons:commons-lang3:3.11'
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/source-exchangeratesapi-singer/build.gradle
+++ b/airbyte-integrations/connectors/source-exchangeratesapi-singer/build.gradle
@@ -11,10 +11,10 @@ airbytePython {
 }
 
 dependencies {
-    integrationTestImplementation project(':airbyte-workers')
-    integrationTestImplementation project(':airbyte-config:models')
-    integrationTestImplementation project(':airbyte-protocol:models')
+    integrationTestJavaImplementation project(':airbyte-workers')
+    integrationTestJavaImplementation project(':airbyte-config:models')
+    integrationTestJavaImplementation project(':airbyte-protocol:models')
     implementation files(project(':airbyte-integrations:bases:base-singer').airbyteDocker.outputs)
 }
 
-integrationTest.dependsOn airbyteDocker
+integrationTestJava.dependsOn airbyteDocker

--- a/airbyte-integrations/connectors/source-jdbc/build.gradle
+++ b/airbyte-integrations/connectors/source-jdbc/build.gradle
@@ -17,8 +17,8 @@ dependencies {
 
     testImplementation "org.testcontainers:postgresql:1.15.0-rc2"
 
-    integrationTestImplementation project(':airbyte-integrations:bases:standard-source-test')
-    integrationTestImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+    integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
+    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.0-rc2"
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/source-mssql/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql/build.gradle
@@ -29,8 +29,8 @@ dependencies {
 
     testImplementation project(':airbyte-test-utils')
 
-    // integrationTestImplementation project(':airbyte-integrations:bases:standard-source-test')
+    // integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
-    // integrationTestImplementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
+    // integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/source-mysql/build.gradle
+++ b/airbyte-integrations/connectors/source-mysql/build.gradle
@@ -22,9 +22,9 @@ dependencies {
 
     implementation 'org.apache.commons:commons-lang3:3.11'
 
-    integrationTestImplementation project(':airbyte-integrations:bases:standard-source-test')
+    integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     testImplementation 'org.testcontainers:mysql:1.15.0-rc2'
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
-    integrationTestImplementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
+    integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     testImplementation project(':airbyte-test-utils')
 
-    integrationTestImplementation project(':airbyte-integrations:bases:standard-source-test')
+    integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/source-redshift/build.gradle
+++ b/airbyte-integrations/connectors/source-redshift/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
     testImplementation project(':airbyte-test-utils')
 
-    integrationTestImplementation project(':airbyte-integrations:bases:standard-source-test')
+    integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/source-stripe-singer/build.gradle
+++ b/airbyte-integrations/connectors/source-stripe-singer/build.gradle
@@ -10,14 +10,14 @@ airbytePython {
 }
 
 dependencies {
-    integrationTestImplementation 'org.apache.commons:commons-dbcp2:2.7.0'
-    integrationTestImplementation 'com.fasterxml.jackson.core:jackson-databind'
-    integrationTestImplementation 'org.apache.commons:commons-text:1.9'
-    integrationTestImplementation "com.stripe:stripe-java:20.6.0"
+    integrationTestJavaImplementation 'org.apache.commons:commons-dbcp2:2.7.0'
+    integrationTestJavaImplementation 'com.fasterxml.jackson.core:jackson-databind'
+    integrationTestJavaImplementation 'org.apache.commons:commons-text:1.9'
+    integrationTestJavaImplementation "com.stripe:stripe-java:20.6.0"
 
-    integrationTestImplementation project(':airbyte-workers')
-    integrationTestImplementation project(':airbyte-config:models')
-    integrationTestImplementation project(':airbyte-protocol:models')
+    integrationTestJavaImplementation project(':airbyte-workers')
+    integrationTestJavaImplementation project(':airbyte-config:models')
+    integrationTestJavaImplementation project(':airbyte-protocol:models')
 
     implementation files(project(':airbyte-integrations:bases:base-singer').airbyteDocker.outputs)
 }

--- a/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
@@ -37,6 +37,7 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
             mustRunAfter project.test
         }
 
+        // make sure we create the integrationTest task once in case a standard source test was already initialized
         if(!project.hasProperty('integrationTest')) {
             project.task('integrationTest')
         }

--- a/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
@@ -5,7 +5,7 @@ import org.gradle.api.tasks.testing.Test
 class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
     void apply(Project project) {
         project.sourceSets {
-            integrationTest {
+            integrationTestJava {
                 java {
                     srcDir 'src/test-integration/java'
                 }
@@ -14,16 +14,16 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
                 }
             }
         }
-        project.test.dependsOn('compileIntegrationTestJava')
+        project.test.dependsOn('compileIntegrationTestJavaJava')
 
         project.configurations {
-            integrationTestImplementation.extendsFrom testImplementation
-            integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+            integrationTestJavaImplementation.extendsFrom testImplementation
+            integrationTestJavaRuntimeOnly.extendsFrom testRuntimeOnly
         }
 
-        project.task('integrationTest', type: Test) {
-            testClassesDirs += project.sourceSets.integrationTest.output.classesDirs
-            classpath += project.sourceSets.integrationTest.runtimeClasspath
+        project.task('integrationTestJava', type: Test) {
+            testClassesDirs += project.sourceSets.integrationTestJava.output.classesDirs
+            classpath += project.sourceSets.integrationTestJava.runtimeClasspath
 
             useJUnitPlatform()
             testLogging() {
@@ -37,5 +37,10 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
             mustRunAfter project.test
         }
 
+        if(!project.hasProperty('integrationTest')) {
+            project.task('integrationTest')
+        }
+
+        project.integrationTest.dependsOn(project.integrationTestJava)
     }
 }

--- a/buildSrc/src/main/groovy/airbyte-source-test.gradle
+++ b/buildSrc/src/main/groovy/airbyte-source-test.gradle
@@ -27,6 +27,8 @@ class AirbyteSourceTestPlugin implements Plugin<Project> {
                             '--pythonContainerName', pythonContainerName
                 }
             }
+
+            outputs.upToDateWhen { false }
         }
         project.airbyteDockerTest.dependsOn(':airbyte-integrations:bases:base-python-test:airbyteDocker')
         project.standardSourceTestPython.dependsOn(':airbyte-integrations:bases:standard-source-test:airbyteDocker')

--- a/buildSrc/src/main/groovy/airbyte-source-test.gradle
+++ b/buildSrc/src/main/groovy/airbyte-source-test.gradle
@@ -36,6 +36,7 @@ class AirbyteSourceTestPlugin implements Plugin<Project> {
         project.standardSourceTestPython.dependsOn(project.airbyteDocker)
         project.standardSourceTestPython.dependsOn(project.airbyteDockerTest)
 
+        // make sure we create the integrationTest task once in case a java integration test was already initialized
         if(!project.hasProperty('integrationTest')) {
             project.task('integrationTest')
         }

--- a/buildSrc/src/main/groovy/airbyte-source-test.gradle
+++ b/buildSrc/src/main/groovy/airbyte-source-test.gradle
@@ -35,5 +35,11 @@ class AirbyteSourceTestPlugin implements Plugin<Project> {
         project.standardSourceTestPython.dependsOn(project.build)
         project.standardSourceTestPython.dependsOn(project.airbyteDocker)
         project.standardSourceTestPython.dependsOn(project.airbyteDockerTest)
+
+        if(!project.hasProperty('integrationTest')) {
+            project.task('integrationTest')
+        }
+
+        project.integrationTest.dependsOn(project.standardSourceTestPython)
     }
 }

--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -2,15 +2,14 @@
 
 set -e
 
-# runs integration and/or standard tests for an integration name
+# runs integration tests for an integration name
 
 connector="$1"
 all_integration_tests=$(./gradlew integrationTest --dry-run | grep 'integrationTest SKIPPED' | cut -d: -f 4)
-all_standard_python_tests=$(./gradlew standardSourceTestPython --dry-run | grep 'standardSourceTestPython SKIPPED' | cut -d: -f 4)
 
 if [[ "$connector" == "all" ]] ; then
-  echo "Running: ./gradlew --no-daemon --scan integrationTest standardSourceTestPython"
-  ./gradlew --no-daemon --scan integrationTest standardSourceTestPython
+  echo "Running: ./gradlew --no-daemon --scan integrationTest"
+  ./gradlew --no-daemon --scan integrationTest
 else
   STAT_KEY="$connector"-"$ACTION_RUN_ID"
   trap 'catch $? $LINENO' EXIT
@@ -38,16 +37,8 @@ else
   fi
 
   selected_integration_test=$(echo "$all_integration_tests" | grep "^$connector$" || echo "")
-  selected_standard_python_test=$(echo "$all_standard_python_tests" | grep "^$connector$" || echo "")
   integrationTestCommand=":airbyte-integrations:connectors:$connector:integrationTest"
-  standardPythonTestCommand=":airbyte-integrations:connectors:$connector:standardSourceTestPython"
-  if [ -n "$selected_integration_test" ] && [ -n "$selected_standard_python_test" ] ; then
-    echo "Running: ./gradlew --no-daemon --scan $integrationTestCommand $standardPythonTestCommand"
-    ./gradlew --no-daemon --scan "$integrationTestCommand" "$standardPythonTestCommand"
-  elif [ -z "$selected_integration_test" ] && [ -n "$selected_standard_python_test" ] ; then
-    echo "Running: ./gradlew --no-daemon --scan $standardPythonTestCommand"
-    ./gradlew --no-daemon --scan "$standardPythonTestCommand"
-  elif [ -n "$selected_integration_test" ] && [ -z "$selected_standard_python_test" ] ; then
+  if [ -n "$selected_integration_test" ] ; then
     echo "Running: ./gradlew --no-daemon --scan $integrationTestCommand"
     ./gradlew --no-daemon --scan "$integrationTestCommand"
   else

--- a/tools/bin/ci_integration_workflow_launcher.sh
+++ b/tools/bin/ci_integration_workflow_launcher.sh
@@ -27,7 +27,7 @@ if [ "$RUNNING_MASTER_WORKFLOWS" -gt "$MAX_RUNNING_MASTER_WORKFLOWS" ]  ; then
   exit 0
 fi
 
-CONNECTORS=$(./gradlew integrationTest standardSourceTestPython --dry-run | grep 'integrationTest SKIPPED\|standardSourceTestPython SKIPPED' | cut -d: -f 4 | sort | uniq)
+CONNECTORS=$(./gradlew integrationTest --dry-run | grep 'integrationTest SKIPPED' | cut -d: -f 4 | sort | uniq)
 echo "$CONNECTORS" | while read -r connector ; do
   echo "Issuing request for connector $connector..."
   curl \


### PR DESCRIPTION
Instead of running `integrationTest` for Java integration tests and `standardSourceTestPython` for Python integration tests, let's keep `integrationTest` for anything that uses external resources.

This renames `integrationTest` to `integrationTestJava` and groups both types under `integrationTest`. 