### PR TITLE
add s3 status reporting for integration test builds

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -77,9 +77,7 @@ jobs:
           ZOOM_INTEGRATION_TEST_CREDS: ${{ secrets.ZOOM_INTEGRATION_TEST_CREDS }}
           PLAID_INTEGRATION_TEST_CREDS: ${{ secrets.PLAID_INTEGRATION_TEST_CREDS }}
       - run: |
-          exit 0
-#      - run: |
-#          ./tools/bin/ci_integration_test.sh ${{ github.event.inputs.connector }}
+          ./tools/bin/ci_integration_test.sh ${{ github.event.inputs.connector }}
         name: test ${{ github.event.inputs.connector }}
         id: test
         env:

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -86,7 +86,7 @@ jobs:
           BUILD_STAT_BUCKET: ${{ secrets.BUILD_STAT_BUCKET }}
           GITHUB_REF: ${{ github.ref }}
       - name: Report Status
-        if: github.ref != 'refs/heads/master' && always() # todo: change this to ==
+        if: github.ref == 'refs/heads/master' && always()
         run: ./tools/status/report.sh ${{ github.event.inputs.connector }} ${{github.repository}} ${{github.run_id}} ${{steps.test.outcome}}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.STATUS_API_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -77,12 +77,23 @@ jobs:
           ZOOM_INTEGRATION_TEST_CREDS: ${{ secrets.ZOOM_INTEGRATION_TEST_CREDS }}
           PLAID_INTEGRATION_TEST_CREDS: ${{ secrets.PLAID_INTEGRATION_TEST_CREDS }}
       - run: |
-          ./tools/bin/ci_integration_test.sh ${{ github.event.inputs.connector }}
+          exit 0
+#      - run: |
+#          ./tools/bin/ci_integration_test.sh ${{ github.event.inputs.connector }}
+        name: test ${{ github.event.inputs.connector }}
+        id: test
         env:
           ACTION_RUN_ID: ${{github.run_id}}
           BUILD_STAT_WRITE_KEY: ${{ secrets.BUILD_STAT_WRITE_KEY }}
           BUILD_STAT_BUCKET: ${{ secrets.BUILD_STAT_BUCKET }}
           GITHUB_REF: ${{ github.ref }}
+      - name: Report Status
+        if: github.ref != 'refs/heads/master' && always() # todo: change this to ==
+        run: ./tools/status/report.sh ${{ github.event.inputs.connector }} ${{github.repository}} ${{github.run_id}} ${{steps.test.outcome}}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.STATUS_API_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.STATUS_API_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-2'
       - name: Add Success Comment
         if: github.event.inputs.comment-id && success()
         uses: peter-evans/create-or-update-comment@v1

--- a/tools/status/defaults/error.html
+++ b/tools/status/defaults/error.html
@@ -1,0 +1,1 @@
+404 This page doesn't exist. Want to try https://airbyte.io/ ?

--- a/tools/status/defaults/index.html
+++ b/tools/status/defaults/index.html
@@ -1,0 +1,1 @@
+Welcome to our static status site. Want to try https://airbyte.io/ ?

--- a/tools/status/init.sh
+++ b/tools/status/init.sh
@@ -8,6 +8,11 @@ set -e
 BUCKET=airbyte-status
 PROFILE=prod
 REGION=us-east-2
+S3_DOMAIN="$BUCKET.s3-website.$REGION.amazonaws.com"
+
+export AWS_PAGER=""
+
+echo "This has already been created. Comment out this line if you really want to run this again." && exit 1
 
 echo "Creating bucket..."
 aws s3api create-bucket --bucket "$BUCKET" --region "$REGION"  --create-bucket-configuration LocationConstraint="$REGION" --profile "$PROFILE"
@@ -21,4 +26,13 @@ aws s3 sync "$(pwd)"/tools/status/defaults/ s3://"$BUCKET"/ --profile "$PROFILE"
 echo "Setting bucket as website..."
 aws s3 website s3://"$BUCKET"/ --index-document index.html --error-document error.html --profile "$PROFILE"
 
