### PR TITLE
have dev use docker volumes instead of bindmounts the same way that stable does

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,22 +1,20 @@
-# DEV_ROOT must be in a directory that can be mounted by docker
-# we highly recommend a directory in /tmp
 VERSION=dev
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_DB=airbyte
-DEV_ROOT=/tmp/dev_root
-CONFIG_ROOT=/tmp/data
+CONFIG_ROOT=/data
+WORKSPACE_ROOT=/tmp/workspace
+DATA_DOCKER_MOUNT=airbyte_data_dev
+DB_DOCKER_MOUNT=airbyte_db_dev
+WORKSPACE_DOCKER_MOUNT=airbyte_workspace_dev
 # todo (cgardens) - when we are mount raw directories instead of named volumes, *_DOCKER_MOUNT must
 # be the same as *_ROOT.
 # Issue: https://github.com/airbytehq/airbyte/issues/578
-WORKSPACE_ROOT=/tmp/workspace
-WORKSPACE_DOCKER_MOUNT=/tmp/dev_root/workspace
-LOCAL_ROOT=/tmp/airbyte_local
-LOCAL_DOCKER_MOUNT=/tmp/airbyte_local
+LOCAL_ROOT=/tmp/airbyte_local_dev
+LOCAL_DOCKER_MOUNT=/tmp/airbyte_local_dev
 TRACKING_STRATEGY=logging
 # todo (cgardens) - hack to handle behavior change in docker compose. *_PARENT directories MUST
 # already exist on the host filesystem and MUST be parents of *_ROOT.
 # Issue: https://github.com/airbytehq/airbyte/issues/577
-HACK_DEV_ROOT_PARENT=/tmp
 HACK_LOCAL_ROOT_PARENT=/tmp
 BUILD_TAG=dev

--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -1,18 +1,18 @@
 version: "3.7"
 
 services:
-  db:
-    image: airbyte/db:${BUILD_TAG}
-    build:
-      dockerfile: Dockerfile
-      context: airbyte-db
-      labels:
-        io.airbyte.git-revision: ${GIT_REVISION}
   init:
     image: airbyte/init:${BUILD_TAG}
     build:
       dockerfile: Dockerfile
       context: airbyte-config/init
+      labels:
+        io.airbyte.git-revision: ${GIT_REVISION}
+  db:
+    image: airbyte/db:${BUILD_TAG}
+    build:
+      dockerfile: Dockerfile
+      context: airbyte-db
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   seed:

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,42 +1,15 @@
 version: "3.7"
 
 services:
+  # hook in case we need to add init behavior
+  # every root service (no depends_on) should depend on init
   init:
-    command: /bin/sh -c "
-      ./scripts/create_mount_directories.sh /local_parent ${HACK_LOCAL_ROOT_PARENT} ${LOCAL_ROOT};
-      ./scripts/create_mount_directories.sh /dev_parent ${HACK_DEV_ROOT_PARENT} ${DEV_ROOT}/db;
-      ./scripts/create_mount_directories.sh /dev_parent ${HACK_DEV_ROOT_PARENT} ${DEV_ROOT}/data;
-      ./scripts/create_mount_directories.sh /dev_parent ${HACK_DEV_ROOT_PARENT} ${DEV_ROOT}/workspace;
-      "
-    environment:
-      - HACK_DEV_ROOT_PARENT=${HACK_DEV_ROOT_PARENT}
-      - DEV_ROOT=${DEV_ROOT}
-      - HACK_LOCAL_ROOT_PARENT=${HACK_LOCAL_ROOT_PARENT}
-      - LOCAL_ROOT=${LOCAL_ROOT}
-    volumes:
-      - ${HACK_DEV_ROOT_PARENT}:/dev_parent
-      - ${HACK_LOCAL_ROOT_PARENT}:/local_parent
-  db:
-    ports:
-      - 5432:5432
-    volumes:
-      - ${DEV_ROOT}/db:/var/lib/postgresql/data
+    container_name: init-dev
   seed:
-    command: /bin/sh -c "./scripts/copy_seed_data.sh"
-    volumes:
-      - ${DEV_ROOT}/data:/seed
+    container_name: airbyte-data-seed-dev
   scheduler:
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ${DEV_ROOT}/workspace:${WORKSPACE_ROOT}
-      - ${DEV_ROOT}/data:${CONFIG_ROOT}
-      - ${LOCAL_ROOT}:${LOCAL_DOCKER_MOUNT}
+    container_name: airbyte-scheduler-dev
   server:
-    volumes:
-      - ${DEV_ROOT}/workspace:${WORKSPACE_ROOT}
-      - ${DEV_ROOT}/data:${CONFIG_ROOT}
+    container_name: airbyte-server-dev
   webapp:
-
-volumes:
-  # needed so that we do not try to use the mount name to create the volume like we do in prod.
-  workspace:
+    container_name: airbyte-webapp-dev


### PR DESCRIPTION
~~closes~~ https://github.com/airbytehq/airbyte/issues/1262. Actually doesn't fully close it since it does not remove bindmounts for local for both dev and stable

## What
* Bind mounts have been nothing but headache and break with every new version of docker / docker-compose.
* They also make developing on dev further away from the reality of how the app actually works. 
* I'm also spending a ton of time manually dealing with issues when developing around using bind mounts requiring an expensive tear down process.

## How
* Have dev docker-compose use the exact same configuration as stable (except for changing the container names and volume names) so that they don't collide on the off chance that you're running dev and stable in the same docker instance.