### PR TITLE
Handle Version Metadata in Migration App

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/functional/Consumers.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/functional/Consumers.java
@@ -1,0 +1,47 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.commons.functional;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class Consumers {
+
+  /**
+   * Adds a function in front of a consumer. The return of the function will be consumed by the
+   * original consumer.
+   *
+   * @param beforeFunction function that will be execute on an item intended for a consumer.
+   * @param consumer the consumer that is being preempted.
+   * @param <T> type of the consumer.
+   * @return consumer that will run the function and then the original consumer on accept.
+   */
+  public static <T> Consumer<T> wrapConsumer(Function<T, T> beforeFunction, Consumer<T> consumer) {
+    return (json) -> {
+      consumer.accept(beforeFunction.apply(json));
+    };
+  }
+
+}

--- a/airbyte-commons/src/main/java/io/airbyte/commons/functional/ListConsumer.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/functional/ListConsumer.java
@@ -1,0 +1,55 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.commons.functional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Consumes elements and saves them into a list. This list can be accessed at anytime. Because this
+ * class stores everything it consumes in memory, it must be used carefully (the original use case
+ * is for testing interfaces that operate on consumers)
+ *
+ * @param <T> type of the consumed elements
+ */
+public class ListConsumer<T> implements Consumer<T> {
+
+  private final List<T> consumed;
+
+  public ListConsumer() {
+    this.consumed = new ArrayList<>();
+  }
+
+  @Override
+  public void accept(T t) {
+    consumed.add(t);
+  }
+
+  public List<T> getConsumed() {
+    return new ArrayList<>(consumed);
+  }
+
+}

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/Migrate.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/Migrate.java
@@ -43,7 +43,6 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.function.Consumer;
 import java.util.stream.BaseStream;
 import java.util.stream.Collectors;
