### PR TITLE
Document command to only build core Airbyte systems.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 *.iml
 build
+out
 .DS_Store
 data
 .dockerversions

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ def createSpotlessTarget = { pattern ->
         'tools'
     ]
 
-    if(System.getenv().containsKey("CORE_ONLY")) {
+    if (System.getenv().containsKey("CORE_ONLY")) {
         excludes.add("airbyte-integrations/connectors")
     }
 

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -38,6 +38,11 @@ This will build all the code and run all the unit tests.
 
 `./gradle build` creates all the necessary artifacts \(Webapp, Jars and Docker images\) so that you can run Airbyte locally.
 
+The `./gradlew build` builds the core Airbyte system, and all the connectors. This can take some time. To compile and build just the core systems:
+```bash
+export CORE_ONLY=1 && ./gradlew build
+```
+
 {% hint style="info" %}
 On Mac, if you run into an error while compiling openssl \(this happens when running pip install\), you may need to explicitly add these flags to your bash profile so that the C compiler can find the appropriate libraries.
 

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -36,7 +36,7 @@ To compile the code and run unit tests:
 
 This will build all the code and run all the unit tests.
 
-`./gradlew build` creates all the necessary artifacts \(Webapp, Jars and Docker images\) so that you can run Airbyte locally. Since this build everything, it can take some time.
+`./gradlew build` creates all the necessary artifacts \(Webapp, Jars and Docker images\) so that you can run Airbyte locally. Since this builds everything, it can take some time.
 
 To compile and build just the core systems:
 ```bash

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -36,11 +36,11 @@ To compile the code and run unit tests:
 
 This will build all the code and run all the unit tests.
 
-`./gradle build` creates all the necessary artifacts \(Webapp, Jars and Docker images\) so that you can run Airbyte locally.
+`./gradlew build` creates all the necessary artifacts \(Webapp, Jars and Docker images\) so that you can run Airbyte locally. Since this build everything, it can take some time.
 
-The `./gradlew build` builds the core Airbyte system, and all the connectors. This can take some time. To compile and build just the core systems:
+To compile and build just the core systems:
 ```bash
-export CORE_ONLY=1 && ./gradlew build
+CORE_ONLY=1 ./gradlew build
 ```
 
 {% hint style="info" %}

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,9 +11,6 @@ gradleEnterprise {
     }
 }
 
-import groovy.io.FileType
-import java.nio.file.Files
-
 rootProject.name = 'airbyte'
 
 include ':airbyte-analytics'
@@ -49,6 +46,7 @@ include ':airbyte-test-utils'
 include ':tools:code-generator'
 
 if(!System.getenv().containsKey("CORE_ONLY")) {
+    println "Building all of Airbyte."
     // include all connector projects
     def integrationsPath = rootDir.toPath().resolve('airbyte-integrations/connectors')
     println integrationsPath
@@ -59,4 +57,6 @@ if(!System.getenv().containsKey("CORE_ONLY")) {
             include ":airbyte-integrations:connectors:${dir.getFileName()}"
         }
     }
+} else {
+    println "Building Airbyte Core."
 }


### PR DESCRIPTION
## What
Since the full airbyte build takes some time, devs might want to save time and only build the core airbyte system. This functionality already exists, however is not documented anywhere.

Also take the chance to add the `out` directories to the .gitignore file.
## How
Documenting it.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*
