### PR TITLE
filter hash ids in destination standard tests

### DIFF
--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
@@ -524,7 +524,8 @@ public abstract class TestDestination {
           "AB_ID",
           "NORMALIZED_AT",
           "HASHID");
-      if (airbyteInternalFields.stream().anyMatch(key::contains) || json.get(key).isNull()) {
+      if (airbyteInternalFields.stream().anyMatch(internalField -> key.toLowerCase().contains(internalField.toLowerCase()))
+          || json.get(key).isNull()) {
         ((ObjectNode) json).remove(key);
       }
     }

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
@@ -523,7 +523,7 @@ public abstract class TestDestination {
           "EMITTED_AT",
           "AB_ID",
           "NORMALIZED_AT",
-          "hashid");
+          "HASHID");
       if (airbyteInternalFields.stream().anyMatch(key::contains) || json.get(key).isNull()) {
         ((ObjectNode) json).remove(key);
       }


### PR DESCRIPTION
## What
* normalization started to handle nesting differently, I think. (I am having trouble tracking down the exact change @ChristopheDuong . Looks related to the regex that the test uses ). This means that the hash id fields are included in the fields returned by the tests. when this happens the tests can't pass because they are comparing to the non-normalized version. Opting to just hack around it for now, but we probably need to look at how we are testing normalization a little more closely. between this issue and this one https://github.com/airbytehq/airbyte/pull/1446 there seem to be a couple rough edges.
* https://github.com/airbytehq/airbyte/pull/1436 depends on this PR.
* @ChristopheDuong this is another case where we need to make sure we are running integration tests when making changes to the normalization code.