### PR TITLE
Organise and label DefaultJobPersistence tests.

### DIFF
--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/DefaultJobPersistence.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/persistence/DefaultJobPersistence.java
@@ -420,7 +420,8 @@ public class DefaultJobPersistence implements JobPersistence {
         .collect(Collectors.toList());
   }
 
-  public static Optional<Job> getJobFromResult(Result<Record> result) {
+  @VisibleForTesting
+  static Optional<Job> getJobFromResult(Result<Record> result) {
     return getJobsFromResult(result).stream().findFirst();
   }
 

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobPersistenceTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/persistence/DefaultJobPersistenceTest.java
@@ -75,23 +75,22 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.MountableFile;
 
+@DisplayName("DefaultJobPersistance")
 class DefaultJobPersistenceTest {
-
-  private static PostgreSQLContainer<?> container;
 
   private static final Instant NOW = Instant.now();
   private static final Path LOG_PATH = Path.of("/tmp/logs/all/the/way/down");
-
   private static final UUID CONNECTION_ID = UUID.randomUUID();
   private static final String SCOPE = CONNECTION_ID.toString();
   private static final String SPEC_SCOPE = SCOPE + "-spec";
   private static final String CHECK_SCOPE = SCOPE + "-check";
   private static final String SYNC_SCOPE = SCOPE + "-sync";
-
   private static final JobConfig SPEC_JOB_CONFIG = new JobConfig()
       .withConfigType(ConfigType.GET_SPEC)
       .withGetSpec(new JobGetSpecConfig());
@@ -101,6 +100,7 @@ class DefaultJobPersistenceTest {
   private static final JobConfig SYNC_JOB_CONFIG = new JobConfig()
       .withConfigType(ConfigType.SYNC)
       .withSync(new JobSyncConfig());
+  private static PostgreSQLContainer<?> container;
 
   private Database database;
   private Supplier<Instant> timeSupplier;
@@ -122,598 +122,6 @@ class DefaultJobPersistenceTest {
   @AfterAll
   public static void dbDown() {
     container.close();
-  }
-
-  @SuppressWarnings("unchecked")
-  @BeforeEach
-  public void setup() throws Exception {
-    database = Databases.createPostgresDatabase(container.getUsername(), container.getPassword(), container.getJdbcUrl());
-
-    // todo (cgardens) - truncate whole db.
-    database.query(ctx -> ctx.execute("DELETE FROM jobs"));
-    database.query(ctx -> ctx.execute("DELETE FROM attempts"));
-
-    timeSupplier = mock(Supplier.class);
-    when(timeSupplier.get()).thenReturn(NOW);
-
-    jobPersistence = new DefaultJobPersistence(database, timeSupplier);
-  }
-
-  @AfterEach
-  void tearDown() throws Exception {
-    database.close();
-  }
-
-  private Result<Record> getJobRecord(long jobId) throws SQLException {
-    return database.query(ctx -> ctx.fetch(DefaultJobPersistence.BASE_JOB_SELECT_AND_JOIN + "WHERE jobs.id = ?", jobId));
-  }
-
-  @Test
-  public void testCreateJobAndGetWithoutAttemptJob() throws IOException {
-    when(timeSupplier.get()).thenReturn(NOW);
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-
-    final Job actual = jobPersistence.getJob(jobId);
-    final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  public void testCreateJobNoQueueing() throws IOException {
-    when(timeSupplier.get()).thenReturn(NOW);
-    final Optional<Long> jobId1 = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG);
-    final Optional<Long> jobId2 = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG);
-
-    assertTrue(jobId1.isPresent());
-    assertTrue(jobId2.isEmpty());
-
-    final Job actual = jobPersistence.getJob(jobId1.get());
-    final Job expected = createJob(jobId1.get(), SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  void testResetJob() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
-    final Job created = jobPersistence.getJob(jobId);
-
-    jobPersistence.failAttempt(jobId, attemptNumber);
-    when(timeSupplier.get()).thenReturn(Instant.ofEpochMilli(4242));
-    jobPersistence.resetJob(jobId);
-
-    final Job updated = jobPersistence.getJob(jobId);
-    assertEquals(JobStatus.PENDING, updated.getStatus());
-    assertNotEquals(created.getUpdatedAtInSecond(), updated.getUpdatedAtInSecond());
-  }
-
-  @Test
-  void testResetJobCancelled() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-
-    jobPersistence.cancelJob(jobId);
-    assertThrows(IllegalStateException.class, () -> jobPersistence.resetJob(jobId));
-
-    final Job updated = jobPersistence.getJob(jobId);
-    assertEquals(JobStatus.CANCELLED, updated.getStatus());
-  }
-
-  @Test
-  void testCancelJob() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    final Job created = jobPersistence.getJob(jobId);
-
-    when(timeSupplier.get()).thenReturn(Instant.ofEpochMilli(4242));
-    jobPersistence.cancelJob(jobId);
-
-    final Job updated = jobPersistence.getJob(jobId);
-    assertEquals(JobStatus.CANCELLED, updated.getStatus());
-    assertNotEquals(created.getUpdatedAtInSecond(), updated.getUpdatedAtInSecond());
-  }
-
-  @Test
-  void testCancelJobAlreadyTerminal() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
-    jobPersistence.succeedAttempt(jobId, attemptNumber);
-
-    jobPersistence.cancelJob(jobId);
-
-    final Job updated = jobPersistence.getJob(jobId);
-    assertEquals(JobStatus.SUCCEEDED, updated.getStatus());
-  }
-
-  @Test
-  void failJob() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    final Job created = jobPersistence.getJob(jobId);
-
-    when(timeSupplier.get()).thenReturn(Instant.ofEpochMilli(4242));
-    jobPersistence.failJob(jobId);
-
-    final Job updated = jobPersistence.getJob(jobId);
-    assertEquals(JobStatus.FAILED, updated.getStatus());
-    assertNotEquals(created.getUpdatedAtInSecond(), updated.getUpdatedAtInSecond());
-  }
-
-  @Test
-  void testFailJobAlreadyTerminal() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
-    jobPersistence.succeedAttempt(jobId, attemptNumber);
-
-    jobPersistence.failJob(jobId);
-
-    final Job updated = jobPersistence.getJob(jobId);
-    assertEquals(JobStatus.SUCCEEDED, updated.getStatus());
-  }
-
-  @Test
-  void testCreateAttempt() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    jobPersistence.createAttempt(jobId, LOG_PATH);
-
-    final Job actual = jobPersistence.getJob(jobId);
-    final Job expected = createJob(
-        jobId,
-        SPEC_JOB_CONFIG,
-        JobStatus.RUNNING,
-        Lists.newArrayList(createAttempt(0L, jobId, AttemptStatus.RUNNING, LOG_PATH)),
-        NOW.getEpochSecond());
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  void testCreateAttemptAttemptId() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    final int attemptNumber1 = jobPersistence.createAttempt(jobId, LOG_PATH);
-    jobPersistence.failAttempt(jobId, attemptNumber1);
-
-    final Job jobAfterOneAttempts = jobPersistence.getJob(jobId);
-    assertEquals(0, attemptNumber1);
-    assertEquals(0, jobAfterOneAttempts.getAttempts().get(0).getId());
-
-    final int attemptNumber2 = jobPersistence.createAttempt(jobId, LOG_PATH);
-    final Job jobAfterTwoAttempts = jobPersistence.getJob(jobId);
-    assertEquals(1, attemptNumber2);
-    assertEquals(Sets.newHashSet(0L, 1L), jobAfterTwoAttempts.getAttempts().stream().map(Attempt::getId).collect(Collectors.toSet()));
-  }
-
-  @Test
-  void testCreateAttemptWhileAttemptAlreadyRunning() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    jobPersistence.createAttempt(jobId, LOG_PATH);
-
-    assertThrows(IllegalStateException.class, () -> jobPersistence.createAttempt(jobId, LOG_PATH));
-
-    final Job actual = jobPersistence.getJob(jobId);
-    final Job expected = createJob(
-        jobId,
-        SPEC_JOB_CONFIG,
-        JobStatus.RUNNING,
-        Lists.newArrayList(createAttempt(0L, jobId, AttemptStatus.RUNNING, LOG_PATH)),
-        NOW.getEpochSecond());
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  void testCreateAttemptTerminal() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
-    jobPersistence.succeedAttempt(jobId, attemptNumber);
-
-    assertThrows(IllegalStateException.class, () -> jobPersistence.createAttempt(jobId, LOG_PATH));
-
-    final Job actual = jobPersistence.getJob(jobId);
-    final Job expected = createJob(
-        jobId,
-        SPEC_JOB_CONFIG,
-        JobStatus.SUCCEEDED,
-        Lists.newArrayList(createAttempt(0L, jobId, AttemptStatus.SUCCEEDED, LOG_PATH)),
-        NOW.getEpochSecond());
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  void testCompleteAttemptFailed() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
-
-    jobPersistence.failAttempt(jobId, attemptNumber);
-
-    final Job actual = jobPersistence.getJob(jobId);
-    final Job expected = createJob(
-        jobId,
-        SPEC_JOB_CONFIG,
-        JobStatus.INCOMPLETE,
-        Lists.newArrayList(createAttempt(0L, jobId, AttemptStatus.FAILED, LOG_PATH)),
-        NOW.getEpochSecond());
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  void testCompleteAttemptSuccess() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
-
-    jobPersistence.succeedAttempt(jobId, attemptNumber);
-
-    final Job actual = jobPersistence.getJob(jobId);
-    final Job expected = createJob(
-        jobId,
-        SPEC_JOB_CONFIG,
-        JobStatus.SUCCEEDED,
-        Lists.newArrayList(createAttempt(0L, jobId, AttemptStatus.SUCCEEDED, LOG_PATH)),
-        NOW.getEpochSecond());
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  void testWriteOutput() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
-    final Job created = jobPersistence.getJob(jobId);
-    final JobOutput jobOutput = new JobOutput().withOutputType(JobOutput.OutputType.DISCOVER_CATALOG);
-
-    when(timeSupplier.get()).thenReturn(Instant.ofEpochMilli(4242));
-    jobPersistence.writeOutput(jobId, attemptNumber, jobOutput);
-
-    final Job updated = jobPersistence.getJob(jobId);
-    assertEquals(Optional.of(jobOutput), updated.getAttempts().get(0).getOutput());
-    assertNotEquals(created.getAttempts().get(0).getUpdatedAtInSecond(), updated.getAttempts().get(0).getUpdatedAtInSecond());
-  }
-
-  @Test
-  public void testListJobs() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-
-    final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString());
-
-    final Job actual = actualList.get(0);
-    final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
-
-    assertEquals(1, actualList.size());
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  public void testListJobsWithMultipleAttempts() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    final int attemptNumber0 = jobPersistence.createAttempt(jobId, LOG_PATH);
-
-    jobPersistence.failAttempt(jobId, attemptNumber0);
-
-    final Path secondAttemptLogPath = LOG_PATH.resolve("2");
-    final int attemptNumber1 = jobPersistence.createAttempt(jobId, secondAttemptLogPath);
-
-    jobPersistence.succeedAttempt(jobId, attemptNumber1);
-
-    final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString());
-
-    final Job actual = actualList.get(0);
-    final Job expected = createJob(
-        jobId,
-        SPEC_JOB_CONFIG,
-        JobStatus.SUCCEEDED,
-        Lists.newArrayList(
-            createAttempt(0L, jobId, AttemptStatus.FAILED, LOG_PATH),
-            createAttempt(1L, jobId, AttemptStatus.SUCCEEDED, secondAttemptLogPath)),
-        NOW.getEpochSecond());
-
-    assertEquals(1, actualList.size());
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  public void testListJobsWithStatus() throws IOException {
-    // not failed.
-    final long pendingSpecJobId = jobPersistence.enqueueJob(SPEC_SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    final long pendingSyncJobId = jobPersistence.enqueueJob(SYNC_SCOPE, SYNC_JOB_CONFIG).orElseThrow();
-    final long pendingCheckJobId = jobPersistence.enqueueJob(CHECK_SCOPE, CHECK_JOB_CONFIG).orElseThrow();
-
-    // failed
-    final long failedSpecJobId = jobPersistence.enqueueJob(SPEC_SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    final int attemptNumber = jobPersistence.createAttempt(failedSpecJobId, LOG_PATH);
-    jobPersistence.failAttempt(failedSpecJobId, attemptNumber);
-
-    final List<Job> allPendingJobs = jobPersistence.listJobsWithStatus(JobStatus.PENDING);
-    final Job expectedPendingSpecJob =
-        createJob(pendingSpecJobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), SPEC_SCOPE);
-    final Job expectedPendingCheckJob =
-        createJob(pendingCheckJobId, CHECK_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), CHECK_SCOPE);
-    final Job expectedPendingSyncJob =
-        createJob(pendingSyncJobId, SYNC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), SYNC_SCOPE);
-
-    final List<Job> allPendingSyncAndSpecJobs = jobPersistence.listJobsWithStatus(Set.of(ConfigType.GET_SPEC, ConfigType.SYNC), JobStatus.PENDING);
-
-    final List<Job> incompleteJobs = jobPersistence.listJobsWithStatus(SPEC_JOB_CONFIG.getConfigType(), JobStatus.INCOMPLETE);
-    final Job actualIncompleteJob = incompleteJobs.get(0);
-    final Job expectedIncompleteJob = createJob(
-        failedSpecJobId,
-        SPEC_JOB_CONFIG,
-        JobStatus.INCOMPLETE,
-        Lists.newArrayList(
-            createAttempt(0L, failedSpecJobId, AttemptStatus.FAILED, LOG_PATH)),
-        NOW.getEpochSecond(),
-        SPEC_SCOPE);
-
-    assertEquals(Sets.newHashSet(expectedPendingCheckJob, expectedPendingSpecJob, expectedPendingSyncJob), Sets.newHashSet(allPendingJobs));
-    assertEquals(Sets.newHashSet(expectedPendingSpecJob, expectedPendingSyncJob), Sets.newHashSet(allPendingSyncAndSpecJobs));
-
-    assertEquals(1, incompleteJobs.size());
-    assertEquals(expectedIncompleteJob, actualIncompleteJob);
-  }
-
-  @Test
-  public void testListJobsWithStatuses() throws IOException {
-    // not failed.
-    jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG);
-    // failed
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
-    jobPersistence.failAttempt(jobId, attemptNumber);
-
-    final List<Job> actualList = jobPersistence.listJobsWithStatus(JobStatus.INCOMPLETE);
-
-    final Job actual = actualList.get(0);
-    final Job expected = createJob(
-        jobId,
-        SPEC_JOB_CONFIG,
-        JobStatus.INCOMPLETE,
-        Lists.newArrayList(
-            createAttempt(0L, jobId, AttemptStatus.FAILED, LOG_PATH)),
-        NOW.getEpochSecond());
-
-    assertEquals(1, actualList.size());
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  public void testGetLastSyncJobForConnectionId() throws IOException {
-    final long jobId1 = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
-    jobPersistence.succeedAttempt(jobId1, jobPersistence.createAttempt(jobId1, LOG_PATH));
-
-    final Instant afterNow = NOW.plusSeconds(1000);
-    when(timeSupplier.get()).thenReturn(afterNow);
-    final long jobId2 = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
-
-    final Optional<Job> actual = jobPersistence.getLastReplicationJob(CONNECTION_ID);
-    Job expected = createJob(jobId2, SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), afterNow.getEpochSecond());
-
-    assertEquals(Optional.of(expected), actual);
-  }
-
-  @Test
-  public void testGetLastSyncJobForConnectionIdEmpty() throws IOException {
-    final Optional<Job> actual = jobPersistence.getLastReplicationJob(CONNECTION_ID);
-
-    assertTrue(actual.isEmpty());
-  }
-
-  @Test
-  public void testGetCurrentStateForConnectionIdNoState() throws IOException {
-    // no state when the connection has never had a job.
-    assertEquals(Optional.empty(), jobPersistence.getCurrentState(CONNECTION_ID));
-
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
-    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
-
-    // no state when connection has a job but it has not completed that has not completed
-    assertEquals(Optional.empty(), jobPersistence.getCurrentState(CONNECTION_ID));
-
-    jobPersistence.failJob(jobId);
-
-    // no state when connection has a job but it is failed.
-    assertEquals(Optional.empty(), jobPersistence.getCurrentState(CONNECTION_ID));
-
-    jobPersistence.cancelJob(jobId);
-
-    // no state when connection has a job but it is cancelled.
-    assertEquals(Optional.empty(), jobPersistence.getCurrentState(CONNECTION_ID));
-
-    final JobOutput jobOutput1 = new JobOutput()
-        .withSync(new StandardSyncOutput().withState(new State().withState(Jsons.jsonNode(ImmutableMap.of("checkpoint", "1")))));
-    jobPersistence.writeOutput(jobId, attemptNumber, jobOutput1);
-    jobPersistence.succeedAttempt(jobId, attemptNumber);
-
-    // job 1 state, after first success.
-    assertEquals(Optional.of(jobOutput1.getSync().getState()), jobPersistence.getCurrentState(CONNECTION_ID));
-
-    when(timeSupplier.get()).thenReturn(NOW.plusSeconds(1000));
-    final long jobId2 = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
-    final int attemptNumber2 = jobPersistence.createAttempt(jobId2, LOG_PATH);
-
-    // job 1 state, second job created.
-    assertEquals(Optional.of(jobOutput1.getSync().getState()), jobPersistence.getCurrentState(CONNECTION_ID));
-
-    jobPersistence.failJob(jobId2);
-
-    // job 1 state, second job failed.
-    assertEquals(Optional.of(jobOutput1.getSync().getState()), jobPersistence.getCurrentState(CONNECTION_ID));
-
-    jobPersistence.cancelJob(jobId2);
-
-    // job 1 state, second job cancelled
-    assertEquals(Optional.of(jobOutput1.getSync().getState()), jobPersistence.getCurrentState(CONNECTION_ID));
-
-    final JobOutput jobOutput2 = new JobOutput()
-        .withSync(new StandardSyncOutput().withState(new State().withState(Jsons.jsonNode(ImmutableMap.of("checkpoint", "2")))));
-    jobPersistence.writeOutput(jobId2, attemptNumber2, jobOutput2);
-    jobPersistence.succeedAttempt(jobId2, attemptNumber2);
-
-    // job 2 state, after second job success.
-    assertEquals(Optional.of(jobOutput2.getSync().getState()), jobPersistence.getCurrentState(CONNECTION_ID));
-  }
-
-  @Test
-  public void testGetOldestPendingJob() throws IOException {
-    final long jobId = createJobAt(NOW);
-    createJobAt(NOW.plusSeconds(1000));
-
-    final Optional<Job> actual = jobPersistence.getNextJob();
-
-    Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
-    assertEquals(Optional.of(expected), actual);
-  }
-
-  @Test
-  public void testGetOldestPendingJobWithOtherJobWithSameScopeRunning() throws IOException {
-    // create a job and set it to running.
-    final long jobId = createJobAt(NOW.minusSeconds(1000));
-    jobPersistence.createAttempt(jobId, LOG_PATH);
-
-    // create a pending job.
-    createJobAt(NOW);
-
-    final Optional<Job> actual = jobPersistence.getNextJob();
-
-    assertTrue(actual.isEmpty());
-  }
-
-  @Test
-  public void testGetOldestPendingJobWithOtherJobWithSameScopeIncomplete() throws IOException {
-    // create a job and set it to incomplete.
-    final long jobId = createJobAt(NOW.minusSeconds(1000));
-    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
-    jobPersistence.failAttempt(jobId, attemptNumber);
-
-    // create a pending job.
-    final Instant afterNow = NOW.plusSeconds(1000);
-    when(timeSupplier.get()).thenReturn(afterNow);
-    createJobAt(NOW);
-
-    final Optional<Job> actual = jobPersistence.getNextJob();
-
-    assertTrue(actual.isEmpty());
-  }
-
-  @Test
-  public void testGetOldestPendingJobWithOtherJobWithSameScopeFailed() throws IOException {
-    // create a job and set it to incomplete.
-    final long jobId = createJobAt(NOW.minusSeconds(1000));
-    jobPersistence.createAttempt(jobId, LOG_PATH);
-    jobPersistence.failJob(jobId);
-
-    // create a pending job.
-    final long jobId2 = createJobAt(NOW);
-
-    final Optional<Job> actual = jobPersistence.getNextJob();
-
-    Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
-    assertEquals(Optional.of(expected), actual);
-  }
-
-  @Test
-  public void testGetOldestPendingJobWithOtherJobWithSameScopeCancelled() throws IOException {
-    // create a job and set it to incomplete.
-    final long jobId = createJobAt(NOW.minusSeconds(1000));
-    jobPersistence.cancelJob(jobId);
-
-    // create a pending job.
-    final long jobId2 = createJobAt(NOW);
-
-    final Optional<Job> actual = jobPersistence.getNextJob();
-
-    Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
-    assertEquals(Optional.of(expected), actual);
-  }
-
-  @Test
-  public void testGetOldestPendingJobWithOtherJobWithSameScopeSucceeded() throws IOException {
-    // create a job and set it to incomplete.
-    final long jobId = createJobAt(NOW.minusSeconds(1000));
-    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
-    jobPersistence.succeedAttempt(jobId, attemptNumber);
-
-    // create a pending job.
-    final long jobId2 = createJobAt(NOW);
-
-    final Optional<Job> actual = jobPersistence.getNextJob();
-
-    Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
-    assertEquals(Optional.of(expected), actual);
-  }
-
-  private long createJobAt(Instant created_at) throws IOException {
-    when(timeSupplier.get()).thenReturn(created_at);
-    return jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-  }
-
-  @Test
-  public void testGetOldestPendingJobOnlyPendingJobs() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    jobPersistence.cancelJob(jobId);
-
-    final Optional<Job> actual = jobPersistence.getNextJob();
-
-    assertTrue(actual.isEmpty());
-  }
-
-  @Test
-  void testGetNextJobWithMultipleAttempts() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-    jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
-    jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
-    jobPersistence.resetJob(jobId);
-
-    final Optional<Job> actual = jobPersistence.getNextJob();
-
-    final Job expected = createJob(
-        jobId,
-        SPEC_JOB_CONFIG,
-        JobStatus.PENDING,
-        Lists.newArrayList(
-            createAttempt(0L, jobId, AttemptStatus.FAILED, LOG_PATH),
-            createAttempt(1L, jobId, AttemptStatus.FAILED, LOG_PATH)),
-        NOW.getEpochSecond());
-
-    assertEquals(Optional.of(expected), actual);
-  }
-
-  @Test
-  void testGetCurrentStateWithMultipleAttempts() throws IOException {
-    final State state = new State().withState(Jsons.jsonNode(ImmutableMap.of("checkpoint", 4)));
-    final JobOutput jobOutput = new JobOutput().withOutputType(OutputType.SYNC).withSync(new StandardSyncOutput().withState(state));
-
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
-    jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
-    final int attemptId = jobPersistence.createAttempt(jobId, LOG_PATH);
-    jobPersistence.writeOutput(jobId, attemptId, jobOutput);
-    jobPersistence.succeedAttempt(jobId, attemptId);
-
-    final Optional<State> actual = jobPersistence.getCurrentState(UUID.fromString(SCOPE));
-
-    assertEquals(Optional.of(state), actual);
-  }
-
-  @Test
-  void testGetLastSyncJobWithMultipleAttempts() throws IOException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
-    jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
-    jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
-
-    final Optional<Job> actual = jobPersistence.getLastReplicationJob(UUID.fromString(SCOPE));
-
-    final Job expected = createJob(
-        jobId,
-        SYNC_JOB_CONFIG,
-        JobStatus.INCOMPLETE,
-        Lists.newArrayList(
-            createAttempt(0L, jobId, AttemptStatus.FAILED, LOG_PATH),
-            createAttempt(1L, jobId, AttemptStatus.FAILED, LOG_PATH)),
-        NOW.getEpochSecond());
-
-    assertEquals(Optional.of(expected), actual);
-  }
-
-  @Test
-  public void testGetJobFromRecord() throws IOException, SQLException {
-    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
-
-    final Optional<Job> actual = DefaultJobPersistence.getJobFromResult(getJobRecord(jobId));
-
-    Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
-    assertEquals(Optional.of(expected), actual);
   }
 
   private static Attempt createAttempt(long id, long jobId, AttemptStatus status, Path logPath) {
@@ -745,7 +153,119 @@ class DefaultJobPersistenceTest {
         time);
   }
 
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  public void setup() throws Exception {
+    database = Databases.createPostgresDatabase(container.getUsername(), container.getPassword(), container.getJdbcUrl());
+    resetDb();
+
+    timeSupplier = mock(Supplier.class);
+    when(timeSupplier.get()).thenReturn(NOW);
+
+    jobPersistence = new DefaultJobPersistence(database, timeSupplier);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    database.close();
+  }
+
+  private void resetDb() throws SQLException {
+    // todo (cgardens) - truncate whole db.
+    database.query(ctx -> ctx.execute("TRUNCATE TABLE jobs"));
+    database.query(ctx -> ctx.execute("TRUNCATE TABLE attempts"));
+  }
+
+  private Result<Record> getJobRecord(long jobId) throws SQLException {
+    return database.query(ctx -> ctx.fetch(DefaultJobPersistence.BASE_JOB_SELECT_AND_JOIN + "WHERE jobs.id = ?", jobId));
+  }
+
   @Test
