### PR TITLE
Source support primary keys

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/435bb9a5-7887-4809-aa58-28c27df0d7ad.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/435bb9a5-7887-4809-aa58-28c27df0d7ad.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "435bb9a5-7887-4809-aa58-28c27df0d7ad",
   "name": "MySQL",
   "dockerRepository": "airbyte/source-mysql",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://docs.airbyte.io/integrations/sources/mysql"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b5ea17b1-f170-46dc-bc31-cc744ca984c1.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b5ea17b1-f170-46dc-bc31-cc744ca984c1.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "b5ea17b1-f170-46dc-bc31-cc744ca984c1",
   "name": "Microsoft SQL Server (MSSQL)",
   "dockerRepository": "airbyte/source-mssql",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-mssql"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/decd338e-5647-4c0b-adf4-da0e75f5a750.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/decd338e-5647-4c0b-adf4-da0e75f5a750.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "decd338e-5647-4c0b-adf4-da0e75f5a750",
   "name": "Postgres",
   "dockerRepository": "airbyte/source-postgres",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-postgres"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e87ffa8e-a3b5-f69c-9076-6011339de1f6.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e87ffa8e-a3b5-f69c-9076-6011339de1f6.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "e87ffa8e-a3b5-f69c-9076-6011339de1f6",
   "name": "Redshift",
   "dockerRepository": "airbyte/source-redshift",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-redshift"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -21,12 +21,12 @@
 - sourceDefinitionId: b5ea17b1-f170-46dc-bc31-cc744ca984c1
   name: Microsoft SQL Server (MSSQL)
   dockerRepository: airbyte/source-mssql
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-mssql
 - sourceDefinitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
   name: Postgres
   dockerRepository: airbyte/source-postgres
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-postgres
 - sourceDefinitionId: cd42861b-01fc-4658-a8ab-5d11d0510f01
   name: Recurly
@@ -51,7 +51,7 @@
 - sourceDefinitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
   name: MySQL
   dockerRepository: airbyte/source-mysql
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://docs.airbyte.io/integrations/sources/mysql
 - sourceDefinitionId: 2470e835-feaf-4db6-96f3-70fd645acc77
   name: Salesforce
@@ -96,7 +96,7 @@
 - sourceDefinitionId: e87ffa8e-a3b5-f69c-9076-6011339de1f6
   name: Redshift
   dockerRepository: airbyte/source-redshift
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/repository/docker/airbyte/source-redshift
 - sourceDefinitionId: 932e6363-d006-4464-a9f5-102b82e07c06
   name: Twilio

--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -56,6 +56,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -135,7 +136,9 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
               Optional.ofNullable(config.get("schema")).map(JsonNode::asText))
                   .stream()
                   .map(t -> CatalogHelpers.createAirbyteStream(t.getName(), t.getFields())
-                      .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL)))
+                      .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
+                      .withSourceDefinedPrimaryKey(
+                          t.getPrimaryKeys().stream().filter(Objects::nonNull).map(Collections::singletonList).collect(Collectors.toList())))
                   .collect(Collectors.toList()));
     }
   }
@@ -290,7 +293,7 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
               .distinct()
               .collect(Collectors.toList());
 
-          return new TableInfo(JdbcUtils.getFullyQualifiedTableName(t.getSchemaName(), t.getName()), fields);
+          return new TableInfo(JdbcUtils.getFullyQualifiedTableName(t.getSchemaName(), t.getName()), fields, t.getPrimaryKeys());
         })
         .collect(Collectors.toList());
   }
@@ -354,6 +357,16 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
                   return new ColumnInfo(f.get(INTERNAL_COLUMN_NAME).asText(), jdbcType);
                 })
                 .collect(Collectors.toList())))
+        .peek(t -> {
+          try {
+            final List<String> primaryKeys = database.bufferedResultSetQuery(
+                conn -> conn.getMetaData().getPrimaryKeys(databaseOptional.orElse(null), t.getSchemaName(), t.getName()),
+                resultSet -> resultSet.getString(JDBC_COLUMN_COLUMN_NAME));
+            t.addPrimaryKeys(primaryKeys);
+          } catch (SQLException e) {
+            LOGGER.warn(String.format("Could not find primary keys for %s.%s: %s", t.getSchemaName(), t.getName(), e));
+          }
+        })
         .collect(Collectors.toList());
   }
 