@@ -121,10 +120,10 @@ public class Migrate {
     final Map<ResourceId, RecordConsumer> outputStreams = createOutputStreams(migration, tmpOutputDir);
     // make the java compiler happy (it can't resolve that RecordConsumer is, in fact, a
     // Consumer<JsonNode>).
-    final Map<ResourceId, Consumer<JsonNode>> outputDataWithGenericType = mapRecordConsumerToConsumer(outputStreams);
+    final Map<ResourceId, Consumer<JsonNode>> outputDataWithGenericType = MigrationUtils.mapRecordConsumerToConsumer(outputStreams);
 
     // do the migration.
-    migration.migrate(inputData, outputDataWithGenericType);
+    new MigrateWithMetadata(migration).migrate(inputData, outputDataWithGenericType);
 
     // clean up.
     inputData.values().forEach(BaseStream::close);
@@ -186,12 +185,6 @@ public class Migrate {
     }
 
     return pathToOutputStream;
-  }
-
-  private static Map<ResourceId, Consumer<JsonNode>> mapRecordConsumerToConsumer(Map<ResourceId, RecordConsumer> recordConsumers) {
-    return recordConsumers.entrySet()
-        .stream()
-        .collect(Collectors.toMap(Entry::getKey, e -> (v) -> e.getValue().accept(v)));
   }
 
   private static String getCurrentVersion(Path path) {

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/MigrateWithMetadata.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/MigrateWithMetadata.java
@@ -1,0 +1,87 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.migrate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.airbyte.commons.functional.Consumers;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * Additionally there are some migration metadata fields that are important to fill in on each
+ * migration. Instead of leaving this up to the person writing the migration, this class handles it
+ * for them. It writes a record saying when the migration happens. It also updates the version in
+ * the AIRBYTE_METADATA table.
+ */
+public class MigrateWithMetadata {
+
+  private final Migration migration;
+
+  public MigrateWithMetadata(Migration migration) {
+    this.migration = migration;
+  }
+
+  public void migrate(Map<ResourceId, Stream<JsonNode>> inputData, Map<ResourceId, Consumer<JsonNode>> outputData) {
+    final String version = migration.getVersion();
+    final Map<ResourceId, Consumer<JsonNode>> decoratedOutputData = decorateAirbyteMetadataConsumerWithVersionBump(outputData, version);
+    migration.migrate(inputData, decoratedOutputData);
+
+    MigrationUtils.registerMigrationRecord(outputData, MigrationConstants.AIRBYTE_METADATA, version);
+  }
+
+  /**
+   * We inject a mapper in front of the original metadata consumer. This mapper, when it finds the
+   * airbyte version record, bumps it to the correct version.
+   *
+   * @param consumerMap Map of resource ids to output consumer.
+   * @return Map of resource ids to output consumer. The AirbyteMetadata consumer will be altered to
+   *         bump the version.
+   */
+  private static Map<ResourceId, Consumer<JsonNode>> decorateAirbyteMetadataConsumerWithVersionBump(Map<ResourceId, Consumer<JsonNode>> consumerMap,
+                                                                                                    String version) {
+    final HashMap<ResourceId, Consumer<JsonNode>> resourceIdConsumerHashMap = new HashMap<>(consumerMap);
+    final ResourceId metadataResourceId = ResourceId.fromConstantCase(ResourceType.JOB, MigrationConstants.AIRBYTE_METADATA);
+
+    resourceIdConsumerHashMap.put(metadataResourceId, Consumers.wrapConsumer(
+        (json) -> {
+          bumpVersionOnAirbyteMetadata(json, version);
+          return json;
+        },
+        resourceIdConsumerHashMap.get(metadataResourceId)));
+
+    return resourceIdConsumerHashMap;
+  }
+
+  // warning: mutates in place.
+  private static void bumpVersionOnAirbyteMetadata(JsonNode input, String version) {
+    if (input.get("key").asText().equals("airbyte_version")) {
+      ((ObjectNode) input).put("value", version);
+    }
+  }
+
+}

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/MigrationConstants.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/MigrationConstants.java
@@ -1,0 +1,31 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.migrate;
+
+public class MigrationConstants {
+
+  public static final String AIRBYTE_METADATA = "AIRBYTE_METADATA";
+
+}

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/MigrationUtils.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/MigrationUtils.java
@@ -35,8 +35,10 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 
 public class MigrationUtils {
@@ -97,6 +99,12 @@ public class MigrationUtils {
 
   public static String current_timestamp() {
     return ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+  }
+
+  public static Map<ResourceId, Consumer<JsonNode>> mapRecordConsumerToConsumer(Map<ResourceId, ? extends Consumer<JsonNode>> recordConsumers) {
+    return recordConsumers.entrySet()
+        .stream()
+        .collect(Collectors.toMap(Entry::getKey, e -> (v) -> e.getValue().accept(v)));
   }
 
 }

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_14_0.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_14_0.java
@@ -76,7 +76,6 @@ public class MigrationV0_14_0 implements Migration {
       final Consumer<JsonNode> recordConsumer = outputData.get(entry.getKey());
       entry.getValue().forEach(recordConsumer);
     }
-    MigrationUtils.registerMigrationRecord(outputData, JobKeys.AIRBYTE_METADATA.toString(), getVersion());
   }
 
   public enum ConfigKeys {

--- a/airbyte-migration/src/test/java/io/airbyte/migrate/MigrateWithMetadataTest.java
+++ b/airbyte-migration/src/test/java/io/airbyte/migrate/MigrateWithMetadataTest.java
@@ -1,0 +1,109 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.migrate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.functional.ListConsumer;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.migrate.migrations.NoOpMigration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class MigrateWithMetadataTest {
+
+  private static final String VERSION = "v10";
+
+  private static final UUID UUID1 = UUID.randomUUID();
+  private static final UUID UUID2 = UUID.randomUUID();
+  private static final JsonNode STANDARD_SOURCE_DEFINITION1 = Jsons.jsonNode(ImmutableMap.builder()
+      .put("sourceDefinitionId", UUID1)
+      .put("name", "gold")
+      .put("dockerRepository", "fort knox")
+      .put("dockerImageTag", "latest")
+      .put("documentationUrl", "airbyte.io")
+      .build());
+  private static final JsonNode STANDARD_SOURCE_DEFINITION2 = Jsons.jsonNode(ImmutableMap.builder()
+      .put("sourceDefinitionId", UUID2)
+      .put("name", "clones")
+      .put("dockerRepository", "bank of karabraxos")
+      .put("dockerImageTag", "v1.2.0")
+      .put("documentationUrl", "airbyte.io")
+      .build());
+  private static final JsonNode AIRBYTE_METADATA_SERVER_ID = Jsons.jsonNode(ImmutableMap.of("key", "server_uuid", "value", UUID1));
+  private static final JsonNode AIRBYTE_METADATA_VERSION = Jsons.jsonNode(ImmutableMap.of("key", "airbyte_version", "value", "v9"));
+
+  private static final ResourceId SOURCE_DEFINITION_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_SOURCE_DEFINITION");
+  private static final ResourceId AIRBYTE_METADATA_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.JOB, "AIRBYTE_METADATA");
+  private static final Map<ResourceId, List<JsonNode>> INPUT_RECORDS = ImmutableMap
+      .<ResourceId, List<JsonNode>>builder()
+      .put(SOURCE_DEFINITION_RESOURCE_ID, ImmutableList.of(STANDARD_SOURCE_DEFINITION1, STANDARD_SOURCE_DEFINITION2))
+      .put(AIRBYTE_METADATA_RESOURCE_ID, ImmutableList.of(AIRBYTE_METADATA_SERVER_ID, AIRBYTE_METADATA_VERSION))
+      .build();
+
+  @Test
+  void test() {
+    final Migration migration = new NoOpMigration(mock(Migration.class), VERSION);
+
+    final MigrateWithMetadata migrateWithMetadata = new MigrateWithMetadata(migration);
+
+    final Map<ResourceId, ListConsumer<JsonNode>> outputConsumer = MigrationTestUtils.createOutputConsumer(INPUT_RECORDS.keySet());
+    migrateWithMetadata.migrate(MigrationTestUtils.convertListsToValues(INPUT_RECORDS), MigrationUtils.mapRecordConsumerToConsumer(outputConsumer));
+    final Map<ResourceId, List<JsonNode>> outputAsList = MigrationTestUtils.collectConsumersToList(outputConsumer);
+
+    // clone the records
+    assertOutput(INPUT_RECORDS, outputAsList);
+  }
+
+  private void assertOutput(Map<ResourceId, List<JsonNode>> expectedRecords, Map<ResourceId, List<JsonNode>> actualRecords) {
+    // we inject records with timestamp to migrate version changes. filter it out here so that we can
+    // test everything else.
+    final Map<Boolean, List<JsonNode>> partitionedRecords = actualRecords.get(AIRBYTE_METADATA_RESOURCE_ID)
+        .stream()
+        .collect(Collectors.partitioningBy(r -> r.get("key").asText().contains("migrate_to")));
+    final List<JsonNode> migrateRecords = partitionedRecords.get(true);
+    final List<JsonNode> otherRecords = partitionedRecords.get(false);
+
+    final HashMap<ResourceId, List<JsonNode>> actualRecordsCleaned = new HashMap<>(actualRecords);
+    actualRecordsCleaned.put(AIRBYTE_METADATA_RESOURCE_ID, otherRecords);
+
+    final HashMap<ResourceId, List<JsonNode>> cleanedExpectedRecords = new HashMap<>(expectedRecords);
+    ((ObjectNode) cleanedExpectedRecords.get(AIRBYTE_METADATA_RESOURCE_ID).get(1)).put("value", VERSION);
+    assertEquals(cleanedExpectedRecords, actualRecordsCleaned);
+
+    assertEquals(1, migrateRecords.size());
+    assertEquals(VERSION, migrateRecords.get(0).get("value").asText());
+  }
+
+}

--- a/airbyte-migration/src/test/java/io/airbyte/migrate/MigrationIntegrationTest.java
+++ b/airbyte-migration/src/test/java/io/airbyte/migrate/MigrationIntegrationTest.java
@@ -382,7 +382,6 @@ class MigrationIntegrationTest {
         final Consumer<JsonNode> recordConsumer = outputData.get(entry.getKey());
         entry.getValue().forEach(recordConsumer);
       }
-      MigrationUtils.registerMigrationRecord(outputData, "AIRBYTE_METADATA", version);
     }
 
   }

