### PR TITLE
Force same pip version in virtualenv and docker envs

### DIFF
--- a/airbyte-integrations/bases/base-python/Dockerfile
+++ b/airbyte-integrations/bases/base-python/Dockerfile
@@ -4,6 +4,7 @@ COPY --from=airbyte/integration-base:dev /airbyte /airbyte
 WORKDIR /airbyte/base_python_code
 COPY base_python ./base_python
 COPY setup.py ./
+RUN pip install pip==20.2
 RUN pip install .
 
 ENV AIRBYTE_SPEC_CMD "base-python spec"

--- a/airbyte-integrations/connectors/source-shopify-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-shopify-singer/Dockerfile
@@ -10,7 +10,6 @@ ENV AIRBYTE_IMPL_PATH="SourceShopifySinger"
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
-RUN pip install pip==20.3
 RUN pip install tap-shopify==1.2.6
 RUN pip install ".[main]"
 

--- a/airbyte-integrations/connectors/source-shopify-singer/Dockerfile.test
+++ b/airbyte-integrations/connectors/source-shopify-singer/Dockerfile.test
@@ -18,7 +18,6 @@ COPY secrets/config.json $CODE_PATH/config.json
 COPY $MODULE_NAME/*.json $CODE_PATH/
 COPY setup.py ./
 
-RUN pip install pip==20.3
 RUN pip install tap-shopify==1.2.6
 RUN pip install ".[tests]"
 


### PR DESCRIPTION
## What
Ensure that we have the same (20.2) pip version everywhere

## How
*Describe the solution*

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `test.java`
1. `component.ts`
1. the rest
