### PR TITLE
cdc add lsn extraction and comparison

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/concurrency/CloseableLinkedBlockingQueue.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/concurrency/CloseableLinkedBlockingQueue.java
@@ -22,13 +22,12 @@
  * SOFTWARE.
  */
 
-package io.airbyte.integrations.source.postgres;
+package io.airbyte.commons.concurrency;
 
 import io.airbyte.commons.lang.CloseableQueue;
-import io.airbyte.protocol.models.AirbyteMessage;
 import java.util.concurrent.LinkedBlockingQueue;
 
-public class CloseableLinkedBlockingQueue extends LinkedBlockingQueue<AirbyteMessage> implements CloseableQueue<AirbyteMessage> {
+public class CloseableLinkedBlockingQueue<T> extends LinkedBlockingQueue<T> implements CloseableQueue<T> {
 
   private final Runnable onClose;
 

--- a/airbyte-db/src/main/java/io/airbyte/db/PgLsn.java
+++ b/airbyte-db/src/main/java/io/airbyte/db/PgLsn.java
@@ -1,0 +1,104 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.db;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.nio.ByteBuffer;
+
+/**
+ * Doc on the structure of a Postgres LSN
+ * https://www.postgresql.org/docs/current/datatype-pg-lsn.html
+ */
+public class PgLsn implements Comparable<PgLsn> {
+
+  private final long lsn;
+
+  public static PgLsn fromLong(final long lsn) {
+    return new PgLsn(lsn);
+  }
+
+  public static PgLsn fromPgString(final String lsn) {
+    return new PgLsn(lsnToLong(lsn));
+  }
+
+  private PgLsn(final long lsn) {
+    this.lsn = lsn;
+  }
+
+  public long asLong() {
+    return lsn;
+  }
+
+  public String asPgString() {
+    return longToLsn(lsn);
+  }
+
+  @Override
+  public int compareTo(final PgLsn o) {
+    return Long.compare(lsn, o.asLong());
+  }
+
+  /**
+   * The LSN returned by Postgres is a 64-bit integer represented as hex encoded 32-bit integers
+   * separated by a /. reference: https://github.com/davecramer/LogicalDecode
+   *
+   * @param lsn string representation as returned by postgres
+   * @return long representation of the lsn string.
+   */
+  @VisibleForTesting
+  static long lsnToLong(String lsn) {
+    int slashIndex = lsn.lastIndexOf('/');
+    Preconditions.checkArgument(slashIndex >= 0);
+
+    String logicalXLogStr = lsn.substring(0, slashIndex);
+    // parses as a long but then cast to int. this allows us to retain the full 32 bits of the integer
+    // as opposed to the reduced value of Integer.MAX_VALUE.
+    int logicalXlog = (int) Long.parseLong(logicalXLogStr, 16);
+    String segmentStr = lsn.substring(slashIndex + 1, lsn.length());
+    int segment = (int) Long.parseLong(segmentStr, 16);
+
+    ByteBuffer buf = ByteBuffer.allocate(8);
+    buf.putInt(logicalXlog);
+    buf.putInt(segment);
+    buf.position(0);
+    return buf.getLong();
+  }
+
+  @VisibleForTesting
+  static String longToLsn(long long1) {
+    int front = (int) (long1 >> 32);
+    int back = (int) long1;
+    return (Integer.toHexString(front) + "/" + Integer.toHexString(back)).toUpperCase();
+  }
+
+  @Override
+  public String toString() {
+    return "PgLsn{" +
+        "lsn=" + lsn +
+        '}';
+  }
+
+}

--- a/airbyte-db/src/main/java/io/airbyte/db/PostgresUtils.java
+++ b/airbyte-db/src/main/java/io/airbyte/db/PostgresUtils.java
@@ -28,52 +28,18 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.db.jdbc.JdbcUtils;
-import java.nio.ByteBuffer;
 import java.sql.SQLException;
 import java.util.List;
 
 public class PostgresUtils {
 
-  public static String getLsn(JdbcDatabase database) throws SQLException {
+  public static PgLsn getLsn(JdbcDatabase database) throws SQLException {
     // pg version > 9.
     final List<JsonNode> jsonNodes = database
         .bufferedResultSetQuery(conn -> conn.createStatement().executeQuery("SELECT pg_current_wal_lsn()"), JdbcUtils::rowToJson);
 
     Preconditions.checkState(jsonNodes.size() == 1);
-    return jsonNodes.get(0).get("pg_current_wal_lsn").asText();
-  }
-
-  // https://www.postgresql.org/docs/current/datatype-pg-lsn.html
-  public static int compareLsns(String lsn1, String lsn2) {
-    final long decoded1 = lsnToLong(lsn1);
-    final long decoded2 = lsnToLong(lsn2);
-
-    return Long.compare(decoded1, decoded2);
-  }
-
-  // https://github.com/davecramer/LogicalDecode
-  public static long lsnToLong(String lsn) {
-    int slashIndex = lsn.lastIndexOf('/');
-    Preconditions.checkArgument(slashIndex >= 0);
-
-    String logicalXLogStr = lsn.substring(0, slashIndex);
-    // parses as a long but then cast to int. this allows us to retain the full 32 bits of the integer
-    // as opposed to the reduced value of Integer.MAX_VALUE.
-    int logicalXlog = (int) Long.parseLong(logicalXLogStr, 16);
-    String segmentStr = lsn.substring(slashIndex + 1, lsn.length());
-    int segment = (int) Long.parseLong(segmentStr, 16);
-
-    ByteBuffer buf = ByteBuffer.allocate(8);
-    buf.putInt(logicalXlog);
-    buf.putInt(segment);
-    buf.position(0);
-    return buf.getLong();
-  }
-
-  public static String longToLsn(long long1) {
-    int front = (int) (long1 >> 32);
-    int back = (int) long1;
-    return (Integer.toHexString(front) + "/" + Integer.toHexString(back)).toUpperCase();
+    return PgLsn.fromPgString(jsonNodes.get(0).get("pg_current_wal_lsn").asText());
   }
 
 }

--- a/airbyte-db/src/main/java/io/airbyte/db/PostgresUtils.java
+++ b/airbyte-db/src/main/java/io/airbyte/db/PostgresUtils.java
@@ -1,0 +1,79 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.db;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import io.airbyte.db.jdbc.JdbcDatabase;
+import io.airbyte.db.jdbc.JdbcUtils;
+import java.nio.ByteBuffer;
+import java.sql.SQLException;
+import java.util.List;
+
+public class PostgresUtils {
+
+  public static String getLsn(JdbcDatabase database) throws SQLException {
+    // pg version > 9.
+    final List<JsonNode> jsonNodes = database
+        .bufferedResultSetQuery(conn -> conn.createStatement().executeQuery("SELECT pg_current_wal_lsn()"), JdbcUtils::rowToJson);
+
+    Preconditions.checkState(jsonNodes.size() == 1);
+    return jsonNodes.get(0).get("pg_current_wal_lsn").asText();
+  }
+
+  // https://www.postgresql.org/docs/current/datatype-pg-lsn.html
+  public static int compareLsns(String lsn1, String lsn2) {
+    final long decoded1 = lsnToLong(lsn1);
+    final long decoded2 = lsnToLong(lsn2);
+
+    return Long.compare(decoded1, decoded2);
+  }
+
+  // https://github.com/davecramer/LogicalDecode
+  public static long lsnToLong(String lsn) {
+    int slashIndex = lsn.lastIndexOf('/');
+    Preconditions.checkArgument(slashIndex >= 0);
+
+    String logicalXLogStr = lsn.substring(0, slashIndex);
+    // parses as a long but then cast to int. this allows us to retain the full 32 bits of the integer
+    // as opposed to the reduced value of Integer.MAX_VALUE.
+    int logicalXlog = (int) Long.parseLong(logicalXLogStr, 16);
+    String segmentStr = lsn.substring(slashIndex + 1, lsn.length());
+    int segment = (int) Long.parseLong(segmentStr, 16);
+
+    ByteBuffer buf = ByteBuffer.allocate(8);
+    buf.putInt(logicalXlog);
+    buf.putInt(segment);
+    buf.position(0);
+    return buf.getLong();
+  }
+
+  public static String longToLsn(long long1) {
+    int front = (int) (long1 >> 32);
+    int back = (int) long1;
+    return (Integer.toHexString(front) + "/" + Integer.toHexString(back)).toUpperCase();
+  }
+
+}

--- a/airbyte-db/src/test/java/io/airbyte/db/PgLsnTest.java
+++ b/airbyte-db/src/test/java/io/airbyte/db/PgLsnTest.java
@@ -1,0 +1,68 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.db.jdbc.DefaultJdbcDatabase;
+import io.airbyte.db.jdbc.JdbcDatabase;
+import io.airbyte.test.utils.PostgreSQLContainerHelper;
+import java.util.Map;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.MountableFile;
+
+class PgLsnTest {
+
+  private static final Map<String, Long> TEST_LSNS = ImmutableMap.<String, Long>builder()
+      .put("0/15E7A10", 22968848L)
+      .put("0/15E7B08", 22969096L)
+      .put("16/15E7B08", 94512249608L)
+      .put("16/FFFFFFFF", 98784247807L)
+      .put("7FFFFFFF/FFFFFFFF", Long.MAX_VALUE)
+      .put("0/0", 0L)
+      .build();
+
+  @Test
+  void testLsnToLong() {
+    TEST_LSNS.forEach(
+        (key, value) -> assertEquals(value, PgLsn.lsnToLong(key), String.format("Conversion failed. lsn: %s long value: %s", key, value)));
+  }
+
+  @Test
+  void testLongToLsn() {
+    TEST_LSNS.forEach(
+        (key, value) -> assertEquals(key, PgLsn.longToLsn(value), String.format("Conversion failed. lsn: %s long value: %s", key, value)));
+  }
+
+}

--- a/airbyte-db/src/test/java/io/airbyte/db/PgLsnTest.java
+++ b/airbyte-db/src/test/java/io/airbyte/db/PgLsnTest.java
@@ -26,21 +26,9 @@ package io.airbyte.db;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
-import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.resources.MoreResources;
-import io.airbyte.db.jdbc.DefaultJdbcDatabase;
-import io.airbyte.db.jdbc.JdbcDatabase;
-import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.util.Map;
-import org.apache.commons.dbcp2.BasicDataSource;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.utility.MountableFile;
 
 class PgLsnTest {
 

--- a/airbyte-db/src/test/java/io/airbyte/db/PostgresUtilsTest.java
+++ b/airbyte-db/src/test/java/io/airbyte/db/PostgresUtilsTest.java
@@ -1,0 +1,138 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.db.jdbc.DefaultJdbcDatabase;
+import io.airbyte.db.jdbc.JdbcDatabase;
+import io.airbyte.test.utils.PostgreSQLContainerHelper;
+import java.sql.SQLException;
+import java.util.Map;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.MountableFile;
+
+class PostgresUtilsTest {
+
+  private static final Map<String, Long> TEST_LSNS = ImmutableMap.<String, Long>builder()
+      .put("0/15E7A10", 22968848L)
+      .put("0/15E7B08", 22969096L)
+      .put("16/15E7B08", 94512249608L)
+      .put("16/FFFFFFFF", 98784247807L)
+      .put("7FFFFFFF/FFFFFFFF", Long.MAX_VALUE)
+      .put("0/0", 0L)
+      .build();
+
+  private static PostgreSQLContainer<?> PSQL_DB;
+
+  private BasicDataSource dataSource;
+
+  @BeforeAll
+  static void init() {
+    PSQL_DB = new PostgreSQLContainer<>("postgres:13-alpine");
+    PSQL_DB.start();
+
+  }
+
+  @BeforeEach
+  void setup() throws Exception {
+    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+    final JsonNode config = getConfig(PSQL_DB, dbName);
+
+    final String initScriptName = "init_" + dbName.concat(".sql");
+    MoreResources.writeResource(initScriptName, "CREATE DATABASE " + dbName + ";");
+    PostgreSQLContainerHelper.runSqlScript(MountableFile.forClasspathResource(initScriptName), PSQL_DB);
+
+    dataSource = new BasicDataSource();
+    dataSource.setDriverClassName("org.postgresql.Driver");
+    dataSource.setUsername(config.get("username").asText());
+    dataSource.setPassword(config.get("password").asText());
+    dataSource.setUrl(String.format("jdbc:postgresql://%s:%s/%s",
+        config.get("host").asText(),
+        config.get("port").asText(),
+        config.get("database").asText()));
+
+    final JdbcDatabase defaultJdbcDatabase = new DefaultJdbcDatabase(dataSource);
+
+    defaultJdbcDatabase.execute(connection -> {
+      connection.createStatement().execute("CREATE TABLE id_and_name(id INTEGER, name VARCHAR(200));");
+      connection.createStatement().execute("INSERT INTO id_and_name (id, name) VALUES (1,'picard'),  (2, 'crusher'), (3, 'vash');");
+    });
+  }
+
+  private JsonNode getConfig(PostgreSQLContainer<?> psqlDb, String dbName) {
+    return Jsons.jsonNode(ImmutableMap.builder()
+        .put("host", psqlDb.getHost())
+        .put("port", psqlDb.getFirstMappedPort())
+        .put("database", dbName)
+        .put("username", psqlDb.getUsername())
+        .put("password", psqlDb.getPassword())
+        .build());
+  }
+
+  @Test
+  void testGetLsn() throws SQLException {
+    final JdbcDatabase database = new DefaultJdbcDatabase(dataSource);
+
+    final String lsn1 = PostgresUtils.getLsn(database);
+    assertNotNull(lsn1);
+    assertTrue(PostgresUtils.lsnToLong(lsn1) > 0);
+
+    database.execute(connection -> {
+      connection.createStatement().execute("INSERT INTO id_and_name (id, name) VALUES (1,'picard'),  (2, 'crusher'), (3, 'vash');");
+    });
+
+    final String lsn2 = PostgresUtils.getLsn(database);
+    assertNotNull(lsn2);
+    assertTrue(PostgresUtils.lsnToLong(lsn2) > 0);
+
+    assertTrue(PostgresUtils.compareLsns(lsn1, lsn2) < 0, "returned lsns are not ascending.");
+  }
+
+  @Test
+  void testLsnToLong() {
+    TEST_LSNS.forEach(
+        (key, value) -> assertEquals(value, PostgresUtils.lsnToLong(key), String.format("Conversion failed. lsn: %s long value: %s", key, value)));
+  }
+
+  @Test
+  void testLongToLsn() {
+    TEST_LSNS.forEach(
+        (key, value) -> assertEquals(key, PostgresUtils.longToLsn(value), String.format("Conversion failed. lsn: %s long value: %s", key, value)));
+  }
+
+}

--- a/airbyte-db/src/test/java/io/airbyte/db/PostgresUtilsTest.java
+++ b/airbyte-db/src/test/java/io/airbyte/db/PostgresUtilsTest.java
@@ -24,7 +24,6 @@
 
 package io.airbyte.db;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -36,7 +35,6 @@ import io.airbyte.db.jdbc.DefaultJdbcDatabase;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.sql.SQLException;
-import java.util.Map;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeAll;

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceCdcTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceCdcTest.java
@@ -112,7 +112,7 @@ class PostgresSourceCdcTest {
     final JsonNode config = getConfig(PSQL_DB, dbName);
     database = getDatabaseFromConfig(config);
     database.query(ctx -> {
-      ctx.execute("SELECT pg_create_logical_replication_slot('" + SLOT_NAME + "', 'pgoutput');");
+      // ctx.execute("SELECT pg_create_logical_replication_slot('" + SLOT_NAME + "', 'pgoutput');");
 
       // need to re-add record that has -infinity.
       ctx.execute("CREATE TABLE id_and_name(id NUMERIC(20, 10), name VARCHAR(200), power double precision, PRIMARY KEY (id));");
@@ -182,14 +182,14 @@ class PostgresSourceCdcTest {
     Thread.sleep(5000);
     final JsonNode config = getConfig(PSQL_DB, dbName);
     final Database database = getDatabaseFromConfig(config);
-    database.query(ctx -> {
-      ctx.fetch(
-          "UPDATE names SET power = 10000.2 WHERE first_name = 'san';");
-      ctx.fetch(
-          "DELETE FROM names WHERE first_name = 'san';");
-      return null;
-    });
-    database.close();
+    // database.query(ctx -> {
+    // ctx.fetch(
+    // "UPDATE names SET power = 10000.2 WHERE first_name = 'san';");
+    // ctx.fetch(
+    // "DELETE FROM names WHERE first_name = 'san';");
+    // return null;
+    // });
+    // database.close();
 
     long startMillis = System.currentTimeMillis();
     final AtomicInteger i = new AtomicInteger(10);

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceCdcTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceCdcTest.java
@@ -51,6 +51,7 @@ import io.debezium.engine.ChangeEvent;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jooq.SQLDialect;
@@ -90,6 +91,7 @@ class PostgresSourceCdcTest {
   private static PostgreSQLContainer<?> PSQL_DB;
 
   private String dbName;
+  private Database database;
 
   @BeforeAll
   static void init() {
@@ -108,24 +110,28 @@ class PostgresSourceCdcTest {
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forClasspathResource(initScriptName), PSQL_DB);
 
     final JsonNode config = getConfig(PSQL_DB, dbName);
-    final Database database = getDatabaseFromConfig(config);
+    database = getDatabaseFromConfig(config);
     database.query(ctx -> {
       ctx.execute("SELECT pg_create_logical_replication_slot('" + SLOT_NAME + "', 'pgoutput');");
 
       // need to re-add record that has -infinity.
-      ctx.fetch("CREATE TABLE id_and_name(id NUMERIC(20, 10), name VARCHAR(200), power double precision, PRIMARY KEY (id));");
-      ctx.fetch("CREATE INDEX i1 ON id_and_name (id);");
-      ctx.fetch("INSERT INTO id_and_name (id, name, power) VALUES (1,'goku', 'Infinity'),  (2, 'vegeta', 9000.1);");
+      ctx.execute("CREATE TABLE id_and_name(id NUMERIC(20, 10), name VARCHAR(200), power double precision, PRIMARY KEY (id));");
+      ctx.execute("CREATE INDEX i1 ON id_and_name (id);");
+      ctx.execute("begin; INSERT INTO id_and_name (id, name, power) VALUES (1,'goku', 'Infinity'),  (2, 'vegeta', 9000.1); commit;");
 
-      ctx.fetch("CREATE TABLE id_and_name2(id NUMERIC(20, 10), name VARCHAR(200), power double precision);");
-      ctx.fetch("INSERT INTO id_and_name2 (id, name, power) VALUES (1,'goku', 'Infinity'),  (2, 'vegeta', 9000.1);");
-
-      ctx.fetch("CREATE TABLE names(first_name VARCHAR(200), last_name VARCHAR(200), power double precision, PRIMARY KEY (first_name, last_name));");
-      ctx.fetch(
-          "INSERT INTO names (first_name, last_name, power) VALUES ('san', 'goku', 'Infinity'),  ('prince', 'vegeta', 9000.1);");
       return null;
     });
-    database.close();
+    database.query(ctx -> {
+      ctx.execute("begin; INSERT INTO id_and_name (id, name, power) VALUES (4,'picard', '10'); commit;");
+
+      return null;
+    });
+    database.query(ctx -> {
+      ctx.execute("begin; UPDATE id_and_name SET name='picard2' WHERE id=4; commit;");
+
+      return null;
+    });
+    // database.close();
   }
 
   private JsonNode getConfig(PostgreSQLContainer<?> psqlDb, String dbName) {
@@ -186,7 +192,21 @@ class PostgresSourceCdcTest {
     database.close();
 
     long startMillis = System.currentTimeMillis();
-    while (read.hasNext() || startMillis - System.currentTimeMillis() < 10000) {
+    final AtomicInteger i = new AtomicInteger(10);
+    while (read.hasNext()) {
+      database.query(ctx -> {
+        ctx.execute(
+            String.format("begin; INSERT INTO id_and_name (id, name, power) VALUES (%s,'goku%s', 'Infinity'),  (%s, 'vegeta%s', 9000.1); commit;",
+                i.incrementAndGet(), i.incrementAndGet(), i.incrementAndGet(), i.incrementAndGet()));
+        // ctx.execute(String.format("begin; UPDATE id_and_name SET name='goku%s' WHERE id=1; UPDATE
+        // id_and_name SET name='picard%s' WHERE id=4; commit;", i.incrementAndGet(), i.incrementAndGet()));
+        // ctx.execute(String.format("begin; UPDATE id_and_name SET name='goku%s' WHERE id=1; commit;",
+        // i.incrementAndGet()));
+        // ctx.execute(String.format("begin; UPDATE id_and_name SET name='picard%s' WHERE id=4; commit;",
+        // i.incrementAndGet()));
+
+        return null;
+      });
       if (read.hasNext()) {
         System.out.println("it said it had next");
         System.out.println("read.next() = " + read.next());


### PR DESCRIPTION
## What
* Adds helper to extract the current LSN from a postgres db with version > 9. (We can add support for version 9 if we want as well, but let's start here).
* Adds helpers to allow comparing the magnitude of LSNS.
* Still need to fix: it closes too eagerly because multiple records can have the same lsn. need to fix logic slightly so it includes all records with the same lsn.

## Future work
* Figure out how pulling LSN or equivalent can be ergonomic for all databases.
* Use this in the CDC impl of postgres

@jrhizor we can merge this into master or directly into feature branch. Will do the right thing one approved.