### PR TITLE
Register publish command in workflow dispatchers

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -17,6 +17,7 @@ jobs:
           token: ${{ secrets.SLASH_COMMAND_PAT }}
           commands: |
             test
+            publish
           static-args: |
             ref=${{ steps.getref.outputs.ref }}
             comment-id=${{ github.event.comment.id }}


### PR DESCRIPTION
The library we use to dispatch workflows from comments [uses the default branch to find commands](https://github.com/peter-evans/slash-command-dispatch/blob/master/src/github-helper.ts#L202), so I'm merging this to test changes in #1892 