### PR TITLE
rename temporal container to airbyte-temporal

### DIFF
--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/TemporalUtils.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/temporal/TemporalUtils.java
@@ -35,7 +35,7 @@ public class TemporalUtils {
 
   private static final WorkflowServiceStubsOptions TEMPORAL_OPTIONS = WorkflowServiceStubsOptions.newBuilder()
       // todo move to env.
-      .setTarget("temporal:7233")
+      .setTarget("airbyte-temporal:7233")
       .build();
 
   public static final WorkflowServiceStubs TEMPORAL_SERVICE = WorkflowServiceStubs.newInstance(TEMPORAL_OPTIONS);

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -82,9 +82,9 @@ services:
       - IS_DEMO=${IS_DEMO:-}
       - PAPERCUPS_STORYTIME=${PAPERCUPS_STORYTIME:-}
       - TRACKING_STRATEGY=${TRACKING_STRATEGY}
-  temporal:
+  airbyte-temporal:
     image: temporalio/auto-setup:1.7.0
-    container_name: temporal
+    container_name: airbyte-temporal
     ports:
       - 7233:7233
     environment:


### PR DESCRIPTION
Naming of the temporal container should match the rest of our naming.