-echo "Site should be ready at http://$BUCKET.s3-website.$REGION.amazonaws.com"
+
+aws cloudfront create-distribution \
+    --origin-domain-name $S3_DOMAIN \
+    --default-root-object index.html \
+    --profile "$PROFILE"
+
+echo "Site should be ready at http://$S3_DOMAIN"
+echo "1. Add a certificate and cname to the distribution: https://advancedweb.hu/how-to-use-a-custom-domain-on-cloudfront-with-cloudflare-managed-dns/"
+echo "2. Configure a CNAME on Cloudflare for status-api.airbyte.io to point to the bucket!"
+echo "3. Create STATUS_API_AWS_ACCESS_KEY_ID and STATUS_API_AWS_SECRET_ACCESS_KEY Github secrets with access to the bucket."

--- a/tools/status/init.sh
+++ b/tools/status/init.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+# This script should only be used to set up the status site for the first time or to make your own version for testing.
+# Prod refers to the prod environment used for prior Airbyte projects.
+
+BUCKET=airbyte-status
+PROFILE=prod
+REGION=us-east-2
+
+echo "Creating bucket..."
+aws s3api create-bucket --bucket "$BUCKET" --region "$REGION"  --create-bucket-configuration LocationConstraint="$REGION" --profile "$PROFILE"
+
+echo "Setting policy for bucket..."
+aws s3api put-bucket-policy --bucket "$BUCKET" --policy file://"$(pwd)"/tools/status/policy.json --profile "$PROFILE"
+
+echo "Uploading default files..."
+aws s3 sync "$(pwd)"/tools/status/defaults/ s3://"$BUCKET"/ --profile "$PROFILE"
+
+echo "Setting bucket as website..."
+aws s3 website s3://"$BUCKET"/ --index-document index.html --error-document error.html --profile "$PROFILE"
+
+echo "Site should be ready at http://$BUCKET.s3-website.$REGION.amazonaws.com"

--- a/tools/status/policy.json
+++ b/tools/status/policy.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PublicReadGetObject",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::airbyte-status/*"
+    }
+  ]
+}

