### PR TITLE
Document rust as a local dev dependency

### DIFF
--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -9,6 +9,7 @@ The following technologies are required to build Airbyte locally.
 5. `Postgresql`
 6. `Jq`
 7. `CMake`
+8. `Rust`
 
 {% hint style="info" %}
 Manually switching between different language versions can get hairy. We recommend using a version manager such as `pyenv` or `jenv`.


### PR DESCRIPTION
`gradlew build` fails saying that `cryptography`  needs rust
```
           error: Can not find Rust compiler
           ----------------------------------------
           ERROR: Failed building wheel for cryptography
```