### PR TITLE
RFC: add CDC metadata fields to ab protocol

### DIFF
--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -61,6 +61,17 @@ definitions:
       emitted_at:
         description: "when the data was emitted from the source. epoch in millisecond."
         type: integer
+      replication_batch_id:
+        description: "Identifies which sync job replicated the record"
+      cdc_deleted_at:
+        description: "Timestamp when the record was deleted. null or unset if it has not been deleted. Only present for streams syncing data using CDC"
+        type: integer
+      cdc_updated_at:
+        description: "Timestamp when the record was updated. Only present for streams syncing data using CDC."
+        type: integer
+      cdc_lsn:
+        description: "Identifiers the transaction that produced the contained record. Only present for streams syncing data using CDC."
+        type: string
   AirbyteStateMessage:
     type: object
     additionalProperties: true

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -62,14 +62,17 @@ definitions:
         description: When the data was emitted from the source. (epoch in milliseconds)
         type: integer
       metadata:
-        description: "Map of metadata fields. Keys and values must both be strings. Below are some well-known fields.\n
-         replication_batch_id: Identifies which sync job replicated the record\n
-         cdc_deleted_at: Timestamp when the record was deleted. null or unset if it has not been deleted. Only present for streams syncing data using CDC. (epoch in milliseconds)\n
-         cdc_updated_at: Timestamp when the record was updated. Only present for streams syncing data using CDC. (epoch in milliseconds)\n
-         cdc_lsn: Identifies the transaction that produced the contained record. Only present for streams syncing data using CDC.\n
-         "
-        type: object
-        additionaProperties: true
+        "$ref": "#/definitions/AirbyteRecordMessageMetadata"
+  AirbyteRecordMessageMetadata:
+    description: "Map of metadata fields. Keys and values must both be strings. Below are some well-known fields.\n
+     replication_batch_id: Identifies which sync job replicated the record\n
+     cdc_deleted_at: Timestamp when the record was deleted. null or unset if it has not been deleted. Only present for streams syncing data using CDC. (epoch in milliseconds)\n
+     cdc_updated_at: Timestamp when the record was updated. Only present for streams syncing data using CDC. (epoch in milliseconds)\n
+     cdc_lsn: Identifies the transaction that produced the contained record. Only present for streams syncing data using CDC.\n
+     "
+    type: object
+    additionaProperties:
+      type: string
   AirbyteStateMessage:
     type: object
     additionalProperties: true

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -52,26 +52,24 @@ definitions:
       - emitted_at
     properties:
       stream:
-        description: "the name of the stream for this record"
+        description: Name of the stream for this record
         type: string
       data:
-        description: "the record data"
+        description: The data
         type: object
         existingJavaType: com.fasterxml.jackson.databind.JsonNode
       emitted_at:
-        description: "when the data was emitted from the source. epoch in millisecond."
+        description: When the data was emitted from the source. (epoch in milliseconds)
         type: integer
-      replication_batch_id:
-        description: "Identifies which sync job replicated the record"
-      cdc_deleted_at:
-        description: "Timestamp when the record was deleted. null or unset if it has not been deleted. Only present for streams syncing data using CDC"
-        type: integer
-      cdc_updated_at:
-        description: "Timestamp when the record was updated. Only present for streams syncing data using CDC."
-        type: integer
-      cdc_lsn:
-        description: "Identifiers the transaction that produced the contained record. Only present for streams syncing data using CDC."
-        type: string
+      metadata:
+        description: "Map of metadata fields. Keys and values must both be strings. Below are some well-known fields.\n
+         replication_batch_id: Identifies which sync job replicated the record\n
+         cdc_deleted_at: Timestamp when the record was deleted. null or unset if it has not been deleted. Only present for streams syncing data using CDC. (epoch in milliseconds)\n
+         cdc_updated_at: Timestamp when the record was updated. Only present for streams syncing data using CDC. (epoch in milliseconds)\n
+         cdc_lsn: Identifies the transaction that produced the contained record. Only present for streams syncing data using CDC.\n
+         "
+        type: object
+        additionaProperties: true
   AirbyteStateMessage:
     type: object
     additionalProperties: true


### PR DESCRIPTION
## CDC Metadata fields
Based on our conversation yesterday, we are moving forward with adding the CDC metadata fields into the Airbyte protocol. This PR adds a metadata field which is just a string-to-string map. The PR explains the contract with this metadata object, so I will not repeat it here. I am sharing this on its own to make sure that everyone is on the same page about the new contract.