@@ -440,10 +453,12 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
 
     private final String name;
     private final List<Field> fields;
+    private final List<String> primaryKeys;
 
-    public TableInfo(String name, List<Field> fields) {
+    public TableInfo(String name, List<Field> fields, List<String> primaryKeys) {
       this.name = name;
       this.fields = fields;
+      this.primaryKeys = primaryKeys;
     }
 
     public String getName() {
@@ -454,6 +469,10 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
       return fields;
     }
 
+    public List<String> getPrimaryKeys() {
+      return primaryKeys;
+    }
+
   }
 
   protected static class TableInfoInternal {
@@ -461,11 +480,13 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
     private final String schemaName;
     private final String name;
     private final List<ColumnInfo> fields;
+    private final List<String> primaryKeys;
 
     public TableInfoInternal(String schemaName, String tableName, List<ColumnInfo> fields) {
       this.schemaName = schemaName;
       this.name = tableName;
       this.fields = fields;
+      this.primaryKeys = new ArrayList<>();
     }
 
     public String getSchemaName() {
@@ -478,6 +499,14 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
 
     public List<ColumnInfo> getFields() {
       return fields;
+    }
+
+    public void addPrimaryKeys(List<String> primaryKeys) {
+      this.primaryKeys.addAll(primaryKeys);
+    }
+
+    public List<String> getPrimaryKeys() {
+      return primaryKeys;
     }
 
   }

--- a/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
@@ -62,6 +62,7 @@ import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
 import io.airbyte.protocol.models.SyncMode;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -87,6 +88,8 @@ public abstract class JdbcSourceStandardTest {
   private static final Set<String> TEST_SCHEMAS = ImmutableSet.of(SCHEMA_NAME, SCHEMA_NAME2);
 
   private static final String TABLE_NAME = "id_and_name";
+  private static final String TABLE_NAME_WITHOUT_PK = "id_and_name_without_pk";
+  private static final String TABLE_NAME_FULL_NAMES = "full_names";
 
   private JsonNode config;
   private JdbcDatabase database;
@@ -142,7 +145,6 @@ public abstract class JdbcSourceStandardTest {
       createSchemas();
     }
     database.execute(connection -> {
-
       connection.createStatement()
           .execute(String.format("CREATE TABLE %s(id INTEGER, name VARCHAR(200), updated_at DATE, PRIMARY KEY (id));",
               getFullyQualifiedTableName(TABLE_NAME)));
@@ -150,6 +152,23 @@ public abstract class JdbcSourceStandardTest {
           String.format(
               "INSERT INTO %s(id, name, updated_at) VALUES (1,'picard', '2004-10-19'),  (2, 'crusher', '2005-10-19'), (3, 'vash', '2006-10-19');",
               getFullyQualifiedTableName(TABLE_NAME)));
+
+      connection.createStatement()
+          .execute(String.format("CREATE TABLE %s(id INTEGER, name VARCHAR(200), updated_at DATE);",
+              getFullyQualifiedTableName(TABLE_NAME_WITHOUT_PK)));
+      connection.createStatement().execute(
+          String.format(
+              "INSERT INTO %s(id, name, updated_at) VALUES (1,'picard', '2004-10-19'),  (2, 'crusher', '2005-10-19'), (3, 'vash', '2006-10-19');",
+              getFullyQualifiedTableName(TABLE_NAME_WITHOUT_PK)));
+
+      connection.createStatement()
+          .execute(
+              String.format("CREATE TABLE %s(first_name VARCHAR(200), last_name VARCHAR(200), updated_at DATE, PRIMARY KEY (first_name, last_name));",
+                  getFullyQualifiedTableName(TABLE_NAME_FULL_NAMES)));
+      connection.createStatement().execute(
+          String.format(
+              "INSERT INTO %s(first_name, last_name, updated_at) VALUES ('first' ,'picard', '2004-10-19'),  ('second', 'crusher', '2005-10-19'), ('third', 'vash', '2006-10-19');",
+              getFullyQualifiedTableName(TABLE_NAME_FULL_NAMES)));
     });
   }
 
@@ -184,8 +203,14 @@ public abstract class JdbcSourceStandardTest {
 
   @Test
   void testDiscover() throws Exception {
-    final AirbyteCatalog actual = source.discover(config);
-    assertEquals(getCatalog(), filterOutOtherSchemas(actual));
+    final AirbyteCatalog actual = filterOutOtherSchemas(source.discover(config));
+    assertEquals(getCatalog(getDefaultNamespace()).getStreams().size(), actual.getStreams().size());
+    actual.getStreams().forEach(actualStream -> {
+      final Optional<AirbyteStream> expectedStream =
+          getCatalog(getDefaultNamespace()).getStreams().stream().filter(stream -> stream.getName().equals(actualStream.getName())).findAny();
+      assertTrue(expectedStream.isPresent(), String.format("Did not expect stream %s", actualStream.getName()));
+      assertEquals(expectedStream.get(), actualStream);
+    });
   }
 
   private AirbyteCatalog filterOutOtherSchemas(AirbyteCatalog catalog) {
@@ -220,7 +245,7 @@ public abstract class JdbcSourceStandardTest {
 
     final AirbyteCatalog actual = source.discover(config);
 
-    final AirbyteCatalog expected = getCatalog();
+    final AirbyteCatalog expected = getCatalog(getDefaultNamespace());
     expected.getStreams().add(CatalogHelpers.createAirbyteStream(JdbcUtils.getFullyQualifiedTableName(SCHEMA_NAME2, TABLE_NAME),
         Field.of("id", JsonSchemaPrimitive.STRING),
         Field.of("name", JsonSchemaPrimitive.STRING))
@@ -233,7 +258,8 @@ public abstract class JdbcSourceStandardTest {
 
   @Test
   void testReadSuccess() throws Exception {
-    final List<AirbyteMessage> actualMessages = MoreIterators.toList(source.read(config, getConfiguredCatalog(), null));
+    final List<AirbyteMessage> actualMessages =
+        MoreIterators.toList(source.read(config, getConfiguredCatalogWithOneStream(getDefaultNamespace()), null));
 
     setEmittedAtToNull(actualMessages);
 
@@ -260,8 +286,7 @@ public abstract class JdbcSourceStandardTest {
 
   @Test
   void testReadMultipleTables() throws Exception {
-    final ConfiguredAirbyteCatalog catalog =
-        new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(getConfiguredCatalog().getStreams().get(0)));
+    final ConfiguredAirbyteCatalog catalog = getConfiguredCatalogWithOneStream(getDefaultNamespace());
     final List<AirbyteMessage> expectedMessages = new ArrayList<>(getTestMessages());
 
     for (int i = 2; i < 10; i++) {
@@ -301,7 +326,7 @@ public abstract class JdbcSourceStandardTest {
     final ConfiguredAirbyteStream streamForTableWithSpaces = createTableWithSpaces();
 
     final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(
-        getConfiguredCatalog().getStreams().get(0),
+        getConfiguredCatalogWithOneStream(getDefaultNamespace()).getStreams().get(0),
         streamForTableWithSpaces));
     final List<AirbyteMessage> actualMessages = MoreIterators.toList(source.read(config, catalog, null));
 
@@ -325,7 +350,7 @@ public abstract class JdbcSourceStandardTest {
   @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   void testReadFailure() {
-    final ConfiguredAirbyteStream spiedAbStream = spy(getConfiguredCatalog().getStreams().get(0));
+    final ConfiguredAirbyteStream spiedAbStream = spy(getConfiguredCatalogWithOneStream(getDefaultNamespace()).getStreams().get(0));
     final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(spiedAbStream));
     doCallRealMethod().doThrow(new RuntimeException()).when(spiedAbStream).getStream();
 
@@ -408,7 +433,7 @@ public abstract class JdbcSourceStandardTest {
 
   @Test
   void testReadOneTableIncrementallyTwice() throws Exception {
-    final ConfiguredAirbyteCatalog configuredCatalog = getConfiguredCatalog();
+    final ConfiguredAirbyteCatalog configuredCatalog = getConfiguredCatalogWithOneStream(getDefaultNamespace());
     configuredCatalog.getStreams().forEach(airbyteStream -> {
       airbyteStream.setSyncMode(SyncMode.INCREMENTAL);
       airbyteStream.setCursorField(Lists.newArrayList("id"));
@@ -459,7 +484,7 @@ public abstract class JdbcSourceStandardTest {
           String.format("INSERT INTO %s(id, name) VALUES (1,'picard'),  (2, 'crusher'), (3, 'vash');", getFullyQualifiedTableName(tableName2)));
     });
 
-    final ConfiguredAirbyteCatalog configuredCatalog = getConfiguredCatalog();
+    final ConfiguredAirbyteCatalog configuredCatalog = getConfiguredCatalogWithOneStream(getDefaultNamespace());
     configuredCatalog.getStreams().add(CatalogHelpers.createConfiguredAirbyteStream(
         streamName2,
         Field.of("id", JsonSchemaPrimitive.NUMBER),
@@ -538,7 +563,7 @@ public abstract class JdbcSourceStandardTest {
                                       List<AirbyteMessage> expectedRecordMessages)
       throws Exception {
     incrementalCursorCheck(initialCursorField, cursorField, initialCursorValue, endCursorValue, expectedRecordMessages,
-        getConfiguredCatalog().getStreams().get(0));
+        getConfiguredCatalogWithOneStream(getDefaultNamespace()).getStreams().get(0));
   }
 
   private void incrementalCursorCheck(
@@ -578,18 +603,36 @@ public abstract class JdbcSourceStandardTest {
   }
 
   // get catalog and perform a defensive copy.
-  private static ConfiguredAirbyteCatalog getConfiguredCatalog() {
-    return CatalogHelpers.toDefaultConfiguredCatalog(getCatalog());
+  private static ConfiguredAirbyteCatalog getConfiguredCatalogWithOneStream(final String defaultNamespace) {
+    final ConfiguredAirbyteCatalog catalog = CatalogHelpers.toDefaultConfiguredCatalog(getCatalog(defaultNamespace));
+    // Filter to only keep the main stream name as configured stream
+    catalog.withStreams(catalog.getStreams().stream().filter(s -> s.getStream().getName().equals(streamName)).collect(Collectors.toList()));
+    return catalog;
   }
 
-  private static AirbyteCatalog getCatalog() {
-    return new AirbyteCatalog().withStreams(Lists.newArrayList(CatalogHelpers.createAirbyteStream(
-        streamName,
-        Field.of("id", JsonSchemaPrimitive.NUMBER),
-        Field.of("name", JsonSchemaPrimitive.STRING),
-        Field.of("updated_at", JsonSchemaPrimitive.STRING))
-        .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
-        .withSourceDefinedPrimaryKey(List.of(List.of("id")))));
+  private static AirbyteCatalog getCatalog(final String defaultNamespace) {
+    return new AirbyteCatalog().withStreams(Lists.newArrayList(
+        CatalogHelpers.createAirbyteStream(
+            defaultNamespace + "." + TABLE_NAME,
+            Field.of("id", JsonSchemaPrimitive.NUMBER),
+            Field.of("name", JsonSchemaPrimitive.STRING),
+            Field.of("updated_at", JsonSchemaPrimitive.STRING))
+            .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
+            .withSourceDefinedPrimaryKey(List.of(List.of("id"))),
+        CatalogHelpers.createAirbyteStream(
+            defaultNamespace + "." + TABLE_NAME_WITHOUT_PK,
+            Field.of("id", JsonSchemaPrimitive.NUMBER),
+            Field.of("name", JsonSchemaPrimitive.STRING),
+            Field.of("updated_at", JsonSchemaPrimitive.STRING))
+            .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
+            .withSourceDefinedPrimaryKey(Collections.emptyList()),
+        CatalogHelpers.createAirbyteStream(
+            defaultNamespace + "." + TABLE_NAME_FULL_NAMES,
+            Field.of("first_name", JsonSchemaPrimitive.STRING),
+            Field.of("last_name", JsonSchemaPrimitive.STRING),
+            Field.of("updated_at", JsonSchemaPrimitive.STRING))
+            .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
+            .withSourceDefinedPrimaryKey(List.of(List.of("first_name"), List.of("last_name")))));
   }
 
   private static List<AirbyteMessage> getTestMessages() {

--- a/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
@@ -208,7 +208,7 @@ public abstract class JdbcSourceStandardTest {
     actual.getStreams().forEach(actualStream -> {
       final Optional<AirbyteStream> expectedStream =
           getCatalog(getDefaultNamespace()).getStreams().stream().filter(stream -> stream.getName().equals(actualStream.getName())).findAny();
-      assertTrue(expectedStream.isPresent(), String.format("Expecting stream %s but did not find it!", actualStream.getName()));
+      assertTrue(expectedStream.isPresent(), String.format("Unexpected stream %s", actualStream.getName()));
       assertEquals(expectedStream.get(), actualStream);
     });
   }

--- a/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
@@ -144,7 +144,8 @@ public abstract class JdbcSourceStandardTest {
     database.execute(connection -> {
 
       connection.createStatement()
-          .execute(String.format("CREATE TABLE %s(id INTEGER, name VARCHAR(200), updated_at DATE);", getFullyQualifiedTableName(TABLE_NAME)));
+          .execute(String.format("CREATE TABLE %s(id INTEGER, name VARCHAR(200), updated_at DATE, PRIMARY KEY (id));",
+              getFullyQualifiedTableName(TABLE_NAME)));
       connection.createStatement().execute(
           String.format(
               "INSERT INTO %s(id, name, updated_at) VALUES (1,'picard', '2004-10-19'),  (2, 'crusher', '2005-10-19'), (3, 'vash', '2006-10-19');",
@@ -587,7 +588,8 @@ public abstract class JdbcSourceStandardTest {
         Field.of("id", JsonSchemaPrimitive.NUMBER),
         Field.of("name", JsonSchemaPrimitive.STRING),
         Field.of("updated_at", JsonSchemaPrimitive.STRING))
-        .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))));
+        .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
+        .withSourceDefinedPrimaryKey(List.of(List.of("id")))));
   }
 
   private static List<AirbyteMessage> getTestMessages() {

--- a/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
@@ -208,7 +208,7 @@ public abstract class JdbcSourceStandardTest {
     actual.getStreams().forEach(actualStream -> {
       final Optional<AirbyteStream> expectedStream =
           getCatalog(getDefaultNamespace()).getStreams().stream().filter(stream -> stream.getName().equals(actualStream.getName())).findAny();
-      assertTrue(expectedStream.isPresent(), String.format("Did not expect stream %s", actualStream.getName()));
+      assertTrue(expectedStream.isPresent(), String.format("Expecting stream %s but did not find it!", actualStream.getName()));
       assertEquals(expectedStream.get(), actualStream);
     });
   }

--- a/airbyte-integrations/connectors/source-mssql/Dockerfile
+++ b/airbyte-integrations/connectors/source-mssql/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-mssql

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlSourceTest.java
@@ -39,6 +39,7 @@ import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
 import io.airbyte.protocol.models.SyncMode;
 import java.sql.SQLException;
+import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -54,7 +55,8 @@ class MssqlSourceTest {
       Field.of("id", JsonSchemaPrimitive.NUMBER),
       Field.of("name", JsonSchemaPrimitive.STRING),
       Field.of("born", JsonSchemaPrimitive.STRING))
-      .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))));
+      .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
+      .withSourceDefinedPrimaryKey(List.of(List.of("id")))));
 
   private JsonNode configWithoutDbName;
   private JsonNode config;

--- a/airbyte-integrations/connectors/source-mysql/Dockerfile
+++ b/airbyte-integrations/connectors/source-mysql/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-mysql

--- a/airbyte-integrations/connectors/source-postgres/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-postgres

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
@@ -25,6 +25,7 @@
 package io.airbyte.integrations.source.postgres;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
@@ -39,6 +40,7 @@ import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
+import io.airbyte.protocol.models.AirbyteStream;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.Field;
@@ -49,7 +51,9 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jooq.SQLDialect;
 import org.junit.jupiter.api.AfterAll;
@@ -69,7 +73,20 @@ class PostgresSourceTest {
           Field.of("name", JsonSchemaPrimitive.STRING),
           Field.of("power", JsonSchemaPrimitive.NUMBER))
           .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
-          .withSourceDefinedPrimaryKey(List.of(List.of("id")))));
+          .withSourceDefinedPrimaryKey(List.of(List.of("id"))),
+      CatalogHelpers.createAirbyteStream(
+          STREAM_NAME + "2",
+          Field.of("id", JsonSchemaPrimitive.NUMBER),
+          Field.of("name", JsonSchemaPrimitive.STRING),
+          Field.of("power", JsonSchemaPrimitive.NUMBER))
+          .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL)),
+      CatalogHelpers.createAirbyteStream(
+          "public.names",
+          Field.of("first_name", JsonSchemaPrimitive.STRING),
+          Field.of("last_name", JsonSchemaPrimitive.STRING),
+          Field.of("power", JsonSchemaPrimitive.NUMBER))
+          .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
+          .withSourceDefinedPrimaryKey(List.of(List.of("first_name"), List.of("last_name")))));
   private static final ConfiguredAirbyteCatalog CONFIGURED_CATALOG = CatalogHelpers.toDefaultConfiguredCatalog(CATALOG);
   private static final Set<AirbyteMessage> ASCII_MESSAGES = Sets.newHashSet(
       createRecord(STREAM_NAME, map("id", new BigDecimal("1.0"), "name", "goku", "power", null)),
@@ -104,6 +121,13 @@ class PostgresSourceTest {
       ctx.fetch("CREATE TABLE id_and_name(id NUMERIC(20, 10), name VARCHAR(200), power double precision, PRIMARY KEY (id));");
       ctx.fetch("CREATE INDEX i1 ON id_and_name (id);");
       ctx.fetch("INSERT INTO id_and_name (id, name, power) VALUES (1,'goku', 'Infinity'),  (2, 'vegeta', 9000.1), ('NaN', 'piccolo', '-Infinity');");
+
+      ctx.fetch("CREATE TABLE id_and_name2(id NUMERIC(20, 10), name VARCHAR(200), power double precision);");
+      ctx.fetch("INSERT INTO id_and_name2 (id, name, power) VALUES (1,'goku', 'Infinity'),  (2, 'vegeta', 9000.1), ('NaN', 'piccolo', '-Infinity');");
+
+      ctx.fetch("CREATE TABLE names(first_name VARCHAR(200), last_name VARCHAR(200), power double precision, PRIMARY KEY (first_name, last_name));");
+      ctx.fetch(
+          "INSERT INTO names (first_name, last_name, power) VALUES ('san', 'goku', 'Infinity'),  ('prince', 'vegeta', 9000.1), ('piccolo', 'junior', '-Infinity');");
       return null;
     });
     database.close();
@@ -173,12 +197,20 @@ class PostgresSourceTest {
   @Test
   void testDiscoverWithPk() throws Exception {
     final AirbyteCatalog actual = new PostgresSource().discover(getConfig(PSQL_DB, dbName));
-    assertEquals(CATALOG, actual);
+    actual.getStreams().forEach(actualStream -> {
+      final Optional<AirbyteStream> expectedStream =
+          CATALOG.getStreams().stream().filter(stream -> stream.getName().equals(actualStream.getName())).findAny();
+      assertTrue(expectedStream.isPresent());
+      assertEquals(expectedStream.get(), actualStream);
+    });
   }
 
   @Test
   void testReadSuccess() throws Exception {
-    final Set<AirbyteMessage> actualMessages = MoreIterators.toSet(new PostgresSource().read(getConfig(PSQL_DB, dbName), CONFIGURED_CATALOG, null));
+    final ConfiguredAirbyteCatalog configuredCatalog =
+        CONFIGURED_CATALOG.withStreams(CONFIGURED_CATALOG.getStreams().stream().filter(s -> s.getStream().getName().equals(STREAM_NAME)).collect(
+            Collectors.toList()));
+    final Set<AirbyteMessage> actualMessages = MoreIterators.toSet(new PostgresSource().read(getConfig(PSQL_DB, dbName), configuredCatalog, null));
     setEmittedAtToNull(actualMessages);
 
     assertEquals(ASCII_MESSAGES, actualMessages);

--- a/airbyte-integrations/connectors/source-redshift/Dockerfile
+++ b/airbyte-integrations/connectors/source-redshift/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-redshift


### PR DESCRIPTION
## What
Closes #2461 

## How
JDBC Abstract Sources are filling up the `sourceDefinedPrimaryKey` field

## Pre-merge Checklist
- [x] *Run integration tests*
- [x] *Publish Docker images*

## Recommended reading order
1. `airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java`
1. the rest
