### PR TITLE
Update Exchange Rates API start_date regex pattern

### DIFF
--- a/airbyte-integrations/connectors/source-exchangeratesapi-singer/source_exchangeratesapi_singer/spec.json
+++ b/airbyte-integrations/connectors/source-exchangeratesapi-singer/source_exchangeratesapi_singer/spec.json
@@ -10,6 +10,7 @@
       "start_date": {
         "type": "string",
         "description": "Start getting data from that date.",
+        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
         "examples": ["YYYY-MM-DD"]
       },
       "base": {


### PR DESCRIPTION
## What
This change adds a regex validation to the `start_date` field in the Exchange Rates API source.