### PR TITLE
Update required fields in google-analytics source

### DIFF
--- a/airbyte-integrations/connectors/source-googleanalytics-singer/source_googleanalytics_singer/spec.json
+++ b/airbyte-integrations/connectors/source-googleanalytics-singer/source_googleanalytics_singer/spec.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Airbyte Google Analytics Source Spec",
     "type": "object",
-    "required": ["credentials_json"],
+    "required": ["credentials_json", "view_id", "start_date"],
     "additionalProperties": false,
     "properties": {
       "credentials_json": {


### PR DESCRIPTION
## What
Google Analytics Source has an incorrect required field definition.

## How
Per https://github.com/transferwise/pipelinewise-tap-google-analytics#required-configuration-parameters both `view_id` and `start_date` are required
