### PR TITLE
Source shopify: coerce union type to string

### DIFF
--- a/airbyte-integrations/connectors/source-shopify-singer/source_shopify_singer/source.py
+++ b/airbyte-integrations/connectors/source-shopify-singer/source_shopify_singer/source.py
@@ -25,7 +25,7 @@ SOFTWARE.
 import json
 
 import shopify
-from airbyte_protocol import AirbyteConnectionStatus, Status, AirbyteCatalog
+from airbyte_protocol import AirbyteCatalog, AirbyteConnectionStatus, Status
 from base_python import AirbyteLogger
 from base_singer import SingerSource
 
@@ -67,8 +67,8 @@ class SourceShopifySinger(SingerSource):
         for stream in catalog.streams:
             if stream.name == "metafields":
                 schema = stream.json_schema
-                if "properties" in schema and "metafields" in schema["properties"]:
-                    schema["properties"]["metafields"]["type"] = ["null", "string"]
+                if "properties" in schema and "value" in schema["properties"]:
+                    schema["properties"]["value"]["type"] = ["null", "string"]
 
         return catalog
 


### PR DESCRIPTION
## What
Context in #1861 -- this implementation instead coerces the union type in the shopify connector to be a string. 

## Pre-merge Checklist
- [ ] *Bump & publish*

## Follow up work
- [ ] assert in standard tests that union types are not emitted in the catalog