### PR TITLE
Core: Use correct casing for source GitHub's name

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ef69ef6e-aa7f-4af1-a01d-ef775033524e.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ef69ef6e-aa7f-4af1-a01d-ef775033524e.json
@@ -1,6 +1,6 @@
 {
   "sourceDefinitionId": "ef69ef6e-aa7f-4af1-a01d-ef775033524e",
-  "name": "Github",
+  "name": "GitHub",
   "dockerRepository": "airbyte/source-github-singer",
   "dockerImageTag": "0.1.8",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-github-singer"

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -14,7 +14,7 @@
   dockerImageTag: 0.1.5
   documentationUrl: https://hub.docker.com/r/airbyte/source-google-adwords
 - sourceDefinitionId: ef69ef6e-aa7f-4af1-a01d-ef775033524e
-  name: Github
+  name: GitHub
   dockerRepository: airbyte/source-github-singer
   dockerImageTag: 0.1.8
   documentationUrl: https://hub.docker.com/r/airbyte/source-github-singer


### PR DESCRIPTION
closes #1766 