### PR TITLE
NoOpMigration (and migration v0.15.0)

### DIFF
--- a/airbyte-migration/src/main/java/io/airbyte/migrate/Migrations.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/Migrations.java
@@ -34,8 +34,9 @@ public class Migrations {
 
   private static final MigrationV0_14_0 MIGRATION_V_0_14_0 = new MigrationV0_14_0();
   private static final MigrationV0_14_3 MIGRATION_V_0_14_3 = new MigrationV0_14_3(MIGRATION_V_0_14_0);
+  private static final Migration MIGRATION_V_0_15_0 = new NoOpMigration(MIGRATION_V_0_14_3, "0.15.0-alpha");
 
   // all migrations must be added to the list in the order that they should be applied.
-  public static final List<Migration> MIGRATIONS = ImmutableList.of(MIGRATION_V_0_14_0, MIGRATION_V_0_14_3);
+  public static final List<Migration> MIGRATIONS = ImmutableList.of(MIGRATION_V_0_14_0, MIGRATION_V_0_14_3, MIGRATION_V_0_15_0);
 
 }

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/Migrations.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/Migrations.java
@@ -37,6 +37,10 @@ public class Migrations {
   private static final Migration MIGRATION_V_0_15_0 = new NoOpMigration(MIGRATION_V_0_14_3, "0.15.0-alpha");
 
   // all migrations must be added to the list in the order that they should be applied.
-  public static final List<Migration> MIGRATIONS = ImmutableList.of(MIGRATION_V_0_14_0, MIGRATION_V_0_14_3, MIGRATION_V_0_15_0);
+  public static final List<Migration> MIGRATIONS = ImmutableList.of(
+      MIGRATION_V_0_14_0,
+      MIGRATION_V_0_14_3,
+      MIGRATION_V_0_15_0
+  );
 
 }

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/Migrations.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/Migrations.java
@@ -40,7 +40,6 @@ public class Migrations {
   public static final List<Migration> MIGRATIONS = ImmutableList.of(
       MIGRATION_V_0_14_0,
       MIGRATION_V_0_14_3,
-      MIGRATION_V_0_15_0
-  );
+      MIGRATION_V_0_15_0);
 
 }

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/NoOpMigration.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/NoOpMigration.java
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.migrate.migrations;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.migrate.Migration;
+import io.airbyte.migrate.ResourceId;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * Placeholder migration for when the minor version changes but there were no schema changes for the
+ * underlying data. In this scenario we just need to bump the versions in the data and move on.
+ */
+public class NoOpMigration extends BaseMigration implements Migration {
+
+  private final String version;
+  private final Migration previousMigration;
+
+  public NoOpMigration(Migration previousMigration, String version) {
+    super(previousMigration);
+    this.previousMigration = previousMigration;
+    this.version = version;
+  }
+
+  @Override
+  public String getVersion() {
+    return version;
+  }
+
+  @Override
+  public Map<ResourceId, JsonNode> getOutputSchema() {
+    return previousMigration.getOutputSchema();
+  }
+
+  @Override
+  public void migrate(Map<ResourceId, Stream<JsonNode>> inputData, Map<ResourceId, Consumer<JsonNode>> outputData) {
+    for (Map.Entry<ResourceId, Stream<JsonNode>> entry : inputData.entrySet()) {
+      final Consumer<JsonNode> recordConsumer = outputData.get(entry.getKey());
+      entry.getValue().forEach(recordConsumer);
+    }
+  }
+
+}

--- a/airbyte-migration/src/test/java/io/airbyte/migrate/MigrationV0_14_1.java
+++ b/airbyte-migration/src/test/java/io/airbyte/migrate/MigrationV0_14_1.java
@@ -30,7 +30,6 @@ import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.yaml.Yamls;
 import io.airbyte.migrate.migrations.MigrationV0_14_0;
-import io.airbyte.migrate.migrations.MigrationV0_14_0.JobKeys;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;

--- a/airbyte-migration/src/test/java/io/airbyte/migrate/migrations/NoOpMigrationTest.java
+++ b/airbyte-migration/src/test/java/io/airbyte/migrate/migrations/NoOpMigrationTest.java
@@ -1,0 +1,78 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.migrate.migrations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.functional.ListConsumer;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.migrate.Migration;
+import io.airbyte.migrate.MigrationTestUtils;
+import io.airbyte.migrate.MigrationUtils;
+import io.airbyte.migrate.ResourceId;
+import io.airbyte.migrate.ResourceType;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class NoOpMigrationTest {
+
+  private static final String VERSION = "v9";
+  private static final ResourceId SYNC_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_SYNC");
+
+  @Test
+  void testMigration() throws IOException {
+    final JsonNode schema = Jsons.deserialize(MoreResources.readResource("migrations/migrationV0_14_3/example_input_schema.json"));
+    final JsonNode sync = Jsons.jsonNode(ImmutableMap.<String, Object>builder()
+        .put("sourceId", UUID.randomUUID().toString())
+        .put("destinationId", UUID.randomUUID().toString())
+        .put("connectionId", UUID.randomUUID().toString())
+        .put("name", "users_sync")
+        .put("status", "active")
+        .put("schema", schema)
+        .build());
+
+    final Map<ResourceId, Stream<JsonNode>> records = ImmutableMap.of(SYNC_RESOURCE_ID, Stream.of(sync));
+
+    final Migration migration = new NoOpMigration(new MigrationV0_14_0(), VERSION);
+    final Map<ResourceId, ListConsumer<JsonNode>> outputConsumer = MigrationTestUtils.createOutputConsumer(migration.getOutputSchema().keySet());
+    migration.migrate(records, MigrationUtils.mapRecordConsumerToConsumer(outputConsumer));
+
+    final Map<ResourceId, List<JsonNode>> expectedOutputOverrides = ImmutableMap.of(SYNC_RESOURCE_ID, ImmutableList.of(sync));
+    final Map<ResourceId, List<JsonNode>> expectedOutput =
+        MigrationTestUtils.createExpectedOutput(migration.getOutputSchema().keySet(), expectedOutputOverrides);
+
+    final Map<ResourceId, List<JsonNode>> outputAsList = MigrationTestUtils.collectConsumersToList(outputConsumer);
+    assertEquals(expectedOutput, outputAsList);
+  }
+
+}


### PR DESCRIPTION
## What
* Transitioning from 0.14.3 => 0.15.0 is a no op migration. This PR creates a NoOpMigration to make it safe and easy to handle the cases when a minor version does not include any schema changes.
* After everything is merged we will bump to version 0.15.0 and if anyone has problems ask them to upgrade to that. that should force all installs of airbyte into a good state regardless of when people upgraded. Until then, people could see weird behavior if they created data in versions 0.14.0-0.14.2 and then upgraded to 0.14.3 but < 0.15.0. 
