### PR TITLE
Discover Schema sets Namespace field.

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1888,6 +1888,9 @@ components:
             type: array
             items:
               type: string
+        namespace:
+          type: string
+          description: Optional Source-defined namespace. Airbyte streams from the same sources should have the same namespace. Currently only used by JDBC destinations to determine what schema to write to.
     StreamJsonSchema:
       type: object
     AirbyteStreamConfiguration:

--- a/airbyte-commons/src/main/java/io/airbyte/commons/io/IOs.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/io/IOs.java
@@ -34,9 +34,11 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import org.apache.commons.io.input.ReversedLinesFileReader;
 
 public class IOs {
@@ -50,6 +52,23 @@ public class IOs {
     try {
       Files.writeString(filePath, contents, StandardCharsets.UTF_8);
       return filePath;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Writes a file to a random directory in the /tmp folder. Useful as a staging group for test
+   * resources.
+   */
+  public static String writeFileToRandomTmpDir(String filename, String contents) {
+    final Path source = Paths.get("/tmp", UUID.randomUUID().toString());
+    try {
+      Path tmpFile = source.resolve(filename);
+      Files.deleteIfExists(tmpFile);
+      Files.createDirectory(source);
+      writeFile(tmpFile, contents);
+      return tmpFile.toString();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/airbyte-commons/src/main/java/io/airbyte/commons/resources/MoreResources.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/resources/MoreResources.java
@@ -38,6 +38,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 public class MoreResources {
@@ -81,12 +82,15 @@ public class MoreResources {
   }
 
   @SuppressWarnings("UnstableApiUsage")
-  public static void writeResource(String filename, String contents) {
-    final Path source = Paths.get(Resources.getResource("").getPath());
+  public static String writeTmpFile(String filename, String contents) {
+    final Path source = Paths.get("/tmp", UUID.randomUUID().toString());
     try {
-      Files.deleteIfExists(source.resolve(filename));
-      Files.createFile(source.resolve(filename));
-      IOs.writeFile(Path.of(Resources.getResource(filename).getPath()), contents);
+      Path tmpFile = source.resolve(filename);
+      Files.deleteIfExists(tmpFile);
+      Files.createDirectory(source);
+      Files.createFile(tmpFile);
+      IOs.writeFile(tmpFile, contents);
+      return tmpFile.toString();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/airbyte-commons/src/main/java/io/airbyte/commons/resources/MoreResources.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/resources/MoreResources.java
@@ -26,7 +26,6 @@ package io.airbyte.commons.resources;
 
 import com.google.common.base.Preconditions;
 import com.google.common.io.Resources;
-import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.lang.Exceptions;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -36,9 +35,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 public class MoreResources {
@@ -77,21 +74,6 @@ public class MoreResources {
       }
 
     } catch (URISyntaxException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  @SuppressWarnings("UnstableApiUsage")
-  public static String writeTmpFile(String filename, String contents) {
-    final Path source = Paths.get("/tmp", UUID.randomUUID().toString());
-    try {
-      Path tmpFile = source.resolve(filename);
-      Files.deleteIfExists(tmpFile);
-      Files.createDirectory(source);
-      Files.createFile(tmpFile);
-      IOs.writeFile(tmpFile, contents);
-      return tmpFile.toString();
-    } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }

--- a/airbyte-commons/src/test/java/io/airbyte/commons/io/IOsTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/io/IOsTest.java
@@ -56,6 +56,13 @@ class IOsTest {
   }
 
   @Test
+  public void testWriteFileToRandomDir() throws IOException {
+    final String contents = "something to remember";
+    final String tmpFilePath = IOs.writeFileToRandomTmpDir("file.txt", contents);
+    assertEquals(contents, Files.readString(Path.of(tmpFilePath)));
+  }
+
+  @Test
   public void testGetTailDoesNotExist() throws IOException {
     List<String> tail = IOs.getTail(100, Path.of(RandomStringUtils.random(100)));
     assertEquals(Collections.emptyList(), tail);

--- a/airbyte-commons/src/test/java/io/airbyte/commons/resources/MoreResourcesTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/resources/MoreResourcesTest.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.Sets;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
@@ -58,13 +57,6 @@ class MoreResourcesTest {
             .map(Path::getFileName)
             .map(Path::toString)
             .collect(Collectors.toSet()));
-  }
-
-  @Test
-  void testWriteTmpFile() throws IOException {
-    final String contents = "something to remember";
-    final String tmpFilePath = MoreResources.writeTmpFile("file.txt", contents);
-    assertEquals(contents, Files.readString(Path.of(tmpFilePath)));
   }
 
 }

--- a/airbyte-commons/src/test/java/io/airbyte/commons/resources/MoreResourcesTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/resources/MoreResourcesTest.java
@@ -24,10 +24,12 @@
 
 package io.airbyte.commons.resources;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.Sets;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
@@ -59,10 +61,10 @@ class MoreResourcesTest {
   }
 
   @Test
-  void testWriteResource() throws IOException {
+  void testWriteTmpFile() throws IOException {
     final String contents = "something to remember";
-    MoreResources.writeResource("file.txt", contents);
-    assertEquals(contents, MoreResources.readResource("file.txt"));
+    final String tmpFilePath = MoreResources.writeTmpFile("file.txt", contents);
+    assertEquals(contents, Files.readString(Path.of(tmpFilePath)));
   }
 
 }

--- a/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestDefaultJdbcDatabase.java
+++ b/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestDefaultJdbcDatabase.java
@@ -29,8 +29,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.db.Databases;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.sql.SQLException;
@@ -70,7 +70,7 @@ public class TestDefaultJdbcDatabase {
     config = getConfig(PSQL_DB, dbName);
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     final JdbcDatabase database = getDatabaseFromConfig(config);

--- a/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestDefaultJdbcDatabase.java
+++ b/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestDefaultJdbcDatabase.java
@@ -70,8 +70,8 @@ public class TestDefaultJdbcDatabase {
     config = getConfig(PSQL_DB, dbName);
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    MoreResources.writeResource(initScriptName, "CREATE DATABASE " + dbName + ";");
-    PostgreSQLContainerHelper.runSqlScript(MountableFile.forClasspathResource(initScriptName), PSQL_DB);
+    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     final JdbcDatabase database = getDatabaseFromConfig(config);
     database.execute(connection -> {

--- a/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestJdbcUtils.java
+++ b/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestJdbcUtils.java
@@ -31,8 +31,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.stream.MoreStreams;
 import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
@@ -80,7 +80,7 @@ public class TestJdbcUtils {
     final JsonNode config = getConfig(PSQL_DB, dbName);
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     dataSource = new BasicDataSource();

--- a/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestJdbcUtils.java
+++ b/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestJdbcUtils.java
@@ -80,8 +80,8 @@ public class TestJdbcUtils {
     final JsonNode config = getConfig(PSQL_DB, dbName);
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    MoreResources.writeResource(initScriptName, "CREATE DATABASE " + dbName + ";");
-    PostgreSQLContainerHelper.runSqlScript(MountableFile.forClasspathResource(initScriptName), PSQL_DB);
+    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     dataSource = new BasicDataSource();
     dataSource.setDriverClassName("org.postgresql.Driver");

--- a/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestStreamingJdbcDatabase.java
+++ b/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestStreamingJdbcDatabase.java
@@ -36,8 +36,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.functional.CheckedConsumer;
+import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -84,7 +84,7 @@ public class TestStreamingJdbcDatabase {
     final JsonNode config = getConfig(PSQL_DB, dbName);
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     final BasicDataSource connectionPool = new BasicDataSource();

--- a/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestStreamingJdbcDatabase.java
+++ b/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestStreamingJdbcDatabase.java
@@ -84,8 +84,8 @@ public class TestStreamingJdbcDatabase {
     final JsonNode config = getConfig(PSQL_DB, dbName);
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    MoreResources.writeResource(initScriptName, "CREATE DATABASE " + dbName + ";");
-    PostgreSQLContainerHelper.runSqlScript(MountableFile.forClasspathResource(initScriptName), PSQL_DB);
+    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     final BasicDataSource connectionPool = new BasicDataSource();
     connectionPool.setDriverClassName("org.postgresql.Driver");

--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -139,7 +139,7 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
               Optional.ofNullable(config.get("database")).map(JsonNode::asText),
               Optional.ofNullable(config.get("schema")).map(JsonNode::asText))
                   .stream()
-                  .map(t -> CatalogHelpers.createAirbyteStream(t.getName(), t.getFields())
+                  .map(t -> CatalogHelpers.createAirbyteStream(t.getName(), t.getSchemaName(), t.getFields())
                       .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
                       .withSourceDefinedPrimaryKey(t.getPrimaryKeys()
                           .stream()
@@ -351,7 +351,7 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
               .collect(Collectors.toList());
           final String streamName = JdbcUtils.getFullyQualifiedTableName(t.getSchemaName(), t.getName());
           final List<String> primaryKeys = tablePrimaryKeys.getOrDefault(streamName, Collections.emptyList());
-          return new TableInfo(streamName, fields, primaryKeys);
+          return new TableInfo(streamName, t.getSchemaName(), fields, primaryKeys);
         })
         .collect(Collectors.toList());
   }
@@ -561,20 +561,29 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
         jdbcStreamingQueryConfiguration);
   }
 
+  /**
+   * This class encapsulates all externally relevant Table information.
+   */
   protected static class TableInfo {
 
     private final String name;
+    private final String schemaName;
     private final List<Field> fields;
     private final List<String> primaryKeys;
 
-    public TableInfo(String name, List<Field> fields, List<String> primaryKeys) {
+    public TableInfo(String name, String schemaName, List<Field> fields, List<String> primaryKeys) {
       this.name = name;
+      this.schemaName = schemaName;
       this.fields = fields;
       this.primaryKeys = primaryKeys;
     }
 
     public String getName() {
       return name;
+    }
+
+    public String getSchemaName() {
+      return schemaName;
     }
 
     public List<Field> getFields() {
@@ -587,7 +596,11 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
 
   }
 
-  protected static class TableInfoInternal {
+  /**
+   * The following two classes are internal data structures to ease managing tables. Any external
+   * information should be revealed through the {@link TableInfo} class.
+   */
+  static class TableInfoInternal {
 
     private final String schemaName;
     private final String name;
@@ -613,7 +626,7 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
 
   }
 
-  protected static class ColumnInfo {
+  static class ColumnInfo {
 
     private final String columnName;
     private final JDBCType columnType;

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceStandardTest.java
@@ -73,8 +73,8 @@ class AbstractJdbcSourceStandardTest extends JdbcSourceStandardTest {
         .build());
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    MoreResources.writeResource(initScriptName, "CREATE DATABASE " + dbName + ";");
-    PostgreSQLContainerHelper.runSqlScript(MountableFile.forClasspathResource(initScriptName), PSQL_DB);
+    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     super.setup();
   }

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceStandardTest.java
@@ -26,8 +26,8 @@ package io.airbyte.integrations.source.jdbc;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.db.jdbc.PostgresJdbcStreamingQueryConfiguration;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
@@ -73,7 +73,7 @@ class AbstractJdbcSourceStandardTest extends JdbcSourceStandardTest {
         .build());
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     super.setup();

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/DefaultJdbcStressTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/DefaultJdbcStressTest.java
@@ -26,8 +26,8 @@ package io.airbyte.integrations.source.jdbc;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.db.jdbc.PostgresJdbcStreamingQueryConfiguration;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
@@ -80,7 +80,7 @@ class DefaultJdbcStressTest extends JdbcStressTest {
     System.out.println("config = " + config);
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     super.setup();

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/DefaultJdbcStressTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/DefaultJdbcStressTest.java
@@ -77,8 +77,6 @@ class DefaultJdbcStressTest extends JdbcStressTest {
         .put("password", PSQL_DB.getPassword())
         .build());
 
-    System.out.println("config = " + config);
-
     final String initScriptName = "init_" + dbName.concat(".sql");
     final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/DefaultJdbcStressTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/DefaultJdbcStressTest.java
@@ -80,8 +80,8 @@ class DefaultJdbcStressTest extends JdbcStressTest {
     System.out.println("config = " + config);
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    MoreResources.writeResource(initScriptName, "CREATE DATABASE " + dbName + ";");
-    PostgreSQLContainerHelper.runSqlScript(MountableFile.forClasspathResource(initScriptName), PSQL_DB);
+    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     super.setup();
   }

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/JdbcSourceStressTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/JdbcSourceStressTest.java
@@ -26,8 +26,8 @@ package io.airbyte.integrations.source.jdbc;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.db.jdbc.PostgresJdbcStreamingQueryConfiguration;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
@@ -78,7 +78,7 @@ class JdbcSourceStressTest extends JdbcStressTest {
     System.out.println("config = " + config);
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     super.setup();

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/JdbcSourceStressTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/JdbcSourceStressTest.java
@@ -78,8 +78,8 @@ class JdbcSourceStressTest extends JdbcStressTest {
     System.out.println("config = " + config);
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    MoreResources.writeResource(initScriptName, "CREATE DATABASE " + dbName + ";");
-    PostgreSQLContainerHelper.runSqlScript(MountableFile.forClasspathResource(initScriptName), PSQL_DB);
+    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     super.setup();
   }

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/JdbcSourceStressTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/JdbcSourceStressTest.java
@@ -75,8 +75,6 @@ class JdbcSourceStressTest extends JdbcStressTest {
         .put("password", PSQL_DB.getPassword())
         .build());
 
-    System.out.println("config = " + config);
-
     final String initScriptName = "init_" + dbName.concat(".sql");
     final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);

--- a/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
@@ -246,10 +246,11 @@ public abstract class JdbcSourceStandardTest {
   @Test
   void testDiscover() throws Exception {
     final AirbyteCatalog actual = filterOutOtherSchemas(source.discover(config));
-    assertEquals(getCatalog(getDefaultNamespace()).getStreams().size(), actual.getStreams().size());
+    AirbyteCatalog expected = getCatalog(getDefaultNamespace());
+    assertEquals(expected.getStreams().size(), actual.getStreams().size());
     actual.getStreams().forEach(actualStream -> {
       final Optional<AirbyteStream> expectedStream =
-          getCatalog(getDefaultNamespace()).getStreams().stream().filter(stream -> stream.getName().equals(actualStream.getName())).findAny();
+          expected.getStreams().stream().filter(stream -> stream.getName().equals(actualStream.getName())).findAny();
       assertTrue(expectedStream.isPresent(), String.format("Unexpected stream %s", actualStream.getName()));
       assertEquals(expectedStream.get(), actualStream);
     });
@@ -297,6 +298,7 @@ public abstract class JdbcSourceStandardTest {
     final AirbyteCatalog expected = getCatalog(getDefaultNamespace());
     expected.getStreams().add(CatalogHelpers
         .createAirbyteStream(JdbcUtils.getFullyQualifiedTableName(SCHEMA_NAME2, TABLE_NAME),
+            SCHEMA_NAME2,
             Field.of(COL_ID, JsonSchemaPrimitive.STRING),
             Field.of(COL_NAME, JsonSchemaPrimitive.STRING))
         .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL)));
@@ -729,6 +731,7 @@ public abstract class JdbcSourceStandardTest {
     return new AirbyteCatalog().withStreams(Lists.newArrayList(
         CatalogHelpers.createAirbyteStream(
             defaultNamespace + "." + TABLE_NAME,
+            defaultNamespace,
             Field.of(COL_ID, JsonSchemaPrimitive.NUMBER),
             Field.of(COL_NAME, JsonSchemaPrimitive.STRING),
             Field.of(COL_UPDATED_AT, JsonSchemaPrimitive.STRING))
@@ -736,6 +739,7 @@ public abstract class JdbcSourceStandardTest {
             .withSourceDefinedPrimaryKey(List.of(List.of(COL_ID))),
         CatalogHelpers.createAirbyteStream(
             defaultNamespace + "." + TABLE_NAME_WITHOUT_PK,
+            defaultNamespace,
             Field.of(COL_ID, JsonSchemaPrimitive.NUMBER),
             Field.of(COL_NAME, JsonSchemaPrimitive.STRING),
             Field.of(COL_UPDATED_AT, JsonSchemaPrimitive.STRING))
@@ -743,6 +747,7 @@ public abstract class JdbcSourceStandardTest {
             .withSourceDefinedPrimaryKey(Collections.emptyList()),
         CatalogHelpers.createAirbyteStream(
             defaultNamespace + "." + TABLE_NAME_COMPOSITE_PK,
+            defaultNamespace,
             Field.of(COL_FIRST_NAME, JsonSchemaPrimitive.STRING),
             Field.of(COL_LAST_NAME, JsonSchemaPrimitive.STRING),
             Field.of(COL_UPDATED_AT, JsonSchemaPrimitive.STRING))

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlSourceTest.java
@@ -48,10 +48,11 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.MSSQLServerContainer;
 
 class MssqlSourceTest {
-
-  private static final String STREAM_NAME = "dbo.id_and_name";
+  private static final String DB_NAME = "dbo";
+  private static final String STREAM_NAME = DB_NAME + ".id_and_name";
   private static final AirbyteCatalog CATALOG = new AirbyteCatalog().withStreams(Lists.newArrayList(CatalogHelpers.createAirbyteStream(
       STREAM_NAME,
+      DB_NAME,
       Field.of("id", JsonSchemaPrimitive.NUMBER),
       Field.of("name", JsonSchemaPrimitive.STRING),
       Field.of("born", JsonSchemaPrimitive.STRING))

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlSourceTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.MSSQLServerContainer;
 
 class MssqlSourceTest {
+
   private static final String DB_NAME = "dbo";
   private static final String STREAM_NAME = DB_NAME + ".id_and_name";
   private static final AirbyteCatalog CATALOG = new AirbyteCatalog().withStreams(Lists.newArrayList(CatalogHelpers.createAirbyteStream(

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresJdbcStandardSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresJdbcStandardSourceTest.java
@@ -26,8 +26,8 @@ package io.airbyte.integrations.source.postgres;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
 import io.airbyte.integrations.source.jdbc.test.JdbcSourceStandardTest;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
@@ -63,7 +63,7 @@ class PostgresJdbcStandardSourceTest extends JdbcSourceStandardTest {
         .build());
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     super.setup();

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresJdbcStandardSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresJdbcStandardSourceTest.java
@@ -63,8 +63,8 @@ class PostgresJdbcStandardSourceTest extends JdbcSourceStandardTest {
         .build());
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    MoreResources.writeResource(initScriptName, "CREATE DATABASE " + dbName + ";");
-    PostgreSQLContainerHelper.runSqlScript(MountableFile.forClasspathResource(initScriptName), PSQL_DB);
+    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     super.setup();
   }

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
@@ -31,8 +31,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.util.MoreIterators;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
@@ -116,7 +116,7 @@ class PostgresSourceTest {
     dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     final JsonNode config = getConfig(PSQL_DB, dbName);

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
@@ -65,10 +65,12 @@ import org.testcontainers.utility.MountableFile;
 
 class PostgresSourceTest {
 
-  private static final String STREAM_NAME = "public.id_and_name";
+  private static final String SCHEMA_NAME = "public";
+  private static final String STREAM_NAME = SCHEMA_NAME + ".id_and_name";
   private static final AirbyteCatalog CATALOG = new AirbyteCatalog().withStreams(List.of(
       CatalogHelpers.createAirbyteStream(
           STREAM_NAME,
+          SCHEMA_NAME,
           Field.of("id", JsonSchemaPrimitive.NUMBER),
           Field.of("name", JsonSchemaPrimitive.STRING),
           Field.of("power", JsonSchemaPrimitive.NUMBER))
@@ -76,12 +78,14 @@ class PostgresSourceTest {
           .withSourceDefinedPrimaryKey(List.of(List.of("id"))),
       CatalogHelpers.createAirbyteStream(
           STREAM_NAME + "2",
+          SCHEMA_NAME,
           Field.of("id", JsonSchemaPrimitive.NUMBER),
           Field.of("name", JsonSchemaPrimitive.STRING),
           Field.of("power", JsonSchemaPrimitive.NUMBER))
           .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL)),
       CatalogHelpers.createAirbyteStream(
           "public.names",
+          SCHEMA_NAME,
           Field.of("first_name", JsonSchemaPrimitive.STRING),
           Field.of("last_name", JsonSchemaPrimitive.STRING),
           Field.of("power", JsonSchemaPrimitive.NUMBER))

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
@@ -112,8 +112,8 @@ class PostgresSourceTest {
     dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    MoreResources.writeResource(initScriptName, "CREATE DATABASE " + dbName + ";");
-    PostgreSQLContainerHelper.runSqlScript(MountableFile.forClasspathResource(initScriptName), PSQL_DB);
+    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     final JsonNode config = getConfig(PSQL_DB, dbName);
     final Database database = getDatabaseFromConfig(config);

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresStressTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresStressTest.java
@@ -79,8 +79,8 @@ class PostgresStressTest extends JdbcStressTest {
     System.out.println("config = " + config);
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    MoreResources.writeResource(initScriptName, "CREATE DATABASE " + dbName + ";");
-    PostgreSQLContainerHelper.runSqlScript(MountableFile.forClasspathResource(initScriptName), PSQL_DB);
+    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     super.setup();
   }

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresStressTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresStressTest.java
@@ -26,8 +26,8 @@ package io.airbyte.integrations.source.postgres;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.db.jdbc.PostgresJdbcStreamingQueryConfiguration;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
@@ -79,7 +79,7 @@ class PostgresStressTest extends JdbcStressTest {
     System.out.println("config = " + config);
 
     final String initScriptName = "init_" + dbName.concat(".sql");
-    final String tmpFilePath = MoreResources.writeTmpFile(initScriptName, "CREATE DATABASE " + dbName + ";");
+    final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);
 
     super.setup();

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresStressTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresStressTest.java
@@ -76,8 +76,6 @@ class PostgresStressTest extends JdbcStressTest {
         .put("password", PSQL_DB.getPassword())
         .build());
 
-    System.out.println("config = " + config);
-
     final String initScriptName = "init_" + dbName.concat(".sql");
     final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");
     PostgreSQLContainerHelper.runSqlScript(MountableFile.forHostPath(tmpFilePath), PSQL_DB);

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -49,8 +49,16 @@ public class CatalogHelpers {
     return createAirbyteStream(streamName, Arrays.asList(fields));
   }
 
+  public static AirbyteStream createAirbyteStream(String streamName, String schemaName, Field... fields) {
+    return createAirbyteStream(streamName, schemaName, Arrays.asList(fields));
+  }
+
   public static AirbyteStream createAirbyteStream(String streamName, List<Field> fields) {
     return new AirbyteStream().withName(streamName).withJsonSchema(fieldsToJsonSchema(fields));
+  }
+
+  public static AirbyteStream createAirbyteStream(String streamName, String schemaName, List<Field> fields) {
+    return new AirbyteStream().withName(streamName).withNamespace(schemaName).withJsonSchema(fieldsToJsonSchema(fields));
   }
 
   public static ConfiguredAirbyteCatalog createConfiguredAirbyteCatalog(String streamName, Field... fields) {

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/CatalogConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/CatalogConverter.java
@@ -41,7 +41,8 @@ public class CatalogConverter {
         .supportedSyncModes(Enums.convertListTo(stream.getSupportedSyncModes(), io.airbyte.api.model.SyncMode.class))
         .sourceDefinedCursor(stream.getSourceDefinedCursor())
         .defaultCursorField(stream.getDefaultCursorField())
-        .sourceDefinedPrimaryKey(stream.getSourceDefinedPrimaryKey());
+        .sourceDefinedPrimaryKey(stream.getSourceDefinedPrimaryKey())
+        .namespace(stream.getNamespace());
   }
 
   private static io.airbyte.protocol.models.AirbyteStream toProtocol(final io.airbyte.api.model.AirbyteStream stream) {
@@ -51,7 +52,8 @@ public class CatalogConverter {
         .withSupportedSyncModes(Enums.convertListTo(stream.getSupportedSyncModes(), io.airbyte.protocol.models.SyncMode.class))
         .withSourceDefinedCursor(stream.getSourceDefinedCursor())
         .withDefaultCursorField(stream.getDefaultCursorField())
-        .withSourceDefinedPrimaryKey(stream.getSourceDefinedPrimaryKey());
+        .withSourceDefinedPrimaryKey(stream.getSourceDefinedPrimaryKey())
+        .withNamespace(stream.getNamespace());
   }
 
   public static io.airbyte.api.model.AirbyteCatalog toApi(final io.airbyte.protocol.models.AirbyteCatalog catalog) {

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -68,6 +68,7 @@ import io.airbyte.api.client.model.LogsRequestBody;
 import io.airbyte.api.client.model.SourceCreate;
 import io.airbyte.api.client.model.SourceDefinitionIdRequestBody;
 import io.airbyte.api.client.model.SourceDefinitionSpecificationRead;
+import io.airbyte.api.client.model.SourceDefinitionUpdate;
 import io.airbyte.api.client.model.SourceIdRequestBody;
 import io.airbyte.api.client.model.SourceRead;
 import io.airbyte.api.client.model.SyncMode;
@@ -270,6 +271,11 @@ public class AcceptanceTests {
   @Test
   @Order(5)
   public void testDiscoverSourceSchema() throws ApiException {
+    //TODO(davin): Temporary use the dev image for schema tests. This will be removed once the version is released.
+    var update = new SourceDefinitionUpdate()
+        .sourceDefinitionId(UUID.fromString("decd338e-5647-4c0b-adf4-da0e75f5a750"))
+        .dockerImageTag("dev");
+    apiClient.getSourceDefinitionApi().updateSourceDefinition(update);
     final UUID sourceId = createPostgresSource().getSourceId();
 
     final AirbyteCatalog actual = discoverSourceSchema(sourceId);

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -271,7 +271,8 @@ public class AcceptanceTests {
   @Test
   @Order(5)
   public void testDiscoverSourceSchema() throws ApiException {
-    //TODO(davin): Temporary use the dev image for schema tests. This will be removed once the version is released.
+    // TODO(davin): Temporary use the dev image for schema tests. This will be removed once the version
+    // is released.
     var update = new SourceDefinitionUpdate()
         .sourceDefinitionId(UUID.fromString("decd338e-5647-4c0b-adf4-da0e75f5a750"))
         .dockerImageTag("dev");

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -283,6 +283,7 @@ public class AcceptanceTests {
         .build());
     final AirbyteStream stream = new AirbyteStream()
         .name(STREAM_NAME)
+        .namespace("public")
         .jsonSchema(jsonSchema)
         .defaultCursorField(Collections.emptyList())
         .sourceDefinedPrimaryKey(Collections.emptyList())

--- a/docs/api/generated-api-html/index.html
+++ b/docs/api/generated-api-html/index.html
@@ -370,6 +370,7 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
+        "namespace" : "namespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
@@ -384,6 +385,7 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
+        "namespace" : "namespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
@@ -506,6 +508,7 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
+        "namespace" : "namespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
@@ -520,6 +523,7 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
+        "namespace" : "namespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
@@ -604,6 +608,7 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
+          "namespace" : "namespace",
           "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
@@ -618,6 +623,7 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
+          "namespace" : "namespace",
           "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
@@ -645,6 +651,7 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
+          "namespace" : "namespace",
           "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
@@ -659,6 +666,7 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
+          "namespace" : "namespace",
           "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
@@ -919,6 +927,7 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
+        "namespace" : "namespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
@@ -933,6 +942,7 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
+        "namespace" : "namespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
@@ -2448,6 +2458,7 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
+        "namespace" : "namespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
@@ -2462,6 +2473,7 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
+        "namespace" : "namespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
@@ -2786,6 +2798,7 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
+        "namespace" : "namespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
@@ -2800,6 +2813,7 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
+        "namespace" : "namespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
@@ -3484,6 +3498,7 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
+        "namespace" : "namespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
@@ -3498,6 +3513,7 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
+        "namespace" : "namespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
@@ -3604,6 +3620,7 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
+          "namespace" : "namespace",
           "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
@@ -3618,6 +3635,7 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
+          "namespace" : "namespace",
           "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
@@ -3667,6 +3685,7 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
+          "namespace" : "namespace",
           "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
@@ -3681,6 +3700,7 @@ font-style: italic;
           "supportedSyncModes" : [ null, null ],
           "sourceDefinedCursor" : true,
           "name" : "name",
+          "namespace" : "namespace",
           "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
         },
         "config" : {
@@ -3888,6 +3908,7 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
+        "namespace" : "namespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
@@ -3902,6 +3923,7 @@ font-style: italic;
         "supportedSyncModes" : [ null, null ],
         "sourceDefinedCursor" : true,
         "name" : "name",
+        "namespace" : "namespace",
         "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
       },
       "config" : {
@@ -4335,6 +4357,7 @@ font-style: italic;
 <div class="param">sourceDefinedCursor (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> If the source defines the cursor field, then any other cursor field inputs will be ignored. If it does not, either the user_provided one is used, or the default one is used as a backup. </div>
 <div class="param">defaultCursorField (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> Path to the field that will be used to determine if a record is new or modified since the last sync. If not provided by the source, the end user will have to specify the comparable themselves. </div>
 <div class="param">sourceDefinedPrimaryKey (optional)</div><div class="param-desc"><span class="param-type"><a href="#array">array[array[String]]</a></span> If the source defines the primary key, paths to the fields that will be used as a primary key. If not provided by the source, the end user will have to specify the primary key themselves. </div>
+<div class="param">namespace (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Optional Source-defined namespace. Airbyte streams from the same sources should have the same namespace. Currently only used by JDBC destinations to determine what schema to write to. </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What
This PR is step 5 of this [tech spec](https://docs.google.com/document/d/1qFk4YqnwxE4MCGeJ9M2scGOYej6JnDy9A0zbICP_zjI/edit#).

Follow up PR to #2704.

The first of (at least) 2 PRs to implement this on the source side. I made some headway before deciding to break the changes into one PR implementing this for discover schema job, and another PR implementing this for read. The combined PR would have been too big otherwise. 

I had to refactor the `MoreResources` class along the way. Left inline comments explaining why. 

I've scoped the changes pretty tightly by commit, so feel free to review by commit (especially for the `MoreResources` change).

## How
* Expose schema in the `TableInfo` class in `AbstractJdbcSource`. Use this to set an Airbyte Stream's namespace field in the Catalog. Update tests.
* Add the namespace field to the Airbyte Stream struct in the Airbyte Api. Update tests.

## Pre-merge Checklist
- [x] *Run integration tests*

## Recommended reading order
1. `AbstractJdbcSource` for main change and `AbstractJdbcSourceStandardTest` for matching testing changes (Discover changes).
2. `config.yaml`, `CatalogConverter` and `AcceptanceTest` (understand API changes).
3. `ManyResources` (to understand the method that was failing for me)

The various test classes propagate patterns in the above classes, so not terribly interesting.

