### PR TITLE
hotfix: run normalization AFTER source and destination are closed (release v0.7.1-alpha)

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.7.1-alpha
+VERSION=0.7.0-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_DB=airbyte

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.7.0-alpha
+VERSION=0.7.1-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_DB=airbyte

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultSyncWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultSyncWorker.java
@@ -109,9 +109,9 @@ public class DefaultSyncWorker implements SyncWorker {
         throw new WorkerException("Normalization Failed.");
       }
     } catch (Exception e) {
-    LOGGER.error("Normalization Failed.", e);
-    return new OutputAndStatus<>(JobStatus.FAILED, null);
-  }
+      LOGGER.error("Normalization Failed.", e);
+      return new OutputAndStatus<>(JobStatus.FAILED, null);
+    }
 
     final StandardSyncSummary summary = new StandardSyncSummary()
         .withStatus(cancelled.get() ? Status.FAILED : Status.COMPLETED)

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultSyncWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultSyncWorker.java
@@ -95,19 +95,23 @@ public class DefaultSyncWorker implements SyncWorker {
 
       destination.notifyEndOfStream();
 
-      try (normalizationRunner) {
-        LOGGER.info("Running normalization.");
-        normalizationRunner.start();
-        final Path normalizationRoot = Files.createDirectories(jobRoot.resolve("normalize"));
-        if (!normalizationRunner.normalize(normalizationRoot, syncInput.getDestinationConnection().getConfiguration(), syncInput.getCatalog())) {
-          throw new WorkerException("Normalization Failed.");
-        }
-      }
     } catch (Exception e) {
       LOGGER.error("Sync worker failed.", e);
 
       return new OutputAndStatus<>(JobStatus.FAILED, null);
     }
+
+    try (normalizationRunner) {
+      LOGGER.info("Running normalization.");
+      normalizationRunner.start();
+      final Path normalizationRoot = Files.createDirectories(jobRoot.resolve("normalize"));
+      if (!normalizationRunner.normalize(normalizationRoot, syncInput.getDestinationConnection().getConfiguration(), syncInput.getCatalog())) {
+        throw new WorkerException("Normalization Failed.");
+      }
+    } catch (Exception e) {
+    LOGGER.error("Normalization Failed.", e);
+    return new OutputAndStatus<>(JobStatus.FAILED, null);
+  }
 
     final StandardSyncSummary summary = new StandardSyncSummary()
         .withStatus(cancelled.get() ? Status.FAILED : Status.COMPLETED)

--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -13,7 +13,7 @@ GIT_REVISION=$(git rev-parse HEAD)
 [[ ! -z "$(git status --porcelain)" ]] && echo "Cannot tag revision if all changes aren't checked in..." && exit 1
 
 echo "Building and publishing version $VERSION for git revision $GIT_REVISION..."
-./gradlew clean build
+./gradlew clean composeBuild
 GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker-compose.yaml build
 GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker-compose.yaml push
 echo "Completed building and publishing..."


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/1258

## What
* The code to run the normalization runner was inside the try-with-resource block for source and destination. This means that normalization could start running before the destination was closed. We do not have a guarantee that all data was written until the destination closes. So in some cases normalization would start too soon.

