### PR TITLE
fix connector base versioning

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/00405b19-9768-4e0c-b1ae-9fc2ee2b2a8c.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/00405b19-9768-4e0c-b1ae-9fc2ee2b2a8c.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "00405b19-9768-4e0c-b1ae-9fc2ee2b2a8c",
   "name": "Looker",
   "dockerRepository": "airbyte/source-looker",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-looker"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2470e835-feaf-4db6-96f3-70fd645acc77.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2470e835-feaf-4db6-96f3-70fd645acc77.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "2470e835-feaf-4db6-96f3-70fd645acc77",
   "name": "Salesforce",
   "dockerRepository": "airbyte/source-salesforce-singer",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-salesforce-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2af123bf-0aaf-4e0d-9784-cb497f23741a.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2af123bf-0aaf-4e0d-9784-cb497f23741a.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "2af123bf-0aaf-4e0d-9784-cb497f23741a",
   "name": "Appstore",
   "dockerRepository": "airbyte/source-appstore-singer",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-appstore-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/36c891d9-4bd9-43ac-bad2-10e12756272c.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/36c891d9-4bd9-43ac-bad2-10e12756272c.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "36c891d9-4bd9-43ac-bad2-10e12756272c",
   "name": "Hubspot",
   "dockerRepository": "airbyte/source-hubspot",
-  "dockerImageTag": "0.1.1",
+  "dockerImageTag": "0.1.2",
   "documentationUrl": "https://https://docs.airbyte.io/integrations/sources/hubspot"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/396e4ca3-8a97-4b85-aa4e-c9d8c2d5f992.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/396e4ca3-8a97-4b85-aa4e-c9d8c2d5f992.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "396e4ca3-8a97-4b85-aa4e-c9d8c2d5f992",
   "name": "Braintree",
   "dockerRepository": "airbyte/source-braintree-singer",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-braintree-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/39f092a6-8c87-4f6f-a8d9-5cef45b7dbe1.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/39f092a6-8c87-4f6f-a8d9-5cef45b7dbe1.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "39f092a6-8c87-4f6f-a8d9-5cef45b7dbe1",
   "name": "Google Analytics",
   "dockerRepository": "airbyte/source-googleanalytics-singer",
-  "dockerImageTag": "0.2.2",
+  "dockerImageTag": "0.2.3",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-googleanalytics-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/41375467-61ae-4204-8e38-e2b8b7365f23.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/41375467-61ae-4204-8e38-e2b8b7365f23.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "41375467-61ae-4204-8e38-e2b8b7365f23",
   "name": "Slack",
   "dockerRepository": "airbyte/source-slack-singer",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-slack-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/445831eb-78db-4b1f-8f1f-0d96ad8739e2.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/445831eb-78db-4b1f-8f1f-0d96ad8739e2.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "445831eb-78db-4b1f-8f1f-0d96ad8739e2",
   "name": "Drift",
   "dockerRepository": "airbyte/source-drift",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-drift"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/59f1e50a-331f-4f09-b3e8-2e8d4d355f44.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/59f1e50a-331f-4f09-b3e8-2e8d4d355f44.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "59f1e50a-331f-4f09-b3e8-2e8d4d355f44",
   "name": "Greenhouse",
   "dockerRepository": "airbyte/source-greenhouse",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://https://docs.airbyte.io/integrations/sources/greenhouse"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/5e6175e5-68e1-4c17-bff9-56103bbb0d80.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/5e6175e5-68e1-4c17-bff9-56103bbb0d80.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "5e6175e5-68e1-4c17-bff9-56103bbb0d80",
   "name": "Gitlab",
   "dockerRepository": "airbyte/source-gitlab-singer",
-  "dockerImageTag": "0.1.0",
+  "dockerImageTag": "0.1.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-gitlab-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/68e63de2-bb83-4c7e-93fa-a8a9051e3993.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/68e63de2-bb83-4c7e-93fa-a8a9051e3993.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "68e63de2-bb83-4c7e-93fa-a8a9051e3993",
   "name": "Jira",
   "dockerRepository": "airbyte/source-jira",
-  "dockerImageTag": "0.2.1",
+  "dockerImageTag": "0.2.2",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-jira"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/6acf6b55-4f1e-4fca-944e-1a3caef8aba8.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/6acf6b55-4f1e-4fca-944e-1a3caef8aba8.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "6acf6b55-4f1e-4fca-944e-1a3caef8aba8",
   "name": "Instagram",
   "dockerRepository": "airbyte/source-instagram",
