### PR TITLE
postgres cdc catalog

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -360,6 +360,12 @@ public class PostgresSource extends AbstractJdbcSource implements Source {
     return !(config.get("replication_slot") == null);
   }
 
+  /*
+   * It isn't possible to recreate the state of the original database unless we include extra
+   * information (like an oid) when using logical replication. By limiting to Full Refresh when we
+   * don't have a primary key we dodge the problem for now. As a work around a CDC and non-CDC source
+   * could be configured if there's a need to replicate a large non-PK table.
+   */
   private static AirbyteStream removeIncrementalWithoutPk(AirbyteStream stream) {
     if (stream.getSourceDefinedPrimaryKey().isEmpty()) {
       stream.getSupportedSyncModes().remove(SyncMode.INCREMENTAL);

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceCdcTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceCdcTest.java
@@ -161,6 +161,10 @@ class PostgresSourceCdcTest {
     // coerce to incremental so it uses CDC.
     configuredCatalog.getStreams().forEach(s -> s.setSyncMode(SyncMode.INCREMENTAL));
 
+    AirbyteCatalog catalog = source.discover(getConfig(PSQL_DB, dbName));
+
+    System.out.println("catalog = " + catalog);
+
     final AutoCloseableIterator<AirbyteMessage> read = source.read(getConfig(PSQL_DB, dbName), configuredCatalog, null);
 
     long startMillis = System.currentTimeMillis();

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceCdcTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceCdcTest.java
@@ -58,10 +58,14 @@ import org.jooq.SQLDialect;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.MountableFile;
 
 class PostgresSourceCdcTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PostgresSourceCdcTest.class);
 
   private static final String SLOT_NAME = "debezium_slot";
   private static final String STREAM_NAME = "public.id_and_name";
@@ -135,7 +139,6 @@ class PostgresSourceCdcTest {
   }
 
   private JsonNode getConfig(PostgreSQLContainer<?> psqlDb, String dbName) {
-    System.out.println("psqlDb.getFirstMappedPort() = " + psqlDb.getFirstMappedPort());
     return Jsons.jsonNode(ImmutableMap.builder()
         .put("host", psqlDb.getHost())
         .put("port", psqlDb.getFirstMappedPort())
@@ -144,14 +147,6 @@ class PostgresSourceCdcTest {
         .put("password", psqlDb.getPassword())
         .put("replication_slot", SLOT_NAME)
         .build());
-    // return Jsons.jsonNode(ImmutableMap.builder()
-    // .put("host", "localhost")
-    // .put("port", 5432)
-    // .put("database", "debezium_test")
-    // .put("username", "postgres")
-    // .put("password", "")
-    // .put("replication_slot", SLOT_NAME)
-    // .build());
   }
 
   private Database getDatabaseFromConfig(JsonNode config) {
@@ -179,7 +174,7 @@ class PostgresSourceCdcTest {
 
     AirbyteCatalog catalog = source.discover(getConfig(PSQL_DB, dbName));
 
-    System.out.println("catalog = " + catalog);
+    LOGGER.info("catalog = " + catalog);
 
     final AutoCloseableIterator<AirbyteMessage> read = source.read(getConfig(PSQL_DB, dbName), configuredCatalog, null);
 


### PR DESCRIPTION
Pretty straightforward. Adds CDC columns to all streams in discover. Output values will be missing and therefore null in Full refresh outputs. Also this disables incremental cdc if there isn't a primary key. 

Testing for this stuff will happen after merge. 