### PR TITLE
Update Airbyte local preq documentation. Remove outdated Gitbook section.

### DIFF
--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -1,6 +1,18 @@
 # Developing Locally
 
-Airbyte uses `java 14` , `node 14` and `docker`
+The following technologies are required to build Airbyte locally.
+
+1. `Java 14`
+2. `Node 14`
+3. `Python 3.7`
+4. `Docker`
+5. `Postgresql`
+6. `Jq`
+7. `CMake`i
+
+{% hint style="info" %}
+Python versioning can get hairy. We recommend using a version manager such as `pyenv`.
+{% endhint %}
 
 To start contributing:
 

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -11,7 +11,7 @@ The following technologies are required to build Airbyte locally.
 7. `CMake`
 
 {% hint style="info" %}
-Python versioning can get hairy. We recommend using a version manager such as `pyenv`.
+Manually switching between different language versions can get hairy. We recommend using a version manager such as `pyenv` or `jenv`.
 {% endhint %}
 
 To start contributing:

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -8,7 +8,7 @@ The following technologies are required to build Airbyte locally.
 4. `Docker`
 5. `Postgresql`
 6. `Jq`
-7. `CMake`i
+7. `CMake`
 
 {% hint style="info" %}
 Python versioning can get hairy. We recommend using a version manager such as `pyenv`.

--- a/docs/contributing-to-airbyte/updating-documentation.md
+++ b/docs/contributing-to-airbyte/updating-documentation.md
@@ -19,17 +19,3 @@ All our docs are stored in the `docs` directory. You can use other files as exam
 If you're adding new files, don't forget to update `docs/SUMMARY.md`.
 
 Once you're satisfied with your changes just follow the regular PR process.
-
-## For Airbyte's team
-
-To update with GitBook, follow these instructions:
-
-1. Create a [new variant](https://docs.gitbook.com/editing-content/variants#create-a-variant). This will create a new branch on [GitHub](https://github.com/airbytehq/airbyte) with the same name. 
-2. Modify the documentation, as you see fit on all pages, in that new variant.
-3. Save & merge regularly. Each time you merge, your changes will propagate to your branch. It can take a couple minutes for the changes to show up in [GitHub](https://github.com/airbytehq/airbyte).
-4. Once you're satisfied, go on [GitHub](https://github.com/airbytehq/airbyte) and create a PR for your variant branch.
-5. After the PR is approved, your changes will be merged to `master`. 
-6. Don't forget to remove the branch and the variant once your change has been merged.
-
-Just [contact us](mailto:hey@airbyte.io) and we will invite you to our space.
-


### PR DESCRIPTION
## What
- Add some missing prerequisites for Airbyte local development.
- Remove the Gitbook section on updating documentation. Gitbook's editor does funky autoformatting.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*
