### PR TITLE
pkg: rest-hooks patch

### DIFF
--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -3893,35 +3893,35 @@
       }
     },
     "@rest-hooks/core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rest-hooks/core/-/core-1.0.3.tgz",
-      "integrity": "sha512-xQx1Q04JYAup+yCJYg1wtVyiGAuzYeIofW6ku28m3rwbe+rvbgJo0PCQYfab0asEYvFT+mmkrRudaHR+BrPbOw==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@rest-hooks/core/-/core-1.0.9.tgz",
+      "integrity": "sha512-eUDy4+lxEax/kjnPc/6BLD63XUE4NsmAzqBvCQiopLLoBWD8D/cIsAGP2K7U9xeC0HzHGLWBIour3Zgob/hDRA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@rest-hooks/endpoint": "^1.0.3",
-        "@rest-hooks/normalizr": "^6.0.2",
+        "@rest-hooks/endpoint": "^1.0.7",
+        "@rest-hooks/normalizr": "^6.0.6",
         "@rest-hooks/use-enhanced-reducer": "^1.0.5",
         "flux-standard-action": "^2.1.1"
       }
     },
     "@rest-hooks/endpoint": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rest-hooks/endpoint/-/endpoint-1.0.3.tgz",
-      "integrity": "sha512-Sv+1mqk591Zd51tj7zGg10hIgrPdALtwPtQjLpXfu7DfwO4yq+4+eMQEz3FOo5NuoQS+Rpav1ZAbwqukazWE3Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@rest-hooks/endpoint/-/endpoint-1.0.7.tgz",
+      "integrity": "sha512-/k2hu2zVbb6sCaqRSkvo1eDCUGHKPQbbl0ViMIqickPRrsSeVE7zrJyAlLhaNf7nBKKOdvIxK9B2Yj11cJ+mag==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@rest-hooks/normalizr": "^6.0.2"
+        "@rest-hooks/normalizr": "^6.0.6"
       }
     },
     "@rest-hooks/legacy": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rest-hooks/legacy/-/legacy-2.0.1.tgz",
-      "integrity": "sha512-YeILIcnI21RlItKLiXuCdVenCtxbLbnm2JAthBZcvJ7EUOwHLm8AXCF++n987SJRpuXJhegvCDw07LRpiDmEaw=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@rest-hooks/legacy/-/legacy-2.0.5.tgz",
+      "integrity": "sha512-5hPqHkvQ5iC7QJSjUpufMNlg3fhMUJ2kVS24QczkJlj2usj0ffuHMN24TKqByLDlRdmaFAH0ebqnF0La170bSg=="
     },
     "@rest-hooks/normalizr": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@rest-hooks/normalizr/-/normalizr-6.0.2.tgz",
-      "integrity": "sha512-mvN5/RCdjEBy3U5cLTYSj1Vdksv3M0LEsydkFew05PsELGa57uRB/8inELMolYmeZ5uUlGaTzOtOGTzKdXdxzg==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@rest-hooks/normalizr/-/normalizr-6.0.6.tgz",
+      "integrity": "sha512-Q+vnCBbzlr7WIC2mJSpuZr1u27QomrTnFjYCHLEhj0TC9ge1evLk7NbHKcoIDCwSTREIn9gJon4oWkn+CznjzQ==",
       "requires": {
         "@babel/runtime": "^7.7.2"
       }
@@ -19499,13 +19499,13 @@
       }
     },
     "rest-hooks": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/rest-hooks/-/rest-hooks-5.0.3.tgz",
-      "integrity": "sha512-QWbfc7NdwS2uj6VU/an1+HdknizG2Xr5dKC9vwHemuNp75RSqHXBL3vgYW2nwjdMe23PJkJl7ddofC+c0jMbww==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/rest-hooks/-/rest-hooks-5.0.13.tgz",
+      "integrity": "sha512-aSAd3PBEATpNDlv2Hc18OO2uk3+HOoPzKZeV46US3AXG1V2WRgyn9tanRfMqQ6iwbgsmn8QWzet9ogK+MJ/D0Q==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@rest-hooks/core": "^1.0.3",
-        "@rest-hooks/endpoint": "^1.0.3"
+        "@rest-hooks/core": "^1.0.9",
+        "@rest-hooks/endpoint": "^1.0.7"
       }
     },
     "restore-cursor": {

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -3893,24 +3893,24 @@
       }
     },
     "@rest-hooks/core": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@rest-hooks/core/-/core-1.0.9.tgz",
