### PR TITLE
Improve Slack MeiliSearch Search UI

### DIFF
--- a/docs/tutorials/slack-history/index.html
+++ b/docs/tutorials/slack-history/index.html
@@ -9,76 +9,81 @@
 <div class="wrapper">
   <div id="searchbox" focus></div>
   <div id="hits"></div>
+  <div id="hits2"></div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/@meilisearch/instant-meilisearch/dist/instant-meilisearch.umd.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/meilisearch@latest/dist/bundles/meilisearch.umd.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4"></script>
 <script>
-    const searchMessages = instantsearch({
-        indexName: "messages",
-        searchClient: instantMeiliSearch(
-            "http://localhost:7700"
-        )
-    });
-    const searchThreads = instantsearch({
-        indexName: "threads",
-        searchClient: instantMeiliSearch(
-            "http://localhost:7700"
-        )
-    });
+    (async function () {
+        const searchMessages = instantsearch({
+            indexName: "messages",
+            searchClient: instantMeiliSearch(
+                "http://localhost:7700"
+            )
+        });
 
-    const client = new MeiliSearch({ host: "http://localhost:7700" });
-    // put this in a map.
-    let users1 = {};
-    client.getIndex("users").then(users => users.getDocuments()).then(users => users1 = users.reduce((map, obj) => {
-        map[obj.id] = obj.name;
-        return map;
-    }, {}));
-    console.log(users1);
-    // access the map from there.
-    // client.get
-
+        const client = new MeiliSearch({host: "http://localhost:7700"});
+        // put all users in a map so that we can display user names.
+        const users = await client.getIndex("users")
+            .then(usersResult => usersResult.getDocuments())
+            .then(usersResult => usersResult.reduce((map, obj) => {
+                map[obj.id] = obj.name;
+                return map;
+            }, {}));
+        console.log(users);
 
         searchMessages.addWidgets([
-        instantsearch.widgets.searchBox({
-            container: "#searchbox"
-        }),
-        instantsearch.widgets.configure({ hitsPerPage: 8 }),
-        instantsearch.widgets.hits({
-            container: "#hits",
-            templates: {
-                item: `
+            instantsearch.widgets.searchBox({
+                container: "#searchbox"
+            }),
+            instantsearch.widgets.configure({hitsPerPage: 8}),
+            instantsearch.widgets.hits({
+                container: "#hits",
+                templates: {
+                    item(hit) {
+                        return `
                       <div>
                       <div class="hit-name">
-                          {{#helpers.highlight}}{ "attribute": "text" }{{/helpers.highlight}}
-                          {{#helpers.highlight}}{ "attribute": "user" }{{/helpers.highlight}}
+                          ${users[hit.user] || hit.user}
+                          (
+                          ${instantsearch.highlight({attribute: 'ts', highlightedTagName: 'mark', hit})}
+                          ):
+                          ${instantsearch.highlight({attribute: 'text', highlightedTagName: 'mark', hit})}
                       </div>
                       </div>
                   `
-            }
-        })
-    ]);
-    searchMessages.start();
+                    }
+                }
+            }),
 
-    // searchThreads.addWidgets([
-    //     instantsearch.widgets.searchBox({
-    //         container: "#searchbox"
-    //     }),
-    //     instantsearch.widgets.configure({ hitsPerPage: 8 }),
-    //     instantsearch.widgets.hits({
-    //         container: "#hits",
-    //         templates: {
-    //             item: `
-    //                   <div>
-    //                   <div class="hit-name">
-    //                       {{#helpers.highlight}}{ "attribute": "text" }{{/helpers.highlight}}
-    //                   </div>
-    //                   </div>
-    //               `
-    //         }
-    //     })
-    // ]);
-    // searchThreads.start();
+            // todo (cgardens) - include messages that are in threads. something like this should work, but it is
+            //  throwing an exception that we need to dig into.
+            //  https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/multi-index-search/js/#overview
+            // instantsearch.widgets
+            //     .index({indexName: 'threads'})
+            //     .addWidgets([
+            //         instantsearch.widgets.hits({
+            //             container: "#hits2",
+            //             templates: {
+            //                 item(hit) {
+            //                     return `
+            //             <div>
+            //             <div class="hit-name">
+            //                 ${users[hit.user] || hit.user} :
+            //                 ${instantsearch.highlight({attribute: 'text', highlightedTagName: 'mark', hit})}
+            //                 ${instantsearch.highlight({attribute: 'ts', highlightedTagName: 'mark', hit})}
+            //             </div>
+            //             </div>
+            //         `
+            //                 }
+            //             }
+            //         })
+            //     ])
+        ]);
+
+        searchMessages.start()
+    })();
 </script>
 </body>
 </html>

--- a/docs/tutorials/slack-history/index.html
+++ b/docs/tutorials/slack-history/index.html
@@ -11,13 +11,14 @@
   <div id="hits"></div>
   <div id="hits2"></div>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/@meilisearch/instant-meilisearch/dist/instant-meilisearch.umd.min.js"></script>
+<script
+    src="https://cdn.jsdelivr.net/npm/@meilisearch/instant-meilisearch/dist/instant-meilisearch.umd.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/meilisearch@latest/dist/bundles/meilisearch.umd.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4"></script>
 <script>
     (async function () {
         const searchMessages = instantsearch({
-            indexName: "messages",
+            indexName: "threads",
             searchClient: instantMeiliSearch(
                 "http://localhost:7700"
             )
@@ -31,7 +32,14 @@
                 map[obj.id] = obj.name;
                 return map;
             }, {}));
-        console.log(users);
+
+        // put all channels in a map so that we can display channel names.
+        const channels = await client.getIndex("channels")
+            .then(usersResult => usersResult.getDocuments())
+            .then(usersResult => usersResult.reduce((map, obj) => {
+                map[obj.id] = obj.name;
+                return map;
+            }, {}));
 
         searchMessages.addWidgets([
             instantsearch.widgets.searchBox({
@@ -45,41 +53,19 @@
                         return `
                       <div>
                       <div class="hit-name">
-                          ${users[hit.user] || hit.user}
-                          (
-                          ${instantsearch.highlight({attribute: 'ts', highlightedTagName: 'mark', hit})}
-                          ):
+                          <b>${users[hit.user] || hit.user}</b>
+                          (<i>${channels[hit.channel_id] || hit.channel_id}, ${instantsearch.highlight({
+                            attribute: 'ts',
+                            highlightedTagName: 'mark',
+                            hit
+                        })}</i>):
                           ${instantsearch.highlight({attribute: 'text', highlightedTagName: 'mark', hit})}
                       </div>
                       </div>
                   `
                     }
                 }
-            }),
-
-            // todo (cgardens) - include messages that are in threads. something like this should work, but it is
-            //  throwing an exception that we need to dig into.
-            //  https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/multi-index-search/js/#overview
-            // instantsearch.widgets
-            //     .index({indexName: 'threads'})
-            //     .addWidgets([
-            //         instantsearch.widgets.hits({
-            //             container: "#hits2",
-            //             templates: {
-            //                 item(hit) {
-            //                     return `
-            //             <div>
-            //             <div class="hit-name">
-            //                 ${users[hit.user] || hit.user} :
-            //                 ${instantsearch.highlight({attribute: 'text', highlightedTagName: 'mark', hit})}
-            //                 ${instantsearch.highlight({attribute: 'ts', highlightedTagName: 'mark', hit})}
-            //             </div>
-            //             </div>
-            //         `
-            //                 }
-            //             }
-            //         })
-            //     ])
+            })
         ]);
 
         searchMessages.start()

--- a/docs/tutorials/slack-history/index.html
+++ b/docs/tutorials/slack-history/index.html
@@ -11,6 +11,7 @@
   <div id="hits"></div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/@meilisearch/instant-meilisearch/dist/instant-meilisearch.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/meilisearch@latest/dist/bundles/meilisearch.umd.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4"></script>
 <script>
     const searchMessages = instantsearch({
@@ -26,7 +27,19 @@
         )
     });
 
-    searchMessages.addWidgets([
+    const client = new MeiliSearch({ host: "http://localhost:7700" });
+    // put this in a map.
+    let users1 = {};
+    client.getIndex("users").then(users => users.getDocuments()).then(users => users1 = users.reduce((map, obj) => {
+        map[obj.id] = obj.name;
+        return map;
+    }, {}));
+    console.log(users1);
+    // access the map from there.
+    // client.get
+
+
+        searchMessages.addWidgets([
         instantsearch.widgets.searchBox({
             container: "#searchbox"
         }),
@@ -38,6 +51,7 @@
                       <div>
                       <div class="hit-name">
                           {{#helpers.highlight}}{ "attribute": "text" }{{/helpers.highlight}}
+                          {{#helpers.highlight}}{ "attribute": "user" }{{/helpers.highlight}}
                       </div>
                       </div>
                   `
@@ -46,25 +60,26 @@
     ]);
     searchMessages.start();
 
-    searchThreads.addWidgets([
-        instantsearch.widgets.searchBox({
-            container: "#searchbox"
-        }),
-        instantsearch.widgets.configure({ hitsPerPage: 8 }),
-        instantsearch.widgets.hits({
-            container: "#hits",
-            templates: {
-                item: `
-                      <div>
-                      <div class="hit-name">
-                          {{#helpers.highlight}}{ "attribute": "text" }{{/helpers.highlight}}
-                      </div>
-                      </div>
-                  `
-            }
-        })
-    ]);
-    searchThreads.start();
+    // searchThreads.addWidgets([
+    //     instantsearch.widgets.searchBox({
+    //         container: "#searchbox"
+    //     }),
+    //     instantsearch.widgets.configure({ hitsPerPage: 8 }),
+    //     instantsearch.widgets.hits({
+    //         container: "#hits",
+    //         templates: {
+    //             item: `
+    //                   <div>
+    //                   <div class="hit-name">
+    //                       {{#helpers.highlight}}{ "attribute": "text" }{{/helpers.highlight}}
+    //                   </div>
+    //                   </div>
+    //               `
+    //         }
+    //     })
+    // ]);
+    // searchThreads.start();
 </script>
 </body>
 </html>
+


### PR DESCRIPTION
## What
* add username to messages
* add timestamp to messages
* remove messages from threads (because they were causing everything to be duplicated)
  * I want to bring this back, but I am having trouble getting the instructions in the tutorial to work. asking for help in the [meilisearch slack](https://meilicommunity.slack.com/archives/CP9DVS1RQ/p1613172183126500). UPDATE (2020/02/16): just using the threads index seems to have the desired effect. it finds messages in a channel without any threaded messages. so we should now be good here.

It now looks like this:
![Screen Shot 2021-02-12 at 3 15 02 PM](https://user-images.githubusercontent.com/9092207/107832517-72230200-6d45-11eb-94f2-e85c9d77bdee.png)

UPDATE (2020/02/16)
![Screen Shot 2021-02-16 at 3 59 32 PM](https://user-images.githubusercontent.com/9092207/108137633-1e7c2580-7071-11eb-9d0a-e520e7f86284.png)


I am happy to accept contributions to this PR to make it prettier, but i'm not going to spend anymore time beautifying it.