### PR TITLE
fix file clean up for BigQueue

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
@@ -37,7 +37,7 @@ import io.airbyte.integrations.base.AirbyteStreamNameNamespacePair;
 import io.airbyte.integrations.base.FailureTrackingAirbyteMessageConsumer;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
-import io.airbyte.queue.BigQueue;
+import io.airbyte.queue.OnDiskQueue;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -121,7 +121,7 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
     for (AirbyteStreamNameNamespacePair pair : pairs) {
       LOGGER.info("Buffer creation for stream {}.", pair);
       try {
-        final BigQueue writeBuffer = new BigQueue(queueRoot.resolve(pair.getName()), pair.getName());
+        final OnDiskQueue writeBuffer = new OnDiskQueue(queueRoot.resolve(pair.getName()), pair.getName());
         pairToWriteBuffer.put(pair, writeBuffer);
       } catch (Exception e) {
         LOGGER.error("Error creating buffer: ", e);
@@ -143,7 +143,6 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
     Preconditions.checkState(hasStarted, "Cannot accept records until consumer has started");
 
     // ignore other message types.
-    final String streamName = message.getStream();
     final AirbyteStreamNameNamespacePair pair = AirbyteStreamNameNamespacePair.fromRecordMessage(message);
     if (!pairs.contains(pair)) {
       throw new IllegalArgumentException(

--- a/airbyte-queue/src/main/java/io/airbyte/queue/BigQueue.java
+++ b/airbyte-queue/src/main/java/io/airbyte/queue/BigQueue.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 import java.util.AbstractQueue;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.io.FileUtils;
 
 /**
  * Wraps BigQueueImpl behind Airbyte persistent queue interface. BigQueueImpl is threadsafe.
@@ -42,8 +43,10 @@ public class BigQueue extends AbstractQueue<byte[]> implements CloseableQueue<by
 
   private final IBigQueue queue;
   private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final Path persistencePath;
 
   public BigQueue(Path persistencePath, String queueName) throws IOException {
+    this.persistencePath = persistencePath;
     queue = new BigQueueImpl(persistencePath.toString(), queueName);
   }
 
@@ -105,10 +108,15 @@ public class BigQueue extends AbstractQueue<byte[]> implements CloseableQueue<by
   @Override
   public void close() throws Exception {
     closed.set(true);
-    // todo (cgardens) - this barfs out a huge warning. known issue with the lib:
-    // https://github.com/bulldog2011/bigqueue/issues/35.
-    queue.close();
-    queue.gc();
+    try {
+      // todo (cgardens) - this barfs out a huge warning. known issue with the lib:
+      // https://github.com/bulldog2011/bigqueue/issues/35.
+      // deallocates memory used by bigqueue
+      queue.close();
+    } finally {
+      // deletes all data files.
+      FileUtils.deleteQuietly(persistencePath.toFile());
+    }
   }
 
 }

--- a/airbyte-queue/src/main/java/io/airbyte/queue/OnDiskQueue.java
+++ b/airbyte-queue/src/main/java/io/airbyte/queue/OnDiskQueue.java
@@ -37,15 +37,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.io.FileUtils;
 
 /**
+ * This Queue should be used when it is possible for the contents of the queue to be greater than
+ * the size of memory. It is meant for use by a single process. Closing this queue deletes the data
+ * on disk. It is NOT meant to be a long-lived, persistent queue.
+ *
  * Wraps BigQueueImpl behind Airbyte persistent queue interface. BigQueueImpl is threadsafe.
  */
-public class BigQueue extends AbstractQueue<byte[]> implements CloseableQueue<byte[]> {
+public class OnDiskQueue extends AbstractQueue<byte[]> implements CloseableQueue<byte[]> {
 
   private final IBigQueue queue;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private final Path persistencePath;
 
-  public BigQueue(Path persistencePath, String queueName) throws IOException {
+  public OnDiskQueue(Path persistencePath, String queueName) throws IOException {
     this.persistencePath = persistencePath;
     queue = new BigQueueImpl(persistencePath.toString(), queueName);
   }


### PR DESCRIPTION
## What
While reading through our usage of BigQueue, I realized that it might not clean up properly in error cases. `gc` only deletes "used" files. So in an error case where some of the underlying files haven't been consumed yet from the queue, then they would not be deleted.

## How
Replace it by blowing away the entire persistence layer. If we ever want to use BigQueue to persist data across processes, then we will need to rethink it, but the way we are wrapping it now this should be safe.
