### PR TITLE
add isort to format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -218,8 +218,7 @@ task('generate') {
 task('format') {
     dependsOn generate
     dependsOn spotlessApply
-    dependsOn subprojects.collect { it.getTasksByName('blackFormat', true) }
-    dependsOn subprojects.collect { it.getTasksByName('isortFormat', true) }
+    dependsOn subprojects.collect { it.getTasksByName('airbytePythonFormat', true) }
 }
 
 // produce reproducible archives

--- a/build.gradle
+++ b/build.gradle
@@ -219,6 +219,7 @@ task('format') {
     dependsOn generate
     dependsOn spotlessApply
     dependsOn subprojects.collect { it.getTasksByName('blackFormat', true) }
+    dependsOn subprojects.collect { it.getTasksByName('isortFormat', true) }
 }
 
 // produce reproducible archives

--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -90,11 +90,15 @@ class AirbytePythonPlugin implements Plugin<Project> {
             project.check.dependsOn mypyCheck
         }
 
-        project.task('airbytePythonApply', type: DefaultTask) {
-            dependsOn project.installReqs
+        project.task('airbytePythonFormat', type: DefaultTask) {
             dependsOn project.blackFormat
             dependsOn project.isortFormat
             dependsOn project.flakeCheck
+        }
+
+        project.task('airbytePythonApply', type: DefaultTask) {
+            dependsOn project.installReqs
+            dependsOn project.airbytePythonFormat
         }
 
 


### PR DESCRIPTION
We weren't including `isort` as part of `format` so builds could fail late like https://github.com/airbytehq/airbyte/pull/2052/checks?check_run_id=1911855951