### PR TITLE
upgrade test containers

### DIFF
--- a/airbyte-db/build.gradle
+++ b/airbyte-db/build.gradle
@@ -8,5 +8,5 @@ dependencies {
     api 'org.jooq:jooq:3.13.4'
     api 'org.postgresql:postgresql:42.2.18'
 
-    testImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+    testImplementation "org.testcontainers:postgresql:1.15.1"
 }

--- a/airbyte-integrations/connectors/destination-jdbc/build.gradle
+++ b/airbyte-integrations/connectors/destination-jdbc/build.gradle
@@ -14,10 +14,10 @@ dependencies {
     implementation project(':airbyte-integrations:bases:base-java')
     implementation project(':airbyte-protocol:models')
 
-    testImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+    testImplementation "org.testcontainers:postgresql:1.15.1"
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
-    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.1"
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)

--- a/airbyte-integrations/connectors/destination-postgres/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres/build.gradle
@@ -15,10 +15,10 @@ dependencies {
     implementation project(':airbyte-protocol:models')
     implementation project(':airbyte-integrations:connectors:destination-jdbc')
 
-    testImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+    testImplementation "org.testcontainers:postgresql:1.15.1"
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
-    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.1"
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)

--- a/airbyte-integrations/connectors/source-jdbc/build.gradle
+++ b/airbyte-integrations/connectors/source-jdbc/build.gradle
@@ -18,10 +18,10 @@ dependencies {
     implementation project(':airbyte-protocol:models')
     implementation 'org.apache.commons:commons-lang3:3.11'
 
-    testImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+    testImplementation "org.testcontainers:postgresql:1.15.1"
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
-    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.1"
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/source-mssql/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql/build.gradle
@@ -18,9 +18,7 @@ dependencies {
 
     implementation 'com.microsoft.sqlserver:mssql-jdbc:8.4.1.jre14'
 
-    // on rc version due to docker pull bug in current stable version.
-    // issue: https://github.com/airbytehq/airbyte/issues/493
-    testImplementation "org.testcontainers:mssqlserver:1.15.0-rc2"
+    testImplementation "org.testcontainers:mssqlserver:1.15.1"
 
     testImplementation 'org.apache.commons:commons-text:1.9'
     testImplementation 'org.apache.commons:commons-lang3:3.11'

--- a/airbyte-integrations/connectors/source-mysql/build.gradle
+++ b/airbyte-integrations/connectors/source-mysql/build.gradle
@@ -16,14 +16,12 @@ dependencies {
     implementation project(':airbyte-integrations:connectors:source-jdbc')
 
     implementation 'mysql:mysql-connector-java:8.0.22'
-    // on rc version due to docker pull bug in current stable version.
-    // issue: https://github.com/airbytehq/airbyte/issues/493
-    testImplementation 'org.testcontainers:mysql:1.15.0-rc2'
+    testImplementation 'org.testcontainers:mysql:1.15.1'
 
     implementation 'org.apache.commons:commons-lang3:3.11'
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
-    testImplementation 'org.testcontainers:mysql:1.15.0-rc2'
+    testImplementation 'org.testcontainers:mysql:1.15.1'
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testImplementation 'org.apache.commons:commons-text:1.9'
     testImplementation 'org.apache.commons:commons-lang3:3.11'
     testImplementation 'org.apache.commons:commons-dbcp2:2.7.0'
-    testImplementation 'org.testcontainers:postgresql:1.15.0-rc2'
+    testImplementation 'org.testcontainers:postgresql:1.15.1'
 
     testImplementation project(':airbyte-test-utils')
 

--- a/airbyte-scheduler/build.gradle
+++ b/airbyte-scheduler/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation project(':airbyte-protocol:models')
     implementation project(':airbyte-workers')
 
-    testImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+    testImplementation "org.testcontainers:postgresql:1.15.1"
 }
 
 application {

--- a/airbyte-test-utils/build.gradle
+++ b/airbyte-test-utils/build.gradle
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-    implementation 'org.testcontainers:postgresql:1.15.0-rc2'
+    implementation 'org.testcontainers:postgresql:1.15.1'
 }

--- a/airbyte-tests/build.gradle
+++ b/airbyte-tests/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     acceptanceTestsImplementation project(':airbyte-test-utils')
 
     acceptanceTestsImplementation 'org.apache.commons:commons-csv:1.4'
-    acceptanceTestsImplementation "org.testcontainers:postgresql:1.15.0-rc2"
+    acceptanceTestsImplementation "org.testcontainers:postgresql:1.15.1"
     acceptanceTestsImplementation "org.postgresql:postgresql:42.2.18"
     acceptanceTestsImplementation "com.fasterxml.jackson.core:jackson-databind"
 }

--- a/airbyte-workers/build.gradle
+++ b/airbyte-workers/build.gradle
@@ -16,6 +16,6 @@ dependencies {
 
     testImplementation 'org.mockito:mockito-inline:2.13.0'
     testImplementation 'org.testcontainers:testcontainers:1.14.3'
-    testImplementation 'org.testcontainers:postgresql:1.15.0-rc2'
+    testImplementation 'org.testcontainers:postgresql:1.15.1'
     testImplementation 'org.postgresql:postgresql:42.2.18'
 }


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/493

## What
* We have been using an rc version of test containers to handle a bug docker caching issue when pulling databases.

## How
* Fix is now in the stable release 1.15.1. Upgraded everything to use this version.