### PR TITLE
file ttl manager

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/io/FileTtlManager.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/io/FileTtlManager.java
@@ -68,7 +68,7 @@ public class FileTtlManager {
         .build();
   }
 
-  public void registerTtl(Path path) {
+  public void register(Path path) {
     Preconditions.checkNotNull(path);
     Preconditions.checkArgument(path.toFile().isFile()); // only accept files.
 

--- a/airbyte-commons/src/main/java/io/airbyte/commons/io/FileTtlManager.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/io/FileTtlManager.java
@@ -1,0 +1,101 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.commons.io;
+
+import com.google.common.base.Preconditions;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalNotification;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The goal of this class is to remove files given a ttl. It does so WITHOUT adding any background
+ * threads. The tradeoff it makes is that it only removes files that have reached their TTL (or if
+ * the cache is full) whenever a new file is added to the manager. This is a good choice when trying
+ * to avoid file size growing monotonically over long stretches of time.
+ */
+public class FileTtlManager {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileTtlManager.class);
+
+  private final Cache<Path, Instant> cache;
+  private final long expirationDuration;
+  private final TimeUnit expirationTimeUnit;
+
+  public FileTtlManager(long expirationDuration, TimeUnit expirationTimeUnit, long maxSize) {
+    this.expirationDuration = expirationDuration;
+    this.expirationTimeUnit = expirationTimeUnit;
+    cache = CacheBuilder.newBuilder()
+        .expireAfterWrite(expirationDuration, expirationTimeUnit)
+        .maximumSize(maxSize)
+        .removalListener((RemovalNotification<Path, Instant> removalNotification) -> {
+          try {
+            Files.deleteIfExists(removalNotification.getKey());
+          } catch (IOException e) {
+            throw new RuntimeException("Failed to delete file at end of ttl: " + removalNotification.getKey(), e);
+          }
+        })
+        .build();
+  }
+
+  public void registerTtl(Path path) {
+    Preconditions.checkNotNull(path);
+    Preconditions.checkArgument(path.toFile().isFile()); // only accept files.
+
+    // add to cache so that it will be deleted when expiration time is reached.
+    cache.put(path, Instant.now());
+    // also add schedule deletion when jvm ends (in case jvm ends before expiration is reached).
+    path.toFile().deleteOnExit();
+    reportCacheStatus();
+  }
+
+  private void reportCacheStatus() {
+    final Instant now = Instant.now();
+    final StringBuilder sb = new StringBuilder(String.format("Files with ttls (total files: %s):\n", cache.size()));
+
+    cache.asMap().forEach((path, registeredAt) -> {
+      try {
+        final Duration timeElapsed = Duration.between(registeredAt, now);
+        final Duration diffBetweenTotalLifeTimeAndTimeElapsed = Duration.of(expirationDuration, expirationTimeUnit.toChronoUnit()).minus(timeElapsed);
+        final long minutesRemaining = Math.max(diffBetweenTotalLifeTimeAndTimeElapsed.toMinutes(), 0L);
+
+        sb.append(String.format("File name: %s, Size (MB) %s, TTL %s\n", path, FileUtils.byteCountToDisplaySize(Files.size(path)), minutesRemaining));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+    sb.append("---\n");
+    LOGGER.info(sb.toString());
+  }
+
+}

--- a/airbyte-commons/src/test/java/io/airbyte/commons/io/FileTtlManagerTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/io/FileTtlManagerTest.java
@@ -1,0 +1,78 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.commons.io;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FileTtlManagerTest {
+
+  private Path file1;
+  private Path file2;
+  private Path file3;
+
+  @BeforeEach
+
+  void setup() throws IOException {
+    Path testRoot = Files.createTempDirectory(Path.of("/tmp"), "ttl_test");
+    file1 = Files.createFile(testRoot.resolve("file1"));
+    file2 = Files.createFile(testRoot.resolve("file2"));
+    file3 = Files.createFile(testRoot.resolve("file3"));
+  }
+
+  @Test
+  void testExpiresAfterTime() throws InterruptedException {
+    final FileTtlManager fileTtlManager = new FileTtlManager(1, TimeUnit.SECONDS, 10);
+
+    assertTrue(Files.exists(file1));
+    fileTtlManager.registerTtl(file1);
+    fileTtlManager.registerTtl(file2);
+    assertTrue(Files.exists(file1));
+    Thread.sleep(10001L);
+    fileTtlManager.registerTtl(file3);
+    assertFalse(Files.exists(file1));
+  }
+
+  @Test
+  void testExpiresAfterSizeLimit() {
+    final FileTtlManager fileTtlManager = new FileTtlManager(1, TimeUnit.HOURS, 2);
+
+    assertTrue(Files.exists(file1));
+    fileTtlManager.registerTtl(file1);
+    assertTrue(Files.exists(file1));
+    fileTtlManager.registerTtl(file2);
+    assertTrue(Files.exists(file1));
+    fileTtlManager.registerTtl(file3);
+    assertFalse(Files.exists(file1));
+  }
+
+}

--- a/airbyte-commons/src/test/java/io/airbyte/commons/io/FileTtlManagerTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/io/FileTtlManagerTest.java
@@ -54,11 +54,11 @@ class FileTtlManagerTest {
     final FileTtlManager fileTtlManager = new FileTtlManager(1, TimeUnit.SECONDS, 10);
 
     assertTrue(Files.exists(file1));
-    fileTtlManager.registerTtl(file1);
-    fileTtlManager.registerTtl(file2);
+    fileTtlManager.register(file1);
+    fileTtlManager.register(file2);
     assertTrue(Files.exists(file1));
     Thread.sleep(10001L);
-    fileTtlManager.registerTtl(file3);
+    fileTtlManager.register(file3);
     assertFalse(Files.exists(file1));
   }
 
@@ -67,11 +67,11 @@ class FileTtlManagerTest {
     final FileTtlManager fileTtlManager = new FileTtlManager(1, TimeUnit.HOURS, 2);
 
     assertTrue(Files.exists(file1));
-    fileTtlManager.registerTtl(file1);
+    fileTtlManager.register(file1);
     assertTrue(Files.exists(file1));
-    fileTtlManager.registerTtl(file2);
+    fileTtlManager.register(file2);
     assertTrue(Files.exists(file1));
-    fileTtlManager.registerTtl(file3);
+    fileTtlManager.register(file3);
     assertFalse(Files.exists(file1));
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigurationApiFactory.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigurationApiFactory.java
@@ -24,6 +24,7 @@
 
 package io.airbyte.server;
 
+import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.db.Database;
 import io.airbyte.scheduler.client.CachingSchedulerJobClient;
@@ -38,6 +39,7 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
   private static CachingSchedulerJobClient schedulerJobClient;
   private static String airbyteVersion;
   private static Database database;
+  private static FileTtlManager archiveTtlManager;
 
   public static void setConfigRepository(final ConfigRepository configRepository) {
     ConfigurationApiFactory.configRepository = configRepository;
@@ -47,7 +49,7 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
     ConfigurationApiFactory.jobPersistence = jobPersistence;
   }
 
-  public static void setSpecCache(final CachingSchedulerJobClient schedulerJobClient) {
+  public static void setSchedulerJobClient(final CachingSchedulerJobClient schedulerJobClient) {
     ConfigurationApiFactory.schedulerJobClient = schedulerJobClient;
   }
 
@@ -59,6 +61,10 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
     ConfigurationApiFactory.database = database;
   }
 
+  public static void setArchiveTtlManager(final FileTtlManager archiveTtlManager) {
+    ConfigurationApiFactory.archiveTtlManager = archiveTtlManager;
+  }
+
   @Override
   public ConfigurationApi provide() {
     return new ConfigurationApi(
@@ -66,7 +72,8 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
         ConfigurationApiFactory.database,
         ConfigurationApiFactory.configRepository,
         ConfigurationApiFactory.jobPersistence,
-        ConfigurationApiFactory.schedulerJobClient);
+        ConfigurationApiFactory.schedulerJobClient,
+        ConfigurationApiFactory.archiveTtlManager);
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -25,6 +25,7 @@
 package io.airbyte.server;
 
 import io.airbyte.analytics.TrackingClientSingleton;
+import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.config.Configs;
 import io.airbyte.config.EnvConfigs;
@@ -49,6 +50,7 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -91,9 +93,10 @@ public class ServerApp {
 
     ConfigurationApiFactory.setAirbyteVersion(airbyteVersion);
     ConfigurationApiFactory.setDatabase(database);
-    ConfigurationApiFactory.setSpecCache(new SpecCachingSchedulerJobClient(jobPersistence, new DefaultJobCreator(jobPersistence)));
+    ConfigurationApiFactory.setSchedulerJobClient(new SpecCachingSchedulerJobClient(jobPersistence, new DefaultJobCreator(jobPersistence)));
     ConfigurationApiFactory.setConfigRepository(configRepository);
     ConfigurationApiFactory.setJobPersistence(jobPersistence);
+    ConfigurationApiFactory.setArchiveTtlManager(new FileTtlManager(10, TimeUnit.MINUTES, 10));
 
     ResourceConfig rc =
         new ResourceConfig()

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -71,6 +71,7 @@ import io.airbyte.api.model.WebBackendConnectionUpdate;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.api.model.WorkspaceRead;
 import io.airbyte.api.model.WorkspaceUpdate;
+import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.db.Database;
@@ -119,7 +120,8 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
                           final Database database,
                           final ConfigRepository configRepository,
                           final JobPersistence jobPersistence,
-                          final CachingSchedulerJobClient schedulerJobClient) {
+                          final CachingSchedulerJobClient schedulerJobClient,
+                          final FileTtlManager archiveTtlManager) {
     final JsonSchemaValidator schemaValidator = new JsonSchemaValidator();
     schedulerHandler = new SchedulerHandler(configRepository, schedulerJobClient);
     workspacesHandler = new WorkspacesHandler(configRepository);
@@ -135,7 +137,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
     webBackendSourceHandler = new WebBackendSourceHandler(sourceHandler, schedulerHandler);
     webBackendDestinationHandler = new WebBackendDestinationHandler(destinationHandler, schedulerHandler);
     healthCheckHandler = new HealthCheckHandler(configRepository);
-    archiveHandler = new ArchiveHandler(airbyteVersion, configRepository, database);
+    archiveHandler = new ArchiveHandler(airbyteVersion, configRepository, database, archiveTtlManager);
   }
 
   // WORKSPACE

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
@@ -77,7 +77,7 @@ public class ArchiveHandler {
     try {
       final Path tempFolder = Files.createTempDirectory(Path.of("/tmp"), ARCHIVE_FILE_NAME);
       final File archive = Files.createTempFile(ARCHIVE_FILE_NAME, ".tar.gz").toFile();
-      fileTtlManager.registerTtl(archive.toPath());
+      fileTtlManager.register(archive.toPath());
       try {
         exportVersionFile(tempFolder);
         exportAirbyteConfig(tempFolder);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
@@ -27,6 +27,7 @@ package io.airbyte.server.handlers;
 import io.airbyte.api.model.ImportRead;
 import io.airbyte.api.model.ImportRead.StatusEnum;
 import io.airbyte.commons.io.Archives;
+import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.DestinationConnection;
@@ -63,8 +64,10 @@ public class ArchiveHandler {
   private final String version;
   private final ConfigRepository configRepository;
   private final Database database;
+  private final FileTtlManager fileTtlManager;
 
-  public ArchiveHandler(final String version, final ConfigRepository configRepository, final Database database) {
+  public ArchiveHandler(final String version, final ConfigRepository configRepository, final Database database, final FileTtlManager fileTtlManager) {
+    this.fileTtlManager = fileTtlManager;
     this.version = version;
     this.configRepository = configRepository;
     this.database = database;
@@ -74,7 +77,7 @@ public class ArchiveHandler {
     try {
       final Path tempFolder = Files.createTempDirectory(Path.of("/tmp"), ARCHIVE_FILE_NAME);
       final File archive = Files.createTempFile(ARCHIVE_FILE_NAME, ".tar.gz").toFile();
-      archive.deleteOnExit();
+      fileTtlManager.registerTtl(archive.toPath());
       try {
         exportVersionFile(tempFolder);
         exportAirbyteConfig(tempFolder);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -145,7 +145,7 @@ public class ArchiveHandlerTest {
     verify(configRepository).writeStandardSync(sourceSync);
     verify(configRepository).writeStandardSync(destinationSync);
     verify(configRepository).writeStandardSchedule(syncSchedule);
-    verify(fileTtlManager).registerTtl(any());
+    verify(fileTtlManager).register(any());
   }
 
   @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -27,12 +27,12 @@ package io.airbyte.server.handlers;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
@@ -69,6 +69,7 @@ public class ArchiveHandlerTest {
   private PostgreSQLContainer<?> container;
   private Database database;
   private ArchiveHandler archiveHandler;
+  private FileTtlManager fileTtlManager;
 
   @BeforeEach
   void setUp() {
@@ -76,7 +77,8 @@ public class ArchiveHandlerTest {
     dbConfig = null;
     container = mock(PostgreSQLContainer.class);
     database = mock(Database.class);
-    archiveHandler = new ArchiveHandler("test-version", configRepository, database);
+    fileTtlManager = mock(FileTtlManager.class);
+    archiveHandler = new ArchiveHandler("test-version", configRepository, database, fileTtlManager);
   }
 
   @AfterEach
@@ -123,32 +125,27 @@ public class ArchiveHandlerTest {
     final StandardSync sourceSync = ConnectionHelpers.generateSyncWithSourceId(sourceConnection1.getSourceId());
     final StandardSyncSchedule syncSchedule = ConnectionHelpers.generateSchedule(sourceSync.getConnectionId());
 
-    when(configRepository.getStandardWorkspace(PersistenceConstants.DEFAULT_WORKSPACE_ID))
-        .thenReturn(workspace);
-    when(configRepository.listStandardSources())
-        .thenReturn(List.of(standardSource));
-    when(configRepository.listStandardDestinationDefinitions())
-        .thenReturn(List.of(standardDestination));
-    when(configRepository.listSourceConnection())
-        .thenReturn(List.of(sourceConnection1, sourceConnection2));
-    when(configRepository.listDestinationConnection())
-        .thenReturn(List.of(destinationConnection));
-    when(configRepository.listStandardSyncs())
-        .thenReturn(List.of(destinationSync, sourceSync));
-    when(configRepository.getStandardSyncSchedule(sourceSync.getConnectionId()))
-        .thenReturn(syncSchedule);
+    // Read operations
+    when(configRepository.getStandardWorkspace(PersistenceConstants.DEFAULT_WORKSPACE_ID)).thenReturn(workspace);
+    when(configRepository.listStandardSources()).thenReturn(List.of(standardSource));
+    when(configRepository.listStandardDestinationDefinitions()).thenReturn(List.of(standardDestination));
+    when(configRepository.listSourceConnection()).thenReturn(List.of(sourceConnection1, sourceConnection2));
+    when(configRepository.listDestinationConnection()).thenReturn(List.of(destinationConnection));
+    when(configRepository.listStandardSyncs()).thenReturn(List.of(destinationSync, sourceSync));
+    when(configRepository.getStandardSyncSchedule(sourceSync.getConnectionId())).thenReturn(syncSchedule);
 
     archiveHandler.importData(archiveHandler.exportData());
 
-    verify(configRepository, times(1)).writeStandardWorkspace(workspace);
-    verify(configRepository, times(1)).writeStandardSource(standardSource);
-    verify(configRepository, times(1)).writeStandardDestinationDefinition(standardDestination);
-    verify(configRepository, times(1)).writeSourceConnection(sourceConnection1);
-    verify(configRepository, times(1)).writeSourceConnection(sourceConnection2);
-    verify(configRepository, times(1)).writeDestinationConnection(destinationConnection);
-    verify(configRepository, times(1)).writeStandardSync(sourceSync);
-    verify(configRepository, times(1)).writeStandardSync(destinationSync);
-    verify(configRepository, times(1)).writeStandardSchedule(syncSchedule);
+    verify(configRepository).writeStandardWorkspace(workspace);
+    verify(configRepository).writeStandardSource(standardSource);
+    verify(configRepository).writeStandardDestinationDefinition(standardDestination);
+    verify(configRepository).writeSourceConnection(sourceConnection1);
+    verify(configRepository).writeSourceConnection(sourceConnection2);
+    verify(configRepository).writeDestinationConnection(destinationConnection);
+    verify(configRepository).writeStandardSync(sourceSync);
+    verify(configRepository).writeStandardSync(destinationSync);
+    verify(configRepository).writeStandardSchedule(syncSchedule);
+    verify(fileTtlManager).registerTtl(any());
   }
 
   @Test
@@ -173,7 +170,7 @@ public class ArchiveHandlerTest {
           "INSERT INTO id_and_name (id, name, updated_at) VALUES (1,'picard', '2004-10-19'),  (2, 'crusher', '2005-10-19'), (3, 'vash', '2006-10-19');");
       return null;
     });
-    archiveHandler = new ArchiveHandler("test-version", configRepository, database);
+    archiveHandler = new ArchiveHandler("test-version", configRepository, database, fileTtlManager);
 
     archiveHandler.importData(archiveHandler.exportData());
   }


### PR DESCRIPTION
## What
* We have [a problem](https://github.com/airbytehq/airbyte/pull/1551#discussion_r554244916) that when we return a file in our API we need to provide our open api library with a `File`. But that means we do not have an obvious opportunity to clean up that file afterwards. If we do not clean up the file then we we will eventually blow up the disk space for the server. We definitely need to guard against this.

## How
* This solution uses a guava cache to handle deleting files lazily after they get too old or we have too many files. It also adds a "guarantee" that the files will be deleted when the JVM stops.
* One tradeoff here is that we are not running any sort of background thread in order to do this clean up. Instead the implementation is backed by a guava cache. This means that clean up only ever happens when we write to or read from the cache. The drawback here is that that can be a little unintuitive. 
* The other downside is that we don't have any guarantee that we won't run out of disk space, even with this manager. If the archives get huge we will run into problems. I think this trade off is okay to make, because when we hit that size, we will likely want to be rethinking whether we want to be moving this data via API at all anyway.
* If someone has an idea for something more intuitive and/or safe, I'm all for it and will be happy to trash this. 
