### PR TITLE
More granular CheckConnection reporting.

### DIFF
--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobTracker.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobTracker.java
@@ -154,6 +154,12 @@ public class JobTracker {
     return metadata.build();
   }
 
+  /**
+   * The CheckConnection jobs (both source and destination) of the
+   * {@link io.airbyte.scheduler.client.SynchronousSchedulerClient} interface can have a successful
+   * job with a failed check. Because of this, tracking just the job attempt status does not capture
+   * the whole picture. The `check_connection_outcome` field tracks this.
+   */
   private ImmutableMap<String, Object> generateCheckConnectionMetadata(StandardCheckConnectionOutput output) {
     if (output == null) {
       return ImmutableMap.of();

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobTracker.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/JobTracker.java
@@ -33,6 +33,7 @@ import io.airbyte.analytics.TrackingClientSingleton;
 import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.commons.map.MoreMaps;
 import io.airbyte.config.JobConfig.ConfigType;
+import io.airbyte.config.StandardCheckConnectionOutput;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSyncSchedule;
@@ -68,23 +69,25 @@ public class JobTracker {
     this.trackingClient = trackingClient;
   }
 
-  public void trackCheckConnectionSource(UUID jobId, UUID sourceDefinitionId, JobState jobState) {
+  public void trackCheckConnectionSource(UUID jobId, UUID sourceDefinitionId, JobState jobState, StandardCheckConnectionOutput output) {
     Exceptions.swallow(() -> {
+      final ImmutableMap<String, Object> checkConnMetadata = generateCheckConnectionMetadata(output);
       final ImmutableMap<String, Object> jobMetadata = generateJobMetadata(jobId.toString(), ConfigType.CHECK_CONNECTION_SOURCE);
       final ImmutableMap<String, Object> sourceDefMetadata = generateSourceDefinitionMetadata(sourceDefinitionId);
       final ImmutableMap<String, Object> stateMetadata = generateStateMetadata(jobState);
 
-      track(MoreMaps.merge(jobMetadata, sourceDefMetadata, stateMetadata));
+      track(MoreMaps.merge(checkConnMetadata, jobMetadata, sourceDefMetadata, stateMetadata));
     });
   }
 
-  public void trackCheckConnectionDestination(UUID jobId, UUID destinationDefinitionId, JobState jobState) {
+  public void trackCheckConnectionDestination(UUID jobId, UUID destinationDefinitionId, JobState jobState, StandardCheckConnectionOutput output) {
     Exceptions.swallow(() -> {
+      final ImmutableMap<String, Object> checkConnMetadata = generateCheckConnectionMetadata(output);
       final ImmutableMap<String, Object> jobMetadata = generateJobMetadata(jobId.toString(), ConfigType.CHECK_CONNECTION_DESTINATION);
       final ImmutableMap<String, Object> destinationDefinitionMetadata = generateDestinationDefinitionMetadata(destinationDefinitionId);
       final ImmutableMap<String, Object> stateMetadata = generateStateMetadata(jobState);
 
-      track(MoreMaps.merge(jobMetadata, destinationDefinitionMetadata, stateMetadata));
+      track(MoreMaps.merge(checkConnMetadata, jobMetadata, destinationDefinitionMetadata, stateMetadata));
     });
   }
 
@@ -151,7 +154,16 @@ public class JobTracker {
     return metadata.build();
   }
 
-  public ImmutableMap<String, Object> generateDestinationDefinitionMetadata(UUID destinationDefinitionId)
+  private ImmutableMap<String, Object> generateCheckConnectionMetadata(StandardCheckConnectionOutput output) {
+    if (output == null) {
+      return ImmutableMap.of();
+    }
+    Builder<String, Object> metadata = ImmutableMap.builder();
+    metadata.put("check_connection_outcome", output.getStatus().toString());
+    return metadata.build();
+  }
+
+  private ImmutableMap<String, Object> generateDestinationDefinitionMetadata(UUID destinationDefinitionId)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final Builder<String, Object> metadata = ImmutableMap.builder();
 
@@ -162,7 +174,7 @@ public class JobTracker {
     return metadata.build();
   }
 
-  public ImmutableMap<String, Object> generateSourceDefinitionMetadata(UUID sourceDefinitionId)
+  private ImmutableMap<String, Object> generateSourceDefinitionMetadata(UUID sourceDefinitionId)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final Builder<String, Object> metadata = ImmutableMap.builder();
 

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/client/SpecCachingSynchronousSchedulerClient.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/client/SpecCachingSynchronousSchedulerClient.java
@@ -46,7 +46,7 @@ public class SpecCachingSynchronousSchedulerClient implements CachingSynchronous
   private static final Logger LOGGER = LoggerFactory.getLogger(SpecCachingSynchronousSchedulerClient.class);
 
   private final Cache<String, SynchronousResponse<ConnectorSpecification>> specCache;
-  private SynchronousSchedulerClient decoratedClient;
+  private final SynchronousSchedulerClient decoratedClient;
 
   public SpecCachingSynchronousSchedulerClient(SynchronousSchedulerClient decoratedClient) {
     this.decoratedClient = decoratedClient;

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobTrackerTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobTrackerTest.java
@@ -186,6 +186,7 @@ class JobTrackerTest {
 
   private void assertCheckConnCorrectMessageForEachState(BiConsumer<JobState, StandardCheckConnectionOutput> jobStateConsumer,
                                                          Map<String, Object> metadata) {
+    // Output does not exist when job has started.
     jobStateConsumer.accept(JobState.STARTED, null);
     assertCorrectMessageForStartedState(metadata);
 
@@ -201,6 +202,7 @@ class JobTrackerTest {
     ImmutableMap<String, Object> checkConnFailureMetadata = ImmutableMap.of("check_connection_outcome", "failed");
     assertCorrectMessageForSucceededState(MoreMaps.merge(metadata, checkConnFailureMetadata));
 
+    // Failure implies the job threw an exception which almost always meant no output.
     jobStateConsumer.accept(JobState.FAILED, null);
     assertCorrectMessageForFailedState(metadata);
   }

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobTrackerTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobTrackerTest.java
@@ -34,6 +34,8 @@ import io.airbyte.commons.map.MoreMaps;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.Schedule;
 import io.airbyte.config.Schedule.TimeUnit;
+import io.airbyte.config.StandardCheckConnectionOutput;
+import io.airbyte.config.StandardCheckConnectionOutput.Status;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSyncSchedule;
@@ -44,6 +46,7 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -92,7 +95,24 @@ class JobTrackerTest {
     when(configRepository.getStandardSourceDefinition(UUID1))
         .thenReturn(new StandardSourceDefinition().withSourceDefinitionId(UUID1).withName(SOURCE_DEF_NAME));
 
-    assertCorrectMessageForEachState((jobState) -> jobTracker.trackCheckConnectionSource(JOB_ID, UUID1, jobState, null), metadata);
+    assertCheckConnCorrectMessageForEachState((jobState, output) -> jobTracker.trackCheckConnectionSource(JOB_ID, UUID1, jobState, output), metadata);
+  }
+
+  @Test
+  void testTrackCheckConnectionDestination() throws ConfigNotFoundException, IOException, JsonValidationException {
+    final ImmutableMap<String, Object> metadata = ImmutableMap.<String, Object>builder()
+        .put("job_type", ConfigType.CHECK_CONNECTION_DESTINATION)
+        .put("job_id", JOB_ID.toString())
+        .put("attempt_id", 0)
+        .put("connector_destination", DESTINATION_DEF_NAME)
+        .put("connector_destination_definition_id", UUID2)
+        .build();
+
+    when(configRepository.getStandardDestinationDefinition(UUID2))
+        .thenReturn(new StandardDestinationDefinition().withDestinationDefinitionId(UUID2).withName(DESTINATION_DEF_NAME));
+
+    assertCheckConnCorrectMessageForEachState((jobState, output) -> jobTracker.trackCheckConnectionDestination(JOB_ID, UUID2, jobState, output),
+        metadata);
   }
 
   @Test
@@ -109,22 +129,6 @@ class JobTrackerTest {
         .thenReturn(new StandardSourceDefinition().withSourceDefinitionId(UUID1).withName(SOURCE_DEF_NAME));
 
     assertCorrectMessageForEachState((jobState) -> jobTracker.trackDiscover(JOB_ID, UUID1, jobState), metadata);
-  }
-
-  @Test
-  void testTrackCheckConnectionDestination() throws ConfigNotFoundException, IOException, JsonValidationException {
-    final ImmutableMap<String, Object> metadata = ImmutableMap.<String, Object>builder()
-        .put("job_type", ConfigType.CHECK_CONNECTION_DESTINATION)
-        .put("job_id", JOB_ID.toString())
-        .put("attempt_id", 0)
-        .put("connector_destination", DESTINATION_DEF_NAME)
-        .put("connector_destination_definition_id", UUID2)
-        .build();
-
-    when(configRepository.getStandardDestinationDefinition(UUID2))
-        .thenReturn(new StandardDestinationDefinition().withDestinationDefinitionId(UUID2).withName(DESTINATION_DEF_NAME));
-
-    assertCorrectMessageForEachState((jobState) -> jobTracker.trackCheckConnectionDestination(JOB_ID, UUID2, jobState, null), metadata);
   }
 
   @Test
@@ -178,6 +182,27 @@ class JobTrackerTest {
         .thenReturn(new StandardSyncSchedule().withManual(false).withSchedule(new Schedule().withUnits(1L).withTimeUnit(TimeUnit.MINUTES)));
     final Map<String, Object> scheduledMetadata = MoreMaps.merge(metadata, ImmutableMap.of("frequency", "1 min"));
     assertCorrectMessageForEachState((jobState) -> jobTracker.trackSync(job, jobState), scheduledMetadata);
+  }
+
+  private void assertCheckConnCorrectMessageForEachState(BiConsumer<JobState, StandardCheckConnectionOutput> jobStateConsumer,
+                                                         Map<String, Object> metadata) {
+    jobStateConsumer.accept(JobState.STARTED, null);
+    assertCorrectMessageForStartedState(metadata);
+
+    final var successOutput = new StandardCheckConnectionOutput();
+    successOutput.setStatus(Status.SUCCEEDED);
+    jobStateConsumer.accept(JobState.SUCCEEDED, successOutput);
+    ImmutableMap<String, Object> checkConnSuccessMetadata = ImmutableMap.of("check_connection_outcome", "succeeded");
+    assertCorrectMessageForSucceededState(MoreMaps.merge(metadata, checkConnSuccessMetadata));
+
+    final var failureOutput = new StandardCheckConnectionOutput();
+    failureOutput.setStatus(Status.FAILED);
+    jobStateConsumer.accept(JobState.SUCCEEDED, failureOutput);
+    ImmutableMap<String, Object> checkConnFailureMetadata = ImmutableMap.of("check_connection_outcome", "failed");
+    assertCorrectMessageForSucceededState(MoreMaps.merge(metadata, checkConnFailureMetadata));
+
+    jobStateConsumer.accept(JobState.FAILED, null);
+    assertCorrectMessageForFailedState(metadata);
   }
 
   private void assertCorrectMessageForEachState(Consumer<JobState> jobStateConsumer, Map<String, Object> metadata) {

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobTrackerTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/JobTrackerTest.java
@@ -92,7 +92,7 @@ class JobTrackerTest {
     when(configRepository.getStandardSourceDefinition(UUID1))
         .thenReturn(new StandardSourceDefinition().withSourceDefinitionId(UUID1).withName(SOURCE_DEF_NAME));
 
-    assertCorrectMessageForEachState((jobState) -> jobTracker.trackCheckConnectionSource(JOB_ID, UUID1, jobState), metadata);
+    assertCorrectMessageForEachState((jobState) -> jobTracker.trackCheckConnectionSource(JOB_ID, UUID1, jobState, null), metadata);
   }
 
   @Test
@@ -124,7 +124,7 @@ class JobTrackerTest {
     when(configRepository.getStandardDestinationDefinition(UUID2))
         .thenReturn(new StandardDestinationDefinition().withDestinationDefinitionId(UUID2).withName(DESTINATION_DEF_NAME));
 
-    assertCorrectMessageForEachState((jobState) -> jobTracker.trackCheckConnectionDestination(JOB_ID, UUID2, jobState), metadata);
+    assertCorrectMessageForEachState((jobState) -> jobTracker.trackCheckConnectionDestination(JOB_ID, UUID2, jobState, null), metadata);
   }
 
   @Test


### PR DESCRIPTION
## What
A CheckConnection job can succeed and have the check fail. Because of this, just tracking the `job_attempt` does not let us distinguish between the two cases 1) Job succeeds and Check fails 2) Job succeeds and Check succeeds.

## How
Add a `check_connection_outcome` field in the metadata that pulls from the `StandardCheckConnectionOutput.getStatus` field.

## Recommended reading order
1. `JobTracker.java`
2. the rest of the files
