### PR TITLE
get spec temporal implementation fixes

### DIFF
--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/TemporalWorkerRunFactory.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/TemporalWorkerRunFactory.java
@@ -27,12 +27,9 @@ package io.airbyte.scheduler.temporal;
 import io.airbyte.commons.functional.CheckedSupplier;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.JobOutput;
-import io.airbyte.config.StandardGetSpecOutput;
-import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.Job;
 import io.airbyte.scheduler.temporal.TemporalUtils.TemporalJobType;
 import io.airbyte.scheduler.worker_run.WorkerRun;
-import io.airbyte.workers.JobStatus;
 import io.airbyte.workers.OutputAndStatus;
 import java.nio.file.Path;
 
@@ -55,9 +52,7 @@ public class TemporalWorkerRunFactory {
     final TemporalJobType temporalJobType = toTemporalJobType(job.getConfigType());
     return switch (job.getConfigType()) {
       case GET_SPEC -> () -> {
-        final ConnectorSpecification connectorSpecification = temporalClient.submitGetSpec(job.getId(), attemptId, job.getConfig().getGetSpec());
-        final JobOutput jobOutput = new JobOutput().withGetSpec(new StandardGetSpecOutput().withSpecification(connectorSpecification));
-        return new OutputAndStatus<>(JobStatus.SUCCEEDED, jobOutput);
+        return temporalClient.submitGetSpec(job.getId(), attemptId, job.getConfig().getGetSpec());
       };
       case CHECK_CONNECTION_SOURCE, CHECK_CONNECTION_DESTINATION -> () -> {
         return temporalClient.submitCheckConnection(job.getId(), attemptId, job.getConfig().getCheckConnection());

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/temporal/TemporalWorkerRunFactoryTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/temporal/TemporalWorkerRunFactoryTest.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -59,6 +60,15 @@ class TemporalWorkerRunFactoryTest {
     job = mock(Job.class, RETURNS_DEEP_STUBS);
     when(job.getId()).thenReturn(JOB_ID);
     when(job.getAttemptsCount()).thenReturn(ATTEMPT_ID);
+  }
+
+  @Test
+  void testGetSpec() throws Exception {
+    when(job.getConfigType()).thenReturn(ConfigType.GET_SPEC);
+    final WorkerRun workerRun = workerRunFactory.create(job);
+    workerRun.call();
+    verify(temporalClient).submitGetSpec(JOB_ID, ATTEMPT_ID, job.getConfig().getGetSpec());
+    assertEquals(jobRoot, workerRun.getJobRoot());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## What
* Fix the log path. Currently log aren't written to the correct file.
* Reuse the GetSpecWorker. Based on conversations in this [PR](https://github.com/airbytehq/airbyte/pull/2312). For the initial lift and shift, we will reuse the existing *Worker inside the temporal activities. We will refactor this back after everything is moved.