### PR TITLE
Back-end support destination sync modes #2370

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2040,8 +2040,8 @@ components:
       enum:
         - append
         - overwrite
-        - upsert_dedup
-        - append_dedup
+        #- upsert_dedup # TODO chris: SCD Type 1 can be implemented later
+        - append_dedup # SCD Type 2
     AirbyteArchive:
       type: string
       format: binary

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1764,13 +1764,12 @@ components:
           items:
             type: string
         sourceDefinedPrimaryKey:
-          description: If the source defines the primary key, then any other primary key inputs will be ignored. If it does not, either the user_provided one is used, or the default one is used as a backup.
-          type: boolean
-        defaultPrimaryKey:
-          description: Path to the fields that will be used as a primary key. If not provided by the source, the end user will have to specify the primary key themselves.
+          description: If the source defines the primary key, paths to the fields that will be used as a primary key. If not provided by the source, the end user will have to specify the primary key themselves.
           type: array
           items:
-            type: string
+            type: array
+            items:
+              type: string
     StreamJsonSchema:
       type: object
     AirbyteStreamConfiguration:
@@ -1790,10 +1789,12 @@ components:
           $ref: "#/components/schemas/DestinationSyncMode"
           default: append
         primaryKey:
-          description: Path to the field that will be used as primary key. This field is REQUIRED if `destination_sync_mode` is `*_dedup`. Otherwise it is ignored.
+          description: Paths to the fields that will be used as primary key. This field is REQUIRED if `destination_sync_mode` is `*_dedup`. Otherwise it is ignored.
           type: array
           items:
-            type: string
+            type: array
+            items:
+              type: string
         aliasName:
           description: Alias name to the stream to be used in the destination
           type: string

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1756,10 +1756,18 @@ components:
           items:
             $ref: "#/components/schemas/SyncMode"
         sourceDefinedCursor:
-          description: If the source defines the cursor field, then it does any other cursor field inputs will be ignored. If it does not either the user_provided one is used or as a backup the default one is used.
+          description: If the source defines the cursor field, then any other cursor field inputs will be ignored. If it does not, either the user_provided one is used, or the default one is used as a backup.
           type: boolean
         defaultCursorField:
           description: Path to the field that will be used to determine if a record is new or modified since the last sync. If not provided by the source, the end user will have to specify the comparable themselves.
+          type: array
+          items:
+            type: string
+        sourceDefinedPrimaryKey:
+          description: If the source defines the primary key, then any other primary key inputs will be ignored. If it does not, either the user_provided one is used, or the default one is used as a backup.
+          type: boolean
+        defaultPrimaryKey:
+          description: Path to the fields that will be used as a primary key. If not provided by the source, the end user will have to specify the primary key themselves.
           type: array
           items:
             type: string
@@ -1775,6 +1783,14 @@ components:
           default: full_refresh
         cursorField:
           description: Path to the field that will be used to determine if a record is new or modified since the last sync. This field is REQUIRED if `sync_mode` is `incremental`. Otherwise it is ignored.
+          type: array
+          items:
+            type: string
+        destinationSyncMode:
+          $ref: "#/components/schemas/DestinationSyncMode"
+          default: append
+        primaryKey:
+          description: Path to the field that will be used as primary key. This field is REQUIRED if `destination_sync_mode` is `*_dedup`. Otherwise it is ignored.
           type: array
           items:
             type: string
@@ -2018,6 +2034,13 @@ components:
       enum:
         - full_refresh
         - incremental
+    DestinationSyncMode:
+      type: string
+      enum:
+        - append
+        - overwrite
+        - upsert_dedup
+        - append_dedup
     AirbyteArchive:
       type: string
       format: binary

--- a/airbyte-config/models/src/main/resources/types/DestinationSyncMode.yaml
+++ b/airbyte-config/models/src/main/resources/types/DestinationSyncMode.yaml
@@ -1,0 +1,11 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/DestinationSyncMode.yaml
+title: DestinationSyncMode
+description: destination sync modes.
+type: string
+enum:
+  - append
+  - overwrite
+  - upsert_dedup
+  - append_dedup

--- a/airbyte-config/models/src/main/resources/types/DestinationSyncMode.yaml
+++ b/airbyte-config/models/src/main/resources/types/DestinationSyncMode.yaml
@@ -7,5 +7,5 @@ type: string
 enum:
   - append
   - overwrite
-  - upsert_dedup
-  - append_dedup
+  #- upsert_dedup # TODO chris: SCD Type 1 can be implemented later
+  - append_dedup # SCD Type 2

--- a/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
+++ b/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
@@ -96,6 +96,13 @@ class SyncMode(Enum):
     incremental = "incremental"
 
 
+class DestinationSyncMode(Enum):
+    append = "append"
+    overwrite = "overwrite"
+    upsert_dedup = "upsert_dedup"
+    append_dedup = "append_dedup"
+
+
 class ConnectorSpecification(BaseModel):
     class Config:
         extra = Extra.allow
