### PR TITLE
Fix integration tests of connectors related to sync modes required

### DIFF
--- a/airbyte-integrations/bases/base-normalization/unit_tests/resources/facebook_catalog.json
+++ b/airbyte-integrations/bases/base-normalization/unit_tests/resources/facebook_catalog.json
@@ -46,7 +46,8 @@
         "default_cursor_field": []
       },
       "sync_mode": "incremental",
-      "cursor_field": []
+      "cursor_field": [],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1240,7 +1241,8 @@
         "default_cursor_field": []
       },
       "sync_mode": "incremental",
-      "cursor_field": []
+      "cursor_field": [],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -4522,7 +4524,8 @@
         "default_cursor_field": []
       },
       "sync_mode": "full_refresh",
-      "cursor_field": []
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/bases/base-normalization/unit_tests/resources/hubspot_catalog.json
+++ b/airbyte-integrations/bases/base-normalization/unit_tests/resources/hubspot_catalog.json
@@ -43,7 +43,8 @@
         "default_cursor_field": ["startTimestamp"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["startTimestamp"]
+      "cursor_field": ["startTimestamp"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -105,7 +106,8 @@
         "default_cursor_field": ["startTimestamp"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["startTimestamp"]
+      "cursor_field": ["startTimestamp"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -226,7 +228,8 @@
         "default_cursor_field": ["updatedAt"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updatedAt"]
+      "cursor_field": ["updatedAt"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -262,7 +265,8 @@
         "default_cursor_field": ["updatedAt"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updatedAt"]
+      "cursor_field": ["updatedAt"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -304,7 +308,8 @@
         "default_cursor_field": ["updatedAt"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updatedAt"]
+      "cursor_field": ["updatedAt"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -351,7 +356,8 @@
         "default_cursor_field": []
       },
       "sync_mode": "full_refresh",
-      "cursor_field": []
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -412,7 +418,8 @@
         "default_cursor_field": ["updatedAt"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updatedAt"]
+      "cursor_field": ["updatedAt"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -5472,7 +5479,8 @@
         "default_cursor_field": ["versionTimestamp"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["versionTimestamp"]
+      "cursor_field": ["versionTimestamp"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -8391,7 +8399,8 @@
         "default_cursor_field": ["hs_lastmodifieddate"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["hs_lastmodifieddate"]
+      "cursor_field": ["hs_lastmodifieddate"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -10848,7 +10857,8 @@
         "default_cursor_field": ["hs_lastmodifieddate"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["hs_lastmodifieddate"]
+      "cursor_field": ["hs_lastmodifieddate"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -10882,7 +10892,8 @@
         "default_cursor_field": []
       },
       "sync_mode": "full_refresh",
-      "cursor_field": []
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -10994,7 +11005,8 @@
         "default_cursor_field": ["lastUpdated"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["lastUpdated"]
+      "cursor_field": ["lastUpdated"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -11012,7 +11024,8 @@
         "default_cursor_field": []
       },
       "sync_mode": "full_refresh",
-      "cursor_field": []
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/bases/base-normalization/unit_tests/resources/stripe_catalog.json
+++ b/airbyte-integrations/bases/base-normalization/unit_tests/resources/stripe_catalog.json
@@ -538,7 +538,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -957,7 +958,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1004,7 +1006,9 @@
         "source_defined_cursor": true,
         "default_cursor_field": ["created"]
       },
-      "cursor_field": []
+      "sync_mode": "incremental",
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1115,7 +1119,8 @@
         "default_cursor_field": ["date"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1198,7 +1203,8 @@
         "default_cursor_field": ["date"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1279,7 +1285,8 @@
         "default_cursor_field": []
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1324,7 +1331,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1356,7 +1364,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1492,7 +1501,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1583,7 +1593,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1626,7 +1637,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1689,7 +1701,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1706,7 +1719,8 @@
         "default_cursor_field": ["id"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1783,7 +1797,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1834,7 +1849,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connector-templates/source-python/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connector-templates/source-python/sample_files/configured_catalog.json
@@ -15,7 +15,9 @@
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false,
         "default_cursor_field": ["column_name"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connector-templates/source-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connector-templates/source-singer/sample_files/configured_catalog.json
@@ -15,7 +15,9 @@
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false,
         "default_cursor_field": ["column_name"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-appsflyer-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-appsflyer-singer/sample_files/configured_catalog.json
@@ -2,6 +2,7 @@
   "streams": [
     {
       "sync_mode": "incremental",
+      "destination_sync_mode": "append",
       "stream": {
         "name": "in_app_events",
         "supported_sync_modes": ["incremental"],
@@ -261,6 +262,7 @@
     },
     {
       "sync_mode": "incremental",
+      "destination_sync_mode": "append",
       "stream": {
         "name": "installations",
         "supported_sync_modes": ["incremental"],

--- a/airbyte-integrations/connectors/source-appstore-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-appstore-singer/sample_files/configured_catalog.json
@@ -2,6 +2,7 @@
   "streams": [
     {
       "sync_mode": "incremental",
+      "destination_sync_mode": "append",
       "stream": {
         "name": "sales_report",
         "supported_sync_modes": ["incremental"],
@@ -111,6 +112,7 @@
     },
     {
       "sync_mode": "incremental",
+      "destination_sync_mode": "append",
       "stream": {
         "name": "subscriber_report",
         "supported_sync_modes": ["incremental"],
@@ -214,6 +216,7 @@
     },
     {
       "sync_mode": "incremental",
+      "destination_sync_mode": "append",
       "stream": {
         "name": "subscription_event_report",
         "supported_sync_modes": ["incremental"],
@@ -323,6 +326,7 @@
     },
     {
       "sync_mode": "incremental",
+      "destination_sync_mode": "append",
       "stream": {
         "name": "subscription_report",
         "supported_sync_modes": ["incremental"],

--- a/airbyte-integrations/connectors/source-braintree-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-braintree-singer/sample_files/configured_catalog.json
@@ -196,7 +196,8 @@
         "source_defined_cursor": true,
         "supported_sync_modes": ["incremental"]
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-drift/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-drift/sample_files/configured_catalog.json
@@ -52,7 +52,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -107,7 +109,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -164,7 +168,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-exchangeratesapi-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-exchangeratesapi-singer/sample_files/configured_catalog.json
@@ -116,7 +116,8 @@
         "default_cursor_field": ["date"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["date"]
+      "cursor_field": ["date"],
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/sample_files/configured_catalog.json
@@ -78,7 +78,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1812,7 +1813,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -3871,7 +3873,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-file/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-file/integration_tests/configured_catalog.json
@@ -30,7 +30,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-file/integration_tests/sample_files/formats/json/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-file/integration_tests/sample_files/formats/json/configured_catalog.json
@@ -30,7 +30,9 @@
             "required": ["countries"]
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-freshdesk/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-freshdesk/sample_files/configured_catalog.json
@@ -82,7 +82,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "incremental",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -137,7 +138,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -213,7 +215,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "incremental",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -283,7 +286,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "incremental",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -329,7 +333,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "incremental",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -363,7 +368,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "incremental",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -409,7 +415,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "incremental",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -477,7 +484,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "incremental",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -531,7 +539,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "incremental",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -646,7 +655,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "incremental",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -698,7 +708,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "incremental",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-github-singer/resourcesstandardtest/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-github-singer/resourcesstandardtest/configured_catalog.json
@@ -26,7 +26,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -76,7 +78,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -239,7 +243,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -347,7 +352,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -438,7 +444,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -545,7 +553,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -669,7 +678,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -839,7 +849,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -867,7 +878,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -900,7 +913,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -952,7 +966,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1014,7 +1029,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1051,7 +1067,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1233,7 +1250,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1888,7 +1906,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1951,7 +1970,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-github-singer/resourcesstandardtest/private_configured_catalog.json
+++ b/airbyte-integrations/connectors/source-github-singer/resourcesstandardtest/private_configured_catalog.json
@@ -170,7 +170,8 @@
         "default_cursor_field": []
       },
       "sync_mode": "incremental",
-      "cursor_field": []
+      "cursor_field": [],
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-gitlab-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-gitlab-singer/sample_files/configured_catalog.json
@@ -258,7 +258,8 @@
         "default_cursor_field": ["last_activity_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["last_activity_at"]
+      "cursor_field": ["last_activity_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -297,7 +298,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -402,7 +405,8 @@
         "default_cursor_field": ["created_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created_at"]
+      "cursor_field": ["created_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -540,7 +544,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -669,7 +674,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -836,7 +843,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -860,7 +868,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -921,7 +931,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -982,7 +994,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1012,7 +1026,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1075,7 +1091,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1099,7 +1117,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1135,7 +1155,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1187,7 +1209,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1214,7 +1238,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1262,7 +1288,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1304,7 +1332,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1356,7 +1386,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1487,7 +1518,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-google-adwords-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-google-adwords-singer/sample_files/configured_catalog.json
@@ -171,7 +171,8 @@
         "source_defined_cursor": false
       },
       "sync_mode": "full_refresh",
-      "cursor_field": []
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -324,7 +325,8 @@
         "source_defined_cursor": false
       },
       "sync_mode": "full_refresh",
-      "cursor_field": []
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -404,7 +406,8 @@
         "source_defined_cursor": false
       },
       "sync_mode": "full_refresh",
-      "cursor_field": []
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -436,7 +439,8 @@
         "source_defined_cursor": false
       },
       "sync_mode": "full_refresh",
-      "cursor_field": []
+      "cursor_field": [],
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1008,7 +1012,8 @@
         "source_defined_cursor": false
       },
       "sync_mode": "incremental",
-      "cursor_field": []
+      "cursor_field": [],
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-google-directory/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-google-directory/sample_files/configured_catalog.json
@@ -153,7 +153,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -190,7 +192,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -218,7 +222,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-google-sheets/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-google-sheets/integration_tests/configured_catalog.json
@@ -21,7 +21,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -44,7 +46,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-googleanalytics-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-googleanalytics-singer/sample_files/configured_catalog.json
@@ -52,7 +52,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -115,7 +116,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -169,7 +171,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -241,7 +244,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -268,7 +272,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -295,7 +300,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -322,7 +328,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -349,7 +356,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -376,7 +384,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -439,7 +448,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -469,7 +479,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -505,7 +516,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-googleanalytics-singer/sample_files/test_catalog.json
+++ b/airbyte-integrations/connectors/source-googleanalytics-singer/sample_files/test_catalog.json
@@ -52,7 +52,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -115,7 +116,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -169,7 +171,8 @@
         "source_defined_cursor": true
       },
       "sync_mode": "incremental",
-      "cursor_field": ["report_start_date"]
+      "cursor_field": ["report_start_date"],
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-greenhouse/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-greenhouse/sample_files/configured_catalog.json
@@ -111,7 +111,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -304,7 +306,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-http-request/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-http-request/integration_tests/configured_catalog.json
@@ -7,7 +7,9 @@
           "$schema": "http://json-schema.org/draft-07/schema#",
           "type": "object"
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-hubspot/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-hubspot/sample_files/configured_catalog.json
@@ -100,7 +100,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -517,7 +518,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -623,7 +625,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3551,7 +3554,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3631,7 +3635,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3990,7 +3995,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -4118,7 +4124,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -4767,7 +4774,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -5055,7 +5063,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -5214,7 +5223,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -5297,7 +5307,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -5417,7 +5428,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -5675,7 +5687,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -5740,7 +5753,8 @@
         "default_cursor_field": ["timestamp"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["timestamp"]
+      "cursor_field": ["timestamp"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -5992,7 +6006,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -6049,7 +6064,8 @@
         "default_cursor_field": null
       },
       "sync_mode": "full_refresh",
-      "cursor_field": null
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-instagram/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-instagram/sample_files/configured_catalog.json
@@ -108,7 +108,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -168,7 +170,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -213,7 +217,9 @@
         },
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-intercom-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-intercom-singer/sample_files/configured_catalog.json
@@ -68,7 +68,9 @@
           "type": "object",
           "additionalProperties": false
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -184,7 +186,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -252,7 +255,9 @@
           "type": "object",
           "additionalProperties": false
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -288,7 +293,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -750,7 +756,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -860,7 +867,9 @@
           "type": "object",
           "additionalProperties": false
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -921,7 +930,9 @@
           "type": ["null", "object"],
           "additionalProperties": false
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1219,7 +1230,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1255,7 +1267,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1275,7 +1288,9 @@
           "type": "object",
           "additionalProperties": false
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1308,7 +1323,9 @@
           "type": "object",
           "additionalProperties": false
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-jira/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-jira/sample_files/configured_catalog.json
@@ -185,7 +185,9 @@
           "description": "Details about a project."
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -216,7 +218,9 @@
           "description": "Details of an issue resolution."
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -300,7 +304,9 @@
           "description": "A user with details as permitted by the user's Atlassian Account privacy settings. However, be aware of these exceptions:\n\n *  User record deleted from Atlassian: This occurs as the result of a right to be forgotten request. In this case, `displayName` provides an indication and other parameters have default values or are blank (for example, email is blank).\n *  User record corrupted: This occurs as a results of events such as a server import and can only happen to deleted users. In this case, `accountId` returns *unknown* and all other parameters have fallback values.\n *  User record unavailable: This usually occurs due to an internal service outage. In this case, all parameters have fallback values."
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -403,7 +409,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -467,7 +475,9 @@
           "description": "A comment."
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-jira/sample_files/full_configured_catalog.json
+++ b/airbyte-integrations/connectors/source-jira/sample_files/full_configured_catalog.json
@@ -185,7 +185,9 @@
           "description": "Details about a project."
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -216,7 +218,9 @@
           "description": "Details of an issue resolution."
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -300,7 +304,9 @@
           "description": "A user with details as permitted by the user's Atlassian Account privacy settings. However, be aware of these exceptions:\n\n *  User record deleted from Atlassian: This occurs as the result of a right to be forgotten request. In this case, `displayName` provides an indication and other parameters have default values or are blank (for example, email is blank).\n *  User record corrupted: This occurs as a results of events such as a server import and can only happen to deleted users. In this case, `accountId` returns *unknown* and all other parameters have fallback values.\n *  User record unavailable: This usually occurs due to an internal service outage. In this case, all parameters have fallback values."
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -403,7 +409,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -467,7 +475,9 @@
           "description": "A comment."
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-looker/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-looker/integration_tests/configured_catalog.json
@@ -31,7 +31,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -85,7 +87,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -139,7 +143,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -804,7 +810,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -868,7 +876,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -910,7 +920,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1313,7 +1325,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1358,7 +1372,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1511,7 +1527,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1589,7 +1607,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1649,7 +1669,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1703,7 +1725,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1813,7 +1837,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1997,7 +2023,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2566,7 +2594,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2608,7 +2638,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2635,7 +2667,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2698,7 +2732,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2731,7 +2767,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2776,7 +2814,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2848,7 +2888,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2905,7 +2947,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3037,7 +3081,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3076,7 +3122,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3106,7 +3154,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3675,7 +3725,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3759,7 +3811,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3798,7 +3852,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3838,7 +3894,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -4046,7 +4104,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -4264,7 +4324,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -4285,7 +4347,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -4321,7 +4385,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -4493,7 +4559,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -4646,7 +4714,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-looker/sample_files/full_configured_catalog.json
+++ b/airbyte-integrations/connectors/source-looker/sample_files/full_configured_catalog.json
@@ -31,7 +31,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -85,7 +87,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -139,7 +143,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -804,7 +810,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -868,7 +876,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -914,7 +924,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -956,7 +968,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1359,7 +1373,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1404,7 +1420,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1557,7 +1575,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1635,7 +1655,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1695,7 +1717,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1749,7 +1773,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1859,7 +1885,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2043,7 +2071,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2612,7 +2642,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2654,7 +2686,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2681,7 +2715,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2744,7 +2780,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2777,7 +2815,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2822,7 +2862,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2894,7 +2936,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -2951,7 +2995,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3083,7 +3129,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3122,7 +3170,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3152,7 +3202,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3721,7 +3773,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3805,7 +3859,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3844,7 +3900,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -3884,7 +3942,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -4092,7 +4152,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -4310,7 +4372,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -4331,7 +4395,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -4367,7 +4433,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -4539,7 +4607,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -4692,7 +4762,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-looker/sample_files/sample_configured_catalog.json
+++ b/airbyte-integrations/connectors/source-looker/sample_files/sample_configured_catalog.json
@@ -31,7 +31,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -85,7 +87,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-mailchimp/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-mailchimp/sample_files/configured_catalog.json
@@ -793,7 +793,8 @@
         "default_cursor_field": ["create_time"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["create_time"]
+      "cursor_field": ["create_time"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1159,7 +1160,8 @@
         "default_cursor_field": ["date_created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["date_created"]
+      "cursor_field": ["date_created"],
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-marketo-singer/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-marketo-singer/integration_tests/configured_catalog.json
@@ -45,7 +45,8 @@
         "source_defined_cursor": true,
         "default_cursor_field": []
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -83,7 +84,8 @@
         "source_defined_cursor": true,
         "default_cursor_field": []
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -144,7 +146,8 @@
         "source_defined_cursor": true,
         "default_cursor_field": []
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-microsoft-teams/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-microsoft-teams/sample_files/configured_catalog.json
@@ -55,7 +55,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -216,7 +217,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -273,7 +275,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -333,7 +336,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -362,7 +366,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -404,7 +409,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -478,7 +484,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -552,7 +559,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -594,7 +602,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -696,7 +705,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -782,7 +792,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -832,7 +843,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-mixpanel-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-mixpanel-singer/sample_files/configured_catalog.json
@@ -32,7 +32,8 @@
         "default_cursor_field": ["datetime"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["datetime"]
+      "cursor_field": ["datetime"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -57,7 +58,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-mongodb/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-mongodb/integration_tests/configured_catalog.json
@@ -2,6 +2,7 @@
   "streams": [
     {
       "sync_mode": "incremental",
+      "destination_sync_mode": "append",
       "cursor_field": ["bucket_end_date"],
       "stream": {
         "name": "transactions",
@@ -32,6 +33,7 @@
     },
     {
       "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite",
       "stream": {
         "name": "customers",
         "supported_sync_modes": ["full_refresh", "incremental"],

--- a/airbyte-integrations/connectors/source-plaid/sample_files/fullrefresh_configured_catalog.json
+++ b/airbyte-integrations/connectors/source-plaid/sample_files/fullrefresh_configured_catalog.json
@@ -27,7 +27,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-recurly/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-recurly/integration_tests/configured_catalog.json
@@ -99,7 +99,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-recurly/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-recurly/sample_files/configured_catalog.json
@@ -99,7 +99,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-salesforce-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-salesforce-singer/sample_files/configured_catalog.json
@@ -320,7 +320,8 @@
         "default_cursor_field": ["SystemModstamp"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["SystemModstamp"]
+      "cursor_field": ["SystemModstamp"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -600,7 +601,8 @@
         "default_cursor_field": ["SystemModstamp"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["SystemModstamp"]
+      "cursor_field": ["SystemModstamp"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -779,7 +781,8 @@
         "default_cursor_field": ["SystemModstamp"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["SystemModstamp"]
+      "cursor_field": ["SystemModstamp"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -952,7 +955,8 @@
         "default_cursor_field": ["SystemModstamp"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["SystemModstamp"]
+      "cursor_field": ["SystemModstamp"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1280,7 +1284,8 @@
         "default_cursor_field": ["SystemModstamp"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["SystemModstamp"]
+      "cursor_field": ["SystemModstamp"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1475,7 +1480,8 @@
         "default_cursor_field": ["SystemModstamp"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["SystemModstamp"]
+      "cursor_field": ["SystemModstamp"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1563,7 +1569,8 @@
         "default_cursor_field": ["SystemModstamp"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["SystemModstamp"]
+      "cursor_field": ["SystemModstamp"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1656,7 +1663,8 @@
         "default_cursor_field": ["SystemModstamp"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["SystemModstamp"]
+      "cursor_field": ["SystemModstamp"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1709,7 +1717,8 @@
         "default_cursor_field": ["CreatedDate"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["CreatedDate"]
+      "cursor_field": ["CreatedDate"],
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-scaffold-source-python/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-scaffold-source-python/sample_files/configured_catalog.json
@@ -15,7 +15,9 @@
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false,
         "default_cursor_field": ["column_name"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-sendgrid/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-sendgrid/integration_tests/configured_catalog.json
@@ -28,7 +28,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -56,7 +58,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -135,7 +139,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -196,7 +202,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -231,7 +239,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -257,7 +267,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -274,7 +286,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -300,7 +314,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -323,7 +339,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -346,7 +364,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -369,7 +389,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -389,7 +411,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -409,7 +433,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-shopify-singer/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-shopify-singer/integration_tests/configured_catalog.json
@@ -1589,7 +1589,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -2369,7 +2370,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -2420,7 +2422,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -2626,7 +2629,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -2882,7 +2886,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -2947,7 +2952,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -2985,7 +2991,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -3390,7 +3397,8 @@
         "default_cursor_field": ["created_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -3500,7 +3508,8 @@
         "default_cursor_field": ["created_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-shopify-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-shopify-singer/sample_files/configured_catalog.json
@@ -204,7 +204,8 @@
         "default_cursor_field": ["updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["updated_at"]
+      "cursor_field": ["updated_at"],
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-slack-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-slack-singer/sample_files/configured_catalog.json
@@ -134,7 +134,9 @@
             }
           }
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -205,7 +207,8 @@
         "default_cursor_field": []
       },
       "sync_mode": "incremental",
-      "cursor_field": []
+      "cursor_field": [],
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-stock-ticker-api-tutorial/fullrefresh_configured_catalog.json
+++ b/airbyte-integrations/connectors/source-stock-ticker-api-tutorial/fullrefresh_configured_catalog.json
@@ -18,7 +18,8 @@
           }
         }
       },
-      "sync_mode": "full_refresh"
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-stripe-singer/sample_files/fullrefresh_configured_catalog.json
+++ b/airbyte-integrations/connectors/source-stripe-singer/sample_files/fullrefresh_configured_catalog.json
@@ -1061,7 +1061,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1109,7 +1110,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1975,7 +1977,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -2076,7 +2079,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -2310,7 +2314,8 @@
         "default_cursor_field": ["date"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["date"]
+      "cursor_field": ["date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -2483,7 +2488,8 @@
         "default_cursor_field": ["date"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["date"]
+      "cursor_field": ["date"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -2646,7 +2652,8 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true
       },
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -2742,7 +2749,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -2812,7 +2820,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -3075,7 +3084,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -3251,7 +3261,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -3337,7 +3348,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -3483,7 +3495,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -3504,7 +3517,8 @@
         "default_cursor_field": ["id"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["id"]
+      "cursor_field": ["id"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -3673,7 +3687,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -3771,7 +3786,8 @@
         "default_cursor_field": ["created"]
       },
       "sync_mode": "incremental",
-      "cursor_field": ["created"]
+      "cursor_field": ["created"],
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-tempo/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-tempo/sample_files/configured_catalog.json
@@ -107,7 +107,9 @@
           }
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -132,7 +134,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -189,7 +193,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -275,7 +281,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-twilio-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-twilio-singer/sample_files/configured_catalog.json
@@ -131,7 +131,8 @@
         "default_cursor_field": ["date_updated"]
       },
       "cursor_field": ["date_updated"],
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -194,7 +195,8 @@
         "default_cursor_field": ["date_updated"]
       },
       "cursor_field": ["date_updated"],
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -300,7 +302,9 @@
           "type": "object",
           "additionalProperties": false
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -378,7 +382,8 @@
         "default_cursor_field": ["date_updated"]
       },
       "cursor_field": ["date_updated"],
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -438,7 +443,9 @@
           "type": "object",
           "additionalProperties": false
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -525,7 +532,9 @@
           "type": "object",
           "additionalProperties": false
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -612,7 +621,9 @@
           "type": "object",
           "additionalProperties": false
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -699,7 +710,9 @@
           "type": "object",
           "additionalProperties": false
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -831,7 +844,8 @@
         "default_cursor_field": ["date_updated"]
       },
       "cursor_field": ["date_updated"],
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -864,7 +878,8 @@
         "default_cursor_field": ["date_updated"]
       },
       "cursor_field": ["date_updated"],
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -997,7 +1012,8 @@
         "default_cursor_field": ["end_time"]
       },
       "cursor_field": ["end_time"],
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1064,7 +1080,8 @@
         "default_cursor_field": ["date_updated"]
       },
       "cursor_field": ["date_updated"],
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1116,7 +1133,9 @@
           "type": "object",
           "additionalProperties": false
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1155,7 +1174,8 @@
         "default_cursor_field": ["date_updated"]
       },
       "cursor_field": ["date_updated"],
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1275,7 +1295,8 @@
         "default_cursor_field": ["date_created"]
       },
       "cursor_field": ["date_created"],
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1333,7 +1354,8 @@
         "default_cursor_field": ["date_updated"]
       },
       "cursor_field": ["date_updated"],
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1400,7 +1422,8 @@
         "default_cursor_field": ["date_updated"]
       },
       "cursor_field": ["date_updated"],
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1506,7 +1529,10 @@
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true,
         "default_cursor_field": ["date_sent"]
-      }
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["date_sent"],
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1540,7 +1566,9 @@
           "type": "object",
           "additionalProperties": false
         }
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1682,7 +1710,8 @@
         "default_cursor_field": ["end_date"]
       },
       "cursor_field": ["end_date"],
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1750,7 +1779,8 @@
         "default_cursor_field": ["date_updated"]
       },
       "cursor_field": ["date_updated"],
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     },
     {
       "stream": {
@@ -1814,7 +1844,8 @@
         "default_cursor_field": ["date_updated"]
       },
       "cursor_field": ["date_updated"],
-      "sync_mode": "incremental"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-zoom-singer/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-zoom-singer/sample_files/configured_catalog.json
@@ -63,7 +63,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-zoom-singer/sample_files/full_configured_catalog.json
+++ b/airbyte-integrations/connectors/source-zoom-singer/sample_files/full_configured_catalog.json
@@ -43,7 +43,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -84,7 +86,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -108,7 +112,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -199,7 +205,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -264,7 +272,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -300,7 +310,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -324,7 +336,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -369,7 +383,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -613,7 +629,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -667,7 +685,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -758,7 +778,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -785,7 +807,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -821,7 +845,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -875,7 +901,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -913,7 +941,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1121,7 +1151,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1157,7 +1189,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1248,7 +1282,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1278,7 +1314,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1346,7 +1384,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     },
     {
       "stream": {
@@ -1414,7 +1454,9 @@
           "additionalProperties": false
         },
         "supported_sync_modes": ["full_refresh"]
-      }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }


### PR DESCRIPTION
## What
Following-up on #2500 integrations tests of connectors are broken as these fields are now required in configured catalogs.
(the migration script doesn't affect the files checked into the git repository)

## How
Add `sync_mode` and `destination_sync_mode` to all configured_catalog.json used for tests

## Pre-merge Checklist
- [x] *Run integration tests*
