### PR TITLE
move default PR tempalte to root dir

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_python_source.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_python_source.md
@@ -11,8 +11,8 @@ Thanks for contributing to Airbyte! Please complete the following items in order
 ## Reviewer Pre-merge Checklist 
 - [ ] Finished iterating with the PR author on the code*
 - [ ] Created a branch off master to merge this PR into*
+- [ ] Inject the credentials in CI via `./tools/integrations/ci_credentials.sh` and `.github/workflows/test-command.yml`*
 - [ ] Added the credentials for this integration to Github secrets 
-- [ ] Inject the credentials in CI via `./tools/integrations/ci_credentials.sh` and `.github/workflows/test-command.yml`
 - [ ] Run standard tests on this branch by commenting `/test connector=<name>`*
 - [ ] Add entry in `airbyte-config/init/src/main/resources/seed/source_definitions.yaml` to use the new source in Airbyte core
 - [ ] Deployed the connector to Dockerhub via `./tools/integrations/manage.sh publish airbyte-integrations/connectors/source-<name>`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,10 +10,9 @@ about: Use this for any changes that don't have other templates
 ## How
 *Describe the solution*
 
-## Checklist
-- [ ] *Create config API model*
-- [ ] *Implement config persistence*
-- [ ] *Add persistence tests*
+## Pre-merge Checklist
+- [ ] *Run integration tests*
+- [ ] *Publish Docker images*
 
 ## Recommended reading order
 1. `test.java`


### PR DESCRIPTION
Github doesn't nicely support multiple PR templates like it does for issues. This PR restores the default PR template. To use the new source template, we'll need to add `&template=new_python_source.md` to the URL when creating a PR.