### PR TITLE
Hotfix redshift maven repository 

### DIFF
--- a/airbyte-integrations/connectors/destination-redshift/build.gradle
+++ b/airbyte-integrations/connectors/destination-redshift/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation project(':airbyte-protocol:models')
     implementation project(':airbyte-integrations:connectors:destination-jdbc')
 
-    implementation 'com.amazon.redshift:redshift-jdbc42:1.2.43.1001 '
+    implementation 'com.amazon.redshift:redshift-jdbc42:1.2.43.1067 '
 
     testImplementation 'org.apache.commons:commons-text:1.9'
     testImplementation 'org.apache.commons:commons-lang3:3.11'

--- a/airbyte-integrations/connectors/destination-redshift/build.gradle
+++ b/airbyte-integrations/connectors/destination-redshift/build.gradle
@@ -11,7 +11,7 @@ application {
 
 repositories {
     maven {
-        url "https://repository.mulesoft.org/nexus/content/repositories/public/"
+        url "https://s3.amazonaws.com/redshift-maven-repository/release"
     }
 }
 
@@ -21,7 +21,7 @@ dependencies {
     implementation project(':airbyte-protocol:models')
     implementation project(':airbyte-integrations:connectors:destination-jdbc')
 
-    implementation 'com.amazon.redshift:redshift-jdbc42:1.2.43.1067'
+    implementation 'com.amazon.redshift:redshift-jdbc42:1.2.43.1001 '
 
     testImplementation 'org.apache.commons:commons-text:1.9'
     testImplementation 'org.apache.commons:commons-lang3:3.11'

--- a/airbyte-integrations/connectors/source-redshift/build.gradle
+++ b/airbyte-integrations/connectors/source-redshift/build.gradle
@@ -9,9 +9,7 @@ application {
 }
 
 repositories {
-    maven {
-        url "https://repository.mulesoft.org/nexus/content/repositories/public/"
-    }
+    maven { url "https://s3.amazonaws.com/redshift-maven-repository/release" }
 }
 
 dependencies {


### PR DESCRIPTION
## What
Looks like Mulesoft's Maven repo no longer contains the redshift version we use: https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42/1.2.41.1065

Updating to the correct repo based on the [redshift docs](https://docs.aws.amazon.com/redshift/latest/mgmt/jdbc20-install.html)