### PR TITLE
add file checks to kube/docker github workflows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -143,6 +143,9 @@ jobs:
           GIT_REVISION: ${{ github.sha }}
           CORE_ONLY: true
 
+      - name: Ensure no file change
+        run: git status --porcelain && test -z "$(git status --porcelain)"
+
       - name: Run Docker End-to-End Acceptance Tests
         run: |
           ./tools/bin/acceptance_test.sh
@@ -178,6 +181,9 @@ jobs:
         env:
           GIT_REVISION: ${{ github.sha }}
           CORE_ONLY: true
+
+      - name: Ensure no file change
+        run: git status --porcelain && test -z "$(git status --porcelain)"
 
       - name: Run Kubernetes End-to-End Acceptance Tests
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,11 @@ def createSpotlessTarget = { pattern ->
         'dbt-project-template',
         'tools'
     ]
+
+    if(System.getenv().containsKey("CORE_ONLY")) {
+        excludes.add("airbyte-integrations/connectors")
+    }
+
     return fileTree(dir: rootDir, include: pattern, exclude: excludes.collect {"**/${it}"})
 }
 


### PR DESCRIPTION
I think this is the only remaining thing to use `test_docker` and `test_kube` as "good enough" checks to merge in PRs without running anything against the integration subprojects. 