### PR TITLE
AcceptTracked should accept an AirbyteRecordMessage.

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/FailureTrackingAirbyteMessageConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/FailureTrackingAirbyteMessageConsumer.java
@@ -25,6 +25,7 @@
 package io.airbyte.integrations.base;
 
 import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteRecordMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,12 +59,15 @@ public abstract class FailureTrackingAirbyteMessageConsumer implements AirbyteMe
     }
   }
 
-  protected abstract void acceptTracked(AirbyteMessage t) throws Exception;
+  protected abstract void acceptTracked(AirbyteRecordMessage msg) throws Exception;
 
   @Override
-  public void accept(AirbyteMessage t) throws Exception {
+  public void accept(AirbyteMessage msg) throws Exception {
     try {
-      acceptTracked(t);
+      // ignore all other message types
+      if (msg.getType() == AirbyteMessage.Type.RECORD) {
+        acceptTracked(msg.getRecord());
+      }
     } catch (Exception e) {
       hasFailed = true;
       throw e;

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/FailureTrackingAirbyteMessageConsumerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/FailureTrackingAirbyteMessageConsumerTest.java
@@ -30,8 +30,11 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteMessage.Type;
+import io.airbyte.protocol.models.AirbyteRecordMessage;
 import org.junit.jupiter.api.Test;
 
 class FailureTrackingAirbyteMessageConsumerTest {
@@ -72,6 +75,7 @@ class FailureTrackingAirbyteMessageConsumerTest {
   void testAcceptWithFailure() throws Exception {
     final TestConsumer consumer = spy(new TestConsumer());
     final AirbyteMessage msg = mock(AirbyteMessage.class);
+    when(msg.getType()).thenReturn(Type.RECORD);
     doThrow(new RuntimeException()).when(consumer).acceptTracked(any());
 
     // verify the exception still gets thrown.
@@ -89,7 +93,7 @@ class FailureTrackingAirbyteMessageConsumerTest {
     }
 
     @Override
-    protected void acceptTracked(AirbyteMessage s) {
+    protected void acceptTracked(AirbyteRecordMessage s) {
 
     }
 

--- a/airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
+++ b/airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
@@ -36,7 +36,7 @@ import io.airbyte.integrations.base.JavaBaseConstants;
 import io.airbyte.integrations.destination.StandardNameTransformer;
 import io.airbyte.protocol.models.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
-import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream.DestinationSyncMode;
@@ -165,20 +165,18 @@ public class CsvDestination implements Destination {
     }
 
     @Override
-    protected void acceptTracked(AirbyteMessage message) throws Exception {
+    protected void acceptTracked(AirbyteRecordMessage message) throws Exception {
       // ignore other message types.
-      if (message.getType() == AirbyteMessage.Type.RECORD) {
-        if (!writeConfigs.containsKey(message.getRecord().getStream())) {
-          throw new IllegalArgumentException(
-              String.format("Message contained record from a stream that was not in the catalog. \ncatalog: %s , \nmessage: %s",
-                  Jsons.serialize(catalog), Jsons.serialize(message)));
-        }
-
-        writeConfigs.get(message.getRecord().getStream()).getWriter().printRecord(
-            UUID.randomUUID(),
-            message.getRecord().getEmittedAt(),
-            Jsons.serialize(message.getRecord().getData()));
+      if (!writeConfigs.containsKey(message.getStream())) {
+        throw new IllegalArgumentException(
+            String.format("Message contained record from a stream that was not in the catalog. \ncatalog: %s , \nmessage: %s",
+                Jsons.serialize(catalog), Jsons.serialize(message)));
       }
+
+      writeConfigs.get(message.getStream()).getWriter().printRecord(
+          UUID.randomUUID(),
+          message.getEmittedAt(),
+          Jsons.serialize(message.getData()));
     }
 
     @Override

--- a/airbyte-integrations/connectors/destination-local-json/src/main/java/io/airbyte/integrations/destination/local_json/LocalJsonDestination.java
+++ b/airbyte-integrations/connectors/destination-local-json/src/main/java/io/airbyte/integrations/destination/local_json/LocalJsonDestination.java
@@ -37,7 +37,7 @@ import io.airbyte.integrations.base.JavaBaseConstants;
 import io.airbyte.integrations.destination.StandardNameTransformer;
 import io.airbyte.protocol.models.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
-import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream.DestinationSyncMode;
@@ -159,23 +159,21 @@ public class LocalJsonDestination implements Destination {
     }
 
     @Override
-    protected void acceptTracked(AirbyteMessage message) throws Exception {
+    protected void acceptTracked(AirbyteRecordMessage message) throws Exception {
 
       // ignore other message types.
-      if (message.getType() == AirbyteMessage.Type.RECORD) {
-        if (!writeConfigs.containsKey(message.getRecord().getStream())) {
-          throw new IllegalArgumentException(
-              String.format("Message contained record from a stream that was not in the catalog. \ncatalog: %s , \nmessage: %s",
-                  Jsons.serialize(catalog), Jsons.serialize(message)));
-        }
-
-        final Writer writer = writeConfigs.get(message.getRecord().getStream()).getWriter();
-        writer.write(Jsons.serialize(ImmutableMap.of(
-            JavaBaseConstants.COLUMN_NAME_AB_ID, UUID.randomUUID(),
-            JavaBaseConstants.COLUMN_NAME_EMITTED_AT, message.getRecord().getEmittedAt(),
-            JavaBaseConstants.COLUMN_NAME_DATA, message.getRecord().getData())));
-        writer.write(System.lineSeparator());
+      if (!writeConfigs.containsKey(message.getStream())) {
+        throw new IllegalArgumentException(
+            String.format("Message contained record from a stream that was not in the catalog. \ncatalog: %s , \nmessage: %s",
+                Jsons.serialize(catalog), Jsons.serialize(message)));
       }
+
+      final Writer writer = writeConfigs.get(message.getStream()).getWriter();
+      writer.write(Jsons.serialize(ImmutableMap.of(
+          JavaBaseConstants.COLUMN_NAME_AB_ID, UUID.randomUUID(),
+          JavaBaseConstants.COLUMN_NAME_EMITTED_AT, message.getEmittedAt(),
+          JavaBaseConstants.COLUMN_NAME_DATA, message.getData())));
+      writer.write(System.lineSeparator());
     }
 
     @Override

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftCopyDestination.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftCopyDestination.java
@@ -40,7 +40,7 @@ import io.airbyte.integrations.destination.StandardNameTransformer;
 import io.airbyte.integrations.destination.jdbc.AbstractJdbcDestination;
 import io.airbyte.protocol.models.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
-import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -160,17 +160,15 @@ public class RedshiftCopyDestination {
     }
 
     @Override
-    protected void acceptTracked(AirbyteMessage message) throws Exception {
-      if (message.getType() == AirbyteMessage.Type.RECORD) {
-        var streamName = message.getRecord().getStream();
-        if (!streamNameToCopier.containsKey(streamName)) {
-          throw new IllegalArgumentException(
-              String.format("Message contained record from a stream that was not in the catalog. \ncatalog: %s , \nmessage: %s",
-                  Jsons.serialize(catalog), Jsons.serialize(message)));
-        }
-
-        streamNameToCopier.get(streamName).uploadToS3(message.getRecord());
+    protected void acceptTracked(AirbyteRecordMessage message) throws Exception {
+      var streamName = message.getStream();
+      if (!streamNameToCopier.containsKey(streamName)) {
+        throw new IllegalArgumentException(
+            String.format("Message contained record from a stream that was not in the catalog. \ncatalog: %s , \nmessage: %s",
+                Jsons.serialize(catalog), Jsons.serialize(message)));
       }
+
+      streamNameToCopier.get(streamName).uploadToS3(message);
     }
 
     /**


### PR DESCRIPTION
## What
Follow up to #2637 .

The `acceptTracked` method should accept an `AirbyteRecordMessage` instead of a generic `AirbyteMessage`. This allows us to centralise checking for a record and makes the interface easier to understand.

We can also consolidate checking if a received message has a corresponding stream. However that's more involved and IMO not as useful as these changes.

## How
* Implement as suggested above.

## Recommended reading order
1. `FailureTrackingAirbyteMessageConsumer`
