### PR TITLE
Harmonize /test and /publish commands on github + Fix MySQL tests in CI

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -17,7 +17,7 @@ jobs:
         id: regex
         uses: AsasInnab/regex-action@v1
         with:
-          regex_pattern: '^(connectors|bases)/[a-zA-Z0-9-_]+$'
+          regex_pattern: '^((connectors|bases)/)?[a-zA-Z0-9-_]+$'
           regex_flags: 'i' # required to be set for this plugin
           search_string: ${{ github.event.inputs.connector }}
       - name: Validate input workflow format

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -13,11 +13,11 @@ jobs:
   integration_test:
     runs-on: ubuntu-latest
     steps:
-      - name: Search for valid integration name format
+      - name: Search for valid connector name format
         id: regex
         uses: AsasInnab/regex-action@v1
         with:
-          regex_pattern: '^[a-zA-Z0-9-_]+$'
+          regex_pattern: '^(connectors|bases)/[a-zA-Z0-9-_]+$'
           regex_flags: 'i' # required to be set for this plugin
           search_string: ${{ github.event.inputs.connector }}
       - name: Validate input workflow format

--- a/airbyte-integrations/bases/base-normalization/setup.py
+++ b/airbyte-integrations/bases/base-normalization/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     author_email="contact@airbyte.io",
     url="https://github.com/airbytehq/airbyte",
     packages=setuptools.find_packages(),
-    install_requires=["airbyte-protocol", "dbt==0.18.1", "pyyaml"],
+    install_requires=["airbyte-protocol", "dbt==0.18.2rc1", "pyyaml"],
     package_data={"": ["*.yml"]},
     setup_requires=["pytest-runner"],
     entry_points={

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlJdbcStandardTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlJdbcStandardTest.java
@@ -40,13 +40,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MySQLContainer;
 
 class MySqlJdbcStandardTest extends JdbcSourceStandardTest {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(MySqlJdbcStandardTest.class);
 
   private static final String TEST_USER = "test";
   private static final String TEST_PASSWORD = "test";
@@ -93,8 +89,6 @@ class MySqlJdbcStandardTest extends JdbcSourceStandardTest {
     });
     database.close();
 
-    container.getEnv().forEach(
-        s -> LOGGER.info("Env: {}", s));
     super.setup();
   }
 

--- a/docs/contributing-to-airbyte/building-new-connector/testing-connectors.md
+++ b/docs/contributing-to-airbyte/building-new-connector/testing-connectors.md
@@ -70,8 +70,9 @@ Here are some example commands:
 
 1. `/test connector=all` - Runs integration tests for all connectors in a single GitHub workflow. Some of our integration tests interact with rate-limited resources, so please use this judiciously.
 2. `/test connector=source-sendgrid` - Runs integration tests for a single connector on the latest PR commit.
-3. `/test connector=source-sendgrid ref=master` - Runs integration tests for a single connector on a different branch. 
-4. `/test connector=source-sendgrid ref=d5c53102` - Runs integration tests for a single connector on a specific commit.
+3. `/test connector=connectors/source-sendgrid` - Runs integration tests for a single connector on the latest PR commit.
+4. `/test connector=source-sendgrid ref=master` - Runs integration tests for a single connector on a different branch. 
+5. `/test connector=source-sendgrid ref=d5c53102` - Runs integration tests for a single connector on a specific commit.
 
 A command dispatcher GitHub workflow will launch on comment submission. This dispatcher will add an :eyes: reaction to the comment when it starts processing. If there is an error dispatching your request, an error will be appended to your comment. If it launches the test run successfully, a :rocket: reaction will appear on your comment.
 
@@ -79,7 +80,21 @@ Once the integration test workflow launches, it will append a link to the workfl
 
 Integration tests can also be manually requested by clicking "[Run workflow](https://github.com/airbytehq/airbyte/actions?query=workflow%3Aintegration-test)" and specifying the connector and GitHub ref.
 
