### PR TITLE
Source Appstore: implement probing check connection

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2af123bf-0aaf-4e0d-9784-cb497f23741a.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2af123bf-0aaf-4e0d-9784-cb497f23741a.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "2af123bf-0aaf-4e0d-9784-cb497f23741a",
   "name": "Appstore",
   "dockerRepository": "airbyte/source-appstore-singer",
-  "dockerImageTag": "0.1.2",
+  "dockerImageTag": "0.1.3",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-appstore"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -171,5 +171,5 @@
 - sourceDefinitionId: 2af123bf-0aaf-4e0d-9784-cb497f23741a
   name: Appstore
   dockerRepository: airbyte/source-appstore-singer
-  dockerImageTag: 0.1.2
+  dockerImageTag: 0.1.3
   documentationUrl: https://hub.docker.com/r/airbyte/source-appstore

--- a/airbyte-integrations/connectors/source-appstore-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-appstore-singer/Dockerfile
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install ".[main]"
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/source-appstore-singer

--- a/airbyte-integrations/connectors/source-appstore-singer/setup.py
+++ b/airbyte-integrations/connectors/source-appstore-singer/setup.py
@@ -32,10 +32,10 @@ setup(
     packages=find_packages(),
     install_requires=[
         "airbyte-protocol",
-        "appstoreconnect",
+        "appstoreconnect==0.9.0",
         "base-singer",
         "base-python",
-        "pyjwt==1.7.1",
+        "pyjwt==1.6.4", # required by appstore connect
         "tap-appstore @ https://github.com/airbytehq/tap-appstore/tarball/sherif/probe-discover"
     ],
     package_data={"": ["*.json"]},

--- a/airbyte-integrations/connectors/source-appstore-singer/setup.py
+++ b/airbyte-integrations/connectors/source-appstore-singer/setup.py
@@ -30,15 +30,18 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=["airbyte-protocol", "appstoreconnect", "pyjwt==1.7.1", "tap-appstore @ git+https://github.com/miroapp/tap-appstore"],
+    install_requires=[
+        "airbyte-protocol",
+        "appstoreconnect",
+        "base-singer",
+        "base-python",
+        "pyjwt==1.7.1",
+        "tap-appstore @ https://github.com/airbytehq/tap-appstore/tarball/sherif/probe-discover"
+    ],
     package_data={"": ["*.json"]},
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     extras_require={
-        # Dependencies required by the main package but not tests should go in main. Deps required by
-        # integration tests but not the main package go in tests. Deps required by both should go in
-        # install_requires.
-        "main": ["base-singer", "base-python"],
         "tests": ["airbyte-python-test", "pytest"],
     },
 )

--- a/airbyte-integrations/connectors/source-appstore-singer/setup.py
+++ b/airbyte-integrations/connectors/source-appstore-singer/setup.py
@@ -36,7 +36,7 @@ setup(
         "base-singer",
         "base-python",
         "pyjwt==1.6.4",  # required by appstore connect
-        "tap-appstore @ https://github.com/airbytehq/tap-appstore/tarball/sherif/probe-discover",
+        "tap-appstore @ https://github.com/airbytehq/tap-appstore/tarball/master",
     ],
     package_data={"": ["*.json"]},
     setup_requires=["pytest-runner"],

--- a/airbyte-integrations/connectors/source-appstore-singer/setup.py
+++ b/airbyte-integrations/connectors/source-appstore-singer/setup.py
@@ -35,8 +35,8 @@ setup(
         "appstoreconnect==0.9.0",
         "base-singer",
         "base-python",
-        "pyjwt==1.6.4", # required by appstore connect
-        "tap-appstore @ https://github.com/airbytehq/tap-appstore/tarball/sherif/probe-discover"
+        "pyjwt==1.6.4",  # required by appstore connect
+        "tap-appstore @ https://github.com/airbytehq/tap-appstore/tarball/sherif/probe-discover",
     ],
     package_data={"": ["*.json"]},
     setup_requires=["pytest-runner"],

--- a/airbyte-integrations/connectors/source-appstore-singer/source_appstore_singer/source.py
+++ b/airbyte-integrations/connectors/source-appstore-singer/source_appstore_singer/source.py
@@ -64,7 +64,7 @@ class SourceAppstoreSinger(SingerSource):
 
             api = Api(config["key_id"], config["key_file"], config["issuer_id"])
             stream_to_error = {}
-            for stream, params in api_fields_to_test:
+            for stream, params in api_fields_to_test.items():
                 test_date = date.today() - timedelta(days=2)
                 report_filters = {"reportDate": test_date.strftime("%Y-%m-%d"), "vendorNumber": f"{config['vendor']}"}
                 report_filters.update(api_fields_to_test[stream])

--- a/airbyte-integrations/connectors/source-appstore-singer/source_appstore_singer/source.py
+++ b/airbyte-integrations/connectors/source-appstore-singer/source_appstore_singer/source.py
@@ -36,8 +36,6 @@ from base_singer import SingerSource, Status, SyncMode, SyncModeInfo
 class SourceAppstoreSinger(SingerSource):
     TAP_CMD = "tap-appstore"
 
