### PR TITLE
remove [main] convention for python

### DIFF
--- a/airbyte-integrations/connector-templates/source-python/Dockerfile
+++ b/airbyte-integrations/connector-templates/source-python/Dockerfile
@@ -10,7 +10,7 @@ ENV AIRBYTE_IMPL_PATH="Source{{properCase name}}"
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 LABEL io.airbyte.version=0.1.0
 LABEL io.airbyte.name=airbyte/source-{{dashCase name}}

--- a/airbyte-integrations/connector-templates/source-python/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/setup.py.hbs
@@ -38,10 +38,6 @@ setup(
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     extras_require={
-        # Dependencies required by the main package but not integration tests should go in main. Deps required by
-        # integration tests but not the main package go in integration_tests. Deps required by both should go in
-        # install_requires.
-        "main": [],
         "tests": ["airbyte-python-test", "pytest"],
     },
 )

--- a/airbyte-integrations/connector-templates/source-singer/Dockerfile
+++ b/airbyte-integrations/connector-templates/source-singer/Dockerfile
@@ -10,7 +10,7 @@ ENV AIRBYTE_IMPL_PATH="Source{{properCase name}}Singer"
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 LABEL io.airbyte.version=0.1.0
 LABEL io.airbyte.name=airbyte/source-{{dashCase name}}-singer

--- a/airbyte-integrations/connector-templates/source-singer/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-singer/setup.py.hbs
@@ -30,15 +30,11 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=["airbyte-protocol"],
+    install_requires=["airbyte-protocol", "base-singer", "base-python"],
     package_data={"": ["*.json"]},
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     extras_require={
-        # Dependencies required by the main package but not integration tests should go in main. Deps required by
-        # integration tests but not the main package go in integration_tests. Deps required by both should go in
-        # install_requires.
-        "main": ["base-singer", "base-python"],
         "tests": ["airbyte-python-test", "pytest"],
     },
 )

--- a/airbyte-integrations/connectors/source-braintree-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-braintree-singer/Dockerfile
@@ -12,7 +12,7 @@ LABEL io.airbyte.name=airbyte/source-braintree-singer
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 WORKDIR /airbyte
 

--- a/airbyte-integrations/connectors/source-braintree-singer/setup.py
+++ b/airbyte-integrations/connectors/source-braintree-singer/setup.py
@@ -33,6 +33,6 @@ setup(
     install_requires=["tap-braintree==0.9.1", "python-dateutil==2.8.1", "airbyte-protocol", "base-singer", "base-python"],
     package_data={"": ["*.json"]},
     extras_require={
-        "standardtest": ["airbyte_python_test"],
+        "integration_tests": ["airbyte_python_test"],
     },
 )

--- a/airbyte-integrations/connectors/source-braintree-singer/setup.py
+++ b/airbyte-integrations/connectors/source-braintree-singer/setup.py
@@ -30,9 +30,9 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
+    install_requires=["tap-braintree==0.9.1", "python-dateutil==2.8.1", "airbyte-protocol", "base-singer", "base-python"],
     package_data={"": ["*.json"]},
     extras_require={
-        "main": ["tap-braintree==0.9.1", "python-dateutil==2.8.1", "airbyte-protocol", "base-singer", "base-python"],
         "standardtest": ["airbyte_python_test"],
     },
 )

--- a/airbyte-integrations/connectors/source-facebook-marketing-api-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-facebook-marketing-api-singer/Dockerfile
@@ -11,7 +11,7 @@ ENV AIRBYTE_IMPL_PATH="SourceFacebookMarketingApiSinger"
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/source-facebook-marketing-api-singer

--- a/airbyte-integrations/connectors/source-facebook-marketing-api-singer/setup.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing-api-singer/setup.py
@@ -30,12 +30,11 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=["airbyte-protocol"],
+    install_requires=["airbyte-protocol", "base-singer", "base-python", "tap-facebook==1.9.4"],
     package_data={"": ["*.json"]},
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     extras_require={
-        "main": ["base-singer", "base-python", "tap-facebook==1.9.4"],
         "tests": ["airbyte-python-test", "pytest"],
     },
 )

--- a/airbyte-integrations/connectors/source-file/Dockerfile
+++ b/airbyte-integrations/connectors/source-file/Dockerfile
@@ -9,7 +9,7 @@ ENV AIRBYTE_IMPL_PATH="SourceFile"
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 LABEL io.airbyte.version=0.1.5
 LABEL io.airbyte.name=airbyte/source-file

--- a/airbyte-integrations/connectors/source-file/setup.py
+++ b/airbyte-integrations/connectors/source-file/setup.py
@@ -45,10 +45,6 @@ setup(
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     extras_require={
-        # Dependencies required by the main package but not integration tests should go in main. Deps required by
-        # integration tests but not the main package go in integration_tests. Deps required by both should go in
-        # install_requires.
-        "main": [],
         "integration_tests": ["airbyte-python-test", "boto3", "pytest"],
     },
 )

