### PR TITLE
raise FAIL after stream-read exception

### DIFF
--- a/airbyte-integrations/bases/base-python/base_python/source.py
+++ b/airbyte-integrations/bases/base-python/base_python/source.py
@@ -89,7 +89,7 @@ class BaseSource(Source):
                 
             except Exception as error:
                 logger.exception(f"Encountered an exception while reading stream {self.name}")
-                return AirbyteConnectionStatus(status=Status.FAILED, message=str(error))
+                raise
 
         logger.info(f"Finished syncing {self.name}")
 

--- a/airbyte-integrations/bases/base-python/base_python/source.py
+++ b/airbyte-integrations/bases/base-python/base_python/source.py
@@ -86,9 +86,10 @@ class BaseSource(Source):
         for configured_stream in catalog.streams:
             try:
                 yield from self._read_stream(logger=logger, client=client, configured_stream=configured_stream, state=total_state)
-            # TODO: test stream fail
-            except Exception:
+                
+            except Exception as error:
                 logger.exception(f"Encountered an exception while reading stream {self.name}")
+                return AirbyteConnectionStatus(status=Status.FAILED, message=str(error))
 
         logger.info(f"Finished syncing {self.name}")
 

--- a/airbyte-integrations/bases/base-python/base_python/source.py
+++ b/airbyte-integrations/bases/base-python/base_python/source.py
@@ -87,9 +87,9 @@ class BaseSource(Source):
             try:
                 yield from self._read_stream(logger=logger, client=client, configured_stream=configured_stream, state=total_state)
                 
-            except Exception as error:
+            except Exception:
                 logger.exception(f"Encountered an exception while reading stream {self.name}")
-                raise AirbyteConnectionStatus(status=Status.FAILED, message=str(error))
+                raise
 
         logger.info(f"Finished syncing {self.name}")
 

--- a/airbyte-integrations/bases/base-python/base_python/source.py
+++ b/airbyte-integrations/bases/base-python/base_python/source.py
@@ -89,7 +89,7 @@ class BaseSource(Source):
                 
             except Exception as error:
                 logger.exception(f"Encountered an exception while reading stream {self.name}")
-                raise
+                raise AirbyteConnectionStatus(status=Status.FAILED, message=str(error))
 
         logger.info(f"Finished syncing {self.name}")
 


### PR DESCRIPTION
This is my first contribution to airbyte issues 😁 , hoping this is right but I'm happy to learn if not. Not certain that the AirbyteConnectionStatus object is used for raising 'sync' failures.

## What
Add FAIL state signal when a stream read throws an exception.

## How
Instantiate an `AirbyteConnectionStatus` object with `status=Status.FAILED` within the except block during attempts at reading configured streams

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*
