### PR TITLE
Add db-specific quoting for non-simple names in AbstractJbdcSource

### DIFF
--- a/airbyte-db/src/main/java/io/airbyte/db/jdbc/JdbcUtils.java
+++ b/airbyte-db/src/main/java/io/airbyte/db/jdbc/JdbcUtils.java
@@ -240,12 +240,28 @@ public class JdbcUtils {
 
   }
 
+  /**
+   * Given a database connection and identifier, adds db-specific quoting.
+   *
+   * @param connection database connection
+   * @param identifier identifier to quote
+   * @return quoted identifier
+   * @throws SQLException throws if there are any issues fulling the quoting metadata from the db.
+   */
   public static String enquoteIdentifier(Connection connection, String identifier) throws SQLException {
     final String identifierQuoteString = connection.getMetaData().getIdentifierQuoteString();
 
     return identifierQuoteString + identifier + identifierQuoteString;
   }
 
+  /**
+   * Given a database connection and identifiers, adds db-specific quoting to each identifier.
+   *
+   * @param connection database connection
+   * @param identifiers identifiers to quote
+   * @return quoted identifiers
+   * @throws SQLException throws if there are any issues fulling the quoting metadata from the db.
+   */
   public static String enquoteIdentifierList(Connection connection, List<String> identifiers) throws SQLException {
     final StringJoiner joiner = new StringJoiner(",");
     for (String col : identifiers) {

--- a/airbyte-db/src/main/java/io/airbyte/db/jdbc/JdbcUtils.java
+++ b/airbyte-db/src/main/java/io/airbyte/db/jdbc/JdbcUtils.java
@@ -30,6 +30,7 @@ import io.airbyte.commons.functional.CheckedFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
 import java.math.BigDecimal;
+import java.sql.Connection;
 import java.sql.Date;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
@@ -41,8 +42,10 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.StringJoiner;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -235,6 +238,21 @@ public class JdbcUtils {
 
     O apply() throws SQLException;
 
+  }
+
+  public static String enquoteIdentifier(Connection connection, String identifier) throws SQLException {
+    final String identifierQuoteString = connection.getMetaData().getIdentifierQuoteString();
+
+    return identifierQuoteString + identifier + identifierQuoteString;
+  }
+
+  public static String enquoteIdentifierList(Connection connection, List<String> identifiers) throws SQLException {
+    final StringJoiner joiner = new StringJoiner(",");
+    for (String col : identifiers) {
+      String s = JdbcUtils.enquoteIdentifier(connection, col);
+      joiner.add(s);
+    }
+    return joiner.toString();
   }
 
 }

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/source/mysql/MySqlStandardTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/source/mysql/MySqlStandardTest.java
@@ -45,7 +45,7 @@ import java.util.List;
 import org.jooq.SQLDialect;
 import org.testcontainers.containers.MySQLContainer;
 
-public class MySqlSourceStandardTest extends StandardSourceTest {
+public class MySqlStandardTest extends StandardSourceTest {
 
   private static final String STREAM_NAME = "id_and_name";
   private static final String STREAM_NAME2 = "public.starships";

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlJdbcStandardTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlJdbcStandardTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.containers.MySQLContainer;
 
-class MySqlStandardSourceTest extends JdbcSourceStandardTest {
+class MySqlJdbcStandardTest extends JdbcSourceStandardTest {
 
   private static final String TEST_USER = "test";
   private static final String TEST_PASSWORD = "test";


### PR DESCRIPTION
## What
closes https://github.com/airbytehq/airbyte/issues/1818
closes https://github.com/airbytehq/airbyte/issues/1816
* `AbstractJdbcSource` did not handle tables and columns with non alphanumeric characters (e.g. spaces, ., etc)

## How
* Add db-specific quoting to support these cases

**I am not particularly interested in merging this before the launch.** We can launch after. (unless any reviewer particularly want it right now.)