### PR TITLE
Track connectors versions

### DIFF
--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.util.Strings;
 
 public class JobTracker {
 
@@ -185,9 +186,9 @@ public class JobTracker {
     final StandardDestinationDefinition destinationDefinition = configRepository.getStandardDestinationDefinition(destinationDefinitionId);
     metadata.put("connector_destination", destinationDefinition.getName());
     metadata.put("connector_destination_definition_id", destinationDefinition.getDestinationDefinitionId());
-    final String[] imageTag = destinationDefinition.getDockerImageTag().split(":");
-    if (imageTag.length > 1) {
-      metadata.put("connector_destination_version", imageTag[1]);
+    final String imageTag = destinationDefinition.getDockerImageTag();
+    if (!Strings.isEmpty(imageTag)) {
+      metadata.put("connector_destination_version", imageTag);
     }
     return metadata.build();
   }
@@ -199,9 +200,9 @@ public class JobTracker {
     final StandardSourceDefinition sourceDefinition = configRepository.getStandardSourceDefinition(sourceDefinitionId);
     metadata.put("connector_source", sourceDefinition.getName());
     metadata.put("connector_source_definition_id", sourceDefinition.getSourceDefinitionId());
-    final String[] imageTag = sourceDefinition.getDockerImageTag().split(":");
-    if (imageTag.length > 1) {
-      metadata.put("connector_source_version", imageTag[1]);
+    final String imageTag = sourceDefinition.getDockerImageTag();
+    if (!Strings.isEmpty(imageTag)) {
+      metadata.put("connector_source_version", imageTag);
     }
     return metadata.build();
   }

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
@@ -119,7 +119,7 @@ class JobTrackerTest {
         .thenReturn(new StandardSourceDefinition()
             .withSourceDefinitionId(UUID1)
             .withName(SOURCE_DEF_NAME)
-            .withDockerImageTag(SOURCE_DEF_NAME + ":" + CONNECTOR_VERSION));
+            .withDockerImageTag(CONNECTOR_VERSION));
 
     assertCheckConnCorrectMessageForEachState((jobState, output) -> jobTracker.trackCheckConnectionSource(JOB_ID, UUID1, jobState, output), metadata);
   }
@@ -139,7 +139,7 @@ class JobTrackerTest {
         .thenReturn(new StandardDestinationDefinition()
             .withDestinationDefinitionId(UUID2)
             .withName(DESTINATION_DEF_NAME)
-            .withDockerImageTag(DESTINATION_DEF_NAME + ":" + CONNECTOR_VERSION));
+            .withDockerImageTag(CONNECTOR_VERSION));
 
     assertCheckConnCorrectMessageForEachState((jobState, output) -> jobTracker.trackCheckConnectionDestination(JOB_ID, UUID2, jobState, output),
         metadata);
@@ -160,7 +160,7 @@ class JobTrackerTest {
         .thenReturn(new StandardSourceDefinition()
             .withSourceDefinitionId(UUID1)
             .withName(SOURCE_DEF_NAME)
-            .withDockerImageTag(SOURCE_DEF_NAME + ":" + CONNECTOR_VERSION));
+            .withDockerImageTag(CONNECTOR_VERSION));
 
     assertCorrectMessageForEachState((jobState) -> jobTracker.trackDiscover(JOB_ID, UUID1, jobState), metadata);
   }
@@ -225,23 +225,23 @@ class JobTrackerTest {
         .thenReturn(new StandardSourceDefinition()
             .withSourceDefinitionId(UUID1)
             .withName(SOURCE_DEF_NAME)
-            .withDockerImageTag(SOURCE_DEF_NAME + ":" + CONNECTOR_VERSION));
+            .withDockerImageTag(CONNECTOR_VERSION));
     when(configRepository.getDestinationDefinitionFromConnection(CONNECTION_ID))
         .thenReturn(new StandardDestinationDefinition()
             .withDestinationDefinitionId(UUID2)
             .withName(DESTINATION_DEF_NAME)
-            .withDockerImageTag(DESTINATION_DEF_NAME + ":" + CONNECTOR_VERSION));
+            .withDockerImageTag(CONNECTOR_VERSION));
 
     when(configRepository.getStandardSourceDefinition(UUID1))
         .thenReturn(new StandardSourceDefinition()
             .withSourceDefinitionId(UUID1)
             .withName(SOURCE_DEF_NAME)
-            .withDockerImageTag(SOURCE_DEF_NAME + ":" + CONNECTOR_VERSION));
+            .withDockerImageTag(CONNECTOR_VERSION));
     when(configRepository.getStandardDestinationDefinition(UUID2))
         .thenReturn(new StandardDestinationDefinition()
             .withDestinationDefinitionId(UUID2)
             .withName(DESTINATION_DEF_NAME)
-            .withDockerImageTag(DESTINATION_DEF_NAME + ":" + CONNECTOR_VERSION));
+            .withDockerImageTag(CONNECTOR_VERSION));
 
     final Job job = mock(Job.class);
     when(job.getId()).thenReturn(jobId);


### PR DESCRIPTION
## What
Closes #2615

## How
`dockerImageTag` is actually only the tag, not the full docker image name with the tag.
