### PR TITLE
add latest connector version tag

### DIFF
--- a/airbyte-config/init/src/main/java/io/airbyte/config/init/SeedRepository.java
+++ b/airbyte-config/init/src/main/java/io/airbyte/config/init/SeedRepository.java
@@ -25,6 +25,7 @@
 package io.airbyte.config.init;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.yaml.Yamls;
@@ -84,6 +85,9 @@ public class SeedRepository {
       final JsonNode element = Jsons.clone(elements.next());
       final String name = element.get("name").asText();
       final UUID id = UUID.fromString(element.get(idName).asText());
+
+      // set latestDockerImageTag to be whatever tag is specified in the yaml.
+      ((ObjectNode) element).put("latestDockerImageTag", element.get("dockerImageTag").asText());
 
       // validate the name is unique.
       if (names.contains(name)) {

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/22f6c74f-5699-40ff-833c-4a879ea40133.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/22f6c74f-5699-40ff-833c-4a879ea40133.json
@@ -3,5 +3,6 @@
   "name": "BigQuery",
   "dockerRepository": "airbyte/destination-bigquery",
   "dockerImageTag": "0.1.11",
-  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/bigquery"
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/bigquery",
+  "latestDockerImageTag": "0.1.11"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/25c5221d-dce2-4163-ade9-739ef790f503.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/25c5221d-dce2-4163-ade9-739ef790f503.json
@@ -3,5 +3,6 @@
   "name": "Postgres",
   "dockerRepository": "airbyte/destination-postgres",
   "dockerImageTag": "0.1.9",
-  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/postgres"
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/postgres",
+  "latestDockerImageTag": "0.1.9"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/424892c4-daac-4491-b35d-c6688ba547ba.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/424892c4-daac-4491-b35d-c6688ba547ba.json
@@ -3,5 +3,6 @@
   "name": "Snowflake",
   "dockerRepository": "airbyte/destination-snowflake",
   "dockerImageTag": "0.1.11",
-  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/snowflake"
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/snowflake",
+  "latestDockerImageTag": "0.1.11"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/8be1cf83-fde1-477f-a4ad-318d23c9f3c6.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/8be1cf83-fde1-477f-a4ad-318d23c9f3c6.json
@@ -3,5 +3,6 @@
   "name": "Local CSV",
   "dockerRepository": "airbyte/destination-csv",
   "dockerImageTag": "0.1.5",
-  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/local-csv"
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/local-csv",
+  "latestDockerImageTag": "0.1.5"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/a625d593-bba5-4a1c-a53d-2d246268a816.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/a625d593-bba5-4a1c-a53d-2d246268a816.json
@@ -3,5 +3,6 @@
   "name": "Local JSON",
   "dockerRepository": "airbyte/destination-local-json",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/local-json"
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/local-json",
+  "latestDockerImageTag": "0.1.0"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/f7a7d195-377f-cf5b-70a5-be6b819019dc.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/f7a7d195-377f-cf5b-70a5-be6b819019dc.json
@@ -3,5 +3,6 @@
   "name": "Redshift",
   "dockerRepository": "airbyte/destination-redshift",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/redshift"
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/redshift",
+  "latestDockerImageTag": "0.1.1"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/00405b19-9768-4e0c-b1ae-9fc2ee2b2a8c.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/00405b19-9768-4e0c-b1ae-9fc2ee2b2a8c.json
@@ -3,5 +3,6 @@
   "name": "Looker",
   "dockerRepository": "airbyte/source-looker",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-looker"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-looker",
+  "latestDockerImageTag": "0.1.0"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2470e835-feaf-4db6-96f3-70fd645acc77.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2470e835-feaf-4db6-96f3-70fd645acc77.json
@@ -3,5 +3,6 @@
   "name": "Salesforce",
   "dockerRepository": "airbyte/source-salesforce-singer",
   "dockerImageTag": "0.1.4",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-salesforce-singer"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-salesforce-singer",
+  "latestDockerImageTag": "0.1.4"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/396e4ca3-8a97-4b85-aa4e-c9d8c2d5f992.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/396e4ca3-8a97-4b85-aa4e-c9d8c2d5f992.json
@@ -3,5 +3,6 @@
   "name": "Braintree",
   "dockerRepository": "airbyte/source-braintree-singer",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-braintree-singer"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-braintree-singer",
+  "latestDockerImageTag": "0.1.1"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/39f092a6-8c87-4f6f-a8d9-5cef45b7dbe1.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/39f092a6-8c87-4f6f-a8d9-5cef45b7dbe1.json
@@ -3,5 +3,6 @@
   "name": "Google Analytics",
   "dockerRepository": "airbyte/source-googleanalytics-singer",
   "dockerImageTag": "0.1.5",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-googleanalytics-singer"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-googleanalytics-singer",
+  "latestDockerImageTag": "0.1.5"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/41375467-61ae-4204-8e38-e2b8b7365f23.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/41375467-61ae-4204-8e38-e2b8b7365f23.json
@@ -3,5 +3,6 @@
   "name": "Slack",
   "dockerRepository": "airbyte/source-slack-singer",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-slack-singer"
+  "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-slack-singer",
+  "latestDockerImageTag": "0.1.0"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/435bb9a5-7887-4809-aa58-28c27df0d7ad.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/435bb9a5-7887-4809-aa58-28c27df0d7ad.json
@@ -3,5 +3,6 @@
   "name": "MySQL",
   "dockerRepository": "airbyte/source-mysql",
   "dockerImageTag": "0.1.5",
-  "documentationUrl": "https://docs.airbyte.io/integrations/sources/mysql"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/mysql",
+  "latestDockerImageTag": "0.1.5"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/445831eb-78db-4b1f-8f1f-0d96ad8739e2.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/445831eb-78db-4b1f-8f1f-0d96ad8739e2.json
@@ -3,5 +3,6 @@
   "name": "Drift",
   "dockerRepository": "airbyte/source-drift",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-drift"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-drift",
+  "latestDockerImageTag": "0.1.0"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/57eb1576-8f52-463d-beb6-2e107cdf571d.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/57eb1576-8f52-463d-beb6-2e107cdf571d.json
@@ -3,5 +3,6 @@
   "name": "Hubspot",
   "dockerRepository": "airbyte/source-hubspot-singer",
   "dockerImageTag": "0.1.4",
-  "documentationUrl": "https://https://docs.airbyte.io/integrations/sources/hubspot"
+  "documentationUrl": "https://https://docs.airbyte.io/integrations/sources/hubspot",
+  "latestDockerImageTag": "0.1.4"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/59f1e50a-331f-4f09-b3e8-2e8d4d355f44.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/59f1e50a-331f-4f09-b3e8-2e8d4d355f44.json
@@ -3,5 +3,6 @@
   "name": "Greenhouse",
   "dockerRepository": "airbyte/source-greenhouse",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://https://docs.airbyte.io/integrations/sources/greenhouse"
+  "documentationUrl": "https://https://docs.airbyte.io/integrations/sources/greenhouse",
+  "latestDockerImageTag": "0.1.0"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/68e63de2-bb83-4c7e-93fa-a8a9051e3993.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/68e63de2-bb83-4c7e-93fa-a8a9051e3993.json
@@ -3,5 +3,6 @@
   "name": "Jira",
   "dockerRepository": "airbyte/source-jira",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-jira"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-jira",
+  "latestDockerImageTag": "0.1.0"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/71607ba1-c0ac-4799-8049-7f4b90dd50f7.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/71607ba1-c0ac-4799-8049-7f4b90dd50f7.json
@@ -3,5 +3,6 @@
   "name": "Google Sheets",
   "dockerRepository": "airbyte/source-google-sheets",
   "dockerImageTag": "0.1.5",
-  "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-google-sheets"
+  "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-google-sheets",
+  "latestDockerImageTag": "0.1.5"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/74d47f79-8d01-44ac-9755-f5eb0d7caacb.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/74d47f79-8d01-44ac-9755-f5eb0d7caacb.json
@@ -3,5 +3,6 @@
   "name": "Facebook Marketing APIs",
   "dockerRepository": "airbyte/source-facebook-marketing-api-singer",
   "dockerImageTag": "0.1.5",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-facebook-marketing-api-singer"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-facebook-marketing-api-singer",
+  "latestDockerImageTag": "0.1.5"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/778daa7c-feaf-4db6-96f3-70fd645acc77.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/778daa7c-feaf-4db6-96f3-70fd645acc77.json
@@ -3,5 +3,6 @@
   "name": "File",
   "dockerRepository": "airbyte/source-file",
   "dockerImageTag": "0.1.7",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-file"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-file",
+  "latestDockerImageTag": "0.1.7"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/859e501d-2b67-471f-91bb-1c801414d28f.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/859e501d-2b67-471f-91bb-1c801414d28f.json
@@ -3,5 +3,6 @@
   "name": "Mixpanel",
   "dockerRepository": "airbyte/source-mixpanel-singer",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-mixpanel-singer"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-mixpanel-singer",
+  "latestDockerImageTag": "0.1.1"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/932e6363-d006-4464-a9f5-102b82e07c06.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/932e6363-d006-4464-a9f5-102b82e07c06.json
@@ -3,5 +3,6 @@
   "name": "Twilio",
   "dockerRepository": "airbyte/source-twilio-singer",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-twilio-singer"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-twilio-singer",
+  "latestDockerImageTag": "0.1.1"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9845d17a-45f1-4070-8a60-50914b1c8e2b.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9845d17a-45f1-4070-8a60-50914b1c8e2b.json
@@ -3,5 +3,6 @@
   "name": "HTTP Request",
   "dockerRepository": "airbyte/source-http-request",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-http-request"
+  "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-http-request",
+  "latestDockerImageTag": "0.1.0"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9e0556f4-69df-4522-a3fb-03264d36b348.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9e0556f4-69df-4522-a3fb-03264d36b348.json
@@ -3,5 +3,6 @@
   "name": "Marketo",
   "dockerRepository": "airbyte/source-marketo-singer",
   "dockerImageTag": "0.1.4",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-marketo-singer"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-marketo-singer",
+  "latestDockerImageTag": "0.1.4"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9fed261d-d107-47fd-8c8b-323023db6e20.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9fed261d-d107-47fd-8c8b-323023db6e20.json
@@ -3,5 +3,6 @@
   "name": "Exchange Rates Api",
   "dockerRepository": "airbyte/source-exchangeratesapi-singer",
   "dockerImageTag": "0.1.8",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-exchangeratesapi_io-source"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-exchangeratesapi_io-source",
+  "latestDockerImageTag": "0.1.8"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/aea2fd0d-377d-465e-86c0-4fdc4f688e51.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/aea2fd0d-377d-465e-86c0-4fdc4f688e51.json
@@ -3,5 +3,6 @@
   "name": "Zoom",
   "dockerRepository": "airbyte/source-zoom-singer",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-zoom-singer"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-zoom-singer",
+  "latestDockerImageTag": "0.1.0"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b03a9f3e-22a5-11eb-adc1-0242ac120002.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b03a9f3e-22a5-11eb-adc1-0242ac120002.json
@@ -3,5 +3,6 @@
   "name": "Mailchimp",
   "dockerRepository": "airbyte/source-mailchimp",
   "dockerImageTag": "0.1.6",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-mailchimp"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-mailchimp",
+  "latestDockerImageTag": "0.1.6"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b1892b11-788d-44bd-b9ec-3a436f7b54ce.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b1892b11-788d-44bd-b9ec-3a436f7b54ce.json
@@ -3,5 +3,6 @@
   "name": "Shopify",
   "dockerRepository": "airbyte/source-shopify-singer",
   "dockerImageTag": "0.1.6",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-shopify-singer"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-shopify-singer",
+  "latestDockerImageTag": "0.1.6"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b5ea17b1-f170-46dc-bc31-cc744ca984c1.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b5ea17b1-f170-46dc-bc31-cc744ca984c1.json
@@ -3,5 +3,6 @@
   "name": "Microsoft SQL Server (MSSQL)",
   "dockerRepository": "airbyte/source-mssql",
   "dockerImageTag": "0.1.6",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-mssql"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-mssql",
+  "latestDockerImageTag": "0.1.6"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/cd42861b-01fc-4658-a8ab-5d11d0510f01.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/cd42861b-01fc-4658-a8ab-5d11d0510f01.json
@@ -3,5 +3,6 @@
   "name": "Recurly",
   "dockerRepository": "airbyte/source-recurly",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-recurly"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-recurly",
+  "latestDockerImageTag": "0.1.0"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d29764f8-80d7-4dd7-acbe-1a42005ee5aa.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d29764f8-80d7-4dd7-acbe-1a42005ee5aa.json
@@ -3,5 +3,6 @@
   "name": "Zendesk Support",
   "dockerRepository": "airbyte/source-zendesk-support-singer",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-zendesk-support-singer"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-zendesk-support-singer",
+  "latestDockerImageTag": "0.1.1"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d8313939-3782-41b0-be29-b3ca20d8dd3a.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d8313939-3782-41b0-be29-b3ca20d8dd3a.json
@@ -3,5 +3,6 @@
   "name": "Intercom",
   "dockerRepository": "airbyte/source-intercom-singer",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-intercom-singer"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-intercom-singer",
+  "latestDockerImageTag": "0.1.1"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/decd338e-5647-4c0b-adf4-da0e75f5a750.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/decd338e-5647-4c0b-adf4-da0e75f5a750.json
@@ -3,5 +3,6 @@
   "name": "Postgres",
   "dockerRepository": "airbyte/source-postgres",
   "dockerImageTag": "0.1.6",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-postgres"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-postgres",
+  "latestDockerImageTag": "0.1.6"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e094cb9a-26de-4645-8761-65c0c425d1de.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e094cb9a-26de-4645-8761-65c0c425d1de.json
@@ -3,5 +3,6 @@
   "name": "Stripe",
   "dockerRepository": "airbyte/source-stripe-singer",
   "dockerImageTag": "0.1.8",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-stripe-source"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-stripe-source",
+  "latestDockerImageTag": "0.1.8"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e87ffa8e-a3b5-f69c-9076-6011339de1f6.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e87ffa8e-a3b5-f69c-9076-6011339de1f6.json
@@ -3,5 +3,6 @@
   "name": "Redshift",
   "dockerRepository": "airbyte/source-redshift",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-redshift"
+  "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-redshift",
+  "latestDockerImageTag": "0.1.1"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/eaf50f04-21dd-4620-913b-2a83f5635227.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/eaf50f04-21dd-4620-913b-2a83f5635227.json
@@ -3,5 +3,6 @@
   "name": "Microsoft teams",
   "dockerRepository": "airbyte/source-microsoft-teams",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-microsoft-teams"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-microsoft-teams",
+  "latestDockerImageTag": "0.1.0"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ec4b9503-13cb-48ab-a4ab-6ade4be46567.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ec4b9503-13cb-48ab-a4ab-6ade4be46567.json
@@ -3,5 +3,6 @@
   "name": "Freshdesk",
   "dockerRepository": "airbyte/source-freshdesk",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-freshdesk"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-freshdesk",
+  "latestDockerImageTag": "0.1.0"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ed799e2b-2158-4c66-8da4-b40fe63bc72a.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ed799e2b-2158-4c66-8da4-b40fe63bc72a.json
@@ -3,5 +3,6 @@
   "name": "Plaid",
   "dockerRepository": "airbyte/source-plaid",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-plaid"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-plaid",
+  "latestDockerImageTag": "0.1.0"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ef69ef6e-aa7f-4af1-a01d-ef775033524e.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ef69ef6e-aa7f-4af1-a01d-ef775033524e.json
@@ -3,5 +3,6 @@
   "name": "Github",
   "dockerRepository": "airbyte/source-github-singer",
   "dockerImageTag": "0.1.5",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-github-singer"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-github-singer",
+  "latestDockerImageTag": "0.1.5"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87.json
@@ -3,5 +3,6 @@
   "name": "Sendgrid",
   "dockerRepository": "airbyte/source-sendgrid",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-sendgrid"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-sendgrid",
+  "latestDockerImageTag": "0.1.0"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fdc8b827-3257-4b33-83cc-106d234c34d4.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fdc8b827-3257-4b33-83cc-106d234c34d4.json
@@ -3,5 +3,6 @@
   "name": "Google Adwords",
   "dockerRepository": "airbyte/source-google-adwords-singer",
   "dockerImageTag": "0.1.4",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-google-adwords"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-google-adwords",
+  "latestDockerImageTag": "0.1.4"
 }

--- a/airbyte-config/init/src/test/java/io/airbyte/config/init/SeedRepositoryTest.java
+++ b/airbyte-config/init/src/test/java/io/airbyte/config/init/SeedRepositoryTest.java
@@ -45,10 +45,20 @@ import org.junit.jupiter.api.Test;
 class SeedRepositoryTest {
 
   private static final String CONFIG_ID = "configId";
+  private static final UUID CONFIG_UUID = UUID.randomUUID();
   private static final JsonNode OBJECT = Jsons.jsonNode(ImmutableMap.builder()
-      .put(CONFIG_ID, UUID.randomUUID())
+      .put(CONFIG_ID, CONFIG_UUID.toString())
       .put("name", "barker")
       .put("description", "playwright")
+      .put("dockerImageTag", "1987")
+      .build());
+
+  private static final JsonNode OUTPUT_OBJECT = Jsons.jsonNode(ImmutableMap.builder()
+      .put(CONFIG_ID, CONFIG_UUID.toString())
+      .put("name", "barker")
+      .put("description", "playwright")
+      .put("dockerImageTag", "1987")
+      .put("latestDockerImageTag", "1987")
       .build());
 
   private Path input;
@@ -66,16 +76,16 @@ class SeedRepositoryTest {
   void testWrite() throws IOException {
     new SeedRepository().run(CONFIG_ID, input, output);
     final JsonNode actual = Jsons.deserialize(IOs.readFile(output, OBJECT.get(CONFIG_ID).asText() + ".json"));
-    assertEquals(OBJECT, actual);
+    assertEquals(OUTPUT_OBJECT, actual);
   }
 
   @Test
   void testOverwrites() throws IOException {
     new SeedRepository().run(CONFIG_ID, input, output);
     final JsonNode actual = Jsons.deserialize(IOs.readFile(output, OBJECT.get(CONFIG_ID).asText() + ".json"));
-    assertEquals(OBJECT, actual);
+    assertEquals(OUTPUT_OBJECT, actual);
 
-    final JsonNode clone = Jsons.clone(OBJECT);
+    final JsonNode clone = Jsons.clone(OUTPUT_OBJECT);
     ((ObjectNode) clone).put("description", "revolutionary");
     writeSeedList(clone);
 

--- a/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
@@ -9,6 +9,7 @@ required:
   - name
   - dockerRepository
   - dockerImageTag
+  - latestDockerImageTag
   - documentationUrl
 additionalProperties: false
 properties:
@@ -20,6 +21,8 @@ properties:
   dockerRepository:
     type: string
   dockerImageTag:
+    type: string
+  latestDockerImageTag:
     type: string
   documentationUrl:
     type: string

--- a/airbyte-config/models/src/main/resources/types/StandardSourceDefinition.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSourceDefinition.yaml
@@ -9,6 +9,7 @@ required:
   - name
   - dockerRepository
   - dockerImageTag
+  - latestDockerImageTag
   - documentationUrl
 additionalProperties: false
 properties:
@@ -20,6 +21,8 @@ properties:
   dockerRepository:
     type: string
   dockerImageTag:
+    type: string
+  latestDockerImageTag:
     type: string
   documentationUrl:
     type: string


### PR DESCRIPTION
Don't be intimidated by the number of files. All but 4 files in this PR are autogenerated code.

## What
* Add a field to Source/Destination definitions specifying the latest version of a connector that is available. 
* There are two goals here:
    * First, in the UI we want to be able to tell the user what version they are using versus what is the latests "official" version.
    * Second, when doing data migrations from one version to the next, we want to upgrade in the user's data the latest "official" version without necessarily updating their current version. 

## Misc
* There are a lot of other features around this that we can offer / should offer in the future. e.g. showing which versions of Airbyte a given connector is is compatible with. I think it's out of scope for what we need to do right now.

## Recommended reading order
1. `airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml`
2. `airbyte-config/models/src/main/resources/types/StandardSourceDefinition.yaml`
1. `airbyte-config/init/src/main/java/io/airbyte/config/init/SeedRepository.java`
1. `airbyte-config/init/src/test/java/io/airbyte/config/init/SeedRepositoryTest.java`
1. the rest (the rest is generated code)
