### PR TITLE
Increase time-out of tests?

### DIFF
--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -766,7 +766,7 @@ public class AcceptanceTests {
   private static void waitForSuccessfulJob(JobsApi jobsApi, JobRead originalJob) throws InterruptedException, ApiException {
     JobRead job = originalJob;
     int count = 0;
-    while (count < 15 && (job.getStatus() == JobStatus.PENDING || job.getStatus() == JobStatus.RUNNING)) {
+    while (count < 60 && (job.getStatus() == JobStatus.PENDING || job.getStatus() == JobStatus.RUNNING)) {
       Thread.sleep(1000);
       count++;
 


### PR DESCRIPTION
## What
I'm wondering If we don't need to increase the time for the sync to run...

in my PR https://github.com/airbytehq/airbyte/pull/2460, I've enabled normalization to be running in the acceptance tests so it might need more room