### PR TITLE
Correctly parse json schema union types

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteProtocolConverters.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteProtocolConverters.java
@@ -33,7 +33,6 @@ import io.airbyte.protocol.models.AirbyteStream;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.SyncMode;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -142,7 +141,8 @@ public class AirbyteProtocolConverters {
           .map(typeString -> DataType.valueOf(convertToNumberIfInteger(typeString.asText().toUpperCase())))
           .collect(Collectors.toList());
 
-      // if there are no data types or there are multiple data types (which could happen in the case of JsonSchema type unions)
+      // if there are no data types or there are multiple data types (which could happen in the case of
+      // JsonSchema type unions)
       // then treat it as a string
       if (types.size() != 1) {
         return DataType.STRING;

--- a/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteProtocolConverters.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteProtocolConverters.java
@@ -133,7 +133,7 @@ public class AirbyteProtocolConverters {
    * @param node - list of types from jsonschema.
    * @return reduce down to one type which best matches the field's data type
    */
-  private static DataType jsonSchemaTypesToDataType(JsonNode node) {
+  public static DataType jsonSchemaTypesToDataType(JsonNode node) {
     if (node.isTextual()) {
       return DataType.valueOf(convertToNumberIfInteger(node.asText().toUpperCase()));
     } else if (node.isArray()) {

--- a/airbyte-config/models/src/test/java/io/airbyte/config/AirbyteProtocolConvertersTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/AirbyteProtocolConvertersTest.java
@@ -39,7 +39,9 @@ import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
 import io.airbyte.protocol.models.SyncMode;
+
 import java.util.Collections;
+
 import org.junit.jupiter.api.Test;
 
 class AirbyteProtocolConvertersTest {
@@ -83,18 +85,18 @@ class AirbyteProtocolConvertersTest {
 
   private static final Schema SCHEMA_WITH_UNSELECTED = new Schema()
       .withStreams(Lists.newArrayList(new Stream()
-          .withSelected(true)
-          .withName(STREAM)
-          .withFields(Lists.newArrayList(
-              new io.airbyte.config.Field()
-                  .withName(COLUMN_NAME)
-                  .withDataType(DataType.STRING),
-              new io.airbyte.config.Field()
-                  .withName(COLUMN_AGE)
-                  .withDataType(DataType.NUMBER)))
-          .withSourceDefinedCursor(false)
-          .withSupportedSyncModes(Lists.newArrayList(io.airbyte.config.SyncMode.FULL_REFRESH, io.airbyte.config.SyncMode.INCREMENTAL))
-          .withDefaultCursorField(Lists.newArrayList(COLUMN_AGE)),
+              .withSelected(true)
+              .withName(STREAM)
+              .withFields(Lists.newArrayList(
+                  new io.airbyte.config.Field()
+                      .withName(COLUMN_NAME)
+                      .withDataType(DataType.STRING),
+                  new io.airbyte.config.Field()
+                      .withName(COLUMN_AGE)
+                      .withDataType(DataType.NUMBER)))
+              .withSourceDefinedCursor(false)
+              .withSupportedSyncModes(Lists.newArrayList(io.airbyte.config.SyncMode.FULL_REFRESH, io.airbyte.config.SyncMode.INCREMENTAL))
+              .withDefaultCursorField(Lists.newArrayList(COLUMN_AGE)),
           new Stream()
               .withName(STREAM_2)
               .withFields(Lists.newArrayList(
@@ -169,6 +171,44 @@ class AirbyteProtocolConvertersTest {
 
     final AirbyteCatalog catalog = Jsons.deserialize(testString, AirbyteCatalog.class);
     assertEquals(schema, AirbyteProtocolConverters.toSchema(catalog));
+  }
+
+  @Test
+  void testStreamWithTypeUnion() {
+    final String testString =
+        "{\n" +
+            "  \"streams\": [\n" +
+            "    {\n" +
+            "      \"name\": \"users\",\n" +
+            "      \"json_schema\": {\n" +
+            "        \"type\": \"object\",\n" +
+            "        \"properties\": {\n" +
+            "          \"value\": {\n" +
+            "            \"type\": [\n" +
+            "              \"null\",\n" +
+            "              \"integer\",\n" +
+            "              \"object\",\n" +
+            "              \"string\"\n" +
+            "            ]\n" +
+            "          }\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}\n";
+
+    final Schema expected = new Schema()
+        .withStreams(Lists.newArrayList(new Stream()
+            .withName(STREAM)
+            .withFields(Lists.newArrayList(
+                new io.airbyte.config.Field()
+                    .withName("value")
+                    .withDataType(DataType.STRING)
+                    .withSelected(true)))
+            .withSelected(true)));
+
+    final AirbyteCatalog catalog = Jsons.deserialize(testString, AirbyteCatalog.class);
+    assertEquals(expected, AirbyteProtocolConverters.toSchema(catalog));
   }
 
   @Test

--- a/airbyte-config/models/src/test/java/io/airbyte/config/AirbyteProtocolConvertersTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/AirbyteProtocolConvertersTest.java
@@ -39,9 +39,7 @@ import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
 import io.airbyte.protocol.models.SyncMode;
-
 import java.util.Collections;
-
 import org.junit.jupiter.api.Test;
 
 class AirbyteProtocolConvertersTest {
@@ -85,18 +83,18 @@ class AirbyteProtocolConvertersTest {
 
   private static final Schema SCHEMA_WITH_UNSELECTED = new Schema()
       .withStreams(Lists.newArrayList(new Stream()
-              .withSelected(true)
-              .withName(STREAM)
-              .withFields(Lists.newArrayList(
-                  new io.airbyte.config.Field()
-                      .withName(COLUMN_NAME)
-                      .withDataType(DataType.STRING),
-                  new io.airbyte.config.Field()
-                      .withName(COLUMN_AGE)
-                      .withDataType(DataType.NUMBER)))
-              .withSourceDefinedCursor(false)
-              .withSupportedSyncModes(Lists.newArrayList(io.airbyte.config.SyncMode.FULL_REFRESH, io.airbyte.config.SyncMode.INCREMENTAL))
-              .withDefaultCursorField(Lists.newArrayList(COLUMN_AGE)),
+          .withSelected(true)
+          .withName(STREAM)
+          .withFields(Lists.newArrayList(
+              new io.airbyte.config.Field()
+                  .withName(COLUMN_NAME)
+                  .withDataType(DataType.STRING),
+              new io.airbyte.config.Field()
+                  .withName(COLUMN_AGE)
+                  .withDataType(DataType.NUMBER)))
+          .withSourceDefinedCursor(false)
+          .withSupportedSyncModes(Lists.newArrayList(io.airbyte.config.SyncMode.FULL_REFRESH, io.airbyte.config.SyncMode.INCREMENTAL))
+          .withDefaultCursorField(Lists.newArrayList(COLUMN_AGE)),
           new Stream()
               .withName(STREAM_2)
               .withFields(Lists.newArrayList(

--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -19,5 +19,5 @@ WORKDIR /airbyte
 
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.10
+LABEL io.airbyte.version=0.1.11
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
@@ -145,8 +145,12 @@ def read_json_catalog(input_path: str) -> dict:
     return json.loads(contents)
 
 
+def is_union_type(property_type) -> bool:
+    return type(property_type) is list and len(property_type) > 2
+
+
 def is_string(property_type) -> bool:
-    return property_type == "string" or "string" in property_type
+    return property_type == "string" or "string" in property_type or is_union_type(property_type)
 
 
 def is_integer(property_type) -> bool:

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
@@ -334,7 +334,7 @@ def extract_nested_properties(path: List[str], field: str, properties: dict, int
                         path=path + [field, key], field=key, properties=properties[key][combo], integration_type=integration_type
                     )
                     result.update(found)
-            elif "type" not in properties[key]:
+            elif "type" not in properties[key] or is_string(properties[key]["type"]):
                 pass
             elif is_array(properties[key]["type"]) and "items" in properties[key]:
                 combining = find_combining_schema(properties[key]["items"])

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
@@ -63,7 +63,6 @@ import io.airbyte.workers.process.DockerProcessBuilderFactory;
 import io.airbyte.workers.process.ProcessBuilderFactory;
 import io.airbyte.workers.protocols.airbyte.AirbyteDestination;
 import io.airbyte.workers.protocols.airbyte.DefaultAirbyteDestination;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -78,7 +77,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -132,7 +130,7 @@ public abstract class TestDestination {
    * invoked. These will be used to check that the data actually written is what should actually be
    * there. Note: this returns a set and does not test any order guarantees.
    *
-   * @param testEnv    - information about the test environment.
+   * @param testEnv - information about the test environment.
    * @param streamName - name of the stream for which we are retrieving records.
    * @return All of the records in the destination at the time this method is invoked.
    * @throws Exception - can throw any exception, test framework will handle.
@@ -172,7 +170,7 @@ public abstract class TestDestination {
    * as it would appear in an {@link AirbyteRecordMessage}. Only need to override this method if
    * {@link #implementsBasicNormalization} returns true.
    *
-   * @param testEnv    - information about the test environment.
+   * @param testEnv - information about the test environment.
    * @param streamName - name of the stream for which we are retrieving records.
    * @return All of the records in the destination at the time this method is invoked.
    * @throws Exception - can throw any exception, test framework will handle.

--- a/airbyte-integrations/bases/standard-destination-test/src/main/resources/edge_case_catalog.json
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/resources/edge_case_catalog.json
@@ -96,6 +96,16 @@
           }
         }
       }
+    },
+    {
+      "name": "uniontype",
+      "json_schema": {
+        "properties": {
+          "uniontypecolumn": {
+            "type": ["null", "integer", "object", "string"]
+          }
+        }
+      }
     }
   ]
 }

--- a/airbyte-integrations/bases/standard-destination-test/src/main/resources/edge_case_messages.txt
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/resources/edge_case_messages.txt
@@ -7,3 +7,6 @@
 {"type": "RECORD", "record": {"stream": "reserved_keywords", "emitted_at": 1602637589000, "data": { "order" : "ascending" }}}
 {"type": "RECORD", "record": {"stream": "groups", "emitted_at": 1602637589000, "data": { "authorization" : "into" }}}
 {"type": "RECORD", "record": {"stream": "ProperCase", "emitted_at": 1602637589000, "data": { "ProperCase" : true }}}
+{"type": "RECORD", "record": {"stream": "uniontype", "emitted_at": 1602637589000, "data": { "uniontypecolumn" : "a string" }}}
+{"type": "RECORD", "record": {"stream": "uniontype", "emitted_at": 1602637589000, "data": { "uniontypecolumn" : {"object":"value"} }}}
+{"type": "RECORD", "record": {"stream": "uniontype", "emitted_at": 1602637589000, "data": { "uniontypecolumn" : 42 }}}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
@@ -43,7 +43,7 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNormalizationRunner.class);
 
-  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.10";
+  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:dev";
 
   private final DestinationType destinationType;
   private final ProcessBuilderFactory pbf;


### PR DESCRIPTION
## What
A valid JSONSchema type declaration can be: 

```
"type": ["null", "integer", "string"]
```

which means that the type can be either null, integer, or string. When Airbyte processes such a field, we always want to treat it as a string (at least for the moment). We do not handle this type gracefully in normalization or in converting catalogs to `Schema` objects. This causes connectors like Shopify to break when writing normalized data into a destination. 

This PR fixes the issue by treating this column as a string when normalizing and converting a catalog to a `Schema` object. 

## Pre-merge Checklist
- [ ] *Publish new normalization image*

## Recommended reading order
**Normalization changes:** 
1. transform.py
2. `TestDestination.java`
3. *.json

**Catalog conversion**
1. `AirbyteProtocolConverters.java`
2. AirbyteProtocolConvertersTest.java
