### PR TITLE
test behavior when mutliple files in resources have the same name

### DIFF
--- a/airbyte-commons/src/test/java/io/airbyte/commons/resources/MoreResourcesTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/resources/MoreResourcesTest.java
@@ -51,7 +51,7 @@ class MoreResourcesTest {
   @Test
   void testListResource() throws IOException {
     assertEquals(
-        Sets.newHashSet("subdir", "resource_test_sub", "resource_test_sub_2"),
+        Sets.newHashSet("subdir", "resource_test_sub", "resource_test_sub_2", "resource_test_a"),
         MoreResources.listResources(MoreResourcesTest.class, "subdir")
             .map(Path::getFileName)
             .map(Path::toString)

--- a/airbyte-commons/src/test/java/io/airbyte/commons/resources/MoreResourcesTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/resources/MoreResourcesTest.java
@@ -43,6 +43,12 @@ class MoreResourcesTest {
   }
 
   @Test
+  void testResourceReadDuplicateName() throws IOException {
+    assertEquals("content1\n", MoreResources.readResource("resource_test_a"));
+    assertEquals("content2\n", MoreResources.readResource("subdir/resource_test_a"));
+  }
+
+  @Test
   void testListResource() throws IOException {
     assertEquals(
         Sets.newHashSet("subdir", "resource_test_sub", "resource_test_sub_2"),

--- a/airbyte-commons/src/test/resources/resource_test_a
+++ b/airbyte-commons/src/test/resources/resource_test_a
@@ -1,0 +1,1 @@
+content1

--- a/airbyte-commons/src/test/resources/subdir/resource_test_a
+++ b/airbyte-commons/src/test/resources/subdir/resource_test_a
@@ -1,0 +1,1 @@
+content2


### PR DESCRIPTION
## What
* In the migration testing we had a couple files in the resources that have the same name. I did not know the behavior in the commons library in this case.

## How
* added a test to find out.
