### PR TITLE
remove symlinks from python sources and template

### DIFF
--- a/airbyte-integrations/bases/base-normalization/airbyte_protocol
+++ b/airbyte-integrations/bases/base-normalization/airbyte_protocol
@@ -1,1 +1,0 @@
-../../bases/airbyte-protocol/airbyte_protocol

--- a/airbyte-integrations/connector-templates/generator/plopfile.js
+++ b/airbyte-integrations/connector-templates/generator/plopfile.js
@@ -1,5 +1,4 @@
 'use strict';
-const fs = require('fs');
 const path = require('path');
 
 const getSuccessMessage = function(connectorName, outputPath){
@@ -25,7 +24,6 @@ module.exports = function (plop) {
   const singerSourceInputRoot = '../source-singer';
   const genericSourceInputRoot = '../source-generic';
 
-  const basesDir = '../../bases';
   const outputDir = '../../connectors';
   const pythonSourceOutputRoot = `${outputDir}/source-{{dashCase name}}`;
   const singerSourceOutputRoot = `${outputDir}/source-{{dashCase name}}-singer`;

--- a/airbyte-integrations/connector-templates/generator/plopfile.js
+++ b/airbyte-integrations/connector-templates/generator/plopfile.js
@@ -66,11 +66,6 @@ module.exports = function (plop) {
         templateFile: `${pythonSourceInputRoot}/.dockerignore.hbs`,
         path: `${pythonSourceOutputRoot}/.dockerignore`
       },
-      function(answers, config, plop){
-        const renderedOutputDir = plop.renderString(pythonSourceOutputRoot, answers);
-        fs.symlinkSync(`${basesDir}/base-python/base_python`, `${renderedOutputDir}/base_python`);
-        fs.symlinkSync(`${basesDir}/airbyte-protocol/airbyte_protocol`, `${renderedOutputDir}/airbyte_protocol`);
-      },
       {type: 'emitSuccess', outputPath: pythonSourceOutputRoot}]
   });
 
@@ -103,12 +98,6 @@ module.exports = function (plop) {
         abortOnFail: true,
         templateFile: `${singerSourceInputRoot}/.dockerignore.hbs`,
         path: `${singerSourceOutputRoot}/.dockerignore`
-      },
-      function(answers, config, plop){
-        const renderedOutputDir = plop.renderString(singerSourceOutputRoot, answers);
-        fs.symlinkSync(`${basesDir}/base-python/base_python`, `${renderedOutputDir}/base_python`);
-        fs.symlinkSync(`${basesDir}/airbyte-protocol/airbyte_protocol`, `${renderedOutputDir}/airbyte_protocol`);
-        fs.symlinkSync(`${basesDir}/base-singer/base_singer`, `${renderedOutputDir}/base_singer`);
       },
         {type: 'emitSuccess', outputPath: singerSourceOutputRoot},
     ]

--- a/airbyte-integrations/connectors/source-facebook-marketing-api-singer/airbyte_protocol
+++ b/airbyte-integrations/connectors/source-facebook-marketing-api-singer/airbyte_protocol
@@ -1,1 +1,0 @@
-../../bases/airbyte-protocol/airbyte_protocol

--- a/airbyte-integrations/connectors/source-facebook-marketing-api-singer/base_python
+++ b/airbyte-integrations/connectors/source-facebook-marketing-api-singer/base_python
@@ -1,1 +1,0 @@
-../../bases/base-python/base_python

--- a/airbyte-integrations/connectors/source-facebook-marketing-api-singer/base_singer
+++ b/airbyte-integrations/connectors/source-facebook-marketing-api-singer/base_singer
@@ -1,1 +1,0 @@
-../../bases/base-singer/base_singer

--- a/airbyte-integrations/connectors/source-file/airbyte_protocol
+++ b/airbyte-integrations/connectors/source-file/airbyte_protocol
@@ -1,1 +1,0 @@
-../../bases/airbyte-protocol/airbyte_protocol

--- a/airbyte-integrations/connectors/source-file/base_python
+++ b/airbyte-integrations/connectors/source-file/base_python
@@ -1,1 +1,0 @@
-../../bases/base-python/base_python

