### PR TITLE
Hotfix: Fix log_path bug for jobs with  multiple attempts

### DIFF
--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobSubmitter.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobSubmitter.java
@@ -119,7 +119,8 @@ public class JobSubmitter implements Runnable {
           }
           trackCompletion(job, output.getStatus());
         })
-        .setOnException(noop -> {
+        .setOnException(e -> {
+          LOGGER.error("Exception thrown in Job Submission: ", e);
           persistence.failAttempt(job.getId(), attemptNumber);
           trackCompletion(job, io.airbyte.workers.JobStatus.FAILED);
         })

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobSubmitter.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobSubmitter.java
@@ -38,7 +38,6 @@ import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.validation.json.JsonValidationException;
-import io.airbyte.workers.OutputAndStatus;
 import io.airbyte.workers.WorkerConstants;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -75,9 +74,9 @@ public class JobSubmitter implements Runnable {
     try {
       LOGGER.info("Running job-submitter...");
 
-      final Optional<Job> oldestPendingJob = persistence.getNextJob();
+      final Optional<Job> nextJob = persistence.getNextJob();
 
-      oldestPendingJob.ifPresent(job -> {
+      nextJob.ifPresent(job -> {
         trackSubmission(job);
         submitJob(job);
         LOGGER.info("Job-Submitter Summary. Submitted job with scope {}", job.getScope());
@@ -221,14 +220,6 @@ public class JobSubmitter implements Runnable {
       }
     }
     return metadata;
-  }
-
-  private static JobStatus getStatus(OutputAndStatus<?> output) {
-    return switch (output.getStatus()) {
-      case SUCCEEDED -> JobStatus.SUCCEEDED;
-      case FAILED -> JobStatus.FAILED;
-      default -> throw new IllegalStateException("Unknown state " + output.getStatus());
-    };
   }
 
 }

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobPersistenceTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobPersistenceTest.java
@@ -38,6 +38,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.JobConfig;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.JobOutput;
+import io.airbyte.config.JobOutput.OutputType;
 import io.airbyte.config.JobSyncConfig;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.State;
@@ -545,6 +546,50 @@ class DefaultJobPersistenceTest {
   }
 
   @Test
+  void testGetNextJobWithMultipleAttempts() throws IOException {
+    final long jobId = jobPersistence.createJob(SCOPE, JOB_CONFIG);
+    jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
+    jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
+    jobPersistence.resetJob(jobId);
+
+    final Optional<Job> actual = jobPersistence.getNextJob();
+    final Job expected = getExpectedJobTwoAttempts(jobId, JobStatus.PENDING, AttemptStatus.FAILED);
+
+    assertTrue(actual.isPresent());
+    assertEquals(expected, actual.get());
+  }
+
+  @Test
+  void testGetCurrentStateWithMultipleAttempts() throws IOException {
+    final State state = new State().withState(Jsons.jsonNode(ImmutableMap.of("checkpoint", 4)));
+    final JobOutput jobOutput = new JobOutput().withOutputType(OutputType.SYNC).withSync(new StandardSyncOutput().withState(state));
+
+    final long jobId = jobPersistence.createJob(SCOPE, JOB_CONFIG);
+    jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
+    final int attemptId = jobPersistence.createAttempt(jobId, LOG_PATH);
+    jobPersistence.writeOutput(jobId, attemptId, jobOutput);
+    jobPersistence.succeedAttempt(jobId, attemptId);
+
+    final Optional<State> actual = jobPersistence.getCurrentState(UUID.fromString(ScopeHelper.getConfigId(SCOPE)));
+
+    assertTrue(actual.isPresent());
+    assertEquals(state, actual.get());
+  }
+
+  @Test
+  void testGetLastSyncJobWithMultipleAttempts() throws IOException {
+    final long jobId = jobPersistence.createJob(SCOPE, JOB_CONFIG);
+    jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
+    jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
+
+    final Optional<Job> actual = jobPersistence.getLastSyncJob(UUID.fromString(ScopeHelper.getConfigId(SCOPE)));
+    final Job expected = getExpectedJobTwoAttempts(jobId, JobStatus.INCOMPLETE, AttemptStatus.FAILED);
+
+    assertTrue(actual.isPresent());
+    assertEquals(expected, actual.get());
+  }
+
+  @Test
   public void testGetJobFromRecord() throws IOException, SQLException {
     final long jobId = jobPersistence.createJob(SCOPE, JOB_CONFIG);
 
@@ -557,6 +602,21 @@ class DefaultJobPersistenceTest {
 
   private Job getExpectedJobNoAttempts(long jobId, JobStatus jobStatus) {
     return getExpectedJob(jobId, jobStatus, Collections.emptyList());
+  }
+
+  private Job getExpectedJobTwoAttempts(long jobId, JobStatus jobStatus, AttemptStatus attemptStatus) {
+    final Job job = getExpectedJobOneAttempt(jobId, jobStatus, attemptStatus);
+    job.getAttempts().add(new Attempt(
+        1L,
+        jobId,
+        LOG_PATH,
+        null,
+        attemptStatus,
+        NOW.getEpochSecond(),
+        NOW.getEpochSecond(),
+        null));
+
+    return job;
   }
 
   private Job getExpectedJobOneAttempt(long jobId, JobStatus jobStatus, AttemptStatus attemptStatus) {


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/1425
Closes https://github.com/airbytehq/airbyte/issues/1343

## 2 Problems
* We swallowed exceptions throw in `LifecycledCallable` so it was hard to debug what was going wrong. This is why we were not seeing the exception that would have told us why multiple attempts were getting assigned the same log_path.
* `DefaultJobPersistence` has a bug for `getLastSyncJob`, `getCurrentState`, `getNextJob`. The query included a `LIMIT 1`, which meant that for the desired job it was not fetching all of its attempts. This is why the log paths were the same across multiple attempts. We use the number of attempts to determine the next log path, but because the query only pulled 0 or 1 attempts, the log paths never got passed 1. The fix makes sure we pull all of the attempts.