### PR TITLE
force job submitter to only submit jobs if no other job with same scope is active

### DIFF
--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobSubmitter.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobSubmitter.java
@@ -75,7 +75,7 @@ public class JobSubmitter implements Runnable {
     try {
       LOGGER.info("Running job-submitter...");
 
-      final Optional<Job> oldestPendingJob = persistence.getOldestPendingJob();
+      final Optional<Job> oldestPendingJob = persistence.getNextJob();
 
       oldestPendingJob.ifPresent(job -> {
         trackSubmission(job);

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/JobPersistence.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/JobPersistence.java
@@ -143,6 +143,6 @@ public interface JobPersistence {
    */
   Optional<State> getCurrentState(UUID connectionId) throws IOException;
 
-  Optional<Job> getOldestPendingJob() throws IOException;
+  Optional<Job> getNextJob() throws IOException;
 
 }

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobSubmitterTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobSubmitterTest.java
@@ -92,7 +92,7 @@ public class JobSubmitterTest {
 
     persistence = mock(JobPersistence.class);
     this.logPath = jobRoot.resolve(WorkerConstants.LOG_FILENAME);
-    when(persistence.getOldestPendingJob()).thenReturn(Optional.of(job));
+    when(persistence.getNextJob()).thenReturn(Optional.of(job));
     when(persistence.createAttempt(JOB_ID, logPath)).thenReturn(ATTEMPT_NUMBER);
 
     jobSubmitter = spy(new JobSubmitter(
@@ -118,7 +118,7 @@ public class JobSubmitterTest {
 
   @Test
   public void testPersistenceNoJob() throws Exception {
-    doReturn(Optional.empty()).when(persistence).getOldestPendingJob();
+    doReturn(Optional.empty()).when(persistence).getNextJob();
 
     jobSubmitter.run();
 


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/1342

## What
* JobSubmitter is submitting job when another job of that scope is either already running or awaiting retry. In both of these cases, we do not want to allow the job to be submitted.

## How
* Fixed the query. Added tests.