### PR TITLE
check connection worker on temporal

### DIFF
--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobSubmitter.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobSubmitter.java
@@ -100,7 +100,8 @@ public class JobSubmitter implements Runnable {
   void submitJob(Job job) {
     // todo (cgardens) - this conditional goes away when all workers are run in temporal.
     final WorkerRun workerRun;
-    if (job.getConfigType() == ConfigType.GET_SPEC) {
+    if (job.getConfigType() == ConfigType.GET_SPEC || job.getConfigType() == ConfigType.CHECK_CONNECTION_SOURCE
+        || job.getConfigType() == ConfigType.CHECK_CONNECTION_DESTINATION) {
       LOGGER.info("Using temporal runner.");
       workerRun = temporalWorkerRunFactory.create(job);
     } else {

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/CheckConnectionWorkflow.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/CheckConnectionWorkflow.java
@@ -1,0 +1,127 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.scheduler.temporal;
+
+import com.google.common.base.Preconditions;
+import io.airbyte.config.IntegrationLauncherConfig;
+import io.airbyte.config.JobOutput;
+import io.airbyte.config.StandardCheckConnectionInput;
+import io.airbyte.workers.DefaultCheckConnectionWorker;
+import io.airbyte.workers.JobStatus;
+import io.airbyte.workers.OutputAndStatus;
+import io.airbyte.workers.WorkerConstants;
+import io.airbyte.workers.process.AirbyteIntegrationLauncher;
+import io.airbyte.workers.process.IntegrationLauncher;
+import io.airbyte.workers.process.ProcessBuilderFactory;
+import io.airbyte.workers.protocols.airbyte.AirbyteStreamFactory;
+import io.airbyte.workers.protocols.airbyte.DefaultAirbyteStreamFactory;
+import io.airbyte.workers.wrappers.JobOutputCheckConnectionWorker;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.activity.ActivityOptions;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+@WorkflowInterface
+public interface CheckConnectionWorkflow {
+
+  @WorkflowMethod
+  JobOutput run(IntegrationLauncherConfig launcherConfig, StandardCheckConnectionInput connectionConfiguration) throws TemporalJobException;
+
+  class WorkflowImpl implements CheckConnectionWorkflow {
+
+    ActivityOptions options = ActivityOptions.newBuilder()
+        .setScheduleToCloseTimeout(Duration.ofMinutes(2)) // todo
+        .build();
+
+    private final CheckConnectionActivity activity = Workflow.newActivityStub(CheckConnectionActivity.class, options);
+
+    @Override
+    public JobOutput run(IntegrationLauncherConfig launcherConfig, StandardCheckConnectionInput connectionConfiguration) throws TemporalJobException {
+      return activity.run(launcherConfig, connectionConfiguration);
+    }
+
+  }
+
+  @ActivityInterface
+  interface CheckConnectionActivity {
+
+    @ActivityMethod
+    JobOutput run(IntegrationLauncherConfig launcherConfig, StandardCheckConnectionInput connectionConfiguration) throws TemporalJobException;
+
+  }
+
+  class CheckConnectionActivityImpl implements CheckConnectionActivity {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CheckConnectionActivityImpl.class);
+
+    private final ProcessBuilderFactory pbf;
+    private final Path workspaceRoot;
+
+    public CheckConnectionActivityImpl(ProcessBuilderFactory pbf, Path workspaceRoot) {
+      this.pbf = pbf;
+      this.workspaceRoot = workspaceRoot;
+    }
+
+    public JobOutput run(IntegrationLauncherConfig launcherConfig, StandardCheckConnectionInput connectionConfiguration) throws TemporalJobException {
+      try {
+        // todo (cgardens) - there are 2 sources of truth for job path. we need to reduce this down to one,
+        // once we are fully on temporal.
+        final Path jobRoot = workspaceRoot
+            .resolve(String.valueOf(launcherConfig.getJobId()))
+            .resolve(String.valueOf(launcherConfig.getAttemptId().intValue()));
+
+        MDC.put("job_id", String.valueOf(launcherConfig.getJobId()));
+        MDC.put("job_root", jobRoot.toString());
+        MDC.put("job_log_filename", WorkerConstants.LOG_FILENAME);
+
+        final IntegrationLauncher integrationLauncher =
+            new AirbyteIntegrationLauncher(launcherConfig.getJobId(), launcherConfig.getAttemptId().intValue(), launcherConfig.getDockerImage(), pbf);
+        final AirbyteStreamFactory streamFactory = new DefaultAirbyteStreamFactory();
+        final OutputAndStatus<JobOutput> run =
+            new JobOutputCheckConnectionWorker(new DefaultCheckConnectionWorker(integrationLauncher, streamFactory)).run(connectionConfiguration,
+                jobRoot);
+        if (run.getStatus() == JobStatus.SUCCEEDED) {
+          Preconditions.checkState(run.getOutput().isPresent());
+          LOGGER.info("job output {}", run.getOutput().get());
+          return run.getOutput().get();
+        } else {
+          throw new TemporalJobException();
+        }
+
+      } catch (Exception e) {
+        throw new RuntimeException("Check connection job failed with an exception", e);
+      }
+    }
+
+  }
+
+}

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/TemporalJobException.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/TemporalJobException.java
@@ -1,0 +1,31 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.scheduler.temporal;
+
+public class TemporalJobException extends Exception {
+
+  public TemporalJobException() {}
+
+}

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/TemporalPool.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/TemporalPool.java
@@ -42,11 +42,15 @@ public class TemporalPool implements Runnable {
 
   @Override
   public void run() {
-    WorkerFactory factory = WorkerFactory.newInstance(TemporalUtils.TEMPORAL_CLIENT);
+    final WorkerFactory factory = WorkerFactory.newInstance(TemporalUtils.TEMPORAL_CLIENT);
 
     final Worker specWorker = factory.newWorker(TemporalJobType.GET_SPEC.name());
     specWorker.registerWorkflowImplementationTypes(SpecWorkflow.WorkflowImpl.class);
     specWorker.registerActivitiesImplementations(new SpecWorkflow.SpecActivityImpl(pbf, workspaceRoot));
+
+    final Worker checkConnectionWorker = factory.newWorker(TemporalJobType.CHECK_CONNECTION.name());
+    checkConnectionWorker.registerWorkflowImplementationTypes(CheckConnectionWorkflow.WorkflowImpl.class);
+    checkConnectionWorker.registerActivitiesImplementations(new CheckConnectionWorkflow.CheckConnectionActivityImpl(pbf, workspaceRoot));
 
     // todo (cgardens) - these will come back once we use temporal for these workers.
     // Worker discoverWorker = factory.newWorker(TemporalUtils.DISCOVER_WORKFLOW_QUEUE);
@@ -54,10 +58,6 @@ public class TemporalPool implements Runnable {
     // discoverWorker.registerActivitiesImplementations(new DiscoverWorkflow.DiscoverActivityImpl(pbf,
     // configs.getWorkspaceRoot()));
     //
-    // Worker checkConnectionWorker = factory.newWorker(TemporalUtils.CHECK_CONNECTION_WORKFLOW_QUEUE);
-    // checkConnectionWorker.registerWorkflowImplementationTypes(CheckConnectionWorkflow.WorkflowImpl.class);
-    // checkConnectionWorker.registerActivitiesImplementations(new
-    // CheckConnectionWorkflow.CheckConnectionActivityImpl(pbf, configs.getWorkspaceRoot()));
     //
     // Worker syncWorker = factory.newWorker(TemporalUtils.SYNC_WORKFLOW_QUEUE);
     // syncWorker.registerWorkflowImplementationTypes(SyncWorkflow.WorkflowImpl.class);

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/TemporalWorkerRunFactory.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/TemporalWorkerRunFactory.java
@@ -27,12 +27,9 @@ package io.airbyte.scheduler.temporal;
 import io.airbyte.commons.functional.CheckedSupplier;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.JobOutput;
-import io.airbyte.config.StandardGetSpecOutput;
-import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.Job;
 import io.airbyte.scheduler.temporal.TemporalUtils.TemporalJobType;
 import io.airbyte.scheduler.worker_run.WorkerRun;
-import io.airbyte.workers.JobStatus;
 import io.airbyte.workers.OutputAndStatus;
 import java.nio.file.Path;
 
@@ -55,9 +52,7 @@ public class TemporalWorkerRunFactory {
     final TemporalJobType temporalJobType = toTemporalJobType(job.getConfigType());
     return switch (job.getConfigType()) {
       case GET_SPEC -> () -> {
-        final ConnectorSpecification connectorSpecification = temporalClient.submitGetSpec(job.getId(), attemptId, job.getConfig().getGetSpec());
-        final JobOutput jobOutput = new JobOutput().withGetSpec(new StandardGetSpecOutput().withSpecification(connectorSpecification));
-        return new OutputAndStatus<>(JobStatus.SUCCEEDED, jobOutput);
+        return temporalClient.submitGetSpec(job.getId(), attemptId, job.getConfig().getGetSpec());
       };
       case CHECK_CONNECTION_SOURCE, CHECK_CONNECTION_DESTINATION -> () -> {
         return temporalClient.submitCheckConnection(job.getId(), attemptId, job.getConfig().getCheckConnection());

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/TemporalWorkerRunFactory.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/TemporalWorkerRunFactory.java
@@ -47,7 +47,7 @@ public class TemporalWorkerRunFactory {
   }
 
   public WorkerRun create(Job job) {
-    final int attemptId = job.getAttempts().size();
+    final int attemptId = job.getAttemptsCount();
     return WorkerRun.create(workspaceRoot, job.getId(), attemptId, createSupplier(job, attemptId));
   }
 

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/TemporalWorkerRunFactory.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/TemporalWorkerRunFactory.java
@@ -24,8 +24,8 @@
 
 package io.airbyte.scheduler.temporal;
 
-import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.functional.CheckedSupplier;
+import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.JobOutput;
 import io.airbyte.config.StandardGetSpecOutput;
 import io.airbyte.protocol.models.ConnectorSpecification;
@@ -52,15 +52,26 @@ public class TemporalWorkerRunFactory {
   }
 
   public CheckedSupplier<OutputAndStatus<JobOutput>, Exception> createSupplier(Job job, int attemptId) {
-    final TemporalJobType temporalJobType = Enums.convertTo(job.getConfigType(), TemporalJobType.class);
+    final TemporalJobType temporalJobType = toTemporalJobType(job.getConfigType());
     return switch (job.getConfigType()) {
       case GET_SPEC -> () -> {
-        final ConnectorSpecification connectorSpecification = temporalClient
-            .submitGetSpec(job.getId(), attemptId, job.getConfig().getGetSpec());
+        final ConnectorSpecification connectorSpecification = temporalClient.submitGetSpec(job.getId(), attemptId, job.getConfig().getGetSpec());
         final JobOutput jobOutput = new JobOutput().withGetSpec(new StandardGetSpecOutput().withSpecification(connectorSpecification));
         return new OutputAndStatus<>(JobStatus.SUCCEEDED, jobOutput);
       };
+      case CHECK_CONNECTION_SOURCE, CHECK_CONNECTION_DESTINATION -> () -> {
+        return temporalClient.submitCheckConnection(job.getId(), attemptId, job.getConfig().getCheckConnection());
+      };
       default -> throw new IllegalArgumentException("Does not support job type: " + temporalJobType);
+    };
+  }
+
+  private static TemporalJobType toTemporalJobType(ConfigType jobType) {
+    return switch (jobType) {
+      case GET_SPEC -> TemporalJobType.GET_SPEC;
+      case CHECK_CONNECTION_SOURCE, CHECK_CONNECTION_DESTINATION -> TemporalJobType.CHECK_CONNECTION;
+      case DISCOVER_SCHEMA -> TemporalJobType.DISCOVER_SCHEMA;
+      case SYNC, RESET_CONNECTION -> TemporalJobType.SYNC;
     };
   }
 

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/worker_run/WorkerRun.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/worker_run/WorkerRun.java
@@ -47,6 +47,8 @@ public class WorkerRun implements Callable<OutputAndStatus<JobOutput>> {
   private final CheckedSupplier<OutputAndStatus<JobOutput>, Exception> workerRun;
 
   public static WorkerRun create(Path workspaceRoot, long jobId, int attempt, CheckedSupplier<OutputAndStatus<JobOutput>, Exception> workerRun) {
+    // todo (cgardens) - there are 2 sources of truth for job path. we need to reduce this down to one,
+    // once we are fully on temporal.
     final Path jobRoot = workspaceRoot.resolve(String.valueOf(jobId)).resolve(String.valueOf(attempt));
     return new WorkerRun(jobRoot, workerRun);
   }

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/temporal/TemporalWorkerRunFactoryTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/temporal/TemporalWorkerRunFactoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.scheduler.temporal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.airbyte.config.JobConfig.ConfigType;
+import io.airbyte.scheduler.Job;
+import io.airbyte.scheduler.worker_run.WorkerRun;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class TemporalWorkerRunFactoryTest {
+
+  private static final long JOB_ID = 10L;
+  private static final int ATTEMPT_ID = 20;
+
+  private Path jobRoot;
+  private TemporalClient temporalClient;
+  private TemporalWorkerRunFactory workerRunFactory;
+  private Job job;
+
+  @BeforeEach
+  void setup() throws IOException {
+    Path workspaceRoot = Files.createTempDirectory(Path.of("/tmp"), "temporal_worker_run_test");
+    jobRoot = workspaceRoot.resolve(String.valueOf(JOB_ID)).resolve(String.valueOf(ATTEMPT_ID));
+    temporalClient = mock(TemporalClient.class);
+    workerRunFactory = new TemporalWorkerRunFactory(temporalClient, workspaceRoot);
+    job = mock(Job.class, RETURNS_DEEP_STUBS);
+    when(job.getId()).thenReturn(JOB_ID);
+    when(job.getAttemptsCount()).thenReturn(ATTEMPT_ID);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = ConfigType.class,
+              names = {"CHECK_CONNECTION_SOURCE", "CHECK_CONNECTION_DESTINATION"})
+  void testCheckConnection(ConfigType value) throws Exception {
+    when(job.getConfigType()).thenReturn(value);
+    final WorkerRun workerRun = workerRunFactory.create(job);
+    workerRun.call();
+    verify(temporalClient).submitCheckConnection(JOB_ID, ATTEMPT_ID, job.getConfig().getCheckConnection());
+    assertEquals(jobRoot, workerRun.getJobRoot());
+  }
+
+}

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/temporal/TemporalWorkerRunFactoryTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/temporal/TemporalWorkerRunFactoryTest.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -59,6 +60,15 @@ class TemporalWorkerRunFactoryTest {
     job = mock(Job.class, RETURNS_DEEP_STUBS);
     when(job.getId()).thenReturn(JOB_ID);
     when(job.getAttemptsCount()).thenReturn(ATTEMPT_ID);
+  }
+
+  @Test
+  void testGetSpec() throws Exception {
+    when(job.getConfigType()).thenReturn(ConfigType.GET_SPEC);
+    final WorkerRun workerRun = workerRunFactory.create(job);
+    workerRun.call();
+    verify(temporalClient).submitGetSpec(JOB_ID, ATTEMPT_ID, job.getConfig().getGetSpec());
+    assertEquals(jobRoot, workerRun.getJobRoot());
   }
 
   @ParameterizedTest

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/worker_run/WorkerRunTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/worker_run/WorkerRunTest.java
@@ -25,35 +25,46 @@
 package io.airbyte.scheduler.worker_run;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.airbyte.commons.functional.CheckedSupplier;
 import io.airbyte.config.JobOutput;
+import io.airbyte.workers.OutputAndStatus;
 import io.airbyte.workers.Worker;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class WorkerRunTest {
 
   private Path path;
-  private Worker<Integer, JobOutput> worker;
 
-  @SuppressWarnings("unchecked")
   @BeforeEach
   void setUp() throws IOException {
     path = Files.createTempDirectory("test").resolve("sub").resolve("sub");
-    worker = Mockito.mock(Worker.class);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
-  void name() throws Exception {
+  void testWorkerConstructor() throws Exception {
+    Worker<Integer, JobOutput> worker = mock(Worker.class);
     new WorkerRun(path, 1, worker).call();
 
     assertTrue(Files.exists(path));
     verify(worker).run(1, path);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testSupplierConstructor() throws Exception {
+    final CheckedSupplier<OutputAndStatus<JobOutput>, Exception> supplier = mock(CheckedSupplier.class);
+    new WorkerRun(path, supplier).call();
+
+    assertTrue(Files.exists(path));
+    verify(supplier).get();
   }
 
 }


### PR DESCRIPTION
## What
* Move check connection run in temporal

## Pre-merge Checklist
- [x] *Test!*

## Recommended reading order
1. `test.java`
1. `component.ts`
1. the rest

## Approach
@jrhizor how do you feel about this approach to migration. it leaves the workers intact, which I think makes refactoring after the fact a little easier. It also gives us more ability to do whatever generic temporal base class we might want to do to abstract away like setting up log paths, MDCs, etc (for now we are just duplicating that logic). It also means we don't need to re do a lot of tests since the Workers are already well tested.

the one annoying downside is that Workers output OutputAndStatus which is not serializable, so we need to unwrap it and then rewrap it (see CheckConnectionWorkflow and TemporalClient). This is annoying, but once all workers are on temporal we can just remove OutputAndStatus from the worker iface. wdyt?

(update, jared and I discussed offline and agreed that this is okay as an intermediate step.)