--- a/airbyte-integrations/connectors/source-file/base_python_test
+++ b/airbyte-integrations/connectors/source-file/base_python_test
@@ -1,1 +1,0 @@
-../../bases/base-python-test/base_python_test

--- a/airbyte-integrations/connectors/source-google-adwords-singer/airbyte_protocol
+++ b/airbyte-integrations/connectors/source-google-adwords-singer/airbyte_protocol
@@ -1,1 +1,0 @@
-../../bases/airbyte-protocol/airbyte_protocol

--- a/airbyte-integrations/connectors/source-google-adwords-singer/base_python
+++ b/airbyte-integrations/connectors/source-google-adwords-singer/base_python
@@ -1,1 +1,0 @@
-../../bases/base-python/base_python

--- a/airbyte-integrations/connectors/source-google-adwords-singer/base_singer
+++ b/airbyte-integrations/connectors/source-google-adwords-singer/base_singer
@@ -1,1 +1,0 @@
-../../bases/base-singer/base_singer

--- a/airbyte-integrations/connectors/source-googleanalytics-singer/airbyte-protocol
+++ b/airbyte-integrations/connectors/source-googleanalytics-singer/airbyte-protocol
@@ -1,1 +1,0 @@
-../../bases/airbyte-protocol

--- a/airbyte-integrations/connectors/source-googleanalytics-singer/base_singer
+++ b/airbyte-integrations/connectors/source-googleanalytics-singer/base_singer
@@ -1,1 +1,0 @@
-../../bases/base-singer/base_singer

--- a/airbyte-integrations/connectors/source-http-request/airbyte_protocol
+++ b/airbyte-integrations/connectors/source-http-request/airbyte_protocol
@@ -1,1 +1,0 @@
-../../bases/airbyte-protocol/airbyte_protocol

--- a/airbyte-integrations/connectors/source-http-request/base_python
+++ b/airbyte-integrations/connectors/source-http-request/base_python
@@ -1,1 +1,0 @@
-../../bases/base-python/base_python

--- a/airbyte-integrations/connectors/source-looker/airbyte_protocol
+++ b/airbyte-integrations/connectors/source-looker/airbyte_protocol
@@ -1,1 +1,0 @@
-../../bases/airbyte-protocol/airbyte_protocol

--- a/airbyte-integrations/connectors/source-looker/base_python
+++ b/airbyte-integrations/connectors/source-looker/base_python
@@ -1,1 +1,0 @@
-../../bases/base-python/base_python

--- a/airbyte-integrations/connectors/source-marketo-singer/airbyte_protocol
+++ b/airbyte-integrations/connectors/source-marketo-singer/airbyte_protocol
@@ -1,1 +1,0 @@
-../../bases/airbyte-protocol/airbyte_protocol

--- a/airbyte-integrations/connectors/source-marketo-singer/base_python
+++ b/airbyte-integrations/connectors/source-marketo-singer/base_python
@@ -1,1 +1,0 @@
-../../bases/base-python/base_python

--- a/airbyte-integrations/connectors/source-marketo-singer/base_singer
+++ b/airbyte-integrations/connectors/source-marketo-singer/base_singer
@@ -1,1 +1,0 @@
-../../bases/base-singer/base_singer

--- a/airbyte-integrations/connectors/source-microsoft-teams/airbyte_protocol
+++ b/airbyte-integrations/connectors/source-microsoft-teams/airbyte_protocol
@@ -1,1 +1,0 @@
-../../bases/airbyte-protocol/airbyte_protocol

--- a/airbyte-integrations/connectors/source-microsoft-teams/base_python
+++ b/airbyte-integrations/connectors/source-microsoft-teams/base_python
@@ -1,1 +1,0 @@
-../../bases/base-python/base_python


### PR DESCRIPTION
## What
* Removes the symlinks to internal libraries that we have been adding to all python sources.
* Removes generation of these symlinks from the template generator.
* It appears that these symlinks aren't doing anything. Autocomplete and handling of dependencies on airbyte python modules is fully handled by `requirements.txt`. These symlinks don't appear to be adding anything on top of that. We also are very spotty about where we've remembered to put them. If we find out that they were useful we can bring them back, but at this point they appear to just be cruft. Conferred with @jrhizor on this and he came to a similar conclusion.