### PR TITLE
separate the retrieval of incremental and full refresh streams in the jdbc abstract source

### DIFF
--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -26,6 +26,7 @@ package io.airbyte.integrations.source.jdbc;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.json.Jsons;
@@ -57,6 +58,7 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -67,6 +69,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -163,30 +166,77 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
             .stream()
             .collect(Collectors.toMap(t -> String.format("%s.%s", t.getSchemaName(), t.getName()), Function.identity()));
 
-    final List<AutoCloseableIterator<AirbyteMessage>> iteratorList = new ArrayList<>();
-
-    for (final ConfiguredAirbyteStream airbyteStream : catalog.getStreams()) {
-      final String streamName = airbyteStream.getStream().getName();
-      if (!tableNameToTable.containsKey(streamName)) {
-        LOGGER.info("Skipping stream {} because it is not in the source", streamName);
-        continue;
-      }
-
-      final TableInfoInternal table = tableNameToTable.get(streamName);
-      final AutoCloseableIterator<AirbyteMessage> tableReadIterator = createReadIterator(
-          database,
-          airbyteStream,
-          table,
-          stateManager,
-          emittedAt);
-      iteratorList.add(tableReadIterator);
-    }
+    final List<AutoCloseableIterator<AirbyteMessage>> incrementalIterators = getIncrementalIterators(database, catalog, tableNameToTable, stateManager, emittedAt);
+    final List<AutoCloseableIterator<AirbyteMessage>> fullRefreshIterators = getFullRefreshIterators(database, catalog, tableNameToTable, stateManager, emittedAt);
+    final List<AutoCloseableIterator<AirbyteMessage>> iteratorList = Stream.of(incrementalIterators, fullRefreshIterators)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
 
     return AutoCloseableIterators.appendOnClose(AutoCloseableIterators.concatWithEagerClose(iteratorList), () -> {
       LOGGER.info("Closing database connection pool.");
       Exceptions.toRuntime(database::close);
       LOGGER.info("Closed database connection pool.");
     });
