### PR TITLE
standardize casing in external api

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1324,11 +1324,11 @@ components:
       type: object
       required:
         - schema
-        - job_info
+        - jobInfo
       properties:
         schema:
           $ref: "#/components/schemas/SourceSchema"
-        job_info:
+        jobInfo:
           $ref: "#/components/schemas/JobInfoRead"
     # DESTINATION DEFINITION
     DestinationDefinitionId:
@@ -1529,7 +1529,7 @@ components:
       required:
         - connectionId
       properties:
-        with_refreshed_catalog:
+        withRefreshedCatalog:
           type: boolean
         connectionId:
           $ref: "#/components/schemas/ConnectionId"
@@ -1577,7 +1577,7 @@ components:
         - $ref: "#/components/schemas/ConnectionUpdate"
         - type: object
           properties:
-            with_refreshed_catalog:
+            withRefreshedCatalog:
               type: boolean
     ConnectionRead:
       type: object
@@ -1651,9 +1651,9 @@ components:
     LogsRequestBody:
       type: object
       required:
-        - log_type
+        - logType
       properties:
-        log_type:
+        logType:
           $ref: "#/components/schemas/LogType"
     # SCHEMA
     SourceSchema:
@@ -1894,7 +1894,7 @@ components:
             - failed
         message:
           type: string
-        job_info:
+        jobInfo:
           $ref: "#/components/schemas/JobInfoRead"
     # Web Backend
     WbConnectionRead:

--- a/airbyte-webapp/src/components/hooks/services/useConnectionHook.tsx
+++ b/airbyte-webapp/src/components/hooks/services/useConnectionHook.tsx
@@ -163,7 +163,7 @@ const useConnection = () => {
     } | null;
     withRefreshedCatalog?: boolean;
   }) => {
-    const withRefreshedCatalog = withRefreshedCatalog
+    const withRefreshedCatalogCleaned = withRefreshedCatalog
       ? { withRefreshedCatalog }
       : null;
 
@@ -174,7 +174,7 @@ const useConnection = () => {
         syncSchema,
         status,
         schedule,
-        ...withRefreshedCatalog
+        ...withRefreshedCatalogCleaned
       }
     );
   };

