### PR TITLE
Introduce namespacing to destinations

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1729,6 +1729,8 @@ components:
           type: array
           items:
             type: string
+        sourceNamespace:
+          type: string
         # configurable
         selected:
           type: boolean
@@ -1738,6 +1740,10 @@ components:
           type: array
           items:
             type: string
+        destinationNamespace:
+          type: string
+        destinationName:
+          type: string
     SourceSchemaField:
       type: object
       required:

--- a/airbyte-config/models/build.gradle
+++ b/airbyte-config/models/build.gradle
@@ -6,6 +6,7 @@ plugins {
 
 dependencies {
     implementation project(':airbyte-protocol:models')
+    implementation 'org.apache.commons:commons-lang3:3.11'
 }
 
 jsonSchema2Pojo {

--- a/airbyte-config/models/src/main/resources/types/StandardDataSchema.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardDataSchema.yaml
@@ -41,6 +41,8 @@ definitions:
         type: array
         items:
           type: string
+      sourceNamespace:
+        type: string
       # configurable
       selected:
         type: boolean
@@ -50,6 +52,10 @@ definitions:
         type: array
         items:
           type: string
+      destinationNamespace:
+        type: string
+      destinationName:
+        type: string
   field:
     type: object
     required:

--- a/airbyte-config/models/src/test/java/io/airbyte/config/AirbyteProtocolConvertersTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/AirbyteProtocolConvertersTest.java
@@ -46,6 +46,7 @@ class AirbyteProtocolConvertersTest {
 
   private static final String STREAM = "users";
   private static final String STREAM_2 = "users2";
+  private static final String NAMESPACE = "test";
   private static final String COLUMN_NAME = "name";
   private static final String COLUMN_AGE = "age";
 
@@ -62,6 +63,8 @@ class AirbyteProtocolConvertersTest {
 
   private static final ConfiguredAirbyteCatalog CONFIGURED_CATALOG = new ConfiguredAirbyteCatalog()
       .withStreams(Lists.newArrayList(new ConfiguredAirbyteStream()
+          .withDestinationName(STREAM)
+          .withDestinationNamespace(NAMESPACE)
           .withStream(AB_STREAM)
           .withSyncMode(SyncMode.INCREMENTAL)
           .withCursorField(Lists.newArrayList(COLUMN_NAME))));
@@ -70,6 +73,8 @@ class AirbyteProtocolConvertersTest {
       .withStreams(Lists.newArrayList(new Stream()
           .withSelected(true)
           .withName(STREAM)
+          .withDestinationName(STREAM)
+          .withDestinationNamespace(NAMESPACE)
           .withFields(Lists.newArrayList(
               new io.airbyte.config.Field()
                   .withName(COLUMN_NAME)
@@ -85,6 +90,8 @@ class AirbyteProtocolConvertersTest {
       .withStreams(Lists.newArrayList(new Stream()
           .withSelected(true)
           .withName(STREAM)
+          .withDestinationName(STREAM)
+          .withDestinationNamespace(NAMESPACE)
           .withFields(Lists.newArrayList(
               new io.airbyte.config.Field()
                   .withName(COLUMN_NAME)
@@ -97,6 +104,8 @@ class AirbyteProtocolConvertersTest {
           .withDefaultCursorField(Lists.newArrayList(COLUMN_AGE)),
           new Stream()
               .withName(STREAM_2)
+              .withDestinationName(STREAM_2)
+              .withDestinationNamespace(NAMESPACE)
               .withFields(Lists.newArrayList(
                   new io.airbyte.config.Field()
                       .withName(COLUMN_NAME)
@@ -128,7 +137,7 @@ class AirbyteProtocolConvertersTest {
     final Schema schema = Jsons.clone(SCHEMA);
     schema.getStreams().forEach(table -> table.getFields().forEach(c -> c.setSelected(true))); // select all fields
 
-    assertEquals(schema, AirbyteProtocolConverters.toSchema(CATALOG));
+    assertEquals(schema, AirbyteProtocolConverters.toSchema(CATALOG, NAMESPACE));
   }
 
   @Test
@@ -138,6 +147,8 @@ class AirbyteProtocolConvertersTest {
     final Schema schema = new Schema()
         .withStreams(Lists.newArrayList(new Stream()
             .withName(STREAM)
+            .withDestinationName(STREAM)
+            .withDestinationNamespace(NAMESPACE)
             .withFields(Lists.newArrayList(
                 new io.airbyte.config.Field()
                     .withName("date")
@@ -149,7 +160,7 @@ class AirbyteProtocolConvertersTest {
                     .withSelected(true)))
             .withSelected(true)));
 
-    assertEquals(schema, AirbyteProtocolConverters.toSchema(catalog));
+    assertEquals(schema, AirbyteProtocolConverters.toSchema(catalog, NAMESPACE));
   }
 
   @Test
@@ -160,6 +171,8 @@ class AirbyteProtocolConvertersTest {
     final Schema schema = new Schema()
         .withStreams(Lists.newArrayList(new Stream()
             .withName(STREAM)
+            .withDestinationName(STREAM)
+            .withDestinationNamespace(NAMESPACE)
             .withFields(Lists.newArrayList(
                 new io.airbyte.config.Field()
                     .withName("date")
@@ -168,7 +181,7 @@ class AirbyteProtocolConvertersTest {
             .withSelected(true)));
 
     final AirbyteCatalog catalog = Jsons.deserialize(testString, AirbyteCatalog.class);
-    assertEquals(schema, AirbyteProtocolConverters.toSchema(catalog));
+    assertEquals(schema, AirbyteProtocolConverters.toSchema(catalog, NAMESPACE));
   }
 
   @Test

--- a/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
+++ b/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
@@ -106,6 +106,7 @@ class AirbyteStream(BaseModel):
         None,
         description="Path to the field that will be used to determine if a record is new or modified since the last sync. If not provided by the source, the end user will have to specify the comparable themselves.",
     )
+    namespace: Optional[str] = Field(None, description="Namespace where this stream is coming from")
 
 
 class ConfiguredAirbyteStream(BaseModel):
@@ -115,6 +116,11 @@ class ConfiguredAirbyteStream(BaseModel):
         None,
         description="Path to the field that will be used to determine if a record is new or modified since the last sync. This field is REQUIRED if `sync_mode` is `incremental`. Otherwise it is ignored.",
     )
+    destination_namespace: Optional[str] = Field(
+        None,
+        description="Namespace to use in the destination to store this stream, if left empty, ConfiguredAirbyteCatalog's defaultNamespace is used",
+    )
+    destination_name: Optional[str] = Field(None, description="Alias name to use in the destination to store this stream")
 
 
 class AirbyteCatalog(BaseModel):

--- a/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
+++ b/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
@@ -116,10 +116,7 @@ class ConfiguredAirbyteStream(BaseModel):
         None,
         description="Path to the field that will be used to determine if a record is new or modified since the last sync. This field is REQUIRED if `sync_mode` is `incremental`. Otherwise it is ignored.",
     )
-    destination_namespace: Optional[str] = Field(
-        None,
-        description="Namespace to use in the destination to store this stream, if left empty, ConfiguredAirbyteCatalog's defaultNamespace is used",
-    )
+    destination_namespace: Optional[str] = Field(None, description="Namespace to use in the destination to store this stream")
     destination_name: Optional[str] = Field(None, description="Alias name to use in the destination to store this stream")
 
 

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -175,7 +175,7 @@ definitions:
         items:
           type: string
       destination_namespace:
-        description: Namespace to use in the destination to store this stream, if left empty, ConfiguredAirbyteCatalog's defaultNamespace is used
+        description: Namespace to use in the destination to store this stream
         type: string
       destination_name:
         description: Alias name to use in the destination to store this stream

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -144,6 +144,9 @@ definitions:
         type: array
         items:
           type: string
+      namespace:
+        description: Namespace where this stream is coming from
+        type: string
   ConfiguredAirbyteCatalog:
     description: Airbyte stream schema catalog
     type: object
@@ -171,6 +174,12 @@ definitions:
         type: array
         items:
           type: string
+      destination_namespace:
+        description: Namespace to use in the destination to store this stream, if left empty, ConfiguredAirbyteCatalog's defaultNamespace is used
+        type: string
+      destination_name:
+        description: Alias name to use in the destination to store this stream
+        type: string
   SyncMode:
     type: string
     enum:

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/SchemaConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/SchemaConverter.java
@@ -63,7 +63,10 @@ public class SchemaConverter {
                   // configurable
                   .withSyncMode(Enums.convertTo(apiStream.getSyncMode(), io.airbyte.config.SyncMode.class))
                   .withCursorField(apiStream.getCursorField())
-                  .withSelected(persistenceFields.stream().anyMatch(Field::getSelected));
+                  .withSelected(persistenceFields.stream().anyMatch(Field::getSelected))
+                  .withSourceNamespace(apiStream.getSourceNamespace())
+                  .withDestinationName(apiStream.getDestinationName())
+                  .withDestinationNamespace(apiStream.getDestinationNamespace());
             })
             .collect(Collectors.toList());
 
@@ -105,7 +108,10 @@ public class SchemaConverter {
               .defaultCursorField(persistenceStream.getDefaultCursorField())
               // configurable
               .syncMode(Enums.convertTo(persistenceStream.getSyncMode(), io.airbyte.api.model.SyncMode.class))
-              .cursorField(persistenceStream.getCursorField());
+              .cursorField(persistenceStream.getCursorField())
+              .sourceNamespace(persistenceStream.getSourceNamespace())
+              .destinationName(persistenceStream.getDestinationName())
+              .destinationNamespace(persistenceStream.getDestinationNamespace());
         })
         .collect(Collectors.toList());
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -171,7 +171,7 @@ public class SchedulerHandler {
     final StandardSourceDefinition sourceDef = configRepository.getStandardSourceDefinition(source.getSourceDefinitionId());
     final String imageName = DockerUtils.getTaggedImageName(sourceDef.getDockerRepository(), sourceDef.getDockerImageTag());
     final Job job = schedulerJobClient.createDiscoverSchemaJob(source, imageName);
-    return discoverJobToOutput(job);
+    return discoverJobToOutput(job, source.getName());
   }
 
   public SourceDiscoverSchemaRead discoverSchemaForSourceFromSourceCreate(SourceCoreConfig sourceCreate)
@@ -184,16 +184,16 @@ public class SchedulerHandler {
         .withSourceDefinitionId(sourceCreate.getSourceDefinitionId())
         .withConfiguration(sourceCreate.getConnectionConfiguration());
     final Job job = schedulerJobClient.createDiscoverSchemaJob(source, imageName);
-    return discoverJobToOutput(job);
+    return discoverJobToOutput(job, "");
   }
 
-  private static SourceDiscoverSchemaRead discoverJobToOutput(Job job) {
+  private static SourceDiscoverSchemaRead discoverJobToOutput(Job job, String namespacePrefix) {
     final SourceDiscoverSchemaRead sourceDiscoverSchemaRead = new SourceDiscoverSchemaRead()
         .jobInfo(JobConverter.getJobInfoRead(job));
 
     job.getSuccessOutput()
         .map(JobOutput::getDiscoverCatalog)
-        .map(discoverOutput -> AirbyteProtocolConverters.toSchema(discoverOutput.getCatalog()))
+        .map(discoverOutput -> AirbyteProtocolConverters.toSchema(discoverOutput.getCatalog(), namespacePrefix))
         .ifPresent(catalog -> sourceDiscoverSchemaRead.schema(SchemaConverter.toApiSchema(catalog)));
 
     return sourceDiscoverSchemaRead;

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/SchemaConverterTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/SchemaConverterTest.java
@@ -40,6 +40,8 @@ import org.junit.jupiter.api.Test;
 class SchemaConverterTest {
 
   private static final String STREAM_NAME = "users";
+  private static final String SRC_SCHEMA = "test_src";
+  private static final String DST_SCHEMA = "test_dst";
   private static final String COLUMN_ID = "id";
   private static final Schema SCHEMA = new Schema()
       .withStreams(Lists.newArrayList(new Stream()
@@ -54,7 +56,10 @@ class SchemaConverterTest {
           .withSupportedSyncModes(Lists.newArrayList(io.airbyte.config.SyncMode.FULL_REFRESH, io.airbyte.config.SyncMode.INCREMENTAL))
           .withDefaultCursorField(Lists.newArrayList(COLUMN_ID))
           .withSyncMode(io.airbyte.config.SyncMode.INCREMENTAL)
-          .withCursorField(Lists.newArrayList(COLUMN_ID))));
+          .withCursorField(Lists.newArrayList(COLUMN_ID))
+          .withSourceNamespace(SRC_SCHEMA)
+          .withDestinationName(STREAM_NAME)
+          .withDestinationNamespace(DST_SCHEMA)));
 
   private static final SourceSchema API_SCHEMA = new SourceSchema()
       .streams(Lists.newArrayList(new SourceSchemaStream()
@@ -69,7 +74,10 @@ class SchemaConverterTest {
           .supportedSyncModes(Lists.newArrayList(io.airbyte.api.model.SyncMode.FULL_REFRESH, io.airbyte.api.model.SyncMode.INCREMENTAL))
           .defaultCursorField(Lists.newArrayList(COLUMN_ID))
           .syncMode(io.airbyte.api.model.SyncMode.INCREMENTAL)
-          .cursorField(Lists.newArrayList(COLUMN_ID))));
+          .cursorField(Lists.newArrayList(COLUMN_ID))
+          .sourceNamespace(SRC_SCHEMA)
+          .destinationName(STREAM_NAME)
+          .destinationNamespace(DST_SCHEMA)));
 
   @Test
   void convertToPersistenceSchema() {

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -356,10 +356,13 @@ font-style: italic;
   "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "syncSchema" : {
     "streams" : [ {
+      "destinationNamespace" : "destinationNamespace",
       "supportedSyncModes" : [ null, null ],
       "sourceDefinedCursor" : true,
+      "destinationName" : "destinationName",
       "name" : "name",
       "cleanedName" : "cleanedName",
+      "sourceNamespace" : "sourceNamespace",
       "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
       "fields" : [ {
         "name" : "name",
@@ -373,10 +376,13 @@ font-style: italic;
       "selected" : true,
       "cursorField" : [ "cursorField", "cursorField" ]
     }, {
+      "destinationNamespace" : "destinationNamespace",
       "supportedSyncModes" : [ null, null ],
       "sourceDefinedCursor" : true,
+      "destinationName" : "destinationName",
       "name" : "name",
       "cleanedName" : "cleanedName",
+      "sourceNamespace" : "sourceNamespace",
       "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
       "fields" : [ {
         "name" : "name",
@@ -497,10 +503,13 @@ font-style: italic;
   "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "syncSchema" : {
     "streams" : [ {
+      "destinationNamespace" : "destinationNamespace",
       "supportedSyncModes" : [ null, null ],
       "sourceDefinedCursor" : true,
+      "destinationName" : "destinationName",
       "name" : "name",
       "cleanedName" : "cleanedName",
+      "sourceNamespace" : "sourceNamespace",
       "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
       "fields" : [ {
         "name" : "name",
@@ -514,10 +523,13 @@ font-style: italic;
       "selected" : true,
       "cursorField" : [ "cursorField", "cursorField" ]
     }, {
+      "destinationNamespace" : "destinationNamespace",
       "supportedSyncModes" : [ null, null ],
       "sourceDefinedCursor" : true,
+      "destinationName" : "destinationName",
       "name" : "name",
       "cleanedName" : "cleanedName",
+      "sourceNamespace" : "sourceNamespace",
       "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
       "fields" : [ {
         "name" : "name",
@@ -600,10 +612,13 @@ font-style: italic;
     "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     "syncSchema" : {
       "streams" : [ {
+        "destinationNamespace" : "destinationNamespace",
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
+        "destinationName" : "destinationName",
         "name" : "name",
         "cleanedName" : "cleanedName",
+        "sourceNamespace" : "sourceNamespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
         "fields" : [ {
           "name" : "name",
@@ -617,10 +632,13 @@ font-style: italic;
         "selected" : true,
         "cursorField" : [ "cursorField", "cursorField" ]
       }, {
+        "destinationNamespace" : "destinationNamespace",
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
+        "destinationName" : "destinationName",
         "name" : "name",
         "cleanedName" : "cleanedName",
+        "sourceNamespace" : "sourceNamespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
         "fields" : [ {
           "name" : "name",
@@ -646,10 +664,13 @@ font-style: italic;
     "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     "syncSchema" : {
       "streams" : [ {
+        "destinationNamespace" : "destinationNamespace",
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
+        "destinationName" : "destinationName",
         "name" : "name",
         "cleanedName" : "cleanedName",
+        "sourceNamespace" : "sourceNamespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
         "fields" : [ {
           "name" : "name",
@@ -663,10 +684,13 @@ font-style: italic;
         "selected" : true,
         "cursorField" : [ "cursorField", "cursorField" ]
       }, {
+        "destinationNamespace" : "destinationNamespace",
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
+        "destinationName" : "destinationName",
         "name" : "name",
         "cleanedName" : "cleanedName",
+        "sourceNamespace" : "sourceNamespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
         "fields" : [ {
           "name" : "name",
@@ -925,10 +949,13 @@ font-style: italic;
   "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "syncSchema" : {
     "streams" : [ {
+      "destinationNamespace" : "destinationNamespace",
       "supportedSyncModes" : [ null, null ],
       "sourceDefinedCursor" : true,
+      "destinationName" : "destinationName",
       "name" : "name",
       "cleanedName" : "cleanedName",
+      "sourceNamespace" : "sourceNamespace",
       "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
       "fields" : [ {
         "name" : "name",
@@ -942,10 +969,13 @@ font-style: italic;
       "selected" : true,
       "cursorField" : [ "cursorField", "cursorField" ]
     }, {
+      "destinationNamespace" : "destinationNamespace",
       "supportedSyncModes" : [ null, null ],
       "sourceDefinedCursor" : true,
+      "destinationName" : "destinationName",
       "name" : "name",
       "cleanedName" : "cleanedName",
+      "sourceNamespace" : "sourceNamespace",
       "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
       "fields" : [ {
         "name" : "name",
@@ -2364,10 +2394,13 @@ font-style: italic;
     <pre class="example"><code>{
   "schema" : {
     "streams" : [ {
+      "destinationNamespace" : "destinationNamespace",
       "supportedSyncModes" : [ null, null ],
       "sourceDefinedCursor" : true,
+      "destinationName" : "destinationName",
       "name" : "name",
       "cleanedName" : "cleanedName",
+      "sourceNamespace" : "sourceNamespace",
       "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
       "fields" : [ {
         "name" : "name",
@@ -2381,10 +2414,13 @@ font-style: italic;
       "selected" : true,
       "cursorField" : [ "cursorField", "cursorField" ]
     }, {
+      "destinationNamespace" : "destinationNamespace",
       "supportedSyncModes" : [ null, null ],
       "sourceDefinedCursor" : true,
+      "destinationName" : "destinationName",
       "name" : "name",
       "cleanedName" : "cleanedName",
+      "sourceNamespace" : "sourceNamespace",
       "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
       "fields" : [ {
         "name" : "name",
@@ -2777,10 +2813,13 @@ font-style: italic;
     <pre class="example"><code>{
   "schema" : {
     "streams" : [ {
+      "destinationNamespace" : "destinationNamespace",
       "supportedSyncModes" : [ null, null ],
       "sourceDefinedCursor" : true,
+      "destinationName" : "destinationName",
       "name" : "name",
       "cleanedName" : "cleanedName",
+      "sourceNamespace" : "sourceNamespace",
       "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
       "fields" : [ {
         "name" : "name",
@@ -2794,10 +2833,13 @@ font-style: italic;
       "selected" : true,
       "cursorField" : [ "cursorField", "cursorField" ]
     }, {
+      "destinationNamespace" : "destinationNamespace",
       "supportedSyncModes" : [ null, null ],
       "sourceDefinedCursor" : true,
+      "destinationName" : "destinationName",
       "name" : "name",
       "cleanedName" : "cleanedName",
+      "sourceNamespace" : "sourceNamespace",
       "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
       "fields" : [ {
         "name" : "name",
@@ -3431,10 +3473,13 @@ font-style: italic;
   "isSyncing" : true,
   "syncSchema" : {
     "streams" : [ {
+      "destinationNamespace" : "destinationNamespace",
       "supportedSyncModes" : [ null, null ],
       "sourceDefinedCursor" : true,
+      "destinationName" : "destinationName",
       "name" : "name",
       "cleanedName" : "cleanedName",
+      "sourceNamespace" : "sourceNamespace",
       "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
       "fields" : [ {
         "name" : "name",
@@ -3448,10 +3493,13 @@ font-style: italic;
       "selected" : true,
       "cursorField" : [ "cursorField", "cursorField" ]
     }, {
+      "destinationNamespace" : "destinationNamespace",
       "supportedSyncModes" : [ null, null ],
       "sourceDefinedCursor" : true,
+      "destinationName" : "destinationName",
       "name" : "name",
       "cleanedName" : "cleanedName",
+      "sourceNamespace" : "sourceNamespace",
       "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
       "fields" : [ {
         "name" : "name",
@@ -3556,10 +3604,13 @@ font-style: italic;
     "isSyncing" : true,
     "syncSchema" : {
       "streams" : [ {
+        "destinationNamespace" : "destinationNamespace",
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
+        "destinationName" : "destinationName",
         "name" : "name",
         "cleanedName" : "cleanedName",
+        "sourceNamespace" : "sourceNamespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
         "fields" : [ {
           "name" : "name",
@@ -3573,10 +3624,13 @@ font-style: italic;
         "selected" : true,
         "cursorField" : [ "cursorField", "cursorField" ]
       }, {
+        "destinationNamespace" : "destinationNamespace",
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
+        "destinationName" : "destinationName",
         "name" : "name",
         "cleanedName" : "cleanedName",
+        "sourceNamespace" : "sourceNamespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
         "fields" : [ {
           "name" : "name",
@@ -3624,10 +3678,13 @@ font-style: italic;
     "isSyncing" : true,
     "syncSchema" : {
       "streams" : [ {
+        "destinationNamespace" : "destinationNamespace",
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
+        "destinationName" : "destinationName",
         "name" : "name",
         "cleanedName" : "cleanedName",
+        "sourceNamespace" : "sourceNamespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
         "fields" : [ {
           "name" : "name",
@@ -3641,10 +3698,13 @@ font-style: italic;
         "selected" : true,
         "cursorField" : [ "cursorField", "cursorField" ]
       }, {
+        "destinationNamespace" : "destinationNamespace",
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
+        "destinationName" : "destinationName",
         "name" : "name",
         "cleanedName" : "cleanedName",
+        "sourceNamespace" : "sourceNamespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
         "fields" : [ {
           "name" : "name",
@@ -3861,10 +3921,13 @@ font-style: italic;
   "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "syncSchema" : {
     "streams" : [ {
+      "destinationNamespace" : "destinationNamespace",
       "supportedSyncModes" : [ null, null ],
       "sourceDefinedCursor" : true,
+      "destinationName" : "destinationName",
       "name" : "name",
       "cleanedName" : "cleanedName",
+      "sourceNamespace" : "sourceNamespace",
       "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
       "fields" : [ {
         "name" : "name",
@@ -3878,10 +3941,13 @@ font-style: italic;
       "selected" : true,
       "cursorField" : [ "cursorField", "cursorField" ]
     }, {
+      "destinationNamespace" : "destinationNamespace",
       "supportedSyncModes" : [ null, null ],
       "sourceDefinedCursor" : true,
+      "destinationName" : "destinationName",
       "name" : "name",
       "cleanedName" : "cleanedName",
+      "sourceNamespace" : "sourceNamespace",
       "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
       "fields" : [ {
         "name" : "name",
@@ -4669,9 +4735,12 @@ font-style: italic;
 <div class="param">supportedSyncModes </div><div class="param-desc"><span class="param-type"><a href="#SyncMode">array[SyncMode]</a></span>  </div>
 <div class="param">sourceDefinedCursor (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">defaultCursorField (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span>  </div>
+<div class="param">sourceNamespace (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">selected (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">syncMode (optional)</div><div class="param-desc"><span class="param-type"><a href="#SyncMode">SyncMode</a></span>  </div>
 <div class="param">cursorField (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span>  </div>
+<div class="param">destinationNamespace (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">destinationName (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What
See #1921 
- Add  namespace fields to Catalog and related objects
- Namespace is left empty, renamed_table is the old stream_name
- (when possible) UI can edit and change these new fields
- Stream Name is modified in ConfiguredCatalog and becomes concat of these fields

## How
*Describe the solution*
For now, I've added for each Stream:
- Source namespace
- Destination namespace
- Destination name

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order

