### PR TITLE
Schedule failed jobs

### DIFF
--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/ScheduleJobPredicate.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/ScheduleJobPredicate.java
@@ -57,18 +57,11 @@ public class ScheduleJobPredicate implements BiPredicate<Optional<Job>, Standard
     }
 
     final Job previousJob = previousJobOptional.get();
-    switch (previousJob.getStatus()) {
-      case CANCELLED:
-      case SUCCEEDED:
-      case FAILED:
-        return timeForJobNewJob;
-      case INCOMPLETE:
-      case PENDING:
-      case RUNNING:
-        return false;
-    }
-
-    return false;
+    return switch (previousJob.getStatus()) {
+      case CANCELLED, SUCCEEDED, FAILED -> timeForJobNewJob;
+      case INCOMPLETE, PENDING, RUNNING -> false;
+      default -> throw new IllegalArgumentException("Unrecognized status: " + previousJob.getStatus());
+    };
   }
 
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/ScheduleJobPredicate.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/ScheduleJobPredicate.java
@@ -60,8 +60,9 @@ public class ScheduleJobPredicate implements BiPredicate<Optional<Job>, Standard
     switch (previousJob.getStatus()) {
       case CANCELLED:
       case SUCCEEDED:
-        return timeForJobNewJob;
       case FAILED:
+        return timeForJobNewJob;
+      case INCOMPLETE:
       case PENDING:
       case RUNNING:
         return false;

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/ScheduleJobPredicateTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/ScheduleJobPredicateTest.java
@@ -83,7 +83,8 @@ class ScheduleJobPredicateTest {
     assertFalse(scheduleJobPredicate.test(Optional.of(job), SCHEDULE));
   }
 
-  // use Mode.EXCLUDE so that when new values are added to the enum, these tests will fail if that value has not also been added to the switch statement.
+  // use Mode.EXCLUDE so that when new values are added to the enum, these tests will fail if that
+  // value has not also been added to the switch statement.
   @ParameterizedTest
   @EnumSource(value = JobStatus.class,
               mode = Mode.EXCLUDE,


### PR DESCRIPTION
* Bug: Jobs that failed never retry. This is because when we changed the meaning of failed in the job status enum, I did not update its usage in the switch statement in the scheduler. Reported here: https://airbytehq.slack.com/archives/C019WJFR1JT/p1608531310160200

- [x] **add a test**