### PR TITLE
Fix Airbyte Metadata

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -16,5 +16,5 @@ WORKDIR /airbyte
 
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -16,5 +16,5 @@ WORKDIR /airbyte
 
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.3
+LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
@@ -167,6 +167,10 @@ def is_object(property_type) -> bool:
     return property_type == "object" or "object" in property_type
 
 
+def is_airbyte_column(name: str) -> bool:
+    return name.startswith("_airbyte_")
+
+
 def find_combining_schema(properties: dict) -> set:
     return set(properties).intersection({"anyOf", "oneOf", "allOf"})
 
@@ -279,7 +283,7 @@ def extract_node_properties(path: List[str], json_col: str, properties: dict, in
             sql_field = json_extract_base_property(
                 path=path, json_col=json_col, name=field, definition=properties[field], integration_type=integration_type
             )
-            if sql_field:
+            if sql_field and not is_airbyte_column(field):
                 result[field] = sql_field
     return result
 
@@ -370,9 +374,9 @@ def process_node(
     node_columns = ",\n    ".join([sql for sql in node_properties.values()])
     hash_node_columns = ",\n        ".join([quote(column, integration_type, in_jinja=True) for column in node_properties.keys()])
     hash_node_columns = jinja_call(f"dbt_utils.surrogate_key([\n        {hash_node_columns}\n    ])")
-    hash_id = quote(f"_{name}_hashid", integration_type)
-    foreign_hash_id = quote(f"_{name}_foreign_hashid", integration_type)
-    emitted_col = "emitted_at,\n    {} as normalized_at".format(
+    hash_id = quote(f"_airbyte_{name}_hashid", integration_type)
+    foreign_hash_id = quote(f"_airbyte_{name}_foreign_hashid", integration_type)
+    emitted_col = "emitted_at as _airbyte_emitted_at,\n    {} as _airbyte_normalized_at".format(
         jinja_call("dbt_utils.current_timestamp_in_utc()"),
     )
     node_sql = f"""{prefix}

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
@@ -328,7 +328,8 @@ public abstract class TestDestination {
     final AirbyteCatalog catalog = Jsons.deserialize(MoreResources.readResource(catalogFilename), AirbyteCatalog.class);
     final ConfiguredAirbyteCatalog configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(catalog);
     final List<AirbyteMessage> messages = MoreResources.readResource(messagesFilename).lines()
-        .map(record -> Jsons.deserialize(record, AirbyteMessage.class)).collect(Collectors.toList());
+        .map(record -> Jsons.deserialize(record, AirbyteMessage.class))
+        .collect(Collectors.toList());
     runSync(getConfigWithBasicNormalization(), messages, configuredCatalog);
 
     LOGGER.info("Comparing retrieveRecordsForCatalog for {} and {}", messagesFilename, catalogFilename);
@@ -346,7 +347,8 @@ public abstract class TestDestination {
         Jsons.deserialize(MoreResources.readResource("exchange_rate_catalog.json"), AirbyteCatalog.class);
     final ConfiguredAirbyteCatalog configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(catalog);
     final List<AirbyteMessage> firstSyncMessages = MoreResources.readResource("exchange_rate_messages.txt").lines()
-        .map(record -> Jsons.deserialize(record, AirbyteMessage.class)).collect(Collectors.toList());
+        .map(record -> Jsons.deserialize(record, AirbyteMessage.class))
+        .collect(Collectors.toList());
     runSync(getConfig(), firstSyncMessages, configuredCatalog);
 
     final List<AirbyteMessage> secondSyncMessages = Lists.newArrayList(new AirbyteMessage()
@@ -523,7 +525,8 @@ public abstract class TestDestination {
           "EMITTED_AT",
           "AB_ID",
           "NORMALIZED_AT",
-          "HASHID");
+          "HASHID",
+          "_AIRBYTE");
       if (airbyteInternalFields.stream().anyMatch(internalField -> key.toLowerCase().contains(internalField.toLowerCase()))
           || json.get(key).isNull()) {
         ((ObjectNode) json).remove(key);

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryIntegrationTest.java
@@ -120,10 +120,13 @@ public class BigQueryIntegrationTest extends TestDestination {
   }
 
   private List<JsonNode> retrieveRecordsFromTable(TestDestinationEnv env, String tableName) throws InterruptedException {
+    // todo (cgardens) - see https://github.com/airbytehq/airbyte/pull/1446.
+    final String emittedAtColumn =
+        tableName.toLowerCase().endsWith("raw") || tableName.toLowerCase().endsWith("raw\"") ? "emitted_at" : "_airbyte_emitted_at";
     final QueryJobConfiguration queryConfig =
         QueryJobConfiguration
             .newBuilder(
-                String.format("SELECT * FROM `%s`.`%s` order by emitted_at asc;", dataset.getDatasetId().getDataset(), tableName))
+                String.format("SELECT * FROM `%s`.`%s` order by %s asc;", dataset.getDatasetId().getDataset(), tableName, emittedAtColumn))
             .setUseLegacySql(false).build();
 
     TableResult queryResults = executeQuery(bigquery, queryConfig).getLeft().getQueryResults();

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
@@ -113,10 +113,13 @@ public class PostgresIntegrationTest extends TestDestination {
   }
 
   private List<JsonNode> retrieveRecordsFromTable(String tableName) throws SQLException {
+    // todo (cgardens) - see https://github.com/airbytehq/airbyte/pull/1446.
+    final String emittedAtColumn =
+        tableName.toLowerCase().endsWith("raw") || tableName.toLowerCase().endsWith("raw\"") ? "emitted_at" : "_airbyte_emitted_at";
     return Databases.createPostgresDatabase(db.getUsername(), db.getPassword(),
         db.getJdbcUrl()).query(
             ctx -> ctx
-                .fetch(String.format("SELECT * FROM %s ORDER BY emitted_at ASC;", tableName))
+                .fetch(String.format("SELECT * FROM %s ORDER BY %s ASC;", tableName, emittedAtColumn))
                 .stream()
                 .map(r -> r.formatJSON(JSON_FORMAT))
                 .map(Jsons::deserialize)

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeIntegrationTest.java
@@ -105,9 +105,12 @@ public class SnowflakeIntegrationTest extends TestDestination {
   }
 
   private List<JsonNode> retrieveRecordsFromTable(String tableName) throws SQLException, InterruptedException {
+    // todo (cgardens) - see https://github.com/airbytehq/airbyte/pull/1446.
+    final String emittedAtColumn =
+        tableName.toLowerCase().endsWith("raw") || tableName.toLowerCase().endsWith("raw\"") ? "emitted_at" : "_airbyte_emitted_at";
     return SnowflakeDatabase.executeSync(
         SnowflakeDatabase.getConnectionFactory(getConfig()),
-        String.format("SELECT * FROM %s ORDER BY emitted_at ASC;", tableName),
+        String.format("SELECT * FROM %s ORDER BY %s ASC;", tableName, emittedAtColumn),
         false,
         rs -> {
           try {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
@@ -43,7 +43,7 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNormalizationRunner.class);
 
-  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.3";
+  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.4";
 
   private final DestinationType destinationType;
   private final ProcessBuilderFactory pbf;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
@@ -43,7 +43,7 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNormalizationRunner.class);
 
-  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.2";
+  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.3";
 
   private final DestinationType destinationType;
   private final ProcessBuilderFactory pbf;


### PR DESCRIPTION
## What
* Trying to fix the testing issues introduced here: https://github.com/airbytehq/airbyte/pull/1412 and reverted here: https://github.com/airbytehq/airbyte/pull/1446.

## How
*  When retrieving records in standard destination tests, switch the column name for emitted at (emitted_at or _airbyte_emitted_at) whether the table name is a raw one or not. This is a hack until @ChristopheDuong can circle back and figure out the right thing here. Likely just migrating the raw tables to use the same column is good enough.
