### PR TITLE
Migration to make sure defaultNamespace is set

### DIFF
--- a/airbyte-migration/src/main/java/io/airbyte/migrate/Migrations.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/Migrations.java
@@ -27,6 +27,7 @@ package io.airbyte.migrate;
 import com.google.common.collect.ImmutableList;
 import io.airbyte.migrate.migrations.MigrationV0_14_0;
 import io.airbyte.migrate.migrations.MigrationV0_14_3;
+import io.airbyte.migrate.migrations.MigrationV0_17_0;
 import io.airbyte.migrate.migrations.NoOpMigration;
 import java.util.List;
 
@@ -36,12 +37,14 @@ public class Migrations {
   private static final MigrationV0_14_3 MIGRATION_V_0_14_3 = new MigrationV0_14_3(MIGRATION_V_0_14_0);
   private static final Migration MIGRATION_V_0_15_0 = new NoOpMigration(MIGRATION_V_0_14_3, "0.15.0-alpha");
   private static final Migration MIGRATION_V_0_16_0 = new NoOpMigration(MIGRATION_V_0_15_0, "0.16.0-alpha");
+  private static final Migration MIGRATION_V_0_17_0 = new MigrationV0_17_0(MIGRATION_V_0_16_0);
 
   // all migrations must be added to the list in the order that they should be applied.
   public static final List<Migration> MIGRATIONS = ImmutableList.of(
       MIGRATION_V_0_14_0,
       MIGRATION_V_0_14_3,
       MIGRATION_V_0_15_0,
-      MIGRATION_V_0_16_0);
+      MIGRATION_V_0_16_0,
+      MIGRATION_V_0_17_0);
 
 }

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_17_0.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_17_0.java
@@ -1,0 +1,92 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.migrate.migrations;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.migrate.Migration;
+import io.airbyte.migrate.ResourceId;
+import io.airbyte.migrate.ResourceType;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MigrationV0_17_0 extends BaseMigration implements Migration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MigrationV0_17_0.class);
+
+  private static final String MIGRATION_VERSION = "0.17.0-alpha";
+
+  private static final ResourceId STANDARD_SYNC_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_SYNC");
+
+  private final Migration previousMigration;
+
+  public MigrationV0_17_0(Migration previousMigration) {
+    super(previousMigration);
+    this.previousMigration = previousMigration;
+  }
+
+  @Override
+  public String getVersion() {
+    return MIGRATION_VERSION;
+  }
+
+  @Override
+  public Map<ResourceId, JsonNode> getOutputSchema() {
+    final Map<ResourceId, JsonNode> outputSchema = new HashMap<>(previousMigration.getOutputSchema());
+
+    try {
+      outputSchema.put(STANDARD_SYNC_RESOURCE_ID,
+          Jsons.jsonNode(MoreResources.readResource("migrations/migrationV0_17_0/airbyte_config/StandardSync.yaml")));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return outputSchema;
+  }
+
+  @Override
+  public void migrate(Map<ResourceId, Stream<JsonNode>> inputData, Map<ResourceId, Consumer<JsonNode>> outputData) {
+    for (final Map.Entry<ResourceId, Stream<JsonNode>> entry : inputData.entrySet()) {
+      final Consumer<JsonNode> recordConsumer = outputData.get(entry.getKey());
+
+      entry.getValue().forEach(r -> {
+        if (entry.getKey().equals(STANDARD_SYNC_RESOURCE_ID)) {
+          if (!r.has("defaultNamespace")) {
+            ((ObjectNode) r).set("defaultNamespace", Jsons.jsonNode(""));
+          }
+        }
+        recordConsumer.accept(r);
+      });
+    }
+  }
+
+}

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_17_0/airbyte_config/StandardSync.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_17_0/airbyte_config/StandardSync.yaml
@@ -1,0 +1,35 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSync.yaml
+title: StandardSync
+description: configuration required for sync for ALL taps
+type: object
+required:
+  - defaultNamespace
+  - sourceId
+  - destinationId
+  - name
+  - catalog
+additionalProperties: false
+properties:
+  defaultNamespace:
+    type: string
+  sourceId:
+    type: string
+    format: uuid
+  destinationId:
+    type: string
+    format: uuid
+  connectionId:
+    type: string
+    format: uuid
+  name:
+    type: string
+  catalog:
+    existingJavaType: io.airbyte.protocol.models.ConfiguredAirbyteCatalog
+  status:
+    type: string
+    enum:
+      - active
+      - inactive
+      - deprecated


### PR DESCRIPTION
## What
*Describe what the change is solving*
Following up on https://github.com/airbytehq/airbyte/pull/2298

This is a migration script that makes sure that the new defaultNamespace field for StandardSync is always set with a default value.

## How
*Describe the solution*
Migrate STANDARD_SYNC.yaml file to be defined with empty defaultNamespace to be backward compatible with previous configuration
