### PR TITLE
increase spec and discover worker timeouts to 30 minutes

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultDiscoverCatalogWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultDiscoverCatalogWorker.java
@@ -81,7 +81,7 @@ public class DefaultDiscoverCatalogWorker implements DiscoverCatalogWorker {
             .map(AirbyteMessage::getCatalog)
             .findFirst();
 
-        WorkerUtils.gentleClose(process, 1, TimeUnit.MINUTES);
+        WorkerUtils.gentleClose(process, 10, TimeUnit.MINUTES);
       }
 
       int exitCode = process.exitValue();

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultDiscoverCatalogWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultDiscoverCatalogWorker.java
@@ -81,7 +81,7 @@ public class DefaultDiscoverCatalogWorker implements DiscoverCatalogWorker {
             .map(AirbyteMessage::getCatalog)
             .findFirst();
 
-        WorkerUtils.gentleClose(process, 10, TimeUnit.MINUTES);
+        WorkerUtils.gentleClose(process, 30, TimeUnit.MINUTES);
       }
 
       int exitCode = process.exitValue();

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultGetSpecWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultGetSpecWorker.java
@@ -77,7 +77,7 @@ public class DefaultGetSpecWorker implements GetSpecWorker {
         // this.
         // retrieving spec should generally be instantaneous, but since docker images might not be pulled
         // it could take a while longer depending on internet conditions as well.
-        WorkerUtils.gentleClose(process, 10, TimeUnit.MINUTES);
+        WorkerUtils.gentleClose(process, 30, TimeUnit.MINUTES);
       }
 
       int exitCode = process.exitValue();

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultGetSpecWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultGetSpecWorker.java
@@ -77,7 +77,7 @@ public class DefaultGetSpecWorker implements GetSpecWorker {
         // this.
         // retrieving spec should generally be instantaneous, but since docker images might not be pulled
         // it could take a while longer depending on internet conditions as well.
-        WorkerUtils.gentleClose(process, 2, TimeUnit.MINUTES);
+        WorkerUtils.gentleClose(process, 10, TimeUnit.MINUTES);
       }
 
       int exitCode = process.exitValue();


### PR DESCRIPTION
## What
This will help with issues like #1664 #1669 and #1462 by not failing the worker in cases where the underlying operation fundamentally takes more time