### PR TITLE
Fix issue where check connection always fails on configuration update

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -359,6 +359,29 @@ paths:
           description: Source not found
         "422":
           $ref: "#/components/responses/InvalidInput"
+  /v1/sources/check_connection_for_update:
+    post:
+      tags:
+        - source
+      summary: Check connection for a proposed update to a source
+      operationId: checkConnectionToSourceForUpdate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SourceUpdate"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CheckConnectionRead"
+        "404":
+          description: Source not found
+        "422":
+          $ref: "#/components/responses/InvalidInput"
   /v1/sources/discover_schema:
     post:
       tags:
@@ -584,6 +607,29 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/DestinationIdRequestBody"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CheckConnectionRead"
+        "404":
+          description: Destination  not found
+        "422":
+          $ref: "#/components/responses/InvalidInput"
+  /v1/destinations/check_connection_for_update:
+    post:
+      tags:
+        - destination
+      summary: Check connection for a proposed update to a destination
+      operationId: checkConnectionToDestinationForUpdate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DestinationUpdate"
         required: true
       responses:
         "200":

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -128,7 +128,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
                           final FileTtlManager archiveTtlManager) {
     final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
     final JsonSchemaValidator schemaValidator = new JsonSchemaValidator();
-    schedulerHandler = new SchedulerHandler(configRepository, schedulerJobClient);
+    schedulerHandler = new SchedulerHandler(configRepository, schedulerJobClient, specFetcher);
     workspacesHandler = new WorkspacesHandler(configRepository);
     final DockerImageValidator dockerImageValidator = new DockerImageValidator(schedulerJobClient);
     sourceDefinitionsHandler = new SourceDefinitionsHandler(configRepository, dockerImageValidator, schedulerJobClient);
@@ -228,6 +228,11 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   }
 
   @Override
+  public CheckConnectionRead checkConnectionToSourceForUpdate(@Valid SourceUpdate sourceUpdate) {
+    return execute(() -> schedulerHandler.checkSourceConnectionFromSourceIdForUpdate(sourceUpdate));
+  }
+
+  @Override
   public SourceDiscoverSchemaRead discoverSchemaForSource(@Valid SourceIdRequestBody sourceIdRequestBody) {
     return execute(() -> schedulerHandler.discoverSchemaForSourceFromSourceId(sourceIdRequestBody));
   }