-  "dockerImageTag": "0.1.3",
+  "dockerImageTag": "0.1.4",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-instagram"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/71607ba1-c0ac-4799-8049-7f4b90dd50f7.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/71607ba1-c0ac-4799-8049-7f4b90dd50f7.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "71607ba1-c0ac-4799-8049-7f4b90dd50f7",
   "name": "Google Sheets",
   "dockerRepository": "airbyte/source-google-sheets",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-google-sheets"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/778daa7c-feaf-4db6-96f3-70fd645acc77.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/778daa7c-feaf-4db6-96f3-70fd645acc77.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "778daa7c-feaf-4db6-96f3-70fd645acc77",
   "name": "File",
   "dockerRepository": "airbyte/source-file",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-file"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/859e501d-2b67-471f-91bb-1c801414d28f.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/859e501d-2b67-471f-91bb-1c801414d28f.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "859e501d-2b67-471f-91bb-1c801414d28f",
   "name": "Mixpanel",
   "dockerRepository": "airbyte/source-mixpanel-singer",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-mixpanel-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/932e6363-d006-4464-a9f5-102b82e07c06.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/932e6363-d006-4464-a9f5-102b82e07c06.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "932e6363-d006-4464-a9f5-102b82e07c06",
   "name": "Twilio",
   "dockerRepository": "airbyte/source-twilio-singer",
-  "dockerImageTag": "0.2.1",
+  "dockerImageTag": "0.2.2",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-twilio-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9845d17a-45f1-4070-8a60-50914b1c8e2b.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9845d17a-45f1-4070-8a60-50914b1c8e2b.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "9845d17a-45f1-4070-8a60-50914b1c8e2b",
   "name": "HTTP Request",
   "dockerRepository": "airbyte/source-http-request",
-  "dockerImageTag": "0.2.1",
+  "dockerImageTag": "0.2.2",
   "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-http-request"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9e0556f4-69df-4522-a3fb-03264d36b348.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9e0556f4-69df-4522-a3fb-03264d36b348.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "9e0556f4-69df-4522-a3fb-03264d36b348",
   "name": "Marketo",
   "dockerRepository": "airbyte/source-marketo-singer",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-marketo-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9fed261d-d107-47fd-8c8b-323023db6e20.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9fed261d-d107-47fd-8c8b-323023db6e20.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "9fed261d-d107-47fd-8c8b-323023db6e20",
   "name": "Exchange Rates Api",
   "dockerRepository": "airbyte/source-exchangeratesapi-singer",
-  "dockerImageTag": "0.2.1",
+  "dockerImageTag": "0.2.2",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-exchangeratesapi-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/aea2fd0d-377d-465e-86c0-4fdc4f688e51.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/aea2fd0d-377d-465e-86c0-4fdc4f688e51.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "aea2fd0d-377d-465e-86c0-4fdc4f688e51",
   "name": "Zoom",
   "dockerRepository": "airbyte/source-zoom-singer",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-zoom-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b03a9f3e-22a5-11eb-adc1-0242ac120002.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b03a9f3e-22a5-11eb-adc1-0242ac120002.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "b03a9f3e-22a5-11eb-adc1-0242ac120002",
   "name": "Mailchimp",
   "dockerRepository": "airbyte/source-mailchimp",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-mailchimp"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b1892b11-788d-44bd-b9ec-3a436f7b54ce.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b1892b11-788d-44bd-b9ec-3a436f7b54ce.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "b1892b11-788d-44bd-b9ec-3a436f7b54ce",
   "name": "Shopify",
   "dockerRepository": "airbyte/source-shopify-singer",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-shopify-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/cd42861b-01fc-4658-a8ab-5d11d0510f01.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/cd42861b-01fc-4658-a8ab-5d11d0510f01.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "cd42861b-01fc-4658-a8ab-5d11d0510f01",
   "name": "Recurly",
   "dockerRepository": "airbyte/source-recurly",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-recurly"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d19ae824-e289-4b14-995a-0632eb46d246.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d19ae824-e289-4b14-995a-0632eb46d246.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "d19ae824-e289-4b14-995a-0632eb46d246",
   "name": "Google Directory",
   "dockerRepository": "airbyte/source-google-directory",
-  "dockerImageTag": "0.1.0",
+  "dockerImageTag": "0.1.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-google-directory"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d1aa448b-7c54-498e-ad95-263cbebcd2db.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d1aa448b-7c54-498e-ad95-263cbebcd2db.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "d1aa448b-7c54-498e-ad95-263cbebcd2db",
   "name": "Tempo",
   "dockerRepository": "airbyte/source-tempo",