-    def _probe_report(self, api: Api):
-
     def check_config(self, logger: AirbyteLogger, config_path: str, config: json) -> AirbyteConnectionStatus:
         """
         Tests if the input configuration can be used to successfully connect to the integration

--- a/airbyte-integrations/connectors/source-appstore-singer/source_appstore_singer/source.py
+++ b/airbyte-integrations/connectors/source-appstore-singer/source_appstore_singer/source.py
@@ -28,7 +28,6 @@ from typing import Dict
 
 from airbyte_protocol import AirbyteConnectionStatus
 from appstoreconnect import Api
-from appstoreconnect.api import APIError
 from base_python import AirbyteLogger
 from base_singer import SingerSource, Status, SyncMode, SyncModeInfo
 
@@ -56,10 +55,15 @@ class SourceAppstoreSinger(SingerSource):
             # the account not supporting this kind of report. So to "check connection" we see if any of the reports can be pulled and if so
             # return success. If no reports can be pulled we display the exception messages generated for all reports and return failure.
             api_fields_to_test = {
-                'subscription_event_report': {'reportType': 'SUBSCRIPTION_EVENT', 'frequency': 'DAILY', 'reportSubType': 'SUMMARY', 'version': '1_2'},
-                'subscriber_report': {'reportType': 'SUBSCRIBER', 'frequency': 'DAILY', 'reportSubType': 'DETAILED', 'version': '1_2'},
-                'subscription_report': {'reportType': 'SUBSCRIPTION', 'frequency': 'DAILY', 'reportSubType': 'SUMMARY', 'version': '1_2'},
-                'sales_report': {'reportType': 'SALES', 'frequency': 'DAILY', 'reportSubType': 'SUMMARY', 'version': '1_0'}
+                "subscription_event_report": {
+                    "reportType": "SUBSCRIPTION_EVENT",
+                    "frequency": "DAILY",
+                    "reportSubType": "SUMMARY",
+                    "version": "1_2",
+                },
+                "subscriber_report": {"reportType": "SUBSCRIBER", "frequency": "DAILY", "reportSubType": "DETAILED", "version": "1_2"},
+                "subscription_report": {"reportType": "SUBSCRIPTION", "frequency": "DAILY", "reportSubType": "SUMMARY", "version": "1_2"},
+                "sales_report": {"reportType": "SALES", "frequency": "DAILY", "reportSubType": "SUMMARY", "version": "1_0"},
             }
 
             api = Api(config["key_id"], config["key_file"], config["issuer_id"])

--- a/airbyte-integrations/connectors/source-appstore-singer/source_appstore_singer/source.py
+++ b/airbyte-integrations/connectors/source-appstore-singer/source_appstore_singer/source.py
@@ -28,12 +28,15 @@ from typing import Dict
 
 from airbyte_protocol import AirbyteConnectionStatus
 from appstoreconnect import Api
+from appstoreconnect.api import APIError
 from base_python import AirbyteLogger
 from base_singer import SingerSource, Status, SyncMode, SyncModeInfo
 
 
 class SourceAppstoreSinger(SingerSource):
     TAP_CMD = "tap-appstore"
+
+    def _probe_report(self, api: Api):
 
     def check_config(self, logger: AirbyteLogger, config_path: str, config: json) -> AirbyteConnectionStatus:
         """
