### PR TITLE
2 options for what catalog can look like in the api

### DIFF
--- a/airbyte-api/build.gradle
+++ b/airbyte-api/build.gradle
@@ -26,6 +26,7 @@ task generateApiServer(type: GenerateTask) {
             'SourceConfiguration'               : 'com.fasterxml.jackson.databind.JsonNode',
             'DestinationDefinitionSpecification': 'com.fasterxml.jackson.databind.JsonNode',
             'DestinationConfiguration'          : 'com.fasterxml.jackson.databind.JsonNode',
+            'StreamJsonSchema'                  : 'com.fasterxml.jackson.databind.JsonNode',
     ]
 
     generateApiDocumentation = false
@@ -57,6 +58,7 @@ task generateApiClient(type: GenerateTask) {
             'SourceConfiguration'               : 'com.fasterxml.jackson.databind.JsonNode',
             'DestinationDefinitionSpecification': 'com.fasterxml.jackson.databind.JsonNode',
             'DestinationConfiguration'          : 'com.fasterxml.jackson.databind.JsonNode',
+            'StreamJsonSchema'                  : 'com.fasterxml.jackson.databind.JsonNode',
     ]
 
     library = "native"
@@ -89,6 +91,7 @@ task generateApiDocs(type: GenerateTask) {
             'SourceConfiguration'               : 'com.fasterxml.jackson.databind.JsonNode',
             'DestinationDefinitionSpecification': 'com.fasterxml.jackson.databind.JsonNode',
             'DestinationConfiguration'          : 'com.fasterxml.jackson.databind.JsonNode',
+            'StreamJsonSchema'                  : 'com.fasterxml.jackson.databind.JsonNode',
     ]
 
     generateApiDocumentation = false

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1693,6 +1693,147 @@ components:
         logType:
           $ref: "#/components/schemas/LogType"
     # SCHEMA
+    # OPTION 1 START
+    AirbyteCatalog1:
+      description: describes the available schema.
+      type: object
+      required:
+        - streams
+      properties:
+        streams:
+          type: array
+          items:
+            $ref: "#/components/schemas/AirbyteStreamAndConfiguration1"
+    AirbyteStreamAndConfiguration1:
+      type: object
+      additionalProperties: false
+      properties:
+        stream:
+          $ref: "#/components/schemas/AirbyteStream1"
+        configuration:
+          $ref: "#/components/schemas/AirbyteStreamConfiguration1"
+    AirbyteStreamConfiguration1:
+      type: object
+      additionalProperties: false
+      properties:
+        syncMode:
+          $ref: "#/components/schemas/SyncMode"
+          default: full_refresh
+        cursorField:
+          description: Path to the field that will be used to determine if a record is new or modified since the last sync. This field is REQUIRED if `sync_mode` is `incremental`. Otherwise it is ignored.
+          type: array
+          items:
+            type: string
+    AirbyteStream1:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - json_schema
+        # todo (cgardens) - make required once sources are migrated
+        # - supported_sync_modes
+      properties:
+        name:
+          type: string
+          description: Stream's name.
+        jsonSchema:
+          description: Stream schema using Json Schema specs.
+          $ref: "#/components/schemas/StreamJsonSchema"
+        supportedSyncModes:
+          type: array
+          items:
+            $ref: "#/components/schemas/SyncMode"
+        sourceDefinedCursor:
+          description: If the source defines the cursor field, then it does any other cursor field inputs will be ignored. If it does not either the user_provided one is used or as a backup the default one is used.
+          type: boolean
+        defaultCursorField:
+          description: Path to the field that will be used to determine if a record is new or modified since the last sync. If not provided by the source, the end user will have to specify the comparable themselves.
+          type: array
+          items:
+            type: string
+    StreamJsonSchema:
+      type: object
+    # OPTION 1 END
+    # OPTION 2 START
+    AirbyteCatalog2:
+      description: describes the available schema.
+      type: object
+      required:
+        - streams
+      properties:
+        streams:
+          type: array
+          items:
+            $ref: "#/components/schemas/AirbyteStreamAndConfiguration2"
+    AirbyteStreamAndConfiguration2:
+      type: object
+      additionalProperties: false
+      properties:
+        stream:
+          $ref: "#/components/schemas/AirbyteStream2"
+        configuration:
+          $ref: "#/components/schemas/AirbyteStreamConfiguration2"
+    AirbyteStreamConfiguration2:
+      type: object
+      additionalProperties: false
+      properties:
+        syncMode:
+          $ref: "#/components/schemas/SyncMode"
+          default: full_refresh
+        cursorField:
+          description: Path to the field that will be used to determine if a record is new or modified since the last sync. This field is REQUIRED if `sync_mode` is `incremental`. Otherwise it is ignored.
+          type: array
+          items:
+            type: string
+    AirbyteStream2:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - json_schema
+        # todo (cgardens) - make required once sources are migrated
+        # - supported_sync_modes
+      properties:
+        name:
+          type: string
+          description: Stream's name.
+        fields:
+          type: array
+          items:
+            $ref: "#/components/schemas/AirbyteField2"
+        supportedSyncModes:
+          type: array
+          items:
+            $ref: "#/components/schemas/SyncMode"
+        sourceDefinedCursor:
+          description: If the source defines the cursor field, then it does any other cursor field inputs will be ignored. If it does not either the user_provided one is used or as a backup the default one is used.
+          type: boolean
+        defaultCursorField:
+          description: Path to the field that will be used to determine if a record is new or modified since the last sync. If not provided by the source, the end user will have to specify the comparable themselves.
+          type: array
+          items:
+            type: string
+    AirbyteField2:
+      type: object
+      required:
+        - name
+        - dataType
+        - selected
+        - children
+      properties:
+        name:
+          type: string
+        cleanedName:
+          type: string
+        dataType:
+          $ref: "#/components/schemas/DataType"
+        selected:
+          type: boolean
+        children:
+          type: array
+          items:
+            $ref: "#/components/schemas/AirbyteField2"
+    # OPTION 2 END
     SourceSchema:
       description: describes the available schema.
       type: object

