### PR TITLE
fix json handling in http-request

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9845d17a-45f1-4070-8a60-50914b1c8e2b.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9845d17a-45f1-4070-8a60-50914b1c8e2b.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "9845d17a-45f1-4070-8a60-50914b1c8e2b",
   "name": "HTTP Request",
   "dockerRepository": "airbyte/source-http-request",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-http-request"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -91,7 +91,7 @@
 - sourceDefinitionId: 9845d17a-45f1-4070-8a60-50914b1c8e2b
   name: HTTP Request
   dockerRepository: airbyte/source-http-request
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/repository/docker/airbyte/source-http-request
 - sourceDefinitionId: e87ffa8e-a3b5-f69c-9076-6011339de1f6
   name: Redshift

--- a/airbyte-integrations/connectors/source-http-request/Dockerfile
+++ b/airbyte-integrations/connectors/source-http-request/Dockerfile
@@ -11,5 +11,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install ".[main]"
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-http-request

--- a/airbyte-integrations/connectors/source-http-request/source_http_request/source.py
+++ b/airbyte-integrations/connectors/source-http-request/source_http_request/source.py
@@ -88,9 +88,9 @@ class SourceHttpRequest(Source):
         body = parsed_config.get("body", {})
 
         if http_method == "get":
-            r = requests.get(url, headers=headers, data=body)
+            r = requests.get(url, headers=headers, json=body)
         elif http_method == "post":
-            r = requests.post(url, headers=headers, data=body)
+            r = requests.post(url, headers=headers, json=body)
         else:
             raise Exception(f"Did not recognize http_method: {http_method}")
 


### PR DESCRIPTION
Some web servers don't work when making the request if the JSON body isn't sent in this way via the `requests` library. This should fix the case shown in https://airbytehq.slack.com/archives/C01MFR03D5W/p1615203762192500