### PR TITLE
temporarily exclude connector docker builds from main build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -75,7 +75,7 @@ jobs:
         run: git status --porcelain && test -z "$(git status --porcelain)"
 
       - name: Build
-        run: ./gradlew --no-daemon build --scan
+        run: CORE_ONLY=true ./gradlew --no-daemon build --scan
 
       - name: Ensure no file change
         run: git status --porcelain && test -z "$(git status --porcelain)"


### PR DESCRIPTION
Temporary until we have something like https://github.com/airbytehq/airbyte/issues/2033