--- a/tools/status/report.sh
+++ b/tools/status/report.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -e
+
+BUCKET=airbyte-status
+
+CONNECTOR=$1
+REPOSITORY=$2
+RUN_ID=$3
+OUTCOME=$4
+
+BUCKET_WRITE_ROOT=/tmp/bucket_write_root
+LAST_TEN_ROOT=/tmp/last_ten_root
+SUMMARY_WRITE_ROOT=/tmp/summary_write_root
+
+export AWS_PAGER=""
+
+# write log of job run to s3
+rm -r $BUCKET_WRITE_ROOT || true
+mkdir -p $BUCKET_WRITE_ROOT
+cd $BUCKET_WRITE_ROOT
+mkdir -p tests/history/"$CONNECTOR"
+LINK=https://github.com/$REPOSITORY/actions/runs/$RUN_ID
+TIMESTAMP="$(date +%s)"
+echo "{ \"link\": \"$LINK\", \"outcome\": \"$OUTCOME\" }" > tests/history/"$CONNECTOR"/"$TIMESTAMP".json
+aws s3 sync "$BUCKET_WRITE_ROOT"/tests/history/"$CONNECTOR"/ s3://"$BUCKET"/tests/history/"$CONNECTOR"/
+
+# pull the logs for the latest ten jobs for this connector
+LAST_TEN_FILES=$(aws s3api list-objects-v2 --bucket "$BUCKET"  \
+  --query "reverse(sort_by(Contents[?contains(Key, \`tests/history/$CONNECTOR\`)], &LastModified))[:10].Key" \
+  --output=text)
+
+rm -r $LAST_TEN_ROOT || true
+mkdir -p $LAST_TEN_ROOT
+
+for file in $LAST_TEN_FILES; do
+  aws s3 cp s3://"$BUCKET"/"$file" $LAST_TEN_ROOT/
+done
+
+# build and push tests/CONNECTOR/badge.json and tests/CONNECTOR/index.html
+HTML_TABLE_ROWS=""
+
+successes=0
+failures=0
+
+while IFS= read -r file; do
+  line=$(cat "$LAST_TEN_ROOT/$file")
+  outcome=$(echo "$line" | jq -r '.outcome')
+  if [ "$outcome" = "success" ]; then
+    successes=$((successes+1))
+    outcome_output="<span style=\"color:green;\">&#10004; $outcome</span>"
+  else
+    failures=$((failures+1))
+    outcome_output="<span style=\"color:red;\">&#10008; $outcome</span>"
+  fi
+  LINK=$(echo "$line" | jq -r '.link')
+  HTML_TABLE_ROWS="<tr><td>$(date -r "$(echo "$file" | cut -f 1 -d '.')")</td><td>$outcome_output</td><td><a href=\"$LINK\">$LINK</a></td></tr>$HTML_TABLE_ROWS"
+done <<< "$(ls $LAST_TEN_ROOT)"
+
+echo "successes: $successes"
+echo "failures: $failures"
+
+if [ "$failures" = "0" ]; then
+  color="green"
+  message="✔ $successes"
+elif [ "$(cat $LAST_TEN_ROOT/* | tail -n1 | jq -r ".outcome")" = "success" ]; then
+  color="yellow"
+  message="✔ $successes | ✘ $failures"
+elif [ "$successes" = "0" ]; then
+  color="red"
+  message="✘ $failures"
+else
+  color="red"
+  message="✔ $successes | ✘ $failures"
+fi
+
+echo "color: $color"
+
+echo "message: $message"
+
+HTML_TOP="<html><head><title>$CONNECTOR</title><style>body {padding:20px; font-family:monospace;} table {border-collapse: collapse;} th, td {padding:20px; text-align:left;} th, td { border:1px solid lightblue;} </style></head><body><p><img src=\"https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2F$CONNECTOR%2Fbadge.json\"></p><h1>$CONNECTOR</h1>"
+HTML_BOTTOM="</body></html>"
+HTML_TABLE="<table><tr><th>datetime</th><th>status</th><th>workflow</th></tr>$HTML_TABLE_ROWS</table>"
+
+HTML="$HTML_TOP $HTML_TABLE $HTML_BOTTOM"
+BADGE="{ \"schemaVersion\": 1, \"label\": \"\", \"labelColor\": \"lightblue\", \"message\": \"$message\", \"color\": \"$color\", \"cacheSeconds\": 300, \"logoSvg\": \"<svg version=\\\"1.0\\\" xmlns=\\\"http://www.w3.org/2000/svg\\\"\\n width=\\\"32.000000pt\\\" height=\\\"32.000000pt\\\" viewBox=\\\"0 0 32.000000 32.000000\\\"\\n preserveAspectRatio=\\\"xMidYMid meet\\\">\\n\\n<g transform=\\\"translate(0.000000,32.000000) scale(0.100000,-0.100000)\\\"\\nfill=\\\"#000000\\\" stroke=\\\"none\\\">\\n<path d=\\\"M136 279 c-28 -22 -111 -157 -102 -166 8 -8 34 16 41 38 8 23 21 25\\n29 3 3 -8 -6 -35 -20 -60 -18 -31 -22 -44 -12 -44 20 0 72 90 59 103 -6 6 -11\\n27 -11 47 0 77 89 103 137 41 18 -23 16 -62 -5 -96 -66 -109 -74 -125 -59\\n-125 24 0 97 140 97 185 0 78 -92 123 -154 74z\\\"/>\\n<path d=\\\"M168 219 c-22 -13 -23 -37 -2 -61 12 -12 14 -22 7 -30 -5 -7 -22 -34\\n-37 -60 -20 -36 -23 -48 -12 -48 13 0 106 147 106 169 0 11 -28 41 -38 41 -4\\n0 -15 -5 -24 -11z m32 -34 c0 -8 -4 -15 -10 -15 -5 0 -10 7 -10 15 0 8 5 15\\n10 15 6 0 10 -7 10 -15z\\\"/>\\n</g>\\n</svg>\\n\" }"
+
+rm -r $SUMMARY_WRITE_ROOT || true
+mkdir -p $SUMMARY_WRITE_ROOT/tests/summary/"$CONNECTOR"
+
+echo "$BADGE" > $SUMMARY_WRITE_ROOT/tests/summary/"$CONNECTOR"/badge.json
+echo "$HTML" > $SUMMARY_WRITE_ROOT/tests/summary/"$CONNECTOR"/index.html
+
+aws s3 sync "$SUMMARY_WRITE_ROOT"/tests/summary/"$CONNECTOR"/ s3://"$BUCKET"/tests/summary/"$CONNECTOR"/

