### PR TITLE
Release: 0.8.0-alpha → 0.9.0-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.0-alpha
+current_version = 0.9.0-alpha
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.8.0-alpha
+VERSION=0.9.0-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_DB=airbyte

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.8.0-alpha
+AIRBYTE_VERSION=0.9.0-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_URL=jdbc:postgresql://airbyte-db-svc:5432/airbyte


### PR DESCRIPTION
Bump minor version. Using the script from https://github.com/airbytehq/airbyte/pull/1398