### PR TITLE
fix build

### DIFF
--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WorkspacesHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WorkspacesHandlerTest.java
@@ -62,6 +62,7 @@ class WorkspacesHandlerTest {
   private StandardWorkspace workspace;
   private WorkspacesHandler workspacesHandler;
 
+  @SuppressWarnings("unchecked")
   @BeforeEach
   void setUp() {
     configRepository = mock(ConfigRepository.class);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalAttemptExecutionTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalAttemptExecutionTest.java
@@ -55,7 +55,6 @@ class TemporalAttemptExecutionTest {
 
   private CheckedSupplier<Worker<String, String>, Exception> execution;
   private BiConsumer<Path, String> mdcSetter;
-  private CheckedConsumer<Path, IOException> jobRootDirCreator;
 
   private TemporalAttemptExecution<String, String> attemptExecution;
 
@@ -64,20 +63,25 @@ class TemporalAttemptExecutionTest {
   void setup() throws IOException {
     final Path workspaceRoot = Files.createTempDirectory(Path.of("/tmp"), "temporal_attempt_execution_test");
     jobRoot = workspaceRoot.resolve(JOB_ID).resolve(String.valueOf(ATTEMPT_ID));
-    jobRoot = workspaceRoot.resolve(String.valueOf(JOB_ID)).resolve(String.valueOf(ATTEMPT_ID));
 
     execution = mock(CheckedSupplier.class);
     mdcSetter = mock(BiConsumer.class);
-    jobRootDirCreator = Files::createDirectories;
+    final CheckedConsumer<Path, IOException> jobRootDirCreator = Files::createDirectories;
 
-    attemptExecution = new TemporalAttemptExecution<>(workspaceRoot, JOB_RUN_CONFIG, execution, () -> "", mdcSetter, jobRootDirCreator,
+    attemptExecution = new TemporalAttemptExecution<>(
+        workspaceRoot,
+        JOB_RUN_CONFIG, execution,
+        () -> "",
+        mdcSetter,
+        jobRootDirCreator,
         mock(CancellationHandler.class), () -> "workflow_id");
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   void testSuccessfulSupplierRun() throws Exception {
     final String expected = "louis XVI";
-    Worker<String, String> worker = mock(Worker.class);
+    final Worker<String, String> worker = mock(Worker.class);
     when(worker.run(any(), any())).thenReturn(expected);
 
     when(execution.get()).thenAnswer((Answer<Worker<String, String>>) invocation -> worker);

--- a/build.gradle
+++ b/build.gradle
@@ -99,16 +99,16 @@ allprojects {
 
     afterEvaluate { project ->
         def composeDeps = [
-                "airbyte-config:init",
-                "airbyte-db",
-                "airbyte-migration",
-                "airbyte-scheduler:app",
-                "airbyte-server",
-                "airbyte-webapp",
+                ":airbyte-config:init",
+                ":airbyte-db",
+                ":airbyte-migration",
+                ":airbyte-scheduler:app",
+                ":airbyte-server",
+                ":airbyte-webapp",
         ].toSet().asImmutable()
 
-        if (project.name in composeDeps) {
-            composeBuild.dependsOn(project.tasks.assemble)
+        if (project.getPath() in composeDeps) {
+            composeBuild.dependsOn(project.getPath() + ':assemble')
         }
     }
 }


### PR DESCRIPTION
This is annoying because I swear we've run into this before. The issue is that `project.name` in gradle isn't the fully qualified path. For `airbyte-scheduler:app`, `project. name` is just `app`. To get the full name you need to do `project.getPath()` which returns `:airbyte-scheduler:app`. `airbyte-config:init` was set up wrong too, but because other things in composeBuild depend on it, the problem was hidden. 

This originally worked fine on my local machine because the order in which gradle was building the modules just happened to work out. It was revealed only in the CI.