### PR TITLE
hotfix: fix acceptance test

### DIFF
--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -378,7 +378,8 @@ public class AcceptanceTests {
     assertDestinationContains(expectedRecords, STREAM_NAME);
 
     // reset back to no data.
-    apiClient.getConnectionApi().resetConnection(new ConnectionIdRequestBody().connectionId(connectionId));
+    final JobInfoRead jobInfoRead = apiClient.getConnectionApi().resetConnection(new ConnectionIdRequestBody().connectionId(connectionId));
+    waitForSuccessfulJob(apiClient.getJobsApi(), jobInfoRead.getJob());
     assertDestinationContains(Collections.emptyList(), STREAM_NAME);
 
     // sync one more time. verify it is the equivalent of a full refresh.


### PR DESCRIPTION
## What
* the reset API endpoint no longer blocks until the reset is complete. this meant the test was evaluating what was in the destination before the reset job had completed and was therefore getting the wrong result.