### PR TITLE
downgrade pip from 20.3 to 20.2

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -23,7 +23,7 @@ class AirbytePythonPlugin implements Plugin<Project> {
             pip 'mypy:0.790'
             pip 'isort:5.6.4'
             pip 'pytest:6.1.2'
-            pip 'pip:20.3'
+            pip 'pip:20.2'
         }
 
         project.task('blackFormat', type: PythonTask) {


### PR DESCRIPTION
## What
The new Pip dependency resolver is intractably slow and often runs for more than 30 minutes, making it impossible to develop using it. This PR downgrades Pip so we can get work done until this issue https://github.com/pypa/pip/issues/9187 and others like it in Pip are fixed. 


If you have been facing issues with the infinite looping issue in Pip, do the following to get back up and running: 
1. merge this PR
2. `rm -rf .venv` directory in your connector directory
3. `./gradlew :airbyte-integrations:connectors:<name>:build`