-      "integrity": "sha512-eUDy4+lxEax/kjnPc/6BLD63XUE4NsmAzqBvCQiopLLoBWD8D/cIsAGP2K7U9xeC0HzHGLWBIour3Zgob/hDRA==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@rest-hooks/core/-/core-1.0.16.tgz",
+      "integrity": "sha512-9Owt4hACJL6uwarEfQGn05/+hTa/GIFiSsQA1+ZGd5aIOX3LDC5gEXbk1AI4mScDmHrorWAVAy2YsLg6oHWoVA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@rest-hooks/endpoint": "^1.0.7",
-        "@rest-hooks/normalizr": "^6.0.6",
+        "@rest-hooks/endpoint": "^1.0.12",
+        "@rest-hooks/normalizr": "^6.0.9",
         "@rest-hooks/use-enhanced-reducer": "^1.0.5",
         "flux-standard-action": "^2.1.1"
       }
     },
     "@rest-hooks/endpoint": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@rest-hooks/endpoint/-/endpoint-1.0.7.tgz",
-      "integrity": "sha512-/k2hu2zVbb6sCaqRSkvo1eDCUGHKPQbbl0ViMIqickPRrsSeVE7zrJyAlLhaNf7nBKKOdvIxK9B2Yj11cJ+mag==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@rest-hooks/endpoint/-/endpoint-1.0.12.tgz",
+      "integrity": "sha512-PYTkBa9tvX/fytscd16WokYO6d1iuYvd8Cj17T8C4Re0GmJXAxsinA+rfyViw3cxXiMO7f4B0rWkDkdwQJhNRw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@rest-hooks/normalizr": "^6.0.6"
+        "@rest-hooks/normalizr": "^6.0.9"
       }
     },
     "@rest-hooks/legacy": {
@@ -3919,9 +3919,9 @@
       "integrity": "sha512-5hPqHkvQ5iC7QJSjUpufMNlg3fhMUJ2kVS24QczkJlj2usj0ffuHMN24TKqByLDlRdmaFAH0ebqnF0La170bSg=="
     },
     "@rest-hooks/normalizr": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@rest-hooks/normalizr/-/normalizr-6.0.6.tgz",
-      "integrity": "sha512-Q+vnCBbzlr7WIC2mJSpuZr1u27QomrTnFjYCHLEhj0TC9ge1evLk7NbHKcoIDCwSTREIn9gJon4oWkn+CznjzQ==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@rest-hooks/normalizr/-/normalizr-6.0.9.tgz",
+      "integrity": "sha512-TFV8lEpktlevVqwvMOsIQ4EMbRseRjglJX8Sbq4UtYbBruH2OKmKQThYjDttOHZrTlH55sQ0qCtP/U2dCt9Tyg==",
       "requires": {
         "@babel/runtime": "^7.7.2"
       }
@@ -19499,13 +19499,13 @@
       }
     },
     "rest-hooks": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/rest-hooks/-/rest-hooks-5.0.13.tgz",
-      "integrity": "sha512-aSAd3PBEATpNDlv2Hc18OO2uk3+HOoPzKZeV46US3AXG1V2WRgyn9tanRfMqQ6iwbgsmn8QWzet9ogK+MJ/D0Q==",
+      "version": "5.0.20",
+      "resolved": "https://registry.npmjs.org/rest-hooks/-/rest-hooks-5.0.20.tgz",
+      "integrity": "sha512-FXgN8I1Jd/zv/HIJ/7tpZjkl6bH2mtNh6wmSJYL3KypDSyysq5SFS8khXN8eoo6CzGDSYYWqmpHi6XN37cflwQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@rest-hooks/core": "^1.0.9",
-        "@rest-hooks/endpoint": "^1.0.7"
+        "@rest-hooks/core": "^1.0.16",
+        "@rest-hooks/endpoint": "^1.0.12"
       }
     },
     "restore-cursor": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -17,7 +17,7 @@
     "@fortawesome/react-fontawesome": "^0.1.8",
     "@papercups-io/chat-widget": "^1.1.5",
     "@papercups-io/storytime": "^1.0.6",
