### PR TITLE
switch from exchangerates.io to ratesapi.io

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9fed261d-d107-47fd-8c8b-323023db6e20.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9fed261d-d107-47fd-8c8b-323023db6e20.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "9fed261d-d107-47fd-8c8b-323023db6e20",
   "name": "Exchange Rates Api",
   "dockerRepository": "airbyte/source-exchangeratesapi-singer",
-  "dockerImageTag": "0.2.2",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-exchangeratesapi-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9fed261d-d107-47fd-8c8b-323023db6e20.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9fed261d-d107-47fd-8c8b-323023db6e20.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "9fed261d-d107-47fd-8c8b-323023db6e20",
   "name": "Exchange Rates Api",
   "dockerRepository": "airbyte/source-exchangeratesapi-singer",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.2",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-exchangeratesapi-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9fed261d-d107-47fd-8c8b-323023db6e20.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9fed261d-d107-47fd-8c8b-323023db6e20.json
@@ -3,5 +3,5 @@
   "name": "Exchange Rates Api",
   "dockerRepository": "airbyte/source-exchangeratesapi-singer",
   "dockerImageTag": "0.2.0",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-exchangeratesapi_io-source"
+  "documentationUrl": "https://hub.docker.com/r/airbyte/source-exchangeratesapi-singer"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1,7 +1,7 @@
 - sourceDefinitionId: 9fed261d-d107-47fd-8c8b-323023db6e20
   name: Exchange Rates Api
   dockerRepository: airbyte/source-exchangeratesapi-singer
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.2
   documentationUrl: https://hub.docker.com/r/airbyte/source-exchangeratesapi-singer
 - sourceDefinitionId: 778daa7c-feaf-4db6-96f3-70fd645acc77
   name: File

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -2,7 +2,7 @@
   name: Exchange Rates Api
   dockerRepository: airbyte/source-exchangeratesapi-singer
   dockerImageTag: 0.2.0
-  documentationUrl: https://hub.docker.com/r/airbyte/integration-singer-exchangeratesapi_io-source
+  documentationUrl: https://hub.docker.com/r/airbyte/source-exchangeratesapi-singer
 - sourceDefinitionId: 778daa7c-feaf-4db6-96f3-70fd645acc77
   name: File
   dockerRepository: airbyte/source-file

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1,7 +1,7 @@
 - sourceDefinitionId: 9fed261d-d107-47fd-8c8b-323023db6e20
   name: Exchange Rates Api
   dockerRepository: airbyte/source-exchangeratesapi-singer
-  dockerImageTag: 0.2.2
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-exchangeratesapi-singer
 - sourceDefinitionId: 778daa7c-feaf-4db6-96f3-70fd645acc77
   name: File

--- a/airbyte-integrations/connectors/source-exchangeratesapi-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-exchangeratesapi-singer/Dockerfile
@@ -8,7 +8,7 @@ ENV CODE_PATH="source_exchangeratesapi_singer"
 ENV AIRBYTE_IMPL_MODULE="source_exchangeratesapi_singer"
 ENV AIRBYTE_IMPL_PATH="SourceExchangeRatesApiSinger"
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-exchangeratesapi-singer
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-exchangeratesapi-singer/setup.py
+++ b/airbyte-integrations/connectors/source-exchangeratesapi-singer/setup.py
@@ -31,5 +31,10 @@ setup(
     author_email="contact@airbyte.io",
     packages=find_packages(),
     package_data={"": ["*.json"]},
-    install_requires=["tap-exchangeratesapi==0.1.1", "base-python", "airbyte-protocol", "pytest==6.1.2"],
+    install_requires=[
+        "tap-exchangeratesapi @ https://github.com/airbytehq/tap-exchangeratesapi/tarball/v0.1.1-patched",
+        "base-python",
+        "airbyte-protocol",
+        "pytest==6.1.2",
+    ],
 )

--- a/airbyte-integrations/connectors/source-exchangeratesapi-singer/source_exchangeratesapi_singer/source.py
+++ b/airbyte-integrations/connectors/source-exchangeratesapi-singer/source_exchangeratesapi_singer/source.py
@@ -22,9 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-import urllib.request
 from typing import Dict
 
+import requests
 from airbyte_protocol import AirbyteConnectionStatus, Status, SyncMode
 from base_singer import SingerSource, SyncModeInfo
 
@@ -32,7 +32,7 @@ from base_singer import SingerSource, SyncModeInfo
 class SourceExchangeRatesApiSinger(SingerSource):
     def check(self, logger, config_path) -> AirbyteConnectionStatus:
         try:
-            code = urllib.request.urlopen("https://api.ratesapi.io/").getcode()
+            code = requests.get("https://api.ratesapi.io/").status_code
             logger.info(f"Ping response code: {code}")
             return AirbyteConnectionStatus(status=Status.SUCCEEDED if (code == 200) else Status.FAILED)
         except Exception as e:

--- a/airbyte-integrations/connectors/source-exchangeratesapi-singer/source_exchangeratesapi_singer/source.py
+++ b/airbyte-integrations/connectors/source-exchangeratesapi-singer/source_exchangeratesapi_singer/source.py
@@ -32,7 +32,7 @@ from base_singer import SingerSource, SyncModeInfo
 class SourceExchangeRatesApiSinger(SingerSource):
     def check(self, logger, config_path) -> AirbyteConnectionStatus:
         try:
