### PR TITLE
add --init to docker run

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessBuilderFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessBuilderFactory.java
@@ -89,6 +89,7 @@ public class DockerProcessBuilderFactory implements ProcessBuilderFactory {
             "docker",
             "run",
             "--rm",
+            "--init",
             "-i",
             "-v",
             String.format("%s:%s", workspaceMountSource, DATA_MOUNT_DESTINATION),


### PR DESCRIPTION
While doing the final round of manual testing on the cancellation API on real sources (not just loops I was setting up), I noticed that while the `docker run` process that was running on `airbyte-scheduler` would always get killed, in some cases for sources the underlying container would not get killed.

Here's discussion on this: 
https://github.com/moby/moby/issues/2838#issuecomment-394131408

This change fixes the behavior and means that `process.destroy()` will actually destroy the underlying container. (Btw, this also means timeouts weren't actually working properly before.)

I'm putting this in a separate PR since it seems like a pretty wide-reaching but low-impact change.