### PR TITLE
use bumpversion for releasing

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,10 +1,10 @@
 [bumpversion]
-current_version = 0.8.0-alpha
+current_version = 0.8.1-alpha
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?
-serialize =
-    {major}.{minor}.{patch}-alpha
+serialize = 
+	{major}.{minor}.{patch}-alpha
 
 [bumpversion:file:.bumpversion.cfg]
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,14 @@
+[bumpversion]
+current_version = 0.8.0-alpha
+commit = True
+tag = True
+tag_name = Version {new_version}
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?
+serialize =
+    {major}.{minor}.{patch}-alpha
+
+[bumpversion:file:.bumpversion.cfg]
+
+[bumpversion:file:.env]
+
+[bumpversion:file:kube/overlays/stable/.env]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.2-alpha
+current_version = 0.8.0-alpha
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.1-alpha
+current_version = 0.8.2-alpha
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,7 @@
 [bumpversion]
 current_version = 0.8.0-alpha
 commit = True
-tag = True
-tag_name = Version {new_version}
+tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?
 serialize =
     {major}.{minor}.{patch}-alpha

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.8.0-alpha
+VERSION=0.8.1-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_DB=airbyte

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.8.2-alpha
+VERSION=0.8.0-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_DB=airbyte

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.8.1-alpha
+VERSION=0.8.2-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_DB=airbyte

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.8.0-alpha
+AIRBYTE_VERSION=0.8.1-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_URL=jdbc:postgresql://airbyte-db-svc:5432/airbyte

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.8.2-alpha
+AIRBYTE_VERSION=0.8.0-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_URL=jdbc:postgresql://airbyte-db-svc:5432/airbyte

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.7.2-alpha
+AIRBYTE_VERSION=0.8.0-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_URL=jdbc:postgresql://airbyte-db-svc:5432/airbyte

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.8.1-alpha
+AIRBYTE_VERSION=0.8.2-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_URL=jdbc:postgresql://airbyte-db-svc:5432/airbyte

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,12 @@
+# Tools
+
+## Releasing a new version
+```
+git branch -b your-release-branch
+./tools/bin/release_version.sh patch # or minor or major
+git push --set-upstream origin your-release-branch
+# create PR from branch
+# merge PR
+git checkout master
+./tools/bin/tag_version.sh
+```

--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -23,11 +23,11 @@ bumpversion "$PART_TO_BUMP"
 GIT_REVISION=$(git rev-parse HEAD)
 [[ -z "$GIT_REVISION" ]] && echo "Couldn't get the git revision..." && exit 1
 
-#echo "Building and publishing version $VERSION for git revision $GIT_REVISION..."
-#./gradlew clean composeBuild
-#GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker-compose.yaml build
-#GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker-compose.yaml push
-#echo "Completed building and publishing..."
+echo "Building and publishing version $VERSION for git revision $GIT_REVISION..."
+./gradlew clean composeBuild
+GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker-compose.yaml build
+GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker-compose.yaml push
+echo "Completed building and publishing..."
 
 echo "Pushing bumped version code..."
 git push

--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -18,7 +18,7 @@ PART_TO_BUMP=$1
 # requires no git diffs to run
 # commits the bumped versions code to your branch
 pip install bumpversion
-VERSION=$(bumpversion "$PART_TO_BUMP" | grep new_version | sed -r s,"^.*=",,)
+bumpversion "$PART_TO_BUMP"
 
 GIT_REVISION=$(git rev-parse HEAD)
 [[ -z "$GIT_REVISION" ]] && echo "Couldn't get the git revision..." && exit 1

--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -31,4 +31,4 @@ GIT_REVISION=$(git rev-parse HEAD)
 
 echo "Pushing bumped version code..."
 git push
-echo "Completed. After you merge, remember to switch to master, "
+echo "Completed. After you merge, remember to switch to master and run ./tools/bin/tag_version.sh"

--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -4,13 +4,17 @@ set -e
 
 . tools/lib/lib.sh
 
-VERSION=$(cat .env | grep VERSION= | cut -d= -f 2)
-[[ -z "$VERSION" ]] && echo "Couldn't find version in env file..." && exit 1
+PART_TO_BUMP=$1
+[[ -z "$PART_TO_BUMP" ]] && echo "Usage ./tools/bin/release_version.sh (major|minor|patch)" && exit 1
+
+# uses .bumpversion.cfg to find files to bump
+# requires no git diffs to run
+# commits the bumped versions code  to your branch
+pip install bumpversion
+VERSION=$(bumpversion --tag-message "Version {new_version}" "$PART_TO_BUMP" | grep new_version | sed -r s,"^.*=",,)
 
 GIT_REVISION=$(git rev-parse HEAD)
 [[ -z "$GIT_REVISION" ]] && echo "Couldn't get the git revision..." && exit 1
-
-[[ ! -z "$(git status --porcelain)" ]] && echo "Cannot tag revision if all changes aren't checked in..." && exit 1
 
 echo "Building and publishing version $VERSION for git revision $GIT_REVISION..."
 ./gradlew clean composeBuild
@@ -18,8 +22,7 @@ GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker
 GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker-compose.yaml push
 echo "Completed building and publishing..."
 
