### PR TITLE
allow password to be empty in dbt for postgres

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -19,5 +19,5 @@ WORKDIR /airbyte
 
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.6
+LABEL io.airbyte.version=0.1.7
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_config/transform.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_config/transform.py
@@ -107,7 +107,7 @@ class TransformConfig:
         dbt_config["type"] = "postgres"
         dbt_config["host"] = config["host"]
         dbt_config["user"] = config["username"]
-        dbt_config["pass"] = config["password"]
+        dbt_config["pass"] = config.get("password", "")
         dbt_config["port"] = config["port"]
         dbt_config["dbname"] = config["database"]
         dbt_config["schema"] = config["schema"]

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
@@ -43,7 +43,7 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNormalizationRunner.class);
 
-  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.6";
+  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.7";
 
   private final DestinationType destinationType;
   private final ProcessBuilderFactory pbf;


### PR DESCRIPTION
## What
The postgres source allows empty password, but normalization currently fails if the password is empty. This PR fixes that.