### PR TITLE
Include credentials in API requests

### DIFF
--- a/airbyte-webapp/src/core/request/AirbyteRequestService.ts
+++ b/airbyte-webapp/src/core/request/AirbyteRequestService.ts
@@ -13,6 +13,7 @@ abstract class AirbyteRequestService {
     const response = await fetch(url, {
       method: "POST",
       body: body ? JSON.stringify(body) : undefined,
+      credentials: "include",
       ...options,
     });
 


### PR DESCRIPTION
## What
I have an nginx proxy in front of the app/API that does HTTPS and [auth](https://github.com/vouch/vouch-proxy) on different subdomains (e.g. `https://airbyte.example.team` & `https://airbyte-api.example.team`). It does this via a cookie on the domain.

I can use nginx to setup all the rules I need for the api-side (specifically CORS), but unless the frontend passes `credentials: 'include'` to `fetch`, the cookie never gets sent through and the auth fails.

Given that Airbyte doesn't offer auth yet, this seems like a pattern others are likely to repeat, so default including credentials seems correct. Additionally, once Airbyte does provide some kind of auth, this will likely be necessary anyway (assuming cookie-based auth is chosen).

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*
