### PR TITLE
Propagate error message from Microsoft Graph API to Microsoft Teams s…

### DIFF
--- a/airbyte-integrations/connectors/source-microsoft-teams/source_microsoft_teams/source.py
+++ b/airbyte-integrations/connectors/source-microsoft-teams/source_microsoft_teams/source.py
@@ -61,8 +61,9 @@ class SourceMicrosoftTeams(BaseSource):
             try:
                 for record in self._read_record(client=client, stream=stream.name):
                     yield AirbyteMessage(type=Type.RECORD, record=record)
-            except requests.exceptions.RequestException:
-                logger.error(f"Get {stream.name} error")
+            except requests.exceptions.RequestException as e:
+                error = json.loads(e.args[0])['error']
+                logger.error(f"Get {stream.name} error. Error: {error['code']} {error['message']}")
         logger.info(f"Finished syncing {self.__class__.__name__}")
 
     def _read_record(self, client: Client, stream: str):


### PR DESCRIPTION
…ource connector log (#1536)

## What
This change propagates the error message from the exception thrown by the Microsoft Graph API to Microsoft Teams to the source logger.

before the fix, if the correct permissions have not been granted, the following error can be found in the logs
`{"type": "LOG", "log": {"level": "ERROR", "message": "Get channels error. "}}`

after the fix, the following error can be found:
`{"type": "LOG", "log": {"level": "ERROR", "message": "Get channels error. Error: Authorization_RequestDenied Insufficient privileges to complete the operation."}}`

## How
The error code and message from the raised exception is copied into the source error log

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `source.py`
