### PR TITLE
test postgres timestamp handling (wip)

### DIFF
--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/JooqSourceTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/JooqSourceTest.java
@@ -78,13 +78,13 @@ class JooqSourceTest {
   private static final List<AirbyteMessage> MESSAGES = Lists.newArrayList(
       new AirbyteMessage().withType(Type.RECORD)
           .withRecord(new AirbyteRecordMessage().withStream(STREAM_NAME)
-              .withData(Jsons.jsonNode(ImmutableMap.of("id", 1, "name", "picard", "updated_at", "2004-10-19T10:23:54-07:00")))),
+              .withData(Jsons.jsonNode(ImmutableMap.of("id", 1, "name", "picard", "updated_at", "2004-10-19T10:23:54Z")))),
       new AirbyteMessage().withType(Type.RECORD)
           .withRecord(new AirbyteRecordMessage().withStream(STREAM_NAME)
-              .withData(Jsons.jsonNode(ImmutableMap.of("id", 2, "name", "crusher", "updated_at", "2005-10-19T10:23:54-07:00")))),
+              .withData(Jsons.jsonNode(ImmutableMap.of("id", 2, "name", "crusher", "updated_at", "2005-10-19T10:23:54Z")))),
       new AirbyteMessage().withType(Type.RECORD)
           .withRecord(new AirbyteRecordMessage().withStream(STREAM_NAME)
-              .withData(Jsons.jsonNode(ImmutableMap.of("id", 3, "name", "vash", "updated_at", "2006-10-19T10:23:54-07:00")))));
+              .withData(Jsons.jsonNode(ImmutableMap.of("id", 3, "name", "vash", "updated_at", "2006-10-19T10:23:54Z")))));
 
   private JsonNode config;
 
@@ -115,7 +115,7 @@ class JooqSourceTest {
     database.query(ctx -> {
       ctx.fetch("CREATE TABLE id_and_name(id INTEGER, name VARCHAR(200), updated_at TIMESTAMP WITH TIME ZONE);");
       ctx.fetch(
-          "INSERT INTO id_and_name (id, name, updated_at) VALUES (1,'picard', '2004-10-19T10:23:54-07:00'),  (2, 'crusher', '2005-10-19T10:23:54-07:00'), (3, 'vash', '2006-10-19T10:23:54-07:00');");
+          "INSERT INTO id_and_name (id, name, updated_at) VALUES (1,'picard', '2004-10-19T10:23:54Z'),  (2, 'crusher', '2005-10-19T10:23:54Z'), (3, 'vash', '2006-10-19T10:23:54Z');");
       return null;
     });
   }
@@ -271,8 +271,8 @@ class JooqSourceTest {
   void testIncrementalTimestampCheckCursor() throws Exception {
     incrementalCursorCheck(
         "updated_at",
-        "2005-10-19T9:23:54-07:00",
-        "2006-10-19T10:23:54-07:00",
+        "2005-10-19T9:23:54Z",
+        "2006-10-19T10:23:54Z",
         Lists.newArrayList(MESSAGES.get(1), MESSAGES.get(2)));
   }
 
@@ -305,7 +305,7 @@ class JooqSourceTest {
 
     database.query(ctx -> {
       ctx.fetch(
-          "INSERT INTO id_and_name (id, name, updated_at) VALUES (4,'riker', '2006-10-19T10:23:54-07:00'),  (5, 'data', '2006-10-19T10:23:54-07:00');");
+          "INSERT INTO id_and_name (id, name, updated_at) VALUES (4,'riker', '2006-10-19T10:23:54Z'),  (5, 'data', '2006-10-19T10:23:54Z');");
       return null;
     });
 
@@ -317,10 +317,10 @@ class JooqSourceTest {
     final List<AirbyteMessage> expectedMessages = new ArrayList<>();
     expectedMessages.add(new AirbyteMessage().withType(Type.RECORD)
         .withRecord(new AirbyteRecordMessage().withStream(STREAM_NAME)
-            .withData(Jsons.jsonNode(ImmutableMap.of("id", 4, "name", "riker", "updated_at", "2006-10-19T10:23:54-07:00")))));
+            .withData(Jsons.jsonNode(ImmutableMap.of("id", 4, "name", "riker", "updated_at", "2006-10-19T10:23:54Z")))));
     expectedMessages.add(new AirbyteMessage().withType(Type.RECORD)
         .withRecord(new AirbyteRecordMessage().withStream(STREAM_NAME)
-            .withData(Jsons.jsonNode(ImmutableMap.of("id", 5, "name", "data", "updated_at", "2006-10-19T10:23:54-07:00")))));
+            .withData(Jsons.jsonNode(ImmutableMap.of("id", 5, "name", "data", "updated_at", "2006-10-19T10:23:54Z")))));
     expectedMessages.add(new AirbyteMessage()
         .withType(Type.STATE)
         .withState(new AirbyteStateMessage()

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/PostgresJooqTestSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/PostgresJooqTestSource.java
@@ -46,6 +46,11 @@ public class PostgresJooqTestSource extends AbstractJooqSource implements Source
     return config;
   }
 
+  @Override
+  public String setTimezoneToUTCQuery() {
+    return "set time zone UTC;";
+  }
+
   public static void main(String[] args) throws Exception {
     final Source source = new PostgresJooqTestSource();
     LOGGER.info("starting source: {}", PostgresJooqTestSource.class);

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -58,6 +58,11 @@ public class PostgresSource extends AbstractJooqSource implements Source {
     return Jsons.jsonNode(configBuilder.build());
   }
 
+  @Override
+  public String setTimezoneToUTCQuery() {
+    return "set time zone UTC;";
+  }
+
   public static void main(String[] args) throws Exception {
     final Source source = new PostgresSource();
     LOGGER.info("starting source: {}", PostgresSource.class);

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
@@ -52,7 +52,6 @@ import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
 import io.airbyte.protocol.models.SyncMode;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
-import java.sql.SQLException;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
@@ -52,6 +52,7 @@ import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
 import io.airbyte.protocol.models.SyncMode;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;


### PR DESCRIPTION
## What
* Jooq seems to use the timezone from the system clock of the host it is running on to decide what timezone to use unless the timezone is explicitly set in the db client. This meant tests that ran successfully on my local machine would fail in the CI because the string representation of the time with timezone was different.
* I am considering 3 approaches:
  1. always set the timezone in the query so that the date comes in the expected format. (downside is we need to add a set time zone method to the abstract jooq source, because jooq doesn't have a dsl for this)
  1. look at the records that are returned from the read query and if any of them are temporal, mutate them to use the UTC time. (less excited about this, because if we are using jooq, i'd prefer it make good choices around how to format stuff so that i don't have to parse their output and risk messing it up. seems risky to me once you take into account all of the different temporal outputs)
  1. throw out jooq entirely. (🤷‍♀️ ).

## How
* this PR is exploring option 1.

## Pre-merge Checklist
* [ ] _Run integration tests_
* [ ] _Publish Docker images_

## Recommended reading order
1. `test.java`
1. `component.ts`
1. the rest



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200367912513076/1200368201269960) by [Unito](https://www.unito.io)