--- a/tools/status/report.sh
+++ b/tools/status/report.sh
@@ -54,7 +54,7 @@ while IFS= read -r file; do
     outcome_output="<span style=\"color:red;\">&#10008; $outcome</span>"
   fi
   LINK=$(echo "$line" | jq -r '.link')
-  HTML_TABLE_ROWS="<tr><td>$(date -r "$(echo "$file" | cut -f 1 -d '.')")</td><td>$outcome_output</td><td><a href=\"$LINK\">$LINK</a></td></tr>$HTML_TABLE_ROWS"
+  HTML_TABLE_ROWS="<tr><td>$(date -d @"$(echo "$file" | cut -f 1 -d '.')")</td><td>$outcome_output</td><td><a href=\"$LINK\">$LINK</a></td></tr>$HTML_TABLE_ROWS"
 done <<< "$(ls $LAST_TEN_ROOT)"
 
 echo "successes: $successes"

--- a/tools/status/report.sh
+++ b/tools/status/report.sh
@@ -15,80 +15,100 @@ SUMMARY_WRITE_ROOT=/tmp/summary_write_root
 
 export AWS_PAGER=""
 
-# write log of job run to s3
-rm -r $BUCKET_WRITE_ROOT || true
-mkdir -p $BUCKET_WRITE_ROOT
-cd $BUCKET_WRITE_ROOT
-mkdir -p tests/history/"$CONNECTOR"
-LINK=https://github.com/$REPOSITORY/actions/runs/$RUN_ID
-TIMESTAMP="$(date +%s)"
-echo "{ \"link\": \"$LINK\", \"outcome\": \"$OUTCOME\" }" > tests/history/"$CONNECTOR"/"$TIMESTAMP".json
-aws s3 sync "$BUCKET_WRITE_ROOT"/tests/history/"$CONNECTOR"/ s3://"$BUCKET"/tests/history/"$CONNECTOR"/
+function write_job_log() {
+  rm -r $BUCKET_WRITE_ROOT || true
+  mkdir -p $BUCKET_WRITE_ROOT
+  cd $BUCKET_WRITE_ROOT
+  mkdir -p tests/history/"$CONNECTOR"
+  LINK=https://github.com/$REPOSITORY/actions/runs/$RUN_ID
+  TIMESTAMP="$(date +%s)"
+  echo "{ \"link\": \"$LINK\", \"outcome\": \"$OUTCOME\" }" > tests/history/"$CONNECTOR"/"$TIMESTAMP".json
+  aws s3 sync "$BUCKET_WRITE_ROOT"/tests/history/"$CONNECTOR"/ s3://"$BUCKET"/tests/history/"$CONNECTOR"/
+}
 
