### PR TITLE
Local File Destinations UX change with destination paths

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/8be1cf83-fde1-477f-a4ad-318d23c9f3c6.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/8be1cf83-fde1-477f-a4ad-318d23c9f3c6.json
@@ -2,6 +2,6 @@
   "destinationDefinitionId": "8be1cf83-fde1-477f-a4ad-318d23c9f3c6",
   "name": "Local CSV",
   "dockerRepository": "airbyte/destination-csv",
-  "dockerImageTag": "0.1.7",
+  "dockerImageTag": "0.1.8",
   "documentationUrl": "https://docs.airbyte.io/integrations/destinations/local-csv"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/a625d593-bba5-4a1c-a53d-2d246268a816.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/a625d593-bba5-4a1c-a53d-2d246268a816.json
@@ -2,6 +2,6 @@
   "destinationDefinitionId": "a625d593-bba5-4a1c-a53d-2d246268a816",
   "name": "Local JSON",
   "dockerRepository": "airbyte/destination-local-json",
-  "dockerImageTag": "0.1.3",
+  "dockerImageTag": "0.1.4",
   "documentationUrl": "https://docs.airbyte.io/integrations/destinations/local-json"
 }

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -1,12 +1,12 @@
 - destinationDefinitionId: a625d593-bba5-4a1c-a53d-2d246268a816
   name: Local JSON
   dockerRepository: airbyte/destination-local-json
-  dockerImageTag: 0.1.3
+  dockerImageTag: 0.1.4
   documentationUrl: https://docs.airbyte.io/integrations/destinations/local-json
 - destinationDefinitionId: 8be1cf83-fde1-477f-a4ad-318d23c9f3c6
   name: Local CSV
   dockerRepository: airbyte/destination-csv
-  dockerImageTag: 0.1.7
+  dockerImageTag: 0.1.8
   documentationUrl: https://docs.airbyte.io/integrations/destinations/local-csv
 - destinationDefinitionId: 25c5221d-dce2-4163-ade9-739ef790f503
   name: Postgres

--- a/airbyte-integrations/connectors/destination-csv/Dockerfile
+++ b/airbyte-integrations/connectors/destination-csv/Dockerfile
@@ -7,5 +7,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.1.7
+LABEL io.airbyte.version=0.1.8
 LABEL io.airbyte.name=airbyte/destination-csv

