### PR TITLE
temporary hotfix for jdbc source oom

### DIFF
--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -31,7 +31,6 @@ import com.google.common.collect.Lists;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.commons.resources.MoreResources;
-import io.airbyte.commons.stream.MoreStreams;
 import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Databases;
 import io.airbyte.db.jdbc.JdbcDatabase;
@@ -210,15 +209,14 @@ public abstract class AbstractJdbcSource implements Source {
       }
 
       final JsonSchemaPrimitive cursorType = IncrementalUtils.getCursorType(airbyteStream, cursorField);
-      final StateDecoratingIterator stateDecoratingIterator = new StateDecoratingIterator(
+
+      stream = StateDecoratingIterator.stream(
           internalMessageStream,
           stateManager,
           streamName,
           cursorField,
           cursorOptional.orElse(null),
           cursorType);
-
-      stream = MoreStreams.toStream(stateDecoratingIterator);
     } else if (airbyteStream.getSyncMode() == SyncMode.FULL_REFRESH || airbyteStream.getSyncMode() == null) {
       stream = getFullRefreshStream(database, streamName, selectedDatabaseFields, table, emittedAt);
     } else {

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/StateDecoratingStreamTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/StateDecoratingStreamTest.java
@@ -1,0 +1,125 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.integrations.source.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteMessage.Type;
+import io.airbyte.protocol.models.AirbyteRecordMessage;
+import io.airbyte.protocol.models.AirbyteStateMessage;
+import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+class StateDecoratingStreamTest {
+
+  private static final String STREAM_NAME = "shoes";
+  private static final String UUID_FIELD_NAME = "ascending_inventory_uuid";
+  private static final AirbyteMessage RECORD_MESSAGE1 = new AirbyteMessage()
+      .withType(Type.RECORD)
+      .withRecord(new AirbyteRecordMessage()
+          .withData(Jsons.jsonNode(ImmutableMap.of(UUID_FIELD_NAME, "abc"))));
+  private static final AirbyteMessage RECORD_MESSAGE2 = new AirbyteMessage()
+      .withType(Type.RECORD)
+      .withRecord(new AirbyteRecordMessage()
+          .withData(Jsons.jsonNode(ImmutableMap.of(UUID_FIELD_NAME, "def"))));
+
+  private static Stream<AirbyteMessage> messageStream;
+  private JdbcStateManager stateManager;
+  private AirbyteStateMessage stateMessage;
+
+  @BeforeEach
+  void setup() {
+    messageStream = Stream.of(RECORD_MESSAGE1, RECORD_MESSAGE2);
+    stateManager = mock(JdbcStateManager.class);
+    stateMessage = mock(AirbyteStateMessage.class);
+    when(stateManager.getOriginalCursorField(STREAM_NAME)).thenReturn(Optional.empty());
+    when(stateManager.getOriginalCursor(STREAM_NAME)).thenReturn(Optional.empty());
+    when(stateManager.getCursorField(STREAM_NAME)).thenReturn(Optional.empty());
+    when(stateManager.getCursor(STREAM_NAME)).thenReturn(Optional.empty());
+  }
+
+  @Test
+  void test() {
+    when(stateManager.updateAndEmit(STREAM_NAME, "def")).thenReturn(stateMessage);
+
+    final Iterator<AirbyteMessage> iterator = StateDecoratingIterator.stream(
+        messageStream,
+        stateManager,
+        STREAM_NAME,
+        UUID_FIELD_NAME,
+        null,
+        JsonSchemaPrimitive.STRING).iterator();
+
+    assertEquals(RECORD_MESSAGE1, iterator.next());
+    assertEquals(RECORD_MESSAGE2, iterator.next());
+    assertEquals(stateMessage, iterator.next().getState());
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  void testWithInitialCursor() {
+    when(stateManager.updateAndEmit(STREAM_NAME, "xyz")).thenReturn(stateMessage);
+
+    final Iterator<AirbyteMessage> iterator = StateDecoratingIterator.stream(
+        messageStream,
+        stateManager,
+        STREAM_NAME,
+        UUID_FIELD_NAME,
+        "xyz",
+        JsonSchemaPrimitive.STRING).iterator();
+
+    assertEquals(RECORD_MESSAGE1, iterator.next());
+    assertEquals(RECORD_MESSAGE2, iterator.next());
+    assertEquals(stateMessage, iterator.next().getState());
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  void testEmptyStream() {
+    when(stateManager.updateAndEmit(STREAM_NAME, null)).thenReturn(stateMessage);
+
+    final Iterator<AirbyteMessage> iterator = StateDecoratingIterator.stream(
+        Stream.empty(),
+        stateManager,
+        STREAM_NAME,
+        UUID_FIELD_NAME,
+        null,
+        JsonSchemaPrimitive.STRING).iterator();
+
+    assertEquals(stateMessage, iterator.next().getState());
+    assertFalse(iterator.hasNext());
+  }
+
+}

--- a/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStressTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStressTest.java
@@ -40,6 +40,7 @@ import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
 import io.airbyte.protocol.models.SyncMode;
@@ -139,13 +140,31 @@ public abstract class JdbcSourceStressTest {
 
   }
 
+  // todo (cgardens) - restructure these tests so that testFullRefresh() and testIncremental() can be
+  // separate tests. current constrained by only wanting to setup the fixture in the database once,
+  // but it is not trivial to move them to @BeforeAll because it is static and we are doing
+  // inheritance. Not impossible, just needs to be done thoughtfully and for all JdbcSources.
   @Test
   public void stressTest() throws Exception {
-    final Stream<AirbyteMessage> read = source.read(config, getConfiguredCatalog(), Jsons.jsonNode(Collections.emptyMap()));
+    testFullRefresh();
+    testIncremental();
+  }
+
+  private void testFullRefresh() throws Exception {
+    runTest(getConfiguredCatalogFullRefresh(), "full_refresh");
+  }
+
+  private void testIncremental() throws Exception {
+    runTest(getConfiguredCatalogIncremental(), "incremental");
+  }
+
+  private void runTest(ConfiguredAirbyteCatalog configuredCatalog, String testName) throws Exception {
+    LOGGER.info("running stress test for: " + testName);
+    final Stream<AirbyteMessage> read = source.read(config, configuredCatalog, Jsons.jsonNode(Collections.emptyMap()));
     final long actualCount = read
         .filter(m -> m.getType() == Type.RECORD)
         .peek(m -> {
-          if (m.getRecord().getData().get("id").asLong() % 10000 == 0) {
+          if (m.getRecord().getData().get("id").asLong() % 100000 == 0) {
             LOGGER.info("reading batch: " + m.getRecord().getData().get("id").asLong() / 1000);
           }
         })
@@ -155,8 +174,8 @@ public abstract class JdbcSourceStressTest {
     final long expectedRoundedRecordsCount = TOTAL_RECORDS - TOTAL_RECORDS % 1000;
     LOGGER.info("expected records count: " + TOTAL_RECORDS);
     LOGGER.info("actual records count: " + actualCount);
-    assertEquals(expectedRoundedRecordsCount, actualCount);
-    assertEquals(expectedRoundedRecordsCount, bitSet.cardinality());
+    assertEquals(expectedRoundedRecordsCount, actualCount, "testing: " + testName);
+    assertEquals(expectedRoundedRecordsCount, bitSet.cardinality(), "testing: " + testName);
   }
 
   // each is roughly 106 bytes.
@@ -171,8 +190,15 @@ public abstract class JdbcSourceStressTest {
     assertEquals(expectedMessage, actualMessage);
   }
 
-  private static ConfiguredAirbyteCatalog getConfiguredCatalog() {
+  private static ConfiguredAirbyteCatalog getConfiguredCatalogFullRefresh() {
     return CatalogHelpers.toDefaultConfiguredCatalog(getCatalog());
+  }
+
+  private static ConfiguredAirbyteCatalog getConfiguredCatalogIncremental() {
+    return new ConfiguredAirbyteCatalog()
+        .withStreams(Collections.singletonList(new ConfiguredAirbyteStream().withStream(getCatalog().getStreams().get(0))
+            .withCursorField(Collections.singletonList("id"))
+            .withSyncMode(SyncMode.INCREMENTAL)));
   }
 
   private static AirbyteCatalog getCatalog() {

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -47,7 +47,7 @@ public class PostgresSource extends AbstractJdbcSource implements Source {
 
   @Override
   public JsonNode toJdbcConfig(JsonNode config) {
-    ImmutableMap.Builder<Object, Object> configBuilder = ImmutableMap.builder()
+    final ImmutableMap.Builder<Object, Object> configBuilder = ImmutableMap.builder()
         .put("username", config.get("username").asText())
         .put("jdbc_url", String.format("jdbc:postgresql://%s:%s/%s",
             config.get("host").asText(),

--- a/airbyte-integrations/connectors/source-postgres/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-postgres/src/main/resources/spec.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Postgres Source Spec",
     "type": "object",
-    "required": ["host", "password", "port", "database", "username"],
+    "required": ["host", "port", "database", "username"],
     "additionalProperties": false,
     "properties": {
       "host": {

--- a/airbyte-server/src/main/java/io/airbyte/server/validators/DockerImageValidator.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/validators/DockerImageValidator.java
@@ -47,7 +47,7 @@ public class DockerImageValidator {
     try {
       schedulerHandler.getConnectorSpecification(imageName);
     } catch (Exception e) {
-      throw new KnownException(422, "Encountered an issue while validating input docker image: " + e.getMessage());
+      throw new KnownException(422, String.format("Encountered an issue while validating input docker image (%s): %s", imageName, e.getMessage()));
     }
   }
 


### PR DESCRIPTION
related issue: https://github.com/airbytehq/airbyte/issues/1582

## What
* incremental for JdbcSources OOMs. This appears to be due to an operation where we are turning the stream of messages into an iterator and then back into a stream. I have NOT been entirely able to figure out _why_ this operation is causing an OOM. Specifically using `StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);` causes the OOM. My hunch is it has to do with how the `IteratorSpliterator` allocates memory under the hood for internal arrays. I've had trouble reproducing it in any simple test case outside of the JdbcSource. But have definitely narrowed it down to this operation is the the reasource the source is failing. Even doing `StreamSupport.stream(Spliterators.spliteratorUnknownSize(internalMessageStream.iterator(), Spliterator.ORDERED), false);` induces the error.
* **This PR is more of a status update than anything. it is probably NOT worth merging, but it leaves us with something that does at least works**. I want to keep digging into this tomorrow and get to a place where I either:
    1. make a decent stream version of this or 
    2. figure out why the conversation from iterator <> stream is causing the OOM and fix it.

## How
* Hack to avoid converting from stream => iterator => stream.
* Add incremental to stress test

## Reading Order
* AbstractJdbcSource
* StateDecoratingIterator