### PR TITLE
Fixed: typo in google sheets spec.json

### DIFF
--- a/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/spec.json
+++ b/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/spec.json
@@ -13,7 +13,7 @@
       },
       "credentials_json": {
         "type": "string",
-        "description": "The contents of the JSON service account key. See the <a href=\"https://docs.airbyte.io/integrations/sources/googlesheets\">docs</a> for more information on how to generate this key.",
+        "description": "The contents of the JSON service account key. See the <a href=\"https://docs.airbyte.io/integrations/sources/google-sheets\">docs</a> for more information on how to generate this key.",
         "airbyte_secret": true
       }
     }


### PR DESCRIPTION
## What
Google Sheets source `spec.json` has a typo in a link to docs