--- a/airbyte-integrations/connectors/source-github-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-github-singer/Dockerfile
@@ -14,7 +14,7 @@ LABEL io.airbyte.name=airbyte/source-github-singer
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 WORKDIR /airbyte
 

--- a/airbyte-integrations/connectors/source-github-singer/setup.py
+++ b/airbyte-integrations/connectors/source-github-singer/setup.py
@@ -30,10 +30,10 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
+    install_requires=["tap-github==1.9.0", "requests", "airbyte-protocol", "base-singer", "base-python"],
     package_data={"": ["*.json"]},
     # two sets of dependencies: 1) for main 2) for standard test deps. 2 does not have all of the dependencies of 1, which is we cannot use install_requires.
     extras_require={
-        "main": ["tap-github==1.9.0", "requests", "airbyte-protocol", "base-singer", "base-python"],
         "standardtest": ["airbyte_python_test"],
     },
 )

--- a/airbyte-integrations/connectors/source-google-adwords-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-adwords-singer/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install tap-adwords==1.12.0
-RUN pip install ".[main]"
+RUN pip install .
 
 LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/source-google-adwords-singer

--- a/airbyte-integrations/connectors/source-google-adwords-singer/setup.py
+++ b/airbyte-integrations/connectors/source-google-adwords-singer/setup.py
@@ -30,15 +30,11 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=["airbyte-protocol"],
+    install_requires=["airbyte-protocol", "base-singer", "base-python"],
     package_data={"": ["*.json"]},
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     extras_require={
-        # Dependencies required by the main package but not integration tests should go in main. Deps required by
-        # integration tests but not the main package go in integration_tests. Deps required by both should go in
-        # install_requires.
-        "main": ["base-singer", "base-python"],
         "tests": ["airbyte-python-test", "pytest"],
     },
 )

--- a/airbyte-integrations/connectors/source-googleanalytics-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-googleanalytics-singer/Dockerfile
@@ -14,6 +14,6 @@ LABEL io.airbyte.name=airbyte/source-googleanalytics-singer
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 WORKDIR /airbyte

--- a/airbyte-integrations/connectors/source-googleanalytics-singer/setup.py
+++ b/airbyte-integrations/connectors/source-googleanalytics-singer/setup.py
@@ -30,16 +30,9 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
+    install_requires=["pipelinewise-tap-google-analytics==1.1.1", "pydantic==1.6.1", "base-singer", "base-python", "airbyte-protocol",],
     package_data={"": ["*.json", "*.txt"]},
-    # two sets of dependencies: 1) for main 2) for standard test deps. 2 does not have all of the dependencies of 1, which is we cannot use install_requires.
     extras_require={
-        "main": [
-            "pipelinewise-tap-google-analytics==1.1.1",
-            "pydantic==1.6.1",
-            "base-singer",
-            "base-python",
-            "airbyte-protocol",
-        ],
         "standardtest": ["airbyte-python-test", "requests"],
     },
 )

--- a/airbyte-integrations/connectors/source-googleanalytics-singer/setup.py
+++ b/airbyte-integrations/connectors/source-googleanalytics-singer/setup.py
@@ -30,7 +30,13 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=["pipelinewise-tap-google-analytics==1.1.1", "pydantic==1.6.1", "base-singer", "base-python", "airbyte-protocol",],
+    install_requires=[
+        "pipelinewise-tap-google-analytics==1.1.1",
+        "pydantic==1.6.1",
+        "base-singer",
+        "base-python",
+        "airbyte-protocol",
+    ],
     package_data={"": ["*.json", "*.txt"]},
     extras_require={
         "standardtest": ["airbyte-python-test", "requests"],

--- a/airbyte-integrations/connectors/source-http-request/Dockerfile
+++ b/airbyte-integrations/connectors/source-http-request/Dockerfile
@@ -9,7 +9,7 @@ ENV AIRBYTE_IMPL_PATH="SourceHttpRequest"
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 LABEL io.airbyte.version=0.1.0
 LABEL io.airbyte.name=airbyte/source-http-request

--- a/airbyte-integrations/connectors/source-http-request/setup.py
+++ b/airbyte-integrations/connectors/source-http-request/setup.py
@@ -30,12 +30,11 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=["airbyte-protocol", "requests"],
+    install_requires=["airbyte-protocol", "requests", "base-python"],
     package_data={"": ["*.json"]},
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     extras_require={
-        "main": ["base-python"],
         "tests": ["airbyte-python-test", "pytest"],
     },
 )