-# pull the logs for the latest ten jobs for this connector
-LAST_TEN_FILES=$(aws s3api list-objects-v2 --bucket "$BUCKET"  \
-  --query "reverse(sort_by(Contents[?contains(Key, \`tests/history/$CONNECTOR\`)], &LastModified))[:10].Key" \
-  --output=text)
+function pull_latest_job_logs() {
+  # pull the logs for the latest ten jobs for this connector
+  LAST_TEN_FILES=$(aws s3api list-objects-v2 --bucket "$BUCKET"  \
+    --query "reverse(sort_by(Contents[?contains(Key, \`tests/history/$CONNECTOR\`)], &LastModified))[:10].Key" \
+    --output=text)
 
-rm -r $LAST_TEN_ROOT || true
-mkdir -p $LAST_TEN_ROOT
+  rm -r $LAST_TEN_ROOT || true
+  mkdir -p $LAST_TEN_ROOT
 
-for file in $LAST_TEN_FILES; do
-  aws s3 cp s3://"$BUCKET"/"$file" $LAST_TEN_ROOT/
-done
+  for file in $LAST_TEN_FILES; do
+    aws s3 cp s3://"$BUCKET"/"$file" $LAST_TEN_ROOT/
+  done
+}
 
-# build and push tests/CONNECTOR/badge.json and tests/CONNECTOR/index.html
-HTML_TABLE_ROWS=""
+function write_badge_and_summary() {
+  HTML_TABLE_ROWS=""
 
-successes=0
-failures=0
+  successes=0
+  failures=0
 
-while IFS= read -r file; do
-  line=$(cat "$LAST_TEN_ROOT/$file")
-  outcome=$(echo "$line" | jq -r '.outcome')
-  if [ "$outcome" = "success" ]; then
-    successes=$((successes+1))
-    outcome_output="<span style=\"color:green;\">&#10004; $outcome</span>"
+  while IFS= read -r file; do
+    line=$(cat "$LAST_TEN_ROOT/$file")
+    outcome=$(echo "$line" | jq -r '.outcome')
+    if [ "$outcome" = "success" ]; then
+      successes=$((successes+1))
+      outcome_output="<span style=\"color:green;\">&#10004; $outcome</span>"
+    else
+      failures=$((failures+1))
+      outcome_output="<span style=\"color:red;\">&#10008; $outcome</span>"
+    fi
+    link=$(echo "$line" | jq -r '.link')
+    date_string=$(echo "$file" | cut -f 1 -d '.')
+
+    # Mac uses a different way to render datetime strings with "date"
+    uname_output="$(uname -s)"
+    case "${uname_output}" in
+        Darwin*)    rendered_date=$(date -r "$date_string");;
+        *)          rendered_date=$(date -d @"$date_string")
+    esac
+    HTML_TABLE_ROWS="<tr><td>$rendered_date</td><td>$outcome_output</td><td><a href=\"$link\">$link</a></td></tr>$HTML_TABLE_ROWS"
+  done <<< "$(ls $LAST_TEN_ROOT)"
+
+  echo "successes: $successes"
+  echo "failures: $failures"
+
+  if [ "$failures" = "0" ]; then
+    color="green"
+    message="✔ $successes"
+  elif [ "$(cat $LAST_TEN_ROOT/* | tail -n1 | jq -r ".outcome")" = "success" ]; then
+    color="yellow"
+    message="✔ $successes | ✘ $failures"
+  elif [ "$successes" = "0" ]; then
+    color="red"
+    message="✘ $failures"
   else
-    failures=$((failures+1))
-    outcome_output="<span style=\"color:red;\">&#10008; $outcome</span>"
+    color="red"
+    message="✔ $successes | ✘ $failures"
   fi
-  LINK=$(echo "$line" | jq -r '.link')
-  HTML_TABLE_ROWS="<tr><td>$(date -d @"$(echo "$file" | cut -f 1 -d '.')")</td><td>$outcome_output</td><td><a href=\"$LINK\">$LINK</a></td></tr>$HTML_TABLE_ROWS"
-done <<< "$(ls $LAST_TEN_ROOT)"
 