+  @DisplayName("Should set a job to incomplete if an attempt fails")
+  void testCompleteAttemptFailed() throws IOException {
+    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
+
+    jobPersistence.failAttempt(jobId, attemptNumber);
+
+    final Job actual = jobPersistence.getJob(jobId);
+    final Job expected = createJob(
+        jobId,
+        SPEC_JOB_CONFIG,
+        JobStatus.INCOMPLETE,
+        Lists.newArrayList(createAttempt(0L, jobId, AttemptStatus.FAILED, LOG_PATH)),
+        NOW.getEpochSecond());
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  @DisplayName("Should set a job to succeeded if an attempt succeeds")
+  void testCompleteAttemptSuccess() throws IOException {
+    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
+
+    jobPersistence.succeedAttempt(jobId, attemptNumber);
+
+    final Job actual = jobPersistence.getJob(jobId);
+    final Job expected = createJob(
+        jobId,
+        SPEC_JOB_CONFIG,
+        JobStatus.SUCCEEDED,
+        Lists.newArrayList(createAttempt(0L, jobId, AttemptStatus.SUCCEEDED, LOG_PATH)),
+        NOW.getEpochSecond());
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  @DisplayName("Should be able to read what is written")
+  void testWriteOutput() throws IOException {
+    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+    final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
+    final Job created = jobPersistence.getJob(jobId);
+    final JobOutput jobOutput = new JobOutput().withOutputType(JobOutput.OutputType.DISCOVER_CATALOG);
+
+    when(timeSupplier.get()).thenReturn(Instant.ofEpochMilli(4242));
+    jobPersistence.writeOutput(jobId, attemptNumber, jobOutput);
+
+    final Job updated = jobPersistence.getJob(jobId);
+    assertEquals(Optional.of(jobOutput), updated.getAttempts().get(0).getOutput());
+    assertNotEquals(created.getAttempts().get(0).getUpdatedAtInSecond(), updated.getAttempts().get(0).getUpdatedAtInSecond());
+  }
+
+  @Test
+  @DisplayName("When getting the last replication job should return the most recently created job")
+  void testGetLastSyncJobWithMultipleAttempts() throws IOException {
+    final long jobId = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
+    jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
+    jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
+
+    final Optional<Job> actual = jobPersistence.getLastReplicationJob(UUID.fromString(SCOPE));
+
+    final Job expected = createJob(
+        jobId,
+        SYNC_JOB_CONFIG,
+        JobStatus.INCOMPLETE,
+        Lists.newArrayList(
+            createAttempt(0L, jobId, AttemptStatus.FAILED, LOG_PATH),
+            createAttempt(1L, jobId, AttemptStatus.FAILED, LOG_PATH)),
+        NOW.getEpochSecond());
+
+    assertEquals(Optional.of(expected), actual);
+  }
+
+  @Test
+  @DisplayName("Should extract a Job model from a JOOQ result set")
+  public void testGetJobFromRecord() throws IOException, SQLException {
+    final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+
+    final Optional<Job> actual = DefaultJobPersistence.getJobFromResult(getJobRecord(jobId));
+
+    Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+    assertEquals(Optional.of(expected), actual);
+  }
+
+  @Test
+  @DisplayName("Should be able to import database that was exported")
   void testExportImport() throws IOException, SQLException {
     final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
     final int attemptNumber0 = jobPersistence.createAttempt(jobId, LOG_PATH);
@@ -764,9 +284,7 @@ class DefaultJobPersistenceTest {
       tempData.put(entry.getKey(), tableData);
       outputStreams.put(entry.getKey(), tableData.stream());
     }
-    // Reset database
-    database.query(ctx -> ctx.execute("DELETE FROM jobs"));
-    database.query(ctx -> ctx.execute("DELETE FROM attempts"));
+    resetDb();
 
     jobPersistence.importDatabase("test", outputStreams);
 
@@ -787,6 +305,7 @@ class DefaultJobPersistenceTest {
   }
 
   @Test
+  @DisplayName("Should have valid yaml schemas in exported database")
   void testYamlSchemas() throws IOException {
     final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
     final int attemptNumber0 = jobPersistence.createAttempt(jobId, LOG_PATH);
@@ -810,6 +329,581 @@ class DefaultJobPersistenceTest {
         }
       });
     });
