### PR TITLE
Minor Gradle Property Tweaks.

### DIFF
--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -44,6 +44,10 @@ CORE_ONLY=1 ./gradlew build
 ```
 
 {% hint style="info" %}
+If Gradle is using too much/too little CPU, change the `workers.max` property in `gradle.properties` accordingly.
+{% endhint %}
+
+{% hint style="info" %}
 On Mac, if you run into an error while compiling openssl \(this happens when running pip install\), you may need to explicitly add these flags to your bash profile so that the C compiler can find the appropriate libraries.
 
 ```text

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -44,7 +44,12 @@ CORE_ONLY=1 ./gradlew build
 ```
 
 {% hint style="info" %}
-If Gradle uses too much/too little CPU, adjust the `workers.max` property in the `gradle.properties` file accordingly.
+If Gradle uses too much/too little CPU, it helps to tune the number of CPU cores it uses. 
+
+Adjust this by either, 
+1. Setting an env var: `export GRADLE_OPTS="-Dorg.gradle.workers.max=3"`.
+2. Setting a cli option: `./gradlew build --max-workers 3`
+3. Setting the `org.gradle.workers.max` property in the `gradle.properties` file.
 {% endhint %}
 
 {% hint style="info" %}

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -44,7 +44,7 @@ CORE_ONLY=1 ./gradlew build
 ```
 
 {% hint style="info" %}
-If Gradle is using too much/too little CPU, change the `workers.max` property in `gradle.properties` accordingly.
+If Gradle uses too much/too little CPU, adjust the `workers.max` property in the `gradle.properties` file accordingly.
 {% endhint %}
 
 {% hint style="info" %}

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -44,12 +44,14 @@ CORE_ONLY=1 ./gradlew build
 ```
 
 {% hint style="info" %}
-If Gradle uses too much/too little CPU, it helps to tune the number of CPU cores it uses. 
+Gradle will use all CPU cores by default. If Gradle uses too much/too little CPU, tuning the number of CPU cores it uses to better suit a dev's need can help.
 
 Adjust this by either, 
 1. Setting an env var: `export GRADLE_OPTS="-Dorg.gradle.workers.max=3"`.
 2. Setting a cli option: `./gradlew build --max-workers 3`
 3. Setting the `org.gradle.workers.max` property in the `gradle.properties` file.
+
+A good rule of thumb is to set this to (# of cores - 1).
 {% endhint %}
 
 {% hint style="info" %}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ org.gradle.caching=true
 org.gradle.vfs.watch=true
 
 # Gradle will use all CPU cores by default. A Dev can tune the workers.max property to control the number of cores Gradle uses to suit their needs.
-# i.e. Give Gradle all cores if wanting to build as fast as possible. Setting this to # of cores - 1 is a good start.
+# i.e. Give Gradle all cores if wanting to build as fast as possible. Setting this to (# of cores - 1) is a good default.
 org.gradle.workers.max=3

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ org.gradle.caching=true
 org.gradle.vfs.watch=true
 
 # Gradle will use all CPU cores by default. A Dev can tune the workers.max property to control the number of cores Gradle uses to suit their needs.
-# i.e. Give Gradle all cores if wanting to build as fast as possible. Setting this to (# of cores - 1) is a good default.
+# i.e. Give Gradle all cores to build as fast as possible. Setting this to (# of cores - 1) is a good default.
 org.gradle.workers.max=3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,8 @@
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx2g
 org.gradle.caching=true
+org.gradle.vfs.watch=true
+
+# Gradle will use all CPU cores by default. A Dev can tune the workers.max property to control the number of cores Gradle uses to suit their needs.
+# i.e. Give Gradle all cores if wanting to build as fast as possible. Setting this to # of cores - 1 is a good start.
+org.gradle.workers.max=3

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,5 @@ org.gradle.jvmargs=-Xmx2g
 org.gradle.caching=true
 org.gradle.vfs.watch=true
 
-# Gradle will use all CPU cores by default. A Dev can tune the workers.max property to control the number of cores Gradle uses to suit their needs.
-# i.e. Give Gradle all cores to build as fast as possible. Setting this to (# of cores - 1) is a good default.
+# Tune # of cores Gradle uses.
 # org.gradle.workers.max=3

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ org.gradle.vfs.watch=true
 
 # Gradle will use all CPU cores by default. A Dev can tune the workers.max property to control the number of cores Gradle uses to suit their needs.
 # i.e. Give Gradle all cores to build as fast as possible. Setting this to (# of cores - 1) is a good default.
-org.gradle.workers.max=3
+# org.gradle.workers.max=3


### PR DESCRIPTION
## What
I get annoyed that I am unable to do anything for 10 - 15 mins as I run `./gradlew build` as Gradle sucks up all CPU and leaves me flailing in frustration.

## How
Expose the `workers.max` property in `gradle.properties`. This allows a dev to set the number of processors Gradle uses per their needs. See [this](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties).

Also take the chance to turn on `vfs.watch`. This allows Gradle to watch the virtual file system it creates in memory. In theory, this makes it slightly faster for incremental builds. See [this](https://docs.gradle.org/current/userguide/performance.html#enable_file_system_watching).

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*
