### PR TITLE
Redshift Destination Table Casing

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -19,5 +19,5 @@ WORKDIR /airbyte
 
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.10
+LABEL io.airbyte.version=0.1.11
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
@@ -185,25 +185,27 @@ def strip_accents(s):
     return "".join(c for c in ud.normalize("NFD", s) if ud.category(c) != "Mn")
 
 
+# Temporarily disabling the behavior of the ExtendedNameTransformer, see (issue #1785)
 def normalize_identifier_name(input_name: str, integration_type: str) -> str:
-    # Temporarily disabling the behavior of the ExtendedNameTransformer, see (issue #1785)
-    # if integration_type == "bigquery":
+    if integration_type == "redshift" or integration_type == "postgres":
+        input_name = input_name.lower()
+
     input_name = strip_accents(input_name)
     input_name = sub(r"\s+", "_", input_name)
     return sub(r"[^a-zA-Z0-9_]", "_", input_name)
 
 
-# else:
-#   return input_name
-
-
 def table_name(input_name: str, integration_type) -> str:
+
     if integration_type == "bigquery":
         return normalize_identifier_name(input_name, integration_type)
     elif match("[^A-Za-z_]", input_name[0]) or match(".*[^A-Za-z0-9_].*", input_name):
         return '"' + input_name + '"'
     else:
-        return input_name
+        if integration_type == "redshift" or integration_type == "postgres":
+            return input_name.lower()
+        else:
+            return input_name
 
 
 def quote(input_name: str, integration_type: str, in_jinja=False) -> str:

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/transform.py
@@ -187,7 +187,8 @@ def strip_accents(s):
 
 # Temporarily disabling the behavior of the ExtendedNameTransformer, see (issue #1785)
 def normalize_identifier_name(input_name: str, integration_type: str) -> str:
-    if integration_type == "redshift" or integration_type == "postgres":
+    # all tables (even quoted ones) are coerced to lowercase.
+    if integration_type == "redshift":
         input_name = input_name.lower()
 
     input_name = strip_accents(input_name)
@@ -196,13 +197,17 @@ def normalize_identifier_name(input_name: str, integration_type: str) -> str:
 
 
 def table_name(input_name: str, integration_type) -> str:
+    # all tables (even quoted ones) are coerced to lowercase.
+    if integration_type == "redshift":
+        input_name = input_name.lower()
 
     if integration_type == "bigquery":
         return normalize_identifier_name(input_name, integration_type)
     elif match("[^A-Za-z_]", input_name[0]) or match(".*[^A-Za-z0-9_].*", input_name):
         return '"' + input_name + '"'
     else:
-        if integration_type == "redshift" or integration_type == "postgres":
+        # postgres coerces non-quoted table names to lower case.
+        if integration_type == "postgres":
             return input_name.lower()
         else:
             return input_name

--- a/airbyte-integrations/bases/base-normalization/unit_tests/test_transform_catalog.py
+++ b/airbyte-integrations/bases/base-normalization/unit_tests/test_transform_catalog.py
@@ -1,0 +1,52 @@
+"""
+MIT License
+
+Copyright (c) 2020 Airbyte
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+from normalization.transform_catalog.transform import normalize_identifier_name, table_name
+
+
+class TestTransformCatalog:
+    def test_normalize_identifier_name(self):
+        identifier_name = "Approved@Users"
+
+        # unless quoted, redshift and postgres coerce table names to lower case.
+        assert normalize_identifier_name(identifier_name, "redshift") == "approved_users"
+        assert normalize_identifier_name(identifier_name, "postgres") == "approved_users"
+        assert normalize_identifier_name(identifier_name, "bigquery") == "Approved_Users"
+        assert normalize_identifier_name(identifier_name, "snowflake") == "Approved_Users"
+
+    def test_table_name(self):
+        tableName1 = "Approved@Users"
+
+        assert table_name(tableName1, "redshift") == '"Approved@Users"'
+        assert table_name(tableName1, "postgres") == '"Approved@Users"'
+        assert table_name(tableName1, "bigquery") == "Approved_Users"
+        assert table_name(tableName1, "snowflake") == '"Approved@Users"'
+
+        tableName2 = "ApprovedUsers"
+
+        # unless quoted, redshift and postgres coerce table names to lower case.
+        assert table_name(tableName2, "redshift") == "approvedusers"
+        assert table_name(tableName2, "postgres") == "approvedusers"
+        assert table_name(tableName2, "bigquery") == "ApprovedUsers"
+        assert table_name(tableName2, "snowflake") == "ApprovedUsers"

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
@@ -64,6 +64,8 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
 
   @Override
   public boolean normalize(long jobId, int attempt, Path jobRoot, JsonNode config, ConfiguredAirbyteCatalog catalog) throws Exception {
+    LOGGER.info("normalization version: {}", NORMALIZATION_IMAGE_NAME);
+
     IOs.writeFile(jobRoot, WorkerConstants.TARGET_CONFIG_JSON_FILENAME, Jsons.serialize(config));
     IOs.writeFile(jobRoot, WorkerConstants.CATALOG_JSON_FILENAME, Jsons.serialize(catalog));
 
@@ -94,10 +96,10 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
       return;
     }
 
-    LOGGER.debug("Closing tap process");
+    LOGGER.debug("Closing normalization process");
     WorkerUtils.gentleClose(process, 1, TimeUnit.MINUTES);
     if (process.isAlive() || process.exitValue() != 0) {
-      throw new WorkerException("Tap process wasn't successful");
+      throw new WorkerException("Normalization process wasn't successful");
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
@@ -43,7 +43,7 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNormalizationRunner.class);
 
-  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.10";
+  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.11";
 
   private final DestinationType destinationType;
   private final ProcessBuilderFactory pbf;


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/1926

## What
* If an input stream name contains upper case characters, normalization on the nth sync fails. This is due to how dbt redshift handles this case. It doesn't like to make any assumptions about case coercion (even if redshift does)

## How
* Fix redshift normalization so it can accept table names with capital letters
* Fix postgres normalization so it can accept table names with capital letters (turns out it had a similar, though not identical problem 🙄 ).
* Add unit tests

## Pre-merge Checklist
- [ ] *Run destination integration tests*
- [x] *Bump normalization version and set it in core.*