-echo "successes: $successes"
-echo "failures: $failures"
+  echo "color: $color"
 
-if [ "$failures" = "0" ]; then
-  color="green"
-  message="✔ $successes"
-elif [ "$(cat $LAST_TEN_ROOT/* | tail -n1 | jq -r ".outcome")" = "success" ]; then
-  color="yellow"
-  message="✔ $successes | ✘ $failures"
-elif [ "$successes" = "0" ]; then
-  color="red"
-  message="✘ $failures"
-else
-  color="red"
-  message="✔ $successes | ✘ $failures"
-fi
+  echo "message: $message"
 
-echo "color: $color"
+  HTML_TOP="<html><head><title>$CONNECTOR</title><style>body {padding:20px; font-family:monospace;} table {border-collapse: collapse;} th, td {padding:20px; text-align:left;} th, td { border:1px solid lightblue;} </style></head><body><p><img src=\"https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2F$CONNECTOR%2Fbadge.json\"></p><h1>$CONNECTOR</h1>"
+  HTML_BOTTOM="</body></html>"
+  HTML_TABLE="<table><tr><th>datetime</th><th>status</th><th>workflow</th></tr>$HTML_TABLE_ROWS</table>"
 
-echo "message: $message"
+  HTML="$HTML_TOP $HTML_TABLE $HTML_BOTTOM"
+  BADGE="{ \"schemaVersion\": 1, \"label\": \"\", \"labelColor\": \"lightblue\", \"message\": \"$message\", \"color\": \"$color\", \"cacheSeconds\": 300, \"logoSvg\": \"<svg version=\\\"1.0\\\" xmlns=\\\"http://www.w3.org/2000/svg\\\"\\n width=\\\"32.000000pt\\\" height=\\\"32.000000pt\\\" viewBox=\\\"0 0 32.000000 32.000000\\\"\\n preserveAspectRatio=\\\"xMidYMid meet\\\">\\n\\n<g transform=\\\"translate(0.000000,32.000000) scale(0.100000,-0.100000)\\\"\\nfill=\\\"#000000\\\" stroke=\\\"none\\\">\\n<path d=\\\"M136 279 c-28 -22 -111 -157 -102 -166 8 -8 34 16 41 38 8 23 21 25\\n29 3 3 -8 -6 -35 -20 -60 -18 -31 -22 -44 -12 -44 20 0 72 90 59 103 -6 6 -11\\n27 -11 47 0 77 89 103 137 41 18 -23 16 -62 -5 -96 -66 -109 -74 -125 -59\\n-125 24 0 97 140 97 185 0 78 -92 123 -154 74z\\\"/>\\n<path d=\\\"M168 219 c-22 -13 -23 -37 -2 -61 12 -12 14 -22 7 -30 -5 -7 -22 -34\\n-37 -60 -20 -36 -23 -48 -12 -48 13 0 106 147 106 169 0 11 -28 41 -38 41 -4\\n0 -15 -5 -24 -11z m32 -34 c0 -8 -4 -15 -10 -15 -5 0 -10 7 -10 15 0 8 5 15\\n10 15 6 0 10 -7 10 -15z\\\"/>\\n</g>\\n</svg>\\n\" }"
 
-HTML_TOP="<html><head><title>$CONNECTOR</title><style>body {padding:20px; font-family:monospace;} table {border-collapse: collapse;} th, td {padding:20px; text-align:left;} th, td { border:1px solid lightblue;} </style></head><body><p><img src=\"https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2F$CONNECTOR%2Fbadge.json\"></p><h1>$CONNECTOR</h1>"
-HTML_BOTTOM="</body></html>"
-HTML_TABLE="<table><tr><th>datetime</th><th>status</th><th>workflow</th></tr>$HTML_TABLE_ROWS</table>"
+  rm -r $SUMMARY_WRITE_ROOT || true
+  mkdir -p $SUMMARY_WRITE_ROOT/tests/summary/"$CONNECTOR"
 
