### PR TITLE
Update rules for when discover_schema returns http error codes

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1320,9 +1320,9 @@ components:
           items:
             $ref: "#/components/schemas/SourceRead"
     SourceDiscoverSchemaRead:
+      description: Returns the results of a discover schema job. If the job was not successful, the schema field will not be present. jobInfo will aways be present and its status be used to determine if the job was successful or not.
       type: object
       required:
-        - schema
         - jobInfo
       properties:
         schema:

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4413,9 +4413,9 @@ font-style: italic;
   </div>
   <div class="model">
     <h3><a name="SourceDiscoverSchemaRead"><code>SourceDiscoverSchemaRead</code> - </a> <a class="up" href="#__Models">Up</a></h3>
-    <div class='model-description'></div>
+    <div class='model-description'>Returns the results of a discover schema job. If the job was not successful, the schema field will not be present. jobInfo will aways be present and its status be used to determine if the job was successful or not.</div>
     <div class="field-items">
-      <div class="param">schema </div><div class="param-desc"><span class="param-type"><a href="#SourceSchema">SourceSchema</a></span>  </div>
+      <div class="param">schema (optional)</div><div class="param-desc"><span class="param-type"><a href="#SourceSchema">SourceSchema</a></span>  </div>
 <div class="param">jobInfo </div><div class="param-desc"><span class="param-type"><a href="#JobInfoRead">JobInfoRead</a></span>  </div>
     </div>  <!-- field-items -->
   </div>


### PR DESCRIPTION
* Previously if the job failed at all the API would return a 4XX or 500. This prevented the UI from being able to display logs from the failed job.

* Instead, if the underlying job fails the API will still return a 200. The schema field will be empty however and the consumer must check the jobInfo.status field to determine if the job succeeded or not.

* Will still return 422 on invalid inputs.

