### PR TITLE
fix app store private key access error

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2af123bf-0aaf-4e0d-9784-cb497f23741a.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2af123bf-0aaf-4e0d-9784-cb497f23741a.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "2af123bf-0aaf-4e0d-9784-cb497f23741a",
   "name": "Appstore",
   "dockerRepository": "airbyte/source-appstore-singer",
-  "dockerImageTag": "0.1.0",
+  "dockerImageTag": "0.1.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-appstore"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -171,5 +171,5 @@
 - sourceDefinitionId: 2af123bf-0aaf-4e0d-9784-cb497f23741a
   name: Appstore
   dockerRepository: airbyte/source-appstore-singer
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-appstore

--- a/airbyte-integrations/connectors/source-appstore-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-appstore-singer/Dockerfile
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install ".[main]"
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-appstore-singer

--- a/airbyte-integrations/connectors/source-appstore-singer/source_appstore_singer/spec.json
+++ b/airbyte-integrations/connectors/source-appstore-singer/source_appstore_singer/spec.json
@@ -11,9 +11,9 @@
         "type": "string",
         "description": "<a href=\"https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api\">Key_id</a> is the API key you use to connect to appstore's API."
       },
-      "key_file": {
+      "private_key": {
         "type": "string",
-        "description": "<a href=\"https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api\">Key_file</a> is the key file you use to connect to appstore's API."
+        "description": "Private_key is the contents of the <a href=\"https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api\">key file</a> you use to connect to appstore's API."
       },
       "issuer_id": {
         "type": "string",
@@ -25,7 +25,7 @@
       },
       "start_date": {
         "type": "string",
-        "description": "date from which to start pulling data",
+        "description": "date from which to start pulling data (example: 2020-11-16T00:00:00Z)",
         "examples": ["2020-11-16T00:00:00Z"],
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
       }

--- a/airbyte-integrations/connectors/source-appstore-singer/source_appstore_singer/spec.json
+++ b/airbyte-integrations/connectors/source-appstore-singer/source_appstore_singer/spec.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Source Appstore Singer Spec",
     "type": "object",
-    "required": ["key_id", "key_file", "issuer_id", "vendor", "start_date"],
+    "required": ["key_id", "private_key", "issuer_id", "vendor", "start_date"],
     "additionalProperties": false,
     "properties": {
       "key_id": {

--- a/airbyte-integrations/connectors/source-appstore-singer/source_appstore_singer/spec.json
+++ b/airbyte-integrations/connectors/source-appstore-singer/source_appstore_singer/spec.json
@@ -13,7 +13,8 @@
       },
       "private_key": {
         "type": "string",
-        "description": "Private_key is the contents of the <a href=\"https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api\">key file</a> you use to connect to appstore's API."
+        "description": "Private_key is the contents of the <a href=\"https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api\">key file</a> you use to connect to appstore's API.",
+        "airbyte_secret": true
       },
       "issuer_id": {
         "type": "string",
@@ -25,7 +26,7 @@
       },
       "start_date": {
         "type": "string",
-        "description": "date from which to start pulling data (example: 2020-11-16T00:00:00Z)",
+        "description": "Date from which to start pulling data.",
         "examples": ["2020-11-16T00:00:00Z"],
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
       }


### PR DESCRIPTION
Any check connection for app store has problems like:
```
2021-02-05 18:18:37 INFO (/tmp/workspace/21/0) WorkerRun(call):58 - Executing worker wrapper...
2021-02-05 18:18:37 INFO (/tmp/workspace/21/0) LineGobbler(voidCall):69 - Checking if airbyte/source-appstore-singer:0.1.0 exists...
2021-02-05 18:18:37 INFO (/tmp/workspace/21/0) LineGobbler(voidCall):69 - airbyte/source-appstore-singer:0.1.0 was found locally.
2021-02-05 18:18:37 DEBUG (/tmp/workspace/21/0) DockerProcessBuilderFactory(create):104 - Preparing command: docker run --rm -i -v airbyte_workspace:/data -v /tmp/airbyte_local:/local -w /data/21/0 --network host airbyte/source-appstore-singer:0.1.0 check --config tap_config.json
2021-02-05 18:18:38 ERROR (/tmp/workspace/21/0) LineGobbler(voidCall):69 - Traceback (most recent call last):
2021-02-05 18:18:38 ERROR (/tmp/workspace/21/0) LineGobbler(voidCall):69 - File "/usr/local/bin/base-python", line 8, in <module>
2021-02-05 18:18:38 ERROR (/tmp/workspace/21/0) LineGobbler(voidCall):69 - sys.exit(main())
2021-02-05 18:18:38 ERROR (/tmp/workspace/21/0) LineGobbler(voidCall):69 - File "/usr/local/lib/python3.7/site-packages/base_python/entrypoint.py", line 135, in main
2021-02-05 18:18:38 ERROR (/tmp/workspace/21/0) LineGobbler(voidCall):69 - launch(source, sys.argv[1:])
2021-02-05 18:18:38 ERROR (/tmp/workspace/21/0) LineGobbler(voidCall):69 - File "/usr/local/lib/python3.7/site-packages/base_python/entrypoint.py", line 120, in launch
2021-02-05 18:18:38 ERROR (/tmp/workspace/21/0) LineGobbler(voidCall):69 - AirbyteEntrypoint(source).start(args)
2021-02-05 18:18:38 ERROR (/tmp/workspace/21/0) LineGobbler(voidCall):69 - File "/usr/local/lib/python3.7/site-packages/base_python/entrypoint.py", line 91, in start
2021-02-05 18:18:38 ERROR (/tmp/workspace/21/0) LineGobbler(voidCall):69 - config = self.source.configure(raw_config, temp_dir)
2021-02-05 18:18:38 ERROR (/tmp/workspace/21/0) LineGobbler(voidCall):69 - File "/usr/local/lib/python3.7/site-packages/base_singer/source.py", line 50, in configure
2021-02-05 18:18:38 ERROR (/tmp/workspace/21/0) LineGobbler(voidCall):69 - config = self.transform_config(raw_config)
2021-02-05 18:18:38 ERROR (/tmp/workspace/21/0) LineGobbler(voidCall):69 - File "/usr/local/lib/python3.7/site-packages/source_appstore_singer/source.py", line 99, in transform_config
2021-02-05 18:18:38 ERROR (/tmp/workspace/21/0) LineGobbler(voidCall):69 - private_key = raw_config["private_key"]
2021-02-05 18:18:38 ERROR (/tmp/workspace/21/0) LineGobbler(voidCall):69 - KeyError: 'private_key'
```

This changes the spec to include `private_key` instead of `key_file` and bumps the version.
