### PR TITLE
add more logging in JdbcSource and JdbcDestination

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
@@ -115,11 +115,17 @@ public class BufferedStreamConsumer extends FailureTrackingConsumer<AirbyteMessa
     Preconditions.checkState(!hasStarted, "Consumer has already been started.");
     hasStarted = true;
 
+    LOGGER.info("{} started.", BufferedStreamConsumer.class);
+
+    LOGGER.info("Buffer creation started for {} streams.", streamNames.size());
     final Path queueRoot = Files.createTempDirectory("queues");
     for (String streamName : streamNames) {
+      LOGGER.info("Buffer creation for stream {}.", streamName);
       final BigQueue writeBuffer = new BigQueue(queueRoot.resolve(streamName), streamName);
       writeBuffers.put(streamName, writeBuffer);
     }
+    LOGGER.info("Buffer creation completed.");
+
     onStart.call();
 
     writerPool.scheduleWithFixedDelay(

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/JdbcBufferedConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/JdbcBufferedConsumerFactory.java
@@ -44,6 +44,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // Strategy:
 // 1. Create a temporary table for each stream
@@ -55,6 +57,8 @@ import java.util.stream.Collectors;
 // 5. In a single transaction, delete the target tables if they exist and rename the temp tables to
 // the final table name.
 public class JdbcBufferedConsumerFactory {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JdbcBufferedConsumerFactory.class);
 
   public static DestinationConsumer<AirbyteMessage> create(JdbcDatabase database,
                                                            SqlOperations sqlOperations,
@@ -87,13 +91,17 @@ public class JdbcBufferedConsumerFactory {
 
   private static OnStartFunction onStartFunction(JdbcDatabase database, SqlOperations sqlOperations, List<WriteConfig> writeConfigs) {
     return () -> {
+      LOGGER.info("Preparing tmp tables in destination started for {} streams", writeConfigs.size());
       for (final WriteConfig writeConfig : writeConfigs) {
         final String schemaName = writeConfig.getOutputNamespaceName();
         final String tmpTableName = writeConfig.getTmpTableName();
+        LOGGER.info("Preparing tmp table in destination started for stream {}. schema {}, tmp table name: {}", writeConfig.getStreamName(),
+            schemaName, tmpTableName);
 
         sqlOperations.createSchemaIfNotExists(database, schemaName);
         sqlOperations.createTableIfNotExists(database, schemaName, tmpTableName);
       }
+      LOGGER.info("Preparing tables in destination completed.");
     };
   }
 
@@ -120,10 +128,13 @@ public class JdbcBufferedConsumerFactory {
       // copy data
       if (!hasFailed) {
         final StringBuilder queries = new StringBuilder();
+        LOGGER.info("Finalizing tables in destination started for {} streams", writeConfigs.size());
         for (WriteConfig writeConfig : writeConfigs) {
           final String schemaName = writeConfig.getOutputNamespaceName();
           final String srcTableName = writeConfig.getTmpTableName();
           final String dstTableName = writeConfig.getOutputTableName();
+          LOGGER.info("Finalizing stream {}. schema {}, tmp table {}, final table {}", writeConfig.getStreamName(), schemaName, srcTableName,
+              dstTableName);
 
           sqlOperations.createTableIfNotExists(database, schemaName, dstTableName);
           switch (writeConfig.getSyncMode()) {
@@ -133,14 +144,22 @@ public class JdbcBufferedConsumerFactory {
           }
           queries.append(sqlOperations.copyTableQuery(schemaName, srcTableName, dstTableName));
         }
+
+        LOGGER.info("Executing finalization of tables.");
         sqlOperations.executeTransaction(database, queries.toString());
+        LOGGER.info("Finalizing tables in destination completed.");
       }
       // clean up
+      LOGGER.info("Cleaning tmp tables in destination started for {} streams", writeConfigs.size());
       for (WriteConfig writeConfig : writeConfigs) {
         final String schemaName = writeConfig.getOutputNamespaceName();
         final String tmpTableName = writeConfig.getTmpTableName();
+        LOGGER.info("Cleaning tmp table in destination started for stream {}. schema {}, tmp table name: {}", writeConfig.getStreamName(), schemaName,
+            tmpTableName);
+
         sqlOperations.dropTableIfExists(database, schemaName, tmpTableName);
       }
+      LOGGER.info("Cleaning tmp tables in destination completed.");
     };
   }
 

--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -63,6 +63,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -226,7 +227,13 @@ public abstract class AbstractJdbcSource implements Source {
       throw new IllegalArgumentException(String.format("%s does not support sync mode: %s.", airbyteStream.getSyncMode(), AbstractJdbcSource.class));
     }
 
-    return stream;
+    final AtomicLong recordCount = new AtomicLong();
+    return stream.peek(r -> {
+      final long count = recordCount.incrementAndGet();
+      if (count % 10000 == 0) {
+        LOGGER.info("Reading stream {}. Records read: {}", streamName, count);
+      }
+    });
   }
 
   private static Stream<AirbyteMessage> getIncrementalStream(JdbcDatabase database,


### PR DESCRIPTION
## What
* Trying to help a team debug some issues. It is really had to tell if it is failing because of a large table or while the destination is setting up temporary tables. These logs are intended to make this easier. As far as I can tell there's no reason not to put these in source. It'll be a little verbose if you have a ton of table, but really not at all relative to our other logging.