### PR TITLE
stop building and bumping kube until we have temporal

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -9,7 +9,3 @@ serialize =
 [bumpversion:file:.bumpversion.cfg]
 
 [bumpversion:file:.env]
-
-[bumpversion:file:kube/overlays/stable/.env]
-
-[bumpversion:file:kube/overlays/stable/kustomization.yaml]

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -162,42 +162,43 @@ jobs:
       - name: Run Docker End-to-End Acceptance Tests
         run: |
           ./tools/bin/acceptance_test.sh
-  test_kube:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Airbyte
-        uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '14'
-
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '14.7'
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
-
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.3.0
-        with:
-          minikube version: 'v1.16.0'
-          kubernetes version: 'v1.19.2'
-
-      - name: Install socat
-        run: sudo apt-get install socat
-
-      - name: Build Core Docker Images and Run Tests
-        run: CORE_ONLY=true ./gradlew --no-daemon format composeBuild test -x :airbyte-webapp:test --scan
-        env:
-          GIT_REVISION: ${{ github.sha }}
-          CORE_ONLY: true
-
-      - name: Ensure no file change
-        run: git status --porcelain && test -z "$(git status --porcelain)"
-
-      - name: Run Kubernetes End-to-End Acceptance Tests
-        run: |
-          ./tools/bin/acceptance_test_kube.sh
+# DISABLED UNTIL WE HAVE TEMPORAL ON KUBE
+#  test_kube:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout Airbyte
+#        uses: actions/checkout@v2
+#
+#      - uses: actions/setup-java@v1
+#        with:
+#          java-version: '14'
+#
+#      - uses: actions/setup-node@v1
+#        with:
+#          node-version: '14.7'
+#
+#      - uses: actions/setup-python@v2
+#        with:
+#          python-version: '3.7'
+#
+#      - name: Setup Minikube
+#        uses: manusa/actions-setup-minikube@v2.3.0
+#        with:
+#          minikube version: 'v1.16.0'
+#          kubernetes version: 'v1.19.2'
+#
+#      - name: Install socat
+#        run: sudo apt-get install socat
+#
+#      - name: Build Core Docker Images and Run Tests
+#        run: CORE_ONLY=true ./gradlew --no-daemon format composeBuild test -x :airbyte-webapp:test --scan
+#        env:
+#          GIT_REVISION: ${{ github.sha }}
+#          CORE_ONLY: true
+#
+#      - name: Ensure no file change
+#        run: git status --porcelain && test -z "$(git status --porcelain)"
+#
+#      - name: Run Kubernetes End-to-End Acceptance Tests
+#        run: |
+#          ./tools/bin/acceptance_test_kube.sh

--- a/docs/deploying-airbyte/on-kubernetes.md
+++ b/docs/deploying-airbyte/on-kubernetes.md
@@ -1,4 +1,6 @@
-# On Kubernetes \(Alpha\)
+# On Kubernetes
+
+> :warning: **Alpha Preview**: This is an early preview of Kubernetes that is pinned to Airbyte version 0.16.1. We do not recommend this preview for production use.
 
 ## Support
 
@@ -88,7 +90,7 @@ This would allow you to define custom resources or extend existing resources, ev
 
 ## View Raw Manifests
 
-For a specific overlay, you can run `kubectl kustomize kube/overlays/dev` to view the manifests that Kustomize will apply to your Kubernetes cluster. This is useful for debugging because it will show the exact resources you are defining.
+For a specific overlay, you can run `kubectl kustomize kube/overlays/stable` to view the manifests that Kustomize will apply to your Kubernetes cluster. This is useful for debugging because it will show the exact resources you are defining.
 
 ## Resizing Volumes
 


### PR DESCRIPTION
Let's table setting up temporal on kube until after temporal is in a more final state. I don't want to be spending any time maintaining / updating kube until we're working on removing the Docker-in-Docker requirement and fixing the other limitations.