### PR TITLE
Clean up external API

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -203,7 +203,6 @@ paths:
           description: SourceDefinition not found
         "422":
           $ref: "#/components/responses/InvalidInput"
-  # todo (cgardens) - rename to source_specifications/get_latest_from_source_id
   /v1/source_definition_specifications/get:
     post:
       tags:
@@ -1538,7 +1537,6 @@ components:
       required:
         - sourceId
         - destinationId
-        - syncMode
         - status
       properties:
         name:
@@ -1548,9 +1546,6 @@ components:
           $ref: "#/components/schemas/SourceId"
         destinationId:
           $ref: "#/components/schemas/DestinationId"
-        # todo (cgardens) - remove this after we migrate to incremental schema
-        syncMode:
-          $ref: "#/components/schemas/SyncMode"
         syncSchema:
           $ref: "#/components/schemas/SourceSchema"
         schedule:
@@ -1586,7 +1581,6 @@ components:
         - name
         - sourceId
         - destinationId
-        - syncMode
         - syncSchema
         - status
       properties:
@@ -1598,9 +1592,6 @@ components:
           $ref: "#/components/schemas/SourceId"
         destinationId:
           $ref: "#/components/schemas/DestinationId"
-        # todo (cgardens) - remove this after we migrate to incremental schema
-        syncMode:
-          $ref: "#/components/schemas/SyncMode"
         syncSchema:
           $ref: "#/components/schemas/SourceSchema"
         schedule:
@@ -1671,8 +1662,7 @@ components:
       required:
         - name
         - fields
-        # todo (cgardens) - make required once sources are migrated
-        # - supportedSyncModes
+        - supportedSyncModes
       properties:
         # immutable
         name:
@@ -1904,7 +1894,6 @@ components:
         - name
         - sourceId
         - destinationId
-        - syncMode
         - syncSchema
         - status
         - source
@@ -1919,8 +1908,6 @@ components:
           $ref: "#/components/schemas/SourceId"
         destinationId:
           $ref: "#/components/schemas/DestinationId"
-        syncMode:
-          $ref: "#/components/schemas/SyncMode"
         syncSchema:
           $ref: "#/components/schemas/SourceSchema"
         schedule:

--- a/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteProtocolConverters.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteProtocolConverters.java
@@ -95,7 +95,7 @@ public class AirbyteProtocolConverters {
             .withFields(toFields(airbyteStream.getJsonSchema().get("properties")))
             .withSupportedSyncModes(airbyteStream.getSupportedSyncModes()
                 .stream()
-                .map(e -> Enums.convertTo(e, StandardSync.SyncMode.class))
+                .map(e -> Enums.convertTo(e, io.airbyte.config.SyncMode.class))
                 .collect(Collectors.toList()))
             .withSourceDefinedCursor(airbyteStream.getSourceDefinedCursor())
             .withDefaultCursorField(airbyteStream.getDefaultCursorField())

--- a/airbyte-config/models/src/main/resources/types/StandardSync.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSync.yaml
@@ -8,7 +8,6 @@ required:
   - sourceId
   - destinationId
   - name
-  - syncMode
   - schema
 additionalProperties: false
 properties:
@@ -23,10 +22,6 @@ properties:
     format: uuid
   name:
     type: string
-  # todo (cgardens) - this is deprecated. we should remove it.
-  # https://github.com/airbytehq/airbyte/issues/1224
-  syncMode:
-    "$ref": SyncMode.yaml
   schema:
     "$ref": StandardDataSchema.yaml#/definitions/schema
   status:

--- a/airbyte-config/models/src/main/resources/types/StandardTargetConfig.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardTargetConfig.yaml
@@ -7,7 +7,6 @@ type: object
 additionalProperties: false
 required:
   - destinationConnectionConfiguration
-  - syncMode
   - catalog
   - connectionId
 properties:
@@ -15,8 +14,6 @@ properties:
     description: Integration specific blob. Must be a valid JSON string.
     type: object
     existingJavaType: com.fasterxml.jackson.databind.JsonNode
-  syncMode:
-    "$ref": SyncMode.yaml
   catalog:
     type: object
     existingJavaType: io.airbyte.protocol.models.ConfiguredAirbyteCatalog

--- a/airbyte-config/models/src/test/java/io/airbyte/config/AirbyteProtocolConvertersTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/AirbyteProtocolConvertersTest.java
@@ -78,7 +78,7 @@ class AirbyteProtocolConvertersTest {
                   .withName(COLUMN_AGE)
                   .withDataType(DataType.NUMBER)))
           .withSourceDefinedCursor(false)