--- a/airbyte-webapp/src/components/hooks/services/useConnectionHook.tsx
+++ b/airbyte-webapp/src/components/hooks/services/useConnectionHook.tsx
@@ -51,7 +51,7 @@ export const useConnectionLoad = (
         setConnection(
           await fetchConnection({
             connectionId,
-            with_refreshed_catalog: withRefresh
+            withRefreshedCatalog: withRefresh
           })
         );
 
@@ -152,7 +152,7 @@ const useConnection = () => {
     syncSchema,
     status,
     schedule,
-    with_refreshed_catalog
+    withRefreshedCatalog
   }: {
     connectionId: string;
     syncSchema?: SyncSchema;
@@ -161,10 +161,10 @@ const useConnection = () => {
       units: number;
       timeUnit: string;
     } | null;
-    with_refreshed_catalog?: boolean;
+    withRefreshedCatalog?: boolean;
   }) => {
-    const withRefreshedCatalog = with_refreshed_catalog
-      ? { with_refreshed_catalog }
+    const withRefreshedCatalog = withRefreshedCatalog
+      ? { withRefreshedCatalog }
       : null;
 
     return await updateConnectionResource(

--- a/airbyte-webapp/src/core/resources/Connection.ts
+++ b/airbyte-webapp/src/core/resources/Connection.ts
@@ -70,7 +70,7 @@ export default class ConnectionResource extends BaseResource
       ...super.detailShape(),
       getFetchKey: (params: {
         connectionId: string;
-        with_refreshed_catalog?: boolean;
+        withRefreshedCatalog?: boolean;
       }) => "POST /web_backend/get" + JSON.stringify(params),
       fetch: async (params: any): Promise<any> =>
         await this.fetch(

--- a/airbyte-webapp/src/core/resources/Scheduler.ts
+++ b/airbyte-webapp/src/core/resources/Scheduler.ts
@@ -15,14 +15,14 @@ export type JobInfo = {
 export interface Scheduler {
   status: string;
   message: string;
-  job_info?: JobInfo;
+  jobInfo?: JobInfo;
 }
 
 export default class SchedulerResource extends BaseResource
   implements Scheduler {
   readonly status: string = "";
   readonly message: string = "";
-  readonly job_info: JobInfo | undefined = undefined;
+  readonly jobInfo: JobInfo | undefined = undefined;
 
   pk() {
     return Date.now().toString();
@@ -47,8 +47,8 @@ export default class SchedulerResource extends BaseResource
         // If check connection for source has status 'failed'
         if (result.status === Status.FAILED) {
           const jobInfo = {
-            ...result.job_info,
-            job: { ...result.job_info.job, status: result.status }
+            ...result.jobInfo,
+            job: { ...result.jobInfo.job, status: result.status }
           };
 
           const e = new NetworkError(result);
@@ -81,8 +81,8 @@ export default class SchedulerResource extends BaseResource
         // If check connection for destination has status 'failed'
         if (result.status === Status.FAILED) {
           const jobInfo = {
-            ...result.job_info,
-            job: { ...result.job_info.job, status: result.status }
+            ...result.jobInfo,
+            job: { ...result.jobInfo.job, status: result.status }
           };
 
           const e = new NetworkError(result);

--- a/airbyte-webapp/src/core/resources/Schema.ts
+++ b/airbyte-webapp/src/core/resources/Schema.ts
@@ -35,13 +35,13 @@ export type SyncSchema = {
 export interface Schema {
   id: string;
   schema: SyncSchema;
-  job_info?: JobInfo;
+  jobInfo?: JobInfo;
 }
 
 export default class SchemaResource extends BaseResource implements Schema {
   readonly schema: SyncSchema = { streams: [] };
   readonly id: string = "";
-  readonly job_info: JobInfo | undefined = undefined;
+  readonly jobInfo: JobInfo | undefined = undefined;
 
   pk() {
     return this.id?.toString();
@@ -63,17 +63,17 @@ export default class SchemaResource extends BaseResource implements Schema {
           params
         );
 
-        if (result.job_info.job.status === Status.FAILED || !result.schema) {
+        if (result.jobInfo.job.status === Status.FAILED || !result.schema) {
           const e = new NetworkError(result);
           // Generate error with failed status and received logs
           e.status = 400;
-          e.response = result.job_info;
+          e.response = result.jobInfo;
           throw e;
         }
 
         return {
           schema: result.schema,
-          job_info: result.job_info,
+          jobInfo: result.jobInfo,
           id: params.sourceId
         };
       },

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/SettingsView.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/SettingsView.tsx
@@ -112,7 +112,7 @@ const SettingsView: React.FC<IProps> = ({
         syncSchema: values.schema,
         status: connection?.status || "",
         schedule: frequencyData?.config || null,
-        with_refreshed_catalog: activeUpdatingSchemaMode
+        withRefreshedCatalog: activeUpdatingSchemaMode
       });
 
       setSaved(true);

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -1102,7 +1102,8 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "job_info" : {
+  "message" : "message",
+  "jobInfo" : {
     "job" : {
       "createdAt" : 6,
       "configId" : "configId",
@@ -1135,7 +1136,6 @@ font-style: italic;
       }
     } ]
   },
-  "message" : "message",
   "status" : "succeeded"
 }</code></pre>
 
@@ -2089,7 +2089,8 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "job_info" : {
+  "message" : "message",
+  "jobInfo" : {
     "job" : {
       "createdAt" : 6,
       "configId" : "configId",
@@ -2122,7 +2123,6 @@ font-style: italic;
       }
     } ]
   },
-  "message" : "message",
   "status" : "succeeded"
 }</code></pre>
 
@@ -2178,7 +2178,8 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "job_info" : {
+  "message" : "message",
+  "jobInfo" : {
     "job" : {
       "createdAt" : 6,
       "configId" : "configId",
@@ -2211,7 +2212,6 @@ font-style: italic;
       }
     } ]
   },
-  "message" : "message",
   "status" : "succeeded"
 }</code></pre>
 
@@ -2304,7 +2304,7 @@ font-style: italic;
       "cursorField" : [ "cursorField", "cursorField" ]
     } ]
   },
-  "job_info" : {
+  "jobInfo" : {
     "job" : {
       "createdAt" : 6,
       "configId" : "configId",
@@ -2392,7 +2392,8 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "job_info" : {
+  "message" : "message",
+  "jobInfo" : {
     "job" : {
       "createdAt" : 6,
       "configId" : "configId",
@@ -2425,7 +2426,6 @@ font-style: italic;
       }
     } ]
   },
-  "message" : "message",
   "status" : "succeeded"
 }</code></pre>
 
@@ -2625,7 +2625,7 @@ font-style: italic;
       "cursorField" : [ "cursorField", "cursorField" ]
     } ]
   },
