### PR TITLE
Incremental singer sources

### DIFF
--- a/airbyte-integrations/bases/base-singer/base_singer/singer_helpers.py
+++ b/airbyte-integrations/bases/base-singer/base_singer/singer_helpers.py
@@ -97,6 +97,7 @@ def override_sync_modes_from_metadata(airbyte_stream: AirbyteStream, metadatas: 
             # TODO if there are multiple replication keys, allow configuring which one is used. For now we deterministically take the first
             airbyte_stream.default_cursor_field = [sorted(replication_keys)[0]]
 
+
 @staticmethod
 def override_sync_modes_from_overrides(airbyte_stream: AirbyteStream, overrides: SyncModeInfo):
     airbyte_stream.source_defined_cursor = overrides.source_defined_cursor or False
@@ -105,8 +106,8 @@ def override_sync_modes_from_overrides(airbyte_stream: AirbyteStream, overrides:
     if overrides.default_cursor_field:
         airbyte_stream.default_cursor_field = overrides.default_cursor_field
 
-class SingerHelper:
 
+class SingerHelper:
     @staticmethod
     def _transform_types(stream_properties: DefaultDict):
         for field_name in stream_properties:

--- a/airbyte-integrations/bases/base-singer/base_singer/source.py
+++ b/airbyte-integrations/bases/base-singer/base_singer/source.py
@@ -22,12 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from typing import Generator, Type, Dict
+from typing import Dict, Generator, Type
 
 from airbyte_protocol import AirbyteCatalog, AirbyteConnectionStatus, AirbyteMessage, ConfiguredAirbyteCatalog, Status
 from base_python import AirbyteLogger, CatalogHelper, ConfigContainer, Source
 
-from .singer_helpers import SingerHelper, Catalogs, SyncModeInfo
+from .singer_helpers import Catalogs, SingerHelper, SyncModeInfo
 
 
 class SingerSource(Source):

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/TestSource.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/TestSource.java
@@ -265,8 +265,12 @@ public abstract class TestSource {
       return;
     }
 
-    ConfiguredAirbyteCatalog configuredAirbyteCatalog = withSourceDefinedCursors(getConfiguredCatalog());
-    List<AirbyteMessage> airbyteMessages = runRead(configuredAirbyteCatalog, getState());
+    ConfiguredAirbyteCatalog configuredCatalog = withSourceDefinedCursors(getConfiguredCatalog());
+    // only sync incremental streams
+    configuredCatalog.setStreams(
+        configuredCatalog.getStreams().stream().filter(s -> s.getSyncMode() == INCREMENTAL).collect(Collectors.toList())
+    );
+    List<AirbyteMessage> airbyteMessages = runRead(configuredCatalog, getState());
     List<AirbyteRecordMessage> recordMessages = filterRecords(airbyteMessages);
     List<AirbyteStateMessage> stateMessages = airbyteMessages
         .stream()

--- a/airbyte-integrations/connectors/source-github-singer/source_github_singer/source.py
+++ b/airbyte-integrations/connectors/source-github-singer/source_github_singer/source.py
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+
 from typing import Dict
 
 import requests
@@ -68,7 +69,8 @@ class SourceGithubSinger(SingerSource):
             "project_columns",
             "team_members",
             "pull_request_reviews",
-            "pr_commits"]
+            "pr_commits",
+        ]
 
         full_refreshes = ["assignees", "collaborators", "pull_requests", "reviews", "releases"]
         overrides = {}

--- a/airbyte-integrations/connectors/source-intercom-singer/Dockerfile.test
+++ b/airbyte-integrations/connectors/source-intercom-singer/Dockerfile.test
@@ -18,7 +18,7 @@ LABEL io.airbyte.name=airbyte/source-intercom-singer-standard-test
 WORKDIR /airbyte/integration_code
 COPY $MODULE_NAME $MODULE_NAME
 COPY $CODE_PATH $CODE_PATH