+  }
+
+  private long createJobAt(Instant created_at) throws IOException {
+    when(timeSupplier.get()).thenReturn(created_at);
+    return jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+  }
+
+  @Nested
+  @DisplayName("When cancelling job")
+  class CancelJob {
+
+    @Test
+    @DisplayName("Should cancel job and leave job in cancelled state")
+    void testCancelJob() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      final Job created = jobPersistence.getJob(jobId);
+
+      when(timeSupplier.get()).thenReturn(Instant.ofEpochMilli(4242));
+      jobPersistence.cancelJob(jobId);
+
+      final Job updated = jobPersistence.getJob(jobId);
+      assertEquals(JobStatus.CANCELLED, updated.getStatus());
+      assertNotEquals(created.getUpdatedAtInSecond(), updated.getUpdatedAtInSecond());
+    }
+
+    @Test
+    @DisplayName("Should do nothing to job already in terminal state")
+    void testCancelJobAlreadyTerminal() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
+      jobPersistence.succeedAttempt(jobId, attemptNumber);
+
+      jobPersistence.cancelJob(jobId);
+
+      final Job updated = jobPersistence.getJob(jobId);
+      assertEquals(JobStatus.SUCCEEDED, updated.getStatus());
+    }
+
+  }
+
+  @Nested
+  @DisplayName("When creating attempt")
+  class CreateAttempt {
+
+    @Test
+    @DisplayName("Should create an attempt")
+    void testCreateAttempt() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      jobPersistence.createAttempt(jobId, LOG_PATH);
+
+      final Job actual = jobPersistence.getJob(jobId);
+      final Job expected = createJob(
+          jobId,
+          SPEC_JOB_CONFIG,
+          JobStatus.RUNNING,
+          Lists.newArrayList(createAttempt(0L, jobId, AttemptStatus.RUNNING, LOG_PATH)),
+          NOW.getEpochSecond());
+      assertEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("Should increment attempt id if creating multiple attemps")
+    void testCreateAttemptAttemptId() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      final int attemptNumber1 = jobPersistence.createAttempt(jobId, LOG_PATH);
+      jobPersistence.failAttempt(jobId, attemptNumber1);
+
+      final Job jobAfterOneAttempts = jobPersistence.getJob(jobId);
+      assertEquals(0, attemptNumber1);
+      assertEquals(0, jobAfterOneAttempts.getAttempts().get(0).getId());
+
+      final int attemptNumber2 = jobPersistence.createAttempt(jobId, LOG_PATH);
+      final Job jobAfterTwoAttempts = jobPersistence.getJob(jobId);
+      assertEquals(1, attemptNumber2);
+      assertEquals(Sets.newHashSet(0L, 1L), jobAfterTwoAttempts.getAttempts().stream().map(Attempt::getId).collect(Collectors.toSet()));
+    }
+
+    @Test
+    @DisplayName("Should not create an attempt if an attempt is running")
+    void testCreateAttemptWhileAttemptAlreadyRunning() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      jobPersistence.createAttempt(jobId, LOG_PATH);
+
+      assertThrows(IllegalStateException.class, () -> jobPersistence.createAttempt(jobId, LOG_PATH));
+
+      final Job actual = jobPersistence.getJob(jobId);
+      final Job expected = createJob(
+          jobId,
+          SPEC_JOB_CONFIG,
+          JobStatus.RUNNING,
+          Lists.newArrayList(createAttempt(0L, jobId, AttemptStatus.RUNNING, LOG_PATH)),
+          NOW.getEpochSecond());
+      assertEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("Should not create an attempt if job is in terminal state")
+    void testCreateAttemptTerminal() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
+      jobPersistence.succeedAttempt(jobId, attemptNumber);
+
+      assertThrows(IllegalStateException.class, () -> jobPersistence.createAttempt(jobId, LOG_PATH));
+
+      final Job actual = jobPersistence.getJob(jobId);
+      final Job expected = createJob(
+          jobId,
+          SPEC_JOB_CONFIG,
+          JobStatus.SUCCEEDED,
+          Lists.newArrayList(createAttempt(0L, jobId, AttemptStatus.SUCCEEDED, LOG_PATH)),
+          NOW.getEpochSecond());
+      assertEquals(expected, actual);
+    }
+
+  }
+
+  @Nested
+  @DisplayName("When creating job")
+  class CreateJob {
+
+    @Test
+    @DisplayName("Should create initial job without attempt")
+    public void testCreateJobAndGetWithoutAttemptJob() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+
+      final Job actual = jobPersistence.getJob(jobId);
+      final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+      assertEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("Should not create a second job under the same scope if a first job already exists")
+    public void testCreateJobNoQueueing() throws IOException {
+      final Optional<Long> jobId1 = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG);
+      final Optional<Long> jobId2 = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG);
+
+      assertTrue(jobId1.isPresent());
+      assertTrue(jobId2.isEmpty());
+
+      final Job actual = jobPersistence.getJob(jobId1.get());
+      final Job expected = createJob(jobId1.get(), SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+      assertEquals(expected, actual);
+    }
+
+  }
+
+  @Nested
+  @DisplayName("When failing job")
+  class FailJob {
+
+    @Test
+    @DisplayName("Should set job status to failed")
+    void failJob() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      final Job created = jobPersistence.getJob(jobId);
+
+      when(timeSupplier.get()).thenReturn(Instant.ofEpochMilli(4242));
+      jobPersistence.failJob(jobId);
+
+      final Job updated = jobPersistence.getJob(jobId);
+      assertEquals(JobStatus.FAILED, updated.getStatus());
+      assertNotEquals(created.getUpdatedAtInSecond(), updated.getUpdatedAtInSecond());
+    }
+
+    @Test
+    @DisplayName("Should ignore job already in terminal state")
+    void testFailJobAlreadyTerminal() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
+      jobPersistence.succeedAttempt(jobId, attemptNumber);
+
+      jobPersistence.failJob(jobId);
+
+      final Job updated = jobPersistence.getJob(jobId);
+      assertEquals(JobStatus.SUCCEEDED, updated.getStatus());
+    }
+
+  }
+
+  @Nested
+  @DisplayName("When getting last replication job")
+  class GetLastReplicationJob {
+
+    @Test
+    @DisplayName("Should return nothing if no job exists")
+    public void testGetLastSyncJobForConnectionIdEmpty() throws IOException {
+      final Optional<Job> actual = jobPersistence.getLastReplicationJob(CONNECTION_ID);
+
+      assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should return the last enqueued job")
+    public void testGetLastSyncJobForConnectionId() throws IOException {
+      final long jobId1 = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
+      jobPersistence.succeedAttempt(jobId1, jobPersistence.createAttempt(jobId1, LOG_PATH));
+
+      final Instant afterNow = NOW.plusSeconds(1000);
+      when(timeSupplier.get()).thenReturn(afterNow);
+      final long jobId2 = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
+
+      final Optional<Job> actual = jobPersistence.getLastReplicationJob(CONNECTION_ID);
+      Job expected = createJob(jobId2, SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), afterNow.getEpochSecond());
+
+      assertEquals(Optional.of(expected), actual);
+    }
+
+  }
+
+  @Nested
+  @DisplayName("When getting current state")
+  class GetCurrentState {
+
+    @Test
+    @DisplayName("Should only have state if the latest attempt succeeded")
+    void testGetCurrentStateWithMultipleAttempts() throws IOException {
+      final State state = new State().withState(Jsons.jsonNode(ImmutableMap.of("checkpoint", 4)));
+      final JobOutput jobOutput = new JobOutput().withOutputType(OutputType.SYNC).withSync(new StandardSyncOutput().withState(state));
+
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
+      jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
+      final int attemptId = jobPersistence.createAttempt(jobId, LOG_PATH);
+      jobPersistence.writeOutput(jobId, attemptId, jobOutput);
+      jobPersistence.succeedAttempt(jobId, attemptId);
+
+      final Optional<State> actual = jobPersistence.getCurrentState(UUID.fromString(SCOPE));
+      assertEquals(Optional.of(state), actual);
+    }
+
+    @Test
+    @DisplayName("Should not have state if the latest attempt did not succeeded and have state otherwise")
+    public void testGetCurrentStateForConnectionIdNoState() throws IOException {
+      // no state when the connection has never had a job.
+      assertEquals(Optional.empty(), jobPersistence.getCurrentState(CONNECTION_ID));
+
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
+      final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
+
+      // no state when connection has a job but it has not completed that has not completed
+      assertEquals(Optional.empty(), jobPersistence.getCurrentState(CONNECTION_ID));
+
+      jobPersistence.failJob(jobId);
+
+      // no state when connection has a job but it is failed.
+      assertEquals(Optional.empty(), jobPersistence.getCurrentState(CONNECTION_ID));
+
+      jobPersistence.cancelJob(jobId);
+
+      // no state when connection has a job but it is cancelled.
+      assertEquals(Optional.empty(), jobPersistence.getCurrentState(CONNECTION_ID));
+
+      final JobOutput jobOutput1 = new JobOutput()
+          .withSync(new StandardSyncOutput().withState(new State().withState(Jsons.jsonNode(ImmutableMap.of("checkpoint", "1")))));
+      jobPersistence.writeOutput(jobId, attemptNumber, jobOutput1);
+      jobPersistence.succeedAttempt(jobId, attemptNumber);
+
+      // job 1 state, after first success.
+      assertEquals(Optional.of(jobOutput1.getSync().getState()), jobPersistence.getCurrentState(CONNECTION_ID));
+
+      when(timeSupplier.get()).thenReturn(NOW.plusSeconds(1000));
+      final long jobId2 = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
+      final int attemptNumber2 = jobPersistence.createAttempt(jobId2, LOG_PATH);
+
+      // job 1 state, second job created.
+      assertEquals(Optional.of(jobOutput1.getSync().getState()), jobPersistence.getCurrentState(CONNECTION_ID));
+
+      jobPersistence.failJob(jobId2);
+
+      // job 1 state, second job failed.
+      assertEquals(Optional.of(jobOutput1.getSync().getState()), jobPersistence.getCurrentState(CONNECTION_ID));
+
+      jobPersistence.cancelJob(jobId2);
+
+      // job 1 state, second job cancelled
+      assertEquals(Optional.of(jobOutput1.getSync().getState()), jobPersistence.getCurrentState(CONNECTION_ID));
+
+      final JobOutput jobOutput2 = new JobOutput()
+          .withSync(new StandardSyncOutput().withState(new State().withState(Jsons.jsonNode(ImmutableMap.of("checkpoint", "2")))));
+      jobPersistence.writeOutput(jobId2, attemptNumber2, jobOutput2);
+      jobPersistence.succeedAttempt(jobId2, attemptNumber2);
+
+      // job 2 state, after second job success.
+      assertEquals(Optional.of(jobOutput2.getSync().getState()), jobPersistence.getCurrentState(CONNECTION_ID));
+    }
+
+  }
+
+  @Nested
+  @DisplayName("When getting next job")
+  class GetNextJob {
+
+    @Test
+    @DisplayName("Should always return oldest pending job")
+    public void testGetOldestPendingJob() throws IOException {
+      final long jobId = createJobAt(NOW);
+      createJobAt(NOW.plusSeconds(1000));
+
+      final Optional<Job> actual = jobPersistence.getNextJob();
+
+      Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+      assertEquals(Optional.of(expected), actual);
+    }
+
+    @Test
+    @DisplayName("Should return nothing if no jobs pending")
+    public void testGetOldestPendingJobOnlyPendingJobs() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      jobPersistence.cancelJob(jobId);
+
+      final Optional<Job> actual = jobPersistence.getNextJob();
+
+      assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should return job if job is pending even if it has multiple failed attempts")
+    void testGetNextJobWithMultipleAttempts() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
+      jobPersistence.failAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
+      jobPersistence.resetJob(jobId);
+
+      final Optional<Job> actual = jobPersistence.getNextJob();
+
+      final Job expected = createJob(
+          jobId,
+          SPEC_JOB_CONFIG,
+          JobStatus.PENDING,
+          Lists.newArrayList(
+              createAttempt(0L, jobId, AttemptStatus.FAILED, LOG_PATH),
+              createAttempt(1L, jobId, AttemptStatus.FAILED, LOG_PATH)),
+          NOW.getEpochSecond());
+
+      assertEquals(Optional.of(expected), actual);
+    }
+
+    @Test
+    @DisplayName("Should return oldest pending job even if another job with same scope failed")
+    public void testGetOldestPendingJobWithOtherJobWithSameScopeFailed() throws IOException {
+      // create a job and set it to incomplete.
+      final long jobId = createJobAt(NOW.minusSeconds(1000));
+      jobPersistence.createAttempt(jobId, LOG_PATH);
+      jobPersistence.failJob(jobId);
+
+      // create a pending job.
+      final long jobId2 = createJobAt(NOW);
+
+      final Optional<Job> actual = jobPersistence.getNextJob();
+
+      Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+      assertEquals(Optional.of(expected), actual);
+    }
+
+    @Test
+    @DisplayName("Should return oldest pending job even if another job with same scope cancelled")
+    public void testGetOldestPendingJobWithOtherJobWithSameScopeCancelled() throws IOException {
+      // create a job and set it to incomplete.
+      final long jobId = createJobAt(NOW.minusSeconds(1000));
+      jobPersistence.cancelJob(jobId);
+
+      // create a pending job.
+      final long jobId2 = createJobAt(NOW);
+
+      final Optional<Job> actual = jobPersistence.getNextJob();
+
+      Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+      assertEquals(Optional.of(expected), actual);
+    }
+
+    @Test
+    @DisplayName("Should return oldest pending job even if another job with same scope succeeded")
+    public void testGetOldestPendingJobWithOtherJobWithSameScopeSucceeded() throws IOException {
+      // create a job and set it to incomplete.
+      final long jobId = createJobAt(NOW.minusSeconds(1000));
+      final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
+      jobPersistence.succeedAttempt(jobId, attemptNumber);
+
+      // create a pending job.
+      final long jobId2 = createJobAt(NOW);
+
+      final Optional<Job> actual = jobPersistence.getNextJob();
+
+      Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+      assertEquals(Optional.of(expected), actual);
+    }
+
+    @Test
+    @DisplayName("Should not return pending job if job with same scope is running")
+    public void testGetOldestPendingJobWithOtherJobWithSameScopeRunning() throws IOException {
+      // create a job and set it to running.
+      final long jobId = createJobAt(NOW.minusSeconds(1000));
+      jobPersistence.createAttempt(jobId, LOG_PATH);
+
+      // create a pending job.
+      createJobAt(NOW);
+
+      final Optional<Job> actual = jobPersistence.getNextJob();
+
+      assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should not return pending job if job with same scope is incomplete")
+    public void testGetOldestPendingJobWithOtherJobWithSameScopeIncomplete() throws IOException {
+      // create a job and set it to incomplete.
+      final long jobId = createJobAt(NOW.minusSeconds(1000));
+      final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
+      jobPersistence.failAttempt(jobId, attemptNumber);
+
+      // create a pending job.
+      final Instant afterNow = NOW.plusSeconds(1000);
+      when(timeSupplier.get()).thenReturn(afterNow);
+      createJobAt(NOW);
+
+      final Optional<Job> actual = jobPersistence.getNextJob();
+
+      assertTrue(actual.isEmpty());
+    }
+
+  }
+
+  @Nested
+  @DisplayName("When listing jobs")
+  class ListJobs {
+
+    @Test
+    @DisplayName("Should list all jobs")
+    public void testListJobs() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+
+      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString());
+
+      final Job actual = actualList.get(0);
+      final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+
+      assertEquals(1, actualList.size());
+      assertEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("Should list all jobs with all attempts")
+    public void testListJobsWithMultipleAttempts() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      final int attemptNumber0 = jobPersistence.createAttempt(jobId, LOG_PATH);
+
+      jobPersistence.failAttempt(jobId, attemptNumber0);
+
+      final Path secondAttemptLogPath = LOG_PATH.resolve("2");
+      final int attemptNumber1 = jobPersistence.createAttempt(jobId, secondAttemptLogPath);
+
+      jobPersistence.succeedAttempt(jobId, attemptNumber1);
+
+      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString());
+
+      final Job actual = actualList.get(0);
+      final Job expected = createJob(
+          jobId,
+          SPEC_JOB_CONFIG,
+          JobStatus.SUCCEEDED,
+          Lists.newArrayList(
+              createAttempt(0L, jobId, AttemptStatus.FAILED, LOG_PATH),
+              createAttempt(1L, jobId, AttemptStatus.SUCCEEDED, secondAttemptLogPath)),
+          NOW.getEpochSecond());
+
+      assertEquals(1, actualList.size());
+      assertEquals(expected, actual);
+    }
+
+  }
+
+  @Nested
+  @DisplayName("When listing job with status")
+  class ListJobsWithStatus {
+
+    @Test
+    @DisplayName("Should only list jobs with requested status")
+    public void testListJobsWithStatus() throws IOException {
+      // not failed.
+      jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG);
+      // failed
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
+      jobPersistence.failAttempt(jobId, attemptNumber);
+
+      final List<Job> actualList = jobPersistence.listJobsWithStatus(JobStatus.INCOMPLETE);
+
+      final Job actual = actualList.get(0);
+      final Job expected = createJob(
+          jobId,
+          SPEC_JOB_CONFIG,
+          JobStatus.INCOMPLETE,
+          Lists.newArrayList(
+              createAttempt(0L, jobId, AttemptStatus.FAILED, LOG_PATH)),
+          NOW.getEpochSecond());
+
+      assertEquals(1, actualList.size());
+      assertEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("Should only list jobs with requested status and config type")
+    public void testListJobsWithStatusAndConfigType() throws IOException, InterruptedException {
+      // not failed.
+      final long pendingSpecJobId = jobPersistence.enqueueJob(SPEC_SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      final long pendingSyncJobId = jobPersistence.enqueueJob(SYNC_SCOPE, SYNC_JOB_CONFIG).orElseThrow();
+      final long pendingCheckJobId = jobPersistence.enqueueJob(CHECK_SCOPE, CHECK_JOB_CONFIG).orElseThrow();
+
+      // failed
+      final long failedSpecJobId = jobPersistence.enqueueJob(SPEC_SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      final int attemptNumber = jobPersistence.createAttempt(failedSpecJobId, LOG_PATH);
+      jobPersistence.failAttempt(failedSpecJobId, attemptNumber);
+
+      final List<Job> allPendingJobs = jobPersistence.listJobsWithStatus(JobStatus.PENDING);
+
+      final Job expectedPendingSpecJob =
+          createJob(pendingSpecJobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), SPEC_SCOPE);
+      final Job expectedPendingCheckJob =
+          createJob(pendingCheckJobId, CHECK_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), CHECK_SCOPE);
+      final Job expectedPendingSyncJob =
+          createJob(pendingSyncJobId, SYNC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), SYNC_SCOPE);
+
+      final List<Job> allPendingSyncAndSpecJobs = jobPersistence.listJobsWithStatus(Set.of(ConfigType.GET_SPEC, ConfigType.SYNC), JobStatus.PENDING);
+
+      final List<Job> incompleteJobs = jobPersistence.listJobsWithStatus(SPEC_JOB_CONFIG.getConfigType(), JobStatus.INCOMPLETE);
+      final Job actualIncompleteJob = incompleteJobs.get(0);
+      final Job expectedIncompleteJob = createJob(
+          failedSpecJobId,
+          SPEC_JOB_CONFIG,
+          JobStatus.INCOMPLETE,
+          Lists.newArrayList(
+              createAttempt(0L, failedSpecJobId, AttemptStatus.FAILED, LOG_PATH)),
+          NOW.getEpochSecond(),
+          SPEC_SCOPE);
+
+      assertEquals(Sets.newHashSet(expectedPendingCheckJob, expectedPendingSpecJob, expectedPendingSyncJob), Sets.newHashSet(allPendingJobs));
+      assertEquals(Sets.newHashSet(expectedPendingSpecJob, expectedPendingSyncJob), Sets.newHashSet(allPendingSyncAndSpecJobs));
+
+      assertEquals(1, incompleteJobs.size());
+      assertEquals(expectedIncompleteJob, actualIncompleteJob);
+    }
+
+  }
+
+  @Nested
+  @DisplayName("When resetting job")
+  class ResetJob {
+
+    @Test
+    @DisplayName("Should reset job and put job in pending state")
+    void testResetJob() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+      final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
+      final Job created = jobPersistence.getJob(jobId);
+
+      jobPersistence.failAttempt(jobId, attemptNumber);
+      when(timeSupplier.get()).thenReturn(Instant.ofEpochMilli(4242));
+      jobPersistence.resetJob(jobId);
+
+      final Job updated = jobPersistence.getJob(jobId);
+      assertEquals(JobStatus.PENDING, updated.getStatus());
+      assertNotEquals(created.getUpdatedAtInSecond(), updated.getUpdatedAtInSecond());
+    }
+
+    @Test
+    @DisplayName("Should not be able to reset a cancelled job")
+    void testResetJobCancelled() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
+
+      jobPersistence.cancelJob(jobId);
+      assertThrows(IllegalStateException.class, () -> jobPersistence.resetJob(jobId));
+
+      final Job updated = jobPersistence.getJob(jobId);
+      assertEquals(JobStatus.CANCELLED, updated.getStatus());
+    }
+
   }
 
 }


### PR DESCRIPTION
## What
I was reading the job persistence class as part of #2332 . I was specifically trying to understand the `list` behavior. I found the tests confusing. The test file is quite large and the tests weren't grouped in an intuitive way, which resulted in lots of skipping around to read bits here and there.

## How
I took this opportunity to reorganize the tests with JUnit 5's nested class. I also added more human friendly descriptions to each test method via the DisplayName annotation.

In general, I've nested tests for the same method under the same class (usually named after the method being tested). The classes are alphabetically sorted for easy reading. I've left singular tests at the top of the file (they are easy to read as is). This should make it easier for devs to jump to the methods they are interested in, read the related test cases to understand behavior, and write new tests.

I also added test cases to verify the list methods are returning Jobs in descending order and an additional enqueue test to clarify enqueue job behaviour.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
Although this is mainly within one file, this PR might be annoying to review since code has shifted quite a bit. 

Might be easier to review by commits - first commit is the reorganization, second/thirds commits are the new tests.

Within the first commit, going down the file should be the easiest way to read this. We currently have 2 more tests than before (37 to 35) and no duplicate tests, which makes me believe I'm ported things over correctly.


