### PR TITLE
freeze dbt version at 0.18.1

### DIFF
--- a/airbyte-integrations/bases/base-normalization/setup.py
+++ b/airbyte-integrations/bases/base-normalization/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     author_email="contact@airbyte.io",
     url="https://github.com/airbytehq/airbyte",
     packages=setuptools.find_packages(),
-    install_requires=["airbyte-protocol", "dbt>=0.18.1", "pyyaml"],
+    install_requires=["airbyte-protocol", "dbt==0.18.1", "pyyaml"],
     package_data={"": ["*.yml"]},
     setup_requires=["pytest-runner"],
     entry_points={


### PR DESCRIPTION
## What
* Above dbt v0.18.1 (or more specifically numpy) doesn't compile properly on mac. fix discovered and confirmed by @jrhizor.
* It seems like there's alot of these sort of issues with numpy, etc right now as they start to deal with different chipsets and bigsur. I don't think it's worth tearing our hair out now to get newer versions to work. I think we can be patient and upgrade when these newer versions are more stable.

sample of errors:
[c_errors.txt](https://github.com/airbytehq/airbyte/files/5953036/c_errors.txt)
