### PR TITLE
allow formatting just the current python module

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -97,6 +97,11 @@ class AirbytePythonPlugin implements Plugin<Project> {
             dependsOn project.flakeCheck
         }
 
+        // enabled running format for just the current python module (not the whole world).
+        project.task('format', type: DefaultTask) {
+            dependsOn project.airbytePythonApply
+            dependsOn project.rootProject.spotlessApply
+        }
 
         project.task('airbytePythonTest', type: DefaultTask) {
             dependsOn project.airbytePythonApply

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,7 +48,6 @@ include ':tools:code-generator'
 
 // include all connector projects
 def integrationsPath = rootDir.toPath().resolve('airbyte-integrations/connectors')
-println integrationsPath
 integrationsPath.eachDir { dir ->
     def buildFiles = file(dir).list { file, name -> name == "build.gradle" }
 


### PR DESCRIPTION
## What
* the command we use for formatting our project is a bit intimidating if you are a new contributor. it runs the python formatting for every single python project that we have. it often fails for transient reasons (e.g. pip install, connectivity, etc) which requires a contributor to have to sort through what's going on needlessly. we should allow a contributor to be able to run the format command for _just_ the module that they are working on.
* My goal here is in the walkthrough for adding a source, giving the user a command that does just the formatting for their module with little risk of other random errors.

## How
* adds `:airbyte-integrations:connectors:<source-name>:format`. It will run all of the checks for just that module. 
* It does run `spotlessApply` which does affect the whole project, but it is generally very fast and not flakey.
