### PR TITLE
Remove outdated docs about running scheduler and server with gradle run

### DIFF
--- a/airbyte-scheduler/app/build.gradle
+++ b/airbyte-scheduler/app/build.gradle
@@ -28,11 +28,17 @@ rootProject.file('.env.dev').withInputStream { env.load(it) }
 
 run {
     // default for running on local machine.
-    environment "CONFIG_ROOT", "${env.DEV_ROOT}/data"
-    environment "WORKSPACE_ROOT", "${env.DEV_ROOT}/workspace"
-    environment "WORKSPACE_DOCKER_MOUNT", env.WORKSPACE_DOCKER_MOUNT
-    environment "VERSION", env.VERSION
     environment "DATABASE_USER", env.DATABASE_USER
     environment "DATABASE_PASSWORD", env.DATABASE_PASSWORD
-    environment "DATABASE_URL", "jdbc:postgresql://localhost:5432/airbyte"
+    // we map the docker pg db to port 5433 so it does not conflict with other pg instances.
+    environment "DATABASE_URL", "jdbc:postgresql://localhost:5433/${env.DATABASE_DB}"
+    environment "WORKSPACE_ROOT", env.WORKSPACE_ROOT
+    environment "WORKSPACE_DOCKER_MOUNT", env.WORKSPACE_DOCKER_MOUNT
+    environment "LOCAL_DOCKER_MOUNT", env.LOCAL_DOCKER_MOUNT
+    environment "CONFIG_ROOT", "/tmp/airbyte_config"
+    environment "TRACKING_STRATEGY", env.TRACKING_STRATEGY
+    environment "AIRBYTE_VERSION", env.VERSION
+    environment "AIRBYTE_ROLE", System.getenv('AIRBYTE_ROLE')
+    environment "TEMPORAL_HOST", "localhost:7233"
+
 }

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -47,10 +47,15 @@ rootProject.file('.env.dev').withInputStream { env.load(it) }
 
 run {
     // default for running on local machine.
-    environment "CONFIG_ROOT", "${env.DEV_ROOT}/data"
-    environment "WORKSPACE_ROOT", "${env.DEV_ROOT}/workspace"
-    environment "VERSION", env.VERSION
     environment "DATABASE_USER", env.DATABASE_USER
     environment "DATABASE_PASSWORD", env.DATABASE_PASSWORD
-    environment "DATABASE_URL", "jdbc:postgresql://localhost:5432/airbyte"
+    // we map the docker pg db to port 5433 so it does not conflict with other pg instances.
+    environment "DATABASE_URL", "jdbc:postgresql://localhost:5433/${env.DATABASE_DB}"
+    environment "WORKSPACE_ROOT", env.WORKSPACE_ROOT
+    environment "CONFIG_ROOT", "/tmp/airbyte_config"
+    environment "TRACKING_STRATEGY", env.TRACKING_STRATEGY
+    environment "AIRBYTE_VERSION", env.VERSION
+    environment "AIRBYTE_ROLE", System.getenv('AIRBYTE_ROLE')
+    environment "TEMPORAL_HOST", "localhost:7233"
+
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,12 +32,12 @@ services:
     image: airbyte/scheduler:${VERSION}
     container_name: airbyte-scheduler
     environment:
-      - DATABASE_USER=${DATABASE_USER}
-      - DATABASE_PASSWORD=${DATABASE_PASSWORD}
-      - DATABASE_URL=jdbc:postgresql://db:5432/${DATABASE_DB}
       - WAIT_BEFORE_HOSTS=5
       - WAIT_HOSTS_TIMEOUT=45
       - WAIT_HOSTS=db:5432
+      - DATABASE_USER=${DATABASE_USER}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD}
+      - DATABASE_URL=jdbc:postgresql://db:5432/${DATABASE_DB}
       - WORKSPACE_ROOT=${WORKSPACE_ROOT}
       - WORKSPACE_DOCKER_MOUNT=${WORKSPACE_DOCKER_MOUNT}
       - LOCAL_DOCKER_MOUNT=${LOCAL_DOCKER_MOUNT}
@@ -55,17 +55,17 @@ services:
     image: airbyte/server:${VERSION}
     container_name: airbyte-server
     environment:
-      - DATABASE_USER=${DATABASE_USER}
-      - DATABASE_PASSWORD=${DATABASE_PASSWORD}
-      - DATABASE_URL=jdbc:postgresql://db:5432/${DATABASE_DB}
       - WAIT_BEFORE_HOSTS=5
       - WAIT_HOSTS_TIMEOUT=45
       - WAIT_HOSTS=db:5432
+      - DATABASE_USER=${DATABASE_USER}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD}
+      - DATABASE_URL=jdbc:postgresql://db:5432/${DATABASE_DB}
+      - WORKSPACE_ROOT=${WORKSPACE_ROOT}
       - CONFIG_ROOT=${CONFIG_ROOT}
       - TRACKING_STRATEGY=${TRACKING_STRATEGY}
       - AIRBYTE_VERSION=${VERSION}
       - AIRBYTE_ROLE=${AIRBYTE_ROLE:-}
