### PR TITLE
add import to build.gradle.hbs so that python module will build

### DIFF
--- a/airbyte-integrations/connector-templates/source-python/build.gradle.hbs
+++ b/airbyte-integrations/connector-templates/source-python/build.gradle.hbs
@@ -1,6 +1,7 @@
 plugins {
     id 'airbyte-python'
     id 'airbyte-docker'
+    id 'airbyte-standard-source-test-file'
 }
 
 airbytePython {


### PR DESCRIPTION
without this when running :build on a newly generated python connector the build fails because the gradle task isn't imported.