### PR TITLE
alias customer id upon import of configuration data

### DIFF
--- a/airbyte-analytics/src/main/java/io/airbyte/analytics/LoggingTrackingClient.java
+++ b/airbyte-analytics/src/main/java/io/airbyte/analytics/LoggingTrackingClient.java
@@ -46,6 +46,11 @@ public class LoggingTrackingClient implements TrackingClient {
   }
 
   @Override
+  public void alias(String previousCustomerId) {
+    LOGGER.info("merge. userId: {} previousUserId: {}", identitySupplier.get().getCustomerId(), previousCustomerId);
+  }
+
+  @Override
   public void track(String action) {
     track(action, Collections.emptyMap());
   }

--- a/airbyte-analytics/src/main/java/io/airbyte/analytics/SegmentTrackingClient.java
+++ b/airbyte-analytics/src/main/java/io/airbyte/analytics/SegmentTrackingClient.java
@@ -28,6 +28,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.segment.analytics.Analytics;
+import com.segment.analytics.messages.AliasMessage;
 import com.segment.analytics.messages.IdentifyMessage;
 import com.segment.analytics.messages.TrackMessage;
 import java.util.Collections;
@@ -77,6 +78,11 @@ public class SegmentTrackingClient implements TrackingClient {
     analytics.enqueue(IdentifyMessage.builder()
         .userId(trackingIdentity.getCustomerId().toString())
         .traits(identityMetadataBuilder.build()));
+  }
+
+  @Override
+  public void alias(String previousCustomerId) {
+    analytics.enqueue(AliasMessage.builder(previousCustomerId).userId(identitySupplier.get().getCustomerId().toString()));
   }
 
   @Override

--- a/airbyte-analytics/src/main/java/io/airbyte/analytics/TrackingClient.java
+++ b/airbyte-analytics/src/main/java/io/airbyte/analytics/TrackingClient.java
@@ -30,6 +30,8 @@ public interface TrackingClient {
 
   void identify();
 
+  void alias(String previousCustomerId);
+
   void track(String action);
 
   void track(String action, Map<String, Object> metadata);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
@@ -24,12 +24,14 @@
 
 package io.airbyte.server.handlers;
 
+import io.airbyte.analytics.TrackingClientSingleton;
 import io.airbyte.api.model.ImportRead;
 import io.airbyte.api.model.ImportRead.StatusEnum;
 import io.airbyte.commons.io.Archives;
 import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.PersistenceConstants;
 import io.airbyte.db.AirbyteVersion;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.server.converters.ConfigFileArchiver;
@@ -40,6 +42,8 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
+import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +55,7 @@ public class ArchiveHandler {
   private static final String VERSION_FILE_NAME = "VERSION";
 
   private final String version;
+  private final ConfigRepository configRepository;
   private final ConfigFileArchiver configFileArchiver;
   private final DatabaseArchiver databaseArchiver;
   private final FileTtlManager fileTtlManager;
@@ -60,6 +65,7 @@ public class ArchiveHandler {
                         final JobPersistence persistence,
                         final FileTtlManager fileTtlManager) {
     this.version = version;
+    this.configRepository = configRepository;
     configFileArchiver = new ConfigFileArchiver(configRepository);
     databaseArchiver = new DatabaseArchiver(persistence);
     this.fileTtlManager = fileTtlManager;
@@ -106,6 +112,9 @@ public class ArchiveHandler {
    * @return a status object describing if import was successful or not.
    */
   public ImportRead importData(File archive) {
+    // customerId before import happens.
+    final Optional<UUID> previousCustomerIdOptional = getCurrentCustomerId();
+
     ImportRead result;
     try {
       final Path tempFolder = Files.createTempDirectory("airbyte_archive");
@@ -119,9 +128,12 @@ public class ArchiveHandler {
         FileUtils.deleteDirectory(tempFolder.toFile());
         FileUtils.deleteQuietly(archive);
       }
+      // report that the previous customer id now superseded by the imported one.
+      previousCustomerIdOptional.ifPresent(previousCustomerId -> TrackingClientSingleton.get().alias(previousCustomerId.toString()));
     } catch (IOException | JsonValidationException | ConfigNotFoundException | RuntimeException e) {
       result = new ImportRead().status(StatusEnum.FAILED).reason(e.getMessage());
     }
+
     return result;
   }
 
@@ -137,6 +149,16 @@ public class ArchiveHandler {
     databaseArchiver.checkVersion(version);
     // Check if all files to import are valid and with expected airbyte version
     configFileArchiver.importConfigsFromArchive(tempFolder, true);
+  }
+
+  private Optional<UUID> getCurrentCustomerId() {
+    try {
+      return Optional.of(configRepository.getStandardWorkspace(PersistenceConstants.DEFAULT_WORKSPACE_ID).getCustomerId());
+    } catch (Exception e) {
+      // because this is used for tracking we prefer to log instead of killing the import.
+      LOGGER.error("failed to fetch current customerId.", e);
+      return Optional.empty();
+    }
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
@@ -128,7 +128,10 @@ public class ArchiveHandler {
         FileUtils.deleteDirectory(tempFolder.toFile());
         FileUtils.deleteQuietly(archive);
       }
-      // report that the previous customer id now superseded by the imported one.
+
+      // identify this instance as the new customer id.
+      TrackingClientSingleton.get().identify();
+      // report that the previous customer id is now superseded by the imported one.
       previousCustomerIdOptional.ifPresent(previousCustomerId -> TrackingClientSingleton.get().alias(previousCustomerId.toString()));
     } catch (IOException | JsonValidationException | ConfigNotFoundException | RuntimeException e) {
       result = new ImportRead().status(StatusEnum.FAILED).reason(e.getMessage());


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/1634

## What
* Currently when someone imports data subsequent, the tracking behavior is undefined. What I think happens now is that that it will appear like we had a new user try out airbyte and then they stopped at the top of the funnel because there will be no way to link them to the newly imported data. This messes up all of our analytics.

## How
* When a new configuration is imported into Airbyte report the imported customer id as the new tracking id (identify - which is meant to be called anytime a user logs in). 
* Alias the previous customer id as a child of the imported customer id (alias)

## Checklist
- [x] *Manually test this in amplitude*
- [x] *Follow up: we need to do the same thing in the UI (a task for next week. now that we know this works it is safe for the UI part to wait until after launch, it just has to happen before our first minor version bump after launch. [issue](https://github.com/airbytehq/airbyte/issues/1797))* 


## Manual Tests Result
* deployed an airbyte instance from scratch (creating a new amplitude user)
![original_user](https://user-images.githubusercontent.com/9092207/105559831-11b11f80-5cc7-11eb-891d-c18d3a27e062.png)

* created some configs then exported the data

* then i tore down the airbyte instance and deployed a new one from scratch (creating another new amplitude user).
![new_user](https://user-images.githubusercontent.com/9092207/105559860-242b5900-5cc7-11eb-9518-4c49f9bb0ab9.png)

* then I imported the data from the previous instance into the new one.

the state of the original user after the:
![original_user_remapped](https://user-images.githubusercontent.com/9092207/105559918-563cbb00-5cc7-11eb-8d24-8f175a1d5042.png)


the state of the second user after the import:
![new_user_remapped](https://user-images.githubusercontent.com/9092207/105559933-5fc62300-5cc7-11eb-8edb-368212cfdc01.png)

This looks like it is working reasonably correctly (note: the `remapped user id` field on the "primary" user and `remapping into user id` on the child user). Hopefully this doesn't mess up any of the analytics stuff. 

@johnlafleur  I want to make sure you grok this so that there are no surprises for you. lmk if you have any questions