### PR TITLE
Add pre/post hooks for std tests

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-standard-source-test-file.gradle
+++ b/buildSrc/src/main/groovy/airbyte-standard-source-test-file.gradle
@@ -2,6 +2,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 abstract class AirbyteStandardSourceTestFileConfiguration {
+    Closure prehook
+    Closure posthook
     String configPath
     String configuredCatalogPath
     String specPath
@@ -26,32 +28,37 @@ class AirbyteStandardSourceTestFilePlugin implements Plugin<Project> {
 
         project.task('standardSourceTestFile') {
             doFirst {
-                project.exec {
-                    validateConfig(config)
-                    def targetMountDirectory = "/test_input"
-                    def args = [
-                            'docker', 'run', '--rm', '-i',
-                            // provide access to the docker daemon
-                            '-v', "/var/run/docker.sock:/var/run/docker.sock",
-                            // A container within a container mounts from the host filesystem, not the parent container.
-                            // this forces /tmp to be the same directory for host, parent container, and child container.
-                            '-v', "/tmp:/tmp",
-                            // mount the project dir. all provided input paths must be relative to that dir.
-                            '-v', "${project.projectDir.absolutePath}:${targetMountDirectory}",
-                            '--name', "std-fs-source-test-${project.name}",
-                            'airbyte/base-standard-source-test-file:dev',
-                            '--imageName', DockerHelpers.getDevTaggedImage(project.projectDir, 'Dockerfile'),
-                            '--catalog', "${targetMountDirectory}/${config.configuredCatalogPath}",
-                            '--spec', "${targetMountDirectory}/${config.specPath}",
-                            '--config', "${targetMountDirectory}/${config.configPath}",
-                    ]
+                config.prehook.call()
+                try {
+                    project.exec {
+                        validateConfig(config)
+                        def targetMountDirectory = "/test_input"
+                        def args = [
+                                'docker', 'run', '--rm', '-i',
+                                // provide access to the docker daemon
+                                '-v', "/var/run/docker.sock:/var/run/docker.sock",
+                                // A container within a container mounts from the host filesystem, not the parent container.
+                                // this forces /tmp to be the same directory for host, parent container, and child container.
+                                '-v', "/tmp:/tmp",
+                                // mount the project dir. all provided input paths must be relative to that dir.
+                                '-v', "${project.projectDir.absolutePath}:${targetMountDirectory}",
+                                '--name', "std-fs-source-test-${project.name}",
+                                'airbyte/base-standard-source-test-file:dev',
+                                '--imageName', DockerHelpers.getDevTaggedImage(project.projectDir, 'Dockerfile'),
+                                '--catalog', "${targetMountDirectory}/${config.configuredCatalogPath}",
+                                '--spec', "${targetMountDirectory}/${config.specPath}",
+                                '--config', "${targetMountDirectory}/${config.configPath}",
+                        ]
 
-                    if (config.statePath != null){
-                        args.add("--state")
-                        args.add("${targetMountDirectory}/${config.statePath}")
+                        if (config.statePath != null) {
+                            args.add("--state")
+                            args.add("${targetMountDirectory}/${config.statePath}")
+                        }
+
+                        commandLine args
                     }
-
-                    commandLine args
+                } finally {
+                    config.posthook.call()
                 }
             }
 

--- a/buildSrc/src/main/groovy/airbyte-standard-source-test-file.gradle
+++ b/buildSrc/src/main/groovy/airbyte-standard-source-test-file.gradle
@@ -28,8 +28,8 @@ class AirbyteStandardSourceTestFilePlugin implements Plugin<Project> {
 
         project.task('standardSourceTestFile') {
             doFirst {
-                config.prehook.call()
                 try {
+                    config.prehook.call()
                     project.exec {
                         validateConfig(config)
                         def targetMountDirectory = "/test_input"


### PR DESCRIPTION
## What
Adds pre/post hooks that can be run for file-based standard tests. This allows configuring inputs  to the test and cleaning them up afterwards. 

The first use case will be in the Mongodb PR #2125 to init and tear down the dockerized DB. See an example usage https://github.com/narrative-bi/airbyte/pull/2