-      - WORKSPACE_ROOT=${WORKSPACE_ROOT}
       - TEMPORAL_HOST=${TEMPORAL_HOST}
     ports:
       - 8001:8001

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -65,7 +65,7 @@ export CPPFLAGS="-I/usr/local/opt/openssl/include"
 
 ```bash
 ./gradlew build
-docker-compose --env-file .env.dev -f docker-compose.yaml -f docker-compose.dev.yaml up
+VERSION=dev docker-compose up
 ```
 
 The build will take a few minutes. Once it completes, Airbyte compiled at current git revision will be running in `dev` mode in your environment.
@@ -144,7 +144,7 @@ docker-compose stop scheduler
 * Run the `scheduler` with the command line. It will build and start a `scheduler` with the current state of the code. You can also start the `scheduler`from your IDE if you need to use a debugger.
 
 ```bash
-./gradlew :airbyte-scheduler:run
+./gradlew :airbyte-scheduler:app:run
 ```
 
 * Happy Hacking!
@@ -154,8 +154,8 @@ docker-compose stop scheduler
 The Configuration API caches connector specifications. This is done to avoid needing to run docker everytime one is needed in the UI. Without this caching, the UI crawls. If you update the specification of a connector and you need to clear this cache so the API / UI pick up the change. You have two options: 1. Go to the Admin page in the UI and update the version of the connector. Updating to the same version will for the cache to clear for that connector. 1. Restart the server
 
 ```bash
-        docker-compose --env-file .env.dev -f docker-compose.yaml -f docker-compose.dev.yaml down -v
-        docker-compose --env-file .env.dev -f docker-compose.yaml -f docker-compose.dev.yaml up
+VERSION=dev docker-compose down -v
+VERSION=dev docker-compose up
 ```
 
 ### Resetting the Airbyte developer environment
@@ -165,7 +165,7 @@ Sometimes you'll want to reset the data in your local environment. One common ca
 * Delete the datastore volumes in docker
 
   ```bash
-    docker-compose --env-file .env.dev -f docker-compose.yaml -f docker-compose.dev.yaml down -v
+    VERSION=dev docker-compose down -v
   ```
 
 * Remove the data on disk
@@ -179,7 +179,7 @@ Sometimes you'll want to reset the data in your local environment. One common ca
 
   ```bash
    ./gradlew build
-   docker-compose --env-file .env.dev -f docker-compose.yaml -f docker-compose.dev.yaml up -V
+   VERSION=dev docker-compose up -V
   ```
 
 ## Troubleshooting

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -82,10 +82,6 @@ VERSION=dev docker-compose up
 ./gradlew :airbyte-tests:acceptanceTests
 ```
 
-## Develop on individual applications
-
-The easiest way to develop on one of Airbyte's modules is to spin up the whole Airbyte system on your workstation, and shutdown the module you want to work on.
-
 ### Develop on `airbyte-webapp`
 
 * Spin up Airbyte locally so the UI can make requests against the local API.
@@ -101,50 +97,6 @@ docker-compose stop webapp
 cd airbyte-webapp
 npm install
 npm start
-```
-
-* Happy Hacking!
-
-### Develop on `airbyte-server` \(APIs\)
-
-* Spin up Airbyte locally.
-* Stop the `server`.
-
-```bash
-docker-compose stop server
-```
-
-* Run the `server` with the command line. It will build and start a `server` with the current state of the code. You can also start the `server` from your IDE if you need to use a debugger.
-
-```bash
-./gradlew :airbyte-server:run
-```
-
-* Make sure everything is working by testing out a call to the API.
-
-```bash
-curl -H "Content-Type: application/json"\
- -X POST localhost:8001/api/v1/workspaces/get\
- -d '{ "workspaceId": "5ae6b09b-fdec-41af-aaf7-7d94cfc33ef6" }'
-```
-
-* Happy Hacking!
-
-_Note: We namespace most API calls with a workspace id. For now there is only ever one workspace that is hardcoded to the id used in this example. If you ever need a workspace id, just use this one._
-
-### Develop on `airbyte-scheduler`
-
-* Spin up Airbyte locally.
-* Stop the `scheduler`.
-
-```bash
-docker-compose stop scheduler
-```
-
-* Run the `scheduler` with the command line. It will build and start a `scheduler` with the current state of the code. You can also start the `scheduler`from your IDE if you need to use a debugger.
-
-```bash
-./gradlew :airbyte-scheduler:app:run
 ```
 
 * Happy Hacking!


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/2528

## What
* Removes references in the docs for using gradle `:run` for running the scheduler and server. 
* I tried to get it so we could use `:run` again (so that we could easily use the intellij debugger). Unfortunately the fact that the config repository is in a docker volume breaks this. I have left the env variable set up as close as I got it so that we can do this in the future if we ever change our config repository set up.
* Internally, if you know what you're doing you can run apps in intellij. Otherwise, removed from external docs.