--- a/airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
+++ b/airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
@@ -46,6 +46,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.Map;
@@ -129,11 +130,18 @@ public class CsvDestination implements Destination {
    * @param config - csv config object
    * @return absolute path with the relative path appended to the local volume mount.
    */
-  private Path getDestinationPath(JsonNode config) {
-    final String destinationRelativePath = config.get(DESTINATION_PATH_FIELD).asText();
-    Preconditions.checkNotNull(destinationRelativePath);
+  protected Path getDestinationPath(JsonNode config) {
+    Path destinationPath = Paths.get(config.get(DESTINATION_PATH_FIELD).asText());
+    Preconditions.checkNotNull(destinationPath);
 
-    return Path.of(destinationRelativePath);
+    if (!destinationPath.startsWith("/local"))
+      destinationPath = Path.of("/local", destinationPath.toString());
+    final Path normalizePath = destinationPath.normalize();
+    if (!normalizePath.startsWith("/local")) {
+      throw new IllegalArgumentException("Destination file should be inside the /local directory");
+    }
+
+    return destinationPath;
   }
 
   /**

--- a/airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
+++ b/airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
@@ -197,19 +197,23 @@ public class CsvDestination implements Destination {
         }
       }
       // do not persist the data, if there are any failures.
-      if (!hasFailed) {
-        for (final WriteConfig writeConfig : writeConfigs.values()) {
-          Files.move(writeConfig.getTmpPath(), writeConfig.getFinalPath(), StandardCopyOption.REPLACE_EXISTING);
-          LOGGER.info(String.format("File output: %s", writeConfig.getFinalPath()));
+      try {
+        if (!hasFailed) {
+          for (final WriteConfig writeConfig : writeConfigs.values()) {
+            Files.move(writeConfig.getTmpPath(), writeConfig.getFinalPath(), StandardCopyOption.REPLACE_EXISTING);
+            LOGGER.info(String.format("File output: %s", writeConfig.getFinalPath()));
+          }
+        } else {
+          final String message = "Failed to output files in destination";
+          LOGGER.error(message);
+          throw new IOException(message);
         }
-      } else {
-        LOGGER.error("Failed to output files in destination");
+      } finally {
+        // clean up tmp files.
+        for (final WriteConfig writeConfig : writeConfigs.values()) {
+          Files.deleteIfExists(writeConfig.getTmpPath());
+        }
       }
-      // clean up tmp files.
-      for (final WriteConfig writeConfig : writeConfigs.values()) {
-        Files.deleteIfExists(writeConfig.getTmpPath());
-      }
-
     }
 
   }

--- a/airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
+++ b/airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
@@ -192,7 +192,10 @@ public class CsvDestination implements Destination {
       if (!hasFailed) {
         for (final WriteConfig writeConfig : writeConfigs.values()) {
           Files.move(writeConfig.getTmpPath(), writeConfig.getFinalPath(), StandardCopyOption.REPLACE_EXISTING);
+          LOGGER.info(String.format("File output: %s", writeConfig.getFinalPath()));
         }
+      } else {
+        LOGGER.error("Failed to output files in destination");
       }
       // clean up tmp files.
       for (final WriteConfig writeConfig : writeConfigs.values()) {

--- a/airbyte-integrations/connectors/destination-csv/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-csv/src/main/resources/spec.json
@@ -9,10 +9,9 @@
     "additionalProperties": false,
     "properties": {
       "destination_path": {
-        "description": "Path to the directory where csv files will be written. Must start with the local mount \"/local\". Any other directory appended on the end will be placed inside that local mount. For more information check out our <a href=\"https://docs.airbyte.io/integrations/destinations/local-csv\">docs</a>",
+        "description": "Path to the directory where csv files will be written. The destination uses the local mount \"/local\" and any data files will be placed inside that local mount. For more information check out our <a href=\"https://docs.airbyte.io/integrations/destinations/local-csv\">docs</a>",
         "type": "string",
-        "examples": ["/local"],
-        "pattern": "(^\\/local\\/.*)|(^\\/local$)"
+        "examples": ["/local"]
       }
     }
   }

--- a/airbyte-integrations/connectors/destination-csv/src/test/java/io/airbyte/integrations/destination/csv/CsvDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-csv/src/test/java/io/airbyte/integrations/destination/csv/CsvDestinationTest.java
@@ -210,7 +210,7 @@ class CsvDestinationTest {
 
     assertThrows(RuntimeException.class, () -> consumer.accept(spiedMessage));
     consumer.accept(MESSAGE_USERS2);
-    consumer.close();
+    assertThrows(IOException.class, consumer::close);
 
     // verify tmp files are cleaned up and no files are output at all
     final Set<String> actualFilenames = Files.list(destinationPath).map(Path::getFileName).map(Path::toString).collect(Collectors.toSet());

--- a/airbyte-integrations/connectors/destination-local-json/Dockerfile
+++ b/airbyte-integrations/connectors/destination-local-json/Dockerfile
@@ -7,5 +7,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.1.3
+LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/destination-local-json

--- a/airbyte-integrations/connectors/destination-local-json/src/main/java/io/airbyte/integrations/destination/local_json/LocalJsonDestination.java
+++ b/airbyte-integrations/connectors/destination-local-json/src/main/java/io/airbyte/integrations/destination/local_json/LocalJsonDestination.java
@@ -194,19 +194,23 @@ public class LocalJsonDestination implements Destination {
         }
       }
       // do not persist the data, if there are any failures.
-      if (!hasFailed) {
-        for (final WriteConfig writeConfig : writeConfigs.values()) {
-          Files.move(writeConfig.getTmpPath(), writeConfig.getFinalPath(), StandardCopyOption.REPLACE_EXISTING);
-          LOGGER.info(String.format("File output: %s", writeConfig.getFinalPath()));
+      try {
+        if (!hasFailed) {
+          for (final WriteConfig writeConfig : writeConfigs.values()) {
+            Files.move(writeConfig.getTmpPath(), writeConfig.getFinalPath(), StandardCopyOption.REPLACE_EXISTING);
+            LOGGER.info(String.format("File output: %s", writeConfig.getFinalPath()));
+          }
+        } else {
+          final String message = "Failed to output files in destination";
+          LOGGER.error(message);
+          throw new IOException(message);
         }
-      } else {
-        LOGGER.error("Failed to output files in destination");
+      } finally {
+        // clean up tmp files.
+        for (final WriteConfig writeConfig : writeConfigs.values()) {
+          Files.deleteIfExists(writeConfig.getTmpPath());
+        }
       }
-      // clean up tmp files.
-      for (final WriteConfig writeConfig : writeConfigs.values()) {
-        Files.deleteIfExists(writeConfig.getTmpPath());
-      }
-
     }
 
   }

--- a/airbyte-integrations/connectors/destination-local-json/src/main/java/io/airbyte/integrations/destination/local_json/LocalJsonDestination.java
+++ b/airbyte-integrations/connectors/destination-local-json/src/main/java/io/airbyte/integrations/destination/local_json/LocalJsonDestination.java
@@ -191,7 +191,10 @@ public class LocalJsonDestination implements Destination {
       if (!hasFailed) {
         for (final WriteConfig writeConfig : writeConfigs.values()) {
           Files.move(writeConfig.getTmpPath(), writeConfig.getFinalPath(), StandardCopyOption.REPLACE_EXISTING);
+          LOGGER.info(String.format("File output: %s", writeConfig.getFinalPath()));
         }
+      } else {
+        LOGGER.error("Failed to output files in destination");
       }
       // clean up tmp files.
       for (final WriteConfig writeConfig : writeConfigs.values()) {

--- a/airbyte-integrations/connectors/destination-local-json/src/main/java/io/airbyte/integrations/destination/local_json/LocalJsonDestination.java
+++ b/airbyte-integrations/connectors/destination-local-json/src/main/java/io/airbyte/integrations/destination/local_json/LocalJsonDestination.java
@@ -25,6 +25,7 @@
 package io.airbyte.integrations.destination.local_json;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
@@ -124,11 +125,16 @@ public class LocalJsonDestination implements Destination {
    * @param config - config object
    * @return absolute path where to write files.
    */
-  private Path getDestinationPath(JsonNode config) {
+  protected Path getDestinationPath(JsonNode config) {
     Path destinationPath = Paths.get(config.get(DESTINATION_PATH_FIELD).asText());
+    Preconditions.checkNotNull(destinationPath);
 
     if (!destinationPath.startsWith("/local"))
-      destinationPath = Path.of("/local").resolve(destinationPath);
+      destinationPath = Path.of("/local", destinationPath.toString());
+    final Path normalizePath = destinationPath.normalize();
+    if (!normalizePath.startsWith("/local")) {
+      throw new IllegalArgumentException("Destination file should be inside the /local directory");
+    }
 
     return destinationPath;
   }

--- a/airbyte-integrations/connectors/destination-local-json/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-local-json/src/main/resources/spec.json
@@ -11,8 +11,7 @@
       "destination_path": {
         "description": "Path to the directory where json files will be written. The files will be placed inside that local mount. For more information check out our <a href=\"https://docs.airbyte.io/integrations/destinations/local-json\">docs</a>",
         "type": "string",
-        "examples": ["/json_data"],
-        "pattern": "(^\\/json_data\\/.*)|(^\\/json_data$)"
+        "examples": ["/json_data"]
       }
     }
   }

--- a/airbyte-integrations/connectors/destination-local-json/src/test/java/io/airbyte/integrations/destination/local_json/LocalJsonDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-local-json/src/test/java/io/airbyte/integrations/destination/local_json/LocalJsonDestinationTest.java
@@ -200,7 +200,7 @@ class LocalJsonDestinationTest {
 
     assertThrows(RuntimeException.class, () -> consumer.accept(spiedMessage));
     consumer.accept(MESSAGE_USERS2);
-    consumer.close();
+    assertThrows(IOException.class, consumer::close);
 
     // verify tmp files are cleaned up and no files are output at all
     final Set<String> actualFilenames = Files.list(destinationPath).map(Path::getFileName).map(Path::toString).collect(Collectors.toSet());

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,7 +71,7 @@ From there, you can look at the logs, download them, force a sync and adjust the
 Now let's verify that this worked:
 
 ```bash
-cat /tmp/airbyte_local/json_data/exchange_rate_raw.jsonl
+cat /tmp/airbyte_local/json_data/_airbyte_raw_exchange_rate.jsonl
 ```
 
 You should see one line for each day that was replicated.
@@ -79,7 +79,7 @@ You should see one line for each day that was replicated.
 If you have [`jq`](https://stedolan.github.io/jq/) installed, let's look at the evolution of `EUR`.
 
 ```bash
-cat /tmp/airbyte_local/test_json/exchange_rate_raw.jsonl | 
+cat /tmp/airbyte_local/test_json/_airbyte_raw_exchange_rate.jsonl | 
 jq -c '.data | {date: .date, EUR: .EUR }'
 ```
 

--- a/docs/integrations/destinations/local-csv.md
+++ b/docs/integrations/destinations/local-csv.md
@@ -6,7 +6,7 @@ This destination is meant to be used on a local workstation and won't work on Ku
 
 ## Overview
 
-This destination writes data to a directory on the _local_ filesystem on the host running Airbyte. By default, data is written to [/tmp/airbyte\_local](file:///tmp/airbyte_local/). To change this location, modify the `LOCAL_ROOT` environment variable for Airbyte.
+This destination writes data to a directory on the _local_ filesystem on the host running Airbyte. By default, data is written to `/tmp/airbyte_local`. To change this location, modify the `LOCAL_ROOT` environment variable for Airbyte.
 
 ### Sync Overview
 
@@ -31,7 +31,18 @@ This integration will be constrained by the speed at which your filesystem accep
 
 ## Getting Started
 
-### Requirements:
+The `destination_path` will always start with `/local` whether it is specified by the user or not.
+Any directory nesting within local will be mapped onto the local mount.
 
-* The `destination_path` must start with `/local`. Any directory nesting within local will be mapped onto the local mount. By default, the local mount is mounted onto `/tmp/airbyte_local`. This is controlled by the `LOCAL_ROOT` env variable in the `.env` file. If `destination_path` is set to `/local/cars/models` and the local mount is using the `/tmp/airbyte_local` default, then data will be written to `/tmp/airbyte_local/cars/models` directory.
+By default, the `LOCAL_ROOT` env variable in the `.env` file is set `/tmp/airbyte_local`.
 
+The local mount is mounted by Docker onto `LOCAL_ROOT`.
+This means the `/local` is substituted by `/tmp/airbyte_local` by default.
+
+### Example:
+
+- If `destination_path` is set to `/local/cars/models`
+- the local mount is using the `/tmp/airbyte_local` default
+- then all data will be written to `/tmp/airbyte_local/cars/models` directory.
+
+(If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to [file:///tmp/airbyte_local](file:///tmp/airbyte_local) and look at the replicated data locally)

--- a/docs/integrations/destinations/local-json.md
+++ b/docs/integrations/destinations/local-json.md
@@ -6,7 +6,7 @@ This destination is meant to be used on a local workstation and won't work on Ku
 
 ## Overview
 
-This destination writes data to a directory on the _local_ filesystem on the host running Airbyte. By default, data is written to [/tmp/airbyte\_local](file:///tmp/airbyte_local/). To change this location, modify the `LOCAL_ROOT` environment variable for Airbyte.
+This destination writes data to a directory on the _local_ filesystem on the host running Airbyte. By default, data is written to `/tmp/airbyte_local`. To change this location, modify the `LOCAL_ROOT` environment variable for Airbyte.
 
 ### Sync Overview
 
@@ -29,3 +29,20 @@ Each stream will be output into its own file. Each file will a collections of `j
 
 This integration will be constrained by the speed at which your filesystem accepts writes.
 
+## Getting Started
+
+The `destination_path` will always start with `/local` whether it is specified by the user or not.
+Any directory nesting within local will be mapped onto the local mount.
+
+By default, the `LOCAL_ROOT` env variable in the `.env` file is set `/tmp/airbyte_local`.
+
+The local mount is mounted by Docker onto `LOCAL_ROOT`.
+This means the `/local` is substituted by `/tmp/airbyte_local` by default.
+
+### Example:
+
+- If `destination_path` is set to `/local/cars/models`
+- the local mount is using the `/tmp/airbyte_local` default
+- then all data will be written to `/tmp/airbyte_local/cars/models` directory.
+
+(If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to [file:///tmp/airbyte_local](file:///tmp/airbyte_local) and look at the replicated data locally)


### PR DESCRIPTION
## What
*Describe what the change is solving*

Many users seem to be having troubles with the local destinations... 

Maybe it is not clear how to fill up the destination path? 
It was reported multiple times that even though sync were marked as successful, there would be no files in `/tmp/airbyte_local/`

## How
*Describe the solution*

We could make it a little easier by not bothering about asking/expecting the user to write the prefix `/local` but we would always make sure it is there instead.

Plus if you were trying edgy things like `/local/../etc/passwd` as destination paths, then you shouldn't be able to do that...

## Pre-merge Checklist
- [x] *Run integration tests*
- [x] *Publish Docker images*