-  "job_info" : {
+  "jobInfo" : {
     "job" : {
       "createdAt" : 6,
       "configId" : "configId",
@@ -4036,7 +4036,7 @@ font-style: italic;
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">succeeded</div><div class="param-enum">failed</div>
 <div class="param">message (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">job_info (optional)</div><div class="param-desc"><span class="param-type"><a href="#JobInfoRead">JobInfoRead</a></span>  </div>
+<div class="param">jobInfo </div><div class="param-desc"><span class="param-type"><a href="#JobInfoRead">JobInfoRead</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -4323,7 +4323,7 @@ font-style: italic;
     <h3><a name="LogsRequestBody"><code>LogsRequestBody</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">log_type </div><div class="param-desc"><span class="param-type"><a href="#LogType">LogType</a></span>  </div>
+      <div class="param">logType </div><div class="param-desc"><span class="param-type"><a href="#LogType">LogType</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -4416,7 +4416,7 @@ font-style: italic;
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">schema </div><div class="param-desc"><span class="param-type"><a href="#SourceSchema">SourceSchema</a></span>  </div>
-<div class="param">job_info </div><div class="param-desc"><span class="param-type"><a href="#JobInfoRead">JobInfoRead</a></span>  </div>
+<div class="param">jobInfo </div><div class="param-desc"><span class="param-type"><a href="#JobInfoRead">JobInfoRead</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -4532,7 +4532,7 @@ font-style: italic;
     <h3><a name="WebBackendConnectionRequestBody"><code>WebBackendConnectionRequestBody</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">with_refreshed_catalog (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+      <div class="param">withRefreshedCatalog (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">connectionId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
     </div>  <!-- field-items -->
   </div>
@@ -4544,14 +4544,14 @@ font-style: italic;
 <div class="param">syncSchema </div><div class="param-desc"><span class="param-type"><a href="#SourceSchema">SourceSchema</a></span>  </div>
 <div class="param">schedule (optional)</div><div class="param-desc"><span class="param-type"><a href="#ConnectionSchedule">ConnectionSchedule</a></span>  </div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
-<div class="param">with_refreshed_catalog (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+<div class="param">withRefreshedCatalog (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
     <h3><a name="WebBackendConnectionUpdate_allOf"><code>WebBackendConnectionUpdate_allOf</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">with_refreshed_catalog (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+      <div class="param">withRefreshedCatalog (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What
* This is a dumb PR, but it's our last best chance to do it. We know who is using our API and give them a heads up.
* A couple fields in the API are snake cased while everything else is camel cased. This just makes them all camel cased.
* I don't entirely no why i picked camel case for the API. in retrospect i would have done snake case as i generally thing that's the more common casing for json that being said, i don't think it really matters. in other words i am inclined to keep camel case and not try to switch to snake case just cause it's not worth the effort / risk of changing it before tuesday. if folks disagree though i am happy to give it a shot.

## Pre-Release Checklist
- [x] update frontend (replaced `with_refreshed_catalog` and `job_type` in the webapp. `log_lines` was not used in the FE so no change was required)
- [ ] notify sam, justin, and hudson