@@ -294,6 +299,11 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   @Override
   public CheckConnectionRead checkConnectionToDestination(@Valid DestinationIdRequestBody destinationIdRequestBody) {
     return execute(() -> schedulerHandler.checkDestinationConnectionFromDestinationId(destinationIdRequestBody));
+  }
+
+  @Override
+  public CheckConnectionRead checkConnectionToDestinationForUpdate(@Valid DestinationUpdate destinationUpdate) {
+    return execute(() -> schedulerHandler.checkDestinationConnectionFromDestinationIdForUpdate(destinationUpdate));
   }
 
   // CONNECTION

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -128,7 +128,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
                           final FileTtlManager archiveTtlManager) {
     final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
     final JsonSchemaValidator schemaValidator = new JsonSchemaValidator();
-    schedulerHandler = new SchedulerHandler(configRepository, schedulerJobClient, specFetcher);
+    schedulerHandler = new SchedulerHandler(configRepository, schedulerJobClient);
     workspacesHandler = new WorkspacesHandler(configRepository);
     final DockerImageValidator dockerImageValidator = new DockerImageValidator(schedulerJobClient);
     sourceDefinitionsHandler = new SourceDefinitionsHandler(configRepository, dockerImageValidator, schedulerJobClient);

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/ConfigurationUpdate.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/ConfigurationUpdate.java
@@ -30,6 +30,7 @@ import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
+import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
@@ -76,8 +77,8 @@ public class ConfigurationUpdate {
     // get existing destination
     final DestinationConnection persistedDestination = configRepository.getDestinationConnection(destinationId);
     // get spec
-    final StandardSourceDefinition destinationDefinition =
-        configRepository.getStandardSourceDefinition(persistedDestination.getDestinationDefinitionId());
+    final StandardDestinationDefinition destinationDefinition = configRepository
+        .getStandardDestinationDefinition(persistedDestination.getDestinationDefinitionId());
     final String imageName = DockerUtils.getTaggedImageName(destinationDefinition.getDockerRepository(), destinationDefinition.getDockerImageTag());
     final ConnectorSpecification spec = specFetcher.execute(imageName);
     // copy any necessary secrets from the current destination to the incoming updated destination

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
@@ -48,7 +48,7 @@ public class SpecFetcher {
         .getSuccessOutput()
         .map(JobOutput::getGetSpec)
         .map(StandardGetSpecOutput::getSpecification)
-        .orElseThrow(() -> new IllegalStateException("no spec output found"));
+        .orElseThrow(() -> new IllegalArgumentException("no spec output found"));
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -31,12 +31,14 @@ import io.airbyte.api.model.DestinationCoreConfig;
 import io.airbyte.api.model.DestinationDefinitionIdRequestBody;
 import io.airbyte.api.model.DestinationDefinitionSpecificationRead;
 import io.airbyte.api.model.DestinationIdRequestBody;
+import io.airbyte.api.model.DestinationUpdate;
 import io.airbyte.api.model.JobInfoRead;
 import io.airbyte.api.model.SourceCoreConfig;
 import io.airbyte.api.model.SourceDefinitionIdRequestBody;
 import io.airbyte.api.model.SourceDefinitionSpecificationRead;
 import io.airbyte.api.model.SourceDiscoverSchemaRead;
 import io.airbyte.api.model.SourceIdRequestBody;
+import io.airbyte.api.model.SourceUpdate;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.config.AirbyteProtocolConverters;
@@ -53,9 +55,11 @@ import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.Job;
 import io.airbyte.scheduler.client.SchedulerJobClient;
+import io.airbyte.server.converters.ConfigurationUpdate;
 import io.airbyte.server.converters.JobConverter;
 import io.airbyte.server.converters.SchemaConverter;
 import io.airbyte.server.converters.SpecFetcher;
+import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.UUID;
@@ -65,20 +69,28 @@ public class SchedulerHandler {
   private final ConfigRepository configRepository;
   private final SchedulerJobClient schedulerJobClient;
   private final SpecFetcher specFetcher;
+  private final ConfigurationUpdate configurationUpdate;
+  private final JsonSchemaValidator jsonSchemaValidator;
 
-  public SchedulerHandler(ConfigRepository configRepository, SchedulerJobClient schedulerJobClient) {
+  public SchedulerHandler(ConfigRepository configRepository, SchedulerJobClient schedulerJobClient, SpecFetcher specFetcher) {
     this(
         configRepository,
         schedulerJobClient,
-        new SpecFetcher(schedulerJobClient));
+        new ConfigurationUpdate(configRepository, specFetcher),
+        new JsonSchemaValidator(),
+        specFetcher);
   }
 
   @VisibleForTesting
   SchedulerHandler(ConfigRepository configRepository,
                    SchedulerJobClient schedulerJobClient,
+                   ConfigurationUpdate configurationUpdate,
+                   JsonSchemaValidator jsonSchemaValidator,
                    SpecFetcher specFetcher) {
     this.configRepository = configRepository;
     this.schedulerJobClient = schedulerJobClient;
+    this.configurationUpdate = configurationUpdate;
+    this.jsonSchemaValidator = jsonSchemaValidator;
     this.specFetcher = specFetcher;
   }
 
@@ -104,6 +116,20 @@ public class SchedulerHandler {
     return reportConnectionStatus(schedulerJobClient.createSourceCheckConnectionJob(source, imageName));
   }
 
+  public CheckConnectionRead checkSourceConnectionFromSourceIdForUpdate(SourceUpdate sourceUpdate)
+      throws ConfigNotFoundException, IOException, JsonValidationException {
+    final SourceConnection updatedSource = configurationUpdate.source(sourceUpdate.getSourceId(), sourceUpdate.getConnectionConfiguration());
+
+    final ConnectorSpecification spec = getSpecFromSourceDefinitionId(updatedSource.getSourceDefinitionId());
+    jsonSchemaValidator.validate(spec.getConnectionSpecification(), updatedSource.getConfiguration());
+
+    final SourceCoreConfig sourceCoreConfig = new SourceCoreConfig()
+        .connectionConfiguration(updatedSource.getConfiguration())
+        .sourceDefinitionId(updatedSource.getSourceDefinitionId());
+
+    return checkSourceConnectionFromSourceCreate(sourceCoreConfig);
+  }
+
   public CheckConnectionRead checkDestinationConnectionFromDestinationId(DestinationIdRequestBody destinationIdRequestBody)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final DestinationConnection destination = configRepository.getDestinationConnection(destinationIdRequestBody.getDestinationId());
@@ -122,6 +148,21 @@ public class SchedulerHandler {
         .withDestinationDefinitionId(destinationConfig.getDestinationDefinitionId())
         .withConfiguration(destinationConfig.getConnectionConfiguration());
     return reportConnectionStatus(schedulerJobClient.createDestinationCheckConnectionJob(destination, imageName));
+  }
+
+  public CheckConnectionRead checkDestinationConnectionFromDestinationIdForUpdate(DestinationUpdate destinationUpdate)
+      throws JsonValidationException, IOException, ConfigNotFoundException {
+    final DestinationConnection updatedDestination = configurationUpdate
+        .destination(destinationUpdate.getDestinationId(), destinationUpdate.getConnectionConfiguration());
+
+    final ConnectorSpecification spec = getSpecFromDestinationDefinitionId(updatedDestination.getDestinationDefinitionId());
+    jsonSchemaValidator.validate(spec.getConnectionSpecification(), updatedDestination.getConfiguration());
+
+    final DestinationCoreConfig destinationCoreConfig = new DestinationCoreConfig()
+        .connectionConfiguration(updatedDestination.getConfiguration())
+        .destinationDefinitionId(updatedDestination.getDestinationDefinitionId());
+
+    return checkDestinationConnectionFromDestinationCreate(destinationCoreConfig);
   }
 
   public SourceDiscoverSchemaRead discoverSchemaForSourceFromSourceId(SourceIdRequestBody sourceIdRequestBody)
@@ -234,6 +275,21 @@ public class SchedulerHandler {
         .status(Enums.convertTo(checkConnectionOutput.getStatus(), CheckConnectionRead.StatusEnum.class))
         .message(checkConnectionOutput.getMessage())
         .jobInfo(JobConverter.getJobInfoRead(job));
+  }
+
+
+  private ConnectorSpecification getSpecFromSourceDefinitionId(UUID sourceDefId)
+      throws IOException, JsonValidationException, ConfigNotFoundException {
+    final StandardSourceDefinition sourceDef = configRepository.getStandardSourceDefinition(sourceDefId);
+    final String imageName = DockerUtils.getTaggedImageName(sourceDef.getDockerRepository(), sourceDef.getDockerImageTag());
+    return specFetcher.execute(imageName);
+  }
+
+  private ConnectorSpecification getSpecFromDestinationDefinitionId(UUID destDefId)
+      throws IOException, JsonValidationException, ConfigNotFoundException {
+    final StandardDestinationDefinition destinationDef = configRepository.getStandardDestinationDefinition(destDefId);
+    final String imageName = DockerUtils.getTaggedImageName(destinationDef.getDockerRepository(), destinationDef.getDockerImageTag());
+    return specFetcher.execute(imageName);
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -72,13 +72,13 @@ public class SchedulerHandler {
   private final ConfigurationUpdate configurationUpdate;
   private final JsonSchemaValidator jsonSchemaValidator;
 
-  public SchedulerHandler(ConfigRepository configRepository, SchedulerJobClient schedulerJobClient, SpecFetcher specFetcher) {
+  public SchedulerHandler(ConfigRepository configRepository, SchedulerJobClient schedulerJobClient) {
     this(
         configRepository,
         schedulerJobClient,
-        new ConfigurationUpdate(configRepository, specFetcher),
+        new ConfigurationUpdate(configRepository, new SpecFetcher(schedulerJobClient)),
         new JsonSchemaValidator(),
-        specFetcher);
+        new SpecFetcher(schedulerJobClient));
   }
 
   @VisibleForTesting
@@ -276,7 +276,6 @@ public class SchedulerHandler {
         .message(checkConnectionOutput.getMessage())
         .jobInfo(JobConverter.getJobInfoRead(job));
   }
-
 
   private ConnectorSpecification getSpecFromSourceDefinitionId(UUID sourceDefId)
       throws IOException, JsonValidationException, ConfigNotFoundException {

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/ConfigurationUpdateTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/ConfigurationUpdateTest.java
@@ -1,0 +1,130 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.server.converters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.DestinationConnection;
+import io.airbyte.config.SourceConnection;
+import io.airbyte.config.StandardDestinationDefinition;
+import io.airbyte.config.StandardSourceDefinition;
+import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.protocol.models.CatalogHelpers;
+import io.airbyte.protocol.models.ConnectorSpecification;
+import io.airbyte.protocol.models.Field;
+import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
+import io.airbyte.validation.json.JsonValidationException;
+import java.io.IOException;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConfigurationUpdateTest {
+
+  private static final String IMAGE_REPOSITORY = "foo";
+  private static final String IMAGE_TAG = "bar";
+  private static final String IMAGE_NAME = IMAGE_REPOSITORY + ":" + IMAGE_TAG;
+  private static final UUID UUID1 = UUID.randomUUID();
+  private static final UUID UUID2 = UUID.randomUUID();
+  private static final JsonNode SPEC = CatalogHelpers.fieldsToJsonSchema(
+      Field.of("username", JsonSchemaPrimitive.STRING),
+      Field.of("password", JsonSchemaPrimitive.STRING));
+  private static final ConnectorSpecification CONNECTOR_SPECIFICATION = new ConnectorSpecification().withConnectionSpecification(SPEC);
+  private static final JsonNode ORIGINAL_CONFIGURATION = Jsons.jsonNode(ImmutableMap.builder()
+      .put("username", "airbyte")
+      .put("password", "abc")
+      .build());
+  private static final JsonNode NEW_CONFIGURATION = Jsons.jsonNode(ImmutableMap.builder()
+      .put("username", "airbyte")
+      .put("password", "xyz")
+      .build());
+  private static final StandardSourceDefinition SOURCE_DEFINITION = new StandardSourceDefinition()
+      .withDockerRepository(IMAGE_REPOSITORY)
+      .withDockerImageTag(IMAGE_TAG);
+  private static final SourceConnection ORIGINAL_SOURCE_CONNECTION = new SourceConnection()
+      .withSourceId(UUID1)
+      .withSourceDefinitionId(UUID2)
+      .withConfiguration(ORIGINAL_CONFIGURATION);
+  private static final SourceConnection NEW_SOURCE_CONNECTION = new SourceConnection()
+      .withSourceId(UUID1)
+      .withSourceDefinitionId(UUID2)
+      .withConfiguration(NEW_CONFIGURATION);
+  private static final StandardDestinationDefinition DESTINATION_DEFINITION = new StandardDestinationDefinition()
+      .withDockerRepository(IMAGE_REPOSITORY)
+      .withDockerImageTag(IMAGE_TAG);
+  private static final DestinationConnection ORIGINAL_DESTINATION_CONNECTION = new DestinationConnection()
+      .withDestinationId(UUID1)
+      .withDestinationDefinitionId(UUID2)
+      .withConfiguration(ORIGINAL_CONFIGURATION);
+  private static final DestinationConnection NEW_DESTINATION_CONNECTION = new DestinationConnection()
+      .withDestinationId(UUID1)
+      .withDestinationDefinitionId(UUID2)
+      .withConfiguration(NEW_CONFIGURATION);
+
+  private ConfigRepository configRepository;
+  private SpecFetcher specFetcher;
+  private JsonSecretsProcessor secretsProcessor;
+  private ConfigurationUpdate configurationUpdate;
+
+  @BeforeEach
+  void setup() {
+    configRepository = mock(ConfigRepository.class);
+    specFetcher = mock(SpecFetcher.class);
+    secretsProcessor = mock(JsonSecretsProcessor.class);
+
+    configurationUpdate = new ConfigurationUpdate(configRepository, specFetcher, secretsProcessor);
+  }
+
+  @Test
+  void testSourceUpdate() throws JsonValidationException, IOException, ConfigNotFoundException {
+    when(configRepository.getSourceConnection(UUID1)).thenReturn(ORIGINAL_SOURCE_CONNECTION);
+    when(configRepository.getStandardSourceDefinition(UUID2)).thenReturn(SOURCE_DEFINITION);
+    when(specFetcher.execute(IMAGE_NAME)).thenReturn(CONNECTOR_SPECIFICATION);
+    when(secretsProcessor.copySecrets(ORIGINAL_CONFIGURATION, NEW_CONFIGURATION, SPEC)).thenReturn(NEW_CONFIGURATION);
+
+    final SourceConnection actual = configurationUpdate.source(UUID1, NEW_CONFIGURATION);
+
+    assertEquals(NEW_SOURCE_CONNECTION, actual);
+  }
+
+  @Test
+  void testDestinationUpdate() throws JsonValidationException, IOException, ConfigNotFoundException {
+    when(configRepository.getDestinationConnection(UUID1)).thenReturn(ORIGINAL_DESTINATION_CONNECTION);
+    when(configRepository.getStandardDestinationDefinition(UUID2)).thenReturn(DESTINATION_DEFINITION);
+    when(specFetcher.execute(IMAGE_NAME)).thenReturn(CONNECTOR_SPECIFICATION);
+    when(secretsProcessor.copySecrets(ORIGINAL_CONFIGURATION, NEW_CONFIGURATION, SPEC)).thenReturn(NEW_CONFIGURATION);
+
+    final DestinationConnection actual = configurationUpdate.destination(UUID1, NEW_CONFIGURATION);
+
+    assertEquals(NEW_DESTINATION_CONNECTION, actual);
+  }
+
+}

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/SpecFetcherTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/SpecFetcherTest.java
@@ -1,0 +1,84 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.server.converters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.JobOutput;
+import io.airbyte.config.StandardGetSpecOutput;
+import io.airbyte.protocol.models.ConnectorSpecification;
+import io.airbyte.scheduler.Job;
+import io.airbyte.scheduler.client.SchedulerJobClient;
+import java.io.IOException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SpecFetcherTest {
+
+  private static final String IMAGE_NAME = "foo:bar";
+
+  private SchedulerJobClient schedulerJobClient;
+  private Job job;
+  private JobOutput jobOutput;
+  private ConnectorSpecification connectorSpecification;
+  private StandardGetSpecOutput specOutput;
+
+  @BeforeEach
+  void setup() {
+    schedulerJobClient = mock(SchedulerJobClient.class);
+    job = mock(Job.class);
+    jobOutput = mock(JobOutput.class);
+    connectorSpecification = new ConnectorSpecification().withConnectionSpecification(Jsons.jsonNode(ImmutableMap.of("foo", "bar")));
+    specOutput = new StandardGetSpecOutput().withSpecification(connectorSpecification);
+
+    when(job.getSuccessOutput()).thenReturn(Optional.ofNullable(jobOutput));
+
+  }
+
+  @Test
+  void testFetch() throws IOException {
+    when(schedulerJobClient.createGetSpecJob(IMAGE_NAME)).thenReturn(job);
+    when(jobOutput.getGetSpec()).thenReturn(specOutput);
+
+    final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
+    assertEquals(connectorSpecification, specFetcher.execute(IMAGE_NAME));
+  }
+
+  @Test
+  void testFetchEmpty() throws IOException {
+    when(schedulerJobClient.createGetSpecJob(IMAGE_NAME)).thenReturn(job);
+    when(job.getSuccessOutput()).thenReturn(Optional.empty());
+
+    final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
+    assertThrows(IllegalArgumentException.class, () -> specFetcher.execute(IMAGE_NAME));
+  }
+
+}

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -236,6 +236,7 @@ font-style: italic;
   <h4><a href="#Destination">Destination</a></h4>
   <ul>
   <li><a href="#checkConnectionToDestination"><code><span class="http-method">post</span> /v1/destinations/check_connection</code></a></li>
+  <li><a href="#checkConnectionToDestinationForUpdate"><code><span class="http-method">post</span> /v1/destinations/check_connection_for_update</code></a></li>
   <li><a href="#createDestination"><code><span class="http-method">post</span> /v1/destinations/create</code></a></li>
   <li><a href="#deleteDestination"><code><span class="http-method">post</span> /v1/destinations/delete</code></a></li>
   <li><a href="#getDestination"><code><span class="http-method">post</span> /v1/destinations/get</code></a></li>
@@ -275,6 +276,7 @@ font-style: italic;
   <h4><a href="#Source">Source</a></h4>
   <ul>
   <li><a href="#checkConnectionToSource"><code><span class="http-method">post</span> /v1/sources/check_connection</code></a></li>
+  <li><a href="#checkConnectionToSourceForUpdate"><code><span class="http-method">post</span> /v1/sources/check_connection_for_update</code></a></li>
   <li><a href="#createSource"><code><span class="http-method">post</span> /v1/sources/create</code></a></li>
   <li><a href="#deleteSource"><code><span class="http-method">post</span> /v1/sources/delete</code></a></li>
   <li><a href="#discoverSchemaForSource"><code><span class="http-method">post</span> /v1/sources/discover_schema</code></a></li>
@@ -1084,6 +1086,98 @@ font-style: italic;
     <h3 class="field-label">Request body</h3>
     <div class="field-items">
       <div class="param">DestinationIdRequestBody <a href="#DestinationIdRequestBody">DestinationIdRequestBody</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#CheckConnectionRead">CheckConnectionRead</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "message" : "message",
+  "jobInfo" : {
+    "job" : {
+      "createdAt" : 6,
+      "configId" : "configId",
+      "id" : 0,
+      "updatedAt" : 1
+    },
+    "attempts" : [ {
+      "attempt" : {
+        "createdAt" : 5,
+        "bytesSynced" : 9,
+        "endedAt" : 7,
+        "id" : 5,
+        "recordsSynced" : 3,
+        "updatedAt" : 2
+      },
+      "logs" : {
+        "logLines" : [ "logLines", "logLines" ]
+      }
+    }, {
+      "attempt" : {
+        "createdAt" : 5,
+        "bytesSynced" : 9,
+        "endedAt" : 7,
+        "id" : 5,
+        "recordsSynced" : 3,
+        "updatedAt" : 2
+      },
+      "logs" : {
+        "logLines" : [ "logLines", "logLines" ]
+      }
+    } ]
+  },
+  "status" : "succeeded"
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#CheckConnectionRead">CheckConnectionRead</a>
+    <h4 class="field-label">404</h4>
+    Destination  not found
+        <a href="#"></a>
+    <h4 class="field-label">422</h4>
+    Invalid Input
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="checkConnectionToDestinationForUpdate"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/destinations/check_connection_for_update</code></pre></div>
+    <div class="method-summary">Check connection for a proposed update to a destination (<span class="nickname">checkConnectionToDestinationForUpdate</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">DestinationUpdate <a href="#DestinationUpdate">DestinationUpdate</a> (required)</div>
 
       <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
 
@@ -2374,6 +2468,98 @@ font-style: italic;
     <h3 class="field-label">Request body</h3>
     <div class="field-items">
       <div class="param">SourceIdRequestBody <a href="#SourceIdRequestBody">SourceIdRequestBody</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#CheckConnectionRead">CheckConnectionRead</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "message" : "message",
+  "jobInfo" : {
+    "job" : {
+      "createdAt" : 6,
+      "configId" : "configId",
+      "id" : 0,
+      "updatedAt" : 1
+    },
+    "attempts" : [ {
+      "attempt" : {
+        "createdAt" : 5,
+        "bytesSynced" : 9,
+        "endedAt" : 7,
+        "id" : 5,
+        "recordsSynced" : 3,
+        "updatedAt" : 2
+      },
+      "logs" : {
+        "logLines" : [ "logLines", "logLines" ]
+      }
+    }, {
+      "attempt" : {
+        "createdAt" : 5,
+        "bytesSynced" : 9,
+        "endedAt" : 7,
+        "id" : 5,
+        "recordsSynced" : 3,
+        "updatedAt" : 2
+      },
+      "logs" : {
+        "logLines" : [ "logLines", "logLines" ]
+      }
+    } ]
+  },
+  "status" : "succeeded"
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#CheckConnectionRead">CheckConnectionRead</a>
+    <h4 class="field-label">404</h4>
+    Source not found
+        <a href="#"></a>
+    <h4 class="field-label">422</h4>
+    Invalid Input
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="checkConnectionToSourceForUpdate"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/sources/check_connection_for_update</code></pre></div>
+    <div class="method-summary">Check connection for a proposed update to a source (<span class="nickname">checkConnectionToSourceForUpdate</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">SourceUpdate <a href="#SourceUpdate">SourceUpdate</a> (required)</div>
 
       <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
 


### PR DESCRIPTION
## What
* Fixes the backend component of this issue: https://github.com/airbytehq/airbyte/issues/1849
* The issue is explained in depth in the issue, not doing to repeat.

## How
* Add an endpoint that accepts a source update configuration. It merges that update with the persisted version of the source to populate it with secrets. It then submits that merged version to the scheduler to do check connection.
* Same for destination.

## Pre-merge Checklist
- [x] *Unit Tests*
- [ ] *Follow up: Have UI use new endpoints*

## Other solutions
* I can't figure another way of doing this that doesn't involve passing secrets back to the UI which obviously we don't want to do.