--- a/airbyte-commons/src/main/java/io/airbyte/commons/enums/Enums.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/enums/Enums.java
@@ -28,6 +28,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -41,6 +42,13 @@ public class Enums {
     }
 
     return Enum.valueOf(oe, ie.name());
+  }
+
+  public static <T1 extends Enum<T1>, T2 extends Enum<T2>> List<T2> convertListTo(List<T1> ies, Class<T2> oe) {
+    return ies
+        .stream()
+        .map(ie -> convertTo(ie, oe))
+        .collect(Collectors.toList());
   }
 
   public static <T1 extends Enum<T1>, T2 extends Enum<T2>> boolean isCompatible(Class<T1> c1,

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4120,6 +4120,15 @@ font-style: italic;
 
   <h3>Table of Contents</h3>
   <ol>
+    <li><a href="#AirbyteCatalog1"><code>AirbyteCatalog1</code> - </a></li>
+    <li><a href="#AirbyteCatalog2"><code>AirbyteCatalog2</code> - </a></li>
+    <li><a href="#AirbyteField2"><code>AirbyteField2</code> - </a></li>
+    <li><a href="#AirbyteStream1"><code>AirbyteStream1</code> - </a></li>
+    <li><a href="#AirbyteStream2"><code>AirbyteStream2</code> - </a></li>
+    <li><a href="#AirbyteStreamAndConfiguration1"><code>AirbyteStreamAndConfiguration1</code> - </a></li>
+    <li><a href="#AirbyteStreamAndConfiguration2"><code>AirbyteStreamAndConfiguration2</code> - </a></li>
+    <li><a href="#AirbyteStreamConfiguration1"><code>AirbyteStreamConfiguration1</code> - </a></li>
+    <li><a href="#AirbyteStreamConfiguration2"><code>AirbyteStreamConfiguration2</code> - </a></li>
     <li><a href="#AttemptInfoRead"><code>AttemptInfoRead</code> - </a></li>
     <li><a href="#AttemptRead"><code>AttemptRead</code> - </a></li>
     <li><a href="#AttemptStatus"><code>AttemptStatus</code> - </a></li>
@@ -4188,6 +4197,85 @@ font-style: italic;
     <li><a href="#WorkspaceUpdate"><code>WorkspaceUpdate</code> - </a></li>
   </ol>
 
+  <div class="model">
+    <h3><a name="AirbyteCatalog1"><code>AirbyteCatalog1</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'>describes the available schema.</div>
+    <div class="field-items">
+      <div class="param">streams </div><div class="param-desc"><span class="param-type"><a href="#AirbyteStreamAndConfiguration1">array[AirbyteStreamAndConfiguration1]</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AirbyteCatalog2"><code>AirbyteCatalog2</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'>describes the available schema.</div>
+    <div class="field-items">
+      <div class="param">streams </div><div class="param-desc"><span class="param-type"><a href="#AirbyteStreamAndConfiguration2">array[AirbyteStreamAndConfiguration2]</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AirbyteField2"><code>AirbyteField2</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">cleanedName (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">dataType </div><div class="param-desc"><span class="param-type"><a href="#DataType">DataType</a></span>  </div>
+<div class="param">selected </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+<div class="param">children </div><div class="param-desc"><span class="param-type"><a href="#AirbyteField2">array[AirbyteField2]</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AirbyteStream1"><code>AirbyteStream1</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Stream's name. </div>
+<div class="param">jsonSchema (optional)</div><div class="param-desc"><span class="param-type"><a href="#StreamJsonSchema">StreamJsonSchema</a></span>  </div>
+<div class="param">supportedSyncModes (optional)</div><div class="param-desc"><span class="param-type"><a href="#SyncMode">array[SyncMode]</a></span>  </div>
+<div class="param">sourceDefinedCursor (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> If the source defines the cursor field, then it does any other cursor field inputs will be ignored. If it does not either the user_provided one is used or as a backup the default one is used. </div>
+<div class="param">defaultCursorField (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> Path to the field that will be used to determine if a record is new or modified since the last sync. If not provided by the source, the end user will have to specify the comparable themselves. </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AirbyteStream2"><code>AirbyteStream2</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Stream's name. </div>
+<div class="param">fields (optional)</div><div class="param-desc"><span class="param-type"><a href="#AirbyteField2">array[AirbyteField2]</a></span>  </div>
+<div class="param">supportedSyncModes (optional)</div><div class="param-desc"><span class="param-type"><a href="#SyncMode">array[SyncMode]</a></span>  </div>
+<div class="param">sourceDefinedCursor (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> If the source defines the cursor field, then it does any other cursor field inputs will be ignored. If it does not either the user_provided one is used or as a backup the default one is used. </div>
+<div class="param">defaultCursorField (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> Path to the field that will be used to determine if a record is new or modified since the last sync. If not provided by the source, the end user will have to specify the comparable themselves. </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AirbyteStreamAndConfiguration1"><code>AirbyteStreamAndConfiguration1</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">stream (optional)</div><div class="param-desc"><span class="param-type"><a href="#AirbyteStream1">AirbyteStream1</a></span>  </div>
+<div class="param">configuration (optional)</div><div class="param-desc"><span class="param-type"><a href="#AirbyteStreamConfiguration1">AirbyteStreamConfiguration1</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AirbyteStreamAndConfiguration2"><code>AirbyteStreamAndConfiguration2</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">stream (optional)</div><div class="param-desc"><span class="param-type"><a href="#AirbyteStream2">AirbyteStream2</a></span>  </div>
+<div class="param">configuration (optional)</div><div class="param-desc"><span class="param-type"><a href="#AirbyteStreamConfiguration2">AirbyteStreamConfiguration2</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AirbyteStreamConfiguration1"><code>AirbyteStreamConfiguration1</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">syncMode (optional)</div><div class="param-desc"><span class="param-type"><a href="#SyncMode">SyncMode</a></span>  </div>
+<div class="param">cursorField (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> Path to the field that will be used to determine if a record is new or modified since the last sync. This field is REQUIRED if <code>sync_mode</code> is <code>incremental</code>. Otherwise it is ignored. </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AirbyteStreamConfiguration2"><code>AirbyteStreamConfiguration2</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">syncMode (optional)</div><div class="param-desc"><span class="param-type"><a href="#SyncMode">SyncMode</a></span>  </div>
+<div class="param">cursorField (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> Path to the field that will be used to determine if a record is new or modified since the last sync. This field is REQUIRED if <code>sync_mode</code> is <code>incremental</code>. Otherwise it is ignored. </div>
+    </div>  <!-- field-items -->
+  </div>
   <div class="model">
     <h3><a name="AttemptInfoRead"><code>AttemptInfoRead</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>


### PR DESCRIPTION
## What
We need the API and FE to be able to model the fact that many data schemas have nesting. They are not all table / column:
```
users: [{ id: 1, name: charles }, { id: 2, name: artem }]
```
but must support nesting
```
users: [{ id: 1, name: charles, employer: { name: airbyte, ... } }, 
        { id: 2, name: artem, employer: { name: entrepreneur, ... }]
```

This PR shows 2 options for what the API interface can be. We want feedback on which one will be easier for our frontend (and any frontend) to work with. Please look at `config.yaml` below to see 2 options for what we can replace the `SourceSchema` object with. 

You can ignore the rest of PR--it is autogenerated stuff and me just sanity checking that the conversions won't be insane for the API.

## Recommended reading order
1. `config.yaml`