-  "dockerImageTag": "0.2.1",
+  "dockerImageTag": "0.2.2",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-tempo"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d29764f8-80d7-4dd7-acbe-1a42005ee5aa.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d29764f8-80d7-4dd7-acbe-1a42005ee5aa.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "d29764f8-80d7-4dd7-acbe-1a42005ee5aa",
   "name": "Zendesk Support",
   "dockerRepository": "airbyte/source-zendesk-support-singer",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-zendesk-support-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d8313939-3782-41b0-be29-b3ca20d8dd3a.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d8313939-3782-41b0-be29-b3ca20d8dd3a.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "d8313939-3782-41b0-be29-b3ca20d8dd3a",
   "name": "Intercom",
   "dockerRepository": "airbyte/source-intercom-singer",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-intercom-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e094cb9a-26de-4645-8761-65c0c425d1de.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e094cb9a-26de-4645-8761-65c0c425d1de.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "e094cb9a-26de-4645-8761-65c0c425d1de",
   "name": "Stripe",
   "dockerRepository": "airbyte/source-stripe-singer",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/integration-singer-stripe-source"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e7778cfc-e97c-4458-9ecb-b4f2bba8946c.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e7778cfc-e97c-4458-9ecb-b4f2bba8946c.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "e7778cfc-e97c-4458-9ecb-b4f2bba8946c",
   "name": "Facebook Marketing",
   "dockerRepository": "airbyte/source-facebook-marketing",
-  "dockerImageTag": "0.2.1",
+  "dockerImageTag": "0.2.2",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-facebook-marketing"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/eaf50f04-21dd-4620-913b-2a83f5635227.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/eaf50f04-21dd-4620-913b-2a83f5635227.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "eaf50f04-21dd-4620-913b-2a83f5635227",
   "name": "Microsoft teams",
   "dockerRepository": "airbyte/source-microsoft-teams",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-microsoft-teams"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ec4b9503-13cb-48ab-a4ab-6ade4be46567.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ec4b9503-13cb-48ab-a4ab-6ade4be46567.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "ec4b9503-13cb-48ab-a4ab-6ade4be46567",
   "name": "Freshdesk",
   "dockerRepository": "airbyte/source-freshdesk",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-freshdesk"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ed9dfefa-1bbc-419d-8c5e-4d78f0ef6734.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ed9dfefa-1bbc-419d-8c5e-4d78f0ef6734.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "ed9dfefa-1bbc-419d-8c5e-4d78f0ef6734",
   "name": "Google Workspace Admin Reports",
   "dockerRepository": "airbyte/source-google-workspace-admin-reports",
-  "dockerImageTag": "0.1.0",
+  "dockerImageTag": "0.1.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-google-workspace-admin-reports"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ef69ef6e-aa7f-4af1-a01d-ef775033524e.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ef69ef6e-aa7f-4af1-a01d-ef775033524e.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "ef69ef6e-aa7f-4af1-a01d-ef775033524e",
   "name": "GitHub",
   "dockerRepository": "airbyte/source-github-singer",
-  "dockerImageTag": "0.2.1",
+  "dockerImageTag": "0.2.2",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-github-singer"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87",
   "name": "Sendgrid",
   "dockerRepository": "airbyte/source-sendgrid",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-sendgrid"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fdc8b827-3257-4b33-83cc-106d234c34d4.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fdc8b827-3257-4b33-83cc-106d234c34d4.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "fdc8b827-3257-4b33-83cc-106d234c34d4",
   "name": "Google Adwords",
   "dockerRepository": "airbyte/source-google-adwords-singer",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-google-adwords"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1,22 +1,22 @@
 - sourceDefinitionId: 9fed261d-d107-47fd-8c8b-323023db6e20
   name: Exchange Rates Api
   dockerRepository: airbyte/source-exchangeratesapi-singer
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2
   documentationUrl: https://hub.docker.com/r/airbyte/source-exchangeratesapi-singer
 - sourceDefinitionId: 778daa7c-feaf-4db6-96f3-70fd645acc77
   name: File
   dockerRepository: airbyte/source-file
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-file
 - sourceDefinitionId: fdc8b827-3257-4b33-83cc-106d234c34d4
   name: Google Adwords
   dockerRepository: airbyte/source-google-adwords-singer
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-google-adwords
 - sourceDefinitionId: ef69ef6e-aa7f-4af1-a01d-ef775033524e
   name: GitHub
   dockerRepository: airbyte/source-github-singer
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2
   documentationUrl: https://hub.docker.com/r/airbyte/source-github-singer
 - sourceDefinitionId: b5ea17b1-f170-46dc-bc31-cc744ca984c1
   name: Microsoft SQL Server (MSSQL)
