### PR TITLE
regex for json_data path

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/a625d593-bba5-4a1c-a53d-2d246268a816.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/a625d593-bba5-4a1c-a53d-2d246268a816.json
@@ -2,6 +2,6 @@
   "destinationDefinitionId": "a625d593-bba5-4a1c-a53d-2d246268a816",
   "name": "Local JSON",
   "dockerRepository": "airbyte/destination-local-json",
-  "dockerImageTag": "0.1.1",
+  "dockerImageTag": "0.1.2",
   "documentationUrl": "https://docs.airbyte.io/integrations/destinations/local-json"
 }

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -1,7 +1,7 @@
 - destinationDefinitionId: a625d593-bba5-4a1c-a53d-2d246268a816
   name: Local JSON
   dockerRepository: airbyte/destination-local-json
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   documentationUrl: https://docs.airbyte.io/integrations/destinations/local-json
 - destinationDefinitionId: 8be1cf83-fde1-477f-a4ad-318d23c9f3c6
   name: Local CSV

--- a/airbyte-integrations/connectors/destination-local-json/Dockerfile
+++ b/airbyte-integrations/connectors/destination-local-json/Dockerfile
@@ -7,5 +7,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/destination-local-json

--- a/airbyte-integrations/connectors/destination-local-json/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-local-json/src/main/resources/spec.json
@@ -11,7 +11,8 @@
       "destination_path": {
         "description": "Path to the directory where json files will be written. The files will be placed inside that local mount. For more information check out our <a href=\"https://docs.airbyte.io/integrations/destinations/local-json\">docs</a>",
         "type": "string",
-        "examples": ["/json_data"]
+        "examples": ["/json_data"],
+        "pattern": "(^\\/json_data\\/.*)|(^\\/json_data$)"
       }
     }
   }


### PR DESCRIPTION
## What
* It was easy to misconfigured json destinations because the UI doesn't force you to put the necessary prefix.

## How
* now it does