### PR TITLE
Namespace destination tables

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/text/Names.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/text/Names.java
@@ -44,28 +44,6 @@ public class Names {
         .replaceAll(NON_ALPHANUMERIC_AND_UNDERSCORE_PATTERN, "_");
   }
 
-  /**
-   * Concatenate Strings together, but handles the case where the strings are already quoted
-   */
-  public static String concatQuotedNames(final String inputStr1, final String inputStr2) {
-    boolean anyQuotes = false;
-    String unquotedStr1 = inputStr1;
-    String unquotedStr2 = inputStr2;
-    if (inputStr1.startsWith("\"")) {
-      unquotedStr1 = inputStr1.substring(1, inputStr1.length() - 1);
-      anyQuotes = true;
-    }
-    if (inputStr2.startsWith("\"")) {
-      unquotedStr2 = inputStr2.substring(1, inputStr2.length() - 1);
-      anyQuotes = true;
-    }
-    if (anyQuotes) {
-      return "\"" + unquotedStr1 + unquotedStr2 + "\"";
-    } else {
-      return unquotedStr1 + unquotedStr2;
-    }
-  }
-
   public static String doubleQuote(String value) {
     return internalQuote(value, '"');
   }

--- a/airbyte-integrations/bases/base-java/build.gradle
+++ b/airbyte-integrations/bases/base-java/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     implementation 'commons-cli:commons-cli:1.4'
+    implementation 'org.apache.commons:commons-lang3:3.11'
 
     implementation project(':airbyte-db')
     implementation project(':airbyte-config:models')

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/NamingConventionTransformer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/NamingConventionTransformer.java
@@ -25,44 +25,19 @@
 package io.airbyte.integrations.destination;
 
 /**
- * Destination have their own Naming conventions (which characters are valid or rejected in
+ * Databases have their own Naming conventions (which characters are valid or rejected in
  * identifiers names) This class transform a random string used to a valid identifier names for each
- * specific destination.
+ * specific database.
  */
 public interface NamingConventionTransformer {
 
   /**
    * Handle Naming Conversions of an input name to output a valid identifier name for the desired
-   * destination.
+   * database.
    *
    * @param name of the identifier to check proper naming conventions
-   * @return modified name with invalid characters replaced by '_' and adapted for the chosen
-   *         destination.
+   * @return modified name with invalid characters replaced by '_' or quoted identifiers
    */
   String getIdentifier(String name);
-
-  /**
-   * Same as getIdentifier but returns also the name of the table for storing raw data
-   *
-   * @param name of the identifier to check proper naming conventions
-   * @return modified name with invalid characters replaced by '_' and adapted for the chosen
-   *         destination.
-   *
-   * @deprecated as this is very SQL specific, prefer using getIdentifier instead
-   */
-  @Deprecated
-  String getRawTableName(String name);
-
-  /**
-   * Same as getIdentifier but returns also the name of the table for storing tmp data
-   *
-   * @param name of the identifier to check proper naming conventions
-   * @return modified name with invalid characters replaced by '_' and adapted for the chosen
-   *         destination.
-   *
-   * @deprecated as this is very SQL specific, prefer using getIdentifier instead
-   */
-  @Deprecated
-  String getTmpTableName(String name);
 
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/NamingHelper.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/NamingHelper.java
@@ -24,41 +24,29 @@
 
 package io.airbyte.integrations.destination;
 
-/**
- * When choosing identifiers names in destinations, extended Names can handle more special
- * characters than standard Names by using the quoting characters: "..."
- *
- * This class detects when such special characters are used and adds the appropriate quoting when
- * necessary.
- */
-public class ExtendedNameTransformer extends StandardNameTransformer {
+import java.time.Instant;
+import org.apache.commons.lang3.RandomStringUtils;
 
-  @Override
-  public String getIdentifier(String input) {
-    return super.getIdentifier(input);
+public class NamingHelper {
+
+  /**
+   * Returns the name of a schema for storing raw data associated with a schema name. Make sure to
+   * apply the proper naming convention on the final table name for the database
+   */
+  public static String getTmpSchemaName(NamingConventionTransformer transformer, String schemaName) {
+    if (schemaName != null)
+      return transformer.getIdentifier("_airbyte_" + schemaName);
+    else
+      return transformer.getIdentifier("_airbyte");
   }
 
-  // Temporarily disabling the behavior of the ExtendedNameTransformer, see (issue #1785)
-  protected String disabled_getIdentifier(String input) {
-    if (useExtendedIdentifiers(input)) {
-      return "\"" + input + "\"";
-    } else {
-      return applyDefaultCase(input);
-    }
-  }
-
-  protected String applyDefaultCase(String input) {
-    return input;
-  }
-
-  protected boolean useExtendedIdentifiers(String input) {
-    boolean result = false;
-    if (input.matches("[^\\p{Alpha}_].*")) {
-      result = true;
-    } else if (input.matches(".*[^\\p{Alnum}_].*")) {
-      result = true;
-    }
-    return result;
+  /**
+   * Returns the name of the table for storing tmp data associated with a stream name. Name is
+   * randomly generated.
+   */
+  public static String getTmpTableName(NamingConventionTransformer transformer, String streamName) {
+    return transformer
+        .getIdentifier(String.format("_tmp_%s%s_%s", RandomStringUtils.randomAlphanumeric(4), Instant.now().toEpochMilli(), streamName));
   }
 
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/StandardNameTransformer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/StandardNameTransformer.java
@@ -25,27 +25,27 @@
 package io.airbyte.integrations.destination;
 
 import io.airbyte.commons.text.Names;
-import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class StandardNameTransformer implements NamingConventionTransformer {
 
+  private static final int MAX_IDENTIFIER_LENGTH = 1024;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StandardNameTransformer.class);
+
+  protected int getMaxIdentifierLength() {
+    return MAX_IDENTIFIER_LENGTH;
+  }
+
   @Override
   public String getIdentifier(String name) {
-    return convertStreamName(name);
-  }
-
-  @Override
-  public String getRawTableName(String streamName) {
-    return convertStreamName("_airbyte_raw_" + streamName);
-  }
-
-  @Override
-  public String getTmpTableName(String streamName) {
-    return convertStreamName("_airbyte_" + Instant.now().toEpochMilli() + "_" + streamName);
-  }
-
-  protected String convertStreamName(String input) {
-    return Names.toAlphanumericAndUnderscore(input);
+    if (name.length() >= getMaxIdentifierLength()) {
+      final String newName = name.substring(0, getMaxIdentifierLength() - 1);
+      LOGGER.warn(String.format("Identifier '%s' is too long, truncating it to: `%s`", name, newName));
+      name = newName;
+    }
+    return Names.toAlphanumericAndUnderscore(name);
   }
 
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/WriteConfig.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/WriteConfig.java
@@ -29,14 +29,14 @@ import io.airbyte.protocol.models.SyncMode;
 public class WriteConfig {
 
   private final String streamName;
-  private final String outputNamespaceName;
+  private final String tmpNamespaceName;
   private final String tmpTableName;
   private final String outputTableName;
   private final SyncMode syncMode;
 
-  public WriteConfig(String streamName, String outputNamespaceName, String tmpTableName, String outputTableName, SyncMode syncMode) {
+  public WriteConfig(String streamName, String tmpNamespaceName, String tmpTableName, String outputTableName, SyncMode syncMode) {
     this.streamName = streamName;
-    this.outputNamespaceName = outputNamespaceName;
+    this.tmpNamespaceName = tmpNamespaceName;
     this.tmpTableName = tmpTableName;
     this.outputTableName = outputTableName;
     this.syncMode = syncMode;
@@ -46,12 +46,12 @@ public class WriteConfig {
     return streamName;
   }
 
-  public String getTmpTableName() {
-    return tmpTableName;
+  public String getTmpNamespaceName() {
+    return tmpNamespaceName;
   }
 
-  public String getOutputNamespaceName() {
-    return outputNamespaceName;
+  public String getTmpTableName() {
+    return tmpTableName;
   }
 
   public String getOutputTableName() {

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunnerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunnerTest.java
@@ -71,12 +71,13 @@ class IntegrationRunnerTest {
 
   private static final String CONFIG_STRING = "{ \"username\": \"airbyte\" }";
   private static final JsonNode CONFIG = Jsons.deserialize(CONFIG_STRING);
+  private static final String NAMESPACE = "test";
   private static final String STREAM_NAME = "users";
   private static final Long EMITTED_AT = Instant.now().toEpochMilli();
   private static final Path TEST_ROOT = Path.of("/tmp/airbyte_tests");
 
   private static final AirbyteCatalog CATALOG = new AirbyteCatalog().withStreams(Lists.newArrayList(new AirbyteStream().withName(STREAM_NAME)));
-  private static final ConfiguredAirbyteCatalog CONFIGURED_CATALOG = CatalogHelpers.toDefaultConfiguredCatalog(CATALOG);
+  private static final ConfiguredAirbyteCatalog CONFIGURED_CATALOG = CatalogHelpers.toDefaultConfiguredCatalog(NAMESPACE, CATALOG);
   private static final JsonNode STATE = Jsons.jsonNode(ImmutableMap.of("checkpoint", "05/08/1945"));
 
   private IntegrationCliParser cliParser;

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/NameTransformerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/NameTransformerTest.java
@@ -51,8 +51,6 @@ class NameTransformerTest {
     assertEquals("identifier_name", namingResolver.getIdentifier("identifier name"));
     assertEquals("identifier_", namingResolver.getIdentifier("identifier%"));
     assertEquals("_identifier_", namingResolver.getIdentifier("`identifier`"));
-
-    assertEquals("_airbyte_raw_identifier_name", namingResolver.getRawTableName("identifier_name"));
   }
 
   // Temporarily disabling the behavior of the ExtendedNameTransformer, see (issue #1785)
@@ -74,9 +72,6 @@ class NameTransformerTest {
     assertEquals("\"identifier name\"", namingResolver.getIdentifier("identifier name"));
     assertEquals("\"identifier%\"", namingResolver.getIdentifier("identifier%"));
     assertEquals("\"`identifier`\"", namingResolver.getIdentifier("`identifier`"));
-
-    assertEquals("_airbyte_raw_identifier_name", namingResolver.getRawTableName("identifier_name"));
-    assertEquals("\"_airbyte_raw_identifiêr name\"", namingResolver.getRawTableName("identifiêr name"));
   }
 
 }

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
@@ -86,6 +86,7 @@ public abstract class TestDestination {
 
   private static final long JOB_ID = 0L;
   private static final int JOB_ATTEMPT = 0;
+  private static final String NAMESPACE = "standard-integration-tests";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TestDestination.class);
 
@@ -130,6 +131,13 @@ public abstract class TestDestination {
    * @throws Exception - can throw any exception, test framework will handle.
    */
   protected abstract List<JsonNode> retrieveRecords(TestDestinationEnv testEnv, String streamName) throws Exception;
+
+  /**
+   * Function that @returns the namespace to use for running standard tests in the destination
+   */
+  protected String getNamespace() {
+    return NAMESPACE;
+  }
 
   /**
    * Override to return true to if the destination implements basic normalization and it should be
@@ -272,7 +280,7 @@ public abstract class TestDestination {
   @ArgumentsSource(DataArgumentsProvider.class)
   public void testSync(String messagesFilename, String catalogFilename) throws Exception {
     final AirbyteCatalog catalog = Jsons.deserialize(MoreResources.readResource(catalogFilename), AirbyteCatalog.class);
-    final ConfiguredAirbyteCatalog configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(catalog);
+    final ConfiguredAirbyteCatalog configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(getNamespace(), catalog);
     final List<AirbyteMessage> messages = MoreResources.readResource(messagesFilename).lines()
         .map(record -> Jsons.deserialize(record, AirbyteMessage.class)).collect(Collectors.toList());
     runSync(getConfig(), messages, configuredCatalog);
@@ -293,7 +301,7 @@ public abstract class TestDestination {
 
     final AirbyteCatalog catalog =
         Jsons.deserialize(MoreResources.readResource("exchange_rate_catalog.json"), AirbyteCatalog.class);
-    final ConfiguredAirbyteCatalog configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(catalog);
+    final ConfiguredAirbyteCatalog configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(getNamespace(), catalog);
     configuredCatalog.getStreams().forEach(s -> s.withSyncMode(SyncMode.INCREMENTAL));
     final List<AirbyteMessage> firstSyncMessages = MoreResources.readResource("exchange_rate_messages.txt").lines()
         .map(record -> Jsons.deserialize(record, AirbyteMessage.class)).collect(Collectors.toList());
@@ -326,7 +334,7 @@ public abstract class TestDestination {
     }
 
     final AirbyteCatalog catalog = Jsons.deserialize(MoreResources.readResource(catalogFilename), AirbyteCatalog.class);
-    final ConfiguredAirbyteCatalog configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(catalog);
+    final ConfiguredAirbyteCatalog configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(getNamespace(), catalog);
     final List<AirbyteMessage> messages = MoreResources.readResource(messagesFilename).lines()
         .map(record -> Jsons.deserialize(record, AirbyteMessage.class)).collect(Collectors.toList());
     runSync(getConfigWithBasicNormalization(), messages, configuredCatalog);
@@ -344,7 +352,7 @@ public abstract class TestDestination {
   public void testSecondSync() throws Exception {
     final AirbyteCatalog catalog =
         Jsons.deserialize(MoreResources.readResource("exchange_rate_catalog.json"), AirbyteCatalog.class);
-    final ConfiguredAirbyteCatalog configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(catalog);
+    final ConfiguredAirbyteCatalog configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(getNamespace(), catalog);
     final List<AirbyteMessage> firstSyncMessages = MoreResources.readResource("exchange_rate_messages.txt").lines()
         .map(record -> Jsons.deserialize(record, AirbyteMessage.class)).collect(Collectors.toList());
     runSync(getConfig(), firstSyncMessages, configuredCatalog);

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/resources/spec.json
@@ -5,18 +5,13 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "BigQuery Destination Spec",
     "type": "object",
-    "required": ["project_id", "dataset_id", "credentials_json"],
+    "required": ["project_id", "credentials_json"],
     "additionalProperties": false,
     "properties": {
       "project_id": {
         "type": "string",
         "description": "The GCP project ID for the project containing the target BigQuery dataset.",
         "title": "Project ID"
-      },
-      "dataset_id": {
-        "type": "string",
-        "description": "The BigQuery dataset id that will house replicated tables.",
-        "title": "Dataset ID"
       },
       "credentials_json": {
         "type": "string",

--- a/airbyte-integrations/connectors/destination-csv/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-csv/src/test-integration/java/io/airbyte/integrations/destination/csv/CsvDestinationIntegrationTest.java
@@ -75,13 +75,13 @@ public class CsvDestinationIntegrationTest extends TestDestination {
 
   @Override
   protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv, String streamName) throws Exception {
-    final List<Path> allOutputs = Files.list(testEnv.getLocalRoot().resolve(RELATIVE_PATH)).collect(Collectors.toList());
-    final Optional<Path> streamOutput =
-        allOutputs.stream().filter(path -> path.getFileName().toString().contains(new StandardNameTransformer().getRawTableName(streamName)))
-            .findFirst();
+    final String namespace = new StandardNameTransformer().getIdentifier(getNamespace());
+    final List<Path> allOutputs = Files.list(testEnv.getLocalRoot().resolve(RELATIVE_PATH).resolve(namespace)).collect(Collectors.toList());
+    final Optional<Path> streamOutput = allOutputs.stream()
+        .filter(path -> path.getFileName().toString().contains(new StandardNameTransformer().getIdentifier(streamName)))
+        .findFirst();
 
     assertTrue(streamOutput.isPresent(), "could not find output file for stream: " + streamName);
-
     final FileReader in = new FileReader(streamOutput.get().toFile());
     final Iterable<CSVRecord> records = CSVFormat.DEFAULT
         .withHeader(JavaBaseConstants.COLUMN_NAME_DATA)

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/AbstractJdbcDestination.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/AbstractJdbcDestination.java
@@ -74,11 +74,12 @@ public abstract class AbstractJdbcDestination implements Destination {
 
       // verify we have write permissions on the target schema by creating a table with a random name,
       // then dropping that table
-      String outputSchema = namingResolver.getIdentifier(config.get("schema").asText());
-      String outputTableName = "_airbyte_connection_test_" + UUID.randomUUID().toString().replaceAll("-", "");
-      sqlOperations.createSchemaIfNotExists(database, outputSchema);
-      sqlOperations.createTableIfNotExists(database, outputSchema, outputTableName);
-      sqlOperations.dropTableIfExists(database, outputSchema, outputTableName);
+      final String outputSchemaName = "_airbyte_schema_connection_test_" + UUID.randomUUID().toString().replaceAll("-", "");
+      final String outputTableName = "_airbyte_table_connection_test_" + UUID.randomUUID().toString().replaceAll("-", "");
+      sqlOperations.createSchemaIfNotExists(database, outputSchemaName);
+      sqlOperations.createTableIfNotExists(database, outputSchemaName, outputTableName);
+      sqlOperations.dropTableIfExists(database, outputSchemaName, outputTableName);
+      sqlOperations.dropSchemaIfExists(database, outputSchemaName);
 
       return new AirbyteConnectionStatus().withStatus(Status.SUCCEEDED);
     } catch (Exception e) {

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/DefaultSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/DefaultSqlOperations.java
@@ -48,6 +48,15 @@ public class DefaultSqlOperations implements SqlOperations {
   }
 
   @Override
+  public void dropSchemaIfExists(JdbcDatabase database, String schemaName) throws Exception {
+    database.execute(dropSchemaQuery(schemaName));
+  }
+
+  private String dropSchemaQuery(String schemaName) {
+    return String.format("DROP SCHEMA IF EXISTS %s CASCADE;\n", schemaName);
+  }
+
+  @Override
   public void createTableIfNotExists(JdbcDatabase database, String schemaName, String tableName) throws SQLException {
     database.execute(createTableQuery(schemaName, tableName));
   }

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/SqlOperations.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/SqlOperations.java
@@ -41,6 +41,14 @@ public interface SqlOperations {
   void createSchemaIfNotExists(JdbcDatabase database, String schemaName) throws Exception;
 
   /**
+   * Drop a schema with provided name if it exists.
+   *
+   * @param schemaName name of schema.
+   * @throws Exception exception
+   */
+  void dropSchemaIfExists(JdbcDatabase database, String schemaName) throws Exception;
+
+  /**
    * Create a table with provided name in provided schema if it does not already exist.
    *
    * @param schemaName name of schema

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/resources/spec.json
@@ -20,12 +20,6 @@
       "jdbc_url": {
         "description": "JDBC formatted url. See the standard <a href=\"https://docs.oracle.com/cd/E17952_01/connector-j-8.0-en/connector-j-reference-jdbc-url-format.html\">here</a>.",
         "type": "string"
-      },
-      "schema": {
-        "description": "Unless specifically configured, the usual value for this field is \"public\".",
-        "type": "string",
-        "examples": ["public"],
-        "default": "public"
       }
     }
   }

--- a/airbyte-integrations/connectors/destination-local-json/src/test-integration/java/io/airbyte/integrations/destination/local_json/LocalJsonDestinationIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-local-json/src/test-integration/java/io/airbyte/integrations/destination/local_json/LocalJsonDestinationIntegrationTest.java
@@ -71,9 +71,10 @@ public class LocalJsonDestinationIntegrationTest extends TestDestination {
 
   @Override
   protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv, String streamName) throws Exception {
-    final List<Path> allOutputs = Files.list(testEnv.getLocalRoot().resolve(RELATIVE_PATH)).collect(Collectors.toList());
+    final String namespace = new StandardNameTransformer().getIdentifier(getNamespace());
+    final List<Path> allOutputs = Files.list(testEnv.getLocalRoot().resolve(RELATIVE_PATH).resolve(namespace)).collect(Collectors.toList());
     final Optional<Path> streamOutput = allOutputs.stream()
-        .filter(path -> path.getFileName().toString().contains(new StandardNameTransformer().getRawTableName(streamName)))
+        .filter(path -> path.getFileName().toString().contains(new StandardNameTransformer().getIdentifier(streamName)))
         .findFirst();
 
     assertTrue(streamOutput.isPresent(), "could not find output file for stream: " + streamName);

--- a/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java
@@ -31,7 +31,6 @@ import io.airbyte.integrations.base.Destination;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.destination.jdbc.AbstractJdbcDestination;
 import io.airbyte.integrations.destination.jdbc.DefaultSqlOperations;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,15 +46,12 @@ public class PostgresDestination extends AbstractJdbcDestination implements Dest
 
   @Override
   public JsonNode toJdbcConfig(JsonNode config) {
-    final String schema = Optional.ofNullable(config.get("schema")).map(JsonNode::asText).orElse("public");
-
     final ImmutableMap.Builder<Object, Object> configBuilder = ImmutableMap.builder()
         .put("username", config.get("username").asText())
         .put("jdbc_url", String.format("jdbc:postgresql://%s:%s/%s",
             config.get("host").asText(),
             config.get("port").asText(),
-            config.get("database").asText()))
-        .put("schema", schema);
+            config.get("database").asText()));
 
     if (config.has("password")) {
       configBuilder.put("password", config.get("password").asText());

--- a/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/PostgresSQLNameTransformer.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/PostgresSQLNameTransformer.java
@@ -28,6 +28,13 @@ import io.airbyte.integrations.destination.ExtendedNameTransformer;
 
 public class PostgresSQLNameTransformer extends ExtendedNameTransformer {
 
+  private static int POSTGRES_NAMELEN = 63;
+
+  @Override
+  protected int getMaxIdentifierLength() {
+    return POSTGRES_NAMELEN;
+  }
+
   @Override
   protected String applyDefaultCase(String input) {
     return input.toLowerCase();

--- a/airbyte-integrations/connectors/destination-postgres/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/resources/spec.json
@@ -5,7 +5,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Postgres Destination Spec",
     "type": "object",
-    "required": ["host", "port", "username", "database", "schema"],
+    "required": ["host", "port", "username", "database"],
     "additionalProperties": false,
     "properties": {
       "host": {
@@ -29,14 +29,6 @@
         "description": "Name of the database.",
         "type": "string",
         "order": 2
-      },
-      "schema": {
-        "title": "Schema",
-        "description": "Unless specifically configured, the usual value for this field is \"public\".",
-        "type": "string",
-        "examples": ["public"],
-        "default": "public",
-        "order": 3
       },
       "username": {
         "title": "User",

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresIntegrationTest.java
@@ -30,6 +30,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.Databases;
 import io.airbyte.integrations.base.JavaBaseConstants;
 import io.airbyte.integrations.destination.ExtendedNameTransformer;
+import io.airbyte.integrations.destination.NamingHelper;
 import io.airbyte.integrations.standardtest.destination.TestDestination;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -77,7 +78,8 @@ public class PostgresIntegrationTest extends TestDestination {
 
   @Override
   protected List<JsonNode> retrieveRecords(TestDestinationEnv env, String streamName) throws Exception {
-    return retrieveRecordsFromTable(namingResolver.getRawTableName(streamName))
+    streamName = NamingHelper.getTmpSchemaName(namingResolver, getNamespace()) + "." + namingResolver.getIdentifier(streamName);
+    return retrieveRecordsFromTable(streamName)
         .stream()
         .map(r -> Jsons.deserialize(r.get(JavaBaseConstants.COLUMN_NAME_DATA).asText()))
         .collect(Collectors.toList());
@@ -91,12 +93,15 @@ public class PostgresIntegrationTest extends TestDestination {
   @Override
   protected List<JsonNode> retrieveNormalizedRecords(TestDestinationEnv env, String streamName)
       throws Exception {
+    String schemaName = namingResolver.getIdentifier(getNamespace());
     String tableName = namingResolver.getIdentifier(streamName);
-    if (!tableName.startsWith("\"")) {
-      // Currently, Normalization always quote tables identifiers
+    // Currently, Normalization always quote tables identifiers, see quoting rules
+    // in airbyte-integrations/bases/base-normalization/dbt-project-template/dbt_project.yml
+    if (!schemaName.startsWith("\""))
+      schemaName = "\"" + schemaName + "\"";
+    if (!tableName.startsWith("\""))
       tableName = "\"" + tableName + "\"";
-    }
-    return retrieveRecordsFromTable(tableName);
+    return retrieveRecordsFromTable(schemaName + "." + tableName);
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftDestination.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftDestination.java
@@ -30,7 +30,6 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.base.Destination;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.destination.jdbc.AbstractJdbcDestination;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,8 +45,6 @@ public class RedshiftDestination extends AbstractJdbcDestination implements Dest
 
   @Override
   public JsonNode toJdbcConfig(JsonNode redshiftConfig) {
-    final String schema = Optional.ofNullable(redshiftConfig.get("schema")).map(JsonNode::asText).orElse("public");
-
     return Jsons.jsonNode(ImmutableMap.builder()
         .put("username", redshiftConfig.get("username").asText())
         .put("password", redshiftConfig.get("password").asText())
@@ -55,7 +52,6 @@ public class RedshiftDestination extends AbstractJdbcDestination implements Dest
             redshiftConfig.get("host").asText(),
             redshiftConfig.get("port").asText(),
             redshiftConfig.get("database").asText()))
-        .put("schema", schema)
         .build());
   }
 

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftSQLNameTransformer.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftSQLNameTransformer.java
@@ -28,9 +28,16 @@ import io.airbyte.integrations.destination.ExtendedNameTransformer;
 
 public class RedshiftSQLNameTransformer extends ExtendedNameTransformer {
 
+  private static final int MAX_IDENTIFIER_LENGTH = 127;
+
   @Override
-  protected String convertStreamName(String input) {
-    return super.convertStreamName(input).toLowerCase();
+  protected int getMaxIdentifierLength() {
+    return MAX_IDENTIFIER_LENGTH;
+  }
+
+  @Override
+  public String getIdentifier(String input) {
+    return super.getIdentifier(input).toLowerCase();
   }
 
 }

--- a/airbyte-integrations/connectors/destination-redshift/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/resources/spec.json
@@ -5,7 +5,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Redshift Destination Spec",
     "type": "object",
-    "required": ["host", "port", "database", "username", "password", "schema"],
+    "required": ["host", "port", "database", "username", "password"],
     "additionalProperties": false,
     "properties": {
       "host": {
@@ -32,12 +32,6 @@
       "database": {
         "description": "Name of the database.",
         "type": "string"
-      },
-      "schema": {
-        "description": "Unless specifically configured, the usual value for this field is \"public\".",
-        "type": "string",
-        "examples": ["public"],
-        "default": "public"
       },
       "basic_normalization": {
         "type": "boolean",

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeSQLNameTransformer.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeSQLNameTransformer.java
@@ -28,6 +28,13 @@ import io.airbyte.integrations.destination.ExtendedNameTransformer;
 
 public class SnowflakeSQLNameTransformer extends ExtendedNameTransformer {
 
+  private static final int MAX_IDENTIFIER_LENGTH = 255;
+
+  @Override
+  protected int getMaxIdentifierLength() {
+    return MAX_IDENTIFIER_LENGTH;
+  }
+
   @Override
   protected String applyDefaultCase(String input) {
     return input.toUpperCase();

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/resources/spec.json
@@ -10,7 +10,6 @@
       "role",
       "warehouse",
       "database",
-      "schema",
       "username",
       "password"
     ],
@@ -35,11 +34,6 @@
       "database": {
         "description": "The database you created for Airbyte to sync data into.",
         "examples": ["AIRBYTE_DATABASE"],
-        "type": "string"
-      },
-      "schema": {
-        "description": "The Snowflake schema you created for Airbyte to sync data into.",
-        "examples": ["AIRBYTE_SCHEMA"],
         "type": "string"
       },
       "username": {

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeIntegrationTest.java
@@ -31,6 +31,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.base.JavaBaseConstants;
 import io.airbyte.integrations.destination.ExtendedNameTransformer;
+import io.airbyte.integrations.destination.NamingHelper;
 import io.airbyte.integrations.standardtest.destination.TestDestination;
 import java.nio.file.Path;
 import java.sql.SQLException;
@@ -41,11 +42,14 @@ import org.apache.commons.lang3.RandomStringUtils;
 
 public class SnowflakeIntegrationTest extends TestDestination {
 
-  // config from which to create / delete schemas.
-  private JsonNode baseConfig;
-  // config which refers to the schema that the test is being run in.
+  private String namespace;
   private JsonNode config;
   private final ExtendedNameTransformer namingResolver = new ExtendedNameTransformer();
+
+  @Override
+  protected String getNamespace() {
+    return namespace;
+  }
 
   @Override
   protected String getImageName() {
@@ -70,7 +74,8 @@ public class SnowflakeIntegrationTest extends TestDestination {
 
   @Override
   protected List<JsonNode> retrieveRecords(TestDestinationEnv env, String streamName) throws Exception {
-    return retrieveRecordsFromTable(namingResolver.getRawTableName(streamName))
+    streamName = NamingHelper.getTmpSchemaName(namingResolver, getNamespace()) + "." + namingResolver.getIdentifier(streamName);
+    return retrieveRecordsFromTable(streamName)
         .stream()
         .map(j -> Jsons.deserialize(j.get(JavaBaseConstants.COLUMN_NAME_DATA).asText()))
         .collect(Collectors.toList());
@@ -83,12 +88,15 @@ public class SnowflakeIntegrationTest extends TestDestination {
 
   @Override
   protected List<JsonNode> retrieveNormalizedRecords(TestDestinationEnv testEnv, String streamName) throws Exception {
+    String schemaName = namingResolver.getIdentifier(getNamespace());
     String tableName = namingResolver.getIdentifier(streamName);
-    if (!tableName.startsWith("\"")) {
-      // Currently, Normalization always quote tables identifiers
+    // Currently, Normalization always quote tables identifiers, see quoting rules
+    // in airbyte-integrations/bases/base-normalization/dbt-project-template/dbt_project.yml
+    if (!schemaName.startsWith("\""))
+      schemaName = "\"" + schemaName + "\"";
+    if (!tableName.startsWith("\""))
       tableName = "\"" + tableName + "\"";
-    }
-    return retrieveRecordsFromTable(tableName);
+    return retrieveRecordsFromTable(schemaName + "." + tableName);
   }
 
   @Override
@@ -114,21 +122,15 @@ public class SnowflakeIntegrationTest extends TestDestination {
   // for each test we create a new schema in the database. run the test in there and then remove it.
   @Override
   protected void setup(TestDestinationEnv testEnv) throws Exception {
-    final String schemaName = ("integration_test_" + RandomStringUtils.randomAlphanumeric(5));
-    final String createSchemaQuery = String.format("CREATE SCHEMA %s", schemaName);
-
-    baseConfig = getStaticConfig();
-    SnowflakeDatabase.getDatabase(baseConfig).execute(createSchemaQuery);
-
-    final JsonNode configForSchema = Jsons.clone(baseConfig);
-    ((ObjectNode) configForSchema).put("schema", schemaName);
-    config = configForSchema;
+    namespace = ("integration_test_" + RandomStringUtils.randomAlphanumeric(5));
+    config = getStaticConfig();
   }
 
   @Override
   protected void tearDown(TestDestinationEnv testEnv) throws Exception {
-    final String createSchemaQuery = String.format("DROP SCHEMA IF EXISTS %s", config.get("schema").asText());
-    SnowflakeDatabase.getDatabase(baseConfig).execute(createSchemaQuery);
+    final String tmpSchema = NamingHelper.getTmpSchemaName(namingResolver, getNamespace());
+    SnowflakeDatabase.getDatabase(config).execute(String.format("DROP SCHEMA IF EXISTS %s CASCADE", tmpSchema));
+    SnowflakeDatabase.getDatabase(config).execute(String.format("DROP SCHEMA IF EXISTS %s CASCADE", getNamespace()));
   }
 
 }


### PR DESCRIPTION
## What
*Describe what the change is solving*
Following-up on #1993, implements in destinations by using the new namespace fields
 
Implements #1921 

## How
*Describe the solution*
- Refactor the NamingTransformer to split into 
  - a NamingHelper class: where we specify prefix/suffix to table/schema names
  - NamingTransformer classes: only handles identifier specificities to each destinations only
- Destination read and use namespace field in ConfiguredCatalog to specify where they should write the final table.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
Refactoring naming utils classes to handle schema+table names: 
1. `airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/NamingConventionTransformer.java`
2. `airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/NamingHelper.java`
3. `airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/StandardNameTransformer.java`

Adapting destinations to new naming:
1. `airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/JdbcBufferedConsumerFactory.java`
2. `airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java`
3. `airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java`
4. the rest