-            code = urllib.request.urlopen("https://api.exchangeratesapi.io/").getcode()
+            code = urllib.request.urlopen("https://api.ratesapi.io/").getcode()
             logger.info(f"Ping response code: {code}")
             return AirbyteConnectionStatus(status=Status.SUCCEEDED if (code == 200) else Status.FAILED)
         except Exception as e:

--- a/airbyte-integrations/connectors/source-exchangeratesapi-singer/source_exchangeratesapi_singer/spec.json
+++ b/airbyte-integrations/connectors/source-exchangeratesapi-singer/source_exchangeratesapi_singer/spec.json
@@ -1,8 +1,8 @@
 {
-  "documentationUrl": "https://docs.airbyte.io/integrations/sources/exchangeratesapi-io",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/ratesapi-io",
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "exchangeratesapi.io Source Spec",
+    "title": "ratesapi.io Source Spec",
     "type": "object",
     "required": ["start_date", "base"],
     "additionalProperties": false,

--- a/airbyte-integrations/connectors/source-github-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-github-singer/Dockerfile
@@ -8,7 +8,7 @@ ENV CODE_PATH="source_github_singer"
 ENV AIRBYTE_IMPL_MODULE="source_github_singer"
 ENV AIRBYTE_IMPL_PATH="SourceGithubSinger"
 
-LABEL io.airbyte.version=0.2.1
+LABEL io.airbyte.version=0.2.2
 LABEL io.airbyte.name=airbyte/source-github-singer
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-github-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-github-singer/Dockerfile
@@ -8,7 +8,7 @@ ENV CODE_PATH="source_github_singer"
 ENV AIRBYTE_IMPL_MODULE="source_github_singer"
 ENV AIRBYTE_IMPL_PATH="SourceGithubSinger"
 
-LABEL io.airbyte.version=0.2.2
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-github-singer
 
 WORKDIR /airbyte/integration_code

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -24,7 +24,7 @@
     * [Appstore](integrations/sources/appstore.md)
     * [Braintree](integrations/sources/braintree.md)
     * [Drift](integrations/sources/drift.md)
-    * [Exchange Rates API](integrations/sources/exchangeratesapi-io.md)
+    * [Exchange Rates API](integrations/sources/exchangeratesapi.md)
     * [Facebook Marketing](integrations/sources/facebook-marketing.md)
     * [Files](integrations/sources/file.md)
     * [Freshdesk](integrations/sources/freshdesk.md)

--- a/docs/architecture/incremental-append.md
+++ b/docs/architecture/incremental-append.md
@@ -70,7 +70,7 @@ The output we expect to see in the warehouse is as follows:
 
 ## Source-Defined Cursor
 
-Some sources are able to determine the cursor that they use without any user input. For example, in the [exchange rates source](../integrations/sources/exchangeratesapi-io.md), the source knows that the date field should be used to determine the last record that was synced. In these cases, simply select the incremental option in the UI.
+Some sources are able to determine the cursor that they use without any user input. For example, in the [exchange rates source](../integrations/sources/exchangeratesapi.md), the source knows that the date field should be used to determine the last record that was synced. In these cases, simply select the incremental option in the UI.
 
 ![](../.gitbook/assets/incremental_source_defined.png)
 

--- a/docs/architecture/incremental-deduped-history.md
+++ b/docs/architecture/incremental-deduped-history.md
@@ -87,12 +87,12 @@ In the final de-duplicated table:
     { "name": "Louis XVI", "deceased": true, "updated_at": 1793 },
     { "name": "Louis XVII", "deceased": false, "updated_at": 1785 },
     { "name": "Marie Antoinette", "deceased": true, "updated_at": 1793 }
-]
+] 
 ```
 
 ## Source-Defined Cursor
 
-Some sources are able to determine the cursor that they use without any user input. For example, in the [exchange rates source](../integrations/sources/exchangeratesapi-io.md), the source knows that the date field should be used to determine the last record that was synced. In these cases, simply select the incremental option in the UI.
+Some sources are able to determine the cursor that they use without any user input. For example, in the [exchange rates source](../integrations/sources/exchangeratesapi.md), the source knows that the date field should be used to determine the last record that was synced. In these cases, simply select the incremental option in the UI.
 
 ![](../.gitbook/assets/incremental_source_defined.png)
 

--- a/docs/integrations/sources/exchangeratesapi.md
+++ b/docs/integrations/sources/exchangeratesapi.md
@@ -4,7 +4,7 @@
 
 The exchange rates integration is a toy integration to demonstrate how Airbyte works with a very simple source.
 
-It pulls all its data from [https://exchangeratesapi.io/](https://exchangeratesapi.io/)
+It pulls all its data from [https://ratesapi.io/](https://ratesapi.io/)
 
 #### Output schema
 


### PR DESCRIPTION
Policies changed for exchangerates.io (they require a key now) so we're switching to ratesapi.io. On their website they say they're compatible and free. They are only asking for people to cache, which these taps effectively do, so we should be good.

Still need to test manually.