@@ -31,22 +31,22 @@
 - sourceDefinitionId: cd42861b-01fc-4658-a8ab-5d11d0510f01
   name: Recurly
   dockerRepository: airbyte/source-recurly
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-recurly
 - sourceDefinitionId: fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87
   name: Sendgrid
   dockerRepository: airbyte/source-sendgrid
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-sendgrid
 - sourceDefinitionId: 9e0556f4-69df-4522-a3fb-03264d36b348
   name: Marketo
   dockerRepository: airbyte/source-marketo-singer
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-marketo-singer
 - sourceDefinitionId: 71607ba1-c0ac-4799-8049-7f4b90dd50f7
   name: Google Sheets
   dockerRepository: airbyte/source-google-sheets
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/repository/docker/airbyte/source-google-sheets
 - sourceDefinitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
   name: MySQL
@@ -56,42 +56,42 @@
 - sourceDefinitionId: 2470e835-feaf-4db6-96f3-70fd645acc77
   name: Salesforce
   dockerRepository: airbyte/source-salesforce-singer
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-salesforce-singer
 - sourceDefinitionId: e094cb9a-26de-4645-8761-65c0c425d1de
   name: Stripe
   dockerRepository: airbyte/source-stripe-singer
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/integration-singer-stripe-source
 - sourceDefinitionId: b03a9f3e-22a5-11eb-adc1-0242ac120002
   name: Mailchimp
   dockerRepository: airbyte/source-mailchimp
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-mailchimp
 - sourceDefinitionId: 39f092a6-8c87-4f6f-a8d9-5cef45b7dbe1
   name: Google Analytics
   dockerRepository: airbyte/source-googleanalytics-singer
-  dockerImageTag: 0.2.2
+  dockerImageTag: 0.2.3
   documentationUrl: https://hub.docker.com/r/airbyte/source-googleanalytics-singer
 - sourceDefinitionId: e7778cfc-e97c-4458-9ecb-b4f2bba8946c
   name: Facebook Marketing
   dockerRepository: airbyte/source-facebook-marketing
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2
   documentationUrl: https://hub.docker.com/r/airbyte/source-facebook-marketing
 - sourceDefinitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
   name: Hubspot
   dockerRepository: airbyte/source-hubspot
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   documentationUrl: https://https://docs.airbyte.io/integrations/sources/hubspot
 - sourceDefinitionId: b1892b11-788d-44bd-b9ec-3a436f7b54ce
   name: Shopify
   dockerRepository: airbyte/source-shopify-singer
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-shopify-singer
 - sourceDefinitionId: 9845d17a-45f1-4070-8a60-50914b1c8e2b
   name: HTTP Request
   dockerRepository: airbyte/source-http-request
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2
   documentationUrl: https://hub.docker.com/repository/docker/airbyte/source-http-request
 - sourceDefinitionId: e87ffa8e-a3b5-f69c-9076-6011339de1f6
   name: Redshift
@@ -101,67 +101,67 @@
 - sourceDefinitionId: 932e6363-d006-4464-a9f5-102b82e07c06
   name: Twilio
   dockerRepository: airbyte/source-twilio-singer
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2
   documentationUrl: https://hub.docker.com/r/airbyte/source-twilio-singer
 - sourceDefinitionId: ec4b9503-13cb-48ab-a4ab-6ade4be46567
   name: Freshdesk
   dockerRepository: airbyte/source-freshdesk
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-freshdesk
 - sourceDefinitionId: 396e4ca3-8a97-4b85-aa4e-c9d8c2d5f992
   name: Braintree
   dockerRepository: airbyte/source-braintree-singer
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-braintree-singer
 - sourceDefinitionId: 41375467-61ae-4204-8e38-e2b8b7365f23
   name: Slack
   dockerRepository: airbyte/source-slack-singer
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/repository/docker/airbyte/source-slack-singer
 - sourceDefinitionId: 59f1e50a-331f-4f09-b3e8-2e8d4d355f44
   name: Greenhouse
   dockerRepository: airbyte/source-greenhouse
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://https://docs.airbyte.io/integrations/sources/greenhouse
 - sourceDefinitionId: d29764f8-80d7-4dd7-acbe-1a42005ee5aa
   name: Zendesk Support
   dockerRepository: airbyte/source-zendesk-support-singer
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-zendesk-support-singer
 - sourceDefinitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
   name: Intercom
   dockerRepository: airbyte/source-intercom-singer
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-intercom-singer
 - sourceDefinitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993
   name: Jira
   dockerRepository: airbyte/source-jira
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2
   documentationUrl: https://hub.docker.com/r/airbyte/source-jira
 - sourceDefinitionId: 859e501d-2b67-471f-91bb-1c801414d28f
   name: Mixpanel
   dockerRepository: airbyte/source-mixpanel-singer
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-mixpanel-singer
 - sourceDefinitionId: aea2fd0d-377d-465e-86c0-4fdc4f688e51
   name: Zoom
   dockerRepository: airbyte/source-zoom-singer
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-zoom-singer
 - sourceDefinitionId: eaf50f04-21dd-4620-913b-2a83f5635227
   name: Microsoft teams
   dockerRepository: airbyte/source-microsoft-teams
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-microsoft-teams
 - sourceDefinitionId: 445831eb-78db-4b1f-8f1f-0d96ad8739e2
   name: Drift
   dockerRepository: airbyte/source-drift
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-drift
 - sourceDefinitionId: 00405b19-9768-4e0c-b1ae-9fc2ee2b2a8c
   name: Looker
   dockerRepository: airbyte/source-looker
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-looker
 - sourceDefinitionId: ed799e2b-2158-4c66-8da4-b40fe63bc72a
   name: Plaid
