### PR TITLE
🎉  fix bug where catalog discovery fails for catalogs >2MB (max catalog size is now 15MB)

### DIFF
--- a/temporal/dynamicconfig/development.yaml
+++ b/temporal/dynamicconfig/development.yaml
@@ -31,3 +31,10 @@ history.defaultWorkflowRetryPolicy:
       MaximumIntervalCoefficient: 100.0
       BackoffCoefficient: 2.0
       MaximumAttempts: 0
+# Limit for responses. This mostly impacts discovery jobs since they have the largest responses.
+limit.blobSize.error:
+  - value: 15728640 # 15MB
+    constraints: {}
+limit.blobSize.warn:
+  - value: 10485760 # 10MB
+    constraints: {}


### PR DESCRIPTION
resolves #2619 

Here's where the constants are listed (I don't think there's any other documentation....): https://github.com/temporalio/temporal/blob/master/common/dynamicconfig/constants.go

Based on this question https://community.temporal.io/t/find-cause-of-complete-result-exceeds-size-limit-error/457/4 I updated these values. 

Manually tested failure cases with low values for warnings and errors. Seems to work as expected.