### PR TITLE
safe boxed Boolean to boolean

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/lang/MoreBooleans.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/lang/MoreBooleans.java
@@ -1,0 +1,40 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.commons.lang;
+
+public class MoreBooleans {
+
+  /**
+   * Safely handles converting boxed Booleans to booleans, even when they are null. Evaluates null as
+   * false.
+   *
+   * @param bool boxed
+   * @return unboxed
+   */
+  public static boolean evaluateNullAsFalse(Boolean bool) {
+    return bool != null && bool;
+  }
+
+}

--- a/airbyte-commons/src/main/java/io/airbyte/commons/lang/MoreBooleans.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/lang/MoreBooleans.java
@@ -33,7 +33,7 @@ public class MoreBooleans {
    * @param bool boxed
    * @return unboxed
    */
-  public static boolean evaluateNullAsFalse(Boolean bool) {
+  public static boolean isTruthy(Boolean bool) {
     return bool != null && bool;
   }
 

--- a/airbyte-commons/src/test/java/io/airbyte/commons/lang/MoreBooleansTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/lang/MoreBooleansTest.java
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.commons.lang;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MoreBooleansTest {
+
+  @SuppressWarnings("ConstantConditions")
+  @Test
+  void evaluateNullAsFalse() {
+    assertTrue(MoreBooleans.evaluateNullAsFalse(Boolean.TRUE));
+    assertFalse(MoreBooleans.evaluateNullAsFalse(Boolean.FALSE));
+    assertFalse(MoreBooleans.evaluateNullAsFalse(null));
+  }
+
+}

--- a/airbyte-commons/src/test/java/io/airbyte/commons/lang/MoreBooleansTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/lang/MoreBooleansTest.java
@@ -34,9 +34,9 @@ class MoreBooleansTest {
   @SuppressWarnings("ConstantConditions")
   @Test
   void evaluateNullAsFalse() {
-    assertTrue(MoreBooleans.evaluateNullAsFalse(Boolean.TRUE));
-    assertFalse(MoreBooleans.evaluateNullAsFalse(Boolean.FALSE));
-    assertFalse(MoreBooleans.evaluateNullAsFalse(null));
+    assertTrue(MoreBooleans.isTruthy(Boolean.TRUE));
+    assertFalse(MoreBooleans.isTruthy(Boolean.FALSE));
+    assertFalse(MoreBooleans.isTruthy(null));
   }
 
 }


### PR DESCRIPTION
## What
* Handle the null case.
* We run into this a lot since all of the json => pojo things expose booleans as `Boolean` and not `boolean`.