-echo "Tagging git revision..."
-TAG_NAME="v$VERSION"
-git tag -a "$TAG_NAME" -m "Version $VERSION"
-git push origin "$TAG_NAME"
+echo "Pushing bumped version code and tags..."
+git push # pushes code
+git push origin "v$VERSION" # pushes tag
 echo "Completed..."

--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -4,14 +4,21 @@ set -e
 
 . tools/lib/lib.sh
 
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [[ "$BRANCH" == "master" ]]; then
+  echo 'This script should be run from a branch!';
+  exit 1;
+fi
+
 PART_TO_BUMP=$1
 [[ -z "$PART_TO_BUMP" ]] && echo "Usage ./tools/bin/release_version.sh (major|minor|patch)" && exit 1
 
 # uses .bumpversion.cfg to find files to bump
 # requires no git diffs to run
-# commits the bumped versions code  to your branch
+# commits the bumped versions code to your branch
 pip install bumpversion
-VERSION=$(bumpversion --tag-message "Version {new_version}" "$PART_TO_BUMP" | grep new_version | sed -r s,"^.*=",,)
+VERSION=$(bumpversion "$PART_TO_BUMP" | grep new_version | sed -r s,"^.*=",,)
 
 GIT_REVISION=$(git rev-parse HEAD)
 [[ -z "$GIT_REVISION" ]] && echo "Couldn't get the git revision..." && exit 1
@@ -22,7 +29,6 @@ GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker
 GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker-compose.yaml push
 echo "Completed building and publishing..."
 
-echo "Pushing bumped version code and tags..."
-git push # pushes code
-git push origin "v$VERSION" # pushes tag
-echo "Completed..."
+echo "Pushing bumped version code..."
+git push
+echo "Completed. After you merge, remember to switch to master, "

--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -23,11 +23,11 @@ VERSION=$(bumpversion "$PART_TO_BUMP" | grep new_version | sed -r s,"^.*=",,)
 GIT_REVISION=$(git rev-parse HEAD)
 [[ -z "$GIT_REVISION" ]] && echo "Couldn't get the git revision..." && exit 1
 
-echo "Building and publishing version $VERSION for git revision $GIT_REVISION..."
-./gradlew clean composeBuild
-GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker-compose.yaml build
-GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker-compose.yaml push
-echo "Completed building and publishing..."
+#echo "Building and publishing version $VERSION for git revision $GIT_REVISION..."
+#./gradlew clean composeBuild
+#GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker-compose.yaml build
+#GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker-compose.yaml push
+#echo "Completed building and publishing..."
 
 echo "Pushing bumped version code..."
 git push

--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -29,6 +29,8 @@ GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker
 GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml -f docker-compose.yaml push
 echo "Completed building and publishing..."
 
-echo "Pushing bumped version code..."
-git push
-echo "Completed. After you merge, remember to switch to master and run ./tools/bin/tag_version.sh"
+echo "Final Steps:"
+echo "1. Push your changes"
+echo "2. Merge your PR"
+echo "3. Switch to master"
+echo "4. Run ./tools/bin/tag_version.sh"

--- a/tools/bin/tag_version.sh
+++ b/tools/bin/tag_version.sh
@@ -15,7 +15,7 @@ fi
 # make sure your master branch is up to date
 git pull --rebase
 
-VERSION=$(cat .env | grep VERSION= | cut -d= -f 2)	PART_TO_BUMP=$1
+VERSION=$(cat .env | grep VERSION= | cut -d= -f 2)
 [[ -z "$VERSION" ]] && echo "Couldn't find version in env file..." && exit 1
 
 TAG_NAME="v$VERSION"

--- a/tools/bin/tag_version.sh
+++ b/tools/bin/tag_version.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+. tools/lib/lib.sh
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" != "master" ]]; then
+  echo 'This script should be run from master after merging the changes from release_version.sh!';
+  exit 1;
+fi
+
+[[ ! -z "$(git status --porcelain)" ]] && echo "Cannot tag revision if all changes aren't checked in..." && exit 1
+
+# make sure your master branch is up to date
+git pull --rebase
+
+VERSION=$(cat .env | grep VERSION= | cut -d= -f 2)	PART_TO_BUMP=$1
+[[ -z "$VERSION" ]] && echo "Couldn't find version in env file..." && exit 1
+
+TAG_NAME="v$VERSION"
+git tag -a "$TAG_NAME" -m "Version $VERSION"
+git push origin "$TAG_NAME"


### PR DESCRIPTION
The end to end workflow for creating a release is:
```
git branch -b your-release-branch
./tools/bin/release_version.sh patch # or minor or major
git push --set-upstream origin your-release-branch
# create PR from branch
# merge PR
git checkout master
./tools/bin/tag_version.sh
```

These instructions are also in `tools/README.md`

As @cgardens pointed out, it's beneficial to tag after the PR is squashed and committed to `master` so it's easier to parse `master` commits to see where it switched to a new version. 

Here's an example bumping commit: https://github.com/airbytehq/airbyte/pull/1398/commits/1db093f08f03877c34c75d3fe0074c31d6f22e57