### PR TITLE
bring back bigquery tests

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/build.gradle
+++ b/airbyte-integrations/connectors/destination-bigquery/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
+    integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-bigquery')
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTest.java
@@ -69,6 +69,7 @@ import java.util.stream.StreamSupport;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -181,8 +182,7 @@ class BigQueryDestinationTest {
     tornDown = true;
   }
 
-  // todo - same test as csv destination
-  // @Test
+  @Test
   void testSpec() throws IOException {
     final ConnectorSpecification actual = new BigQueryDestination().spec();
     final String resourceString = MoreResources.readResource("spec.json");
@@ -191,15 +191,14 @@ class BigQueryDestinationTest {
     assertEquals(expected, actual);
   }
 
-  // todo - same test as csv destination
-  // @Test
+  @Test
   void testCheckSuccess() {
     final AirbyteConnectionStatus actual = new BigQueryDestination().check(config);
     final AirbyteConnectionStatus expected = new AirbyteConnectionStatus().withStatus(Status.SUCCEEDED);
     assertEquals(expected, actual);
   }
 
-  // @Test
+  @Test
   void testCheckFailure() {
     ((ObjectNode) config).put(BigQueryDestination.CONFIG_PROJECT_ID, "fake");
     final AirbyteConnectionStatus actual = new BigQueryDestination().check(config);
@@ -208,7 +207,7 @@ class BigQueryDestinationTest {
     assertEquals(expected, actual);
   }
 
-  // @Test
+  @Test
   void testWriteSuccess() throws Exception {
     final BigQueryDestination destination = new BigQueryDestination();
     final DestinationConsumer<AirbyteMessage> consumer = destination.write(config, CATALOG);
@@ -237,8 +236,7 @@ class BigQueryDestinationTest {
         .collect(Collectors.toList()));
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
-  // @Test
+  @Test
   void testWriteFailure() throws Exception {
     // hack to force an exception to be thrown from within the consumer.
     final AirbyteMessage spiedMessage = spy(MESSAGE_USERS1);

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTest.java
@@ -275,7 +275,12 @@ class BigQueryDestinationTest {
 
   private void assertTmpTablesNotPresent(List<String> tableNames) throws InterruptedException {
     final Set<String> tmpTableNamePrefixes = tableNames.stream().map(name -> name + "_").collect(Collectors.toSet());
-    assertTrue(fetchNamesOfTablesInDb().stream().noneMatch(tableName -> tmpTableNamePrefixes.stream().anyMatch(tableName::startsWith)));
+    final Set<String> finalTableNames = tableNames.stream().map(name -> name + "_raw").collect(Collectors.toSet());
+    // search for table names that have the tmp table prefix but are not raw tables.
+    assertTrue(fetchNamesOfTablesInDb()
+        .stream()
+        .filter(tableName -> !finalTableNames.contains(tableName))
+        .noneMatch(tableName -> tmpTableNamePrefixes.stream().anyMatch(tableName::startsWith)));
   }
 
   private List<JsonNode> retrieveRecords(String tableName) throws Exception {

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTest.java
@@ -203,7 +203,7 @@ class BigQueryDestinationTest {
     ((ObjectNode) config).put(BigQueryDestination.CONFIG_PROJECT_ID, "fake");
     final AirbyteConnectionStatus actual = new BigQueryDestination().check(config);
     final AirbyteConnectionStatus expected = new AirbyteConnectionStatus().withStatus(Status.FAILED)
-        .withMessage("Access Denied: Project fake: User does not have bigquery.jobs.create permission in project fake.");
+        .withMessage("Access Denied: Project fake: User does not have bigquery.datasets.create permission in project fake.");
     assertEquals(expected, actual);
   }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryStandardTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryStandardTest.java
@@ -60,9 +60,9 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class BigQueryIntegrationTest extends TestDestination {
+public class BigQueryStandardTest extends TestDestination {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryIntegrationTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryStandardTest.class);
 
   private static final Path CREDENTIALS_PATH = Path.of("secrets/credentials.json");
 


### PR DESCRIPTION
## What
* These tests were removed because they were in the unit test section but required access to big query (including credentials).

## How
* Bring back the tests and move them into integration tests so that they can leverage creds.

## Note
* These overlap with the standard tests some but they are a little more granular so i'm inclined to keep them for now.