### PR TITLE
add beginner's guide to the airbytecatalog

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,6 +6,7 @@
   * [Postgres Replication](tutorials/postgres-replication.md)
   * [Config & Persistence](tutorials/airbyte-config-persistence.md)
   * [Building a toy connector](tutorials/toy-connector.md)
+  * [Beginner's Guide to the AirbyteCatalog](tutorials/beginners-guide-to-catalog.md)
 * [Changelog](changelog.md)
   * [Releases](deploying-airbyte/releases.md)
 * [Roadmap](roadmap.md)

--- a/docs/tutorials/beginners-guide-to-catalog.md
+++ b/docs/tutorials/beginners-guide-to-catalog.md
@@ -95,7 +95,7 @@ Let's walk through what each field in a stream means.
 Now we understand _what_ data is available from this source. Next we will configure _how_ we want to replicate that data.
 
 ### ConfiguredAirbyteCatalog
-Let's say that we do not care about replicating the pilot data at all. We do want to replicate the airlines data as a `FULL_REFRESH`. Here's what our `ConfiguredaAirbyteCatalog` would look like.
+Let's say that we do not care about replicating the pilot data at all. We do want to replicate the airlines data as a `FULL_REFRESH`. Here's what our `ConfiguredAirbyteCatalog` would look like.
 
 ```json
 {

--- a/docs/tutorials/beginners-guide-to-catalog.md
+++ b/docs/tutorials/beginners-guide-to-catalog.md
@@ -1,0 +1,317 @@
+# Beginner's Guide to the AirbyteCatalog
+
+## Overview
+The goal of this article is to make the `AirbyteCatalog` approachable to someone contributing to Airbyte for the first time. If you are looking to get deeper into the details of the catalog, you can read our technical specification on it [here](../architecture/catalog.md).
+
+The goal of the `AirbyteCatalog` is to describe _what_ data is available in a source. The goal of the `ConfiguredAirbyteCatalog` is to, based on an `AirbyteCatalog`, specify _how_ data from the source is replicated.
+
+## Contents
+This article will illustrate how to use `AirbyteCatalog` via a series of examples. We recommend reading the [Database Example](#Database-Example) first. The other examples, will refer to knowledge described in that section. After that, jump around to whichever example is most pertinent to your inquiry.
+* [Postgres Example](#Database-Example)
+* [API Example](#API-Examples)
+  * [Static Streams Example](#Static-Streams-Example)
+  * [Dynamic Streams Example](#Dynamic-Streams-Example)
+* [Nested Schema Example](#Nested-Schema-Example)
+
+In order to understand in depth how to configure incremental data replication, head over to the [incremental replication docs](../architecture/incremental.md).
+
+## Database Example
+
+Let's jump into an example using a relational database. We will assume we have a database with the following schema:
+
+```sql
+CREATE TABLE "airlines" (
+    "id"   INTEGER,
+    "name" VARCHAR
+);
+
+CREATE TABLE "pilots" (
+    "id"   INTEGER,
+    "airline_id" INTEGER,
+    "name" INTEGER
+);
+```
+
+### AirbyteCatalog
+
+We would represent this data in a catalog as follows:
+
+```json
+{
+  "streams": [
+    {
+      "name": "airlines",
+      "supported_sync_modes": [
+        "full_refresh",
+        "incremental"
+      ],
+      "source_defined_cursor": false,
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "name": "flights",
+      "supported_sync_modes": [
+        "full_refresh",
+        "incremental"
+      ],
+      "source_defined_cursor": false,
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "airline_id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+The catalog is structured as a list of `AirbyteStream`s. In the case of a database a "stream" is analogous to a table. (For APIs the mapping can be a more creative; we will discuss it later in [API Examples](#API-Examples))
+
+Let's walk through what each field in a stream means.
+* `name` - The name of the stream.
+* `supported_syn_modes` - This field lists the type of data replication that this source supports. The possible values in this array include `FULL_REFRESH` ([docs](../architecture/full-refresh.md)) and `INCREMENTAL` ([docs](../architecture/incremental.md)).
+* `source_defined_cursor` - If the stream supports `INCREMENTAL` replication, then this field signal whether the source can figure out how to detect new records on its own or not.
+* `json_schema` - This field is a [JsonSchema](https://json-schema.org/understanding-json-schema) object that describes the structure of the data. Notice that each key in the `properties` object corresponds to a column name in our database table.
+
+Now we understand _what_ data is available from this source. Next we will configure _how_ we want to replicate that data.
+
+### ConfiguredAirbyteCatalog
+Let's say that we do not care about replicating the pilot data at all. We do want to replicate the airlines data as a `FULL_REFRESH`. Here's what our `ConfiguredaAirbyteCatalog` would look like.
+
+```json
+{
+  "streams": [
+    {
+      "sync_mode": "FULL_REFRESH",
+      "stream": {
+        "name": "airlines",
+        "supported_sync_modes": [
+          "full_refresh",
+          "incremental"
+        ],
+        "source_defined_cursor": false,
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+Just as with the `AirbyteCatalog` the `ConfiguredAirbyteCatalog` contains a list. This time it is a list of `ConfiguredAirbyteStream`s (instead of just `AirbyteStream`s).
+
+Let's walk through each field in the `ConfiguredAirbyteStream`:
+* `sync_mode` - This field must be one of the values that was in `supported_sync_modes` in the `AirbyteStram` - Configures which sync mode will be used when data is replicated.
+* `stream` - Hopefully this one looks familiar! This field contains an `AirbyteStream`. It should be _identical_ the one we saw in the `AirbyteCatalog`.
+* `cursor_field` - When `sync_mode` is `INCREMENTAL` and `source_defined_cursor = false`, this field configures which field in the stream will be used to determine if a record should be replicated or not. Read more about this concept in our [documentation of incremental replication](../architecture/incremental.md).
+
+### Summary of the Postgres Example
+When thinking about `AirbyteCatalog` and `ConfiguredAirbyteCatalog`, remember that the `AirbyteCatalog` describes _what_ data is present in the source (and metadata around what replication configuration it can support). It is output by the `discover` method of source. It should be treated as an immutable object; if you are ever manually editing a catalog outside of a source, you've gone off the rails. The `ConfiguredAirbyteCatalog` is a mutable configuration object that specifies, for each `AirbyteStream`, _how_ (and if) it should be replicated. The `ConfiguredAirbyteCatalog` does this by wrapping each `AirbyteStream` in an `AirbyteCatalog` inside a `ConfiguredAirbyteStream`.
+
+
+## API Examples
+
+The `AirbyteCatalog` offers the flexibility in how to model the data for an API. In the next two example, we will model data from the same API--a stock ticker--in two different ways. In the first, the source will return a single stream called `ticker`, and in the second, the source with return a stream for each stock symbol it is configured to retrieve data for. Each stream's name will be a stock symbol.
+
+### Static Streams Example
+
+Let's imagine we want to create a basic Stock Ticker source. The goal of this source is to take in a single stock symbol and return a single stream. We will call the stream `ticker` and will contain the closing price of the stock. We will assume that you already have a rough understanding of the `AirbyteCatalog` and the `ConfiguredAirbyteCatalog` from the [previous database example](#Database-Example).
+
+#### AirbyteCatalog
+Here is what the `AirbyteCatalog` might look like.
+
+```json
+{
+  "streams": [
+    {
+      "name": "ticker",
+      "supported_sync_modes": [
+        "full_refresh",
+        "incremental"
+      ],
+      "source_defined_cursor": false,
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "symbol": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number"
+          },
+          "date": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+This catalog looks pretty similar to the `AirbyteCatalog` that we created for the [Database Example](#Database-Example). For the data we've picked here, you can think about `ticker` as a table and then each field it returns in a record as a column, so it makes sense that these look pretty similar.
+
+#### ConfiguredAirbyteCatalog
+
+The `ConfiguredAirbyteCatalog` follows the same rules as we described in the [Database Example](#Database-Example). It just wraps the `AirbyteCatalog` described above.
+
+## Dynamic Streams Example
+
+Now let's build a stock ticker source that handles returning ticker data for _multiple_ stocks. The name of each stream will be the stock symbol that it represents.
+
+#### AirbyteCatalog
+```json
+{
+  "streams": [
+    {
+      "name": "TSLA",
+      "supported_sync_modes": [
+        "full_refresh",
+        "incremental"
+      ],
+      "source_defined_cursor": false,
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "symbol": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number"
+          },
+          "date": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "name": "FB",
+      "supported_sync_modes": [
+        "full_refresh",
+        "incremental"
+      ],
+      "source_defined_cursor": false,
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "symbol": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number"
+          },
+          "date": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+This example provides another way of thinking about exposing data in a source. As a developer building a source, you can model the `AirbyteCatalog` for a source however makes most sense to the use case you are trying to fulfill.
+
+## Nested Schema Example
+Often, a data source contains "nested" data. In other words this is data that where each record contains other objects nested inside it. Cases like this are cannot be easily modeled just as tables / columns. This is why Airbyte uses JsonSchema to model the schema of its streams.
+
+Let's imagine we are modeling a flight object. A flight object might look like this:
+
+```json
+{
+  "airline": "alaska",
+  "origin": {
+    "airport_code": "SFO",
+    "terminal": "2",
+    "gate": "G23"
+  },
+  "destination": {
+    "airport_code": "JFK",
+    "terminal": "7",
+    "gate": "1"
+  }
+}
+```
+
+The `AirbyteCatalog` would look like this:
+
+```json
+{
+  "streams": [
+    {
+      "name": "flights",
+      "supported_sync_modes": [
+        "full_refresh"
+      ],
+      "source_defined_cursor": false,
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "airline": {
+            "type": "string"
+          },
+          "origin": {
+            "type": "object",
+            "properties": {
+              "airport_code": {
+                "type": "string"
+              },
+              "terminal": {
+                "type": "string"
+              },
+              "gate": {
+                "type": "string"
+              }
+            }
+          },
+          "destination": {
+            "type": "object",
+            "properties": {
+              "airport_code": {
+                "type": "string"
+              },
+              "terminal": {
+                "type": "string"
+              },
+              "gate": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+Because Airbyte uses JsonSchema to model the schema of streams, it is able to handle arbitrary nesting of data in a way that a table / column based model cannot.

--- a/docs/tutorials/toy-connector.md
+++ b/docs/tutorials/toy-connector.md
@@ -6,6 +6,7 @@ description: Building a toy source connector to illustrate Airbyte's main concep
 
 This tutorial walks you through building a simple Airbyte source to demonstrate the following concepts in Action: 
 * [The Airbyte Specification](../architecture/airbyte-specification.md) and the interface implemented by a source connector
+* [The AirbyteCatalog](beginners-guide-to-catalog.md)
 * [Packaging your connector](../contributing-to-airbyte/building-new-connector/README.md#1-implement--package-the-connector) 
 * [Testing your connector](../contributing-to-airbyte/building-new-connector/testing-connectors.md)
 
@@ -321,7 +322,7 @@ def run(args):
     sys.exit(0)
 ```
 
-and that should be it. Let's test our new method method: 
+and that should be it. Let's test our new method:
 
 ```shell
 $ python source.py check --config secrets/valid_config.json
@@ -333,12 +334,12 @@ $ python source.py check --config secrets/invalid_config.json
 Our connector is able to detect valid and invalid configs correctly. Two methods down, two more to go!
 
 #### Implementing Discover
-The `discover` command, described in the [Airbyte Specification](https://docs.airbyte.io/architecture/airbyte-specification#discover), ouputs a Catalog, a struct which declares the Streams and Fields (Airbyte's equivalents of tables and columns) output by the connector and the sync modes they support. For more information on those concepts, see [Airbyte Specification](../architecture/airbyte-specification.md). For this tutorial, we'll assume familiarity with those concepts. 
+The `discover` command, described in the [Airbyte Specification](https://docs.airbyte.io/architecture/airbyte-specification#discover), outputs a Catalog, a struct which declares the Streams and Fields (Airbyte's equivalents of tables and columns) output by the connector and the sync modes they support. For more information on those concepts, see [Airbyte Specification](../architecture/airbyte-specification.md). For this tutorial, we'll assume familiarity with those concepts.
 
 The data output by this connector will be structured in a very simple way. This connector outputs records belonging to exactly one Stream (table). Each record contains three Fields (columns): `date`, `price`, and `stock_ticker`, corresponding to the price of a stock on a given day.  
 
 To implement `discover`, we'll: 
-1. Add a method `discover` in `source.py` which outputs the Catalog
+1. Add a method `discover` in `source.py` which outputs the Catalog. To better understand what a catalog is, check out our [Beginner's Guide to the AirbyteCatalog](beginners-guide-to-catalog.md).
 2. Extend the arguments parser to use detect the `discover --config <config_path>` command and call the `discover` method. 
 
 Let's implement `discover` by adding the following in `source.py`: 


### PR DESCRIPTION
## What
* Had some time on the plane to take a pass at a beginner's guide to the AirbyteCatalog. The goal is to provide a doc to be used by a first time contributor (someone following the toy connector guide (or equivalent))
* Everyone I have worked with on building a new connector has been confused about the catalog (or at least about how to use it).

## Open Questions
* Should this replace the existing catalog docs? I'm inclined to say no. The existing docs are more detailed and helpful for someone with more experience. 