-HTML="$HTML_TOP $HTML_TABLE $HTML_BOTTOM"
-BADGE="{ \"schemaVersion\": 1, \"label\": \"\", \"labelColor\": \"lightblue\", \"message\": \"$message\", \"color\": \"$color\", \"cacheSeconds\": 300, \"logoSvg\": \"<svg version=\\\"1.0\\\" xmlns=\\\"http://www.w3.org/2000/svg\\\"\\n width=\\\"32.000000pt\\\" height=\\\"32.000000pt\\\" viewBox=\\\"0 0 32.000000 32.000000\\\"\\n preserveAspectRatio=\\\"xMidYMid meet\\\">\\n\\n<g transform=\\\"translate(0.000000,32.000000) scale(0.100000,-0.100000)\\\"\\nfill=\\\"#000000\\\" stroke=\\\"none\\\">\\n<path d=\\\"M136 279 c-28 -22 -111 -157 -102 -166 8 -8 34 16 41 38 8 23 21 25\\n29 3 3 -8 -6 -35 -20 -60 -18 -31 -22 -44 -12 -44 20 0 72 90 59 103 -6 6 -11\\n27 -11 47 0 77 89 103 137 41 18 -23 16 -62 -5 -96 -66 -109 -74 -125 -59\\n-125 24 0 97 140 97 185 0 78 -92 123 -154 74z\\\"/>\\n<path d=\\\"M168 219 c-22 -13 -23 -37 -2 -61 12 -12 14 -22 7 -30 -5 -7 -22 -34\\n-37 -60 -20 -36 -23 -48 -12 -48 13 0 106 147 106 169 0 11 -28 41 -38 41 -4\\n0 -15 -5 -24 -11z m32 -34 c0 -8 -4 -15 -10 -15 -5 0 -10 7 -10 15 0 8 5 15\\n10 15 6 0 10 -7 10 -15z\\\"/>\\n</g>\\n</svg>\\n\" }"
+  echo "$BADGE" > $SUMMARY_WRITE_ROOT/tests/summary/"$CONNECTOR"/badge.json
+  echo "$HTML" > $SUMMARY_WRITE_ROOT/tests/summary/"$CONNECTOR"/index.html
 
-rm -r $SUMMARY_WRITE_ROOT || true
-mkdir -p $SUMMARY_WRITE_ROOT/tests/summary/"$CONNECTOR"
+  aws s3 sync "$SUMMARY_WRITE_ROOT"/tests/summary/"$CONNECTOR"/ s3://"$BUCKET"/tests/summary/"$CONNECTOR"/
+}
 
-echo "$BADGE" > $SUMMARY_WRITE_ROOT/tests/summary/"$CONNECTOR"/badge.json
-echo "$HTML" > $SUMMARY_WRITE_ROOT/tests/summary/"$CONNECTOR"/index.html
+function main() {
+  write_job_log
+  pull_latest_job_logs
+  write_badge_and_summary
+}
 
-aws s3 sync "$SUMMARY_WRITE_ROOT"/tests/summary/"$CONNECTOR"/ s3://"$BUCKET"/tests/summary/"$CONNECTOR"/
+main


### PR DESCRIPTION
## What
- Report status of `master` builds to S3.
- Create summary files that can be used as a shields.io badge and as a listing to find failing bugs for debugging purposes.

Reading order:
- `init.sh` - shouldn't ever be run, just a record of what I did
- `test-command.yml` - how we launch the reporting
- `report.sh` - all of the logic for reporting

**Please look at my later comment with examples from two of the branch builds here.**

I'll add badges everywhere and the actual "dashboard view" in a separate PR. I'll also remove the legacy kv-store / python dashboard in a separate PR.

I've manually tested each case of the displays (all failures, all successes, last one passing with at least one failure, last one failing with at least one success).