### PR TITLE
decrease max attempts to 3

### DIFF
--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobRetrier.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobRetrier.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 public class JobRetrier implements Runnable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JobRetrier.class);
-  private static final int MAX_SYNC_JOB_ATTEMPTS = 5;
+  private static final int MAX_SYNC_JOB_ATTEMPTS = 3;
   private static final int RETRY_WAIT_MINUTES = 1;
 
   private final JobPersistence persistence;


### PR DESCRIPTION
## What
* 5 retries is getting annoying, it means I need to wait 5+ minutes for my job to really die.
* Since we don't support cancellation this gets worse
* Unlikely that the 4th or 5th job succeeds if the first 3 didn't.
* Usually this shouldn't be the right thing but without cancel we get more value from decreasing than we do by having more tries.