### PR TITLE
depend on published base singer/python images in existing connectors

### DIFF
--- a/airbyte-integrations/bases/base-singer/Dockerfile
+++ b/airbyte-integrations/bases/base-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 WORKDIR /airbyte/base_singer_code
 COPY base_singer ./base_singer

--- a/airbyte-integrations/connectors/source-appstore-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-appstore-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash git && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-braintree-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-braintree-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 RUN apt-get update && apt-get install -y bash jq && rm -rf /var/lib/apt/lists/*
 

--- a/airbyte-integrations/connectors/source-drift/Dockerfile
+++ b/airbyte-integrations/connectors/source-drift/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-exchangeratesapi-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-exchangeratesapi-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 RUN apt-get update && apt-get install -y \
     jq \

--- a/airbyte-integrations/connectors/source-facebook-marketing/Dockerfile
+++ b/airbyte-integrations/connectors/source-facebook-marketing/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-file/Dockerfile
+++ b/airbyte-integrations/connectors/source-file/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 RUN apt-get update && apt-get install -y jq curl bash && rm -rf /var/lib/apt/lists/*
 

--- a/airbyte-integrations/connectors/source-freshdesk/Dockerfile
+++ b/airbyte-integrations/connectors/source-freshdesk/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-github-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-github-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 RUN apt-get update && apt-get install -y \
     bash \

--- a/airbyte-integrations/connectors/source-google-adwords-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-adwords-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 RUN apt-get update && apt-get install -y jq curl bash && rm -rf /var/lib/apt/lists/*
 

--- a/airbyte-integrations/connectors/source-google-directory/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-directory/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-google-sheets/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-sheets/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 RUN apt-get update && apt-get install -y jq curl bash && rm -rf /var/lib/apt/lists/*
 

--- a/airbyte-integrations/connectors/source-googleanalytics-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-googleanalytics-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 RUN apt-get update && apt-get install -y \
     jq gcc \

--- a/airbyte-integrations/connectors/source-greenhouse/Dockerfile
+++ b/airbyte-integrations/connectors/source-greenhouse/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-http-request/Dockerfile
+++ b/airbyte-integrations/connectors/source-http-request/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 RUN apt-get update && apt-get install -y jq curl bash && rm -rf /var/lib/apt/lists/*
 

--- a/airbyte-integrations/connectors/source-hubspot-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-hubspot-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 RUN apt-get update && apt-get install -y \
     bash \

--- a/airbyte-integrations/connectors/source-instagram/Dockerfile
+++ b/airbyte-integrations/connectors/source-instagram/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-intercom-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-intercom-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 # Bash is installed for more convenient debugging.
 ENV DEBIAN_FRONTEND noninteractive

--- a/airbyte-integrations/connectors/source-jira/Dockerfile
+++ b/airbyte-integrations/connectors/source-jira/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-looker/Dockerfile
+++ b/airbyte-integrations/connectors/source-looker/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-mailchimp/Dockerfile
+++ b/airbyte-integrations/connectors/source-mailchimp/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-marketo-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-marketo-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 # Bash is installed for more convenient debugging.
 # GCC is needed for CISO8601, a dependency of tap-marketo.

--- a/airbyte-integrations/connectors/source-microsoft-teams/Dockerfile
+++ b/airbyte-integrations/connectors/source-microsoft-teams/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-mixpanel-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-mixpanel-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 # Bash is installed for more convenient debugging.
 ENV DEBIAN_FRONTEND noninteractive

--- a/airbyte-integrations/connectors/source-recurly/Dockerfile
+++ b/airbyte-integrations/connectors/source-recurly/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-salesforce-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-salesforce-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 RUN apt-get update && apt-get install -y \
     bash \

--- a/airbyte-integrations/connectors/source-sendgrid/Dockerfile
+++ b/airbyte-integrations/connectors/source-sendgrid/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-shopify-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-shopify-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash gcc && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-slack-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-slack-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 RUN apt-get update && apt-get install -y bash gcc && rm -rf /var/lib/apt/lists/*
 

--- a/airbyte-integrations/connectors/source-stripe-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 RUN apt-get update && apt-get install -y \
     jq \

--- a/airbyte-integrations/connectors/source-tempo/Dockerfile
+++ b/airbyte-integrations/connectors/source-tempo/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.0
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-twilio-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-twilio-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 RUN apt-get update && apt-get install -y bash gcc && rm -rf /var/lib/apt/lists/*
 

--- a/airbyte-integrations/connectors/source-zendesk-support-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-zendesk-support-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
 

--- a/airbyte-integrations/connectors/source-zoom-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-zoom-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:dev
+FROM airbyte/integration-base-singer:0.1.0
 
 # Bash is installed for more convenient debugging. GCC is required by tap-zoom to compile ciso8601.
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Decouple development lifecycle from Gradle for existing connectors by depending on published base connectors