### PR TITLE
Document how to Upgrade Airbyte

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,6 +7,7 @@
   * [Config & Persistence](tutorials/airbyte-config-persistence.md)
   * [Building a toy connector](tutorials/toy-connector.md)
   * [Beginner's Guide to the AirbyteCatalog](tutorials/beginners-guide-to-catalog.md)
+  * [Upgrading Airbyte](tutorials/upgrading-airbyte.md)
 * [Changelog](changelog/README.md)
   * [Platform](changelog/platform.md)
   * [Connectors](changelog/connectors.md)

--- a/docs/tutorials/upgrading-airbyte.md
+++ b/docs/tutorials/upgrading-airbyte.md
@@ -6,12 +6,14 @@ Coming soon! This tutorial is a work in progress for a feature that is currently
 
 ## Overview
 
-Airbyte releases a new version of its stable version at least once a week. Some of these releases require updating the data that Airbyte stores internally. This tutorial will describe how to determine if you need to run this ugprade process, and if you do, how to do so. This process does require temporarily turning off Airbyte.
+This tutorial will describe how to determine if you need to run this upgrade process, and if you do, how to do so. This process does require temporarily turning off Airbyte.
 
 ## Determining if you need to Upgrade
-Not every new version will require an upgrade. We follow standard [Semantic Versioning](https://semver.org/) conventions. Data migrations should only be required when upgrading to a new major version of Airbyte. You can always find the latest stable version of Airbyte in our repository [here](https://github.com/airbytehq/airbyte/blob/master/.env#L1). If you are upgrading to a new major version follow the steps below.
+All minor and major version releases requiring updating the data that Airbyte stores internally. We follow standard [Semantic Versioning](https://semver.org/) conventions. You can always find the latest stable version of Airbyte in our repository [here](https://github.com/airbytehq/airbyte/blob/master/.env#L1). If you are upgrading to a new major or minor version follow the steps below to upgrade your configuration data.
 
+{% hint style="info" %}
 If you inadvertently upgrade to a version of Airbyte that is not compatible with your data, the docker containers will not start up and will log an error stating the incompatibility. In these cases, you should downgrade to the previous version that worked and follow the steps below.
+{% endhint %}
 
 ## Upgrading (Docker)
 1. Turn off Airbyte
@@ -23,13 +25,10 @@ docker-compose down
 docker-compose up db server webapp
 ```
 3. Navigate to the Admin page in the UI. Then go to the Configuration Tab. Click Export. This will download a gzipped tarball of all of your Airbyte configuration data and sync history. _Note: Any secrets that you have entered into Airbyte will be in this archive, so you should treat it as secret._
-4. Build the Migration App. This is the app that will migrate the data in the archive.
+
+4.  Migrate the archive to the new version using the Migration App (packaged in a docker container).
 ```bash
-./gradlew :airbyte-migration:build
-```
-5.  Migrate the archive to the new version using the Migration App (packaged in a docker container).
-```bash
-docker run --rm -v <path to directory containing downloaded airbyte_archive.tar.gz>:/config airbyte/migration:dev --\
+docker run --rm -v <path to directory containing downloaded airbyte_archive.tar.gz>:/config airbyte/migration:<version you are upgrading to> --\
   --input /config/airbyte_archive.tar.gz\
   --output <path to where migrated archive will be written (should end in .tar.gz)>\
   --target-version <version you are migrating to>
@@ -37,34 +36,38 @@ docker run --rm -v <path to directory containing downloaded airbyte_archive.tar.
 
 Here's an example of what might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 ```bash
-docker run --rm -v /tmp:/config airbyte/migration:dev --\
+docker run --rm -v /tmp:/config airbyte/migration:0.11.1-alpha --\
   --input /config/airbyte_archive.tar.gz\
   --output /config/airbyte_archive_migrated.tar.gz\
   --target-version 0.11.1-alpha
 ```
 
-6. Turn off Airbyte fully.
+{% hint style="info" %}
+It may seem confusing that you need to specify the target version twice. The version passed as `--target-version` specifies the version to which the data will be migrated. Specifying the target version in the docker container tag makes sure that you are pulling an image that at least has the migration for the version you want. Technically the version used in the docker tag can be equal to or greater than the version you are upgrading to. For the simplicity of this tutorial we have them match.
+{% endhint %}
+
+5. Turn off Airbyte fully.
 ```
 docker-compose down
 ```
 
-7. Delete the existing Airbyte docker volumes. _Note: Make sure you have already exported your data (step 3). This command is going to delete your data in Docker!_
+6. Delete the existing Airbyte docker volumes. _Note: Make sure you have already exported your data (step 3). This command is going to delete your data in Docker!_
 ```bash
 docker volume rm $(docker volume ls -q | grep airbyte)
 ```
 
-8. Upgrade the docker instance to new version.
+7. Upgrade the docker instance to new version.
 
     i. If you are running Airbyte from a cloned version of the Airbyte repo and want to use the current most recent stable version, just `git pull`.
 
     ii. If you are running Airbyte from a `.env`, edit the `VERSION` field in that file to be the desired version.
 
-9. Bring Airbyte back online.
+8. Bring Airbyte back online.
 ```
 docker-compose up
 ```
 
-10. Complete Preferences section. In the subsequent setup page click "Skip Onboarding". Navigate to the Admin page in the UI. Then go to the Configuration Tab. Click Import. This will prompt you to upload the migrated archive to Airbyte. After this completes, your upgraded Airbyte instance will now be running with all of your original configuration.
+9. Complete Preferences section. In the subsequent setup page click "Skip Onboarding". Navigate to the Admin page in the UI. Then go to the Configuration Tab. Click Import. This will prompt you to upload the migrated archive to Airbyte. After this completes, your upgraded Airbyte instance will now be running with all of your original configuration.
 
 This step will throw an exception if the data you are trying to upload does not match the version of Airbyte that is running.
 

--- a/docs/tutorials/upgrading-airbyte.md
+++ b/docs/tutorials/upgrading-airbyte.md
@@ -4,7 +4,7 @@ _Coming soon! This tutorial is a work in progress for a feature that is currentl
 
 ## Overview
 
-Airbyte releases a new version of its stable version at least once a week. Some of these releases require updating the data the Airbyte stores internally. This tutorial will describe how to determine if you need to run this ugprade process, and if you do, how to do so. This process does require temporarily turning off Airbyte.
+Airbyte releases a new version of its stable version at least once a week. Some of these releases require updating the data that Airbyte stores internally. This tutorial will describe how to determine if you need to run this ugprade process, and if you do, how to do so. This process does require temporarily turning off Airbyte.
 
 ## Determining if you need to Upgrade
 Not every new version will require an upgrade. We follow standard [Semantic Versioning](https://semver.org/) conventions. Data migrations should only be required when upgrading to a new major version of Airbyte. You can always find the latest stable version of Airbyte in our repository [here](https://github.com/airbytehq/airbyte/blob/master/.env#L1). If you are upgrading to a new major version follow the steps below.

--- a/docs/tutorials/upgrading-airbyte.md
+++ b/docs/tutorials/upgrading-airbyte.md
@@ -1,4 +1,6 @@
-_Coming soon! This tutorial is a work in progress for a feature that is currently in development. It is not usable yet!_
+{% hint style="warning" %}
+Coming soon! This tutorial is a work in progress for a feature that is currently in development. It is not usable yet!
+{% endhint %}
 
 # Upgrading Airbyte
 

--- a/docs/tutorials/upgrading-airbyte.md
+++ b/docs/tutorials/upgrading-airbyte.md
@@ -1,0 +1,89 @@
+_Coming soon! This tutorial is a work in progress for a feature that is currently in development. It is not usable yet!_
+
+# Upgrading Airbyte
+
+## Overview
+
+Airbyte releases a new version of its stable version at least once a week. Some of these releases require updating the data the Airbyte stores internally. This tutorial will describe how to determine if you need to run this ugprade process, and if you do, how to do so. This process does require temporarily turning off Airbyte.
+
+## Determining if you need to Upgrade
+Not every new version will require an upgrade. We follow standard [Semantic Versioning](https://semver.org/) conventions. Data migrations should only be required when upgrading to a new major version of Airbyte. You can always find the latest stable version of Airbyte in our repository [here](https://github.com/airbytehq/airbyte/blob/master/.env#L1). If you are upgrading to a new major version follow the steps below.
+
+If you inadvertently upgrade to a version of Airbyte that is not compatible with your data, the docker containers will not start up and will log an error stating the incompatibility. In these cases, you should downgrade to the previous version that worked and follow the steps below.
+
+## Upgrading (Docker)
+1. Turn off Airbyte
+```
+docker-compose down
+```
+2. Turn on the Airbyte web app, server, and db.
+```
+docker-compose up db server webapp
+```
+3. Navigate to the Admin page in the UI. Then go to the Configuration Tab. Click Export. This will download a gzipped tarball of all of your Airbyte configuration data and sync history. _Note: Any secrets that you have entered into Airbyte will be in this archive, so you should treat it as secret._
+4. Build the Migration App. This is the app that will migrate the data in the archive.
+```bash
+./gradlew :airbyte-migration:build
+```
+5.  Migrate the archive to the new version using the Migration App (packaged in a docker container).
+```bash
+docker run --rm -v <path to directory containing downloaded airbyte_archive.tar.gz>:/config airbyte/migration:dev --\
+  --input /config/airbyte_archive.tar.gz\
+  --output <path to where migrated archive will be written (should end in .tar.gz)>\
+  --target-version <version you are migrating to>
+```
+
+Here's an example of what might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
+```bash
+docker run --rm -v /tmp:/config airbyte/migration:dev --\
+  --input /config/airbyte_archive.tar.gz\
+  --output /config/airbyte_archive_migrated.tar.gz\
+  --target-version 0.11.1-alpha
+```
+
+6. Turn off Airbyte fully.
+```
+docker-compose down
+```
+
+7. Delete the existing Airbyte docker volumes. _Note: Make sure you have already exported your data (step 3). This command is going to delete your data in Docker!_
+```bash
+docker volume rm $(docker volume ls -q | grep airbyte)
+```
+
+8. Upgrade the docker instance to new version.
+
+    i. If you are running Airbyte from a cloned version of the Airbyte repo and want to use the current most recent stable version, just `git pull`.
+
+    ii. If you are running Airbyte from a `.env`, edit the `VERSION` field in that file to be the desired version.
+
+9. Bring Airbyte back online.
+```
+docker-compose up
+```
+
+10. Complete Preferences section. In the subsequent setup page click "Skip Onboarding". Navigate to the Admin page in the UI. Then go to the Configuration Tab. Click Import. This will prompt you to upload the migrated archive to Airbyte. After this completes, your upgraded Airbyte instance will now be running with all of your original configuration.
+
+This step will throw an exception if the data you are trying to upload does not match the version of Airbyte that is running.
+
+## API Instruction
+If you prefer to import and export your data via API instead the UI, follow these instructions:
+
+1. Instead of Step 3 above use the following curl command to export the archive:
+```bash
+curl -H "Content-Type: application/json" -X POST localhost:8001/api/v1/deployment/export --output /tmp/airbyte_archive.tar.gz
+```
+
+2. Instead of Step X above user the following curl command to import the migrated archive:
+```bash
+curl -H "Content-Type: application/x-gzip" -X POST localhost:8001/api/v1/deployment/import --data-binary @<path to arhive>
+```
+
+Here is an example of what this request might look like assuming that the migrated archive is called `airbyte_archive_migrated.tar.gz` and is in the `/tmp` directory.
+```bash
+curl -H "Content-Type: application/x-gzip" -X POST localhost:8001/api/v1/deployment/import --data-binary @/tmp/airbyte_archive_migrated.tar.gz
+```
+
+## Upgrading (K8s)
+
+_coming soon_


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/1510

## What
Documents how to use migration app and import / export to upgrade Airbyte.

A few open questions, issues mentioned in line below

Based on how hard this process is, I am starting to wonder if we could do it without so much manual work from the user. The hard part is orchestrating all of the docker compose stuff, I think. And that feels non trivial. Probably we should leave it for now, but we should listen for feedback on this process.