--- a/airbyte-integrations/connectors/source-hubspot-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-hubspot-singer/Dockerfile
@@ -14,7 +14,7 @@ LABEL io.airbyte.name=airbyte/source-hubspot-singer
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 WORKDIR /airbyte
 

--- a/airbyte-integrations/connectors/source-hubspot-singer/setup.py
+++ b/airbyte-integrations/connectors/source-hubspot-singer/setup.py
@@ -30,9 +30,9 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
+    install_requires=["tap-hubspot==2.8.1", "requests", "airbyte-protocol", "base-singer"],
     package_data={"": ["*.json"]},
     extras_require={
-        "main": ["tap-hubspot==2.8.1", "requests", "airbyte-protocol", "base-singer"],
         "standardtest": ["airbyte_python_test"],
     },
 )

--- a/airbyte-integrations/connectors/source-mailchimp/Dockerfile
+++ b/airbyte-integrations/connectors/source-mailchimp/Dockerfile
@@ -10,7 +10,7 @@ ENV AIRBYTE_IMPL_PATH="SourceMailchimp"
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 LABEL io.airbyte.version=0.1.5
 LABEL io.airbyte.name=airbyte/source-mailchimp

--- a/airbyte-integrations/connectors/source-mailchimp/setup.py
+++ b/airbyte-integrations/connectors/source-mailchimp/setup.py
@@ -35,10 +35,6 @@ setup(
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     extras_require={
-        # Dependencies required by the main package but not integration tests should go in main. Deps required by
-        # integration tests but not the main package go in integration_tests. Deps required by both should go in
-        # install_requires.
-        "main": [],
         "tests": ["airbyte_python_test", "pytest"],
     },
 )

--- a/airbyte-integrations/connectors/source-marketo-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-marketo-singer/Dockerfile
@@ -12,7 +12,7 @@ ENV AIRBYTE_IMPL_PATH="SourceMarketoSinger"
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/source-marketo-singer

--- a/airbyte-integrations/connectors/source-marketo-singer/setup.py
+++ b/airbyte-integrations/connectors/source-marketo-singer/setup.py
@@ -30,7 +30,7 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=["airbyte-protocol","base-singer", "base-python", "tap-marketo==2.4.1"],
+    install_requires=["airbyte-protocol", "base-singer", "base-python", "tap-marketo==2.4.1"],
     package_data={"": ["*.json"]},
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],

--- a/airbyte-integrations/connectors/source-marketo-singer/setup.py
+++ b/airbyte-integrations/connectors/source-marketo-singer/setup.py
@@ -30,15 +30,11 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=["airbyte-protocol"],
+    install_requires=["airbyte-protocol","base-singer", "base-python", "tap-marketo==2.4.1"],
     package_data={"": ["*.json"]},
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     extras_require={
-        # Dependencies required by the main package but not integration tests should go in main. Deps required by
-        # integration tests but not the main package go in integration_tests. Deps required by both should go in
-        # install_requires.
-        "main": ["base-singer", "base-python", "tap-marketo==2.4.1"],
         "tests": ["airbyte_python_test", "pytest"],
     },
 )

--- a/airbyte-integrations/connectors/source-recurly/Dockerfile
+++ b/airbyte-integrations/connectors/source-recurly/Dockerfile
@@ -10,7 +10,7 @@ ENV AIRBYTE_IMPL_PATH="SourceRecurly"
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 LABEL io.airbyte.version=0.1.0
 LABEL io.airbyte.name=airbyte/source-recurly

--- a/airbyte-integrations/connectors/source-recurly/setup.py
+++ b/airbyte-integrations/connectors/source-recurly/setup.py
@@ -35,10 +35,6 @@ setup(
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     extras_require={
-        # Dependencies required by the main package but not integration tests should go in main. Deps required by
-        # integration tests but not the main package go in integration_tests. Deps required by both should go in
-        # install_requires.
-        "main": [],
         "tests": ["airbyte-python-test", "pytest"],
     },
 )

--- a/airbyte-integrations/connectors/source-sendgrid/Dockerfile
+++ b/airbyte-integrations/connectors/source-sendgrid/Dockerfile
@@ -10,7 +10,7 @@ ENV AIRBYTE_IMPL_PATH="SourceSendgrid"
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 LABEL io.airbyte.version=0.1.0
 LABEL io.airbyte.name=airbyte/source-sendgrid

--- a/airbyte-integrations/connectors/source-sendgrid/setup.py
+++ b/airbyte-integrations/connectors/source-sendgrid/setup.py
@@ -30,19 +30,11 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=[
-        "airbyte-protocol",
-        "base-python",
-        "sendgrid==6.4.7",
-    ],
+    install_requires=["airbyte-protocol", "base-python",  "sendgrid==6.4.7"],
     package_data={"": ["*.json", "schemas/*.json"]},
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     extras_require={
-        # Dependencies required by the main package but not integration tests should go in main. Deps required by
-        # integration tests but not the main package go in integration_tests. Deps required by both should go in
-        # install_requires.
-        "main": [],
         "tests": ["airbyte-python-test", "pytest"],
     },
 )

