### PR TITLE
Fix Log Path Handling for Synchronous Jobs

### DIFF
--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/SchedulerApp.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/SchedulerApp.java
@@ -99,7 +99,7 @@ public class SchedulerApp {
 
     final ExecutorService workerThreadPool = Executors.newFixedThreadPool(MAX_WORKERS, THREAD_FACTORY);
     final ScheduledExecutorService scheduledPool = Executors.newSingleThreadScheduledExecutor();
-    final TemporalWorkerRunFactory temporalWorkerRunFactory = new TemporalWorkerRunFactory(TemporalClient.production(), workspaceRoot);
+    final TemporalWorkerRunFactory temporalWorkerRunFactory = new TemporalWorkerRunFactory(TemporalClient.production(workspaceRoot), workspaceRoot);
     final JobRetrier jobRetrier = new JobRetrier(jobPersistence, Instant::now);
     final JobScheduler jobScheduler = new JobScheduler(jobPersistence, configRepository);
     final JobSubmitter jobSubmitter = new JobSubmitter(

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/client/DefaultSynchronousSchedulerClient.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/client/DefaultSynchronousSchedulerClient.java
@@ -116,7 +116,7 @@ public class DefaultSynchronousSchedulerClient implements SynchronousSchedulerCl
       track(jobId, configType, jobTrackerId, JobState.STARTED, null);
       final TemporalResponse<T> operationOutput = executor.apply(jobId);
       JobState outputState = operationOutput.getMetadata().isSucceeded() ? JobState.SUCCEEDED : JobState.FAILED;
-      track(jobId, configType, jobTrackerId, outputState, operationOutput.getOutput());
+      track(jobId, configType, jobTrackerId, outputState, operationOutput.getOutput().orElse(null));
       final long endedAt = Instant.now().toEpochMilli();
 
       return SynchronousResponse.fromTemporalResponse(

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/client/SynchronousJobMetadata.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/client/SynchronousJobMetadata.java
@@ -25,6 +25,7 @@
 package io.airbyte.scheduler.client;
 
 import io.airbyte.config.JobConfig.ConfigType;
+import io.airbyte.workers.temporal.JobMetadata;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Optional;
@@ -41,6 +42,22 @@ public class SynchronousJobMetadata {
   private final boolean succeeded;
 
   private final Path logPath;
+
+  public static SynchronousJobMetadata fromJobMetadata(JobMetadata jobMetadata,
+                                                       UUID id,
+                                                       ConfigType configType,
+                                                       UUID configId,
+                                                       long createdAt,
+                                                       long endedAt) {
+    return new SynchronousJobMetadata(
+        id,
+        configType,
+        configId,
+        createdAt,
+        endedAt,
+        jobMetadata.isSucceeded(),
+        jobMetadata.getLogPath());
+  }
 
   public SynchronousJobMetadata(final UUID id,
                                 final ConfigType configType,
@@ -82,10 +99,8 @@ public class SynchronousJobMetadata {
     return succeeded;
   }
 
-  // todo (cgardens) - this should always be present.
-  // only present if there was an error.
-  public Optional<Path> getLogPath() {
-    return Optional.ofNullable(logPath);
+  public Path getLogPath() {
+    return logPath;
   }
 
   @Override

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/client/SynchronousResponse.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/client/SynchronousResponse.java
@@ -56,7 +56,7 @@ public class SynchronousResponse<T> {
         configId,
         createdAt,
         endedAt);
-    return new SynchronousResponse<>(temporalResponse.getOutput(), metadata);
+    return new SynchronousResponse<>(temporalResponse.getOutput().orElse(null), metadata);
   }
 
   public SynchronousResponse(final T output, final SynchronousJobMetadata metadata) {

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/worker_run/TemporalWorkerRunFactory.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/worker_run/TemporalWorkerRunFactory.java
@@ -90,7 +90,7 @@ public class TemporalWorkerRunFactory {
 
   private OutputAndStatus<JobOutput> toOutputAndStatus(TemporalResponse<StandardSyncOutput> response) {
     final JobStatus status = response.isSuccess() ? JobStatus.SUCCEEDED : JobStatus.FAILED;
-    return new OutputAndStatus<>(status, new JobOutput().withSync(response.getOutput()));
+    return new OutputAndStatus<>(status, new JobOutput().withSync(response.getOutput().orElse(null)));
   }
 
 }

--- a/airbyte-scheduler/src/main/java/io/airbyte/scheduler/worker_run/TemporalWorkerRunFactory.java
+++ b/airbyte-scheduler/src/main/java/io/airbyte/scheduler/worker_run/TemporalWorkerRunFactory.java
@@ -36,9 +36,8 @@ import io.airbyte.workers.JobStatus;
 import io.airbyte.workers.OutputAndStatus;
 import io.airbyte.workers.WorkerConstants;
 import io.airbyte.workers.temporal.TemporalClient;
-import io.airbyte.workers.temporal.TemporalJobException;
 import io.airbyte.workers.temporal.TemporalJobType;
-import io.temporal.failure.TemporalException;
+import io.airbyte.workers.temporal.TemporalResponse;
 import java.nio.file.Path;
 
 public class TemporalWorkerRunFactory {
@@ -56,32 +55,25 @@ public class TemporalWorkerRunFactory {
     return WorkerRun.create(workspaceRoot, job.getId(), attemptId, createSupplier(job, attemptId));
   }
 
-  // suppress "CodeBlock2Expr" because in the lambda syntax without a return statement the formatting
-  // makes the switch statement very hard to read.
-  @SuppressWarnings({"CodeBlock2Expr"})
   public CheckedSupplier<OutputAndStatus<JobOutput>, Exception> createSupplier(Job job, int attemptId) {
     final TemporalJobType temporalJobType = toTemporalJobType(job.getConfigType());
     return switch (job.getConfigType()) {
       case SYNC -> () -> {
-        return toOutputAndStatus(() -> {
-          final StandardSyncOutput output = temporalClient.submitSync(job.getId(), attemptId, job.getConfig().getSync());
-          return new JobOutput().withSync(output);
-        });
+        final TemporalResponse<StandardSyncOutput> output = temporalClient.submitSync(job.getId(), attemptId, job.getConfig().getSync());
+        return toOutputAndStatus(output);
       };
       case RESET_CONNECTION -> () -> {
-        return toOutputAndStatus(() -> {
-          final JobResetConnectionConfig resetConnection = job.getConfig().getResetConnection();
-          final JobSyncConfig config = new JobSyncConfig()
-              .withPrefix(resetConnection.getPrefix())
-              .withSourceDockerImage(WorkerConstants.RESET_JOB_SOURCE_DOCKER_IMAGE_STUB)
-              .withDestinationDockerImage(resetConnection.getDestinationDockerImage())
-              .withSourceConfiguration(Jsons.emptyObject())
-              .withDestinationConfiguration(resetConnection.getDestinationConfiguration())
-              .withConfiguredAirbyteCatalog(resetConnection.getConfiguredAirbyteCatalog());
+        final JobResetConnectionConfig resetConnection = job.getConfig().getResetConnection();
+        final JobSyncConfig config = new JobSyncConfig()
+            .withPrefix(resetConnection.getPrefix())
+            .withSourceDockerImage(WorkerConstants.RESET_JOB_SOURCE_DOCKER_IMAGE_STUB)
+            .withDestinationDockerImage(resetConnection.getDestinationDockerImage())
+            .withSourceConfiguration(Jsons.emptyObject())
+            .withDestinationConfiguration(resetConnection.getDestinationConfiguration())
+            .withConfiguredAirbyteCatalog(resetConnection.getConfiguredAirbyteCatalog());
 
-          final StandardSyncOutput output = temporalClient.submitSync(job.getId(), attemptId, config);
-          return new JobOutput().withSync(output);
-        });
+        final TemporalResponse<StandardSyncOutput> output = temporalClient.submitSync(job.getId(), attemptId, config);
+        return toOutputAndStatus(output);
       };
       default -> throw new IllegalArgumentException("Does not support job type: " + temporalJobType);
     };
@@ -96,16 +88,9 @@ public class TemporalWorkerRunFactory {
     };
   }
 
-  private OutputAndStatus<JobOutput> toOutputAndStatus(CheckedSupplier<JobOutput, TemporalJobException> supplier) {
-    try {
-      return new OutputAndStatus<>(JobStatus.SUCCEEDED, supplier.get());
-    } catch (TemporalJobException | TemporalException e) {
-      // while from within the temporal activity we throw TemporalJobException, Temporal wraps any
-      // exception thrown by an activity in an ApplicationFailure exception, which gets wrapped in
-      // ActivityFailure exception which get wrapped in a WorkflowFailedException. We will need to unwrap
-      // these later, but for now we just catch the parent.
-      return new OutputAndStatus<>(JobStatus.FAILED);
-    }
+  private OutputAndStatus<JobOutput> toOutputAndStatus(TemporalResponse<StandardSyncOutput> response) {
+    final JobStatus status = response.isSuccess() ? JobStatus.SUCCEEDED : JobStatus.FAILED;
+    return new OutputAndStatus<>(status, new JobOutput().withSync(response.getOutput()));
   }
 
 }

--- a/airbyte-scheduler/src/test/java/io/airbyte/scheduler/client/DefaultSynchronousSchedulerClientTest.java
+++ b/airbyte-scheduler/src/test/java/io/airbyte/scheduler/client/DefaultSynchronousSchedulerClientTest.java
@@ -38,7 +38,6 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
-import io.airbyte.commons.functional.CheckedFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.JobCheckConnectionConfig;
@@ -51,11 +50,13 @@ import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.JobTracker;
 import io.airbyte.scheduler.JobTracker.JobState;
+import io.airbyte.workers.temporal.JobMetadata;
 import io.airbyte.workers.temporal.TemporalClient;
-import io.airbyte.workers.temporal.TemporalJobException;
+import io.airbyte.workers.temporal.TemporalResponse;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.UUID;
+import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -66,6 +67,7 @@ import org.junit.jupiter.api.Test;
 // execution exception cases again.
 class DefaultSynchronousSchedulerClientTest {
 
+  private static final Path LOG_PATH = Path.of("/tmp");
   private static final String DOCKER_IMAGE = "foo/bar";
   private static final UUID UUID1 = UUID.randomUUID();
   private static final UUID UUID2 = UUID.randomUUID();
@@ -93,19 +95,25 @@ class DefaultSynchronousSchedulerClientTest {
     schedulerClient = new DefaultSynchronousSchedulerClient(temporalClient, jobTracker);
   }
 
+  private static JobMetadata createMetadata(boolean succeeded) {
+    return new JobMetadata(
+        succeeded,
+        LOG_PATH);
+  }
+
   @Nested
   @DisplayName("Test execute method.")
   class ExecuteSynchronousJob {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testExecute() throws TemporalJobException {
+    void testExecuteJobSuccess() {
       final UUID configId = UUID.randomUUID();
       final UUID jobTrackingId = UUID.randomUUID();
-      final CheckedFunction<UUID, String, TemporalJobException> checkedFunction = mock(CheckedFunction.class);
-      when(checkedFunction.apply(any(UUID.class))).thenReturn("hello");
+      final Function<UUID, TemporalResponse<String>> function = mock(Function.class);
+      when(function.apply(any(UUID.class))).thenReturn(new TemporalResponse<>("hello", createMetadata(true)));
 
-      final SynchronousResponse<String> response = schedulerClient.execute(ConfigType.DISCOVER_SCHEMA, configId, checkedFunction, jobTrackingId);
+      final SynchronousResponse<String> response = schedulerClient.execute(ConfigType.DISCOVER_SCHEMA, configId, function, jobTrackingId);
 
       assertNotNull(response);
       assertEquals("hello", response.getOutput());
@@ -113,7 +121,7 @@ class DefaultSynchronousSchedulerClientTest {
       assertTrue(response.getMetadata().getConfigId().isPresent());
       assertEquals(configId, response.getMetadata().getConfigId().get());
       assertTrue(response.getMetadata().isSucceeded());
-      assertTrue(response.getMetadata().getLogPath().isEmpty());
+      assertEquals(LOG_PATH, response.getMetadata().getLogPath());
 
       verify(jobTracker).trackDiscover(any(UUID.class), eq(jobTrackingId), eq(JobState.STARTED));
       verify(jobTracker).trackDiscover(any(UUID.class), eq(jobTrackingId), eq(JobState.SUCCEEDED));
@@ -121,13 +129,13 @@ class DefaultSynchronousSchedulerClientTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testExecuteTemporalJobException() throws TemporalJobException {
+    void testExecuteJobFailure() {
       final UUID configId = UUID.randomUUID();
       final UUID jobTrackingId = UUID.randomUUID();
-      final CheckedFunction<UUID, String, TemporalJobException> checkedFunction = mock(CheckedFunction.class);
-      when(checkedFunction.apply(any(UUID.class))).thenThrow(new TemporalJobException(Path.of("/tmp")));
+      final Function<UUID, TemporalResponse<String>> function = mock(Function.class);
+      when(function.apply(any(UUID.class))).thenReturn(new TemporalResponse<>(null, createMetadata(false)));
 
-      final SynchronousResponse<String> response = schedulerClient.execute(ConfigType.DISCOVER_SCHEMA, configId, checkedFunction, jobTrackingId);
+      final SynchronousResponse<String> response = schedulerClient.execute(ConfigType.DISCOVER_SCHEMA, configId, function, jobTrackingId);
 
       assertNotNull(response);
       assertNull(response.getOutput());
@@ -135,7 +143,7 @@ class DefaultSynchronousSchedulerClientTest {
       assertTrue(response.getMetadata().getConfigId().isPresent());
       assertEquals(configId, response.getMetadata().getConfigId().get());
       assertFalse(response.getMetadata().isSucceeded());
-      assertTrue(response.getMetadata().getLogPath().isPresent());
+      assertEquals(LOG_PATH, response.getMetadata().getLogPath());
 
       verify(jobTracker).trackDiscover(any(UUID.class), eq(jobTrackingId), eq(JobState.STARTED));
       verify(jobTracker).trackDiscover(any(UUID.class), eq(jobTrackingId), eq(JobState.FAILED));
@@ -143,13 +151,13 @@ class DefaultSynchronousSchedulerClientTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testExecuteRuntimeException() throws TemporalJobException {
+    void testExecuteRuntimeException() {
       final UUID configId = UUID.randomUUID();
       final UUID jobTrackingId = UUID.randomUUID();
-      final CheckedFunction<UUID, String, TemporalJobException> checkedFunction = mock(CheckedFunction.class);
-      when(checkedFunction.apply(any(UUID.class))).thenThrow(new RuntimeException());
+      final Function<UUID, TemporalResponse<String>> function = mock(Function.class);
+      when(function.apply(any(UUID.class))).thenThrow(new RuntimeException());
 
-      assertThrows(RuntimeException.class, () -> schedulerClient.execute(ConfigType.DISCOVER_SCHEMA, configId, checkedFunction, jobTrackingId));
+      assertThrows(RuntimeException.class, () -> schedulerClient.execute(ConfigType.DISCOVER_SCHEMA, configId, function, jobTrackingId));
 
       verify(jobTracker).trackDiscover(any(UUID.class), eq(jobTrackingId), eq(JobState.STARTED));
       verify(jobTracker).trackDiscover(any(UUID.class), eq(jobTrackingId), eq(JobState.FAILED));
@@ -162,49 +170,53 @@ class DefaultSynchronousSchedulerClientTest {
   class TestJobCreation {
 
     @Test
-    void testCreateSourceCheckConnectionJob() throws IOException, TemporalJobException {
+    void testCreateSourceCheckConnectionJob() {
       final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig()
           .withConnectionConfiguration(SOURCE_CONNECTION.getConfiguration())
           .withDockerImage(DOCKER_IMAGE);
 
-      StandardCheckConnectionOutput mockOutput = mock(StandardCheckConnectionOutput.class);
-      when(temporalClient.submitCheckConnection(any(UUID.class), eq(0), eq(jobCheckConnectionConfig))).thenReturn(mockOutput);
+      final StandardCheckConnectionOutput mockOutput = mock(StandardCheckConnectionOutput.class);
+      when(temporalClient.submitCheckConnection(any(UUID.class), eq(0), eq(jobCheckConnectionConfig)))
+          .thenReturn(new TemporalResponse<>(mockOutput, createMetadata(true)));
       final SynchronousResponse<StandardCheckConnectionOutput> response =
           schedulerClient.createSourceCheckConnectionJob(SOURCE_CONNECTION, DOCKER_IMAGE);
       assertEquals(mockOutput, response.getOutput());
     }
 
     @Test
-    void testCreateDestinationCheckConnectionJob() throws IOException, TemporalJobException {
+    void testCreateDestinationCheckConnectionJob() {
       final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig()
           .withConnectionConfiguration(DESTINATION_CONNECTION.getConfiguration())
           .withDockerImage(DOCKER_IMAGE);
 
-      StandardCheckConnectionOutput mockOutput = mock(StandardCheckConnectionOutput.class);
-      when(temporalClient.submitCheckConnection(any(UUID.class), eq(0), eq(jobCheckConnectionConfig))).thenReturn(mockOutput);
+      final StandardCheckConnectionOutput mockOutput = mock(StandardCheckConnectionOutput.class);
+      when(temporalClient.submitCheckConnection(any(UUID.class), eq(0), eq(jobCheckConnectionConfig)))
+          .thenReturn(new TemporalResponse<>(mockOutput, createMetadata(true)));
       final SynchronousResponse<StandardCheckConnectionOutput> response =
           schedulerClient.createDestinationCheckConnectionJob(DESTINATION_CONNECTION, DOCKER_IMAGE);
       assertEquals(mockOutput, response.getOutput());
     }
 
     @Test
-    void testCreateDiscoverSchemaJob() throws IOException, TemporalJobException {
+    void testCreateDiscoverSchemaJob() {
       final JobDiscoverCatalogConfig jobDiscoverCatalogConfig = new JobDiscoverCatalogConfig()
           .withConnectionConfiguration(SOURCE_CONNECTION.getConfiguration())
           .withDockerImage(DOCKER_IMAGE);
 
-      AirbyteCatalog mockOutput = mock(AirbyteCatalog.class);
-      when(temporalClient.submitDiscoverSchema(any(UUID.class), eq(0), eq(jobDiscoverCatalogConfig))).thenReturn(mockOutput);
+      final AirbyteCatalog mockOutput = mock(AirbyteCatalog.class);
+      when(temporalClient.submitDiscoverSchema(any(UUID.class), eq(0), eq(jobDiscoverCatalogConfig)))
+          .thenReturn(new TemporalResponse<>(mockOutput, createMetadata(true)));
       final SynchronousResponse<AirbyteCatalog> response = schedulerClient.createDiscoverSchemaJob(SOURCE_CONNECTION, DOCKER_IMAGE);
       assertEquals(mockOutput, response.getOutput());
     }
 
     @Test
-    void testCreateGetSpecJob() throws IOException, TemporalJobException {
+    void testCreateGetSpecJob() throws IOException {
       final JobGetSpecConfig jobSpecConfig = new JobGetSpecConfig().withDockerImage(DOCKER_IMAGE);
 
-      ConnectorSpecification mockOutput = mock(ConnectorSpecification.class);
-      when(temporalClient.submitGetSpec(any(UUID.class), eq(0), eq(jobSpecConfig))).thenReturn(mockOutput);
+      final ConnectorSpecification mockOutput = mock(ConnectorSpecification.class);
+      when(temporalClient.submitGetSpec(any(UUID.class), eq(0), eq(jobSpecConfig)))
+          .thenReturn(new TemporalResponse<>(mockOutput, createMetadata(true)));
       final SynchronousResponse<ConnectorSpecification> response = schedulerClient.createGetSpecJob(DOCKER_IMAGE);
       assertEquals(mockOutput, response.getOutput());
     }

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -99,8 +99,10 @@ public class ServerApp {
 
     ConfigurationApiFactory.setSchedulerJobClient(new DefaultSchedulerJobClient(jobPersistence, new DefaultJobCreator(jobPersistence)));
     final JobTracker jobTracker = new JobTracker(configRepository);
-    ConfigurationApiFactory.setSynchronousSchedulerClient(
-        new SpecCachingSynchronousSchedulerClient(new DefaultSynchronousSchedulerClient(TemporalClient.production(), jobTracker)));
+    final TemporalClient temporalClient = TemporalClient.production(configs.getWorkspaceRoot());
+
+    ConfigurationApiFactory
+        .setSynchronousSchedulerClient(new SpecCachingSynchronousSchedulerClient(new DefaultSynchronousSchedulerClient(temporalClient, jobTracker)));
     ConfigurationApiFactory.setConfigRepository(configRepository);
     ConfigurationApiFactory.setJobPersistence(jobPersistence);
     ConfigurationApiFactory.setConfigs(configs);

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
@@ -119,7 +119,7 @@ public class JobConverter {
         .createdAt(metadata.getCreatedAt())
         .endedAt(metadata.getEndedAt())
         .succeeded(metadata.isSucceeded())
-        .logs(metadata.getLogPath().map(JobConverter::getLogRead).orElse(null));
+        .logs(JobConverter.getLogRead(metadata.getLogPath()));
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -327,6 +327,10 @@ public class SchedulerHandler {
       checkConnectionRead
           .status(Enums.convertTo(response.getOutput().getStatus(), StatusEnum.class))
           .message(response.getOutput().getMessage());
+    } else {
+      checkConnectionRead
+          .status(StatusEnum.FAILED)
+          .message("Check Connection Failed!");
     }
 
     return checkConnectionRead;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -28,6 +28,7 @@ import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardTapConfig;
 import io.airbyte.config.StandardTargetConfig;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
+import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.process.AirbyteIntegrationLauncher;
 import io.airbyte.workers.process.IntegrationLauncher;
 import io.airbyte.workers.process.ProcessBuilderFactory;
@@ -122,6 +123,14 @@ public class WorkerUtils {
   // once we are fully on temporal.
   public static Path getJobRoot(Path workspaceRoot, IntegrationLauncherConfig launcherConfig) {
     return getJobRoot(workspaceRoot, launcherConfig.getJobId(), Math.toIntExact(launcherConfig.getAttemptId()));
+  }
+
+  public static Path getJobRoot(Path workspaceRoot, JobRunConfig jobRunConfig) {
+    return getJobRoot(workspaceRoot, jobRunConfig.getJobId(), jobRunConfig.getAttemptId());
+  }
+
+  public static Path getLogPath(Path jobRoot) {
+    return jobRoot.resolve(WorkerConstants.LOG_FILENAME);
   }
 
   public static Path getJobRoot(Path workspaceRoot, String jobId, long attemptId) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CheckConnectionWorkflow.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CheckConnectionWorkflow.java
@@ -50,8 +50,7 @@ public interface CheckConnectionWorkflow {
   @WorkflowMethod
   StandardCheckConnectionOutput run(JobRunConfig jobRunConfig,
                                     IntegrationLauncherConfig launcherConfig,
-                                    StandardCheckConnectionInput connectionConfiguration)
-      throws TemporalJobException;
+                                    StandardCheckConnectionInput connectionConfiguration);
 
   class WorkflowImpl implements CheckConnectionWorkflow {
 
@@ -64,8 +63,7 @@ public interface CheckConnectionWorkflow {
     @Override
     public StandardCheckConnectionOutput run(JobRunConfig jobRunConfig,
                                              IntegrationLauncherConfig launcherConfig,
-                                             StandardCheckConnectionInput connectionConfiguration)
-        throws TemporalJobException {
+                                             StandardCheckConnectionInput connectionConfiguration) {
       return activity.run(jobRunConfig, launcherConfig, connectionConfiguration);
     }
 
@@ -77,8 +75,7 @@ public interface CheckConnectionWorkflow {
     @ActivityMethod
     StandardCheckConnectionOutput run(JobRunConfig jobRunConfig,
                                       IntegrationLauncherConfig launcherConfig,
-                                      StandardCheckConnectionInput connectionConfiguration)
-        throws TemporalJobException;
+                                      StandardCheckConnectionInput connectionConfiguration);
 
   }
 
@@ -94,8 +91,7 @@ public interface CheckConnectionWorkflow {
 
     public StandardCheckConnectionOutput run(JobRunConfig jobRunConfig,
                                              IntegrationLauncherConfig launcherConfig,
-                                             StandardCheckConnectionInput connectionConfiguration)
-        throws TemporalJobException {
+                                             StandardCheckConnectionInput connectionConfiguration) {
 
       final Supplier<StandardCheckConnectionInput> inputSupplier = () -> connectionConfiguration;
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/DiscoverCatalogWorkflow.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/DiscoverCatalogWorkflow.java
@@ -52,8 +52,7 @@ public interface DiscoverCatalogWorkflow {
   @WorkflowMethod
   AirbyteCatalog run(JobRunConfig jobRunConfig,
                      IntegrationLauncherConfig launcherConfig,
-                     StandardDiscoverCatalogInput config)
-      throws TemporalJobException;
+                     StandardDiscoverCatalogInput config);
 
   class WorkflowImpl implements DiscoverCatalogWorkflow {
 
@@ -66,8 +65,7 @@ public interface DiscoverCatalogWorkflow {
     @Override
     public AirbyteCatalog run(JobRunConfig jobRunConfig,
                               IntegrationLauncherConfig launcherConfig,
-                              StandardDiscoverCatalogInput config)
-        throws TemporalJobException {
+                              StandardDiscoverCatalogInput config) {
       return activity.run(jobRunConfig, launcherConfig, config);
     }
 
@@ -79,8 +77,7 @@ public interface DiscoverCatalogWorkflow {
     @ActivityMethod
     AirbyteCatalog run(JobRunConfig jobRunConfig,
                        IntegrationLauncherConfig launcherConfig,
-                       StandardDiscoverCatalogInput config)
-        throws TemporalJobException;
+                       StandardDiscoverCatalogInput config);
 
   }
 
@@ -96,8 +93,7 @@ public interface DiscoverCatalogWorkflow {
 
     public AirbyteCatalog run(JobRunConfig jobRunConfig,
                               IntegrationLauncherConfig launcherConfig,
-                              StandardDiscoverCatalogInput config)
-        throws TemporalJobException {
+                              StandardDiscoverCatalogInput config) {
       final Supplier<StandardDiscoverCatalogInput> inputSupplier = () -> config;
 
       final TemporalAttemptExecution<StandardDiscoverCatalogInput, AirbyteCatalog> temporalAttemptExecution = new TemporalAttemptExecution<>(

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/JobMetadata.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/JobMetadata.java
@@ -25,27 +25,49 @@
 package io.airbyte.workers.temporal;
 
 import java.nio.file.Path;
+import java.util.Objects;
 
-public class TemporalJobException extends Exception {
+public class JobMetadata {
 
+  private final boolean succeeded;
   private final Path logPath;
 
-  public TemporalJobException(Path logPath) {
+  public JobMetadata(final boolean succeeded, final Path logPath) {
+    this.succeeded = succeeded;
     this.logPath = logPath;
   }
 
-  public TemporalJobException(Path logPath, Throwable cause) {
-    super(cause);
-    this.logPath = logPath;
-  }
-
-  public TemporalJobException(Path logPath, String message, Throwable cause) {
-    super(message, cause);
-    this.logPath = logPath;
+  public boolean isSucceeded() {
+    return succeeded;
   }
 
   public Path getLogPath() {
     return logPath;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final JobMetadata that = (JobMetadata) o;
+    return succeeded == that.succeeded && Objects.equals(logPath, that.logPath);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(succeeded, logPath);
+  }
+
+  @Override
+  public String toString() {
+    return "JobMetadata{" +
+        "succeeded=" + succeeded +
+        ", logPath=" + logPath +
+        '}';
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/SpecWorkflow.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/SpecWorkflow.java
@@ -48,7 +48,7 @@ import java.util.function.Supplier;
 public interface SpecWorkflow {
 
   @WorkflowMethod
-  ConnectorSpecification run(JobRunConfig jobRunConfig, IntegrationLauncherConfig launcherConfig) throws TemporalJobException;
+  ConnectorSpecification run(JobRunConfig jobRunConfig, IntegrationLauncherConfig launcherConfig);
 
   class WorkflowImpl implements SpecWorkflow {
 
@@ -59,7 +59,7 @@ public interface SpecWorkflow {
     private final SpecActivity activity = Workflow.newActivityStub(SpecActivity.class, options);
 
     @Override
-    public ConnectorSpecification run(JobRunConfig jobRunConfig, IntegrationLauncherConfig launcherConfig) throws TemporalJobException {
+    public ConnectorSpecification run(JobRunConfig jobRunConfig, IntegrationLauncherConfig launcherConfig) {
       return activity.run(jobRunConfig, launcherConfig);
     }
 
@@ -69,7 +69,7 @@ public interface SpecWorkflow {
   interface SpecActivity {
 
     @ActivityMethod
-    ConnectorSpecification run(JobRunConfig jobRunConfig, IntegrationLauncherConfig launcherConfig) throws TemporalJobException;
+    ConnectorSpecification run(JobRunConfig jobRunConfig, IntegrationLauncherConfig launcherConfig);
 
   }
 
@@ -83,7 +83,7 @@ public interface SpecWorkflow {
       this.workspaceRoot = workspaceRoot;
     }
 
-    public ConnectorSpecification run(JobRunConfig jobRunConfig, IntegrationLauncherConfig launcherConfig) throws TemporalJobException {
+    public ConnectorSpecification run(JobRunConfig jobRunConfig, IntegrationLauncherConfig launcherConfig) {
       final Supplier<JobGetSpecConfig> inputSupplier = () -> new JobGetSpecConfig().withDockerImage(launcherConfig.getDockerImage());
 
       final TemporalAttemptExecution<JobGetSpecConfig, ConnectorSpecification> temporalAttemptExecution = new TemporalAttemptExecution<>(

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/SyncWorkflow.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/SyncWorkflow.java
@@ -62,8 +62,7 @@ public interface SyncWorkflow {
   StandardSyncOutput run(JobRunConfig jobRunConfig,
                          IntegrationLauncherConfig sourceLauncherConfig,
                          IntegrationLauncherConfig destinationLauncherConfig,
-                         StandardSyncInput syncInput)
-      throws TemporalJobException;
+                         StandardSyncInput syncInput);
 
   class WorkflowImpl implements SyncWorkflow {
 
@@ -79,8 +78,7 @@ public interface SyncWorkflow {
     public StandardSyncOutput run(JobRunConfig jobRunConfig,
                                   IntegrationLauncherConfig sourceLauncherConfig,
                                   IntegrationLauncherConfig destinationLauncherConfig,
-                                  StandardSyncInput syncInput)
-        throws TemporalJobException {
+                                  StandardSyncInput syncInput) {
       return activity.run(jobRunConfig, sourceLauncherConfig, destinationLauncherConfig, syncInput);
     }
 
@@ -93,8 +91,7 @@ public interface SyncWorkflow {
     StandardSyncOutput run(JobRunConfig jobRunConfig,
                            IntegrationLauncherConfig sourceLauncherConfig,
                            IntegrationLauncherConfig destinationLauncherConfig,
-                           StandardSyncInput syncInput)
-        throws TemporalJobException;
+                           StandardSyncInput syncInput);
 
   }
 
@@ -113,8 +110,7 @@ public interface SyncWorkflow {
     public StandardSyncOutput run(JobRunConfig jobRunConfig,
                                   IntegrationLauncherConfig sourceLauncherConfig,
                                   IntegrationLauncherConfig destinationLauncherConfig,
-                                  StandardSyncInput syncInput)
-        throws TemporalJobException {
+                                  StandardSyncInput syncInput) {
 
       final Supplier<StandardSyncInput> inputSupplier = () -> syncInput;
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -24,6 +24,7 @@
 
 package io.airbyte.workers.temporal;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.config.JobCheckConnectionConfig;
 import io.airbyte.config.JobDiscoverCatalogConfig;
 import io.airbyte.config.JobGetSpecConfig;
@@ -37,33 +38,41 @@ import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.workers.WorkerUtils;
 import io.temporal.client.WorkflowClient;
+import java.nio.file.Path;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 public class TemporalClient {
 
+  private final Path workspaceRoot;
   private final WorkflowClient client;
 
-  public static TemporalClient production() {
-    return new TemporalClient(TemporalUtils.TEMPORAL_CLIENT);
+  public static TemporalClient production(Path workspaceRoot) {
+    return new TemporalClient(TemporalUtils.TEMPORAL_CLIENT, workspaceRoot);
   }
 
-  public TemporalClient(WorkflowClient client) {
+  // todo (cgardens) - there are two sources of truth on workspace root. we need to get this down to
+  // one. either temporal decides and can report it or it is injected into temporal runs.
+  public TemporalClient(WorkflowClient client, Path workspaceRoot) {
     this.client = client;
+    this.workspaceRoot = workspaceRoot;
   }
 
-  public ConnectorSpecification submitGetSpec(UUID jobId, int attempt, JobGetSpecConfig config) throws TemporalJobException {
+  public TemporalResponse<ConnectorSpecification> submitGetSpec(UUID jobId, int attempt, JobGetSpecConfig config) {
     final JobRunConfig jobRunConfig = TemporalUtils.createJobRunConfig(jobId, attempt);
 
     final IntegrationLauncherConfig launcherConfig = new IntegrationLauncherConfig()
         .withJobId(jobId.toString())
         .withAttemptId((long) attempt)
         .withDockerImage(config.getDockerImage());
-    return getWorkflowStub(SpecWorkflow.class, TemporalJobType.GET_SPEC).run(jobRunConfig, launcherConfig);
+    return execute(jobRunConfig,
+        () -> getWorkflowStub(SpecWorkflow.class, TemporalJobType.GET_SPEC).run(jobRunConfig, launcherConfig));
 
   }
 
-  public StandardCheckConnectionOutput submitCheckConnection(UUID jobId, int attempt, JobCheckConnectionConfig config) throws TemporalJobException {
+  public TemporalResponse<StandardCheckConnectionOutput> submitCheckConnection(UUID jobId, int attempt, JobCheckConnectionConfig config) {
     final JobRunConfig jobRunConfig = TemporalUtils.createJobRunConfig(jobId, attempt);
     final IntegrationLauncherConfig launcherConfig = new IntegrationLauncherConfig()
         .withJobId(jobId.toString())
@@ -71,10 +80,11 @@ public class TemporalClient {
         .withDockerImage(config.getDockerImage());
     final StandardCheckConnectionInput input = new StandardCheckConnectionInput().withConnectionConfiguration(config.getConnectionConfiguration());
 
-    return getWorkflowStub(CheckConnectionWorkflow.class, TemporalJobType.CHECK_CONNECTION).run(jobRunConfig, launcherConfig, input);
+    return execute(jobRunConfig,
+        () -> getWorkflowStub(CheckConnectionWorkflow.class, TemporalJobType.CHECK_CONNECTION).run(jobRunConfig, launcherConfig, input));
   }
 
-  public AirbyteCatalog submitDiscoverSchema(UUID jobId, int attempt, JobDiscoverCatalogConfig config) throws TemporalJobException {
+  public TemporalResponse<AirbyteCatalog> submitDiscoverSchema(UUID jobId, int attempt, JobDiscoverCatalogConfig config) {
     final JobRunConfig jobRunConfig = TemporalUtils.createJobRunConfig(jobId, attempt);
     final IntegrationLauncherConfig launcherConfig = new IntegrationLauncherConfig()
         .withJobId(jobId.toString())
@@ -82,10 +92,11 @@ public class TemporalClient {
         .withDockerImage(config.getDockerImage());
     final StandardDiscoverCatalogInput input = new StandardDiscoverCatalogInput().withConnectionConfiguration(config.getConnectionConfiguration());
 
-    return getWorkflowStub(DiscoverCatalogWorkflow.class, TemporalJobType.DISCOVER_SCHEMA).run(jobRunConfig, launcherConfig, input);
+    return execute(jobRunConfig,
+        () -> getWorkflowStub(DiscoverCatalogWorkflow.class, TemporalJobType.DISCOVER_SCHEMA).run(jobRunConfig, launcherConfig, input));
   }
 
-  public StandardSyncOutput submitSync(long jobId, int attempt, JobSyncConfig config) throws TemporalJobException {
+  public TemporalResponse<StandardSyncOutput> submitSync(long jobId, int attempt, JobSyncConfig config) {
     final JobRunConfig jobRunConfig = TemporalUtils.createJobRunConfig(jobId, attempt);
 
     final IntegrationLauncherConfig sourceLauncherConfig = new IntegrationLauncherConfig()
@@ -105,15 +116,34 @@ public class TemporalClient {
         .withCatalog(config.getConfiguredAirbyteCatalog())
         .withState(config.getState());
 
-    return getWorkflowStub(SyncWorkflow.class, TemporalJobType.SYNC).run(
-        jobRunConfig,
-        sourceLauncherConfig,
-        destinationLauncherConfig,
-        input);
+    return execute(jobRunConfig,
+        () -> getWorkflowStub(SyncWorkflow.class, TemporalJobType.SYNC).run(
+            jobRunConfig,
+            sourceLauncherConfig,
+            destinationLauncherConfig,
+            input));
   }
 
   private <T> T getWorkflowStub(Class<T> workflowClass, TemporalJobType jobType) {
     return client.newWorkflowStub(workflowClass, TemporalUtils.getWorkflowOptions(jobType));
+  }
+
+  @VisibleForTesting
+  <T> TemporalResponse<T> execute(JobRunConfig jobRunConfig, Supplier<T> executor) {
+    final Path jobRoot = WorkerUtils.getJobRoot(workspaceRoot, jobRunConfig);
+    final Path logPath = WorkerUtils.getLogPath(jobRoot);
+
+    T operationOutput = null;
+    RuntimeException exception = null;
+
+    try {
+      operationOutput = executor.get();
+    } catch (RuntimeException e) {
+      exception = e;
+    }
+
+    final JobMetadata metadata = new JobMetadata(exception == null, logPath);
+    return new TemporalResponse<>(operationOutput, metadata);
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalResponse.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalResponse.java
@@ -22,44 +22,24 @@
  * SOFTWARE.
  */
 
-package io.airbyte.scheduler.client;
+package io.airbyte.workers.temporal;
 
-import io.airbyte.config.JobConfig.ConfigType;
-import io.airbyte.workers.temporal.TemporalResponse;
 import java.util.Objects;
-import java.util.UUID;
 
-public class SynchronousResponse<T> {
+public class TemporalResponse<T> {
 
   private final T output;
-  private final SynchronousJobMetadata metadata;
+  private final JobMetadata metadata;
 
-  public static <T> SynchronousResponse<T> error(SynchronousJobMetadata metadata) {
-    return new SynchronousResponse<>(null, metadata);
+  public static <T> TemporalResponse<T> error(JobMetadata metadata) {
+    return new TemporalResponse<>(null, metadata);
   }
 
-  public static <T> SynchronousResponse<T> success(T output, SynchronousJobMetadata metadata) {
-    return new SynchronousResponse<>(output, metadata);
+  public static <T> TemporalResponse<T> success(T output, JobMetadata metadata) {
+    return new TemporalResponse<>(output, metadata);
   }
 
-  public static <T> SynchronousResponse<T> fromTemporalResponse(TemporalResponse<T> temporalResponse,
-                                                                UUID id,
-                                                                ConfigType configType,
-                                                                UUID configId,
-                                                                long createdAt,
-                                                                long endedAt) {
-
-    final SynchronousJobMetadata metadata = SynchronousJobMetadata.fromJobMetadata(
-        temporalResponse.getMetadata(),
-        id,
-        configType,
-        configId,
-        createdAt,
-        endedAt);
-    return new SynchronousResponse<>(temporalResponse.getOutput(), metadata);
-  }
-
-  public SynchronousResponse(final T output, final SynchronousJobMetadata metadata) {
+  public TemporalResponse(final T output, final JobMetadata metadata) {
     this.output = output;
     this.metadata = metadata;
   }
@@ -72,7 +52,7 @@ public class SynchronousResponse<T> {
     return output;
   }
 
-  public SynchronousJobMetadata getMetadata() {
+  public JobMetadata getMetadata() {
     return metadata;
   }
 
@@ -84,7 +64,7 @@ public class SynchronousResponse<T> {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final SynchronousResponse<?> that = (SynchronousResponse<?>) o;
+    final TemporalResponse<?> that = (TemporalResponse<?>) o;
     return Objects.equals(output, that.output) && Objects.equals(metadata, that.metadata);
   }
 
@@ -95,7 +75,7 @@ public class SynchronousResponse<T> {
 
   @Override
   public String toString() {
-    return "SynchronousResponse{" +
+    return "TemporalResponse{" +
         "output=" + output +
         ", metadata=" + metadata +
         '}';

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalResponse.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalResponse.java
@@ -25,6 +25,7 @@
 package io.airbyte.workers.temporal;
 
 import java.util.Objects;
+import java.util.Optional;
 
 public class TemporalResponse<T> {
 
@@ -48,8 +49,13 @@ public class TemporalResponse<T> {
     return metadata.isSucceeded();
   }
 
-  public T getOutput() {
-    return output;
+  /**
+   * Returns the output of the Temporal job.
+   *
+   * @return The output of the Temporal job. Empty if no output or if the job failed.
+   */
+  public Optional<T> getOutput() {
+    return Optional.ofNullable(output);
   }
 
   public JobMetadata getMetadata() {

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalAttemptExecutionTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalAttemptExecutionTest.java
@@ -37,8 +37,6 @@ import io.airbyte.commons.functional.CheckedSupplier;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.Worker;
 import io.temporal.internal.common.CheckedExceptionWrapper;
-import io.airbyte.workers.WorkerConstants;
-import io.temporal.internal.common.CheckedExceptionWrapper;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -66,16 +64,7 @@ class TemporalAttemptExecutionTest {
   void setup() throws IOException {
     final Path workspaceRoot = Files.createTempDirectory(Path.of("/tmp"), "temporal_attempt_execution_test");
     jobRoot = workspaceRoot.resolve(JOB_ID).resolve(String.valueOf(ATTEMPT_ID));
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-    expectedException = new TemporalJobException(jobRoot.resolve(WorkerConstants.LOG_FILENAME));
-=======
     jobRoot = workspaceRoot.resolve(String.valueOf(JOB_ID)).resolve(String.valueOf(ATTEMPT_ID));
->>>>>>> 798aa39d3 (fix)
->>>>>>> b9f119fb2 (fix)
-=======
->>>>>>> 16fc42bdc (clean)
 
     execution = mock(CheckedSupplier.class);
     mdcSetter = mock(BiConsumer.class);
@@ -116,34 +105,7 @@ class TemporalAttemptExecutionTest {
   void testThrowsUnCheckedException() throws Exception {
     when(execution.get()).thenThrow(new IllegalArgumentException());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
     assertThrows(IllegalArgumentException.class, () -> attemptExecution.get());
-=======
-<<<<<<< HEAD
-    final TemporalJobException actualException = assertThrows(TemporalJobException.class, () -> attemptExecution.get());
-    assertEquals(expectedException.getLogPath(), actualException.getLogPath());
-    assertEquals(IllegalArgumentException.class, actualException.getCause().getClass());
-
-    verify(execution).get();
-    verify(mdcSetter).accept(jobRoot, JOB_ID);
-  }
-
-  @Test
-  void testThrowsTemporalJobExceptionException() throws Exception {
-    final Path otherFilePath = jobRoot.resolve("other file path");
-    when(execution.get()).thenThrow(new TemporalJobException(otherFilePath));
-
-    final TemporalJobException actualException = assertThrows(TemporalJobException.class, () -> attemptExecution.get());
-    assertEquals(otherFilePath, actualException.getLogPath());
-    assertNull(actualException.getCause());
-=======
-    assertThrows(IllegalArgumentException.class, () -> attemptExecution.get());
->>>>>>> 798aa39d3 (fix)
->>>>>>> b9f119fb2 (fix)
-=======
-    assertThrows(IllegalArgumentException.class, () -> attemptExecution.get());
->>>>>>> 16fc42bdc (clean)
 
     verify(execution).get();
     verify(mdcSetter).accept(jobRoot, JOB_ID);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalAttemptExecutionTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalAttemptExecutionTest.java
@@ -25,7 +25,6 @@
 package io.airbyte.workers.temporal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
@@ -37,7 +36,9 @@ import io.airbyte.commons.functional.CheckedConsumer;
 import io.airbyte.commons.functional.CheckedSupplier;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.Worker;
+import io.temporal.internal.common.CheckedExceptionWrapper;
 import io.airbyte.workers.WorkerConstants;
+import io.temporal.internal.common.CheckedExceptionWrapper;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -53,7 +54,6 @@ class TemporalAttemptExecutionTest {
   private static final JobRunConfig JOB_RUN_CONFIG = new JobRunConfig().withJobId(JOB_ID).withAttemptId((long) ATTEMPT_ID);
 
   private Path jobRoot;
-  private TemporalJobException expectedException;
 
   private CheckedSupplier<Worker<String, String>, Exception> execution;
   private BiConsumer<Path, String> mdcSetter;
@@ -66,7 +66,16 @@ class TemporalAttemptExecutionTest {
   void setup() throws IOException {
     final Path workspaceRoot = Files.createTempDirectory(Path.of("/tmp"), "temporal_attempt_execution_test");
     jobRoot = workspaceRoot.resolve(JOB_ID).resolve(String.valueOf(ATTEMPT_ID));
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
     expectedException = new TemporalJobException(jobRoot.resolve(WorkerConstants.LOG_FILENAME));
+=======
+    jobRoot = workspaceRoot.resolve(String.valueOf(JOB_ID)).resolve(String.valueOf(ATTEMPT_ID));
+>>>>>>> 798aa39d3 (fix)
+>>>>>>> b9f119fb2 (fix)
+=======
+>>>>>>> 16fc42bdc (clean)
 
     execution = mock(CheckedSupplier.class);
     mdcSetter = mock(BiConsumer.class);
@@ -96,9 +105,8 @@ class TemporalAttemptExecutionTest {
   void testThrowsCheckedException() throws Exception {
     when(execution.get()).thenThrow(new IOException());
 
-    final TemporalJobException actualException = assertThrows(TemporalJobException.class, () -> attemptExecution.get());
-    assertEquals(expectedException.getLogPath(), actualException.getLogPath());
-    assertEquals(IOException.class, actualException.getCause().getClass());
+    final CheckedExceptionWrapper actualException = assertThrows(CheckedExceptionWrapper.class, () -> attemptExecution.get());
+    assertEquals(IOException.class, CheckedExceptionWrapper.unwrap(actualException).getClass());
 
     verify(execution).get();
     verify(mdcSetter).accept(jobRoot, JOB_ID);
@@ -108,6 +116,11 @@ class TemporalAttemptExecutionTest {
   void testThrowsUnCheckedException() throws Exception {
     when(execution.get()).thenThrow(new IllegalArgumentException());
 
+<<<<<<< HEAD
+<<<<<<< HEAD
+    assertThrows(IllegalArgumentException.class, () -> attemptExecution.get());
+=======
+<<<<<<< HEAD
     final TemporalJobException actualException = assertThrows(TemporalJobException.class, () -> attemptExecution.get());
     assertEquals(expectedException.getLogPath(), actualException.getLogPath());
     assertEquals(IllegalArgumentException.class, actualException.getCause().getClass());
@@ -124,6 +137,13 @@ class TemporalAttemptExecutionTest {
     final TemporalJobException actualException = assertThrows(TemporalJobException.class, () -> attemptExecution.get());
     assertEquals(otherFilePath, actualException.getLogPath());
     assertNull(actualException.getCause());
+=======
+    assertThrows(IllegalArgumentException.class, () -> attemptExecution.get());
+>>>>>>> 798aa39d3 (fix)
+>>>>>>> b9f119fb2 (fix)
+=======
+    assertThrows(IllegalArgumentException.class, () -> attemptExecution.get());
+>>>>>>> 16fc42bdc (clean)
 
     verify(execution).get();
     verify(mdcSetter).accept(jobRoot, JOB_ID);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
@@ -24,6 +24,11 @@
 
 package io.airbyte.workers.temporal;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,9 +44,16 @@ import io.airbyte.config.StandardSyncInput;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.workers.WorkerConstants;
 import io.temporal.client.WorkflowClient;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.UUID;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class TemporalClientTest {
@@ -65,82 +77,125 @@ class TemporalClientTest {
 
   private WorkflowClient workflowClient;
   private TemporalClient temporalClient;
+  private Path logPath;
 
   @BeforeEach
-  void setup() {
+  void setup() throws IOException {
+    final Path workspaceRoot = Files.createTempDirectory(Path.of("/tmp"), "temporal_client_test");
+    logPath = workspaceRoot.resolve(String.valueOf(JOB_ID)).resolve(String.valueOf(ATTEMPT_ID)).resolve(WorkerConstants.LOG_FILENAME);
     workflowClient = mock(WorkflowClient.class);
-    temporalClient = new TemporalClient(workflowClient);
+    temporalClient = new TemporalClient(workflowClient, workspaceRoot);
   }
 
-  @Test
-  void testSubmitGetSpec() throws TemporalJobException {
-    final SpecWorkflow specWorkflow = mock(SpecWorkflow.class);
-    when(workflowClient.newWorkflowStub(SpecWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.GET_SPEC))).thenReturn(specWorkflow);
-    final JobGetSpecConfig getSpecConfig = new JobGetSpecConfig().withDockerImage(IMAGE_NAME1);
+  @Nested
+  @DisplayName("Test execute method.")
+  class ExecuteJob {
 
-    temporalClient.submitGetSpec(JOB_UUID, ATTEMPT_ID, getSpecConfig);
-    specWorkflow.run(JOB_RUN_CONFIG, UUID_LAUNCHER_CONFIG);
-    verify(workflowClient).newWorkflowStub(SpecWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.GET_SPEC));
+    @SuppressWarnings("unchecked")
+    @Test
+    void testExecute() {
+      final Supplier<String> supplier = mock(Supplier.class);
+      when(supplier.get()).thenReturn("hello");
+
+      final TemporalResponse<String> response = temporalClient.execute(JOB_RUN_CONFIG, supplier);
+
+      assertNotNull(response);
+      assertEquals("hello", response.getOutput());
+      assertTrue(response.getMetadata().isSucceeded());
+      assertEquals(logPath, response.getMetadata().getLogPath());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void testExecuteWithException() {
+      final Supplier<String> supplier = mock(Supplier.class);
+      when(supplier.get()).thenThrow(IllegalStateException.class);
+
+      final TemporalResponse<String> response = temporalClient.execute(JOB_RUN_CONFIG, supplier);
+
+      assertNotNull(response);
+      assertNull(response.getOutput());
+      assertFalse(response.getMetadata().isSucceeded());
+      assertEquals(logPath, response.getMetadata().getLogPath());
+    }
+
   }
 
-  @Test
-  void testSubmitCheckConnection() throws TemporalJobException {
-    final CheckConnectionWorkflow checkConnectionWorkflow = mock(CheckConnectionWorkflow.class);
-    when(workflowClient.newWorkflowStub(CheckConnectionWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.CHECK_CONNECTION)))
-        .thenReturn(checkConnectionWorkflow);
-    final JobCheckConnectionConfig checkConnectionConfig = new JobCheckConnectionConfig()
-        .withDockerImage(IMAGE_NAME1)
-        .withConnectionConfiguration(Jsons.emptyObject());
-    final StandardCheckConnectionInput input = new StandardCheckConnectionInput()
-        .withConnectionConfiguration(checkConnectionConfig.getConnectionConfiguration());
+  @Nested
+  @DisplayName("Test job creation for each configuration type.")
+  class TestJobSubmission {
 
-    temporalClient.submitCheckConnection(JOB_UUID, ATTEMPT_ID, checkConnectionConfig);
-    checkConnectionWorkflow.run(JOB_RUN_CONFIG, UUID_LAUNCHER_CONFIG, input);
-    verify(workflowClient).newWorkflowStub(CheckConnectionWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.CHECK_CONNECTION));
-  }
+    @Test
+    void testSubmitGetSpec() {
+      final SpecWorkflow specWorkflow = mock(SpecWorkflow.class);
+      when(workflowClient.newWorkflowStub(SpecWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.GET_SPEC))).thenReturn(specWorkflow);
+      final JobGetSpecConfig getSpecConfig = new JobGetSpecConfig().withDockerImage(IMAGE_NAME1);
 
-  @Test
-  void testSubmitDiscoverSchema() throws TemporalJobException {
-    final DiscoverCatalogWorkflow discoverCatalogWorkflow = mock(DiscoverCatalogWorkflow.class);
-    when(workflowClient.newWorkflowStub(DiscoverCatalogWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.DISCOVER_SCHEMA)))
-        .thenReturn(discoverCatalogWorkflow);
-    final JobDiscoverCatalogConfig checkConnectionConfig = new JobDiscoverCatalogConfig()
-        .withDockerImage(IMAGE_NAME1)
-        .withConnectionConfiguration(Jsons.emptyObject());
-    final StandardDiscoverCatalogInput input = new StandardDiscoverCatalogInput()
-        .withConnectionConfiguration(checkConnectionConfig.getConnectionConfiguration());
+      temporalClient.submitGetSpec(JOB_UUID, ATTEMPT_ID, getSpecConfig);
+      specWorkflow.run(JOB_RUN_CONFIG, UUID_LAUNCHER_CONFIG);
+      verify(workflowClient).newWorkflowStub(SpecWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.GET_SPEC));
+    }
 
-    temporalClient.submitDiscoverSchema(JOB_UUID, ATTEMPT_ID, checkConnectionConfig);
-    discoverCatalogWorkflow.run(JOB_RUN_CONFIG, UUID_LAUNCHER_CONFIG, input);
-    verify(workflowClient).newWorkflowStub(DiscoverCatalogWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.DISCOVER_SCHEMA));
-  }
+    @Test
+    void testSubmitCheckConnection() {
+      final CheckConnectionWorkflow checkConnectionWorkflow = mock(CheckConnectionWorkflow.class);
+      when(workflowClient.newWorkflowStub(CheckConnectionWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.CHECK_CONNECTION)))
+          .thenReturn(checkConnectionWorkflow);
+      final JobCheckConnectionConfig checkConnectionConfig = new JobCheckConnectionConfig()
+          .withDockerImage(IMAGE_NAME1)
+          .withConnectionConfiguration(Jsons.emptyObject());
+      final StandardCheckConnectionInput input = new StandardCheckConnectionInput()
+          .withConnectionConfiguration(checkConnectionConfig.getConnectionConfiguration());
 
-  @Test
-  void testSubmitSync() throws TemporalJobException {
-    final SyncWorkflow discoverCatalogWorkflow = mock(SyncWorkflow.class);
-    when(workflowClient.newWorkflowStub(SyncWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.SYNC)))
-        .thenReturn(discoverCatalogWorkflow);
-    final JobSyncConfig syncConfig = new JobSyncConfig()
-        .withSourceDockerImage(IMAGE_NAME1)
-        .withSourceDockerImage(IMAGE_NAME2)
-        .withSourceConfiguration(Jsons.emptyObject())
-        .withDestinationConfiguration(Jsons.emptyObject())
-        .withConfiguredAirbyteCatalog(new ConfiguredAirbyteCatalog());
-    final StandardSyncInput input = new StandardSyncInput()
-        .withPrefix(syncConfig.getPrefix())
-        .withSourceConfiguration(syncConfig.getSourceConfiguration())
-        .withDestinationConfiguration(syncConfig.getDestinationConfiguration())
-        .withCatalog(syncConfig.getConfiguredAirbyteCatalog())
-        .withState(syncConfig.getState());
+      temporalClient.submitCheckConnection(JOB_UUID, ATTEMPT_ID, checkConnectionConfig);
+      checkConnectionWorkflow.run(JOB_RUN_CONFIG, UUID_LAUNCHER_CONFIG, input);
+      verify(workflowClient).newWorkflowStub(CheckConnectionWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.CHECK_CONNECTION));
+    }
 
-    final IntegrationLauncherConfig destinationLauncherConfig = new IntegrationLauncherConfig()
-        .withJobId(String.valueOf(JOB_ID))
-        .withAttemptId((long) ATTEMPT_ID)
-        .withDockerImage(IMAGE_NAME2);
+    @Test
+    void testSubmitDiscoverSchema() {
+      final DiscoverCatalogWorkflow discoverCatalogWorkflow = mock(DiscoverCatalogWorkflow.class);
+      when(workflowClient.newWorkflowStub(DiscoverCatalogWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.DISCOVER_SCHEMA)))
+          .thenReturn(discoverCatalogWorkflow);
+      final JobDiscoverCatalogConfig checkConnectionConfig = new JobDiscoverCatalogConfig()
+          .withDockerImage(IMAGE_NAME1)
+          .withConnectionConfiguration(Jsons.emptyObject());
+      final StandardDiscoverCatalogInput input = new StandardDiscoverCatalogInput()
+          .withConnectionConfiguration(checkConnectionConfig.getConnectionConfiguration());
 
-    temporalClient.submitSync(JOB_ID, ATTEMPT_ID, syncConfig);
-    discoverCatalogWorkflow.run(JOB_RUN_CONFIG, LAUNCHER_CONFIG, destinationLauncherConfig, input);
-    verify(workflowClient).newWorkflowStub(SyncWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.SYNC));
+      temporalClient.submitDiscoverSchema(JOB_UUID, ATTEMPT_ID, checkConnectionConfig);
+      discoverCatalogWorkflow.run(JOB_RUN_CONFIG, UUID_LAUNCHER_CONFIG, input);
+      verify(workflowClient).newWorkflowStub(DiscoverCatalogWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.DISCOVER_SCHEMA));
+    }
+
+    @Test
+    void testSubmitSync() {
+      final SyncWorkflow discoverCatalogWorkflow = mock(SyncWorkflow.class);
+      when(workflowClient.newWorkflowStub(SyncWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.SYNC)))
+          .thenReturn(discoverCatalogWorkflow);
+      final JobSyncConfig syncConfig = new JobSyncConfig()
+          .withSourceDockerImage(IMAGE_NAME1)
+          .withSourceDockerImage(IMAGE_NAME2)
+          .withSourceConfiguration(Jsons.emptyObject())
+          .withDestinationConfiguration(Jsons.emptyObject())
+          .withConfiguredAirbyteCatalog(new ConfiguredAirbyteCatalog());
+      final StandardSyncInput input = new StandardSyncInput()
+          .withPrefix(syncConfig.getPrefix())
+          .withSourceConfiguration(syncConfig.getSourceConfiguration())
+          .withDestinationConfiguration(syncConfig.getDestinationConfiguration())
+          .withCatalog(syncConfig.getConfiguredAirbyteCatalog())
+          .withState(syncConfig.getState());
+
+      final IntegrationLauncherConfig destinationLauncherConfig = new IntegrationLauncherConfig()
+          .withJobId(String.valueOf(JOB_ID))
+          .withAttemptId((long) ATTEMPT_ID)
+          .withDockerImage(IMAGE_NAME2);
+
+      temporalClient.submitSync(JOB_ID, ATTEMPT_ID, syncConfig);
+      discoverCatalogWorkflow.run(JOB_RUN_CONFIG, LAUNCHER_CONFIG, destinationLauncherConfig, input);
+      verify(workflowClient).newWorkflowStub(SyncWorkflow.class, TemporalUtils.getWorkflowOptions(TemporalJobType.SYNC));
+    }
+
   }
 
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
@@ -27,7 +27,6 @@ package io.airbyte.workers.temporal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -100,7 +99,8 @@ class TemporalClientTest {
       final TemporalResponse<String> response = temporalClient.execute(JOB_RUN_CONFIG, supplier);
 
       assertNotNull(response);
-      assertEquals("hello", response.getOutput());
+      assertTrue(response.getOutput().isPresent());
+      assertEquals("hello", response.getOutput().get());
       assertTrue(response.getMetadata().isSucceeded());
       assertEquals(logPath, response.getMetadata().getLogPath());
     }
@@ -114,7 +114,7 @@ class TemporalClientTest {
       final TemporalResponse<String> response = temporalClient.execute(JOB_RUN_CONFIG, supplier);
 
       assertNotNull(response);
-      assertNull(response.getOutput());
+      assertFalse(response.getOutput().isPresent());
       assertFalse(response.getMetadata().isSucceeded());
       assertEquals(logPath, response.getMetadata().getLogPath());
     }


### PR DESCRIPTION
Addresses issue mentioned [here](https://airbytehq.slack.com/archives/C019WEENQRM/p1616169199039400).

## What
We misunderstood check exception handling in Temporal. Turns out that you can't throw an exception from a Temporal workflow and then deserialize it on the client side (even if that exception is serializable). We were relying on this for passing the log path in the case of failure. 
 
It may be for the best that this is the case anyway, because we really want to always have access to the log path (regardless of success or failure). Relying on the exception made this only possible in some cases.

## How
Just as we have a SynchronousJobResponse, have the `TemporalClient` wrap return values in a `TemporalResponse`. This wrapping object includes whether or not the job succeeded and the log path.

## Follow up
Our handling of log paths is still really bad. The source of truth for these paths is usually defined in 2 places (client and in the temporal workflow). We reduce the risk right now by using the same helper, but this is just a stop gap. We either need to commit to passing log paths into Temporal workflows or we need Temporal workflows to create them when they receive a new job and make them accessible to the client (regardless of success or failure). See open issues on this topic: [issue 1](https://github.com/airbytehq/airbyte/issues/2175), [issue 2](https://github.com/airbytehq/airbyte/issues/2386)

## Recommended reading order
1. `TemporalClient.java`
1. the rest

A majority of the changes are just wrapping objects in the response time instead of handling it via catching checked exceptions. As part of this TemporalJobException is now completely gone.