@@ -171,7 +171,7 @@
 - sourceDefinitionId: 2af123bf-0aaf-4e0d-9784-cb497f23741a
   name: Appstore
   dockerRepository: airbyte/source-appstore-singer
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-appstore-singer
 - sourceDefinitionId: 487b930d-7f6a-43ce-8bac-46e6b2de0a55
   name: Mongo DB
@@ -181,25 +181,25 @@
 - sourceDefinitionId: d19ae824-e289-4b14-995a-0632eb46d246
   name: Google Directory
   dockerRepository: airbyte/source-google-directory
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-google-directory
 - sourceDefinitionId: 6acf6b55-4f1e-4fca-944e-1a3caef8aba8
   name: Instagram
   dockerRepository: airbyte/source-instagram
-  dockerImageTag: 0.1.3
+  dockerImageTag: 0.1.4
   documentationUrl: https://hub.docker.com/r/airbyte/source-instagram
 - sourceDefinitionId: 5e6175e5-68e1-4c17-bff9-56103bbb0d80
   name: Gitlab
   dockerRepository: airbyte/source-gitlab-singer
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-gitlab-singer
 - sourceDefinitionId: ed9dfefa-1bbc-419d-8c5e-4d78f0ef6734
   name: Google Workspace Admin Reports
   dockerRepository: airbyte/source-google-workspace-admin-reports
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-google-workspace-admin-reports
 - sourceDefinitionId: d1aa448b-7c54-498e-ad95-263cbebcd2db
   name: Tempo
   dockerRepository: airbyte/source-tempo
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2
   documentationUrl: https://hub.docker.com/r/airbyte/source-tempo

--- a/airbyte-integrations/bases/airbyte-protocol/Dockerfile
+++ b/airbyte-integrations/bases/airbyte-protocol/Dockerfile
@@ -5,5 +5,5 @@ COPY airbyte_protocol ./airbyte_protocol
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/base-airbyte-protocol-python

--- a/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
+++ b/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
@@ -133,7 +133,7 @@ class AirbyteStream(BaseModel):
         None,
         description="Path to the field that will be used to determine if a record is new or modified since the last sync. If not provided by the source, the end user will have to specify the comparable themselves.",
     )
-    source_defined_primary_key: Optional[List[str]] = Field(
+    source_defined_primary_key: Optional[List[List[str]]] = Field(
         None,
         description="If the source defines the primary key, paths to the fields that will be used as a primary key. If not provided by the source, the end user will have to specify the primary key themselves.",
     )
@@ -150,7 +150,7 @@ class ConfiguredAirbyteStream(BaseModel):
         description="Path to the field that will be used to determine if a record is new or modified since the last sync. This field is REQUIRED if `sync_mode` is `incremental`. Otherwise it is ignored.",
     )
     destination_sync_mode: DestinationSyncMode
