### PR TITLE
handle tracking for sources / destinations not yet created

### DIFF
--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobSubmitter.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobSubmitter.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -137,6 +138,11 @@ public class JobSubmitter implements Runnable {
   @VisibleForTesting
   void trackSubmission(Job job) {
     try {
+      // if there is no scope, do not track. this is the case where we are running check for sources /
+      // destinations that don't exist.
+      if (Strings.isEmpty(job.getScope())) {
+        return;
+      }
       final Builder<String, Object> metadataBuilder = generateMetadata(job);
       metadataBuilder.put("attempt_stage", "STARTED");
       track(metadataBuilder.build());
@@ -148,6 +154,11 @@ public class JobSubmitter implements Runnable {
   @VisibleForTesting
   void trackCompletion(Job job, io.airbyte.workers.JobStatus status) {
     try {
+      // if there is no scope, do not track. this is the case where we are running check for sources /
+      // destinations that don't exist.
+      if (Strings.isEmpty(job.getScope())) {
+        return;
+      }
       final Builder<String, Object> metadataBuilder = generateMetadata(job);
       metadataBuilder.put("attempt_stage", "ENDED");
       metadataBuilder.put("attempt_completion_status", status);

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
@@ -58,7 +58,8 @@ public class DefaultJobCreator implements JobCreator {
         .withConfigType(ConfigType.CHECK_CONNECTION_SOURCE)
         .withCheckConnection(jobCheckConnectionConfig);
 
-    return jobPersistence.enqueueJob(source.getSourceId().toString(), jobConfig).orElseThrow();
+    final String sourceId = source.getSourceId() != null ? source.getSourceId().toString() : "";
+    return jobPersistence.enqueueJob(sourceId, jobConfig).orElseThrow();
   }
 
   @Override
@@ -71,7 +72,8 @@ public class DefaultJobCreator implements JobCreator {
         .withConfigType(ConfigType.CHECK_CONNECTION_DESTINATION)
         .withCheckConnection(jobCheckConnectionConfig);
 
-    return jobPersistence.enqueueJob(destination.getDestinationId().toString(), jobConfig).orElseThrow();
+    final String destinationId = destination.getDestinationId() != null ? destination.getDestinationId().toString() : "";
+    return jobPersistence.enqueueJob(destinationId, jobConfig).orElseThrow();
   }
 
   @Override
@@ -84,7 +86,8 @@ public class DefaultJobCreator implements JobCreator {
         .withConfigType(ConfigType.DISCOVER_SCHEMA)
         .withDiscoverCatalog(jobDiscoverCatalogConfig);
 
-    return jobPersistence.enqueueJob(source.getSourceId().toString(), jobConfig).orElseThrow();
+    final String sourceId = source.getSourceId() != null ? source.getSourceId().toString() : "";
+    return jobPersistence.enqueueJob(sourceId, jobConfig).orElseThrow();
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -84,6 +84,8 @@ public class SchedulerHandler {
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final StandardSourceDefinition sourceDef = configRepository.getStandardSourceDefinition(sourceCreate.getSourceDefinitionId());
     final String imageName = DockerUtils.getTaggedImageName(sourceDef.getDockerRepository(), sourceDef.getDockerImageTag());
+    // todo (cgardens) - narrow the struct passed to the client. we are not setting fields that are
+    // technically declared as required.
     final SourceConnection source = new SourceConnection()
         .withSourceDefinitionId(sourceCreate.getSourceDefinitionId())
         .withConfiguration(sourceCreate.getConnectionConfiguration());
@@ -103,6 +105,8 @@ public class SchedulerHandler {
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final StandardDestinationDefinition destDef = configRepository.getStandardDestinationDefinition(destinationCreate.getDestinationDefinitionId());
     final String imageName = DockerUtils.getTaggedImageName(destDef.getDockerRepository(), destDef.getDockerImageTag());
+    // todo (cgardens) - narrow the struct passed to the client. we are not setting fields that are
+    // technically declared as required.
     final DestinationConnection destination = new DestinationConnection()
         .withDestinationDefinitionId(destinationCreate.getDestinationDefinitionId())
         .withConfiguration(destinationCreate.getConnectionConfiguration());

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -24,7 +24,6 @@
 
 package io.airbyte.server.handlers;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.api.model.CheckConnectionRead;
 import io.airbyte.api.model.ConnectionIdRequestBody;
 import io.airbyte.api.model.DestinationCoreConfig;
@@ -61,23 +60,15 @@ import io.airbyte.server.converters.SchemaConverter;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.UUID;
-import java.util.function.Supplier;
 
 public class SchedulerHandler {
 
   private final ConfigRepository configRepository;
   private final SchedulerJobClient schedulerJobClient;
-  private final Supplier<UUID> uuidSupplier;
-
-  @VisibleForTesting
-  SchedulerHandler(final ConfigRepository configRepository, SchedulerJobClient schedulerJobClient, Supplier<UUID> uuidSupplier) {
-    this.configRepository = configRepository;
-    this.schedulerJobClient = schedulerJobClient;
-    this.uuidSupplier = uuidSupplier;
-  }
 
   public SchedulerHandler(final ConfigRepository configRepository, SchedulerJobClient schedulerJobClient) {
-    this(configRepository, schedulerJobClient, UUID::randomUUID);
+    this.configRepository = configRepository;
+    this.schedulerJobClient = schedulerJobClient;
   }
 
   public CheckConnectionRead checkSourceConnectionFromSourceId(SourceIdRequestBody sourceIdRequestBody)
@@ -93,14 +84,8 @@ public class SchedulerHandler {
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final StandardSourceDefinition sourceDef = configRepository.getStandardSourceDefinition(sourceCreate.getSourceDefinitionId());
     final String imageName = DockerUtils.getTaggedImageName(sourceDef.getDockerRepository(), sourceDef.getDockerImageTag());
-    final UUID sourceUuid = uuidSupplier.get();
     final SourceConnection source = new SourceConnection()
-        .withName("source:" + sourceUuid) // todo (cgardens) - narrow the struct passed to the client.
         .withSourceDefinitionId(sourceCreate.getSourceDefinitionId())
-        .withWorkspaceId(sourceUuid) // todo (cgardens) - narrow the struct passed to the client.
-        .withTombstone(false)
-        // todo (cgardens) - used to create the scope so we want a random value.
-        .withSourceId(sourceUuid)
         .withConfiguration(sourceCreate.getConnectionConfiguration());
 
     return reportConnectionStatus(schedulerJobClient.createSourceCheckConnectionJob(source, imageName));
@@ -118,14 +103,8 @@ public class SchedulerHandler {
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final StandardDestinationDefinition destDef = configRepository.getStandardDestinationDefinition(destinationCreate.getDestinationDefinitionId());
     final String imageName = DockerUtils.getTaggedImageName(destDef.getDockerRepository(), destDef.getDockerImageTag());
-    final UUID destinationUuid = uuidSupplier.get();
     final DestinationConnection destination = new DestinationConnection()
-        .withName("destination:" + destinationUuid) // todo (cgardens) - narrow the struct passed to the client.
         .withDestinationDefinitionId(destinationCreate.getDestinationDefinitionId())
-        .withWorkspaceId(destinationUuid) // todo (cgardens) - narrow the struct passed to the client.
-        .withTombstone(false)
-        // todo (cgardens) - used to create the scope so we want a random value.
-        .withDestinationId(destinationUuid)
         .withConfiguration(destinationCreate.getConnectionConfiguration());
     return reportConnectionStatus(schedulerJobClient.createDestinationCheckConnectionJob(destination, imageName));
   }
@@ -143,14 +122,10 @@ public class SchedulerHandler {
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final StandardSourceDefinition sourceDef = configRepository.getStandardSourceDefinition(sourceCreate.getSourceDefinitionId());
     final String imageName = DockerUtils.getTaggedImageName(sourceDef.getDockerRepository(), sourceDef.getDockerImageTag());
-    final UUID sourceUuid = uuidSupplier.get();
+    // todo (cgardens) - narrow the struct passed to the client. we are not setting fields that are
+    // technically declared as required.
     final SourceConnection source = new SourceConnection()
-        .withName("source:" + sourceUuid) // todo (cgardens) - narrow the struct passed to the client.
         .withSourceDefinitionId(sourceCreate.getSourceDefinitionId())
-        .withWorkspaceId(sourceUuid) // todo (cgardens) - narrow the struct passed to the client.
-        .withTombstone(false)
-        // todo (cgardens) - used to create the scope so we want a random value.
-        .withSourceId(sourceUuid)
         .withConfiguration(sourceCreate.getConnectionConfiguration());
     final Job job = schedulerJobClient.createDiscoverSchemaJob(source, imageName);
     return discoverJobToOutput(job);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
@@ -75,7 +75,6 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -109,9 +108,7 @@ class SchedulerHandlerTest {
   private ConfigRepository configRepository;
   private Job completedJob;
   private SchedulerJobClient schedulerJobClient;
-  private Supplier<UUID> uuidSupplier;
 
-  @SuppressWarnings("unchecked")
   @BeforeEach
   void setup() {
     completedJob = mock(Job.class, RETURNS_DEEP_STUBS);
@@ -119,11 +116,10 @@ class SchedulerHandlerTest {
     when(completedJob.getConfig().getConfigType()).thenReturn(ConfigType.SYNC);
     when(completedJob.getScope()).thenReturn("sync:123");
 
-    uuidSupplier = mock(Supplier.class);
     schedulerJobClient = spy(SchedulerJobClient.class);
     configRepository = mock(ConfigRepository.class);
 
-    schedulerHandler = new SchedulerHandler(configRepository, schedulerJobClient, uuidSupplier);
+    schedulerHandler = new SchedulerHandler(configRepository, schedulerJobClient);
   }
 
   @Test
@@ -147,11 +143,9 @@ class SchedulerHandlerTest {
 
   @Test
   void testCheckSourceConnectionFromSourceCreate() throws JsonValidationException, IOException, ConfigNotFoundException {
-    final SourceConnection source = Jsons.clone(SOURCE);
-    source.setName("source:" + source.getSourceId());
-    source.setWorkspaceId(source.getSourceId());
-
-    when(uuidSupplier.get()).thenReturn(source.getSourceId());
+    final SourceConnection source = new SourceConnection()
+        .withSourceDefinitionId(SOURCE.getSourceDefinitionId())
+        .withConfiguration(SOURCE.getConfiguration());
 
     final SourceCoreConfig sourceCoreConfig = new SourceCoreConfig()
         .sourceDefinitionId(source.getSourceDefinitionId())
@@ -261,12 +255,10 @@ class SchedulerHandlerTest {
   }
 
   @Test
-  void testCheckSourceConnectionFromDestinationCreate() throws JsonValidationException, IOException, ConfigNotFoundException {
-    final DestinationConnection destination = Jsons.clone(DESTINATION);
-    destination.setName("destination:" + destination.getDestinationId());
-    destination.setWorkspaceId(destination.getDestinationId());
-
-    when(uuidSupplier.get()).thenReturn(destination.getDestinationId());
+  void testCheckDestinationConnectionFromDestinationCreate() throws JsonValidationException, IOException, ConfigNotFoundException {
+    final DestinationConnection destination = new DestinationConnection()
+        .withDestinationDefinitionId(DESTINATION.getDestinationDefinitionId())
+        .withConfiguration(DESTINATION.getConfiguration());
 
     final DestinationCoreConfig destinationCoreConfig = new DestinationCoreConfig()
         .destinationDefinitionId(destination.getDestinationDefinitionId())
@@ -309,11 +301,10 @@ class SchedulerHandlerTest {
 
   @Test
   void testDiscoverSchemaForSourceFromSourceCreate() throws JsonValidationException, IOException, ConfigNotFoundException {
-    final SourceConnection source = Jsons.clone(SOURCE);
-    source.setName("source:" + source.getSourceId());
-    source.setWorkspaceId(source.getSourceId());
+    final SourceConnection source = new SourceConnection()
+        .withSourceDefinitionId(SOURCE.getSourceDefinitionId())
+        .withConfiguration(SOURCE.getConfiguration());
 
-    when(uuidSupplier.get()).thenReturn(source.getSourceId());
     final JobOutput jobOutput = mock(JobOutput.class);
     when(completedJob.getSuccessOutput()).thenReturn(Optional.of(jobOutput));
     when(jobOutput.getDiscoverCatalog()).thenReturn(new StandardDiscoverCatalogOutput().withCatalog(new AirbyteCatalog()));


### PR DESCRIPTION
## What
* The tracking code currently throws an exception when we run check / discover for sources / destinations that haven't been created. This is because it uses the scope to pull information about these runs out of the db. Except since the source / destinations don't exist, it throws an exception. This is _not_ breaking anything because we swallow all exceptions thrown by the tracking code. That being said, since we expose the logs to the user, it _looks_ like there is an error if you don't know what's going on and obscures the actually helpful things in the logs. Especially since we rely on the logs for a user to see any configuration mistakes that they might have made, it is important to keep this super clean.

## How
* If source / destination doesn't exist, we don't set a scope for them. (originally we were generating random uuids which was needed before the change was made to how scope works)
* If no scope is set, we do not attempt to send a tracking message.