### PR TITLE
allow jobs/list to return jobs of multiple types

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1734,8 +1734,10 @@ components:
         - configType
         - configId
       properties:
-        configType:
-          $ref: "#/components/schemas/JobConfigType"
+        configTypes:
+          type: array
+          items:
+            $ref: "#/components/schemas/JobConfigType"
         configId:
           type: string
     JobIdRequestBody:

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1731,7 +1731,7 @@ components:
     JobListRequestBody:
       type: object
       required:
-        - configType
+        - configTypes
         - configId
       properties:
         configTypes:

--- a/airbyte-commons/src/main/java/io/airbyte/commons/stream/MoreStreams.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/stream/MoreStreams.java
@@ -36,4 +36,8 @@ public class MoreStreams {
     return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
   }
 
+  public static <T> Stream<T> toStream(Iterable<T> iterable) {
+    return toStream(iterable.iterator());
+  }
+
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/JobHistoryHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/JobHistoryHandler.java
@@ -24,6 +24,9 @@
 
 package io.airbyte.server.handlers;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import io.airbyte.api.model.JobIdRequestBody;
 import io.airbyte.api.model.JobInfoRead;
 import io.airbyte.api.model.JobListRequestBody;
@@ -35,8 +38,10 @@ import io.airbyte.scheduler.Job;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.server.converters.JobConverter;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public class JobHistoryHandler {
 
@@ -46,16 +51,29 @@ public class JobHistoryHandler {
     this.jobPersistence = jobPersistence;
   }
 
+  @SuppressWarnings("UnstableApiUsage")
   public JobReadList listJobsFor(JobListRequestBody request) throws IOException {
-    final JobConfig.ConfigType configType = Enums.convertTo(request.getConfigType(), JobConfig.ConfigType.class);
+    Preconditions.checkNotNull(request.getConfigTypes(), "configType cannot be null.");
+    Preconditions.checkState(!request.getConfigTypes().isEmpty(), "Must include at least one configType.");
+
+    final List<JobConfig.ConfigType> configTypes = request.getConfigTypes()
+        .stream()
+        .map(type -> Enums.convertTo(type, JobConfig.ConfigType.class))
+        .collect(Collectors.toList());
     final String configId = request.getConfigId();
 
-    final List<JobWithAttemptsRead> jobReads = jobPersistence.listJobs(configType, configId)
-        .stream()
-        .map(JobConverter::getJobWithAttemptsRead)
-        .collect(Collectors.toList());
+    // get jobs for each type and merge them into a single list sorted by created at.
+    Iterable<JobWithAttemptsRead> jobReads = ImmutableList.of();
+    for (final JobConfig.ConfigType configType : configTypes) {
+      final List<JobWithAttemptsRead> jobReadsForType = jobPersistence.listJobs(configType, configId)
+          .stream()
+          .map(JobConverter::getJobWithAttemptsRead)
+          .collect(Collectors.toList());
 
-    return new JobReadList().jobs(jobReads);
+      jobReads = Iterables.mergeSorted(ImmutableList.of(jobReads, jobReadsForType), Comparator.comparing(v -> v.getJob().getCreatedAt()));
+    }
+
+    return new JobReadList().jobs(StreamSupport.stream(jobReads.spliterator(), false).collect(Collectors.toList()));
   }
 
   public JobInfoRead getJobInfo(JobIdRequestBody jobIdRequestBody) throws IOException {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/JobHistoryHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/JobHistoryHandler.java
@@ -33,6 +33,7 @@ import io.airbyte.api.model.JobListRequestBody;
 import io.airbyte.api.model.JobReadList;
 import io.airbyte.api.model.JobWithAttemptsRead;
 import io.airbyte.commons.enums.Enums;
+import io.airbyte.commons.stream.MoreStreams;
 import io.airbyte.config.JobConfig;
 import io.airbyte.scheduler.Job;
 import io.airbyte.scheduler.persistence.JobPersistence;
@@ -41,7 +42,6 @@ import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 public class JobHistoryHandler {
 
@@ -73,7 +73,7 @@ public class JobHistoryHandler {
       jobReads = Iterables.mergeSorted(ImmutableList.of(jobReads, jobReadsForType), Comparator.comparing(v -> v.getJob().getCreatedAt()));
     }
 
-    return new JobReadList().jobs(StreamSupport.stream(jobReads.spliterator(), false).collect(Collectors.toList()));
+    return new JobReadList().jobs(MoreStreams.toStream(jobReads).collect(Collectors.toList()));
   }
 
   public JobInfoRead getJobInfo(JobIdRequestBody jobIdRequestBody) throws IOException {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -57,6 +57,7 @@ import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -101,7 +102,7 @@ public class WebBackendConnectionsHandler {
 
     final JobListRequestBody jobListRequestBody = new JobListRequestBody()
         .configId(connectionRead.getConnectionId().toString())
-        .configType(JobConfigType.SYNC);
+        .configTypes(Collections.singletonList(JobConfigType.SYNC));
 
     final WbConnectionRead wbConnectionRead = new WbConnectionRead()
         .connectionId(connectionRead.getConnectionId())

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/JobHistoryHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/JobHistoryHandlerTest.java
@@ -126,7 +126,9 @@ public class JobHistoryHandlerTest {
   public void testListJobsFor() throws IOException {
     when(jobPersistence.listJobs(CONFIG_TYPE, JOB_CONFIG_ID)).thenReturn(Collections.singletonList(job));
 
-    final JobListRequestBody requestBody = new JobListRequestBody().configType(CONFIG_TYPE_FOR_API).configId(JOB_CONFIG_ID);
+    final JobListRequestBody requestBody = new JobListRequestBody()
+        .configTypes(Collections.singletonList(CONFIG_TYPE_FOR_API))
+        .configId(JOB_CONFIG_ID);
     final JobReadList jobReadList = jobHistoryHandler.listJobsFor(requestBody);
 
     final JobReadList expectedJobReadList = new JobReadList().jobs(Collections.singletonList(JOB_WITH_ATTEMPTS_READ));

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -147,7 +147,7 @@ class WebBackendConnectionsHandlerTest {
     final JobReadList jobReadList = new JobReadList();
     jobReadList.setJobs(Collections.singletonList(jobRead));
     final JobListRequestBody jobListRequestBody = new JobListRequestBody();
-    jobListRequestBody.setConfigType(JobConfigType.SYNC);
+    jobListRequestBody.setConfigTypes(Collections.singletonList(JobConfigType.SYNC));
     jobListRequestBody.setConfigId(connectionRead.getConnectionId().toString());
     when(jobHistoryHandler.listJobsFor(jobListRequestBody)).thenReturn(jobReadList);
 

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4269,7 +4269,7 @@ font-style: italic;
     <h3><a name="JobListRequestBody"><code>JobListRequestBody</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">configTypes (optional)</div><div class="param-desc"><span class="param-type"><a href="#JobConfigType">array[JobConfigType]</a></span>  </div>
+      <div class="param">configTypes </div><div class="param-desc"><span class="param-type"><a href="#JobConfigType">array[JobConfigType]</a></span>  </div>
 <div class="param">configId </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
     </div>  <!-- field-items -->
   </div>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4269,7 +4269,7 @@ font-style: italic;
     <h3><a name="JobListRequestBody"><code>JobListRequestBody</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">configType </div><div class="param-desc"><span class="param-type"><a href="#JobConfigType">JobConfigType</a></span>  </div>
+      <div class="param">configTypes (optional)</div><div class="param-desc"><span class="param-type"><a href="#JobConfigType">array[JobConfigType]</a></span>  </div>
 <div class="param">configId </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
     </div>  <!-- field-items -->
   </div>


### PR DESCRIPTION
## What
* Unblocks https://github.com/airbytehq/airbyte/issues/1433 (showing job type in the job history ui)
* The UI needs to be able to query all of the jobs it needs in one request (previously it was just sync but now it needs sync and reset).

## How
* jobs/list accepts an array of configTypes instead of a single configType. returns jobs for all configTypes.

CANNOT MERGE UNTIL UI IS READY FOR IT.