### PR TITLE
web: Upgrade Rest Hooks to v5

### DIFF
--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -17935,9 +17935,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "uncontrollable": {

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -2115,17 +2115,68 @@
         "tslib": "^1.10.0"
       }
     },
+    "@rest-hooks/core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rest-hooks/core/-/core-1.0.0.tgz",
+      "integrity": "sha512-MKoXjzRmmqdsihgTe9a+WtOBjg6E7daGoc5T4c3gxvFr7LjFf+HPlk3yAwv3neQTImeb3udF9YOptLdk68PhAw==",
+      "requires": {
+        "@babel/runtime": "^7.12.0",
+        "@rest-hooks/endpoint": "^1.0.0",
+        "@rest-hooks/normalizr": "^6.0.0",
+        "@rest-hooks/use-enhanced-reducer": "^1.0.5",
+        "flux-standard-action": "^2.1.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@rest-hooks/endpoint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rest-hooks/endpoint/-/endpoint-1.0.0.tgz",
+      "integrity": "sha512-qO3FtAo/1EZnPe28GjTWMWn/l4p+jfdIxINEPB3AKOj2hy5MsNZqIAsk3xiedTt5XtlQMwaEO9o5gL0/cLyM0A==",
+      "requires": {
+        "@babel/runtime": "^7.12.0",
+        "@rest-hooks/normalizr": "^6.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@rest-hooks/legacy": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@rest-hooks/legacy/-/legacy-1.0.12.tgz",
-      "integrity": "sha512-/kxU5rfR+SKcvIVlXYE453CTJvEtOF63riC8yKPVwLqUBVhSzq/YGKFAuVmFvQFnBHq3O11rusraYDZfNmsNSw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rest-hooks/legacy/-/legacy-2.0.0.tgz",
+      "integrity": "sha512-0oN9Ood5Vy0Fd1S2VJu2+5ApXoRvAERHLiZr+dk18ZB4ebd0DdDcZxuqypU7mFKuj/JWBt6fEQNOBwaXP3HxmA=="
     },
     "@rest-hooks/normalizr": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@rest-hooks/normalizr/-/normalizr-5.0.6.tgz",
-      "integrity": "sha512-eHKpzNPh6bTiyAshmnpXTUg0qMXDGthG61DpiPfRHpq5vl7mtX+t+EVQKi2VXnRZH+SefJF3q8KuAp1O6UcbMA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@rest-hooks/normalizr/-/normalizr-6.0.0.tgz",
+      "integrity": "sha512-Iqyc/zKnF32+4zYmyDMrFWkrJoRrFwnhdvnFkEWo3Ng83wDOqVTsE0YOslD7vPX380EnmMqO7qYMqO2mN19J1Q==",
       "requires": {
-        "@babel/runtime": "^7.7.0"
+        "@babel/runtime": "^7.12.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "@rest-hooks/use-enhanced-reducer": {
@@ -13330,6 +13381,11 @@
           "version": "10.17.32",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.32.tgz",
           "integrity": "sha512-EUq+cjH/3KCzQHikGnNbWAGe548IFLSm93Vl8xA7EuYEEATiyOVDyEVuGkowL7c9V69FF/RiZSAOCFPApMs/ig=="
+        },
+        "typescript": {
+          "version": "3.9.7",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+          "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
         }
       }
     },
@@ -15640,14 +15696,23 @@
       }
     },
     "rest-hooks": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/rest-hooks/-/rest-hooks-4.5.9.tgz",
-      "integrity": "sha512-QKj+c+WffnpBSVEIFPcF39D0si9Eh3fLxyTBmRPRM8YrfipuGyiK6EDQpBYUQQysE43gNg2FTH4t/CZLxnNvEg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rest-hooks/-/rest-hooks-5.0.0.tgz",
+      "integrity": "sha512-vQMwzLEd9tcsiwlf230ZB03ongaUMaZuElvO77a9gZfnmgjEVMw6lmXEh1HaJxqYAJjiJe4TxF8VsmQOwhL1kQ==",
       "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@rest-hooks/normalizr": "^5.0.6",
