### PR TITLE
Step 2: Add Namespace to Airbyte Protocol

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1738,6 +1738,9 @@ components:
       properties:
         name:
           type: string
+          description: Stream's name (deprecated, will be replaced by stream_name).
+        streamName:
+          $ref: "#/components/schemas/AirbyteStreamName"
           description: Stream's name.
         jsonSchema:
           description: Stream schema using Json Schema specs.
@@ -1754,6 +1757,18 @@ components:
           type: array
           items:
             type: string
+    AirbyteStreamName:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        namespace:
+          type: string
+          description: Stream's namespace.
+        name:
+          type: string
+          description: Stream's name.
     StreamJsonSchema:
       type: object
     AirbyteStreamConfiguration:

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1738,7 +1738,7 @@ components:
       properties:
         name:
           type: string
-          description: Stream's name (deprecated, will be replaced by stream_name).
+          description: Stream's name (deprecated, will be replaced by streamName).
         streamName:
           $ref: "#/components/schemas/AirbyteStreamName"
           description: Stream's name.

--- a/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
+++ b/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
@@ -79,6 +79,11 @@ class AirbyteConnectionStatus(BaseModel):
     message: Optional[str] = None
 
 
+class AirbyteStreamName(BaseModel):
+    namespace: Optional[str] = Field(None, description="Stream's namespace.")
+    name: str = Field(..., description="Stream's name.")
+
+
 class SyncMode(Enum):
     full_refresh = "full_refresh"
     incremental = "incremental"
@@ -95,7 +100,8 @@ class ConnectorSpecification(BaseModel):
 
 
 class AirbyteStream(BaseModel):
