### PR TITLE
🐛  fix issue where jobs retried forever

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CheckConnectionWorkflow.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CheckConnectionWorkflow.java
@@ -54,6 +54,7 @@ public interface CheckConnectionWorkflow {
 
     final ActivityOptions options = ActivityOptions.newBuilder()
         .setScheduleToCloseTimeout(Duration.ofHours(1))
+        .setRetryOptions(TemporalUtils.NO_RETRY)
         .build();
     private final CheckConnectionActivity activity = Workflow.newActivityStub(CheckConnectionActivity.class, options);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/DiscoverCatalogWorkflow.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/DiscoverCatalogWorkflow.java
@@ -56,6 +56,7 @@ public interface DiscoverCatalogWorkflow {
 
     final ActivityOptions options = ActivityOptions.newBuilder()
         .setScheduleToCloseTimeout(Duration.ofHours(2))
+        .setRetryOptions(TemporalUtils.NO_RETRY)
         .build();
     private final DiscoverCatalogActivity activity = Workflow.newActivityStub(DiscoverCatalogActivity.class, options);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/SpecWorkflow.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/SpecWorkflow.java
@@ -51,6 +51,7 @@ public interface SpecWorkflow {
 
     final ActivityOptions options = ActivityOptions.newBuilder()
         .setScheduleToCloseTimeout(Duration.ofHours(1))
+        .setRetryOptions(TemporalUtils.NO_RETRY)
         .build();
     private final SpecActivity activity = Workflow.newActivityStub(SpecActivity.class, options);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/SyncWorkflow.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/SyncWorkflow.java
@@ -63,6 +63,7 @@ public interface SyncWorkflow {
 
     final ActivityOptions options = ActivityOptions.newBuilder()
         .setScheduleToCloseTimeout(Duration.ofDays(3))
+        .setRetryOptions(TemporalUtils.NO_RETRY)
         .build();
     private final SyncActivity activity = Workflow.newActivityStub(SyncActivity.class, options);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
@@ -27,6 +27,7 @@ package io.airbyte.workers.temporal;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.common.RetryOptions;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import java.io.Serializable;
@@ -43,6 +44,8 @@ public class TemporalUtils {
 
   public static final WorkflowClient TEMPORAL_CLIENT = WorkflowClient.newInstance(TEMPORAL_SERVICE);
 
+  public static final RetryOptions NO_RETRY = RetryOptions.newBuilder().setMaximumAttempts(1).build();
+
   @FunctionalInterface
   public interface TemporalJobCreator<T extends Serializable> {
 
@@ -52,6 +55,7 @@ public class TemporalUtils {
 
   public static WorkflowOptions getWorkflowOptions(TemporalJobType jobType) {
     return WorkflowOptions.newBuilder()
+        .setRetryOptions(NO_RETRY)
         .setTaskQueue(jobType.name())
         .build();
   }


### PR DESCRIPTION
closes: https://github.com/airbytehq/airbyte/issues/2452
closes: https://github.com/airbytehq/airbyte/issues/2495

## What
Bug where when a worker field, temporal would keep retrying it indefinitely. This was due to a misconfiguration in how we set up temporal. 

## How
* Set temporal to not retry
* Catch the correct temporal exception