--- a/airbyte-migration/src/test/java/io/airbyte/migrate/MigrationTestUtils.java
+++ b/airbyte-migration/src/test/java/io/airbyte/migrate/MigrationTestUtils.java
@@ -1,0 +1,68 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.migrate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.commons.functional.ListConsumer;
+import io.airbyte.commons.json.Jsons;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class MigrationTestUtils {
+
+  public static Map<ResourceId, Stream<JsonNode>> convertListsToValues(Map<ResourceId, List<JsonNode>> map) {
+    return map.entrySet()
+        .stream()
+        .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().stream().map(Jsons::clone)));
+  }
+
+  public static Map<ResourceId, ListConsumer<JsonNode>> createOutputConsumer(Set<ResourceId> resourceIds) {
+    return resourceIds.stream().collect(Collectors.toMap(v -> v, v -> new ListConsumer<>()));
+  }
+
+  public static Map<ResourceId, List<JsonNode>> createExpectedOutput(Set<ResourceId> resourceIds, Map<ResourceId, List<JsonNode>> overrides) {
+    return resourceIds.stream().collect(Collectors.toMap(v -> v, v -> {
+      if (overrides.containsKey(v)) {
+        return overrides.get(v);
+      } else {
+        return new ArrayList<>();
+      }
+    }));
+  }
+
+  public static Map<ResourceId, List<JsonNode>> collectConsumersToList(Map<ResourceId, ListConsumer<JsonNode>> input) {
+    return input.entrySet()
+        .stream()
+        .collect(Collectors.toMap(
+            Entry::getKey,
+            e -> e.getValue().getConsumed()));
+  }
+
+}

--- a/airbyte-migration/src/test/java/io/airbyte/migrate/MigrationV0_14_1.java
+++ b/airbyte-migration/src/test/java/io/airbyte/migrate/MigrationV0_14_1.java
@@ -92,7 +92,6 @@ public class MigrationV0_14_1 implements Migration {
         recordConsumer.accept(r);
       });
     }
-    MigrationUtils.registerMigrationRecord(outputData, JobKeys.AIRBYTE_METADATA.toString(), getVersion());
   }
 
 }


### PR DESCRIPTION
## What
* Some of the Version metadata came together after most of the original migration app was written. It got kinda shoehorned in after. This PR tries to clear this up. 

## How
Instead of haphazardly relying on individual migrations to remember to update the Version metadata, the app itself handles it by wrapping each migration in the appropriate logic. This gives us better guarantees that this metadata is handled correctly. Also allows us to test it very clearly.

## Pre-merge Checklist
- [ ] *messed up a bit splitting up these PRs this won't build until some of the no op stuff is merged because it is used in one of the tests. will be mindful of this when i merge.*


## Recommended reading order
1. `Migrate.java`
1. `MigrateWithMetadata.java`
1. the rest