--- a/airbyte-integrations/connectors/source-sendgrid/setup.py
+++ b/airbyte-integrations/connectors/source-sendgrid/setup.py
@@ -30,7 +30,7 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=["airbyte-protocol", "base-python",  "sendgrid==6.4.7"],
+    install_requires=["airbyte-protocol", "base-python", "sendgrid==6.4.7"],
     package_data={"": ["*.json", "schemas/*.json"]},
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],

--- a/airbyte-integrations/connectors/source-shopify-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-shopify-singer/Dockerfile
@@ -12,7 +12,7 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install pip==20.3
 RUN pip install tap-shopify==1.2.6
-RUN pip install ".[main]"
+RUN pip install .
 
 LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/source-shopify-singer

--- a/airbyte-integrations/connectors/source-shopify-singer/setup.py
+++ b/airbyte-integrations/connectors/source-shopify-singer/setup.py
@@ -30,15 +30,11 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=["airbyte-protocol", "ShopifyAPI==8.0.4"],
+    install_requires=["airbyte-protocol", "ShopifyAPI==8.0.4", "base-singer", "base-python"],
     package_data={"": ["*.json"]},
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     extras_require={
-        # Dependencies required by the main package but not integration tests should go in main. Deps required by
-        # integration tests but not the main package go in integration_tests. Deps required by both should go in
-        # install_requires.
-        "main": ["base-singer", "base-python"],
         "tests": ["airbyte-python-test", "pytest"],
     },
 )

--- a/airbyte-integrations/connectors/source-slack-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-slack-singer/Dockerfile
@@ -12,7 +12,7 @@ LABEL io.airbyte.name=airbyte/source-slack-singer
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 WORKDIR /airbyte
 

--- a/airbyte-integrations/connectors/source-slack-singer/setup.py
+++ b/airbyte-integrations/connectors/source-slack-singer/setup.py
@@ -30,11 +30,11 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
+    install_requires=["tap-slack==1.0.0", "slack-sdk==3.0.0", "airbyte-protocol", "base-singer", "base-python"],
     package_data={"": ["*.json"]},
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     extras_require={
-        "main": ["tap-slack==1.0.0", "slack-sdk==3.0.0", "airbyte-protocol", "base-singer", "base-python"],
         "standardtest": ["airbyte_python_test"],
     },
 )

--- a/airbyte-integrations/connectors/source-twilio-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-twilio-singer/Dockerfile
@@ -12,7 +12,7 @@ LABEL io.airbyte.name=airbyte/source-twilio-singer
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 WORKDIR /airbyte
 

--- a/airbyte-integrations/connectors/source-twilio-singer/setup.py
+++ b/airbyte-integrations/connectors/source-twilio-singer/setup.py
@@ -30,11 +30,11 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
+    install_requires=["tap-twilio==0.0.1", "twilio==6.48.0", "airbyte-protocol", "base-singer", "base-python"],
     package_data={"": ["*.json"]},
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     extras_require={
-        "main": ["tap-twilio==0.0.1", "twilio==6.48.0", "airbyte-protocol", "base-singer", "base-python"],
         "standardtest": ["airbyte_python_test"],
     },
 )

--- a/airbyte-integrations/connectors/source-zendesk-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-zendesk-singer/Dockerfile
@@ -9,7 +9,7 @@ ENV AIRBYTE_IMPL_PATH="SourceZendeskSinger"
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install ".[main]"
+RUN pip install .
 
 LABEL io.airbyte.version=0.1.0
 LABEL io.airbyte.name=airbyte/source-zendesk-singer

--- a/airbyte-integrations/connectors/source-zendesk-singer/setup.py
+++ b/airbyte-integrations/connectors/source-zendesk-singer/setup.py
@@ -30,9 +30,9 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=["airbyte-protocol"],
+    install_requires=["airbyte-protocol", "base-singer", "base-python", "tap-zendesk==1.5.3"],
     package_data={"": ["*.json"]},
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
-    extras_require={"main": ["base-singer", "base-python", "tap-zendesk==1.5.3"], "standardtest": ["airbyte_python_test"]},
+    extras_require={"standardtest": ["airbyte_python_test"]},
 )

--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -58,7 +58,7 @@ class AirbytePythonPlugin implements Plugin<Project> {
 
         project.task('installReqs', type: PythonTask, dependsOn: project.installLocalReqs) {
             module = "pip"
-            command = "install .[main]"
+            command = "install ."
             inputs.file('setup.py')
             outputs.file('build/installedreqs.txt')
         }


### PR DESCRIPTION
Moves `[main]` extras into `install_requires` for simplification.