-          .withSupportedSyncModes(Lists.newArrayList(StandardSync.SyncMode.FULL_REFRESH, StandardSync.SyncMode.INCREMENTAL))
+          .withSupportedSyncModes(Lists.newArrayList(io.airbyte.config.SyncMode.FULL_REFRESH, io.airbyte.config.SyncMode.INCREMENTAL))
           .withDefaultCursorField(Lists.newArrayList(COLUMN_AGE))));
 
   private static final Schema SCHEMA_WITH_UNSELECTED = new Schema()
@@ -93,7 +93,7 @@ class AirbyteProtocolConvertersTest {
                   .withName(COLUMN_AGE)
                   .withDataType(DataType.NUMBER)))
           .withSourceDefinedCursor(false)
-          .withSupportedSyncModes(Lists.newArrayList(StandardSync.SyncMode.FULL_REFRESH, StandardSync.SyncMode.INCREMENTAL))
+          .withSupportedSyncModes(Lists.newArrayList(io.airbyte.config.SyncMode.FULL_REFRESH, io.airbyte.config.SyncMode.INCREMENTAL))
           .withDefaultCursorField(Lists.newArrayList(COLUMN_AGE)),
           new Stream()
               .withName(STREAM_2)
@@ -109,7 +109,7 @@ class AirbyteProtocolConvertersTest {
   void testToConfiguredCatalog() {
     final Schema schema = Jsons.clone(SCHEMA);
     schema.getStreams().get(0).withCursorField(Lists.newArrayList(COLUMN_NAME));
-    schema.getStreams().get(0).withSyncMode(StandardSync.SyncMode.INCREMENTAL);
+    schema.getStreams().get(0).withSyncMode(io.airbyte.config.SyncMode.INCREMENTAL);
     assertEquals(CONFIGURED_CATALOG, AirbyteProtocolConverters.toConfiguredCatalog(schema));
   }
 
@@ -119,7 +119,7 @@ class AirbyteProtocolConvertersTest {
   void testToConfiguredCatalogWithUnselectedStream() {
     final Schema schema = Jsons.clone(SCHEMA_WITH_UNSELECTED);
     schema.getStreams().get(0).withCursorField(Lists.newArrayList(COLUMN_NAME));
-    schema.getStreams().get(0).withSyncMode(StandardSync.SyncMode.INCREMENTAL);
+    schema.getStreams().get(0).withSyncMode(io.airbyte.config.SyncMode.INCREMENTAL);
     assertEquals(CONFIGURED_CATALOG, AirbyteProtocolConverters.toConfiguredCatalog(schema));
   }
 
@@ -175,7 +175,7 @@ class AirbyteProtocolConvertersTest {
   void testStreamWithNoFields() {
     final Schema schema = Jsons.clone(SCHEMA);
     schema.getStreams().get(0).withCursorField(Lists.newArrayList(COLUMN_NAME));
-    schema.getStreams().get(0).withSyncMode(StandardSync.SyncMode.INCREMENTAL);
+    schema.getStreams().get(0).withSyncMode(io.airbyte.config.SyncMode.INCREMENTAL);
     schema.getStreams().get(0).setFields(Lists.newArrayList());
     final ConfiguredAirbyteCatalog actualCatalog = AirbyteProtocolConverters.toConfiguredCatalog(schema);
 
@@ -187,7 +187,7 @@ class AirbyteProtocolConvertersTest {
 
   @Test
   void testEnumConversion() {
-    assertTrue(Enums.isCompatible(io.airbyte.protocol.models.SyncMode.class, io.airbyte.config.StandardSync.SyncMode.class));
+    assertTrue(Enums.isCompatible(io.airbyte.protocol.models.SyncMode.class, io.airbyte.config.SyncMode.class));
   }
 
 }

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DefaultConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DefaultConfigPersistenceTest.java
@@ -106,7 +106,6 @@ class DefaultConfigPersistenceTest {
         .withConnectionId(UUID_1)
         .withSourceId(UUID.randomUUID())
         .withDestinationId(UUID.randomUUID())
-        .withSyncMode(StandardSync.SyncMode.FULL_REFRESH)
         .withStatus(StandardSync.Status.ACTIVE)
         .withSchema(schema);
 

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobSchedulerTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobSchedulerTest.java
@@ -36,7 +36,6 @@ import io.airbyte.config.Field;
 import io.airbyte.config.Schema;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSync.Status;
-import io.airbyte.config.StandardSync.SyncMode;
 import io.airbyte.config.StandardSyncSchedule;
 import io.airbyte.config.Stream;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -83,8 +82,7 @@ class JobSchedulerTest {
         .withStatus(StandardSync.Status.ACTIVE)
         .withSchema(schema)
         .withSourceId(sourceId)
-        .withDestinationId(destinationId)
-        .withSyncMode(SyncMode.FULL_REFRESH);
+        .withDestinationId(destinationId);
 
     // empty. contents not needed for any of these unit tests.
     STANDARD_SYNC_SCHEDULE = new StandardSyncSchedule();

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/WorkerRunFactoryTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/WorkerRunFactoryTest.java
@@ -138,6 +138,7 @@ class WorkerRunFactoryTest {
     Assertions.assertTrue(argument.getValue() instanceof JobOutputSyncWorker);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   void testResetConnection() {
     when(job.getConfig().getConfigType()).thenReturn(ConfigType.RESET_CONNECTION);

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
@@ -47,7 +47,6 @@ import io.airbyte.config.JobSyncConfig;
 import io.airbyte.config.Schema;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSync;
-import io.airbyte.config.StandardSync.SyncMode;
 import io.airbyte.config.Stream;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import java.io.IOException;
@@ -116,8 +115,7 @@ public class DefaultJobCreatorTest {
         .withStatus(StandardSync.Status.ACTIVE)
         .withSchema(schema)
         .withSourceId(sourceId)
-        .withDestinationId(destinationId)
-        .withSyncMode(SyncMode.FULL_REFRESH);
+        .withDestinationId(destinationId);
   }
 
   @BeforeEach
@@ -185,8 +183,7 @@ public class DefaultJobCreatorTest {
         .withConfigType(JobConfig.ConfigType.GET_SPEC)
         .withGetSpec(new JobGetSpecConfig().withDockerImage(integrationImage));
 
-    final String expectedScope = integrationImage;
-    when(jobPersistence.enqueueJob(expectedScope, jobConfig)).thenReturn(Optional.of(JOB_ID));
+    when(jobPersistence.enqueueJob(integrationImage, jobConfig)).thenReturn(Optional.of(JOB_ID));
 
     final long jobId = jobCreator.createGetSpecJob(integrationImage);
     assertEquals(JOB_ID, jobId);

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/SchemaConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/SchemaConverter.java
@@ -56,12 +56,12 @@ public class SchemaConverter {
                   .withFields(persistenceFields)
                   .withSupportedSyncModes(apiStream.getSupportedSyncModes()
                       .stream()
-                      .map(e -> Enums.convertTo(e, io.airbyte.config.StandardSync.SyncMode.class))
+                      .map(e -> Enums.convertTo(e, io.airbyte.config.SyncMode.class))
                       .collect(Collectors.toList()))
                   .withSourceDefinedCursor(apiStream.getSourceDefinedCursor())
                   .withDefaultCursorField(apiStream.getDefaultCursorField())
                   // configurable
-                  .withSyncMode(Enums.convertTo(apiStream.getSyncMode(), io.airbyte.config.StandardSync.SyncMode.class))
+                  .withSyncMode(Enums.convertTo(apiStream.getSyncMode(), io.airbyte.config.SyncMode.class))
                   .withCursorField(apiStream.getCursorField())
                   .withSelected(persistenceFields.stream().anyMatch(Field::getSelected));
             })

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -74,7 +74,6 @@ public class ConnectionsHandler {
         .withName(connectionCreate.getName() != null ? connectionCreate.getName() : "default")
         .withSourceId(connectionCreate.getSourceId())
         .withDestinationId(connectionCreate.getDestinationId())
-        .withSyncMode(Enums.convertTo(connectionCreate.getSyncMode(), StandardSync.SyncMode.class))
         .withStatus(toPersistenceStatus(connectionCreate.getStatus()));
 
     if (connectionCreate.getSyncSchema() != null) {
@@ -208,7 +207,6 @@ public class ConnectionsHandler {
         .destinationId(standardSync.getDestinationId())
         .status(toApiStatus(standardSync.getStatus()))
         .schedule(apiSchedule)
-        .syncMode(toApiSyncMode(standardSync.getSyncMode()))
         .name(standardSync.getName())
         .syncSchema(SchemaConverter.toApiSchema(standardSync.getSchema()));
   }
@@ -217,7 +215,7 @@ public class ConnectionsHandler {
     return Enums.convertTo(apiStatus, StandardSync.Status.class);
   }
 
-  private SyncMode toApiSyncMode(StandardSync.SyncMode persistenceStatus) {
+  private SyncMode toApiSyncMode(io.airbyte.config.SyncMode persistenceStatus) {
     return Enums.convertTo(persistenceStatus, SyncMode.class);
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -46,13 +46,11 @@ import io.airbyte.api.model.SourceRead;
 import io.airbyte.api.model.SourceSchema;
 import io.airbyte.api.model.SourceSchemaField;
 import io.airbyte.api.model.SourceSchemaStream;
-import io.airbyte.api.model.SyncMode;
 import io.airbyte.api.model.WbConnectionRead;
 import io.airbyte.api.model.WbConnectionReadList;
 import io.airbyte.api.model.WebBackendConnectionRequestBody;
 import io.airbyte.api.model.WebBackendConnectionUpdate;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
-import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.MoreBooleans;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -112,7 +110,6 @@ public class WebBackendConnectionsHandler {
         .name(connectionRead.getName())
         .syncSchema(connectionRead.getSyncSchema())
         .status(connectionRead.getStatus())
-        .syncMode(Enums.convertTo(connectionRead.getSyncMode(), SyncMode.class))
         .schedule(connectionRead.getSchedule())
         .source(source)
         .destination(destination);

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/SchemaConverterTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/SchemaConverterTest.java
@@ -34,7 +34,6 @@ import io.airbyte.commons.enums.Enums;
 import io.airbyte.config.DataType;
 import io.airbyte.config.Field;
 import io.airbyte.config.Schema;
-import io.airbyte.config.StandardSync.SyncMode;
 import io.airbyte.config.Stream;
 import org.junit.jupiter.api.Test;
 
@@ -52,9 +51,9 @@ class SchemaConverterTest {
               .withName(COLUMN_ID)
               .withSelected(true)))
           .withSourceDefinedCursor(false)
-          .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
+          .withSupportedSyncModes(Lists.newArrayList(io.airbyte.config.SyncMode.FULL_REFRESH, io.airbyte.config.SyncMode.INCREMENTAL))
           .withDefaultCursorField(Lists.newArrayList(COLUMN_ID))
-          .withSyncMode(SyncMode.INCREMENTAL)
+          .withSyncMode(io.airbyte.config.SyncMode.INCREMENTAL)
           .withCursorField(Lists.newArrayList(COLUMN_ID))));
 
   private static final SourceSchema API_SCHEMA = new SourceSchema()
@@ -85,7 +84,7 @@ class SchemaConverterTest {
   @Test
   void testEnumConversion() {
     assertTrue(Enums.isCompatible(io.airbyte.api.model.DataType.class, DataType.class));
-    assertTrue(Enums.isCompatible(io.airbyte.config.StandardSync.SyncMode.class, io.airbyte.api.model.SyncMode.class));
+    assertTrue(Enums.isCompatible(io.airbyte.config.SyncMode.class, io.airbyte.api.model.SyncMode.class));
   }
 
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -97,7 +97,6 @@ class ConnectionsHandlerTest {
         .destinationId(standardSync.getDestinationId())
         .name("presto to hudi")
         .status(ConnectionStatus.ACTIVE)
-        .syncMode(SyncMode.FULL_REFRESH)
         .schedule(ConnectionHelpers.generateBasicSchedule())
         .syncSchema(ConnectionHelpers.generateBasicApiSchema());
 
@@ -134,7 +133,6 @@ class ConnectionsHandlerTest {
         .withName("presto to hudi")
         .withSourceId(standardSync.getSourceId())
         .withDestinationId(standardSync.getDestinationId())
-        .withSyncMode(standardSync.getSyncMode())
         .withStatus(StandardSync.Status.INACTIVE)
         .withSchema(newPersistenceSchema);
 
@@ -227,7 +225,7 @@ class ConnectionsHandlerTest {
   @Test
   void testEnumConversion() {
     assertTrue(Enums.isCompatible(ConnectionStatus.class, StandardSync.Status.class));
-    assertTrue(Enums.isCompatible(StandardSync.SyncMode.class, SyncMode.class));
+    assertTrue(Enums.isCompatible(io.airbyte.config.SyncMode.class, SyncMode.class));
     assertTrue(Enums.isCompatible(StandardSync.Status.class, ConnectionStatus.class));
     assertTrue(Enums.isCompatible(ConnectionSchedule.TimeUnitEnum.class, Schedule.TimeUnit.class));
     assertTrue(Enums.isCompatible(io.airbyte.api.model.DataType.class, DataType.class));

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -158,7 +158,6 @@ class WebBackendConnectionsHandlerTest {
         .name(connectionRead.getName())
         .syncSchema(connectionRead.getSyncSchema())
         .status(connectionRead.getStatus())
-        .syncMode(connectionRead.getSyncMode())
         .schedule(connectionRead.getSchedule())
         .source(sourceRead)
         .destination(destinationRead)
@@ -190,7 +189,6 @@ class WebBackendConnectionsHandlerTest {
         .name(expected.getName())
         .syncSchema(modifiedSchema)
         .status(expected.getStatus())
-        .syncMode(expected.getSyncMode())
         .schedule(expected.getSchedule())
         .source(expected.getSource())
         .destination(expected.getDestination())
@@ -305,7 +303,6 @@ class WebBackendConnectionsHandlerTest {
             .name(expected.getName())
             .syncSchema(expected.getSyncSchema())
             .status(expected.getStatus())
-            .syncMode(expected.getSyncMode())
             .schedule(expected.getSchedule()));
 
     ConnectionRead connectionRead = wbHandler.webBackendUpdateConnection(updateBody);
@@ -334,7 +331,6 @@ class WebBackendConnectionsHandlerTest {
             .name(expected.getName())
             .syncSchema(expectedWithNewSchema.getSyncSchema())
             .status(expected.getStatus())
-            .syncMode(expected.getSyncMode())
             .schedule(expected.getSchedule()));
 
     ConnectionRead connectionRead = wbHandler.webBackendUpdateConnection(updateBody);

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
@@ -31,7 +31,6 @@ import io.airbyte.api.model.ConnectionStatus;
 import io.airbyte.api.model.SourceSchema;
 import io.airbyte.api.model.SourceSchemaField;
 import io.airbyte.api.model.SourceSchemaStream;
-import io.airbyte.api.model.SyncMode;
 import io.airbyte.config.DataType;
 import io.airbyte.config.Field;
 import io.airbyte.config.Schedule;
@@ -52,8 +51,7 @@ public class ConnectionHelpers {
         .withStatus(StandardSync.Status.ACTIVE)
         .withSchema(generateBasicPersistenceSchema())
         .withSourceId(sourceId)
-        .withDestinationId(UUID.randomUUID())
-        .withSyncMode(StandardSync.SyncMode.FULL_REFRESH);
+        .withDestinationId(UUID.randomUUID());
   }
 
   public static StandardSync generateSyncWithDestinationId(UUID destinationId) {
@@ -65,8 +63,7 @@ public class ConnectionHelpers {
         .withStatus(StandardSync.Status.ACTIVE)
         .withSchema(generateBasicPersistenceSchema())
         .withSourceId(UUID.randomUUID())
-        .withDestinationId(destinationId)
-        .withSyncMode(StandardSync.SyncMode.FULL_REFRESH);
+        .withDestinationId(destinationId);
   }
 
   public static Schema generateBasicPersistenceSchema() {
@@ -115,7 +112,6 @@ public class ConnectionHelpers {
         .destinationId(destinationId)
         .name("presto to hudi")
         .status(ConnectionStatus.ACTIVE)
-        .syncMode(SyncMode.FULL_REFRESH)
         .schedule(generateBasicSchedule())
         .syncSchema(ConnectionHelpers.generateBasicApiSchema());
   }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/TestConfigHelpers.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/TestConfigHelpers.java
@@ -33,7 +33,6 @@ import io.airbyte.config.Field;
 import io.airbyte.config.Schema;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSync;
-import io.airbyte.config.StandardSync.SyncMode;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.State;
 import io.airbyte.config.Stream;
@@ -100,7 +99,6 @@ public class TestConfigHelpers {
         .withDestinationId(destinationId)
         .withSourceId(sourceId)
         .withStatus(StandardSync.Status.ACTIVE)
-        .withSyncMode(SyncMode.FULL_REFRESH)
         .withName(CONNECTION_NAME)
         .withSchema(schema);
 

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4046,7 +4046,6 @@ font-style: italic;
       <div class="param">name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Optional name of the connection </div>
 <div class="param">sourceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">destinationId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
-<div class="param">syncMode </div><div class="param-desc"><span class="param-type"><a href="#SyncMode">SyncMode</a></span>  </div>
 <div class="param">syncSchema (optional)</div><div class="param-desc"><span class="param-type"><a href="#SourceSchema">SourceSchema</a></span>  </div>
 <div class="param">schedule (optional)</div><div class="param-desc"><span class="param-type"><a href="#ConnectionSchedule">ConnectionSchedule</a></span>  </div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
@@ -4067,7 +4066,6 @@ font-style: italic;
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">sourceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">destinationId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
-<div class="param">syncMode </div><div class="param-desc"><span class="param-type"><a href="#SyncMode">SyncMode</a></span>  </div>
 <div class="param">syncSchema </div><div class="param-desc"><span class="param-type"><a href="#SourceSchema">SourceSchema</a></span>  </div>
 <div class="param">schedule (optional)</div><div class="param-desc"><span class="param-type"><a href="#ConnectionSchedule">ConnectionSchedule</a></span>  </div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
@@ -4480,7 +4478,7 @@ font-style: italic;
       <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">cleanedName (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">fields </div><div class="param-desc"><span class="param-type"><a href="#SourceSchemaField">array[SourceSchemaField]</a></span>  </div>
-<div class="param">supportedSyncModes (optional)</div><div class="param-desc"><span class="param-type"><a href="#SyncMode">array[SyncMode]</a></span>  </div>
+<div class="param">supportedSyncModes </div><div class="param-desc"><span class="param-type"><a href="#SyncMode">array[SyncMode]</a></span>  </div>
 <div class="param">sourceDefinedCursor (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">defaultCursorField (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span>  </div>
 <div class="param">selected (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
@@ -4511,7 +4509,6 @@ font-style: italic;
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">sourceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">destinationId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
-<div class="param">syncMode </div><div class="param-desc"><span class="param-type"><a href="#SyncMode">SyncMode</a></span>  </div>
 <div class="param">syncSchema </div><div class="param-desc"><span class="param-type"><a href="#SourceSchema">SourceSchema</a></span>  </div>
 <div class="param">schedule (optional)</div><div class="param-desc"><span class="param-type"><a href="#ConnectionSchedule">ConnectionSchedule</a></span>  </div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>


### PR DESCRIPTION
* remove syncMode from connections (sync mode is already controlled at the stream level, this is just an artifact of the original design.)

* make supportedSyncModes required in the API. (functionally it was already never null because of how we did conversions. it still can be empty.)

