### PR TITLE
Increase Source / Destination Timeout

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -100,7 +100,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
     }
 
     LOGGER.debug("Closing target process");
-    WorkerUtils.gentleClose(targetProcess, 10, TimeUnit.MINUTES);
+    WorkerUtils.gentleClose(targetProcess, 10, TimeUnit.HOURS);
     if (targetProcess.isAlive() || targetProcess.exitValue() != 0) {
       throw new WorkerException("target process wasn't successful");
     }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
@@ -107,7 +107,7 @@ public class DefaultAirbyteSource implements AirbyteSource {
     }
 
     LOGGER.debug("Closing tap process");
-    WorkerUtils.gentleClose(tapProcess, 1, TimeUnit.MINUTES);
+    WorkerUtils.gentleClose(tapProcess, 10, TimeUnit.HOURS);
     if (tapProcess.isAlive() || tapProcess.exitValue() != 0) {
       throw new WorkerException("Tap process wasn't successful");
     }


### PR DESCRIPTION
## What
* I was testing moving "a lot" of data from PG to PG. One observation is quite a bit slower than the source (which is not surprising). It means that while both source and destination were still running the on-disk buffer was growing the whole time. The issue is that once the source completes a timeout counter starts and if the destination can't write everything from the buffer in time then the whole sync fails. This is going to happen a lot of big replication jobs.
* Here are the logs of the attempt I tried. Everything was still healthy when it died, it just got whacked by the time out.
[logs-6-0 (1).txt](https://github.com/airbytehq/airbyte/files/5859280/logs-6-0.1.txt)

## How
* I propose that we increase both the source and destination timeouts pretty massively. I don't think we rely on to do much anyway, it's more of a sanity turn off switch. But it currently block replicating a reasonable amount of data. We have an [issue](https://github.com/airbytehq/airbyte/issues/1600) to remove this time out and go to a heartbeat system, but we can't implement that before the next release and we have existing users who are blocked by these timeouts.
* I picked 10 hours as an arbitrarily large number. I'd be willing to adjust up. I don't think going down gets us much.