### PR TITLE
add connector version to bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -25,7 +25,7 @@ Very low / Low / Medium / High / Critical
 Found in the .env file in the root of the project.
 
 ## Connector Version (if applicable)
-Found in the admin page in the UI in the respective Source and Destination tab.
+Found in the admin page in the UI in the respective Source or Destination tab.
 
 ## Additional context
 *Environment, version, integration...*

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -24,5 +24,8 @@ Very low / Low / Medium / High / Critical
 ## Airbyte Version
 Found in the .env file in the root of the project.
 
+## Connector Version (if applicable)
+Found in the admin page in the UI in the respective Source and Destination tab.
+
 ## Additional context
 *Environment, version, integration...*


### PR DESCRIPTION
## What
We keep investigating the same bugs over and over again because users are using older versions of airbyte or connectors. This PR adds a connector version field to the bug report template. The hope here is that we can catch this bad pattern faster by looking at the version of the connector that the user is using versus the newest one.

## Future
Adding the information on what the newest version of a connector is in the UI will help with this too because it means users might try upgrading their connector if they see theirs it out of date before reporting a bug. [issue](https://github.com/airbytehq/airbyte/issues/1983)