### PR TITLE
disable testcontainer size checks

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Docker Prune
         run: docker image prune --force
 
+      - name: Disable Testcontainer VM Disk Size Checks
+        run: echo "checks.disable=true" > $HOME/.testcontainers.properties
+
       # make sure these always run before pushing core docker images
       - name: Run End-to-End Acceptance Tests
         if: success() && github.ref == 'refs/heads/master'


### PR DESCRIPTION
The testcontainer error of failing the check `Docker environment should have more than 2GB free disk space` isn't due to total node space. It's actually referring to the configured Docker VM allowed disk space.

From when the docker size check was running:
```
TYPE                TOTAL               ACTIVE              SIZE                RECLAIMABLE
Images              102                 2                   11.83GB             11.07GB (93%)
Containers          3                   0                   0B                  0B
Local Volumes       0                   0                   0B                  0B
Build Cache         0                   0                   0B                  0B
```

It doesn't look like any of that space should have been used. I also don't see a way to configure this space. However, the necessary space to run the two postgres instances is very low.

I think disabling this check will get the build passing. It would be nicer if we could configure this value.

I'm still not sure why this would differ between master and branches.