### PR TITLE
Remove papercups chat and instead open slack link

### DIFF
--- a/airbyte-webapp/src/components/SupportChat/SupportChat.tsx
+++ b/airbyte-webapp/src/components/SupportChat/SupportChat.tsx
@@ -1,7 +1,9 @@
 import React, { useContext, useEffect } from "react";
-import ChatWidget from "@papercups-io/chat-widget";
 import { Storytime } from "@papercups-io/storytime";
-import { ThemeContext } from "styled-components";
+import styled, { ThemeContext } from "styled-components";
+import Button from "../Button";
+import { faComment } from "@fortawesome/free-regular-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 type PapercupsConfig = {
   accountId: string;
@@ -12,9 +14,28 @@ type PapercupsConfig = {
 type IProps = {
   papercupsConfig: PapercupsConfig;
   customerId: string;
+  onClick?: () => void;
 };
 
-const SupportChat: React.FC<IProps> = ({ papercupsConfig, customerId }) => {
+const ChatButton = styled(Button)`
+  width: 50px;
+  height: 50px;
+
+  border-radius: 50%;
+  padding: 0;
+
+  position: fixed;
+  bottom: 25px;
+  right: 25px;
+
+  font-size: 30px;
+`;
+
+const SupportChat: React.FC<IProps> = ({
+  papercupsConfig,
+  customerId,
+  onClick
+}) => {
   useEffect(() => {
     if (papercupsConfig.enableStorytime) {
       Storytime.init({
@@ -26,18 +47,12 @@ const SupportChat: React.FC<IProps> = ({ papercupsConfig, customerId }) => {
   }, [customerId, papercupsConfig]);
 
   const theme = useContext(ThemeContext);
+  console.log(theme);
 
   return (
-    <ChatWidget
-      title="Welcome to Airbyte"
-      subtitle="Ask us anything in the chat window below 😊"
-      primaryColor={theme.primaryColor}
-      greeting="Hello!!!"
-      newMessagePlaceholder="Start typing..."
-      customer={{ external_id: customerId }}
-      accountId={papercupsConfig.accountId}
-      baseUrl={papercupsConfig.baseUrl}
-    />
+    <ChatButton onClick={onClick}>
+      <FontAwesomeIcon icon={faComment} />
+    </ChatButton>
   );
 };
 

--- a/airbyte-webapp/src/components/SupportChat/SupportChat.tsx
+++ b/airbyte-webapp/src/components/SupportChat/SupportChat.tsx
@@ -1,6 +1,6 @@
-import React, { useContext, useEffect } from "react";
+import React, { useEffect } from "react";
 import { Storytime } from "@papercups-io/storytime";
-import styled, { ThemeContext } from "styled-components";
+import styled from "styled-components";
 import Button from "../Button";
 import { faComment } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -45,9 +45,6 @@ const SupportChat: React.FC<IProps> = ({
       });
     }
   }, [customerId, papercupsConfig]);
-
-  const theme = useContext(ThemeContext);
-  console.log(theme);
 
   return (
     <ChatButton onClick={onClick}>

--- a/airbyte-webapp/src/pages/routes.tsx
+++ b/airbyte-webapp/src/pages/routes.tsx
@@ -155,6 +155,7 @@ export const Routing = () => {
         <SupportChat
           papercupsConfig={config.papercups}
           customerId={workspace.customerId}
+          onClick={() => (window as any).open(config.ui.slackLink, "_blank")}
         />
         {config.isDemo && (
           <SingletonCard

--- a/airbyte-webapp/src/pages/routes.tsx
+++ b/airbyte-webapp/src/pages/routes.tsx
@@ -155,7 +155,7 @@ export const Routing = () => {
         <SupportChat
           papercupsConfig={config.papercups}
           customerId={workspace.customerId}
-          onClick={() => (window as any).open(config.ui.slackLink, "_blank")}
+          onClick={() => window.open(config.ui.slackLink, "_blank")}
         />
         {config.isDemo && (
           <SingletonCard


### PR DESCRIPTION
## What
Remove papercups chat widget and make it a button that opens our slack

![image](https://user-images.githubusercontent.com/1154337/107608247-3f1b2a00-6bf0-11eb-809c-d35896b1e5da.png)

