### PR TITLE
only add test listener once

### DIFF
--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/TestRunner.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/TestRunner.java
@@ -46,7 +46,6 @@ public class TestRunner {
 
     // Register a listener of your choice
     final SummaryGeneratingListener listener = new SummaryGeneratingListener();
-    launcher.registerTestExecutionListeners(listener);
 
     launcher.execute(plan, listener);
 


### PR DESCRIPTION
resolves https://github.com/airbytehq/airbyte/issues/763

The same listener was being added both via `registerTestExecutionListeners` and `launcher.execute(plan, listener);`.

Tested and resulted with:
```
Test run finished after 70432 ms
[         2 containers found      ]
[         0 containers skipped    ]
[         2 containers started    ]
[         0 containers aborted    ]
[         2 containers successful ]
[         0 containers failed     ]
[         7 tests found           ]
[         0 tests skipped         ]
[         7 tests started         ]
[         0 tests aborted         ]
[         7 tests successful      ]
[         0 tests failed          ]
```

It had 14 originally so it looks like this works as expected.