-### 3. Automatically Run From `master`
+### 3. Requesting GitHub PR publishing Docker Images
+
+In order for users to reference the new versions of a connector, it needs to be published and available in the [dockerhub](https://hub.docker.com/r/airbyte/source-sendgrid/tags?page=1&ordering=last_updated) with the latest tag updated.
+
+As seen previously, GitHub workflow can be triggered by comment submission. 
+Publishing docker images to the dockerhub repository can also be submitted likewise:
+
+Note that integration tests can be triggered with a slightly different syntax for arguments. 
+This second set is required to distinguish between `connectors` and `bases` folders.
+Thus, it is also easier to switch between the `/test` and `/publish` commands:
+
+- `/test connector=connectors/source-sendgrid` - Runs integration tests for a single connector on the latest PR commit.
+- `/publish connector=connectors/source-sendgrid` - Publish the docker image if it doesn't exist for a single connector on the latest PR commit.
+
+### 4. Automatically Run From `master`
 
 Commits to `master` attempt to launch integration tests. Two workflows launch for each commit: one is a launcher for integration tests, the other is the core build \(the same as the default for PR and branch builds\).
 

--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+. tools/lib/lib.sh
+
 # runs integration tests for an integration name
 
 connector="$1"
@@ -11,11 +13,17 @@ if [[ "$connector" == "all" ]] ; then
   echo "Running: ./gradlew --no-daemon --scan integrationTest"
   ./gradlew --no-daemon --scan integrationTest
 else
-  selected_integration_test=$(echo "$all_integration_tests" | grep "^$connector$" || echo "")
-  integrationTestCommand=":airbyte-integrations:connectors:$connector:integrationTest"
+  if [[ "$connector" == *"connector"* ]] || [[ "$connector" == *"bases"* ]]; then
+    connector_name=$(echo $connector | cut -d / -f 2)
+    selected_integration_test=$(echo "$all_integration_tests" | grep "^$connector_name$" || echo "")
+    integrationTestCommand="$(_to_gradle_path "airbyte-integrations/$connector" integrationTest)"
+  else
+    selected_integration_test=$(echo "$all_integration_tests" | grep "^$connector$" || echo "")
+    integrationTestCommand=":airbyte-integrations:connectors:$connector:integrationTest"
+  fi
   if [ -n "$selected_integration_test" ] ; then
-    echo "Running: ./gradlew --no-daemon --scan $integrationTestCommand"
-    ./gradlew --no-daemon --scan "$integrationTestCommand"
+    echo "Running: ./gradlew --no-daemon --scan --debug $integrationTestCommand"
+    ./gradlew --no-daemon --scan --debug "$integrationTestCommand"
   else
     echo "Connector '$connector' not found..."
     exit 1

--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -13,7 +13,7 @@ if [[ "$connector" == "all" ]] ; then
   echo "Running: ./gradlew --no-daemon --scan integrationTest"
   ./gradlew --no-daemon --scan integrationTest
 else
-  if [[ "$connector" == *"connector"* ]] || [[ "$connector" == *"bases"* ]]; then
+  if [[ "$connector" == *"connectors"* ]] || [[ "$connector" == *"bases"* ]]; then
     connector_name=$(echo $connector | cut -d / -f 2)
     selected_integration_test=$(echo "$all_integration_tests" | grep "^$connector_name$" || echo "")
     integrationTestCommand="$(_to_gradle_path "airbyte-integrations/$connector" integrationTest)"
@@ -22,8 +22,8 @@ else
     integrationTestCommand=":airbyte-integrations:connectors:$connector:integrationTest"
   fi
   if [ -n "$selected_integration_test" ] ; then
-    echo "Running: ./gradlew --no-daemon --scan --debug $integrationTestCommand"
-    ./gradlew --no-daemon --scan --debug "$integrationTestCommand"
+    echo "Running: ./gradlew --no-daemon --scan $integrationTestCommand"
+    ./gradlew --no-daemon --scan "$integrationTestCommand"
   else
     echo "Connector '$connector' not found..."
     exit 1


### PR DESCRIPTION
## What
When we want to publish docker images, we can comment on github with
```
/publish connector=connectors/source-gitlab-singer
```

But if we want to run integration tests, it's:
```
/test connector=source-gitlab-singer
```

## How
This PR makes it so that we can also run integration tests with:

```
/test connector=connectors/source-gitlab-singer
```

so it is easier to switch between a publish or a test comment

It is also now possible to run:
```
/test connector=bases/base-normalization
```

whereas, the following command will fail:
```
/test connector=base-normalization
```
with:
```
* What went wrong:
Project 'base-normalization' not found in project ':airbyte-integrations:connectors'.
```


This PR also fix compilation error of normalization image and tests for the MySQL sources when launched from CI

