### PR TITLE
prune dangling image in master build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
 
-      - name: File sizes
-        run: tree --du -h -a
-
       - name: Check images exist
         run: ./tools/bin/check_images_exist.sh
 
@@ -68,9 +65,6 @@ jobs:
         with:
           python-version: '3.7'
 
-      - name: File sizes
-        run: tree --du -h -a
-
       - name: Format
         run: ./gradlew --no-daemon format --scan
 
@@ -79,9 +73,6 @@ jobs:
 
       - name: Build
         run: ./gradlew --no-daemon build --scan
-
-      - name: File sizes
-        run: tree --du -h -a
 
       - name: Ensure no file change
         run: git status --porcelain && test -z "$(git status --porcelain)"
@@ -96,11 +87,8 @@ jobs:
         env:
           GIT_REVISION: ${{ github.sha }}
 
-      - name: File sizes
-        run: tree --du -h -a
-
-      - name: Docker sizes
-        run: docker system df
+      - name: Docker Prune
+        run: docker image prune --force
 
       # make sure these always run before pushing core docker images
       - name: Run End-to-End Acceptance Tests


### PR DESCRIPTION
From the debugging messages I added, the bases directory takes 1gb and the connectors directory takes 5gb.

The real space hog appears to be Docker which claims to be using 12gb. I'm not sure I can trust this number since the Github Action machines are supposed to have only 14gb to begin with...

I'm hoping that cleaning out dangling images will be enough.

An aside:
Just by the raw size of this and the time it takes for the build to run is beginning to make me think that we should be doing `CORE_ONLY` by default and only manually requesting specific connectors to be built at all. This would incidentally fix issues like https://github.com/airbytehq/airbyte/issues/1906. Also it would kind of negate the need for this build step at all since we would solely use connector builds. 