-        "@rest-hooks/use-enhanced-reducer": "^1.0.2",
-        "flux-standard-action": "^2.1.1"
+        "@babel/runtime": "^7.12.0",
+        "@rest-hooks/core": "^1.0.0",
+        "@rest-hooks/endpoint": "^1.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "restore-cursor": {
@@ -17870,9 +17935,10 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "dev": true
     },
     "uncontrollable": {
       "version": "5.1.0",

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -66,7 +66,7 @@
     "react-app-rewired": "^2.1.5",
     "react-hot-loader": "^4.12.20",
     "react-scripts": "3.4.3",
-    "typescript": "4.0.3"
+    "typescript": "4.1.3"
   },
   "husky": {
     "hooks": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -17,7 +17,7 @@
     "@hot-loader/react-dom": "16.13.0",
     "@papercups-io/chat-widget": "^1.1.5",
     "@papercups-io/storytime": "^1.0.6",
-    "@rest-hooks/legacy": "^1.0.12",
+    "@rest-hooks/legacy": "^2.0.0",
     "dayjs": "^1.8.35",
     "formik": "2.1.5",
     "lodash.at": "^4.6.0",
@@ -34,7 +34,7 @@
     "react-router-dom": "^5.1.2",
     "react-table": "^7.5.0",
     "react-widgets": "^4.5.0",
-    "rest-hooks": "^4.5.9",
+    "rest-hooks": "^5.0.0",
     "sanitize-html": "^2.1.2",
     "styled-components": "^5.1.1",
     "yup": "^0.28.1"
@@ -66,7 +66,7 @@
     "react-app-rewired": "^2.1.5",
     "react-hot-loader": "^4.12.20",
     "react-scripts": "3.4.3",
-    "typescript": "3.9.7"
+    "typescript": "4.0.3"
   },
   "husky": {
     "hooks": {

--- a/airbyte-webapp/src/components/hooks/services/useDestinationHook.tsx
+++ b/airbyte-webapp/src/components/hooks/services/useDestinationHook.tsx
@@ -36,7 +36,7 @@ export const useDestinationDefinitionSpecificationLoad = (
       ? {
           destinationDefinitionId
         }
-      : undefined
+      : null
   );
 
   return { destinationDefinitionSpecification, error, isLoading };

--- a/airbyte-webapp/src/components/hooks/services/useSourceHook.tsx
+++ b/airbyte-webapp/src/components/hooks/services/useSourceHook.tsx
@@ -35,7 +35,7 @@ export const useSourceDefinitionSpecificationLoad = (
       ? {
           sourceDefinitionId
         }
-      : undefined
+      : null
   );
 
   return { sourceDefinitionSpecification, error, isLoading };

--- a/airbyte-webapp/src/core/resources/BaseResource.ts
+++ b/airbyte-webapp/src/core/resources/BaseResource.ts
@@ -1,4 +1,13 @@
-import { Method, Resource } from "rest-hooks";
+import {
+  Method,
+  MutateShape,
+  Resource,
+  AbstractInstanceType,
+  ReadShape,
+  schemas,
+  SchemaDetail,
+  SchemaList
+} from "rest-hooks";
 
 // import { authService } from "../auth/authService";
 import config from "../../config";
@@ -67,9 +76,11 @@ export default abstract class BaseResource extends Resource {
     return config.apiUrl;
   }
 
-  static listShape<T extends typeof Resource>(this: T) {
+  static listShape<T extends typeof Resource>(
+    this: T
+  ): ReadShape<SchemaList<AbstractInstanceType<T>>> {
     return {
-      ...super.listShape(),
+      ...(super.listShape() as any),
       getFetchKey: (params: any) =>
         "POST " + this.url(params) + "/list" + JSON.stringify(params),
       fetch: async (
@@ -85,9 +96,11 @@ export default abstract class BaseResource extends Resource {
     };
   }
 
-  static detailShape<T extends typeof Resource>(this: T) {
+  static detailShape<T extends typeof Resource>(
+    this: T
+  ): ReadShape<SchemaDetail<AbstractInstanceType<T>>> {
     return {
-      ...super.detailShape(),
+      ...(super.detailShape() as any),
       getFetchKey: (params: any) =>
         "POST " + this.url(params) + "/get" + JSON.stringify(params),
       fetch: async (
@@ -103,9 +116,11 @@ export default abstract class BaseResource extends Resource {
     };
   }
 
-  static createShape<T extends typeof Resource>(this: T) {
+  static createShape<T extends typeof Resource>(
+    this: T
+  ): MutateShape<SchemaDetail<AbstractInstanceType<T>>> {
     return {
-      ...super.createShape(),
+      ...(super.createShape() as any),
       getFetchKey: (params: any) =>
         "POST " + this.url(params) + "/create" + JSON.stringify(params),
       fetch: async (
@@ -122,9 +137,11 @@ export default abstract class BaseResource extends Resource {
     };
   }
 
-  static deleteShape<T extends typeof Resource>(this: T) {
+  static deleteShape<T extends typeof Resource>(
+    this: T
+  ): MutateShape<schemas.Delete<T>, Readonly<object>, unknown> {
     return {
-      ...super.deleteShape(),
+      ...(super.deleteShape() as any),
       getFetchKey: (params: any) =>
         "POST " + this.url(params) + "/delete" + JSON.stringify(params),
       fetch: async (
@@ -140,9 +157,11 @@ export default abstract class BaseResource extends Resource {
     };
   }
 
-  static partialUpdateShape<T extends typeof Resource>(this: T) {
+  static partialUpdateShape<T extends typeof Resource>(
+    this: T
+  ): MutateShape<SchemaDetail<AbstractInstanceType<T>>> {
     return {
-      ...super.partialUpdateShape(),
+      ...(super.partialUpdateShape() as any),
       getFetchKey: (params: any) =>
         "POST " + this.url(params) + "/partial-update" + JSON.stringify(params),
       fetch: async (

--- a/airbyte-webapp/src/core/resources/Connection.ts
+++ b/airbyte-webapp/src/core/resources/Connection.ts
@@ -46,6 +46,7 @@ export default class ConnectionResource extends BaseResource
   readonly destinationId: string = "";
   readonly syncMode: string = "";
   readonly status: string = "";
+  readonly message: string = "";
   readonly schedule: ScheduleProperties | null = null;
   readonly source: SourceInformation | undefined = undefined;
   readonly destination: DestinationInformation | undefined = undefined;

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/CreationFormPage/CreationFormPage.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/CreationFormPage/CreationFormPage.tsx
@@ -12,7 +12,7 @@ import DestinationForm from "./components/DestinationForm";
 import ConnectionBlock from "../../../../components/ConnectionBlock";
 import { Routes } from "../../../routes";
 import CreateConnectionContent from "../../../../components/CreateConnectionContent";
-import { useResource } from "rest-hooks/lib/react-integration/hooks";
+import { useResource } from "rest-hooks";
 import SourceResource from "../../../../core/resources/Source";
 import DestinationResource from "../../../../core/resources/Destination";
 


### PR DESCRIPTION
## What
Rest Hooks handles networking data for front end. [5](https://github.com/coinbase/rest-hooks/releases/tag/rest-hooks%405.0.0) was just released with many improvements. Full release notes and migration guide to come.

## How
*Describe the solution*
- Some types are more strictly recognized, so fixed those errors
- Updated typescript to v4 to support named tuples
- Fixed super.call generics breaking with some explicit type additions
- Import from /lib/ path is not recommended - moved to top-level import
- Added missing `message` member to one resource.
- We use `SchemaDetail` and `SchemaList` in the BaseResource so they can be overridden children classes.
  - Use the Resource itself in children (`T` or `T[]`)

Given lack of use of `useInvalidator()` as well as custom managers, this should be the extent of changes needed.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*