@@ -49,25 +52,36 @@ class SourceAppstoreSinger(SingerSource):
         :return: AirbyteConnectionStatus indicating a Success or Failure
         """
         try:
-            # create request fields for testing
+            # If an app on the appstore does not support subscriptions or sales, it cannot pull the relevant reports.
+            # However, the way the Appstore API expresses this is not via clear error messages. Instead it expresses it by throwing an unrelated
+            # error, in this case "invalid vendor ID". There is no way to distinguish if this error is due to invalid credentials or due to
+            # the account not supporting this kind of report. So to "check connection" we see if any of the reports can be pulled and if so
+            # return success. If no reports can be pulled we display the exception messages generated for all reports and return failure.
             api_fields_to_test = {
-                "subscription_report": {"reportType": "SUBSCRIPTION", "frequency": "DAILY", "reportSubType": "SUMMARY", "version": "1_2"}
+                'subscription_event_report': {'reportType': 'SUBSCRIPTION_EVENT', 'frequency': 'DAILY', 'reportSubType': 'SUMMARY', 'version': '1_2'},
+                'subscriber_report': {'reportType': 'SUBSCRIBER', 'frequency': 'DAILY', 'reportSubType': 'DETAILED', 'version': '1_2'},
+                'subscription_report': {'reportType': 'SUBSCRIPTION', 'frequency': 'DAILY', 'reportSubType': 'SUMMARY', 'version': '1_2'},
+                'sales_report': {'reportType': 'SALES', 'frequency': 'DAILY', 'reportSubType': 'SUMMARY', 'version': '1_0'}
             }
-            test_date = date.today() - timedelta(days=2)
-            report_filters = {"reportDate": test_date.strftime("%Y-%m-%d"), "vendorNumber": "{}".format(config["vendor"])}
 
-            report_filters.update(api_fields_to_test["subscription_report"])
-
-            # fetch data from appstore api
             api = Api(config["key_id"], config["key_file"], config["issuer_id"])
+            stream_to_error = {}
+            for stream, params in api_fields_to_test:
+                test_date = date.today() - timedelta(days=2)
+                report_filters = {"reportDate": test_date.strftime("%Y-%m-%d"), "vendorNumber": f"{config['vendor']}"}
+                report_filters.update(api_fields_to_test[stream])
+                try:
+                    rep_tsv = api.download_sales_and_trends_reports(filters=report_filters)
+                    if isinstance(rep_tsv, dict):
+                        raise Exception(f"An exception occurred: Received a JSON response instead of" f" the report: {str(rep_tsv)}")
+                except Exception as e:
+                    logger.warn(f"Unable to download {stream}: {e}")
+                    stream_to_error[stream] = e
 
-            rep_tsv = api.download_sales_and_trends_reports(filters=report_filters)
-
-            if isinstance(rep_tsv, dict):
-                return AirbyteConnectionStatus(
-                    status=Status.FAILED,
-                    message=f"An exception occurred: Received a JSON response instead of" f" the report: {str(rep_tsv)}",
-                )
+            # All streams have failed
+            if len(stream_to_error.keys()) == api_fields_to_test.keys():
+                message = "\n".join([f"Unable to access {stream} due to error: {e}" for stream, e in stream_to_error])
+                return AirbyteConnectionStatus(status=Status.FAILED, message=message)
 
             return AirbyteConnectionStatus(status=Status.SUCCEEDED)
         except Exception as e:

--- a/docs/integrations/sources/appstore.md
+++ b/docs/integrations/sources/appstore.md
@@ -2,14 +2,7 @@
 
 ## Sync overview
 
-This source can sync data for the [Appstore API](https://developer.apple.com/documentation/appstoreconnectapi). It supports only Incremental syncs. The Applestore API is available for [many types of services](https://developer.apple.com/documentation/appstoreconnectapi), however this integration focuses only on the 'Reporting' service, from where data is extracted from.
-
-Under the 'Reporting' Service, Appstore API has four different categories of Endpoints available.
-
-1. Sales and Trends =&gt; [API docs](https://developer.apple.com/documentation/appstoreconnectapi/download_sales_and_trends_reports); ["UI docs"](https://help.apple.com/app-store-connect/#/dev061699fdb) 
-2. Finance Reports =&gt; [API docs](https://developer.apple.com/documentation/appstoreconnectapi/download_finance_reports); ["UI docs"](https://help.apple.com/app-store-connect/#/dev716cf3a0d) 
-3. Get Power and Performance Metrics for an App =&gt; [API docs](https://developer.apple.com/documentation/appstoreconnectapi/get_power_and_performance_metrics_for_an_app); 
-4. Get Power and Performance Metrics for a Build =&gt; [API docs](https://developer.apple.com/documentation/appstoreconnectapi/get_power_and_performance_metrics_for_a_build);
+This source can sync data for the [Appstore API](https://developer.apple.com/documentation/appstoreconnectapi). It supports only Incremental syncs. The Appstore API is available for [many types of services](https://developer.apple.com/documentation/appstoreconnectapi). Currently, this API supports syncing Sales and Trends reports. If you'd like to sync data from other endpoints, please create an issue on Github. 
 
 This Source Connector is based on a [Singer Tap](https://github.com/miroapp/tap-appstore).
 
@@ -21,6 +14,8 @@ This Source is capable of syncing the following "Sales and Trends" Streams:
 * [SUBSCRIPTION](https://help.apple.com/app-store-connect/#/itc5dcdf6693)
 * [SUBSCRIPTION\_EVENT](https://help.apple.com/app-store-connect/#/itc0b9b9d5b2)
 * [SUBSCRIBER](https://help.apple.com/app-store-connect/#/itcf20f3392e)
+
+Note that depending on the credentials you enter, you may only be able to sync some of these reports. For example, if your app does not offer subscriptions, then it is not possible to sync subscription related reports. 
 
 ### Data type mapping
 


### PR DESCRIPTION
## What
Closes #2162 
uses changes from https://github.com/airbytehq/tap-appstore/pull/1

## How
If an app on the appstore does not support subscriptions or sales, it cannot pull the relevant reports. However, the way the Appstore API expresses this is not via clear error messages. Instead it expresses it by throwing an unrelated error, in this case "invalid vendor ID". There is no way to distinguish if this error is due to invalid credentials or due to the account not supporting this kind of report. So to "check connection" we see if any of the reports can be pulled and if so return success. If no reports can be pulled we display the exception messages generated for all reports and return failure.

I have run tests manually using credentials shared from a user. We don't have an appstore connector yet (blocked on #2155 ) so we have to run manual testing. 

## Pre-merge Checklist
- [ ] *Publish Docker images*