@@ -118,11 +125,19 @@ class AirbyteStream(BaseModel):
     supported_sync_modes: Optional[List[SyncMode]] = None
     source_defined_cursor: Optional[bool] = Field(
         None,
-        description="If the source defines the cursor field, then it does any other cursor field inputs will be ignored. If it does not either the user_provided one is used or as a backup the default one is used.",
+        description="If the source defines the cursor field, then any other cursor field inputs will be ignored. If it does not, either the user_provided one is used, or the default one is used as a backup.",
     )
     default_cursor_field: Optional[List[str]] = Field(
         None,
         description="Path to the field that will be used to determine if a record is new or modified since the last sync. If not provided by the source, the end user will have to specify the comparable themselves.",
+    )
+    source_defined_primary_key: Optional[bool] = Field(
+        None,
+        description="If the source defines the primary key, then any other primary key inputs will be ignored. If it does not, either the user_provided one is used, or the default one is used as a backup.",
+    )
+    default_primary_key: Optional[List[str]] = Field(
+        None,
+        description="Path to the fields that will be used as a primary key. If not provided by the source, the end user will have to specify the primary key themselves.",
     )
 
 
@@ -135,6 +150,11 @@ class ConfiguredAirbyteStream(BaseModel):
     cursor_field: Optional[List[str]] = Field(
         None,
         description="Path to the field that will be used to determine if a record is new or modified since the last sync. This field is REQUIRED if `sync_mode` is `incremental`. Otherwise it is ignored.",
+    )
+    destination_sync_mode: Optional[DestinationSyncMode] = "append"
+    primary_key: Optional[List[str]] = Field(
+        None,
+        description="Path to the field that will be used as primary key. This field is REQUIRED if `destination_sync_mode` is `*_dedup`. Otherwise it is ignored.",
     )
 
 

--- a/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
+++ b/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
@@ -131,13 +131,9 @@ class AirbyteStream(BaseModel):
         None,
         description="Path to the field that will be used to determine if a record is new or modified since the last sync. If not provided by the source, the end user will have to specify the comparable themselves.",
     )