-COPY secrets/* $CODE_PATH
+COPY secrets/config.json $CODE_PATH/config.json
 COPY $MODULE_NAME/*.json $CODE_PATH/
 COPY sample_files/*.json $CODE_PATH/
 COPY setup.py ./

--- a/airbyte-integrations/connectors/source-intercom-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-intercom-singer/sample_files/configured_catalog.json
@@ -1,586 +1,26 @@
 {
   "streams": [
-    {"stream": {
-      "name": "admins",
-      "json_schema": {
-        "properties": {
-          "admin_ids": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "integer"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "avatar": {
-            "properties": {
-              "image_url": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "away_mode_enabled": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "away_mode_reassign": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "email": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "has_inbox_seat": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "job_title": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "team_ids": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "integer"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      }
-    }},
-    {"stream": {
-      "name": "companies",
-      "json_schema": {
-        "properties": {
-          "company_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "custom_attributes": {
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": true
-          },
-          "id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "industry": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "monthly_spend": {
-            "multipleOf": 1e-08,
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "plan": {
-            "properties": {
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "name": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "remote_created_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "segments": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": [
-                    "null",
-                    "object"
-                  ],
-                  "additionalProperties": false,
-                  "properties": {
-                    "id": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    }
-                  }
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "session_count": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "size": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "tags": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": [
-                    "null",
-                    "object"
-                  ],
-                  "additionalProperties": false,
-                  "properties": {
-                    "id": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    }
-                  }
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "user_count": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "website": {
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "supported_sync_modes": [
-        "incremental"
-      ],
-      "source_defined_cursor": true,
-      "default_cursor_field": [
-        "updated_at"
-      ]
-    }},
-    {"stream": {
-      "name": "company_attributes",
-      "json_schema": {
-        "properties": {
-          "admin_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "api_writable": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "archived": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "created_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "custom": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "data_type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "description": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "full_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "label": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "model": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "options": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "ui_writable": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "updated_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      }
-    }},
-    {"stream": {
-      "name": "company_segments",
-      "json_schema": {
-        "properties": {
-          "created_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "count": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "supported_sync_modes": [
-        "incremental"
-      ],
-      "source_defined_cursor": true,
-      "default_cursor_field": [
-        "updated_at"
-      ]
-    }},
-    {"stream": {
-      "name": "conversations",
-      "json_schema": {
-        "properties": {
-          "assignee": {
-            "properties": {
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "name": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "email": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "source": {
-            "properties": {
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "delivered_as": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "subject": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "body": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "author": {
-                "properties": {
-                  "id": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "type": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "name": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "email": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
+    {
+      "stream": {
+        "name": "admins",
+        "json_schema": {
+          "properties": {
+            "admin_ids": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
                   }
                 },
-                "type": [
-                  "null",
-                  "object"
-                ],
-                "additionalProperties": false
-              },
-              "attachments": {
-                "items": {
-                  "properties": {},
-                  "type": [
-                    "null",
-                    "object"
-                  ],
-                  "additionalProperties": true
-                },
-                "type": [
-                  "null",
-                  "array"
-                ]
-              },
-              "url": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
+                {
+                  "type": "null"
+                }
+              ]
             },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "contacts": {
-            "items": {
+            "avatar": {
               "properties": {
-                "type": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                "id": {
+                "image_url": {
                   "type": [
                     "null",
                     "string"
@@ -593,579 +33,125 @@
               ],
               "additionalProperties": false
             },
-            "type": [
-              "null",
-              "array"
-            ]
-          },
-          "teammates": {
-            "properties": {
-              "admins": {
-                "items": {
-                  "properties": {
-                    "id": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "type": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    }
-                  },
-                  "type": [
-                    "null",
-                    "object"
-                  ],
-                  "additionalProperties": false
-                },
-                "type": [
-                  "null",
-                  "array"
-                ]
-              },
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
+            "away_mode_enabled": {
+              "type": [
+                "null",
+                "boolean"
+              ]
             },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "first_contact_reply": {
-            "properties": {
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "url": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "created_at": {
-                "format": "date-time",
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
+            "away_mode_reassign": {
+              "type": [
+                "null",
+                "boolean"
+              ]
             },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "priority": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "conversation_message": {
-            "properties": {
-              "attachments": {
-                "anyOf": [
-                  {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "type": {
-                          "type": [
-                            "null",
-                            "string"
-                          ]
-                        },
-                        "name": {
-                          "type": [
-                            "null",
-                            "string"
-                          ]
-                        },
-                        "url": {
-                          "type": [
-                            "null",
-                            "string"
-                          ]
-                        },
-                        "content_type": {
-                          "type": [
-                            "null",
-                            "string"
-                          ]
-                        },
-                        "filesize": {
-                          "type": [
-                            "null",
-                            "integer"
-                          ]
-                        },
-                        "height": {
-                          "type": [
-                            "null",
-                            "integer"
-                          ]
-                        },
-                        "width": {
-                          "type": [
-                            "null",
-                            "integer"
-                          ]
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "author": {
-                "properties": {
-                  "id": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "type": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "name": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "email": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
+            "email": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "has_inbox_seat": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "job_title": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "team_ids": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
                   }
                 },
-                "type": [
-                  "null",
-                  "object"
-                ],
-                "additionalProperties": false
-              },
-              "body": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "delivered_as": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "subject": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "url": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "conversation_rating": {
-            "properties": {
-              "created_at": {
-                "format": "date-time",
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "customer": {
-                "properties": {
-                  "id": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "type": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  }
-                },
-                "type": [
-                  "null",
-                  "object"
-                ],
-                "additionalProperties": false
-              },
-              "rating": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "remark": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "teammate": {
-                "properties": {
-                  "id": {
-                    "type": [
-                      "null",
-                      "integer"
-                    ]
-                  },
-                  "type": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  }
-                },
-                "type": [
-                  "null",
-                  "object"
-                ],
-                "additionalProperties": false
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "created_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "customer_first_reply": {
-            "properties": {
-              "created_at": {
-                "format": "date-time",
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "url": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "customers": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": [
-                    "null",
-                    "object"
-                  ],
-                  "additionalProperties": false,
-                  "properties": {
-                    "id": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "type": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    }
-                  }
+                {
+                  "type": "null"
                 }
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "open": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "read": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "sent_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "snoozed_until": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "sla_applied": {
-            "properties": {
-              "sla_name": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "sla_status": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
+              ]
             },
-            "type": [
-              "null",
-              "object"
-            ]
+            "type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
           },
-          "state": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "statistics": {
-            "properties": {
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "time_to_assignment": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "time_to_admin_reply": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "time_to_first_close": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "time_to_last_close": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "median_time_to_reply": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "first_contact_reply_at": {
-                "format": "date-time",
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "first_assignment_at": {
-                "format": "date-time",
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "first_admin_reply_at": {
-                "format": "date-time",
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "first_close_at": {
-                "format": "date-time",
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "last_assignment_at": {
-                "format": "date-time",
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "last_assignment_admin_reply_at": {
-                "format": "date-time",
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "last_contact_reply_at": {
-                "format": "date-time",
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "last_admin_reply_at": {
-                "format": "date-time",
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "last_close_at": {
-                "format": "date-time",
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "last_closed_by_id": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "count_reopens": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "count_assignments": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "count_conversation_parts": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              }
+          "type": "object",
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "stream": {
+        "name": "companies",
+        "json_schema": {
+          "properties": {
+            "company_id": {
+              "type": [
+                "null",
+                "string"
+              ]
             },
-            "type": [
-              "null",
-              "object"
-            ]
-          },
-          "tags": {
-            "items": {
+            "created_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "custom_attributes": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": true
+            },
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "industry": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "monthly_spend": {
+              "multipleOf": 1e-08,
+              "type": [
+                "null",
+                "number"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "plan": {
               "properties": {
-                "applied_at": {
-                  "format": "date-time",
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                "applied_by": {
-                  "properties": {
-                    "id": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "type": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    }
-                  },
-                  "type": [
-                    "null",
-                    "object"
-                  ],
-                  "additionalProperties": false
-                },
                 "id": {
                   "type": [
                     "null",
@@ -1191,432 +177,361 @@
               ],
               "additionalProperties": false
             },
-            "type": [
-              "null",
-              "array"
-            ]
-          },
-          "type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "user": {
-            "properties": {
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "waiting_since": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "supported_sync_modes": [
-        "incremental"
-      ],
-      "source_defined_cursor": true,
-      "default_cursor_field": [
-        "updated_at"
-      ]
-    }},
-    {"stream": {
-      "name": "conversation_parts",
-      "json_schema": {
-        "properties": {
-          "assigned_to": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "attachments": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "type": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "name": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "url": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "content_type": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "filesize": {
-                      "type": [
-                        "null",
-                        "integer"
-                      ]
-                    },
-                    "height": {
-                      "type": [
-                        "null",
-                        "integer"
-                      ]
-                    },
-                    "width": {
-                      "type": [
-                        "null",
-                        "integer"
-                      ]
-                    }
-                  }
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "author": {
-            "properties": {
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "name": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "email": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "body": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "conversation_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "conversation_created_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "conversation_updated_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "conversation_total_parts": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "created_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "external_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "notified_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "part_type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      }
-    }},
-    {"stream": {
-      "name": "contact_attributes",
-      "json_schema": {
-        "properties": {
-          "type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "model": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "full_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "label": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "description": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "data_type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "options": {
-            "items": {
+            "remote_created_at": {
+              "format": "date-time",
               "type": [
                 "null",
                 "string"
               ]
             },
-            "type": [
-              "null",
-              "array"
-            ]
+            "segments": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "session_count": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "size": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "tags": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "updated_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "user_count": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "website": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
           },
-          "api_writable": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "ui_writable": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "custom": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "archived": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "admin_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "created_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          }
+          "type": "object",
+          "additionalProperties": false
         },
-        "type": [
-          "null",
-          "object"
+        "supported_sync_modes": [
+          "incremental"
         ],
-        "additionalProperties": false
+        "source_defined_cursor": true,
+        "default_cursor_field": [
+          "updated_at"
+        ]
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["updated_at"]
+    },
+    {
+      "stream": {
+        "name": "company_attributes",
+        "json_schema": {
+          "properties": {
+            "admin_id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "api_writable": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "archived": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "created_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "custom": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "data_type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "description": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "full_name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "label": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "model": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "options": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ui_writable": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "updated_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
       }
-    }},
-    {"stream": {
-      "name": "contacts",
-      "json_schema": {
-        "properties": {
-          "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+    },
+    {
+      "stream": {
+        "name": "company_segments",
+        "json_schema": {
+          "properties": {
+            "created_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "count": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "updated_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
           },
-          "id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "workspace_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "external_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "role": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "email": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "phone": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "avatar": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "owner_id": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "social_profiles": {
-            "properties": {
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
+          "type": "object",
+          "additionalProperties": false
+        },
+        "supported_sync_modes": [
+          "incremental"
+        ],
+        "source_defined_cursor": true,
+        "default_cursor_field": [
+          "updated_at"
+        ]
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["updated_at"]
+    },
+    {
+      "stream": {
+        "name": "conversations",
+        "json_schema": {
+          "properties": {
+            "assignee": {
+              "properties": {
+                "id": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "name": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "email": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
               },
-              "data": {
-                "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "source": {
+              "properties": {
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "id": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "delivered_as": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "subject": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "body": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "author": {
                   "properties": {
+                    "id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
                     "type": {
                       "type": [
                         "null",
@@ -1629,7 +544,7 @@
                         "string"
                       ]
                     },
-                    "url": {
+                    "email": {
                       "type": [
                         "null",
                         "string"
@@ -1642,570 +557,1687 @@
                   ],
                   "additionalProperties": false
                 },
-                "type": [
-                  "null",
-                  "array"
-                ]
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "has_hard_bounced": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "marked_email_as_spam": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "unsubscribed_from_emails": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
-          "created_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "signed_up_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "last_seen_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "last_replied_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "last_contacted_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "last_email_opened_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "last_email_clicked_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "language_override": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "browser": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "browser_version": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "browser_language": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "os": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "location": {
-            "properties": {
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "country": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "region": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "city": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "android_app_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "android_app_version": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "android_device": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "android_os_version": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "android_sdk_version": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "android_last_seen_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "ios_app_name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "ios_app_version": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "ios_device": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "ios_os_version": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "ios_sdk_version": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "ios_last_seen_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "custom_attributes": {
-            "properties": {},
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": true
-          },
-          "tags": {
-            "properties": {
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "data": {
-                "items": {
-                  "properties": {
-                    "type": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "id": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "url": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    }
+                "attachments": {
+                  "items": {
+                    "properties": {},
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "additionalProperties": true
                   },
                   "type": [
                     "null",
-                    "object"
-                  ],
-                  "additionalProperties": false
+                    "array"
+                  ]
                 },
-                "type": [
-                  "null",
-                  "array"
-                ]
-              },
-              "url": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "total_count": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "has_more": {
-                "type": [
-                  "null",
-                  "boolean"
-                ]
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "notes": {
-            "properties": {
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "data": {
-                "items": {
-                  "properties": {
-                    "type": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "id": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "url": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    }
-                  },
+                "url": {
                   "type": [
                     "null",
-                    "object"
-                  ],
-                  "additionalProperties": false
-                },
-                "type": [
-                  "null",
-                  "array"
-                ]
-              },
-              "url": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "total_count": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "has_more": {
-                "type": [
-                  "null",
-                  "boolean"
-                ]
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          },
-          "companies": {
-            "properties": {
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "data": {
-                "items": {
-                  "properties": {
-                    "type": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "id": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "url": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    }
-                  },
-                  "type": [
-                    "null",
-                    "object"
-                  ],
-                  "additionalProperties": false
-                },
-                "type": [
-                  "null",
-                  "array"
-                ]
-              },
-              "url": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "total_count": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "has_more": {
-                "type": [
-                  "null",
-                  "boolean"
-                ]
-              }
-            },
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": false
-          }
-        },
-        "type": [
-          "null",
-          "object"
-        ],
-        "additionalProperties": false
-      },
-      "supported_sync_modes": [
-        "incremental"
-      ],
-      "source_defined_cursor": true,
-      "default_cursor_field": [
-        "updated_at"
-      ]
-    }},
-    {"stream": {
-      "name": "segments",
-      "json_schema": {
-        "properties": {
-          "created_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "count": {
-            "type": [
-              "null",
-              "integer"
-            ]
-          },
-          "id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "updated_at": {
-            "format": "date-time",
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      },
-      "supported_sync_modes": [
-        "incremental"
-      ],
-      "source_defined_cursor": true,
-      "default_cursor_field": [
-        "updated_at"
-      ]
-    }},
-    {"stream": {
-      "name": "tags",
-      "json_schema": {
-        "properties": {
-          "id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      }
-    }},
-    {"stream": {
-      "name": "teams",
-      "json_schema": {
-        "properties": {
-          "admin_ids": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "integer"
+                    "string"
+                  ]
                 }
               },
-              {
-                "type": "null"
-              }
-            ]
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "contacts": {
+              "items": {
+                "properties": {
+                  "type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                },
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false
+              },
+              "type": [
+                "null",
+                "array"
+              ]
+            },
+            "teammates": {
+              "properties": {
+                "admins": {
+                  "items": {
+                    "properties": {
+                      "id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "type": [
+                    "null",
+                    "array"
+                  ]
+                },
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "first_contact_reply": {
+              "properties": {
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "url": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "created_at": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "priority": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "conversation_message": {
+              "properties": {
+                "attachments": {
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "name": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "url": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "content_type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "filesize": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "height": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "width": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "author": {
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "name": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "email": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "additionalProperties": false
+                },
+                "body": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "delivered_as": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "id": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "subject": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "url": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "conversation_rating": {
+              "properties": {
+                "created_at": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "customer": {
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "additionalProperties": false
+                },
+                "rating": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "remark": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "teammate": {
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "created_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "customer_first_reply": {
+              "properties": {
+                "created_at": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "url": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "customers": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "open": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "read": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "sent_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "snoozed_until": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "sla_applied": {
+              "properties": {
+                "sla_name": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "sla_status": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ]
+            },
+            "state": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "statistics": {
+              "properties": {
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "time_to_assignment": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "time_to_admin_reply": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "time_to_first_close": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "time_to_last_close": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "median_time_to_reply": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "first_contact_reply_at": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "first_assignment_at": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "first_admin_reply_at": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "first_close_at": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "last_assignment_at": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "last_assignment_admin_reply_at": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "last_contact_reply_at": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "last_admin_reply_at": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "last_close_at": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "last_closed_by_id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "count_reopens": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "count_assignments": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "count_conversation_parts": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ]
+            },
+            "tags": {
+              "items": {
+                "properties": {
+                  "applied_at": {
+                    "format": "date-time",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "applied_by": {
+                    "properties": {
+                      "id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                },
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false
+              },
+              "type": [
+                "null",
+                "array"
+              ]
+            },
+            "type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "updated_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "user": {
+              "properties": {
+                "id": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "waiting_since": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
           },
-          "id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "name": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          }
+          "type": "object",
+          "additionalProperties": false
         },
-        "type": "object",
-        "additionalProperties": false
+        "supported_sync_modes": [
+          "incremental"
+        ],
+        "source_defined_cursor": true,
+        "default_cursor_field": [
+          "updated_at"
+        ]
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["updated_at"]
+    },
+    {
+      "stream": {
+        "name": "conversation_parts",
+        "json_schema": {
+          "properties": {
+            "assigned_to": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "attachments": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "url": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "content_type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "filesize": {
+                        "type": [
+                          "null",
+                          "integer"
+                        ]
+                      },
+                      "height": {
+                        "type": [
+                          "null",
+                          "integer"
+                        ]
+                      },
+                      "width": {
+                        "type": [
+                          "null",
+                          "integer"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "author": {
+              "properties": {
+                "id": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "name": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "email": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "body": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "conversation_id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "conversation_created_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "conversation_updated_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "conversation_total_parts": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "created_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "external_id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "notified_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "part_type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "updated_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
       }
-    }}
+    },
+    {
+      "stream": {
+        "name": "contact_attributes",
+        "json_schema": {
+          "properties": {
+            "type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "model": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "full_name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "label": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "description": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "data_type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "options": {
+              "items": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "type": [
+                "null",
+                "array"
+              ]
+            },
+            "api_writable": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "ui_writable": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "custom": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "archived": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "admin_id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "created_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "updated_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "stream": {
+        "name": "contacts",
+        "json_schema": {
+          "properties": {
+            "type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "workspace_id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "external_id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "role": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "email": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "phone": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "avatar": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "owner_id": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "social_profiles": {
+              "properties": {
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "data": {
+                  "items": {
+                    "properties": {
+                      "type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "url": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "type": [
+                    "null",
+                    "array"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "has_hard_bounced": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "marked_email_as_spam": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "unsubscribed_from_emails": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "created_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "updated_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "signed_up_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "last_seen_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "last_replied_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "last_contacted_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "last_email_opened_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "last_email_clicked_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "language_override": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "browser": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "browser_version": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "browser_language": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "os": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "location": {
+              "properties": {
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "country": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "region": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "city": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "android_app_name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "android_app_version": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "android_device": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "android_os_version": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "android_sdk_version": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "android_last_seen_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ios_app_name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ios_app_version": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ios_device": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ios_os_version": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ios_sdk_version": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ios_last_seen_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "custom_attributes": {
+              "properties": {},
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": true
+            },
+            "tags": {
+              "properties": {
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "data": {
+                  "items": {
+                    "properties": {
+                      "type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "url": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "type": [
+                    "null",
+                    "array"
+                  ]
+                },
+                "url": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "total_count": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "has_more": {
+                  "type": [
+                    "null",
+                    "boolean"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "notes": {
+              "properties": {
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "data": {
+                  "items": {
+                    "properties": {
+                      "type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "url": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "type": [
+                    "null",
+                    "array"
+                  ]
+                },
+                "url": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "total_count": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "has_more": {
+                  "type": [
+                    "null",
+                    "boolean"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "companies": {
+              "properties": {
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "data": {
+                  "items": {
+                    "properties": {
+                      "type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "id": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "url": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "type": [
+                    "null",
+                    "array"
+                  ]
+                },
+                "url": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "total_count": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "has_more": {
+                  "type": [
+                    "null",
+                    "boolean"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false
+        },
+        "supported_sync_modes": [
+          "incremental"
+        ],
+        "source_defined_cursor": true,
+        "default_cursor_field": [
+          "updated_at"
+        ]
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["updated_at"]
+    },
+    {
+      "stream": {
+        "name": "segments",
+        "json_schema": {
+          "properties": {
+            "created_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "count": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "updated_at": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "supported_sync_modes": [
+          "incremental"
+        ],
+        "source_defined_cursor": true,
+        "default_cursor_field": [
+          "updated_at"
+        ]
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["updated_at"]
+    },
+    {
+      "stream": {
+        "name": "tags",
+        "json_schema": {
+          "properties": {
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "stream": {
+        "name": "teams",
+        "json_schema": {
+          "properties": {
+            "admin_ids": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      }
+    }
   ]
 }

--- a/airbyte-integrations/connectors/source-intercom-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-intercom-singer/sample_files/configured_catalog.json
@@ -1,188 +1,2211 @@
 {
   "streams": [
-    {
-      "stream": {
-        "name": "admins",
-        "json_schema": {
-          "properties": {
-            "admin_ids": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "integer"
-                  }
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "avatar": {
-              "properties": {
-                "image_url": {
-                  "type": ["null", "string"]
+    {"stream": {
+      "name": "admins",
+      "json_schema": {
+        "properties": {
+          "admin_ids": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "integer"
                 }
               },
-              "type": ["null", "object"],
-              "additionalProperties": false
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "avatar": {
+            "properties": {
+              "image_url": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
             },
-            "away_mode_enabled": {
-              "type": ["null", "boolean"]
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "away_mode_enabled": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "away_mode_reassign": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "email": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "has_inbox_seat": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "job_title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "team_ids": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      }
+    }},
+    {"stream": {
+      "name": "companies",
+      "json_schema": {
+        "properties": {
+          "company_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "custom_attributes": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": true
+          },
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "industry": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "monthly_spend": {
+            "multipleOf": 1e-08,
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "plan": {
+            "properties": {
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
             },
-            "away_mode_reassign": {
-              "type": ["null", "boolean"]
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "remote_created_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "segments": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "session_count": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "size": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "user_count": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "website": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "supported_sync_modes": [
+        "incremental"
+      ],
+      "source_defined_cursor": true,
+      "default_cursor_field": [
+        "updated_at"
+      ]
+    }},
+    {"stream": {
+      "name": "company_attributes",
+      "json_schema": {
+        "properties": {
+          "admin_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "api_writable": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "archived": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "custom": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "data_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "full_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "label": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "model": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "options": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ui_writable": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      }
+    }},
+    {"stream": {
+      "name": "company_segments",
+      "json_schema": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "count": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "supported_sync_modes": [
+        "incremental"
+      ],
+      "source_defined_cursor": true,
+      "default_cursor_field": [
+        "updated_at"
+      ]
+    }},
+    {"stream": {
+      "name": "conversations",
+      "json_schema": {
+        "properties": {
+          "assignee": {
+            "properties": {
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "email": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
             },
-            "email": {
-              "type": ["null", "string"]
-            },
-            "has_inbox_seat": {
-              "type": ["null", "boolean"]
-            },
-            "id": {
-              "type": ["null", "string"]
-            },
-            "job_title": {
-              "type": ["null", "string"]
-            },
-            "name": {
-              "type": ["null", "string"]
-            },
-            "team_ids": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "integer"
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "source": {
+            "properties": {
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "delivered_as": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "subject": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "body": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "author": {
+                "properties": {
+                  "id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "email": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
                   }
                 },
-                {
-                  "type": "null"
-                }
-              ]
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false
+              },
+              "attachments": {
+                "items": {
+                  "properties": {},
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "additionalProperties": true
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "url": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
             },
-            "type": {
-              "type": ["null", "string"]
-            }
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
           },
-          "type": "object",
-          "additionalProperties": false
-        }
-      }
-    },
-    {
-      "stream": {
-        "name": "companies",
-        "json_schema": {
-          "properties": {
-            "company_id": {
-              "type": ["null", "string"]
-            },
-            "created_at": {
-              "format": "date-time",
-              "type": ["null", "string"]
-            },
-            "custom_attributes": {
-              "type": ["null", "object"],
-              "additionalProperties": true
-            },
-            "id": {
-              "type": ["null", "string"]
-            },
-            "industry": {
-              "type": ["null", "string"]
-            },
-            "monthly_spend": {
-              "multipleOf": 1e-8,
-              "type": ["null", "number"]
-            },
-            "name": {
-              "type": ["null", "string"]
-            },
-            "plan": {
+          "contacts": {
+            "items": {
               "properties": {
+                "type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
                 "id": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "teammates": {
+            "properties": {
+              "admins": {
+                "items": {
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "first_contact_reply": {
+            "properties": {
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "url": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "created_at": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "priority": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "conversation_message": {
+            "properties": {
+              "attachments": {
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "url": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "content_type": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "filesize": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        },
+                        "height": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        },
+                        "width": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "author": {
+                "properties": {
+                  "id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "email": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                },
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false
+              },
+              "body": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "delivered_as": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "subject": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "url": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "conversation_rating": {
+            "properties": {
+              "created_at": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "customer": {
+                "properties": {
+                  "id": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                },
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false
+              },
+              "rating": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "remark": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "teammate": {
+                "properties": {
+                  "id": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                },
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "customer_first_reply": {
+            "properties": {
+              "created_at": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "url": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "customers": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "open": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "read": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "sent_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "snoozed_until": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "sla_applied": {
+            "properties": {
+              "sla_name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "sla_status": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ]
+          },
+          "state": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "statistics": {
+            "properties": {
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "time_to_assignment": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "time_to_admin_reply": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "time_to_first_close": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "time_to_last_close": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "median_time_to_reply": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "first_contact_reply_at": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "first_assignment_at": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "first_admin_reply_at": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "first_close_at": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "last_assignment_at": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "last_assignment_admin_reply_at": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "last_contact_reply_at": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "last_admin_reply_at": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "last_close_at": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "last_closed_by_id": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "count_reopens": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "count_assignments": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "count_conversation_parts": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ]
+          },
+          "tags": {
+            "items": {
+              "properties": {
+                "applied_at": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "applied_by": {
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "additionalProperties": false
+                },
+                "id": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "name": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "type": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 }
               },
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": false
             },
-            "remote_created_at": {
-              "format": "date-time",
-              "type": ["null", "string"]
-            },
-            "segments": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": ["null", "object"],
-                    "additionalProperties": false,
-                    "properties": {
-                      "id": {
-                        "type": ["null", "string"]
-                      }
-                    }
-                  }
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "session_count": {
-              "type": ["null", "integer"]
-            },
-            "size": {
-              "type": ["null", "integer"]
-            },
-            "tags": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": ["null", "object"],
-                    "additionalProperties": false,
-                    "properties": {
-                      "id": {
-                        "type": ["null", "string"]
-                      }
-                    }
-                  }
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "type": {
-              "type": ["null", "string"]
-            },
-            "updated_at": {
-              "format": "date-time",
-              "type": ["null", "string"]
-            },
-            "user_count": {
-              "type": ["null", "integer"]
-            },
-            "website": {
-              "type": ["null", "string"]
-            }
+            "type": [
+              "null",
+              "array"
+            ]
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "user": {
+            "properties": {
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "waiting_since": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
         },
-        "supported_sync_modes": ["full_refresh"],
-        "source_defined_cursor": true,
-        "default_cursor_field": ["updated_at"]
+        "type": "object",
+        "additionalProperties": false
+      },
+      "supported_sync_modes": [
+        "incremental"
+      ],
+      "source_defined_cursor": true,
+      "default_cursor_field": [
+        "updated_at"
+      ]
+    }},
+    {"stream": {
+      "name": "conversation_parts",
+      "json_schema": {
+        "properties": {
+          "assigned_to": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "attachments": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "name": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "url": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "content_type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "filesize": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "height": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "width": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "author": {
+            "properties": {
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "email": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "body": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "conversation_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "conversation_created_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "conversation_updated_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "conversation_total_parts": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "external_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "notified_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "part_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
       }
-    }
+    }},
+    {"stream": {
+      "name": "contact_attributes",
+      "json_schema": {
+        "properties": {
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "model": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "full_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "label": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "data_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "options": {
+            "items": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "api_writable": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "ui_writable": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "custom": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "archived": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "admin_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      }
+    }},
+    {"stream": {
+      "name": "contacts",
+      "json_schema": {
+        "properties": {
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "workspace_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "external_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "role": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "email": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "phone": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "avatar": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "owner_id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "social_profiles": {
+            "properties": {
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "data": {
+                "items": {
+                  "properties": {
+                    "type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "name": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "url": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "has_hard_bounced": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "marked_email_as_spam": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "unsubscribed_from_emails": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "signed_up_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "last_seen_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "last_replied_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "last_contacted_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "last_email_opened_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "last_email_clicked_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "language_override": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "browser": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "browser_version": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "browser_language": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "os": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "location": {
+            "properties": {
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "country": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "region": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "city": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "android_app_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "android_app_version": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "android_device": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "android_os_version": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "android_sdk_version": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "android_last_seen_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ios_app_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ios_app_version": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ios_device": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ios_os_version": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ios_sdk_version": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ios_last_seen_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "custom_attributes": {
+            "properties": {},
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": true
+          },
+          "tags": {
+            "properties": {
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "data": {
+                "items": {
+                  "properties": {
+                    "type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "url": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "url": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "total_count": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "has_more": {
+                "type": [
+                  "null",
+                  "boolean"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "notes": {
+            "properties": {
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "data": {
+                "items": {
+                  "properties": {
+                    "type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "url": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "url": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "total_count": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "has_more": {
+                "type": [
+                  "null",
+                  "boolean"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "companies": {
+            "properties": {
+              "type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "data": {
+                "items": {
+                  "properties": {
+                    "type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "id": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "url": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "url": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "total_count": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "has_more": {
+                "type": [
+                  "null",
+                  "boolean"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      },
+      "supported_sync_modes": [
+        "incremental"
+      ],
+      "source_defined_cursor": true,
+      "default_cursor_field": [
+        "updated_at"
+      ]
+    }},
+    {"stream": {
+      "name": "segments",
+      "json_schema": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "count": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "supported_sync_modes": [
+        "incremental"
+      ],
+      "source_defined_cursor": true,
+      "default_cursor_field": [
+        "updated_at"
+      ]
+    }},
+    {"stream": {
+      "name": "tags",
+      "json_schema": {
+        "properties": {
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      }
+    }},
+    {"stream": {
+      "name": "teams",
+      "json_schema": {
+        "properties": {
+          "admin_ids": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      }
+    }}
   ]
 }

--- a/airbyte-integrations/connectors/source-intercom-singer/source_intercom_singer/source.py
+++ b/airbyte-integrations/connectors/source-intercom-singer/source_intercom_singer/source.py
@@ -33,7 +33,6 @@ class SourceIntercomSinger(BaseSingerSource):
     tap_cmd = "tap-intercom"
     tap_name = "Intercom API"
     api_error = IntercomError
-    force_full_refresh = True
 
     def transform_config(self, raw_config) -> Mapping[str, Any]:
         return {

--- a/airbyte-integrations/connectors/source-shopify-singer/integration_tests/integration_test_catalog.json
+++ b/airbyte-integrations/connectors/source-shopify-singer/integration_tests/integration_test_catalog.json
@@ -249,7 +249,7 @@
           },
           "type": "object"
         },
-        "supported_sync_modes": ["full_refresh", "incremental"],
+        "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true,
         "default_cursor_field": ["updated_at"]
       },

--- a/airbyte-integrations/connectors/source-stripe-singer/source_stripe_singer/source.py
+++ b/airbyte-integrations/connectors/source-stripe-singer/source_stripe_singer/source.py
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+
 from typing import Dict
 
 import requests
@@ -62,8 +63,7 @@ class SourceStripeSinger(SingerSource):
             "balance_transactions",
             "payouts",
             "payout_transactions",
-            "products"
-            "transfers",
+            "products" "transfers",
         ]
         #  All streams are incremental only
         return {stream: SyncModeInfo(supported_sync_modes=[SyncMode.incremental]) for stream in streams}


### PR DESCRIPTION
## What
This PR enables incremental syncs for 4 sources: 
* Github
* Intercom
* shopify
* Stripe

## How
* Allows overriding sync modes on a per-stream basis in the singer source 

## Pre-merge checklist
- [x] Make standard source tests work well with mixed incremental/full refresh catalogs #1272 
- [x] ~Test Stripe using standard source tests (currently using java tests)~ -- will do in a future PR. 

## Reading Order
1. `singer_helpers.py`
1. `base_singer/source.py`
1. everything else