### PR TITLE
label documentation tickets automatically

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -2,7 +2,7 @@
 name: Documentation request
 about: Suggest an idea for new or updated documentation
 title: ''
-labels: type/enhancement area/documentation
+labels: type/enhancement, area/documentation
 assignees: ''
 
 ---


### PR DESCRIPTION
Without commas this doesn't work and it has no labels by default.