### PR TITLE
Bump version: 0.17.3-alpha → 0.18.0-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.3-alpha
+current_version = 0.18.0-alpha
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.17.3-alpha
+VERSION=0.18.0-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_DB=airbyte

--- a/docs/tutorials/upgrading-airbyte.md
+++ b/docs/tutorials/upgrading-airbyte.md
@@ -40,7 +40,7 @@ On the other hand, if you don't mind losing your current Airbyte configuration o
 Here's an example of what might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
 ```bash
-docker run --rm -v /tmp:/config airbyte/migration:0.17.3-alpha --\
+docker run --rm -v /tmp:/config airbyte/migration:0.18.0-alpha --\
   --input /config/airbyte_archive.tar.gz\
   --output /config/airbyte_archive_migrated.tar.gz
 ```


### PR DESCRIPTION
## What
Release 0.18.0-alpha

Changes from previous release 0.17.3: https://github.com/airbytehq/airbyte/compare/v0.17.3-alpha...master