-    source_defined_primary_key: Optional[bool] = Field(
+    source_defined_primary_key: Optional[List[str]] = Field(
         None,
-        description="If the source defines the primary key, then any other primary key inputs will be ignored. If it does not, either the user_provided one is used, or the default one is used as a backup.",
-    )
-    default_primary_key: Optional[List[str]] = Field(
-        None,
-        description="Path to the fields that will be used as a primary key. If not provided by the source, the end user will have to specify the primary key themselves.",
+        description="If the source defines the primary key, paths to the fields that will be used as a primary key. If not provided by the source, the end user will have to specify the primary key themselves.",
     )
 
 
@@ -154,7 +150,7 @@ class ConfiguredAirbyteStream(BaseModel):
     destination_sync_mode: Optional[DestinationSyncMode] = "append"
     primary_key: Optional[List[str]] = Field(
         None,
-        description="Path to the field that will be used as primary key. This field is REQUIRED if `destination_sync_mode` is `*_dedup`. Otherwise it is ignored.",
+        description="Paths to the fields that will be used as primary key. This field is REQUIRED if `destination_sync_mode` is `*_dedup`. Otherwise it is ignored.",
     )
 
 

--- a/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
+++ b/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
@@ -99,7 +99,6 @@ class SyncMode(Enum):
 class DestinationSyncMode(Enum):
     append = "append"
     overwrite = "overwrite"
-    upsert_dedup = "upsert_dedup"
     append_dedup = "append_dedup"
 
 

--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/IncrementalUtils.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/IncrementalUtils.java
@@ -33,7 +33,7 @@ public class IncrementalUtils {
     if (stream.getCursorField().size() == 0) {
       throw new IllegalStateException("No cursor field specified for stream attempting to do incremental.");
     } else if (stream.getCursorField().size() > 1) {
-      throw new IllegalStateException("JdbcSource does not support composite cursor fields.");
+      throw new IllegalStateException("JdbcSource does not support nested cursor fields.");
     } else {
       return stream.getCursorField().get(0);
     }

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -29,6 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.protocol.models.ConfiguredAirbyteStream.DestinationSyncMode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -106,7 +107,9 @@ public class CatalogHelpers {
     return new ConfiguredAirbyteStream()
         .withStream(stream)
         .withSyncMode(SyncMode.FULL_REFRESH)
-        .withCursorField(new ArrayList<>());
+        .withCursorField(new ArrayList<>())
+        .withDestinationSyncMode(DestinationSyncMode.APPEND)
+        .withPrimaryKey(new ArrayList<>());
   }
 
   public static JsonNode fieldsToJsonSchema(Field... fields) {

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -137,10 +137,18 @@ definitions:
         items:
           "$ref": "#/definitions/SyncMode"
       source_defined_cursor:
-        description: If the source defines the cursor field, then it does any other cursor field inputs will be ignored. If it does not either the user_provided one is used or as a backup the default one is used.
+        description: If the source defines the cursor field, then any other cursor field inputs will be ignored. If it does not, either the user_provided one is used, or the default one is used as a backup.
         type: boolean
       default_cursor_field:
         description: Path to the field that will be used to determine if a record is new or modified since the last sync. If not provided by the source, the end user will have to specify the comparable themselves.
+        type: array
+        items:
+          type: string
+      source_defined_primary_key:
+        description: If the source defines the primary key, then any other primary key inputs will be ignored. If it does not, either the user_provided one is used, or the default one is used as a backup.
+        type: boolean
+      default_primary_key:
+        description: Path to the fields that will be used as a primary key. If not provided by the source, the end user will have to specify the primary key themselves.
         type: array
         items:
           type: string
@@ -171,11 +179,26 @@ definitions:
         type: array
         items:
           type: string
+      destination_sync_mode:
+        "$ref": "#/definitions/DestinationSyncMode"
+        default: append
+      primary_key:
+        description: Path to the field that will be used as primary key. This field is REQUIRED if `destination_sync_mode` is `*_dedup`. Otherwise it is ignored.
+        type: array
+        items:
+          type: string
   SyncMode:
     type: string
     enum:
       - full_refresh
       - incremental
+  DestinationSyncMode:
+    type: string
+    enum:
+      - append
+      - overwrite
+      - upsert_dedup
+      - append_dedup
   ConnectorSpecification:
     description: Specification of a connector (source/destination)
     type: object

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -145,13 +145,12 @@ definitions:
         items:
           type: string
       source_defined_primary_key:
-        description: If the source defines the primary key, then any other primary key inputs will be ignored. If it does not, either the user_provided one is used, or the default one is used as a backup.
-        type: boolean
-      default_primary_key:
-        description: Path to the fields that will be used as a primary key. If not provided by the source, the end user will have to specify the primary key themselves.
+        description: If the source defines the primary key, paths to the fields that will be used as a primary key. If not provided by the source, the end user will have to specify the primary key themselves.
         type: array
         items:
-          type: string
+          type: array
+          items:
+            type: string
   ConfiguredAirbyteCatalog:
     description: Airbyte stream schema catalog
     type: object
@@ -183,10 +182,12 @@ definitions:
         "$ref": "#/definitions/DestinationSyncMode"
         default: append
       primary_key:
-        description: Path to the field that will be used as primary key. This field is REQUIRED if `destination_sync_mode` is `*_dedup`. Otherwise it is ignored.
+        description: Paths to the fields that will be used as primary key. This field is REQUIRED if `destination_sync_mode` is `*_dedup`. Otherwise it is ignored.
         type: array
         items:
-          type: string
+          type: array
+          items:
+            type: string
   SyncMode:
     type: string
     enum:

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -198,8 +198,8 @@ definitions:
     enum:
       - append
       - overwrite
-      - upsert_dedup
-      - append_dedup
+      #- upsert_dedup # TODO chris: SCD Type 1 can be implemented later
+      - append_dedup # SCD Type 2
   ConnectorSpecification:
     description: Specification of a connector (source/destination)
     type: object

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/CatalogConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/CatalogConverter.java
@@ -41,8 +41,7 @@ public class CatalogConverter {
         .supportedSyncModes(Enums.convertListTo(stream.getSupportedSyncModes(), io.airbyte.api.model.SyncMode.class))
         .sourceDefinedCursor(stream.getSourceDefinedCursor())
         .defaultCursorField(stream.getDefaultCursorField())
-        .sourceDefinedPrimaryKey(stream.getSourceDefinedPrimaryKey())
-        .defaultPrimaryKey(stream.getDefaultPrimaryKey());
+        .sourceDefinedPrimaryKey(stream.getSourceDefinedPrimaryKey());
   }
 
   private static io.airbyte.protocol.models.AirbyteStream toProtocol(final io.airbyte.api.model.AirbyteStream stream) {
@@ -52,8 +51,7 @@ public class CatalogConverter {
         .withSupportedSyncModes(Enums.convertListTo(stream.getSupportedSyncModes(), io.airbyte.protocol.models.SyncMode.class))
         .withSourceDefinedCursor(stream.getSourceDefinedCursor())
         .withDefaultCursorField(stream.getDefaultCursorField())
-        .withSourceDefinedPrimaryKey(stream.getSourceDefinedPrimaryKey())
-        .withDefaultPrimaryKey(stream.getDefaultPrimaryKey());
+        .withSourceDefinedPrimaryKey(stream.getSourceDefinedPrimaryKey());
   }
 
   public static io.airbyte.api.model.AirbyteCatalog toApi(final io.airbyte.protocol.models.AirbyteCatalog catalog) {
@@ -71,7 +69,7 @@ public class CatalogConverter {
     io.airbyte.api.model.AirbyteStreamConfiguration result = new io.airbyte.api.model.AirbyteStreamConfiguration()
         .aliasName(Names.toAlphanumericAndUnderscore(stream.getName()))
         .cursorField(stream.getDefaultCursorField())
-        .primaryKey(stream.getDefaultPrimaryKey())
+        .primaryKey(stream.getSourceDefinedPrimaryKey())
         .destinationSyncMode(io.airbyte.api.model.DestinationSyncMode.APPEND)
         .selected(true);
     if (stream.getSupportedSyncModes().size() > 0)

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/CatalogConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/CatalogConverter.java
@@ -40,7 +40,9 @@ public class CatalogConverter {
         .jsonSchema(stream.getJsonSchema())
         .supportedSyncModes(Enums.convertListTo(stream.getSupportedSyncModes(), io.airbyte.api.model.SyncMode.class))
         .sourceDefinedCursor(stream.getSourceDefinedCursor())
-        .defaultCursorField(stream.getDefaultCursorField());
+        .defaultCursorField(stream.getDefaultCursorField())
+        .sourceDefinedPrimaryKey(stream.getSourceDefinedPrimaryKey())
+        .defaultPrimaryKey(stream.getDefaultPrimaryKey());
   }
 
   private static io.airbyte.protocol.models.AirbyteStream toProtocol(final io.airbyte.api.model.AirbyteStream stream) {
@@ -49,7 +51,9 @@ public class CatalogConverter {
         .withJsonSchema(stream.getJsonSchema())
         .withSupportedSyncModes(Enums.convertListTo(stream.getSupportedSyncModes(), io.airbyte.protocol.models.SyncMode.class))
         .withSourceDefinedCursor(stream.getSourceDefinedCursor())
-        .withDefaultCursorField(stream.getDefaultCursorField());
+        .withDefaultCursorField(stream.getDefaultCursorField())
+        .withSourceDefinedPrimaryKey(stream.getSourceDefinedPrimaryKey())
+        .withDefaultPrimaryKey(stream.getDefaultPrimaryKey());
   }
 
   public static io.airbyte.api.model.AirbyteCatalog toApi(final io.airbyte.protocol.models.AirbyteCatalog catalog) {
@@ -63,13 +67,15 @@ public class CatalogConverter {
             .collect(Collectors.toList()));
   }
 
-  private static io.airbyte.api.model.AirbyteStreamConfiguration generateDefaultConfiguration(final io.airbyte.api.model.AirbyteStream s) {
+  private static io.airbyte.api.model.AirbyteStreamConfiguration generateDefaultConfiguration(final io.airbyte.api.model.AirbyteStream stream) {
     io.airbyte.api.model.AirbyteStreamConfiguration result = new io.airbyte.api.model.AirbyteStreamConfiguration()
-        .aliasName(Names.toAlphanumericAndUnderscore(s.getName()))
-        .cursorField(s.getDefaultCursorField())
+        .aliasName(Names.toAlphanumericAndUnderscore(stream.getName()))
+        .cursorField(stream.getDefaultCursorField())
+        .primaryKey(stream.getDefaultPrimaryKey())
+        .destinationSyncMode(io.airbyte.api.model.DestinationSyncMode.APPEND)
         .selected(true);
-    if (s.getSupportedSyncModes().size() > 0)
-      result.setSyncMode(s.getSupportedSyncModes().get(0));
+    if (stream.getSupportedSyncModes().size() > 0)
+      result.setSyncMode(stream.getSupportedSyncModes().get(0));
     else
       result.setSyncMode(io.airbyte.api.model.SyncMode.INCREMENTAL);
     return result;
@@ -82,6 +88,8 @@ public class CatalogConverter {
           final io.airbyte.api.model.AirbyteStreamConfiguration configuration = new io.airbyte.api.model.AirbyteStreamConfiguration()
               .syncMode(Enums.convertTo(configuredStream.getSyncMode(), io.airbyte.api.model.SyncMode.class))
               .cursorField(configuredStream.getCursorField())
+              .primaryKey(configuredStream.getPrimaryKey())
+              .destinationSyncMode(Enums.convertTo(configuredStream.getDestinationSyncMode(), io.airbyte.api.model.DestinationSyncMode.class))
               .aliasName(Names.toAlphanumericAndUnderscore(configuredStream.getStream().getName()))
               .selected(true);
           return new io.airbyte.api.model.AirbyteStreamAndConfiguration()
@@ -99,7 +107,10 @@ public class CatalogConverter {
         .map(s -> new io.airbyte.protocol.models.ConfiguredAirbyteStream()
             .withStream(toProtocol(s.getStream()))
             .withSyncMode(Enums.convertTo(s.getConfig().getSyncMode(), io.airbyte.protocol.models.SyncMode.class))
-            .withCursorField(s.getConfig().getCursorField()))
+            .withCursorField(s.getConfig().getCursorField())
+            .withPrimaryKey(s.getConfig().getPrimaryKey())
+            .withDestinationSyncMode(Enums.convertTo(s.getConfig().getDestinationSyncMode(),
+                io.airbyte.protocol.models.ConfiguredAirbyteStream.DestinationSyncMode.class)))
         .collect(Collectors.toList());
     return new io.airbyte.protocol.models.ConfiguredAirbyteCatalog()
         .withStreams(streams);

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -285,7 +285,7 @@ public class AcceptanceTests {
         .name(STREAM_NAME)
         .jsonSchema(jsonSchema)
         .defaultCursorField(Collections.emptyList())
-        .defaultPrimaryKey(Collections.emptyList())
+        .sourceDefinedPrimaryKey(Collections.emptyList())
         .supportedSyncModes(List.of(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL));
     final AirbyteStreamConfiguration streamConfig = new AirbyteStreamConfiguration()
         .syncMode(SyncMode.FULL_REFRESH)

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -58,6 +58,7 @@ import io.airbyte.api.client.model.DestinationDefinitionIdRequestBody;
 import io.airbyte.api.client.model.DestinationDefinitionSpecificationRead;
 import io.airbyte.api.client.model.DestinationIdRequestBody;
 import io.airbyte.api.client.model.DestinationRead;
+import io.airbyte.api.client.model.DestinationSyncMode;
 import io.airbyte.api.client.model.JobIdRequestBody;
 import io.airbyte.api.client.model.JobInfoRead;
 import io.airbyte.api.client.model.JobRead;
@@ -284,10 +285,13 @@ public class AcceptanceTests {
         .name(STREAM_NAME)
         .jsonSchema(jsonSchema)
         .defaultCursorField(Collections.emptyList())
+        .defaultPrimaryKey(Collections.emptyList())
         .supportedSyncModes(List.of(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL));
     final AirbyteStreamConfiguration streamConfig = new AirbyteStreamConfiguration()
         .syncMode(SyncMode.FULL_REFRESH)
         .cursorField(Collections.emptyList())
+        .destinationSyncMode(DestinationSyncMode.APPEND)
+        .primaryKey(Collections.emptyList())
         .aliasName(STREAM_NAME.replace(".", "_"))
         .selected(true);
     final AirbyteCatalog expected = new AirbyteCatalog()

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -361,27 +361,33 @@ font-style: italic;
   "syncCatalog" : {
     "streams" : [ {
       "stream" : {
+        "sourceDefinedPrimaryKey" : true,
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
-        "selected" : true
+        "selected" : true,
+        "primaryKey" : [ "primaryKey", "primaryKey" ]
       }
     }, {
       "stream" : {
+        "sourceDefinedPrimaryKey" : true,
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
-        "selected" : true
+        "selected" : true,
+        "primaryKey" : [ "primaryKey", "primaryKey" ]
       }
     } ]
   },
@@ -493,27 +499,33 @@ font-style: italic;
   "syncCatalog" : {
     "streams" : [ {
       "stream" : {
+        "sourceDefinedPrimaryKey" : true,
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
-        "selected" : true
+        "selected" : true,
+        "primaryKey" : [ "primaryKey", "primaryKey" ]
       }
     }, {
       "stream" : {
+        "sourceDefinedPrimaryKey" : true,
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
-        "selected" : true
+        "selected" : true,
+        "primaryKey" : [ "primaryKey", "primaryKey" ]
       }
     } ]
   },
@@ -587,27 +599,33 @@ font-style: italic;
     "syncCatalog" : {
       "streams" : [ {
         "stream" : {
+          "sourceDefinedPrimaryKey" : true,
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
-          "selected" : true
+          "selected" : true,
+          "primaryKey" : [ "primaryKey", "primaryKey" ]
         }
       }, {
         "stream" : {
+          "sourceDefinedPrimaryKey" : true,
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
-          "selected" : true
+          "selected" : true,
+          "primaryKey" : [ "primaryKey", "primaryKey" ]
         }
       } ]
     },
@@ -624,27 +642,33 @@ font-style: italic;
     "syncCatalog" : {
       "streams" : [ {
         "stream" : {
+          "sourceDefinedPrimaryKey" : true,
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
-          "selected" : true
+          "selected" : true,
+          "primaryKey" : [ "primaryKey", "primaryKey" ]
         }
       }, {
         "stream" : {
+          "sourceDefinedPrimaryKey" : true,
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
-          "selected" : true
+          "selected" : true,
+          "primaryKey" : [ "primaryKey", "primaryKey" ]
         }
       } ]
     },
@@ -894,27 +918,33 @@ font-style: italic;
   "syncCatalog" : {
     "streams" : [ {
       "stream" : {
+        "sourceDefinedPrimaryKey" : true,
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
-        "selected" : true
+        "selected" : true,
+        "primaryKey" : [ "primaryKey", "primaryKey" ]
       }
     }, {
       "stream" : {
+        "sourceDefinedPrimaryKey" : true,
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
-        "selected" : true
+        "selected" : true,
+        "primaryKey" : [ "primaryKey", "primaryKey" ]
       }
     } ]
   },
@@ -2360,27 +2390,33 @@ font-style: italic;
   "catalog" : {
     "streams" : [ {
       "stream" : {
+        "sourceDefinedPrimaryKey" : true,
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
-        "selected" : true
+        "selected" : true,
+        "primaryKey" : [ "primaryKey", "primaryKey" ]
       }
     }, {
       "stream" : {
+        "sourceDefinedPrimaryKey" : true,
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
-        "selected" : true
+        "selected" : true,
+        "primaryKey" : [ "primaryKey", "primaryKey" ]
       }
     } ]
   },
@@ -2763,27 +2799,33 @@ font-style: italic;
   "catalog" : {
     "streams" : [ {
       "stream" : {
+        "sourceDefinedPrimaryKey" : true,
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
-        "selected" : true
+        "selected" : true,
+        "primaryKey" : [ "primaryKey", "primaryKey" ]
       }
     }, {
       "stream" : {
+        "sourceDefinedPrimaryKey" : true,
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
-        "selected" : true
+        "selected" : true,
+        "primaryKey" : [ "primaryKey", "primaryKey" ]
       }
     } ]
   },
@@ -3396,27 +3438,33 @@ font-style: italic;
   "syncCatalog" : {
     "streams" : [ {
       "stream" : {
+        "sourceDefinedPrimaryKey" : true,
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
-        "selected" : true
+        "selected" : true,
+        "primaryKey" : [ "primaryKey", "primaryKey" ]
       }
     }, {
       "stream" : {
+        "sourceDefinedPrimaryKey" : true,
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
-        "selected" : true
+        "selected" : true,
+        "primaryKey" : [ "primaryKey", "primaryKey" ]
       }
     } ]
   },
@@ -3512,27 +3560,33 @@ font-style: italic;
     "syncCatalog" : {
       "streams" : [ {
         "stream" : {
+          "sourceDefinedPrimaryKey" : true,
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
-          "selected" : true
+          "selected" : true,
+          "primaryKey" : [ "primaryKey", "primaryKey" ]
         }
       }, {
         "stream" : {
+          "sourceDefinedPrimaryKey" : true,
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
-          "selected" : true
+          "selected" : true,
+          "primaryKey" : [ "primaryKey", "primaryKey" ]
         }
       } ]
     },
@@ -3571,27 +3625,33 @@ font-style: italic;
     "syncCatalog" : {
       "streams" : [ {
         "stream" : {
+          "sourceDefinedPrimaryKey" : true,
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
-          "selected" : true
+          "selected" : true,
+          "primaryKey" : [ "primaryKey", "primaryKey" ]
         }
       }, {
         "stream" : {
+          "sourceDefinedPrimaryKey" : true,
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
-          "selected" : true
+          "selected" : true,
+          "primaryKey" : [ "primaryKey", "primaryKey" ]
         }
       } ]
     },
@@ -3810,27 +3870,33 @@ font-style: italic;
   "syncCatalog" : {
     "streams" : [ {
       "stream" : {
+        "sourceDefinedPrimaryKey" : true,
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
-        "selected" : true
+        "selected" : true,
+        "primaryKey" : [ "primaryKey", "primaryKey" ]
       }
     }, {
       "stream" : {
+        "sourceDefinedPrimaryKey" : true,
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
+        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
-        "selected" : true
+        "selected" : true,
+        "primaryKey" : [ "primaryKey", "primaryKey" ]
       }
     } ]
   },
@@ -4087,6 +4153,7 @@ font-style: italic;
     <li><a href="#DestinationRead"><code>DestinationRead</code> - </a></li>
     <li><a href="#DestinationReadList"><code>DestinationReadList</code> - </a></li>
     <li><a href="#DestinationRecreate"><code>DestinationRecreate</code> - </a></li>
+    <li><a href="#DestinationSyncMode"><code>DestinationSyncMode</code> - </a></li>
     <li><a href="#DestinationUpdate"><code>DestinationUpdate</code> - </a></li>
     <li><a href="#HealthCheckRead"><code>HealthCheckRead</code> - </a></li>
     <li><a href="#ImportRead"><code>ImportRead</code> - </a></li>
@@ -4142,8 +4209,10 @@ font-style: italic;
       <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Stream's name. </div>
 <div class="param">jsonSchema (optional)</div><div class="param-desc"><span class="param-type"><a href="#StreamJsonSchema">StreamJsonSchema</a></span>  </div>
 <div class="param">supportedSyncModes (optional)</div><div class="param-desc"><span class="param-type"><a href="#SyncMode">array[SyncMode]</a></span>  </div>
-<div class="param">sourceDefinedCursor (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> If the source defines the cursor field, then it does any other cursor field inputs will be ignored. If it does not either the user_provided one is used or as a backup the default one is used. </div>
+<div class="param">sourceDefinedCursor (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> If the source defines the cursor field, then any other cursor field inputs will be ignored. If it does not, either the user_provided one is used, or the default one is used as a backup. </div>
 <div class="param">defaultCursorField (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> Path to the field that will be used to determine if a record is new or modified since the last sync. If not provided by the source, the end user will have to specify the comparable themselves. </div>
+<div class="param">sourceDefinedPrimaryKey (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> If the source defines the primary key, then any other primary key inputs will be ignored. If it does not, either the user_provided one is used, or the default one is used as a backup. </div>
+<div class="param">defaultPrimaryKey (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> Path to the fields that will be used as a primary key. If not provided by the source, the end user will have to specify the primary key themselves. </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -4160,6 +4229,8 @@ font-style: italic;
     <div class="field-items">
       <div class="param">syncMode (optional)</div><div class="param-desc"><span class="param-type"><a href="#SyncMode">SyncMode</a></span>  </div>
 <div class="param">cursorField (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> Path to the field that will be used to determine if a record is new or modified since the last sync. This field is REQUIRED if <code>sync_mode</code> is <code>incremental</code>. Otherwise it is ignored. </div>
+<div class="param">destinationSyncMode (optional)</div><div class="param-desc"><span class="param-type"><a href="#DestinationSyncMode">DestinationSyncMode</a></span>  </div>
+<div class="param">primaryKey (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> Path to the field that will be used as primary key. This field is REQUIRED if <code>destination_sync_mode</code> is <code>*_dedup</code>. Otherwise it is ignored. </div>
 <div class="param">aliasName (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Alias name to the stream to be used in the destination </div>
 <div class="param">selected (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
     </div>  <!-- field-items -->
@@ -4382,6 +4453,12 @@ font-style: italic;
 <div class="param">connectionConfiguration </div><div class="param-desc"><span class="param-type"><a href="#DestinationConfiguration">DestinationConfiguration</a></span>  </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
     </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="DestinationSyncMode"><code>DestinationSyncMode</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+          </div>  <!-- field-items -->
   </div>
   <div class="model">
     <h3><a name="DestinationUpdate"><code>DestinationUpdate</code> - </a> <a class="up" href="#__Models">Up</a></h3>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -361,33 +361,31 @@ font-style: italic;
   "syncCatalog" : {
     "streams" : [ {
       "stream" : {
-        "sourceDefinedPrimaryKey" : true,
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
         "selected" : true,
-        "primaryKey" : [ "primaryKey", "primaryKey" ]
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
       }
     }, {
       "stream" : {
-        "sourceDefinedPrimaryKey" : true,
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
         "selected" : true,
-        "primaryKey" : [ "primaryKey", "primaryKey" ]
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
       }
     } ]
   },
@@ -499,33 +497,31 @@ font-style: italic;
   "syncCatalog" : {
     "streams" : [ {
       "stream" : {
-        "sourceDefinedPrimaryKey" : true,
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
         "selected" : true,
-        "primaryKey" : [ "primaryKey", "primaryKey" ]
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
       }
     }, {
       "stream" : {
-        "sourceDefinedPrimaryKey" : true,
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
         "selected" : true,
-        "primaryKey" : [ "primaryKey", "primaryKey" ]
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
       }
     } ]
   },
@@ -599,33 +595,31 @@ font-style: italic;
     "syncCatalog" : {
       "streams" : [ {
         "stream" : {
-          "sourceDefinedPrimaryKey" : true,
+          "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
           "selected" : true,
-          "primaryKey" : [ "primaryKey", "primaryKey" ]
+          "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
         }
       }, {
         "stream" : {
-          "sourceDefinedPrimaryKey" : true,
+          "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
           "selected" : true,
-          "primaryKey" : [ "primaryKey", "primaryKey" ]
+          "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
         }
       } ]
     },
@@ -642,33 +636,31 @@ font-style: italic;
     "syncCatalog" : {
       "streams" : [ {
         "stream" : {
-          "sourceDefinedPrimaryKey" : true,
+          "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
           "selected" : true,
-          "primaryKey" : [ "primaryKey", "primaryKey" ]
+          "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
         }
       }, {
         "stream" : {
-          "sourceDefinedPrimaryKey" : true,
+          "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
           "selected" : true,
-          "primaryKey" : [ "primaryKey", "primaryKey" ]
+          "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
         }
       } ]
     },
@@ -918,33 +910,31 @@ font-style: italic;
   "syncCatalog" : {
     "streams" : [ {
       "stream" : {
-        "sourceDefinedPrimaryKey" : true,
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
         "selected" : true,
-        "primaryKey" : [ "primaryKey", "primaryKey" ]
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
       }
     }, {
       "stream" : {
-        "sourceDefinedPrimaryKey" : true,
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
         "selected" : true,
-        "primaryKey" : [ "primaryKey", "primaryKey" ]
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
       }
     } ]
   },
@@ -2390,33 +2380,31 @@ font-style: italic;
   "catalog" : {
     "streams" : [ {
       "stream" : {
-        "sourceDefinedPrimaryKey" : true,
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
         "selected" : true,
-        "primaryKey" : [ "primaryKey", "primaryKey" ]
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
       }
     }, {
       "stream" : {
-        "sourceDefinedPrimaryKey" : true,
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
         "selected" : true,
-        "primaryKey" : [ "primaryKey", "primaryKey" ]
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
       }
     } ]
   },
@@ -2799,33 +2787,31 @@ font-style: italic;
   "catalog" : {
     "streams" : [ {
       "stream" : {
-        "sourceDefinedPrimaryKey" : true,
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
         "selected" : true,
-        "primaryKey" : [ "primaryKey", "primaryKey" ]
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
       }
     }, {
       "stream" : {
-        "sourceDefinedPrimaryKey" : true,
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
         "selected" : true,
-        "primaryKey" : [ "primaryKey", "primaryKey" ]
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
       }
     } ]
   },
@@ -3438,33 +3424,31 @@ font-style: italic;
   "syncCatalog" : {
     "streams" : [ {
       "stream" : {
-        "sourceDefinedPrimaryKey" : true,
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
         "selected" : true,
-        "primaryKey" : [ "primaryKey", "primaryKey" ]
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
       }
     }, {
       "stream" : {
-        "sourceDefinedPrimaryKey" : true,
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
         "selected" : true,
-        "primaryKey" : [ "primaryKey", "primaryKey" ]
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
       }
     } ]
   },
@@ -3560,33 +3544,31 @@ font-style: italic;
     "syncCatalog" : {
       "streams" : [ {
         "stream" : {
-          "sourceDefinedPrimaryKey" : true,
+          "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
           "selected" : true,
-          "primaryKey" : [ "primaryKey", "primaryKey" ]
+          "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
         }
       }, {
         "stream" : {
-          "sourceDefinedPrimaryKey" : true,
+          "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
           "selected" : true,
-          "primaryKey" : [ "primaryKey", "primaryKey" ]
+          "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
         }
       } ]
     },
@@ -3625,33 +3607,31 @@ font-style: italic;
     "syncCatalog" : {
       "streams" : [ {
         "stream" : {
-          "sourceDefinedPrimaryKey" : true,
+          "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
           "selected" : true,
-          "primaryKey" : [ "primaryKey", "primaryKey" ]
+          "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
         }
       }, {
         "stream" : {
-          "sourceDefinedPrimaryKey" : true,
+          "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
-          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-          "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+          "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
           "aliasName" : "aliasName",
           "cursorField" : [ "cursorField", "cursorField" ],
           "selected" : true,
-          "primaryKey" : [ "primaryKey", "primaryKey" ]
+          "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
         }
       } ]
     },
@@ -3870,33 +3850,31 @@ font-style: italic;
   "syncCatalog" : {
     "streams" : [ {
       "stream" : {
-        "sourceDefinedPrimaryKey" : true,
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
         "selected" : true,
-        "primaryKey" : [ "primaryKey", "primaryKey" ]
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
       }
     }, {
       "stream" : {
-        "sourceDefinedPrimaryKey" : true,
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
-        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ],
-        "defaultPrimaryKey" : [ "defaultPrimaryKey", "defaultPrimaryKey" ]
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
         "aliasName" : "aliasName",
         "cursorField" : [ "cursorField", "cursorField" ],
         "selected" : true,
-        "primaryKey" : [ "primaryKey", "primaryKey" ]
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
       }
     } ]
   },
@@ -4211,8 +4189,7 @@ font-style: italic;
 <div class="param">supportedSyncModes (optional)</div><div class="param-desc"><span class="param-type"><a href="#SyncMode">array[SyncMode]</a></span>  </div>
 <div class="param">sourceDefinedCursor (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> If the source defines the cursor field, then any other cursor field inputs will be ignored. If it does not, either the user_provided one is used, or the default one is used as a backup. </div>
 <div class="param">defaultCursorField (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> Path to the field that will be used to determine if a record is new or modified since the last sync. If not provided by the source, the end user will have to specify the comparable themselves. </div>
-<div class="param">sourceDefinedPrimaryKey (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> If the source defines the primary key, then any other primary key inputs will be ignored. If it does not, either the user_provided one is used, or the default one is used as a backup. </div>
-<div class="param">defaultPrimaryKey (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> Path to the fields that will be used as a primary key. If not provided by the source, the end user will have to specify the primary key themselves. </div>
+<div class="param">sourceDefinedPrimaryKey (optional)</div><div class="param-desc"><span class="param-type"><a href="#array">array[array[String]]</a></span> If the source defines the primary key, paths to the fields that will be used as a primary key. If not provided by the source, the end user will have to specify the primary key themselves. </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -4230,7 +4207,7 @@ font-style: italic;
       <div class="param">syncMode (optional)</div><div class="param-desc"><span class="param-type"><a href="#SyncMode">SyncMode</a></span>  </div>
 <div class="param">cursorField (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> Path to the field that will be used to determine if a record is new or modified since the last sync. This field is REQUIRED if <code>sync_mode</code> is <code>incremental</code>. Otherwise it is ignored. </div>
 <div class="param">destinationSyncMode (optional)</div><div class="param-desc"><span class="param-type"><a href="#DestinationSyncMode">DestinationSyncMode</a></span>  </div>
-<div class="param">primaryKey (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> Path to the field that will be used as primary key. This field is REQUIRED if <code>destination_sync_mode</code> is <code>*_dedup</code>. Otherwise it is ignored. </div>
+<div class="param">primaryKey (optional)</div><div class="param-desc"><span class="param-type"><a href="#array">array[array[String]]</a></span> Paths to the fields that will be used as primary key. This field is REQUIRED if <code>destination_sync_mode</code> is <code>*_dedup</code>. Otherwise it is ignored. </div>
 <div class="param">aliasName (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Alias name to the stream to be used in the destination </div>
 <div class="param">selected (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
     </div>  <!-- field-items -->


### PR DESCRIPTION
## What
*Describe what the change is solving*
Closes #2370

## How

- Introduces `primaryKey` fields in the ConfiguredCatalog for each stream
- Optionally, sources are able to declare `defaultPrimaryKey` fields if they can identify them too so the user doesn't have to input them

To move faster with less risk on this issue:
- I am not refactoring source sync modes and their cursor fields (it would require bumping versions of all source connectors)
- I am not separating the ConfiguredCatalog from the protocol as this work can be done in a dedicated issue, so the new "destination" sync fields are added to the catalog and configured catalog to mirror how it is done with incremental/cursor fields.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py`
1. `airbyte-api/src/main/openapi/config.yaml`
1. the rest