-    primary_key: Optional[List[str]] = Field(
+    primary_key: Optional[List[List[str]]] = Field(
         None,
         description="Paths to the fields that will be used as primary key. This field is REQUIRED if `destination_sync_mode` is `*_dedup`. Otherwise it is ignored.",
     )

--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/base-airbyte-protocol-python:dev
+FROM airbyte/base-airbyte-protocol-python:0.1.1
 
 # dbt needs git in order to run.
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
@@ -19,5 +19,5 @@ WORKDIR /airbyte
 
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.16
+LABEL io.airbyte.version=0.1.17
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-python-test/Dockerfile
+++ b/airbyte-integrations/bases/base-python-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.1
 
 WORKDIR /airbyte/base_python_test_code
 COPY base_python_test ./base_python_test
@@ -7,5 +7,5 @@ RUN pip install .
 
 ENTRYPOINT ["airbyte-python-test"]
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/base-python-test

--- a/airbyte-integrations/bases/base-python/Dockerfile
+++ b/airbyte-integrations/bases/base-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/base-airbyte-protocol-python:dev
+FROM airbyte/base-airbyte-protocol-python:0.1.1
 COPY --from=airbyte/integration-base:dev /airbyte /airbyte
 
 WORKDIR /airbyte/base_python_code
@@ -14,5 +14,5 @@ ENV AIRBYTE_READ_CMD "base-python read"
 
 ENTRYPOINT ["/airbyte/base.sh"]
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/integration-base-python

--- a/airbyte-integrations/bases/base-singer/Dockerfile
+++ b/airbyte-integrations/bases/base-singer/Dockerfile
@@ -1,9 +1,9 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 WORKDIR /airbyte/base_singer_code
 COPY base_singer ./base_singer
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/integration-base-singer

--- a/airbyte-integrations/connector-templates/source-python/Dockerfile
+++ b/airbyte-integrations/connector-templates/source-python/Dockerfile
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-{{dashCase name}}

--- a/airbyte-integrations/connector-templates/source-python/Dockerfile
+++ b/airbyte-integrations/connector-templates/source-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connector-templates/source-singer/Dockerfile
+++ b/airbyte-integrations/connector-templates/source-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-appsflyer-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-appsflyer-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash git gcc && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-appsflyer-singer

--- a/airbyte-integrations/connectors/source-appstore-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-appstore-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash git && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-appstore-singer

--- a/airbyte-integrations/connectors/source-braintree-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-braintree-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 RUN apt-get update && apt-get install -y bash jq && rm -rf /var/lib/apt/lists/*
 
@@ -6,7 +6,7 @@ ENV CODE_PATH="source_braintree_singer"
 ENV AIRBYTE_IMPL_MODULE="source_braintree_singer"
 ENV AIRBYTE_IMPL_PATH="SourceBraintreeSinger"
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-braintree-singer
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-drift/Dockerfile
+++ b/airbyte-integrations/connectors/source-drift/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-drift

--- a/airbyte-integrations/connectors/source-exchangeratesapi-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-exchangeratesapi-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 RUN apt-get update && apt-get install -y \
     jq \
@@ -8,7 +8,7 @@ ENV CODE_PATH="source_exchangeratesapi_singer"
 ENV AIRBYTE_IMPL_MODULE="source_exchangeratesapi_singer"
 ENV AIRBYTE_IMPL_PATH="SourceExchangeRatesApiSinger"
 
-LABEL io.airbyte.version=0.2.1
+LABEL io.airbyte.version=0.2.2
 LABEL io.airbyte.name=airbyte/source-exchangeratesapi-singer
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-facebook-marketing/Dockerfile
+++ b/airbyte-integrations/connectors/source-facebook-marketing/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.1
+LABEL io.airbyte.version=0.2.2
 LABEL io.airbyte.name=airbyte/source-facebook-marketing

--- a/airbyte-integrations/connectors/source-file/Dockerfile
+++ b/airbyte-integrations/connectors/source-file/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 RUN apt-get update && apt-get install -y jq curl bash && rm -rf /var/lib/apt/lists/*
 
@@ -11,5 +11,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-file

--- a/airbyte-integrations/connectors/source-freshdesk/Dockerfile
+++ b/airbyte-integrations/connectors/source-freshdesk/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-freshdesk

--- a/airbyte-integrations/connectors/source-github-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-github-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 RUN apt-get update && apt-get install -y \
     bash \
@@ -8,7 +8,7 @@ ENV CODE_PATH="source_github_singer"
 ENV AIRBYTE_IMPL_MODULE="source_github_singer"
 ENV AIRBYTE_IMPL_PATH="SourceGithubSinger"
 
-LABEL io.airbyte.version=0.2.1
+LABEL io.airbyte.version=0.2.2
 LABEL io.airbyte.name=airbyte/source-github-singer
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-gitlab-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-gitlab-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash -y gcc && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-gitlab-singer

--- a/airbyte-integrations/connectors/source-google-adwords-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-adwords-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 RUN apt-get update && apt-get install -y jq curl bash && rm -rf /var/lib/apt/lists/*
 
@@ -12,5 +12,5 @@ COPY setup.py ./
 RUN pip install tap-adwords==1.12.0
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-google-adwords-singer

--- a/airbyte-integrations/connectors/source-google-directory/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-directory/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install ".[main]"
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-google-directory

--- a/airbyte-integrations/connectors/source-google-sheets/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-sheets/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 RUN apt-get update && apt-get install -y jq curl bash && rm -rf /var/lib/apt/lists/*
 
@@ -11,5 +11,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-google-sheets

--- a/airbyte-integrations/connectors/source-google-sheets/Dockerfile.test
+++ b/airbyte-integrations/connectors/source-google-sheets/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM airbyte/base-python-test:dev
+FROM airbyte/base-python-test:0.1.1
 
 RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-google-workspace-admin-reports/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-workspace-admin-reports/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-google-workspace-admin-reports

--- a/airbyte-integrations/connectors/source-googleanalytics-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-googleanalytics-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 RUN apt-get update && apt-get install -y \
     jq gcc \
@@ -8,7 +8,7 @@ ENV CODE_PATH="source_googleanalytics_singer"
 ENV AIRBYTE_IMPL_MODULE="source_googleanalytics_singer"
 ENV AIRBYTE_IMPL_PATH="GoogleAnalyticsSingerSource"
 
-LABEL io.airbyte.version=0.2.2
+LABEL io.airbyte.version=0.2.3
 LABEL io.airbyte.name=airbyte/source-googleanalytics-singer
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-greenhouse/Dockerfile
+++ b/airbyte-integrations/connectors/source-greenhouse/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-greenhouse

--- a/airbyte-integrations/connectors/source-http-request/Dockerfile
+++ b/airbyte-integrations/connectors/source-http-request/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 RUN apt-get update && apt-get install -y jq curl bash && rm -rf /var/lib/apt/lists/*
 
@@ -11,5 +11,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.1
+LABEL io.airbyte.version=0.2.2
 LABEL io.airbyte.name=airbyte/source-http-request

--- a/airbyte-integrations/connectors/source-hubspot/Dockerfile
+++ b/airbyte-integrations/connectors/source-hubspot/Dockerfile
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install ".[main]"
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/source-hubspot

--- a/airbyte-integrations/connectors/source-hubspot/Dockerfile
+++ b/airbyte-integrations/connectors/source-hubspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:dev
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-instagram/Dockerfile
+++ b/airbyte-integrations/connectors/source-instagram/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install ".[main]"
 
-LABEL io.airbyte.version=0.1.3
+LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/source-instagram

--- a/airbyte-integrations/connectors/source-intercom-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-intercom-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 # Bash is installed for more convenient debugging.
 ENV DEBIAN_FRONTEND noninteractive
@@ -11,7 +11,7 @@ ENV CODE_PATH="source_intercom_singer"
 ENV AIRBYTE_IMPL_MODULE="source_intercom_singer"
 ENV AIRBYTE_IMPL_PATH="SourceIntercomSinger"
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-intercom-singer
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-jira/Dockerfile
+++ b/airbyte-integrations/connectors/source-jira/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.1
+LABEL io.airbyte.version=0.2.2
 LABEL io.airbyte.name=airbyte/source-jira

--- a/airbyte-integrations/connectors/source-looker/Dockerfile
+++ b/airbyte-integrations/connectors/source-looker/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-looker

--- a/airbyte-integrations/connectors/source-mailchimp/Dockerfile
+++ b/airbyte-integrations/connectors/source-mailchimp/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-mailchimp

--- a/airbyte-integrations/connectors/source-marketo-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-marketo-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 # Bash is installed for more convenient debugging.
 # GCC is needed for CISO8601, a dependency of tap-marketo.
@@ -14,5 +14,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-marketo-singer

--- a/airbyte-integrations/connectors/source-microsoft-teams/Dockerfile
+++ b/airbyte-integrations/connectors/source-microsoft-teams/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-microsoft-teams

--- a/airbyte-integrations/connectors/source-mixpanel-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-mixpanel-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 # Bash is installed for more convenient debugging.
 ENV DEBIAN_FRONTEND noninteractive
@@ -17,5 +17,5 @@ COPY setup.py ./
 
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-mixpanel-singer

--- a/airbyte-integrations/connectors/source-recurly/Dockerfile
+++ b/airbyte-integrations/connectors/source-recurly/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-recurly

--- a/airbyte-integrations/connectors/source-salesforce-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-salesforce-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 RUN apt-get update && apt-get install -y \
     bash \
@@ -8,7 +8,7 @@ ENV CODE_PATH="source_salesforce_singer"
 ENV AIRBYTE_IMPL_MODULE="source_salesforce_singer"
 ENV AIRBYTE_IMPL_PATH="SourceSalesforceSinger"
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-salesforce-singer
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-scaffold-source-python/Dockerfile
+++ b/airbyte-integrations/connectors/source-scaffold-source-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-scaffold-source-python

--- a/airbyte-integrations/connectors/source-sendgrid/Dockerfile
+++ b/airbyte-integrations/connectors/source-sendgrid/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-sendgrid

--- a/airbyte-integrations/connectors/source-shopify-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-shopify-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash gcc && rm -rf /var/lib/apt/lists/*
@@ -13,5 +13,5 @@ COPY setup.py ./
 RUN pip install https://github.com/airbytehq/tap-shopify/tarball/master
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-shopify-singer

--- a/airbyte-integrations/connectors/source-slack-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-slack-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 RUN apt-get update && apt-get install -y bash gcc && rm -rf /var/lib/apt/lists/*
 
@@ -6,7 +6,7 @@ ENV CODE_PATH="source_slack_singer"
 ENV AIRBYTE_IMPL_MODULE="source_slack_singer"
 ENV AIRBYTE_IMPL_PATH="SourceSlackSinger"
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-slack-singer
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-stripe-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 RUN apt-get update && apt-get install -y \
     jq \
@@ -10,7 +10,7 @@ ENV CODE_PATH="source_stripe_singer"
 ENV AIRBYTE_IMPL_MODULE="source_stripe_singer"
 ENV AIRBYTE_IMPL_PATH="SourceStripeSinger"
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-stripe-singer
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-tempo/Dockerfile
+++ b/airbyte-integrations/connectors/source-tempo/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-python:0.1.0
+FROM airbyte/integration-base-python:0.1.1
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.1
+LABEL io.airbyte.version=0.2.2
 LABEL io.airbyte.name=airbyte/source-tempo

--- a/airbyte-integrations/connectors/source-twilio-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-twilio-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 RUN apt-get update && apt-get install -y bash gcc && rm -rf /var/lib/apt/lists/*
 
@@ -6,7 +6,7 @@ ENV CODE_PATH="source_twilio_singer"
 ENV AIRBYTE_IMPL_MODULE="source_twilio_singer"
 ENV AIRBYTE_IMPL_PATH="SourceTwilioSinger"
 
-LABEL io.airbyte.version=0.2.1
+LABEL io.airbyte.version=0.2.2
 LABEL io.airbyte.name=airbyte/source-twilio-singer
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-zendesk-support-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-zendesk-support-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
 
@@ -11,5 +11,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-zendesk-support-singer

--- a/airbyte-integrations/connectors/source-zoom-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-zoom-singer/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-singer:0.1.0
+FROM airbyte/integration-base-singer:0.1.1
 
 # Bash is installed for more convenient debugging. GCC is required by tap-zoom to compile ciso8601.
 ENV DEBIAN_FRONTEND noninteractive
@@ -11,7 +11,7 @@ ENV CODE_PATH="source_zoom_singer"
 ENV AIRBYTE_IMPL_MODULE="source_zoom_singer"
 ENV AIRBYTE_IMPL_PATH="SourceZoomSinger"
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-zoom-singer
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
@@ -43,7 +43,7 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNormalizationRunner.class);
 
-  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.16";
+  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.17";
 
   private final DestinationType destinationType;
   private final ProcessBuilderFactory pbf;

--- a/tools/code-generator/Dockerfile
+++ b/tools/code-generator/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.7-slim
-RUN pip install datamodel-code-generator==0.5.39
+RUN pip install datamodel-code-generator==0.10.1
 ENTRYPOINT ["datamodel-codegen"]
 
 LABEL io.airbyte.version=dev

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -32,7 +32,8 @@ cmd_build() {
   echo "Building $path"
   ./gradlew "$(_to_gradle_path "$path" clean)"
   ./gradlew "$(_to_gradle_path "$path" build)"
-  ./gradlew "$(_to_gradle_path "$path" integrationTest)"
+
+  [[ "$path" =~ ^airbyte-integrations/bases* ]] || ./gradlew "$(_to_gradle_path "$path" integrationTest)"
 }
 
 cmd_publish() {


### PR DESCRIPTION
Our Python connectors have not picked up changes from the bases. This leads to problems like JSON decoding errors if a configured catalog has something like primary key configuration which wasn't present in an older base version.

This PR changes everything to use versions and will require testing/publishing all Python-based connectors.