### PR TITLE
Source Hubspot: hotfix client tests

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/36c891d9-4bd9-43ac-bad2-10e12756272c.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/36c891d9-4bd9-43ac-bad2-10e12756272c.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "36c891d9-4bd9-43ac-bad2-10e12756272c",
   "name": "Hubspot",
   "dockerRepository": "airbyte/source-hubspot",
-  "dockerImageTag": "0.1.0",
+  "dockerImageTag": "0.1.1",
   "documentationUrl": "https://https://docs.airbyte.io/integrations/sources/hubspot"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -81,7 +81,7 @@
 - sourceDefinitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
   name: Hubspot
   dockerRepository: airbyte/source-hubspot
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   documentationUrl: https://https://docs.airbyte.io/integrations/sources/hubspot
 - sourceDefinitionId: b1892b11-788d-44bd-b9ec-3a436f7b54ce
   name: Shopify

--- a/airbyte-integrations/connectors/source-hubspot/Dockerfile
+++ b/airbyte-integrations/connectors/source-hubspot/Dockerfile
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install ".[main]"
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-hubspot

--- a/airbyte-integrations/connectors/source-hubspot/integration_tests/client_test.py
+++ b/airbyte-integrations/connectors/source-hubspot/integration_tests/client_test.py
@@ -29,7 +29,7 @@ from source_hubspot.errors import HubspotInvalidAuth
 
 @pytest.fixture(name="wrong_credentials")
 def wrong_credentials_fixture():
-    return {"api_key": "wrong_key"}
+    return {"api_key": "wrongkey-key1-key2-key3-wrongkey1234"}
 
 
 def test__health_check_with_wrong_token(wrong_credentials):

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/api.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/api.py
@@ -34,6 +34,11 @@ import pendulum as pendulum
 import requests
 from base_python.entrypoint import logger
 from source_hubspot.errors import HubspotAccessDenied, HubspotInvalidAuth, HubspotRateLimited, HubspotTimeout
+from http import HTTPStatus
+
+
+# we got this when provided API Token has incorrect format
+CLOUDFLARE_ORIGIN_DNS_ERROR = 530
 
 
 def retry_connection_handler(**kwargs):
@@ -47,7 +52,7 @@ def retry_connection_handler(**kwargs):
     def giveup_handler(exc):
         if isinstance(exc, (HubspotInvalidAuth, HubspotAccessDenied)):
             return True
-        return exc.response is not None and 400 <= exc.response.status_code < 500
+        return exc.response is not None and HTTPStatus.BAD_REQUEST <= exc.response.status_code < HTTPStatus.INTERNAL_SERVER_ERROR
 
     return backoff.on_exception(
         backoff.expo,
@@ -107,7 +112,7 @@ class API:
         }
 
         resp = requests.post(self.BASE_URL + "/oauth/v1/token", data=payload)
-        if resp.status_code == 403:
+        if resp.status_code == HTTPStatus.FORBIDDEN:
             raise HubspotInvalidAuth(resp.content, response=resp)
 
         resp.raise_for_status()
@@ -147,21 +152,21 @@ class API:
     def _parse_and_handle_errors(response) -> Union[MutableMapping[str, Any], List[MutableMapping[str, Any]]]:
         """Handle response"""
         message = "Unknown error"
-        if response.headers.get("content-type") == "application/json;charset=utf-8" and response.status_code != 200:
+        if response.headers.get("content-type") == "application/json;charset=utf-8" and response.status_code != HTTPStatus.OK:
             message = response.json().get("message")
 
-        if response.status_code == 403:
+        if response.status_code == HTTPStatus.FORBIDDEN:
             raise HubspotAccessDenied(message, response=response)
-        elif response.status_code in (401, 530):
+        elif response.status_code in (HTTPStatus.UNAUTHORIZED, CLOUDFLARE_ORIGIN_DNS_ERROR):
             raise HubspotInvalidAuth(message, response=response)
-        elif response.status_code == 429:
+        elif response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
             retry_after = response.headers.get("Retry-After")
             raise HubspotRateLimited(
                 f"429 Rate Limit Exceeded: API rate-limit has been reached until {retry_after} seconds."
                 " See https://developers.hubspot.com/docs/api/usage-details",
                 response=response,
             )
-        elif response.status_code in (502, 504):
+        elif response.status_code in (HTTPStatus.BAD_GATEWAY, HTTPStatus.SERVICE_UNAVAILABLE):
             raise HubspotTimeout(message, response=response)
         else:
             response.raise_for_status()

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/api.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/api.py
@@ -152,7 +152,7 @@ class API:
 
         if response.status_code == 403:
             raise HubspotAccessDenied(message, response=response)
-        elif response.status_code == 401:
+        elif response.status_code in (401, 530):
             raise HubspotInvalidAuth(message, response=response)
         elif response.status_code == 429:
             retry_after = response.headers.get("Retry-After")

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/api.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/api.py
@@ -27,6 +27,7 @@ import time
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from functools import partial
+from http import HTTPStatus
 from typing import Any, Callable, Iterable, Iterator, List, Mapping, MutableMapping, Optional, Union
 
 import backoff
@@ -34,8 +35,6 @@ import pendulum as pendulum
 import requests
 from base_python.entrypoint import logger
 from source_hubspot.errors import HubspotAccessDenied, HubspotInvalidAuth, HubspotRateLimited, HubspotTimeout
-from http import HTTPStatus
-
 
 # we got this when provided API Token has incorrect format
 CLOUDFLARE_ORIGIN_DNS_ERROR = 530

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/client.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/client.py
@@ -26,6 +26,7 @@ from typing import Any, Iterator, Mapping, Tuple
 
 from airbyte_protocol import AirbyteStream
 from base_python import BaseClient
+from requests import HTTPError
 from source_hubspot.api import (
     API,
     CampaignStream,
@@ -39,7 +40,6 @@ from source_hubspot.api import (
     SubscriptionChangeStream,
     WorkflowStream,
 )
-from requests import HTTPError
 
 
 class Client(BaseClient):

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/client.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/client.py
@@ -39,7 +39,7 @@ from source_hubspot.api import (
     SubscriptionChangeStream,
     WorkflowStream,
 )
-from source_hubspot.errors import HubspotError
+from requests import HTTPError
 
 
 class Client(BaseClient):
@@ -102,7 +102,7 @@ class Client(BaseClient):
 
         try:
             _ = self._apis["contacts"].properties
-        except HubspotError as error:
+        except HTTPError as error:
             alive = False
             error_msg = repr(error)
 


### PR DESCRIPTION
## What
It seems that Cloudflare enforced minimal length for hapikey parameter, this causes our custom integration test to fail.

## How
Improved fallback and health_check logic as well.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `test.java`
1. `component.ts`
1. the rest
