### PR TITLE
close when hit max lsn

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/lang/Queues.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/lang/Queues.java
@@ -24,6 +24,7 @@
 
 package io.airbyte.commons.lang;
 
+import java.util.Queue;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.Consumer;
@@ -40,7 +41,7 @@ public class Queues {
    * @param <T> type provided by the queue
    * @return stream interface on top of the queue.
    */
-  public static <T> Stream<T> toStream(CloseableQueue<T> queue) {
+  public static <T> Stream<T> toStream(Queue<T> queue) {
     return StreamSupport.stream(new Spliterators.AbstractSpliterator<>(Long.MAX_VALUE, Spliterator.ORDERED) {
 
       @Override


### PR DESCRIPTION
## description
Augment the existing iterator that @jrhizor to know when it should end. Specifically when it hits the lsn that was was selected when the sync started, it should subsequently only return `hasNext => false`.

Likely this will get scrambled up a bit as we put our code together, but this is the rough outline.

## open question
Open question in the code on how we will be able to exact the LSN number.

## next steps
* Still need to figure out how we will extract the LSN from the database in the first place.