+  }
+
+  public List<AutoCloseableIterator<AirbyteMessage>> getIncrementalIterators(JdbcDatabase database,
+                                                                             ConfiguredAirbyteCatalog catalog,
+                                                                             Map<String, TableInfoInternal> tableNameToTable,
+                                                                             JdbcStateManager stateManager,
+                                                                             Instant emittedAt) {
+    return getSelectedIterators(
+            database,
+            catalog,
+            tableNameToTable,
+            stateManager,
+            emittedAt,
+            cac -> cac.getSyncMode().equals(SyncMode.INCREMENTAL)
+    );
+  }
+
+  public List<AutoCloseableIterator<AirbyteMessage>> getFullRefreshIterators(JdbcDatabase database,
+                                                                             ConfiguredAirbyteCatalog catalog,
+                                                                             Map<String, TableInfoInternal> tableNameToTable,
+                                                                             JdbcStateManager stateManager,
+                                                                             Instant emittedAt) {
+    return getSelectedIterators(
+            database,
+            catalog,
+            tableNameToTable,
+            stateManager,
+            emittedAt,
+            cac -> cac.getSyncMode().equals(SyncMode.FULL_REFRESH)
+    );
+  }
+
+  private List<AutoCloseableIterator<AirbyteMessage>> getSelectedIterators(JdbcDatabase database,
+                                                                           ConfiguredAirbyteCatalog catalog,
+                                                                           Map<String, TableInfoInternal> tableNameToTable,
+                                                                           JdbcStateManager stateManager,
+                                                                           Instant emittedAt,
+                                                                           Predicate<ConfiguredAirbyteStream> selector) {
+    final List<AutoCloseableIterator<AirbyteMessage>> iteratorList = new ArrayList<>();
+
+    for (final ConfiguredAirbyteStream airbyteStream : catalog.getStreams()) {
+      if(selector.test(airbyteStream)) {
+        final String streamName = airbyteStream.getStream().getName();
+        if (!tableNameToTable.containsKey(streamName)) {
+          LOGGER.info("Skipping stream {} because it is not in the source", streamName);
+          continue;
+        }
+
+        final TableInfoInternal table = tableNameToTable.get(streamName);
+        final AutoCloseableIterator<AirbyteMessage> tableReadIterator = createReadIterator(
+                database,
+                airbyteStream,
+                table,
+                stateManager,
+                emittedAt);
+        iteratorList.add(tableReadIterator);
+      }
+    }
+
+    return iteratorList;
   }
 
   private AutoCloseableIterator<AirbyteMessage> createReadIterator(JdbcDatabase database,

--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -191,7 +191,7 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
         tableNameToTable,
         stateManager,
         emittedAt,
-        cac -> cac.getSyncMode().equals(SyncMode.INCREMENTAL));
+        configuredStream -> configuredStream.getSyncMode().equals(SyncMode.INCREMENTAL));
   }
 
   public List<AutoCloseableIterator<AirbyteMessage>> getFullRefreshIterators(JdbcDatabase database,
@@ -205,7 +205,7 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
         tableNameToTable,
         stateManager,
         emittedAt,
-        cac -> cac.getSyncMode().equals(SyncMode.FULL_REFRESH));
+        configuredStream -> configuredStream.getSyncMode().equals(SyncMode.FULL_REFRESH));
   }
 
   private List<AutoCloseableIterator<AirbyteMessage>> getSelectedIterators(JdbcDatabase database,

--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -26,7 +26,6 @@ package io.airbyte.integrations.source.jdbc;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.json.Jsons;
@@ -166,11 +165,13 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
             .stream()
             .collect(Collectors.toMap(t -> String.format("%s.%s", t.getSchemaName(), t.getName()), Function.identity()));
 
-    final List<AutoCloseableIterator<AirbyteMessage>> incrementalIterators = getIncrementalIterators(database, catalog, tableNameToTable, stateManager, emittedAt);
-    final List<AutoCloseableIterator<AirbyteMessage>> fullRefreshIterators = getFullRefreshIterators(database, catalog, tableNameToTable, stateManager, emittedAt);
+    final List<AutoCloseableIterator<AirbyteMessage>> incrementalIterators =
+        getIncrementalIterators(database, catalog, tableNameToTable, stateManager, emittedAt);
+    final List<AutoCloseableIterator<AirbyteMessage>> fullRefreshIterators =
+        getFullRefreshIterators(database, catalog, tableNameToTable, stateManager, emittedAt);
     final List<AutoCloseableIterator<AirbyteMessage>> iteratorList = Stream.of(incrementalIterators, fullRefreshIterators)
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList());
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
 
     return AutoCloseableIterators.appendOnClose(AutoCloseableIterators.concatWithEagerClose(iteratorList), () -> {
       LOGGER.info("Closing database connection pool.");
@@ -185,13 +186,12 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
                                                                              JdbcStateManager stateManager,
                                                                              Instant emittedAt) {
     return getSelectedIterators(
-            database,
-            catalog,
-            tableNameToTable,
-            stateManager,
-            emittedAt,
-            cac -> cac.getSyncMode().equals(SyncMode.INCREMENTAL)
-    );
+        database,
+        catalog,
+        tableNameToTable,
+        stateManager,
+        emittedAt,
+        cac -> cac.getSyncMode().equals(SyncMode.INCREMENTAL));
   }
 
   public List<AutoCloseableIterator<AirbyteMessage>> getFullRefreshIterators(JdbcDatabase database,
@@ -200,13 +200,12 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
                                                                              JdbcStateManager stateManager,
                                                                              Instant emittedAt) {
     return getSelectedIterators(
-            database,
-            catalog,
-            tableNameToTable,
-            stateManager,
-            emittedAt,
-            cac -> cac.getSyncMode().equals(SyncMode.FULL_REFRESH)
-    );
+        database,
+        catalog,
+        tableNameToTable,
+        stateManager,
+        emittedAt,
+        cac -> cac.getSyncMode().equals(SyncMode.FULL_REFRESH));
   }
 
   private List<AutoCloseableIterator<AirbyteMessage>> getSelectedIterators(JdbcDatabase database,
@@ -218,7 +217,7 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
     final List<AutoCloseableIterator<AirbyteMessage>> iteratorList = new ArrayList<>();
 
     for (final ConfiguredAirbyteStream airbyteStream : catalog.getStreams()) {
-      if(selector.test(airbyteStream)) {
+      if (selector.test(airbyteStream)) {
         final String streamName = airbyteStream.getStream().getName();
         if (!tableNameToTable.containsKey(streamName)) {
           LOGGER.info("Skipping stream {} because it is not in the source", streamName);
@@ -227,11 +226,11 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
 
         final TableInfoInternal table = tableNameToTable.get(streamName);
         final AutoCloseableIterator<AirbyteMessage> tableReadIterator = createReadIterator(
-                database,
-                airbyteStream,
-                table,
-                stateManager,
-                emittedAt);
+            database,
+            airbyteStream,
+            table,
+            stateManager,
+            emittedAt);
         iteratorList.add(tableReadIterator);
       }
     }

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -63,7 +63,7 @@ public class CatalogHelpers {
   }
 
   public static ConfiguredAirbyteStream createConfiguredAirbyteStream(String streamName, List<Field> fields) {
-    return new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(streamName).withJsonSchema(fieldsToJsonSchema(fields)));
+    return new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(streamName).withJsonSchema(fieldsToJsonSchema(fields))).withSyncMode(SyncMode.FULL_REFRESH);
   }
 
   public static ConfiguredAirbyteStream createIncrementalConfiguredAirbyteStream(

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -63,7 +63,8 @@ public class CatalogHelpers {
   }
 
   public static ConfiguredAirbyteStream createConfiguredAirbyteStream(String streamName, List<Field> fields) {
-    return new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(streamName).withJsonSchema(fieldsToJsonSchema(fields))).withSyncMode(SyncMode.FULL_REFRESH);
+    return new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(streamName).withJsonSchema(fieldsToJsonSchema(fields)))
+        .withSyncMode(SyncMode.FULL_REFRESH);
   }
 
   public static ConfiguredAirbyteStream createIncrementalConfiguredAirbyteStream(

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
@@ -47,6 +47,7 @@ import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
+import io.airbyte.protocol.models.SyncMode;
 import io.airbyte.workers.WorkerConstants;
 import io.airbyte.workers.WorkerException;
 import io.airbyte.workers.process.IntegrationLauncher;
@@ -73,6 +74,7 @@ class DefaultAirbyteSourceTest {
   private static final ConfiguredAirbyteCatalog CATALOG = new ConfiguredAirbyteCatalog()
       .withStreams(Collections.singletonList(
           new ConfiguredAirbyteStream()
+              .withSyncMode(SyncMode.FULL_REFRESH)
               .withStream(new AirbyteStream()
                   .withName("hudi:latest")
                   .withJsonSchema(CatalogHelpers.fieldsToJsonSchema(new Field(FIELD_NAME, Field.JsonSchemaPrimitive.STRING))))));


### PR DESCRIPTION
The purpose of this PR is to make it easy for downstream sources (Postgres, for example) to add override behavior for either incremental or full refresh iterators. The case in mind is to allow CDC to handle all of the incremental streams in a single iterator.