### PR TITLE
add integration test task to base normalization

### DIFF
--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -12,3 +12,6 @@ dependencies {
 }
 
 installReqs.dependsOn(":airbyte-integrations:bases:airbyte-protocol:installReqs")
+
+project.task('integrationTest')
+integrationTest.dependsOn(build)


### PR DESCRIPTION
## What
This allows us to run `manage.sh` to publish normalization images as usual