-    "@rest-hooks/legacy": "^2.0.1",
+    "@rest-hooks/legacy": "^2.0.5",
     "dayjs": "^1.8.35",
     "flat": "^5.0.2",
     "formik": "2.1.5",
@@ -38,7 +38,7 @@
     "react-table": "^7.5.0",
     "react-use": "^15.3.8",
     "react-widgets": "^4.5.0",
-    "rest-hooks": "^5.0.3",
+    "rest-hooks": "^5.0.13",
     "sanitize-html": "^2.1.2",
     "styled-components": "^5.1.1",
     "yup": "^0.28.1"

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -38,7 +38,7 @@
     "react-table": "^7.5.0",
     "react-use": "^15.3.8",
     "react-widgets": "^4.5.0",
-    "rest-hooks": "^5.0.13",
+    "rest-hooks": "^5.0.20",
     "sanitize-html": "^2.1.2",
     "styled-components": "^5.1.1",
     "yup": "^0.28.1"

--- a/airbyte-webapp/src/components/hooks/services/useDestinationHook.tsx
+++ b/airbyte-webapp/src/components/hooks/services/useDestinationHook.tsx
@@ -26,7 +26,9 @@ export const useDestinationDefinitionSpecificationLoad = (
   destinationDefinitionId: string
 ): {
   isLoading: boolean;
-  destinationDefinitionSpecification: DestinationDefinitionSpecification;
+  destinationDefinitionSpecification:
+    | DestinationDefinitionSpecification
+    | undefined;
   error?: Error;
 } => {
   const {

--- a/airbyte-webapp/src/components/hooks/services/useDestinationHook.tsx
+++ b/airbyte-webapp/src/components/hooks/services/useDestinationHook.tsx
@@ -26,9 +26,7 @@ export const useDestinationDefinitionSpecificationLoad = (
   destinationDefinitionId: string
 ): {
   isLoading: boolean;
-  destinationDefinitionSpecification:
-    | DestinationDefinitionSpecification
-    | undefined;
+  destinationDefinitionSpecification?: DestinationDefinitionSpecification;
   error?: Error;
 } => {
   const {

--- a/airbyte-webapp/src/components/hooks/services/useSourceHook.tsx
+++ b/airbyte-webapp/src/components/hooks/services/useSourceHook.tsx
@@ -28,7 +28,7 @@ export const useSourceDefinitionSpecificationLoad = (
 ): {
   isLoading: boolean;
   error?: Error;
-  sourceDefinitionSpecification: SourceDefinitionSpecification;
+  sourceDefinitionSpecification: SourceDefinitionSpecification | undefined;
 } => {
   const {
     loading: isLoading,

--- a/airbyte-webapp/src/components/hooks/services/useSourceHook.tsx
+++ b/airbyte-webapp/src/components/hooks/services/useSourceHook.tsx
@@ -28,7 +28,7 @@ export const useSourceDefinitionSpecificationLoad = (
 ): {
   isLoading: boolean;
   error?: Error;
-  sourceDefinitionSpecification: SourceDefinitionSpecification | undefined;
+  sourceDefinitionSpecification?: SourceDefinitionSpecification;
 } => {
   const {
     loading: isLoading,


### PR DESCRIPTION
## What
Upgrade rest-hooks to latest version (patch update)

## How
useStatefulResource() types were improved to be more precise. This correctly identified the possible undefined return value when using ternary of null in params. This will now type enforce, the already present optional chaining in these cases.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*
