### PR TITLE
Test connectors only once when building their image

### DIFF
--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -19,8 +19,7 @@ cmd_build() {
   echo "Building $path"
     ./gradlew "$(_get_rule_base "$path"):clean"
     ./gradlew "$(_get_rule_base "$path"):build"
-
-    _execute_task_if_exists $path "integrationTest"
+    ./gradlew "$(_get_rule_base "$path"):integrationTest"
 }
 
 _execute_task_if_exists() {

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -21,7 +21,6 @@ cmd_build() {
     ./gradlew "$(_get_rule_base "$path"):build"
 
     _execute_task_if_exists $path "integrationTest"
-    _execute_task_if_exists $path "standardSourceTestPython"
 }
 
 _execute_task_if_exists() {


### PR DESCRIPTION
This functionality became redundant with the addition of https://github.com/airbytehq/airbyte/pull/1231/files