-    name: str = Field(..., description="Stream's name.")
+    name: str = Field(..., description="Stream's name (deprecated, will be replaced by stream_name).")
+    stream_name: Optional[AirbyteStreamName] = Field(None, description="Stream's name.")
     json_schema: Dict[str, Any] = Field(..., description="Stream schema using Json Schema specs.")
     supported_sync_modes: Optional[List[SyncMode]] = None
     source_defined_cursor: Optional[bool] = Field(

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunnerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunnerTest.java
@@ -34,7 +34,6 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.util.AutoCloseableIterators;
@@ -45,7 +44,6 @@ import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
-import io.airbyte.protocol.models.AirbyteStream;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConnectorSpecification;
@@ -72,10 +70,12 @@ class IntegrationRunnerTest {
   private static final String CONFIG_STRING = "{ \"username\": \"airbyte\" }";
   private static final JsonNode CONFIG = Jsons.deserialize(CONFIG_STRING);
   private static final String STREAM_NAME = "users";
+  private static final String STREAM_NAMESPACE = "tests";
   private static final Long EMITTED_AT = Instant.now().toEpochMilli();
   private static final Path TEST_ROOT = Path.of("/tmp/airbyte_tests");
 
-  private static final AirbyteCatalog CATALOG = new AirbyteCatalog().withStreams(Lists.newArrayList(new AirbyteStream().withName(STREAM_NAME)));
+  private static final AirbyteCatalog CATALOG = CatalogHelpers.createAirbyteCatalog(
+      CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME));
   private static final ConfiguredAirbyteCatalog CONFIGURED_CATALOG = CatalogHelpers.toDefaultConfiguredCatalog(CATALOG);
   private static final JsonNode STATE = Jsons.jsonNode(ImmutableMap.of("checkpoint", "05/08/1945"));
 
@@ -160,7 +160,7 @@ class IntegrationRunnerTest {
   @Test
   void testDiscover() throws Exception {
     final IntegrationConfig intConfig = IntegrationConfig.discover(configPath);
-    final AirbyteCatalog output = new AirbyteCatalog().withStreams(Lists.newArrayList(new AirbyteStream().withName("oceans")));
+    final AirbyteCatalog output = CatalogHelpers.createAirbyteCatalog(CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, "oceans"));
 
     when(cliParser.parse(ARGS)).thenReturn(intConfig);
     when(source.discover(CONFIG)).thenReturn(output);

--- a/airbyte-integrations/bases/standard-destination-test/src/main/resources/edge_case_catalog.json
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/resources/edge_case_catalog.json
@@ -2,6 +2,10 @@
   "streams": [
     {
       "name": "streamWithCamelCase",
+      "stream_name": {
+        "namespace": "tests",
+        "name": "streamWithCamelCase"
+      },
       "json_schema": {
         "properties": {
           "data": {
@@ -13,6 +17,10 @@
 
     {
       "name": "stream_with_underscores",
+      "stream_name": {
+        "namespace": "tests",
+        "name": "stream_with_underscores"
+      },
       "json_schema": {
         "properties": {
           "data": {
@@ -23,6 +31,10 @@
     },
     {
       "name": "STREAM_WITH_ALL_CAPS",
+      "stream_name": {
+        "namespace": "tests",
+        "name": "STREAM_WITH_ALL_CAPS"
+      },
       "json_schema": {
         "properties": {
           "data": {
@@ -33,6 +45,10 @@
     },
     {
       "name": "stream_with_edge_case_field_names",
+      "stream_name": {
+        "namespace": "tests",
+        "name": "stream_with_edge_case_field_names"
+      },
       "json_schema": {
         "properties": {
           "fieldWithCamelCase": {
@@ -49,6 +65,10 @@
     },
     {
       "name": "stream-with:spécial:character_names",
+      "stream_name": {
+        "namespace": "tests",
+        "name": "stream-with:spécial:character_names"
+      },
       "json_schema": {
         "properties": {
           "field_with_spécial_character": {
@@ -59,6 +79,10 @@
     },
     {
       "name": "CapitalCase",
+      "stream_name": {
+        "namespace": "tests",
+        "name": "CapitalCase"
+      },
       "json_schema": {
         "properties": {
           "deleted": {
@@ -69,6 +93,10 @@
     },
     {
       "name": "reserved_keywords",
+      "stream_name": {
+        "namespace": "tests",
+        "name": "reserved_keywords"
+      },
       "json_schema": {
         "properties": {
           "order": {
@@ -79,6 +107,10 @@
     },
     {
       "name": "groups",
+      "stream_name": {
+        "namespace": "tests",
+        "name": "groups"
+      },
       "json_schema": {
         "properties": {
           "authorization": {
@@ -89,6 +121,10 @@
     },
     {
       "name": "ProperCase",
+      "stream_name": {
+        "namespace": "tests",
+        "name": "ProperCase"
+      },
       "json_schema": {
         "properties": {
           "ProperCase": {

--- a/airbyte-integrations/bases/standard-destination-test/src/main/resources/exchange_rate_catalog.json
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/resources/exchange_rate_catalog.json
@@ -2,6 +2,10 @@
   "streams": [
     {
       "name": "exchange_rate",
+      "stream_name": {
+        "namespace": "tests",
+        "name": "exchange_rate"
+      },
       "json_schema": {
         "properties": {
           "date": {

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTest.java
@@ -85,6 +85,7 @@ class BigQueryDestinationTest {
   private static final Instant NOW = Instant.now();
   private static final String USERS_STREAM_NAME = "users";
   private static final String TASKS_STREAM_NAME = "tasks";
+  private static final String STREAM_NAMESPACE = "tests";
   private static final AirbyteMessage MESSAGE_USERS1 = new AirbyteMessage().withType(AirbyteMessage.Type.RECORD)
       .withRecord(new AirbyteRecordMessage().withStream(USERS_STREAM_NAME)
           .withData(Jsons.jsonNode(ImmutableMap.builder().put("name", "john").put("id", "10").build()))
@@ -105,10 +106,11 @@ class BigQueryDestinationTest {
       .withState(new AirbyteStateMessage().withData(Jsons.jsonNode(ImmutableMap.builder().put("checkpoint", "now!").build())));
 
   private static final ConfiguredAirbyteCatalog CATALOG = new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(
-      CatalogHelpers.createConfiguredAirbyteStream(USERS_STREAM_NAME, io.airbyte.protocol.models.Field.of("name", JsonSchemaPrimitive.STRING),
+      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, USERS_STREAM_NAME,
+          io.airbyte.protocol.models.Field.of("name", JsonSchemaPrimitive.STRING),
           io.airbyte.protocol.models.Field
               .of("id", JsonSchemaPrimitive.STRING)),
-      CatalogHelpers.createConfiguredAirbyteStream(TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
+      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
 
   private static final NamingConventionTransformer NAMING_RESOLVER = new StandardNameTransformer();
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTest.java
@@ -106,11 +106,13 @@ class BigQueryDestinationTest {
       .withState(new AirbyteStateMessage().withData(Jsons.jsonNode(ImmutableMap.builder().put("checkpoint", "now!").build())));
 
   private static final ConfiguredAirbyteCatalog CATALOG = new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(
-      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, USERS_STREAM_NAME,
-          io.airbyte.protocol.models.Field.of("name", JsonSchemaPrimitive.STRING),
-          io.airbyte.protocol.models.Field
-              .of("id", JsonSchemaPrimitive.STRING)),
-      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
+      CatalogHelpers.createConfiguredAirbyteStream(
+          CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, USERS_STREAM_NAME),
+          Field.of("name", JsonSchemaPrimitive.STRING),
+          Field.of("id", JsonSchemaPrimitive.STRING)),
+      CatalogHelpers.createConfiguredAirbyteStream(
+          CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, TASKS_STREAM_NAME),
+          Field.of("goal", JsonSchemaPrimitive.STRING))));
 
   private static final NamingConventionTransformer NAMING_RESOLVER = new StandardNameTransformer();
 

--- a/airbyte-integrations/connectors/destination-csv/src/test/java/io/airbyte/integrations/destination/csv/CsvDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-csv/src/test/java/io/airbyte/integrations/destination/csv/CsvDestinationTest.java
@@ -95,9 +95,13 @@ class CsvDestinationTest {
       .withState(new AirbyteStateMessage().withData(Jsons.jsonNode(ImmutableMap.builder().put("checkpoint", "now!").build())));
 
   private static final ConfiguredAirbyteCatalog CATALOG = new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(
-      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, USERS_STREAM_NAME, Field.of("name", JsonSchemaPrimitive.STRING),
+      CatalogHelpers.createConfiguredAirbyteStream(
+          CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, USERS_STREAM_NAME),
+          Field.of("name", JsonSchemaPrimitive.STRING),
           Field.of("id", JsonSchemaPrimitive.STRING)),
-      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
+      CatalogHelpers.createConfiguredAirbyteStream(
+          CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, TASKS_STREAM_NAME),
+          Field.of("goal", JsonSchemaPrimitive.STRING))));
 
   private Path destinationPath;
   private JsonNode config;

--- a/airbyte-integrations/connectors/destination-csv/src/test/java/io/airbyte/integrations/destination/csv/CsvDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-csv/src/test/java/io/airbyte/integrations/destination/csv/CsvDestinationTest.java
@@ -72,6 +72,7 @@ class CsvDestinationTest {
   private static final Path TEST_ROOT = Path.of("/tmp/airbyte_tests");
   private static final String USERS_STREAM_NAME = "users";
   private static final String TASKS_STREAM_NAME = "tasks";
+  private static final String STREAM_NAMESPACE = "tests";
   private static final String USERS_FILE = new StandardNameTransformer().getRawTableName(USERS_STREAM_NAME) + ".csv";
   private static final String TASKS_FILE = new StandardNameTransformer().getRawTableName(TASKS_STREAM_NAME) + ".csv";;
   private static final AirbyteMessage MESSAGE_USERS1 = new AirbyteMessage().withType(AirbyteMessage.Type.RECORD)
@@ -94,9 +95,9 @@ class CsvDestinationTest {
       .withState(new AirbyteStateMessage().withData(Jsons.jsonNode(ImmutableMap.builder().put("checkpoint", "now!").build())));
 
   private static final ConfiguredAirbyteCatalog CATALOG = new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(
-      CatalogHelpers.createConfiguredAirbyteStream(USERS_STREAM_NAME, Field.of("name", JsonSchemaPrimitive.STRING),
+      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, USERS_STREAM_NAME, Field.of("name", JsonSchemaPrimitive.STRING),
           Field.of("id", JsonSchemaPrimitive.STRING)),
-      CatalogHelpers.createConfiguredAirbyteStream(TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
+      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
 
   private Path destinationPath;
   private JsonNode config;

--- a/airbyte-integrations/connectors/destination-jdbc/src/test/java/io/airbyte/integrations/destination/jdbc/JdbcDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/test/java/io/airbyte/integrations/destination/jdbc/JdbcDestinationTest.java
@@ -100,9 +100,13 @@ class JdbcDestinationTest {
       .withState(new AirbyteStateMessage().withData(Jsons.jsonNode(ImmutableMap.builder().put("checkpoint", "now!").build())));
 
   private static final ConfiguredAirbyteCatalog CATALOG = new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(
-      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, USERS_STREAM_NAME, Field.of("name", JsonSchemaPrimitive.STRING),
+      CatalogHelpers.createConfiguredAirbyteStream(
+          CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, USERS_STREAM_NAME),
+          Field.of("name", JsonSchemaPrimitive.STRING),
           Field.of("id", JsonSchemaPrimitive.STRING)),
-      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
+      CatalogHelpers.createConfiguredAirbyteStream(
+          CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, TASKS_STREAM_NAME),
+          Field.of("goal", JsonSchemaPrimitive.STRING))));
 
   private static final NamingConventionTransformer NAMING_TRANSFORMER = new ExtendedNameTransformer();
 

--- a/airbyte-integrations/connectors/destination-jdbc/src/test/java/io/airbyte/integrations/destination/jdbc/JdbcDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/test/java/io/airbyte/integrations/destination/jdbc/JdbcDestinationTest.java
@@ -78,6 +78,7 @@ class JdbcDestinationTest {
   private static final Instant NOW = Instant.now();
   private static final String USERS_STREAM_NAME = "users";
   private static final String TASKS_STREAM_NAME = "tasks-list";
+  private static final String STREAM_NAMESPACE = "tests";
   private static final AirbyteMessage MESSAGE_USERS1 = new AirbyteMessage().withType(AirbyteMessage.Type.RECORD)
       .withRecord(new AirbyteRecordMessage().withStream(USERS_STREAM_NAME)
           .withData(Jsons.jsonNode(ImmutableMap.builder().put("name", "john").put("id", "10").build()))
@@ -99,9 +100,9 @@ class JdbcDestinationTest {
       .withState(new AirbyteStateMessage().withData(Jsons.jsonNode(ImmutableMap.builder().put("checkpoint", "now!").build())));
 
   private static final ConfiguredAirbyteCatalog CATALOG = new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(
-      CatalogHelpers.createConfiguredAirbyteStream(USERS_STREAM_NAME, Field.of("name", JsonSchemaPrimitive.STRING),
+      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, USERS_STREAM_NAME, Field.of("name", JsonSchemaPrimitive.STRING),
           Field.of("id", JsonSchemaPrimitive.STRING)),
-      CatalogHelpers.createConfiguredAirbyteStream(TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
+      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
 
   private static final NamingConventionTransformer NAMING_TRANSFORMER = new ExtendedNameTransformer();
 

--- a/airbyte-integrations/connectors/destination-local-json/src/test/java/io/airbyte/integrations/destination/local_json/LocalJsonDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-local-json/src/test/java/io/airbyte/integrations/destination/local_json/LocalJsonDestinationTest.java
@@ -68,6 +68,7 @@ class LocalJsonDestinationTest {
   private static final Path TEST_ROOT = Path.of("/tmp/airbyte_tests");
   private static final String USERS_STREAM_NAME = "users";
   private static final String TASKS_STREAM_NAME = "tasks";
+  private static final String STREAM_NAMESPACE = "tests";
   private static final String USERS_FILE = new StandardNameTransformer().getRawTableName(USERS_STREAM_NAME) + ".jsonl";
   private static final String TASKS_FILE = new StandardNameTransformer().getRawTableName(TASKS_STREAM_NAME) + ".jsonl";;
   private static final AirbyteMessage MESSAGE_USERS1 = new AirbyteMessage().withType(AirbyteMessage.Type.RECORD)
@@ -90,9 +91,9 @@ class LocalJsonDestinationTest {
       .withState(new AirbyteStateMessage().withData(Jsons.jsonNode(ImmutableMap.builder().put("checkpoint", "now!").build())));
 
   private static final ConfiguredAirbyteCatalog CATALOG = new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(
-      CatalogHelpers.createConfiguredAirbyteStream(USERS_STREAM_NAME, Field.of("name", JsonSchemaPrimitive.STRING),
+      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, USERS_STREAM_NAME, Field.of("name", JsonSchemaPrimitive.STRING),
           Field.of("id", JsonSchemaPrimitive.STRING)),
-      CatalogHelpers.createConfiguredAirbyteStream(TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
+      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
 
   private Path destinationPath;
   private JsonNode config;

--- a/airbyte-integrations/connectors/destination-local-json/src/test/java/io/airbyte/integrations/destination/local_json/LocalJsonDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-local-json/src/test/java/io/airbyte/integrations/destination/local_json/LocalJsonDestinationTest.java
@@ -91,9 +91,13 @@ class LocalJsonDestinationTest {
       .withState(new AirbyteStateMessage().withData(Jsons.jsonNode(ImmutableMap.builder().put("checkpoint", "now!").build())));
 
   private static final ConfiguredAirbyteCatalog CATALOG = new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(
-      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, USERS_STREAM_NAME, Field.of("name", JsonSchemaPrimitive.STRING),
+      CatalogHelpers.createConfiguredAirbyteStream(
+          CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, USERS_STREAM_NAME),
+          Field.of("name", JsonSchemaPrimitive.STRING),
           Field.of("id", JsonSchemaPrimitive.STRING)),
-      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
+      CatalogHelpers.createConfiguredAirbyteStream(
+          CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, TASKS_STREAM_NAME),
+          Field.of("goal", JsonSchemaPrimitive.STRING))));
 
   private Path destinationPath;
   private JsonNode config;

--- a/airbyte-integrations/connectors/destination-postgres/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
@@ -77,6 +77,7 @@ class PostgresDestinationTest {
   private static final Instant NOW = Instant.now();
   private static final String USERS_STREAM_NAME = "users";
   private static final String TASKS_STREAM_NAME = "tasks-list";
+  private static final String STREAM_NAMESPACE = "tests";
   private static final AirbyteMessage MESSAGE_USERS1 = new AirbyteMessage().withType(AirbyteMessage.Type.RECORD)
       .withRecord(new AirbyteRecordMessage().withStream(USERS_STREAM_NAME)
           .withData(Jsons.jsonNode(ImmutableMap.builder().put("name", "john").put("id", "10").build()))
@@ -98,9 +99,9 @@ class PostgresDestinationTest {
       .withState(new AirbyteStateMessage().withData(Jsons.jsonNode(ImmutableMap.builder().put("checkpoint", "now!").build())));
 
   private static final ConfiguredAirbyteCatalog CATALOG = new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(
-      CatalogHelpers.createConfiguredAirbyteStream(USERS_STREAM_NAME, Field.of("name", JsonSchemaPrimitive.STRING),
+      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, USERS_STREAM_NAME, Field.of("name", JsonSchemaPrimitive.STRING),
           Field.of("id", JsonSchemaPrimitive.STRING)),
-      CatalogHelpers.createConfiguredAirbyteStream(TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
+      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
 
   private static final NamingConventionTransformer NAMING_TRANSFORMER = new PostgresSQLNameTransformer();
 

--- a/airbyte-integrations/connectors/destination-postgres/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/java/io/airbyte/integrations/destination/postgres/PostgresDestinationTest.java
@@ -99,9 +99,13 @@ class PostgresDestinationTest {
       .withState(new AirbyteStateMessage().withData(Jsons.jsonNode(ImmutableMap.builder().put("checkpoint", "now!").build())));
 
   private static final ConfiguredAirbyteCatalog CATALOG = new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(
-      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, USERS_STREAM_NAME, Field.of("name", JsonSchemaPrimitive.STRING),
+      CatalogHelpers.createConfiguredAirbyteStream(
+          CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, USERS_STREAM_NAME),
+          Field.of("name", JsonSchemaPrimitive.STRING),
           Field.of("id", JsonSchemaPrimitive.STRING)),
-      CatalogHelpers.createConfiguredAirbyteStream(STREAM_NAMESPACE, TASKS_STREAM_NAME, Field.of("goal", JsonSchemaPrimitive.STRING))));
+      CatalogHelpers.createConfiguredAirbyteStream(
+          CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, TASKS_STREAM_NAME),
+          Field.of("goal", JsonSchemaPrimitive.STRING))));
 
   private static final NamingConventionTransformer NAMING_TRANSFORMER = new PostgresSQLNameTransformer();
 

--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -134,7 +134,8 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
               Optional.ofNullable(config.get("database")).map(JsonNode::asText),
               Optional.ofNullable(config.get("schema")).map(JsonNode::asText))
                   .stream()
-                  .map(t -> CatalogHelpers.createAirbyteStream(t.getSchemaName(), t.getName(), t.getFields())
+                  .map(t -> CatalogHelpers.createAirbyteStream(CatalogHelpers.createAirbyteStreamName(t.getSchemaName(), t.getName()), t.getFields())
+                      // TODO: Switch fully to StreamName instead of temporarily setName() for backward compatibility
                       .withName(JdbcUtils.getFullyQualifiedTableName(t.getSchemaName(), t.getName()))
                       .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL)))
                   .collect(Collectors.toList()));

--- a/airbyte-integrations/connectors/source-jdbc/src/test-integration/java/io/airbyte/integrations/source/jdbc/JdbcIntegrationTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test-integration/java/io/airbyte/integrations/source/jdbc/JdbcIntegrationTest.java
@@ -45,6 +45,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 public class JdbcIntegrationTest extends StandardSourceTest {
 
   private static final String STREAM_NAME = "public.id_and_name";
+  private static final String STREAM_NAMESPACE = "tests";
   private PostgreSQLContainer<?> container;
   private Database database;
   private JsonNode config;
@@ -99,6 +100,7 @@ public class JdbcIntegrationTest extends StandardSourceTest {
   @Override
   protected ConfiguredAirbyteCatalog getConfiguredCatalog() {
     return CatalogHelpers.createConfiguredAirbyteCatalog(
+        STREAM_NAMESPACE,
         STREAM_NAME,
         Field.of("id", JsonSchemaPrimitive.NUMBER),
         Field.of("name", JsonSchemaPrimitive.STRING));

--- a/airbyte-integrations/connectors/source-jdbc/src/test-integration/java/io/airbyte/integrations/source/jdbc/JdbcIntegrationTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test-integration/java/io/airbyte/integrations/source/jdbc/JdbcIntegrationTest.java
@@ -100,8 +100,7 @@ public class JdbcIntegrationTest extends StandardSourceTest {
   @Override
   protected ConfiguredAirbyteCatalog getConfiguredCatalog() {
     return CatalogHelpers.createConfiguredAirbyteCatalog(
-        STREAM_NAMESPACE,
-        STREAM_NAME,
+        CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME),
         Field.of("id", JsonSchemaPrimitive.NUMBER),
         Field.of("name", JsonSchemaPrimitive.STRING));
   }

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/IncrementalUtilsTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/IncrementalUtilsTest.java
@@ -44,8 +44,7 @@ class IncrementalUtilsTest {
   private static final String STREAM_NAMESPACE = "tests";
   private static final String UUID_FIELD_NAME = "ascending_inventory_uuid";
   private static final ConfiguredAirbyteStream STREAM = CatalogHelpers.createConfiguredAirbyteStream(
-      STREAM_NAMESPACE,
-      STREAM_NAME,
+      CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME),
       Field.of("ascending_inventory_uuid", JsonSchemaPrimitive.STRING));
 
   @Test

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/IncrementalUtilsTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/IncrementalUtilsTest.java
@@ -41,8 +41,10 @@ import org.junit.jupiter.api.Test;
 class IncrementalUtilsTest {
 
   private static final String STREAM_NAME = "shoes";
+  private static final String STREAM_NAMESPACE = "tests";
   private static final String UUID_FIELD_NAME = "ascending_inventory_uuid";
   private static final ConfiguredAirbyteStream STREAM = CatalogHelpers.createConfiguredAirbyteStream(
+      STREAM_NAMESPACE,
       STREAM_NAME,
       Field.of("ascending_inventory_uuid", JsonSchemaPrimitive.STRING));
 

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/JdbcStateManagerTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/JdbcStateManagerTest.java
@@ -31,7 +31,7 @@ import io.airbyte.integrations.source.jdbc.JdbcStateManager.CursorInfo;
 import io.airbyte.integrations.source.jdbc.models.JdbcState;
 import io.airbyte.integrations.source.jdbc.models.JdbcStreamState;
 import io.airbyte.protocol.models.AirbyteStateMessage;
-import io.airbyte.protocol.models.AirbyteStream;
+import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import java.util.Collections;
@@ -43,6 +43,7 @@ import org.testcontainers.shaded.com.google.common.collect.Lists;
 
 class JdbcStateManagerTest {
 
+  private static final String STREAM_NAMESPACE = "tests";
   private static final String STREAM_NAME1 = "cars";
   private static final String STREAM_NAME2 = "bicycles";
   private static final String STREAM_NAME3 = "stationary_bicycles";
@@ -102,8 +103,7 @@ class JdbcStateManagerTest {
   }
 
   private static Optional<ConfiguredAirbyteStream> getCatalog(String cursorField) {
-    return Optional.of(new ConfiguredAirbyteStream()
-        .withStream(new AirbyteStream().withName(STREAM_NAME1))
+    return Optional.of(CatalogHelpers.createConfiguredAirbyteStream(CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME1))
         .withCursorField(cursorField == null ? Collections.emptyList() : Lists.newArrayList(cursorField)));
   }
 
@@ -115,11 +115,9 @@ class JdbcStateManagerTest {
 
     final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog()
         .withStreams(Lists.newArrayList(
-            new ConfiguredAirbyteStream()
-                .withStream(new AirbyteStream().withName(STREAM_NAME1))
+            CatalogHelpers.createConfiguredAirbyteStream(CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME1))
                 .withCursorField(Lists.newArrayList(CURSOR_FIELD1)),
-            new ConfiguredAirbyteStream()
-                .withStream(new AirbyteStream().withName(STREAM_NAME2))));
+            CatalogHelpers.createConfiguredAirbyteStream(CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME2))));
 
     final JdbcStateManager stateManager = new JdbcStateManager(state, catalog);
 
@@ -138,14 +136,11 @@ class JdbcStateManagerTest {
   void testToState() {
     final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog()
         .withStreams(Lists.newArrayList(
-            new ConfiguredAirbyteStream()
-                .withStream(new AirbyteStream().withName(STREAM_NAME1))
+            CatalogHelpers.createConfiguredAirbyteStream(CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME1))
                 .withCursorField(Lists.newArrayList(CURSOR_FIELD1)),
-            new ConfiguredAirbyteStream()
-                .withStream(new AirbyteStream().withName(STREAM_NAME2))
+            CatalogHelpers.createConfiguredAirbyteStream(CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME2))
                 .withCursorField(Lists.newArrayList(CURSOR_FIELD2)),
-            new ConfiguredAirbyteStream()
-                .withStream(new AirbyteStream().withName(STREAM_NAME3))));
+            CatalogHelpers.createConfiguredAirbyteStream(CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME3))));
 
     final JdbcStateManager stateManager = new JdbcStateManager(new JdbcState(), catalog);
 
@@ -172,11 +167,9 @@ class JdbcStateManagerTest {
   void testToStateNullCursorField() {
     final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog()
         .withStreams(Lists.newArrayList(
-            new ConfiguredAirbyteStream()
-                .withStream(new AirbyteStream().withName(STREAM_NAME1))
+            CatalogHelpers.createConfiguredAirbyteStream(CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME1))
                 .withCursorField(Lists.newArrayList(CURSOR_FIELD1)),
-            new ConfiguredAirbyteStream()
-                .withStream(new AirbyteStream().withName(STREAM_NAME2))));
+            CatalogHelpers.createConfiguredAirbyteStream(CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME2))));
     final JdbcStateManager stateManager = new JdbcStateManager(new JdbcState(), catalog);
 
     final AirbyteStateMessage expectedFirstEmission = new AirbyteStateMessage()

--- a/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
@@ -220,9 +220,10 @@ public abstract class JdbcSourceStandardTest {
     final AirbyteCatalog actual = source.discover(config);
 
     final AirbyteCatalog expected = getCatalog();
-    expected.getStreams().add(CatalogHelpers.createAirbyteStream(JdbcUtils.getFullyQualifiedTableName(SCHEMA_NAME2, TABLE_NAME),
+    expected.getStreams().add(CatalogHelpers.createAirbyteStream(SCHEMA_NAME2, TABLE_NAME,
         Field.of("id", JsonSchemaPrimitive.STRING),
         Field.of("name", JsonSchemaPrimitive.STRING))
+        .withName(JdbcUtils.getFullyQualifiedTableName(SCHEMA_NAME2, TABLE_NAME))
         .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL)));
     // sort streams by name so that we are comparing lists with the same order.
     expected.getStreams().sort(Comparator.comparing(AirbyteStream::getName));
@@ -241,7 +242,8 @@ public abstract class JdbcSourceStandardTest {
 
   @Test
   void testReadOneColumn() throws Exception {
-    final ConfiguredAirbyteCatalog catalog = CatalogHelpers.createConfiguredAirbyteCatalog(streamName, Field.of("id", JsonSchemaPrimitive.NUMBER));
+    final ConfiguredAirbyteCatalog catalog =
+        CatalogHelpers.createConfiguredAirbyteCatalog(SCHEMA_NAME, streamName, Field.of("id", JsonSchemaPrimitive.NUMBER));
 
     final List<AirbyteMessage> actualMessages = MoreIterators.toList(source.read(config, catalog, null));
 
@@ -273,6 +275,7 @@ public abstract class JdbcSourceStandardTest {
             getFullyQualifiedTableName(TABLE_NAME + iFinal)));
       });
       catalog.getStreams().add(CatalogHelpers.createConfiguredAirbyteStream(
+          SCHEMA_NAME,
           streamName2,
           Field.of("id", JsonSchemaPrimitive.NUMBER),
           Field.of("name", JsonSchemaPrimitive.STRING)));
@@ -460,6 +463,7 @@ public abstract class JdbcSourceStandardTest {
 
     final ConfiguredAirbyteCatalog configuredCatalog = getConfiguredCatalog();
     configuredCatalog.getStreams().add(CatalogHelpers.createConfiguredAirbyteStream(
+        SCHEMA_NAME,
         streamName2,
         Field.of("id", JsonSchemaPrimitive.NUMBER),
         Field.of("name", JsonSchemaPrimitive.STRING)));
@@ -577,16 +581,18 @@ public abstract class JdbcSourceStandardTest {
   }
 
   // get catalog and perform a defensive copy.
-  private static ConfiguredAirbyteCatalog getConfiguredCatalog() {
+  private ConfiguredAirbyteCatalog getConfiguredCatalog() {
     return CatalogHelpers.toDefaultConfiguredCatalog(getCatalog());
   }
 
-  private static AirbyteCatalog getCatalog() {
+  private AirbyteCatalog getCatalog() {
     return new AirbyteCatalog().withStreams(Lists.newArrayList(CatalogHelpers.createAirbyteStream(
-        streamName,
+        getDefaultNamespace(),
+        TABLE_NAME,
         Field.of("id", JsonSchemaPrimitive.NUMBER),
         Field.of("name", JsonSchemaPrimitive.STRING),
         Field.of("updated_at", JsonSchemaPrimitive.STRING))
+        .withName(streamName)
         .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))));
   }
 
@@ -619,6 +625,7 @@ public abstract class JdbcSourceStandardTest {
     });
 
     return CatalogHelpers.createConfiguredAirbyteStream(
+        SCHEMA_NAME,
         streamName2,
         Field.of("id", JsonSchemaPrimitive.NUMBER),
         Field.of(lastNameField, JsonSchemaPrimitive.STRING));

--- a/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
@@ -220,9 +220,11 @@ public abstract class JdbcSourceStandardTest {
     final AirbyteCatalog actual = source.discover(config);
 
     final AirbyteCatalog expected = getCatalog();
-    expected.getStreams().add(CatalogHelpers.createAirbyteStream(SCHEMA_NAME2, TABLE_NAME,
+    expected.getStreams().add(CatalogHelpers.createAirbyteStream(
+        CatalogHelpers.createAirbyteStreamName(SCHEMA_NAME2, TABLE_NAME),
         Field.of("id", JsonSchemaPrimitive.STRING),
         Field.of("name", JsonSchemaPrimitive.STRING))
+        // TODO: Switch fully to StreamName instead of temporarily setName() for backward compatibility
         .withName(JdbcUtils.getFullyQualifiedTableName(SCHEMA_NAME2, TABLE_NAME))
         .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL)));
     // sort streams by name so that we are comparing lists with the same order.
@@ -243,7 +245,9 @@ public abstract class JdbcSourceStandardTest {
   @Test
   void testReadOneColumn() throws Exception {
     final ConfiguredAirbyteCatalog catalog =
-        CatalogHelpers.createConfiguredAirbyteCatalog(SCHEMA_NAME, streamName, Field.of("id", JsonSchemaPrimitive.NUMBER));
+        CatalogHelpers.createConfiguredAirbyteCatalog(
+            CatalogHelpers.createAirbyteStreamName(SCHEMA_NAME, streamName),
+            Field.of("id", JsonSchemaPrimitive.NUMBER));
 
     final List<AirbyteMessage> actualMessages = MoreIterators.toList(source.read(config, catalog, null));
 
@@ -275,8 +279,7 @@ public abstract class JdbcSourceStandardTest {
             getFullyQualifiedTableName(TABLE_NAME + iFinal)));
       });
       catalog.getStreams().add(CatalogHelpers.createConfiguredAirbyteStream(
-          SCHEMA_NAME,
-          streamName2,
+          CatalogHelpers.createAirbyteStreamName(SCHEMA_NAME, streamName2),
           Field.of("id", JsonSchemaPrimitive.NUMBER),
           Field.of("name", JsonSchemaPrimitive.STRING)));
 
@@ -463,8 +466,7 @@ public abstract class JdbcSourceStandardTest {
 
     final ConfiguredAirbyteCatalog configuredCatalog = getConfiguredCatalog();
     configuredCatalog.getStreams().add(CatalogHelpers.createConfiguredAirbyteStream(
-        SCHEMA_NAME,
-        streamName2,
+        CatalogHelpers.createAirbyteStreamName(SCHEMA_NAME, streamName2),
         Field.of("id", JsonSchemaPrimitive.NUMBER),
         Field.of("name", JsonSchemaPrimitive.STRING)));
     configuredCatalog.getStreams().forEach(airbyteStream -> {
@@ -587,11 +589,11 @@ public abstract class JdbcSourceStandardTest {
 
   private AirbyteCatalog getCatalog() {
     return new AirbyteCatalog().withStreams(Lists.newArrayList(CatalogHelpers.createAirbyteStream(
-        getDefaultNamespace(),
-        TABLE_NAME,
+        CatalogHelpers.createAirbyteStreamName(getDefaultNamespace(), TABLE_NAME),
         Field.of("id", JsonSchemaPrimitive.NUMBER),
         Field.of("name", JsonSchemaPrimitive.STRING),
         Field.of("updated_at", JsonSchemaPrimitive.STRING))
+        // TODO: Switch fully to StreamName instead of temporarily setName() for backward compatibility
         .withName(streamName)
         .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))));
   }
@@ -625,8 +627,7 @@ public abstract class JdbcSourceStandardTest {
     });
 
     return CatalogHelpers.createConfiguredAirbyteStream(
-        SCHEMA_NAME,
-        streamName2,
+        CatalogHelpers.createAirbyteStreamName(SCHEMA_NAME, streamName2),
         Field.of("id", JsonSchemaPrimitive.NUMBER),
         Field.of(lastNameField, JsonSchemaPrimitive.STRING));
   }

--- a/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcStressTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcStressTest.java
@@ -70,6 +70,7 @@ public abstract class JdbcStressTest {
   private static final long TOTAL_RECORDS = 10_000_000L;
   private static final int BATCH_SIZE = 1000;
   private static final String TABLE_NAME = "id_and_name";
+  private static final String STREAM_NAMESPACE = "tests";
 
   private static String streamName;
 
@@ -204,6 +205,7 @@ public abstract class JdbcStressTest {
 
   private static AirbyteCatalog getCatalog() {
     return new AirbyteCatalog().withStreams(Lists.newArrayList(CatalogHelpers.createAirbyteStream(
+        STREAM_NAMESPACE,
         streamName,
         Field.of("id", JsonSchemaPrimitive.NUMBER),
         Field.of("name", JsonSchemaPrimitive.STRING))

--- a/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcStressTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcStressTest.java
@@ -205,8 +205,7 @@ public abstract class JdbcStressTest {
 
   private static AirbyteCatalog getCatalog() {
     return new AirbyteCatalog().withStreams(Lists.newArrayList(CatalogHelpers.createAirbyteStream(
-        STREAM_NAMESPACE,
-        streamName,
+        CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, streamName),
         Field.of("id", JsonSchemaPrimitive.NUMBER),
         Field.of("name", JsonSchemaPrimitive.STRING))
         .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))));

--- a/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/MssqlSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/MssqlSourceStandardTest.java
@@ -47,6 +47,8 @@ import org.testcontainers.containers.MSSQLServerContainer;
 public class MssqlSourceStandardTest extends StandardSourceTest {
 
   private static final String STREAM_NAME = "dbo.id_and_name";
+  private static final String STREAM_NAMESPACE = "tests";
+
   private static MSSQLServerContainer<?> db;
   private JsonNode config;
 
@@ -101,6 +103,7 @@ public class MssqlSourceStandardTest extends StandardSourceTest {
   @Override
   protected ConfiguredAirbyteCatalog getConfiguredCatalog() {
     return CatalogHelpers.createConfiguredAirbyteCatalog(
+        STREAM_NAMESPACE,
         STREAM_NAME,
         Field.of("id", JsonSchemaPrimitive.NUMBER),
         Field.of("name", JsonSchemaPrimitive.STRING),

--- a/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/MssqlSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/MssqlSourceStandardTest.java
@@ -103,8 +103,7 @@ public class MssqlSourceStandardTest extends StandardSourceTest {
   @Override
   protected ConfiguredAirbyteCatalog getConfiguredCatalog() {
     return CatalogHelpers.createConfiguredAirbyteCatalog(
-        STREAM_NAMESPACE,
-        STREAM_NAME,
+        CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME),
         Field.of("id", JsonSchemaPrimitive.NUMBER),
         Field.of("name", JsonSchemaPrimitive.STRING),
         Field.of("born", JsonSchemaPrimitive.STRING));

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlSourceTest.java
@@ -52,11 +52,11 @@ class MssqlSourceTest {
   private static final String TABLE_NAME = "id_and_name";
   private static final String STREAM_NAME = STREAM_NAMESPACE + "." + TABLE_NAME;
   private static final AirbyteCatalog CATALOG = new AirbyteCatalog().withStreams(Lists.newArrayList(CatalogHelpers.createAirbyteStream(
-      STREAM_NAMESPACE,
-      TABLE_NAME,
+      CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, TABLE_NAME),
       Field.of("id", JsonSchemaPrimitive.NUMBER),
       Field.of("name", JsonSchemaPrimitive.STRING),
       Field.of("born", JsonSchemaPrimitive.STRING))
+      // TODO: Switch fully to StreamName instead of temporarily setName() for backward compatibility
       .withName(STREAM_NAME)
       .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))));
 

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlSourceTest.java
@@ -48,12 +48,16 @@ import org.testcontainers.containers.MSSQLServerContainer;
 
 class MssqlSourceTest {
 
-  private static final String STREAM_NAME = "dbo.id_and_name";
+  private static final String STREAM_NAMESPACE = "dbo";
+  private static final String TABLE_NAME = "id_and_name";
+  private static final String STREAM_NAME = STREAM_NAMESPACE + "." + TABLE_NAME;
   private static final AirbyteCatalog CATALOG = new AirbyteCatalog().withStreams(Lists.newArrayList(CatalogHelpers.createAirbyteStream(
-      STREAM_NAME,
+      STREAM_NAMESPACE,
+      TABLE_NAME,
       Field.of("id", JsonSchemaPrimitive.NUMBER),
       Field.of("name", JsonSchemaPrimitive.STRING),
       Field.of("born", JsonSchemaPrimitive.STRING))
+      .withName(STREAM_NAME)
       .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))));
 
   private JsonNode configWithoutDbName;

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/source/mysql/MySqlStandardTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/source/mysql/MySqlStandardTest.java
@@ -115,8 +115,7 @@ public class MySqlStandardTest extends StandardSourceTest {
             .withSyncMode(SyncMode.INCREMENTAL)
             .withCursorField(Lists.newArrayList("id"))
             .withStream(CatalogHelpers.createAirbyteStream(
-                STREAM_NAMESPACE,
-                String.format("%s.%s", config.get("database").asText(), STREAM_NAME),
+                CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, String.format("%s.%s", config.get("database").asText(), STREAM_NAME)),
                 Field.of("id", JsonSchemaPrimitive.NUMBER),
                 Field.of("name", JsonSchemaPrimitive.STRING))
                 .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))),
@@ -124,8 +123,7 @@ public class MySqlStandardTest extends StandardSourceTest {
             .withSyncMode(SyncMode.INCREMENTAL)
             .withCursorField(Lists.newArrayList("id"))
             .withStream(CatalogHelpers.createAirbyteStream(
-                STREAM_NAMESPACE,
-                String.format("%s.%s", config.get("database").asText(), STREAM_NAME2),
+                CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, String.format("%s.%s", config.get("database").asText(), STREAM_NAME2)),
                 Field.of("id", JsonSchemaPrimitive.NUMBER),
                 Field.of("name", JsonSchemaPrimitive.STRING))
                 .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL)))));

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/source/mysql/MySqlStandardTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/source/mysql/MySqlStandardTest.java
@@ -49,6 +49,7 @@ public class MySqlStandardTest extends StandardSourceTest {
 
   private static final String STREAM_NAME = "id_and_name";
   private static final String STREAM_NAME2 = "public.starships";
+  private static final String STREAM_NAMESPACE = "tests";
 
   private MySQLContainer<?> container;
   private JsonNode config;
@@ -114,6 +115,7 @@ public class MySqlStandardTest extends StandardSourceTest {
             .withSyncMode(SyncMode.INCREMENTAL)
             .withCursorField(Lists.newArrayList("id"))
             .withStream(CatalogHelpers.createAirbyteStream(
+                STREAM_NAMESPACE,
                 String.format("%s.%s", config.get("database").asText(), STREAM_NAME),
                 Field.of("id", JsonSchemaPrimitive.NUMBER),
                 Field.of("name", JsonSchemaPrimitive.STRING))
@@ -122,6 +124,7 @@ public class MySqlStandardTest extends StandardSourceTest {
             .withSyncMode(SyncMode.INCREMENTAL)
             .withCursorField(Lists.newArrayList("id"))
             .withStream(CatalogHelpers.createAirbyteStream(
+                STREAM_NAMESPACE,
                 String.format("%s.%s", config.get("database").asText(), STREAM_NAME2),
                 Field.of("id", JsonSchemaPrimitive.NUMBER),
                 Field.of("name", JsonSchemaPrimitive.STRING))

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceStandardTest.java
@@ -115,8 +115,7 @@ public class PostgresSourceStandardTest extends StandardSourceTest {
             .withSyncMode(SyncMode.INCREMENTAL)
             .withCursorField(Lists.newArrayList("id"))
             .withStream(CatalogHelpers.createAirbyteStream(
-                STREAM_NAMESPACE,
-                STREAM_NAME,
+                CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME),
                 Field.of("id", JsonSchemaPrimitive.NUMBER),
                 Field.of("name", JsonSchemaPrimitive.STRING))
                 .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))),
@@ -124,8 +123,7 @@ public class PostgresSourceStandardTest extends StandardSourceTest {
             .withSyncMode(SyncMode.INCREMENTAL)
             .withCursorField(Lists.newArrayList("id"))
             .withStream(CatalogHelpers.createAirbyteStream(
-                STREAM_NAMESPACE,
-                STREAM_NAME2,
+                CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME2),
                 Field.of("id", JsonSchemaPrimitive.NUMBER),
                 Field.of("name", JsonSchemaPrimitive.STRING))
                 .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL)))));

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceStandardTest.java
@@ -49,6 +49,7 @@ public class PostgresSourceStandardTest extends StandardSourceTest {
 
   private static final String STREAM_NAME = "public.id_and_name";
   private static final String STREAM_NAME2 = "public.starships";
+  private static final String STREAM_NAMESPACE = "tests";
 
   private PostgreSQLContainer<?> container;
   private JsonNode config;
@@ -114,6 +115,7 @@ public class PostgresSourceStandardTest extends StandardSourceTest {
             .withSyncMode(SyncMode.INCREMENTAL)
             .withCursorField(Lists.newArrayList("id"))
             .withStream(CatalogHelpers.createAirbyteStream(
+                STREAM_NAMESPACE,
                 STREAM_NAME,
                 Field.of("id", JsonSchemaPrimitive.NUMBER),
                 Field.of("name", JsonSchemaPrimitive.STRING))
@@ -122,6 +124,7 @@ public class PostgresSourceStandardTest extends StandardSourceTest {
             .withSyncMode(SyncMode.INCREMENTAL)
             .withCursorField(Lists.newArrayList("id"))
             .withStream(CatalogHelpers.createAirbyteStream(
+                STREAM_NAMESPACE,
                 STREAM_NAME2,
                 Field.of("id", JsonSchemaPrimitive.NUMBER),
                 Field.of("name", JsonSchemaPrimitive.STRING))

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
@@ -65,8 +65,7 @@ class PostgresSourceTest {
   private static final String STREAM_NAMESPACE = "tests";
   private static final AirbyteCatalog CATALOG = new AirbyteCatalog().withStreams(List.of(
       CatalogHelpers.createAirbyteStream(
-          STREAM_NAMESPACE,
-          STREAM_NAME,
+          CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME),
           Field.of("id", JsonSchemaPrimitive.NUMBER),
           Field.of("name", JsonSchemaPrimitive.STRING),
           Field.of("power", JsonSchemaPrimitive.NUMBER))

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
@@ -62,8 +62,10 @@ import org.testcontainers.utility.MountableFile;
 class PostgresSourceTest {
 
   private static final String STREAM_NAME = "public.id_and_name";
+  private static final String STREAM_NAMESPACE = "tests";
   private static final AirbyteCatalog CATALOG = new AirbyteCatalog().withStreams(List.of(
       CatalogHelpers.createAirbyteStream(
+          STREAM_NAMESPACE,
           STREAM_NAME,
           Field.of("id", JsonSchemaPrimitive.NUMBER),
           Field.of("name", JsonSchemaPrimitive.STRING),

--- a/airbyte-integrations/connectors/source-redshift/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/RedshiftStandardSourceTest.java
+++ b/airbyte-integrations/connectors/source-redshift/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/RedshiftStandardSourceTest.java
@@ -103,8 +103,7 @@ public class RedshiftStandardSourceTest extends StandardSourceTest {
   @Override
   protected ConfiguredAirbyteCatalog getConfiguredCatalog() {
     return CatalogHelpers.createConfiguredAirbyteCatalog(
-        SCHEMA_NAME,
-        STREAM_NAME,
+        CatalogHelpers.createAirbyteStreamName(SCHEMA_NAME, STREAM_NAME),
         Field.of("c_custkey", Field.JsonSchemaPrimitive.NUMBER),
         Field.of("c_name", Field.JsonSchemaPrimitive.STRING),
         Field.of("c_nation", Field.JsonSchemaPrimitive.STRING));

--- a/airbyte-integrations/connectors/source-redshift/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/RedshiftStandardSourceTest.java
+++ b/airbyte-integrations/connectors/source-redshift/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/RedshiftStandardSourceTest.java
@@ -103,6 +103,7 @@ public class RedshiftStandardSourceTest extends StandardSourceTest {
   @Override
   protected ConfiguredAirbyteCatalog getConfiguredCatalog() {
     return CatalogHelpers.createConfiguredAirbyteCatalog(
+        SCHEMA_NAME,
         STREAM_NAME,
         Field.of("c_custkey", Field.JsonSchemaPrimitive.NUMBER),
         Field.of("c_name", Field.JsonSchemaPrimitive.STRING),

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -41,56 +41,61 @@ import java.util.stream.Collectors;
 
 public class CatalogHelpers {
 
-  public static AirbyteCatalog createAirbyteCatalog(String namespace, String streamName, Field... fields) {
-    return new AirbyteCatalog().withStreams(Lists.newArrayList(createAirbyteStream(namespace, streamName, fields)));
+  public static AirbyteCatalog createAirbyteCatalog(AirbyteStreamName streamName, Field... fields) {
+    return new AirbyteCatalog().withStreams(Lists.newArrayList(createAirbyteStream(streamName, fields)));
   }
 
-  public static AirbyteStream createAirbyteStream(String namespace, String streamName, Field... fields) {
-    return createAirbyteStream(namespace, streamName, Arrays.asList(fields));
+  public static AirbyteStream createAirbyteStream(AirbyteStreamName streamName, Field... fields) {
+    return createAirbyteStream(streamName, Arrays.asList(fields));
   }
 
-  public static AirbyteStream createAirbyteStream(String namespace, String streamName, List<Field> fields) {
+  public static AirbyteStreamName createAirbyteStreamName(String namespace, String streamName) {
+    return new AirbyteStreamName().withNamespace(namespace).withName(streamName);
+  }
+
+  public static AirbyteStream createAirbyteStream(AirbyteStreamName streamName, List<Field> fields) {
     return new AirbyteStream()
-        .withName(streamName)
-        .withStreamName(new AirbyteStreamName().withNamespace(namespace).withName(streamName))
+        .withStreamName(streamName)
+        // TODO: Switch fully to StreamName instead of temporarily setName() for backward compatibility
+        .withName(streamName.getName())
         .withJsonSchema(fieldsToJsonSchema(fields));
   }
 
-  public static ConfiguredAirbyteCatalog createConfiguredAirbyteCatalog(String namespace, String streamName, Field... fields) {
-    return new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(createConfiguredAirbyteStream(namespace, streamName, fields)));
+  public static ConfiguredAirbyteCatalog createConfiguredAirbyteCatalog(AirbyteStreamName streamName, Field... fields) {
+    return new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(createConfiguredAirbyteStream(streamName, fields)));
   }
 
-  public static ConfiguredAirbyteStream createConfiguredAirbyteStream(String namespace, String streamName, Field... fields) {
-    return createConfiguredAirbyteStream(namespace, streamName, Arrays.asList(fields));
+  public static ConfiguredAirbyteStream createConfiguredAirbyteStream(AirbyteStreamName streamName, Field... fields) {
+    return createConfiguredAirbyteStream(streamName, Arrays.asList(fields));
   }
 
-  public static ConfiguredAirbyteStream createConfiguredAirbyteStream(String namespace, String streamName, List<Field> fields) {
+  public static ConfiguredAirbyteStream createConfiguredAirbyteStream(AirbyteStreamName streamName, List<Field> fields) {
     return new ConfiguredAirbyteStream().withStream(
         new AirbyteStream()
-            .withName(streamName)
-            .withStreamName(new AirbyteStreamName().withNamespace(namespace).withName(streamName))
+            .withStreamName(streamName)
+            // TODO: Switch fully to StreamName instead of temporarily setName() for backward compatibility
+            .withName(streamName.getName())
             .withJsonSchema(fieldsToJsonSchema(fields)));
   }
 
   public static ConfiguredAirbyteStream createIncrementalConfiguredAirbyteStream(
-                                                                                 String namespace,
-                                                                                 String streamName,
+                                                                                 AirbyteStreamName streamName,
                                                                                  SyncMode syncMode,
                                                                                  String cursorFieldName,
                                                                                  Field... fields) {
-    return createIncrementalConfiguredAirbyteStream(namespace, streamName, syncMode, cursorFieldName, Arrays.asList(fields));
+    return createIncrementalConfiguredAirbyteStream(streamName, syncMode, cursorFieldName, Arrays.asList(fields));
   }
 
   public static ConfiguredAirbyteStream createIncrementalConfiguredAirbyteStream(
-                                                                                 String namespace,
-                                                                                 String streamName,
+                                                                                 AirbyteStreamName streamName,
                                                                                  SyncMode syncMode,
                                                                                  String cursorFieldName,
                                                                                  List<Field> fields) {
     return new ConfiguredAirbyteStream()
         .withStream(new AirbyteStream()
-            .withName(streamName)
-            .withStreamName(new AirbyteStreamName().withNamespace(namespace).withName(streamName))
+            .withStreamName(streamName)
+            // TODO: Switch fully to StreamName instead of temporarily setName() for backward compatibility
+            .withName(streamName.getName())
             .withSupportedSyncModes(Collections.singletonList(syncMode))
             .withJsonSchema(fieldsToJsonSchema(fields)))
         .withSyncMode(syncMode)

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -41,39 +41,48 @@ import java.util.stream.Collectors;
 
 public class CatalogHelpers {
 
-  public static AirbyteCatalog createAirbyteCatalog(String streamName, Field... fields) {
-    return new AirbyteCatalog().withStreams(Lists.newArrayList(createAirbyteStream(streamName, fields)));
+  public static AirbyteCatalog createAirbyteCatalog(String namespace, String streamName, Field... fields) {
+    return new AirbyteCatalog().withStreams(Lists.newArrayList(createAirbyteStream(namespace, streamName, fields)));
   }
 
-  public static AirbyteStream createAirbyteStream(String streamName, Field... fields) {
-    return createAirbyteStream(streamName, Arrays.asList(fields));
+  public static AirbyteStream createAirbyteStream(String namespace, String streamName, Field... fields) {
+    return createAirbyteStream(namespace, streamName, Arrays.asList(fields));
   }
 
-  public static AirbyteStream createAirbyteStream(String streamName, List<Field> fields) {
-    return new AirbyteStream().withName(streamName).withJsonSchema(fieldsToJsonSchema(fields));
+  public static AirbyteStream createAirbyteStream(String namespace, String streamName, List<Field> fields) {
+    return new AirbyteStream()
+        .withName(streamName)
+        .withStreamName(new AirbyteStreamName().withNamespace(namespace).withName(streamName))
+        .withJsonSchema(fieldsToJsonSchema(fields));
   }
 
-  public static ConfiguredAirbyteCatalog createConfiguredAirbyteCatalog(String streamName, Field... fields) {
-    return new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(createConfiguredAirbyteStream(streamName, fields)));
+  public static ConfiguredAirbyteCatalog createConfiguredAirbyteCatalog(String namespace, String streamName, Field... fields) {
+    return new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(createConfiguredAirbyteStream(namespace, streamName, fields)));
   }
 
-  public static ConfiguredAirbyteStream createConfiguredAirbyteStream(String streamName, Field... fields) {
-    return createConfiguredAirbyteStream(streamName, Arrays.asList(fields));
+  public static ConfiguredAirbyteStream createConfiguredAirbyteStream(String namespace, String streamName, Field... fields) {
+    return createConfiguredAirbyteStream(namespace, streamName, Arrays.asList(fields));
   }
 
-  public static ConfiguredAirbyteStream createConfiguredAirbyteStream(String streamName, List<Field> fields) {
-    return new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(streamName).withJsonSchema(fieldsToJsonSchema(fields)));
+  public static ConfiguredAirbyteStream createConfiguredAirbyteStream(String namespace, String streamName, List<Field> fields) {
+    return new ConfiguredAirbyteStream().withStream(
+        new AirbyteStream()
+            .withName(streamName)
+            .withStreamName(new AirbyteStreamName().withNamespace(namespace).withName(streamName))
+            .withJsonSchema(fieldsToJsonSchema(fields)));
   }
 
   public static ConfiguredAirbyteStream createIncrementalConfiguredAirbyteStream(
+                                                                                 String namespace,
                                                                                  String streamName,
                                                                                  SyncMode syncMode,
                                                                                  String cursorFieldName,
                                                                                  Field... fields) {
-    return createIncrementalConfiguredAirbyteStream(streamName, syncMode, cursorFieldName, Arrays.asList(fields));
+    return createIncrementalConfiguredAirbyteStream(namespace, streamName, syncMode, cursorFieldName, Arrays.asList(fields));
   }
 
   public static ConfiguredAirbyteStream createIncrementalConfiguredAirbyteStream(
+                                                                                 String namespace,
                                                                                  String streamName,
                                                                                  SyncMode syncMode,
                                                                                  String cursorFieldName,
@@ -81,6 +90,7 @@ public class CatalogHelpers {
     return new ConfiguredAirbyteStream()
         .withStream(new AirbyteStream()
             .withName(streamName)
+            .withStreamName(new AirbyteStreamName().withNamespace(namespace).withName(streamName))
             .withSupportedSyncModes(Collections.singletonList(syncMode))
             .withJsonSchema(fieldsToJsonSchema(fields)))
         .withSyncMode(syncMode)

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -127,6 +127,9 @@ definitions:
     properties:
       name:
         type: string
+        description: Stream's name (deprecated, will be replaced by stream_name).
+      stream_name:
+        "$ref": "#/definitions/AirbyteStreamName"
         description: Stream's name.
       json_schema:
         description: Stream schema using Json Schema specs.
@@ -144,6 +147,18 @@ definitions:
         type: array
         items:
           type: string
+  AirbyteStreamName:
+    type: object
+    additionalProperties: false
+    required:
+      - name
+    properties:
+      namespace:
+        type: string
+        description: Stream's namespace.
+      name:
+        type: string
+        description: Stream's name.
   ConfiguredAirbyteCatalog:
     description: Airbyte stream schema catalog
     type: object

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobSchedulerTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobSchedulerTest.java
@@ -58,6 +58,7 @@ class JobSchedulerTest {
   private Job previousJob;
 
   private static final String STREAM_NAME = "users";
+  private static final String STREAM_NAMESPACE = "tests";
   private static final String FIELD_NAME = "id";
 
   static {
@@ -66,7 +67,7 @@ class JobSchedulerTest {
     final UUID destinationId = UUID.randomUUID();
 
     final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream()
-        .withStream(CatalogHelpers.createAirbyteStream(STREAM_NAME, Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
+        .withStream(CatalogHelpers.createAirbyteStream(STREAM_NAMESPACE, STREAM_NAME, Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
     final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(Collections.singletonList(stream));
 
     final UUID connectionId = UUID.randomUUID();

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobSchedulerTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobSchedulerTest.java
@@ -67,7 +67,9 @@ class JobSchedulerTest {
     final UUID destinationId = UUID.randomUUID();
 
     final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream()
-        .withStream(CatalogHelpers.createAirbyteStream(STREAM_NAMESPACE, STREAM_NAME, Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
+        .withStream(CatalogHelpers.createAirbyteStream(
+            CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME),
+            Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
     final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(Collections.singletonList(stream));
 
     final UUID connectionId = UUID.randomUUID();

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
@@ -57,6 +57,7 @@ import org.junit.jupiter.api.Test;
 public class DefaultJobCreatorTest {
 
   private static final String STREAM_NAME = "users";
+  private static final String STREAM_NAMESPACE = "tests";
   private static final String FIELD_NAME = "id";
 
   private static final String SOURCE_IMAGE_NAME = "daxtarity/sourceimagename";
@@ -97,7 +98,7 @@ public class DefaultJobCreatorTest {
         .withTombstone(false);
 
     final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream()
-        .withStream(CatalogHelpers.createAirbyteStream(STREAM_NAME, Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
+        .withStream(CatalogHelpers.createAirbyteStream(STREAM_NAMESPACE, STREAM_NAME, Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
     final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(Collections.singletonList(stream));
 
     final UUID connectionId = UUID.randomUUID();

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
@@ -98,7 +98,9 @@ public class DefaultJobCreatorTest {
         .withTombstone(false);
 
     final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream()
-        .withStream(CatalogHelpers.createAirbyteStream(STREAM_NAMESPACE, STREAM_NAME, Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
+        .withStream(CatalogHelpers.createAirbyteStream(
+            CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME),
+            Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
     final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(Collections.singletonList(stream));
 
     final UUID connectionId = UUID.randomUUID();

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/CatalogConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/CatalogConverter.java
@@ -34,9 +34,34 @@ import java.util.stream.Collectors;
  */
 public class CatalogConverter {
 
+  private static io.airbyte.api.model.AirbyteStreamName toApi(final String name, final io.airbyte.protocol.models.AirbyteStreamName streamName) {
+    final io.airbyte.api.model.AirbyteStreamName result = new io.airbyte.api.model.AirbyteStreamName();
+    // Try to use streamName object or default to old name field
+    if (streamName != null) {
+      return result
+          .namespace(streamName.getNamespace())
+          .name(streamName.getName());
+    } else {
+      return result.name(name);
+    }
+  }
+
+  private static io.airbyte.protocol.models.AirbyteStreamName toProtocol(final String name, final io.airbyte.api.model.AirbyteStreamName streamName) {
+    final io.airbyte.protocol.models.AirbyteStreamName result = new io.airbyte.protocol.models.AirbyteStreamName();
+    // Try to use streamName object or default to old name field
+    if (streamName != null) {
+      return result
+          .withNamespace(streamName.getNamespace())
+          .withName(streamName.getName());
+    } else {
+      return result.withName(name);
+    }
+  }
+
   private static io.airbyte.api.model.AirbyteStream toApi(final io.airbyte.protocol.models.AirbyteStream stream) {
     return new io.airbyte.api.model.AirbyteStream()
         .name(stream.getName())
+        .streamName(toApi(stream.getName(), stream.getStreamName()))
         .jsonSchema(stream.getJsonSchema())
         .supportedSyncModes(Enums.convertListTo(stream.getSupportedSyncModes(), io.airbyte.api.model.SyncMode.class))
         .sourceDefinedCursor(stream.getSourceDefinedCursor())
@@ -46,6 +71,7 @@ public class CatalogConverter {
   private static io.airbyte.protocol.models.AirbyteStream toProtocol(final io.airbyte.api.model.AirbyteStream stream) {
     return new io.airbyte.protocol.models.AirbyteStream()
         .withName(stream.getName())
+        .withStreamName(toProtocol(stream.getName(), stream.getStreamName()))
         .withJsonSchema(stream.getJsonSchema())
         .withSupportedSyncModes(Enums.convertListTo(stream.getSupportedSyncModes(), io.airbyte.protocol.models.SyncMode.class))
         .withSourceDefinedCursor(stream.getSourceDefinedCursor())

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -148,13 +148,13 @@ public class WebBackendConnectionsHandler {
   protected static AirbyteCatalog updateSchemaWithDiscovery(AirbyteCatalog original, AirbyteCatalog discovered) {
     final Map<String, AirbyteStreamAndConfiguration> originalStreamsByName = original.getStreams()
         .stream()
-        .collect(toMap(s -> s.getStream().getName(), s -> s));
+        .collect(toMap(s -> s.getStream().getStreamName().toString(), s -> s));
 
     final List<AirbyteStreamAndConfiguration> streams = new ArrayList<>();
 
     for (AirbyteStreamAndConfiguration s : discovered.getStreams()) {
       final AirbyteStream stream = s.getStream();
-      final AirbyteStreamAndConfiguration originalStream = originalStreamsByName.get(stream.getName());
+      final AirbyteStreamAndConfiguration originalStream = originalStreamsByName.get(stream.getStreamName().toString());
       AirbyteStreamConfiguration outputStreamConfig;
 
       if (originalStream != null) {

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -118,7 +118,7 @@ class ConnectionsHandlerTest {
   @Test
   void testUpdateConnection() throws JsonValidationException, ConfigNotFoundException, IOException {
     final AirbyteCatalog catalog = ConnectionHelpers.generateBasicApiCatalog();
-    catalog.getStreams().get(0).getStream().setName("azkaban_users");
+    catalog.getStreams().get(0).getStream().getStreamName().setName("azkaban_users");
     catalog.getStreams().get(0).getConfig().setAliasName("azkaban_users");
 
     final ConnectionUpdate connectionUpdate = new ConnectionUpdate()
@@ -128,7 +128,7 @@ class ConnectionsHandlerTest {
         .syncCatalog(catalog);
 
     final ConfiguredAirbyteCatalog configuredCatalog = ConnectionHelpers.generateBasicConfiguredAirbyteCatalog();
-    configuredCatalog.getStreams().get(0).getStream().withName("azkaban_users");
+    configuredCatalog.getStreams().get(0).getStream().getStreamName().withName("azkaban_users");
 
     final StandardSync updatedStandardSync = new StandardSync()
         .withConnectionId(standardSync.getConnectionId())

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
@@ -97,6 +97,7 @@ class SchedulerHandlerTest {
   private static final String DESTINATION_DOCKER_IMAGE = DockerUtils.getTaggedImageName(DESTINATION_DOCKER_REPO, DESTINATION_DOCKER_TAG);
 
   private static final String STREAM_NAMESPACE = "tests";
+  private static final String STREAM_NAME = "shoes";
 
   private static final SourceConnection SOURCE = new SourceConnection()
       .withName("my postgres db")
@@ -334,7 +335,9 @@ class SchedulerHandlerTest {
     when(schedulerJobClient.createDiscoverSchemaJob(source, SOURCE_DOCKER_IMAGE)).thenReturn(completedJob);
     final JobOutput jobOutput = new JobOutput()
         .withDiscoverCatalog(new StandardDiscoverCatalogOutput()
-            .withCatalog(CatalogHelpers.createAirbyteCatalog(STREAM_NAMESPACE, "shoes", Field.of("sku", JsonSchemaPrimitive.STRING))));
+            .withCatalog(CatalogHelpers.createAirbyteCatalog(
+                CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME),
+                Field.of("sku", JsonSchemaPrimitive.STRING))));
     when(completedJob.getSuccessOutput()).thenReturn(Optional.of(jobOutput));
 
     final SourceDiscoverSchemaRead actual = schedulerHandler.discoverSchemaForSourceFromSourceId(request);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
@@ -96,6 +96,8 @@ class SchedulerHandlerTest {
   private static final String DESTINATION_DOCKER_TAG = "tag";
   private static final String DESTINATION_DOCKER_IMAGE = DockerUtils.getTaggedImageName(DESTINATION_DOCKER_REPO, DESTINATION_DOCKER_TAG);
 
+  private static final String STREAM_NAMESPACE = "tests";
+
   private static final SourceConnection SOURCE = new SourceConnection()
       .withName("my postgres db")
       .withWorkspaceId(UUID.randomUUID())
@@ -332,7 +334,7 @@ class SchedulerHandlerTest {
     when(schedulerJobClient.createDiscoverSchemaJob(source, SOURCE_DOCKER_IMAGE)).thenReturn(completedJob);
     final JobOutput jobOutput = new JobOutput()
         .withDiscoverCatalog(new StandardDiscoverCatalogOutput()
-            .withCatalog(CatalogHelpers.createAirbyteCatalog("shoes", Field.of("sku", JsonSchemaPrimitive.STRING))));
+            .withCatalog(CatalogHelpers.createAirbyteCatalog(STREAM_NAMESPACE, "shoes", Field.of("sku", JsonSchemaPrimitive.STRING))));
     when(completedJob.getSuccessOutput()).thenReturn(Optional.of(jobOutput));
 
     final SourceDiscoverSchemaRead actual = schedulerHandler.discoverSchemaForSourceFromSourceId(request);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -239,7 +239,7 @@ class WebBackendConnectionsHandlerTest {
     final StandardSync standardSync = ConnectionHelpers.generateSyncWithSourceId(source.getSourceId());
 
     final AirbyteCatalog catalog = ConnectionHelpers.generateBasicApiCatalog();
-    catalog.getStreams().get(0).getStream().setName("azkaban_users");
+    catalog.getStreams().get(0).getStream().getStreamName().setName("azkaban_users");
 
     final ConnectionSchedule schedule = new ConnectionSchedule().units(1L).timeUnit(ConnectionSchedule.TimeUnitEnum.MINUTES);
 
@@ -335,8 +335,8 @@ class WebBackendConnectionsHandlerTest {
   public void testUpdateSchemaWithDiscoveryFromEmpty() {
     final AirbyteCatalog original = new AirbyteCatalog().streams(List.of());
     final AirbyteCatalog discovered = ConnectionHelpers.generateBasicApiCatalog();
+    discovered.getStreams().get(0).getStream().getStreamName().name("stream1");
     discovered.getStreams().get(0).getStream()
-        .name("stream1")
         .jsonSchema(CatalogHelpers.fieldsToJsonSchema(Field.of("field1", JsonSchemaPrimitive.STRING)))
         .supportedSyncModes(List.of(SyncMode.FULL_REFRESH));
     discovered.getStreams().get(0).getConfig()
@@ -345,8 +345,8 @@ class WebBackendConnectionsHandlerTest {
         .aliasName("stream1");
 
     final AirbyteCatalog expected = ConnectionHelpers.generateBasicApiCatalog();
+    expected.getStreams().get(0).getStream().getStreamName().name("stream1");
     expected.getStreams().get(0).getStream()
-        .name("stream1")
         .jsonSchema(CatalogHelpers.fieldsToJsonSchema(Field.of("field1", JsonSchemaPrimitive.STRING)))
         .supportedSyncModes(List.of(SyncMode.FULL_REFRESH));
     expected.getStreams().get(0).getConfig()
@@ -362,8 +362,8 @@ class WebBackendConnectionsHandlerTest {
   @Test
   public void testUpdateSchemaWithDiscoveryResetStream() {
     final AirbyteCatalog original = ConnectionHelpers.generateBasicApiCatalog();
+    original.getStreams().get(0).getStream().getStreamName().name("random-stream");
     original.getStreams().get(0).getStream()
-        .name("random-stream")
         .defaultCursorField(List.of("field1"))
         .jsonSchema(CatalogHelpers.fieldsToJsonSchema(
             Field.of("field1", JsonSchemaPrimitive.NUMBER),
@@ -376,8 +376,8 @@ class WebBackendConnectionsHandlerTest {
         .aliasName("random_stream");
 
     final AirbyteCatalog discovered = ConnectionHelpers.generateBasicApiCatalog();
+    discovered.getStreams().get(0).getStream().getStreamName().name("stream1");
     discovered.getStreams().get(0).getStream()
-        .name("stream1")
         .defaultCursorField(List.of("field3"))
         .jsonSchema(CatalogHelpers.fieldsToJsonSchema(Field.of("field2", JsonSchemaPrimitive.STRING)))
         .supportedSyncModes(List.of(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL));
@@ -387,8 +387,8 @@ class WebBackendConnectionsHandlerTest {
         .aliasName("stream1");
 
     final AirbyteCatalog expected = ConnectionHelpers.generateBasicApiCatalog();
+    expected.getStreams().get(0).getStream().getStreamName().name("stream1");
     expected.getStreams().get(0).getStream()
-        .name("stream1")
         .defaultCursorField(List.of("field3"))
         .jsonSchema(CatalogHelpers.fieldsToJsonSchema(Field.of("field2", JsonSchemaPrimitive.STRING)))
         .supportedSyncModes(List.of(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL));
@@ -405,8 +405,8 @@ class WebBackendConnectionsHandlerTest {
   @Test
   public void testUpdateSchemaWithDiscoveryMergeNewStream() {
     final AirbyteCatalog original = ConnectionHelpers.generateBasicApiCatalog();
+    original.getStreams().get(0).getStream().getStreamName().name("stream1");
     original.getStreams().get(0).getStream()
-        .name("stream1")
         .defaultCursorField(List.of("field1"))
         .jsonSchema(CatalogHelpers.fieldsToJsonSchema(
             Field.of("field1", JsonSchemaPrimitive.NUMBER),
@@ -419,8 +419,8 @@ class WebBackendConnectionsHandlerTest {
         .aliasName("renamed_stream");
 
     final AirbyteCatalog discovered = ConnectionHelpers.generateBasicApiCatalog();
+    discovered.getStreams().get(0).getStream().getStreamName().name("stream1");
     discovered.getStreams().get(0).getStream()
-        .name("stream1")
         .defaultCursorField(List.of("field3"))
         .jsonSchema(CatalogHelpers.fieldsToJsonSchema(Field.of("field2", JsonSchemaPrimitive.STRING)))
         .supportedSyncModes(List.of(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL));
@@ -429,8 +429,8 @@ class WebBackendConnectionsHandlerTest {
         .cursorField(Collections.emptyList())
         .aliasName("stream1");
     final AirbyteStreamAndConfiguration newStream = ConnectionHelpers.generateBasicApiCatalog().getStreams().get(0);
+    newStream.getStream().getStreamName().name("stream2");
     newStream.getStream()
-        .name("stream2")
         .defaultCursorField(List.of("field5"))
         .jsonSchema(CatalogHelpers.fieldsToJsonSchema(Field.of("field5", JsonSchemaPrimitive.BOOLEAN)))
         .supportedSyncModes(List.of(SyncMode.FULL_REFRESH));
@@ -441,8 +441,8 @@ class WebBackendConnectionsHandlerTest {
     discovered.getStreams().add(newStream);
 
     final AirbyteCatalog expected = ConnectionHelpers.generateBasicApiCatalog();
+    expected.getStreams().get(0).getStream().getStreamName().name("stream1");
     expected.getStreams().get(0).getStream()
-        .name("stream1")
         .defaultCursorField(List.of("field3"))
         .jsonSchema(CatalogHelpers.fieldsToJsonSchema(Field.of("field2", JsonSchemaPrimitive.STRING)))
         .supportedSyncModes(List.of(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL));
@@ -451,8 +451,8 @@ class WebBackendConnectionsHandlerTest {
         .cursorField(List.of("field1"))
         .aliasName("renamed_stream");
     final AirbyteStreamAndConfiguration expectedNewStream = ConnectionHelpers.generateBasicApiCatalog().getStreams().get(0);
+    expectedNewStream.getStream().getStreamName().name("stream2");
     expectedNewStream.getStream()
-        .name("stream2")
         .defaultCursorField(List.of("field5"))
         .jsonSchema(CatalogHelpers.fieldsToJsonSchema(Field.of("field5", JsonSchemaPrimitive.BOOLEAN)))
         .supportedSyncModes(List.of(SyncMode.FULL_REFRESH));

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
@@ -129,7 +129,9 @@ public class ConnectionHelpers {
   }
 
   private static io.airbyte.protocol.models.AirbyteStream generateBasicAirbyteStream() {
-    return CatalogHelpers.createAirbyteStream(STREAM_NAMESPACE, STREAM_NAME, Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING))
+    return CatalogHelpers.createAirbyteStream(
+        CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME),
+        Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING))
         .withDefaultCursorField(Lists.newArrayList(FIELD_NAME))
         .withSourceDefinedCursor(false)
         .withSupportedSyncModes(List.of(io.airbyte.protocol.models.SyncMode.FULL_REFRESH, io.airbyte.protocol.models.SyncMode.INCREMENTAL));
@@ -151,12 +153,17 @@ public class ConnectionHelpers {
 
   private static AirbyteStream generateBasicApiStream() {
     return new AirbyteStream()
+        .streamName(generateBasicApiStreamName())
+        // TODO: Switch fully to StreamName instead of temporarily setName() for backward compatibility
         .name(STREAM_NAME)
-        .streamName(new AirbyteStreamName().name(STREAM_NAME).namespace(STREAM_NAMESPACE))
         .jsonSchema(generateBasicJsonSchema())
         .defaultCursorField(Lists.newArrayList(FIELD_NAME))
         .sourceDefinedCursor(false)
         .supportedSyncModes(List.of(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL));
+  }
+
+  private static AirbyteStreamName generateBasicApiStreamName() {
+    return new AirbyteStreamName().namespace(STREAM_NAMESPACE).name(STREAM_NAME);
   }
 
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
@@ -30,6 +30,7 @@ import io.airbyte.api.model.AirbyteCatalog;
 import io.airbyte.api.model.AirbyteStream;
 import io.airbyte.api.model.AirbyteStreamAndConfiguration;
 import io.airbyte.api.model.AirbyteStreamConfiguration;
+import io.airbyte.api.model.AirbyteStreamName;
 import io.airbyte.api.model.ConnectionRead;
 import io.airbyte.api.model.ConnectionSchedule;
 import io.airbyte.api.model.ConnectionStatus;
@@ -50,6 +51,7 @@ import java.util.UUID;
 public class ConnectionHelpers {
 
   private static final String STREAM_NAME = "users-data";
+  private static final String STREAM_NAMESPACE = "tests";
   private static final String FIELD_NAME = "id";
 
   public static StandardSync generateSyncWithSourceId(UUID sourceId) {
@@ -127,7 +129,7 @@ public class ConnectionHelpers {
   }
 
   private static io.airbyte.protocol.models.AirbyteStream generateBasicAirbyteStream() {
-    return CatalogHelpers.createAirbyteStream(STREAM_NAME, Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING))
+    return CatalogHelpers.createAirbyteStream(STREAM_NAMESPACE, STREAM_NAME, Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING))
         .withDefaultCursorField(Lists.newArrayList(FIELD_NAME))
         .withSourceDefinedCursor(false)
         .withSupportedSyncModes(List.of(io.airbyte.protocol.models.SyncMode.FULL_REFRESH, io.airbyte.protocol.models.SyncMode.INCREMENTAL));
@@ -150,6 +152,7 @@ public class ConnectionHelpers {
   private static AirbyteStream generateBasicApiStream() {
     return new AirbyteStream()
         .name(STREAM_NAME)
+        .streamName(new AirbyteStreamName().name(STREAM_NAME).namespace(STREAM_NAMESPACE))
         .jsonSchema(generateBasicJsonSchema())
         .defaultCursorField(Lists.newArrayList(FIELD_NAME))
         .sourceDefinedCursor(false)

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -45,6 +45,7 @@ import io.airbyte.api.client.model.AirbyteCatalog;
 import io.airbyte.api.client.model.AirbyteStream;
 import io.airbyte.api.client.model.AirbyteStreamAndConfiguration;
 import io.airbyte.api.client.model.AirbyteStreamConfiguration;
+import io.airbyte.api.client.model.AirbyteStreamName;
 import io.airbyte.api.client.model.CheckConnectionRead;
 import io.airbyte.api.client.model.ConnectionCreate;
 import io.airbyte.api.client.model.ConnectionIdRequestBody;
@@ -115,7 +116,8 @@ public class AcceptanceTests {
   private static final boolean IS_KUBE = System.getenv().containsKey("KUBE");
 
   private static final String TABLE_NAME = "id_and_name";
-  private static final String STREAM_NAME = "public." + TABLE_NAME;
+  private static final String STREAM_NAMESPACE = "public";
+  private static final String STREAM_NAME = STREAM_NAMESPACE + "." + TABLE_NAME;
   private static final String COLUMN_ID = "id";
   private static final String COLUMN_NAME = "name";
   private static final String COLUMN_NAME_DATA = "_airbyte_data";
@@ -281,6 +283,7 @@ public class AcceptanceTests {
         .build());
     final AirbyteStream stream = new AirbyteStream()
         .name(STREAM_NAME)
+        .streamName(new AirbyteStreamName().namespace(STREAM_NAMESPACE).name(TABLE_NAME))
         .jsonSchema(jsonSchema)
         .defaultCursorField(Collections.emptyList())
         .supportedSyncModes(List.of(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL));

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultDiscoverCatalogWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultDiscoverCatalogWorkerTest.java
@@ -63,14 +63,13 @@ public class DefaultDiscoverCatalogWorkerTest {
   private static final StandardDiscoverCatalogInput INPUT = new StandardDiscoverCatalogInput().withConnectionConfiguration(CREDENTIALS);
 
   private static final Path TEST_ROOT = Path.of("/tmp/airbyte_tests");
-  private static final String STREAM = "users";
+  private static final String STREAM_NAME = "users";
   private static final String STREAM_NAMESPACE = "tests";
   private static final String COLUMN_NAME = "name";
   private static final String COLUMN_AGE = "age";
   private static final AirbyteCatalog CATALOG = new AirbyteCatalog()
       .withStreams(Lists.newArrayList(CatalogHelpers.createAirbyteStream(
-          STREAM_NAMESPACE,
-          STREAM,
+          CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME),
           Field.of(COLUMN_NAME, JsonSchemaPrimitive.STRING),
           Field.of(COLUMN_AGE, JsonSchemaPrimitive.NUMBER))));
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultDiscoverCatalogWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultDiscoverCatalogWorkerTest.java
@@ -64,10 +64,12 @@ public class DefaultDiscoverCatalogWorkerTest {
 
   private static final Path TEST_ROOT = Path.of("/tmp/airbyte_tests");
   private static final String STREAM = "users";
+  private static final String STREAM_NAMESPACE = "tests";
   private static final String COLUMN_NAME = "name";
   private static final String COLUMN_AGE = "age";
   private static final AirbyteCatalog CATALOG = new AirbyteCatalog()
       .withStreams(Lists.newArrayList(CatalogHelpers.createAirbyteStream(
+          STREAM_NAMESPACE,
           STREAM,
           Field.of(COLUMN_NAME, JsonSchemaPrimitive.STRING),
           Field.of(COLUMN_AGE, JsonSchemaPrimitive.NUMBER))));

--- a/airbyte-workers/src/test/java/io/airbyte/workers/TestConfigHelpers.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/TestConfigHelpers.java
@@ -45,6 +45,7 @@ public class TestConfigHelpers {
 
   private static final String CONNECTION_NAME = "favorite_color_pipe";
   private static final String STREAM_NAME = "user_preferences";
+  private static final String STREAM_NAMESPACE = "tests";
   private static final String FIELD_NAME = "favorite_color";
   private static final long LAST_SYNC_TIME = 1598565106;
 
@@ -83,7 +84,7 @@ public class TestConfigHelpers {
         .withTombstone(false);
 
     final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream()
-        .withStream(CatalogHelpers.createAirbyteStream(STREAM_NAME, Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
+        .withStream(CatalogHelpers.createAirbyteStream(STREAM_NAMESPACE, STREAM_NAME, Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
     final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(Collections.singletonList(stream));
 
     final StandardSync standardSync = new StandardSync()

--- a/airbyte-workers/src/test/java/io/airbyte/workers/TestConfigHelpers.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/TestConfigHelpers.java
@@ -84,7 +84,9 @@ public class TestConfigHelpers {
         .withTombstone(false);
 
     final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream()
-        .withStream(CatalogHelpers.createAirbyteStream(STREAM_NAMESPACE, STREAM_NAME, Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
+        .withStream(CatalogHelpers.createAirbyteStream(
+            CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, STREAM_NAME),
+            Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
     final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(Collections.singletonList(stream));
 
     final StandardSync standardSync = new StandardSync()

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
@@ -41,11 +41,8 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.StandardTapConfig;
 import io.airbyte.config.State;
 import io.airbyte.protocol.models.AirbyteMessage;
-import io.airbyte.protocol.models.AirbyteStream;
-import io.airbyte.protocol.models.AirbyteStreamName;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
-import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
 import io.airbyte.workers.WorkerConstants;
@@ -58,7 +55,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
@@ -72,20 +68,18 @@ class DefaultAirbyteSourceTest {
   private static final String STREAM_NAMESPACE = "tests";
   private static final String FIELD_NAME = "favorite_color";
 
-  private static final ConfiguredAirbyteCatalog CATALOG = new ConfiguredAirbyteCatalog()
-      .withStreams(Collections.singletonList(
-          new ConfiguredAirbyteStream()
-              .withStream(new AirbyteStream()
-                  .withName("hudi:latest")
-                  .withStreamName(new AirbyteStreamName().withName("hudi:latest").withNamespace(STREAM_NAMESPACE))
-                  .withJsonSchema(CatalogHelpers.fieldsToJsonSchema(new Field(FIELD_NAME, Field.JsonSchemaPrimitive.STRING))))));
+  private static final ConfiguredAirbyteCatalog CATALOG = CatalogHelpers.createConfiguredAirbyteCatalog(
+      CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, "hudi:latest"),
+      Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING));
 
   private static final StandardTapConfig TAP_CONFIG = new StandardTapConfig()
       .withState(new State().withState(Jsons.jsonNode(ImmutableMap.of("checkpoint", "the future."))))
       .withSourceConnectionConfiguration(Jsons.jsonNode(Map.of(
           "apiKey", "123",
           "region", "us-east")))
-      .withCatalog(CatalogHelpers.createConfiguredAirbyteCatalog(STREAM_NAMESPACE, "hudi:latest", Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
+      .withCatalog(CatalogHelpers.createConfiguredAirbyteCatalog(
+          CatalogHelpers.createAirbyteStreamName(STREAM_NAMESPACE, "hudi:latest"),
+          Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
 
   private static final List<AirbyteMessage> MESSAGES = Lists.newArrayList(
       AirbyteMessageUtils.createRecordMessage(STREAM_NAME, FIELD_NAME, "blue"),

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
@@ -42,6 +42,7 @@ import io.airbyte.config.StandardTapConfig;
 import io.airbyte.config.State;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteStream;
+import io.airbyte.protocol.models.AirbyteStreamName;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
@@ -68,6 +69,7 @@ class DefaultAirbyteSourceTest {
 
   private static final Path TEST_ROOT = Path.of("/tmp/airbyte_tests");
   private static final String STREAM_NAME = "user_preferences";
+  private static final String STREAM_NAMESPACE = "tests";
   private static final String FIELD_NAME = "favorite_color";
 
   private static final ConfiguredAirbyteCatalog CATALOG = new ConfiguredAirbyteCatalog()
@@ -75,6 +77,7 @@ class DefaultAirbyteSourceTest {
           new ConfiguredAirbyteStream()
               .withStream(new AirbyteStream()
                   .withName("hudi:latest")
+                  .withStreamName(new AirbyteStreamName().withName("hudi:latest").withNamespace(STREAM_NAMESPACE))
                   .withJsonSchema(CatalogHelpers.fieldsToJsonSchema(new Field(FIELD_NAME, Field.JsonSchemaPrimitive.STRING))))));
 
   private static final StandardTapConfig TAP_CONFIG = new StandardTapConfig()
@@ -82,7 +85,7 @@ class DefaultAirbyteSourceTest {
       .withSourceConnectionConfiguration(Jsons.jsonNode(Map.of(
           "apiKey", "123",
           "region", "us-east")))
-      .withCatalog(CatalogHelpers.createConfiguredAirbyteCatalog("hudi:latest", Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
+      .withCatalog(CatalogHelpers.createConfiguredAirbyteCatalog(STREAM_NAMESPACE, "hudi:latest", Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING)));
 
   private static final List<AirbyteMessage> MESSAGES = Lists.newArrayList(
       AirbyteMessageUtils.createRecordMessage(STREAM_NAME, FIELD_NAME, "blue"),

--- a/airbyte-workers/src/test/java/io/airbyte/workers/wrappers/JobOutputDiscoveryWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/wrappers/JobOutputDiscoveryWorkerTest.java
@@ -48,7 +48,7 @@ public class JobOutputDiscoveryWorkerTest {
     DiscoverCatalogWorker discoverWorker = mock(DiscoverCatalogWorker.class);
 
     StandardDiscoverCatalogOutput output = new StandardDiscoverCatalogOutput().withCatalog(
-        CatalogHelpers.createAirbyteCatalog("namespace", "table"));
+        CatalogHelpers.createAirbyteCatalog(CatalogHelpers.createAirbyteStreamName("namespace", "table")));
 
     when(discoverWorker.run(input, jobRoot)).thenReturn(new OutputAndStatus<>(JobStatus.SUCCEEDED, output));
     OutputAndStatus<JobOutput> run = new JobOutputDiscoverSchemaWorker(discoverWorker).run(input, jobRoot);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/wrappers/JobOutputDiscoveryWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/wrappers/JobOutputDiscoveryWorkerTest.java
@@ -48,7 +48,7 @@ public class JobOutputDiscoveryWorkerTest {
     DiscoverCatalogWorker discoverWorker = mock(DiscoverCatalogWorker.class);
 
     StandardDiscoverCatalogOutput output = new StandardDiscoverCatalogOutput().withCatalog(
-        CatalogHelpers.createAirbyteCatalog("table"));
+        CatalogHelpers.createAirbyteCatalog("namespace", "table"));
 
     when(discoverWorker.run(input, jobRoot)).thenReturn(new OutputAndStatus<>(JobStatus.SUCCEEDED, output));
     OutputAndStatus<JobOutput> run = new JobOutputDiscoverSchemaWorker(discoverWorker).run(input, jobRoot);

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,8 @@ def createSpotlessTarget = { pattern ->
         '*.egg-info',
         'build',
         'dbt-project-template',
-        'tools'
+        'tools',
+        'secrets'
     ]
 
     if(System.getenv().containsKey("CORE_ONLY")) {

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -363,7 +363,11 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "streamName" : {
+          "namespace" : "namespace",
+          "name" : "name"
+        }
       },
       "config" : {
         "aliasName" : "aliasName",
@@ -375,7 +379,11 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "streamName" : {
+          "namespace" : "namespace",
+          "name" : "name"
+        }
       },
       "config" : {
         "aliasName" : "aliasName",
@@ -494,7 +502,11 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "streamName" : {
+          "namespace" : "namespace",
+          "name" : "name"
+        }
       },
       "config" : {
         "aliasName" : "aliasName",
@@ -506,7 +518,11 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "streamName" : {
+          "namespace" : "namespace",
+          "name" : "name"
+        }
       },
       "config" : {
         "aliasName" : "aliasName",
@@ -587,7 +603,11 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "streamName" : {
+            "namespace" : "namespace",
+            "name" : "name"
+          }
         },
         "config" : {
           "aliasName" : "aliasName",
@@ -599,7 +619,11 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "streamName" : {
+            "namespace" : "namespace",
+            "name" : "name"
+          }
         },
         "config" : {
           "aliasName" : "aliasName",
@@ -623,7 +647,11 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "streamName" : {
+            "namespace" : "namespace",
+            "name" : "name"
+          }
         },
         "config" : {
           "aliasName" : "aliasName",
@@ -635,7 +663,11 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "streamName" : {
+            "namespace" : "namespace",
+            "name" : "name"
+          }
         },
         "config" : {
           "aliasName" : "aliasName",
@@ -892,7 +924,11 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "streamName" : {
+          "namespace" : "namespace",
+          "name" : "name"
+        }
       },
       "config" : {
         "aliasName" : "aliasName",
@@ -904,7 +940,11 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "streamName" : {
+          "namespace" : "namespace",
+          "name" : "name"
+        }
       },
       "config" : {
         "aliasName" : "aliasName",
@@ -2358,7 +2398,11 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "streamName" : {
+          "namespace" : "namespace",
+          "name" : "name"
+        }
       },
       "config" : {
         "aliasName" : "aliasName",
@@ -2370,7 +2414,11 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "streamName" : {
+          "namespace" : "namespace",
+          "name" : "name"
+        }
       },
       "config" : {
         "aliasName" : "aliasName",
@@ -2761,7 +2809,11 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "streamName" : {
+          "namespace" : "namespace",
+          "name" : "name"
+        }
       },
       "config" : {
         "aliasName" : "aliasName",
@@ -2773,7 +2825,11 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "streamName" : {
+          "namespace" : "namespace",
+          "name" : "name"
+        }
       },
       "config" : {
         "aliasName" : "aliasName",
@@ -3393,7 +3449,11 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "streamName" : {
+          "namespace" : "namespace",
+          "name" : "name"
+        }
       },
       "config" : {
         "aliasName" : "aliasName",
@@ -3405,7 +3465,11 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "streamName" : {
+          "namespace" : "namespace",
+          "name" : "name"
+        }
       },
       "config" : {
         "aliasName" : "aliasName",
@@ -3508,7 +3572,11 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "streamName" : {
+            "namespace" : "namespace",
+            "name" : "name"
+          }
         },
         "config" : {
           "aliasName" : "aliasName",
@@ -3520,7 +3588,11 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "streamName" : {
+            "namespace" : "namespace",
+            "name" : "name"
+          }
         },
         "config" : {
           "aliasName" : "aliasName",
@@ -3566,7 +3638,11 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "streamName" : {
+            "namespace" : "namespace",
+            "name" : "name"
+          }
         },
         "config" : {
           "aliasName" : "aliasName",
@@ -3578,7 +3654,11 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "streamName" : {
+            "namespace" : "namespace",
+            "name" : "name"
+          }
         },
         "config" : {
           "aliasName" : "aliasName",
@@ -3804,7 +3884,11 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "streamName" : {
+          "namespace" : "namespace",
+          "name" : "name"
+        }
       },
       "config" : {
         "aliasName" : "aliasName",
@@ -3816,7 +3900,11 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "streamName" : {
+          "namespace" : "namespace",
+          "name" : "name"
+        }
       },
       "config" : {
         "aliasName" : "aliasName",
@@ -4054,6 +4142,7 @@ font-style: italic;
     <li><a href="#AirbyteStream"><code>AirbyteStream</code> - </a></li>
     <li><a href="#AirbyteStreamAndConfiguration"><code>AirbyteStreamAndConfiguration</code> - </a></li>
     <li><a href="#AirbyteStreamConfiguration"><code>AirbyteStreamConfiguration</code> - </a></li>
+    <li><a href="#AirbyteStreamName"><code>AirbyteStreamName</code> - </a></li>
     <li><a href="#AttemptInfoRead"><code>AttemptInfoRead</code> - </a></li>
     <li><a href="#AttemptRead"><code>AttemptRead</code> - </a></li>
     <li><a href="#AttemptStatus"><code>AttemptStatus</code> - </a></li>
@@ -4130,7 +4219,8 @@ font-style: italic;
     <h3><a name="AirbyteStream"><code>AirbyteStream</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'>the immutable schema defined by the source</div>
     <div class="field-items">
-      <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Stream's name. </div>
+      <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Stream's name (deprecated, will be replaced by stream_name). </div>
+<div class="param">streamName (optional)</div><div class="param-desc"><span class="param-type"><a href="#AirbyteStreamName">AirbyteStreamName</a></span>  </div>
 <div class="param">jsonSchema (optional)</div><div class="param-desc"><span class="param-type"><a href="#StreamJsonSchema">StreamJsonSchema</a></span>  </div>
 <div class="param">supportedSyncModes (optional)</div><div class="param-desc"><span class="param-type"><a href="#SyncMode">array[SyncMode]</a></span>  </div>
 <div class="param">sourceDefinedCursor (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> If the source defines the cursor field, then it does any other cursor field inputs will be ignored. If it does not either the user_provided one is used or as a backup the default one is used. </div>
@@ -4153,6 +4243,14 @@ font-style: italic;
 <div class="param">cursorField (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> Path to the field that will be used to determine if a record is new or modified since the last sync. This field is REQUIRED if <code>sync_mode</code> is <code>incremental</code>. Otherwise it is ignored. </div>
 <div class="param">aliasName (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Alias name to the stream to be used in the destination </div>
 <div class="param">selected (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AirbyteStreamName"><code>AirbyteStreamName</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">namespace (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Stream's namespace. </div>
+<div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Stream's name. </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What
*Describe what the change is solving*
Same as  #1993 to implement  #1921

## How
*Describe the solution*

This introduces a new object `AirbyteStreamName` in both the API and the Airbyte Protocol to represent namespace and table name in a single struct.
The old `name` of `AirbyteStream` is kept as it was but the new fields are properly populated with separate namespace/table names.

So for example, we would have catalog produced by the JDBC sources:
- Stream name: public.users (like before)
- AirbyteStreamName.namespace: public (new)
- AirbyteStreamName.name: users (new)

Non-jdbc sources are now producing:
- Stream name: users (like before)
- AirbyteStreamName.namespace:  (empty)
- AirbyteStreamName.name: users (same as stream name)

These new fields won't be used right away so they shouldn't introduce any change to the product until the last step is implemented. 

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*
- [ ] *Verify Acceptance tests* (depends on new docker images)

## Recommended reading order
1. `airbyte-api/src/main/openapi/config.yaml`
1. `airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml`
2. `airbyte-server/src/main/java/io/airbyte/server/converters/CatalogConverter.java`
3. `airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java`
1. the rest
