### PR TITLE
Allow following symlinks when building docker images 

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-docker.gradle
+++ b/buildSrc/src/main/groovy/airbyte-docker.gradle
@@ -30,6 +30,9 @@ abstract class AirbyteDockerTask extends DefaultTask {
     @Input
     String dockerfileName
 
+    @Input
+    boolean followSymlinks = false
+
     @OutputFile
     abstract File idFileOutput
 
@@ -38,7 +41,7 @@ abstract class AirbyteDockerTask extends DefaultTask {
             def tag = DockerHelpers.getDevTaggedImage(projectDir, dockerfileName)
 
             project.exec {
-                commandLine scriptPath, rootDir.absolutePath, projectDir.absolutePath, dockerfileName, tag, idFileOutput.absolutePath
+                commandLine scriptPath, rootDir.absolutePath, projectDir.absolutePath, dockerfileName, tag, idFileOutput.absolutePath, followSymlinks
             }
         }
     }
@@ -138,6 +141,7 @@ class AirbyteDockerPlugin implements Plugin<Project> {
             def filteredProjectFiles = project.fileTree(project.projectDir).filter {
                 file -> !file.toString().contains(".venv")
             }
+
             project.task(taskName, type: AirbyteDockerTask) {
                 def dockerPath = Paths.get(project.projectDir.absolutePath, dockerFile)
                 def hash = MessageDigest.getInstance("MD5").digest(dockerPath.getBytes()).encodeHex().toString()

--- a/tools/bin/build_image.sh
+++ b/tools/bin/build_image.sh
@@ -7,6 +7,7 @@ PROJECT_DIR="$2"
 DOCKERFILE="$3"
 TAGGED_IMAGE="$4"
 ID_FILE="$5"
+FOLLOW_SYMLINKS="$6"
 
 cd "$ROOT_DIR"
 . tools/lib/lib.sh
@@ -14,7 +15,29 @@ assert_root
 
 cd "$PROJECT_DIR"
 
-docker build \
-  -f "$DOCKERFILE" . \
-  -t "$TAGGED_IMAGE" \
-  --iidfile "$ID_FILE"
+function validate_dockerignore() {
+  excludes_all=$(grep -w '^\*$' .dockerignore)
+  excludes_except=$(grep -w '^!.*' .dockerignore)
+  if [ -n "$excludes_all" ] || [ -n "$excludes_except" ]; then
+    error "Cannot include exclusion exceptions when following symlinks. Please use an exclude pattern that doesn't use exclude-all (e.g: *) or exclude-except (e.g: !/some/pattern)"
+  fi
+}
+
+args=(
+    -f "$DOCKERFILE"
+    -t "$TAGGED_IMAGE"
+    --iidfile "$ID_FILE"
+)
+
+if [ "$FOLLOW_SYMLINKS" == "true" ]; then
+  exclusions=()
+  if [ -f ".dockerignore" ]; then
+    validate_dockerignore
+    exclusions+=(--exclude-from .dockerignore)
+  fi
+  # Docker does not follow symlinks in the build context. So we create a tar of the directory, following symlinks, and provide the archive to Docker
+  # to use as the build context
+  tar cL "${exclusions[@]}" . | docker build - "${args[@]}"
+else
+  docker build . "${args[@]}"
+fi


### PR DESCRIPTION
## What
This PR enables including symlinks in Docker's build context when building a connector image. This is helpful in cases where we want to use symlinks to depend on local versions of other packages in the repo. 

In the consuming `build.gradle`, we only need to add a block

```
airbyteDocker {
  followSymlinks = true
}
```
to use this change. All current consumers should be unaffected since by default symlinks are not followed. 

This is supporting work for @gordalina 's Elixir GA source

## Reading order
1. `build_image.sh`
1. `airbyte-docker.gradle`