### PR TITLE
Add primary key tests to TestDestination

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -19,5 +19,5 @@ WORKDIR /airbyte
 
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.17
+LABEL io.airbyte.version=0.1.18
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
@@ -233,11 +233,6 @@ class StreamProcessor(object):
         for field in self.properties.keys():
             if not is_airbyte_column(field):
                 fields.append(field)
-            if self.destination_sync_mode.value == DestinationSyncMode.append_dedup.value:
-                # When deduping, some airbyte columns could be used as special cursor or primary key columns
-                if field in self.cursor_field[0] or field in [f[0] for f in self.primary_key if len(f) == 1]:
-                    if field not in fields:
-                        fields.append(field)
         result = {}
         field_names = set()
         for field in fields:
@@ -502,7 +497,11 @@ from {{ from_table }}
 
     def get_cursor_field(self, column_names: Dict[str, Tuple[str, str]]) -> str:
         if self.cursor_field and len(self.cursor_field) == 1:
-            return column_names[self.cursor_field[0]][0]
+            if not is_airbyte_column(self.cursor_field[0]):
+                return column_names[self.cursor_field[0]][0]
+            else:
+                # using an airbyte generated column
+                return self.cursor_field[0]
         else:
             if self.cursor_field:
                 raise ValueError(f"Unsupported nested cursor field {'.'.join(self.cursor_field)} for stream {self.stream_name}")
@@ -517,7 +516,11 @@ from {{ from_table }}
 
     def get_primary_key_from_path(self, column_names: Dict[str, Tuple[str, str]], path: List[str]) -> str:
         if path and len(path) == 1:
-            return column_names[path[0]][0]
+            if not is_airbyte_column(path[0]):
+                return column_names[path[0]][0]
+            else:
+                # using an airbyte generated column
+                return path[0]
         else:
             if path:
                 raise ValueError(f"Unsupported nested path {'.'.join(path)} for stream {self.stream_name}")

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
@@ -496,17 +496,16 @@ from {{ from_table }}
         return sql
 
     def get_cursor_field(self, column_names: Dict[str, Tuple[str, str]]) -> str:
-        if self.cursor_field and len(self.cursor_field) == 1:
+        if not self.cursor_field:
+            return "_airbyte_emitted_at"
+        elif len(self.cursor_field) == 1:
             if not is_airbyte_column(self.cursor_field[0]):
                 return column_names[self.cursor_field[0]][0]
             else:
                 # using an airbyte generated column
                 return self.cursor_field[0]
         else:
-            if self.cursor_field:
-                raise ValueError(f"Unsupported nested cursor field {'.'.join(self.cursor_field)} for stream {self.stream_name}")
-            else:
-                raise ValueError(f"No cursor field specified for stream {self.stream_name}")
+            raise ValueError(f"Unsupported nested cursor field {'.'.join(self.cursor_field)} for stream {self.stream_name}")
 
     def get_primary_key(self, column_names: Dict[str, Tuple[str, str]]) -> str:
         if self.primary_key and len(self.primary_key) > 0:
@@ -516,11 +515,20 @@ from {{ from_table }}
 
     def get_primary_key_from_path(self, column_names: Dict[str, Tuple[str, str]], path: List[str]) -> str:
         if path and len(path) == 1:
-            if not is_airbyte_column(path[0]):
-                return column_names[path[0]][0]
+            field = path[0]
+            if not is_airbyte_column(field):
+                if "type" in self.properties[field]:
+                    property_type = self.properties[field]["type"]
+                else:
+                    property_type = "object"
+                if is_number(property_type) or is_boolean(property_type) or is_array(property_type) or is_object(property_type):
+                    # some destinations don't handle float columns (or other types) as primary keys, turn everything to string
+                    return f"cast({self.safe_cast_to_string(field, self.properties[field], column_names[field][1])} as {jinja_call('dbt_utils.type_string()')})"
+                else:
+                    return field
             else:
                 # using an airbyte generated column
-                return path[0]
+                return f"cast({field} as {jinja_call('dbt_utils.type_string()')})"
         else:
             if path:
                 raise ValueError(f"Unsupported nested path {'.'.join(path)} for stream {self.stream_name}")

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
@@ -397,7 +397,7 @@ public abstract class TestDestination {
    * run dedup transformations.
    */
   @Test
-  public void testIncrementalDedupSync() throws Exception {
+  public void testIncrementalDedupeSync() throws Exception {
     if (!implementsAppendDedup()) {
       LOGGER.info("Destination's spec.json does not include 'append_dedup' in its '\"supportedDestinationSyncModes\"'");
       return;

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java
@@ -43,6 +43,7 @@ import io.airbyte.config.StandardCheckConnectionOutput.Status;
 import io.airbyte.config.StandardTargetConfig;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.protocol.models.AirbyteStream;
 import io.airbyte.protocol.models.CatalogHelpers;
@@ -63,10 +64,12 @@ import io.airbyte.workers.protocols.airbyte.AirbyteDestination;
 import io.airbyte.workers.protocols.airbyte.DefaultAirbyteDestination;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -148,16 +151,32 @@ public abstract class TestDestination {
   }
 
   /**
-   * Detects if a destination implements incremental mode from the spec.json that should include
+   * Detects if a destination implements append mode from the spec.json that should include
    * 'supportsIncremental' = true
    *
    * @return - a boolean.
    */
-  protected boolean implementsIncremental() throws WorkerException {
+  protected boolean implementsAppend() throws WorkerException {
     final ConnectorSpecification spec = runSpec();
     assertNotNull(spec);
     if (spec.getSupportsIncremental() != null) {
       return spec.getSupportsIncremental();
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Detects if a destination implements append dedup mode from the spec.json that should include
+   * 'supportedDestinationSyncMode'
+   *
+   * @return - a boolean.
+   */
+  protected boolean implementsAppendDedup() throws WorkerException {
+    final ConnectorSpecification spec = runSpec();
+    assertNotNull(spec);
+    if (spec.getSupportedDestinationSyncModes() != null) {
+      return spec.getSupportedDestinationSyncModes().contains(DestinationSyncMode.APPEND_DEDUP);
     } else {
       return false;
     }
@@ -313,7 +332,7 @@ public abstract class TestDestination {
    */
   @Test
   public void testIncrementalSync() throws Exception {
-    if (!implementsIncremental()) {
+    if (!implementsAppend()) {
       LOGGER.info("Destination's spec.json does not include '\"supportsIncremental\" ; true'");
       return;
     }
@@ -371,6 +390,70 @@ public abstract class TestDestination {
     String defaultSchema = getDefaultSchema(config);
     final List<AirbyteRecordMessage> actualMessages = retrieveNormalizedRecords(catalog, defaultSchema);
     assertSameMessages(messages, actualMessages, true);
+  }
+
+  /**
+   * Verify that the integration successfully writes records successfully both raw and normalized and
+   * run dedup transformations.
+   */
+  @Test
+  public void testIncrementalDedupSync() throws Exception {
+    if (!implementsAppendDedup()) {
+      LOGGER.info("Destination's spec.json does not include 'append_dedup' in its '\"supportedDestinationSyncModes\"'");
+      return;
+    }
+
+    final AirbyteCatalog catalog =
+        Jsons.deserialize(MoreResources.readResource(DataArgumentsProvider.EXCHANGE_RATE_CONFIG.catalogFile), AirbyteCatalog.class);
+    final ConfiguredAirbyteCatalog configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(catalog);
+    configuredCatalog.getStreams().forEach(s -> {
+      s.withSyncMode(SyncMode.INCREMENTAL);
+      s.withDestinationSyncMode(DestinationSyncMode.APPEND_DEDUP);
+      s.withCursorField(List.of("_airbyte_emitted_at"));
+      s.withPrimaryKey(List.of(List.of("date")));
+    });
+
+    final List<AirbyteMessage> firstSyncMessages = MoreResources.readResource(DataArgumentsProvider.EXCHANGE_RATE_CONFIG.messageFile).lines()
+        .map(record -> Jsons.deserialize(record, AirbyteMessage.class)).collect(Collectors.toList());
+    final JsonNode config = getConfigWithBasicNormalization();
+    runSync(config, firstSyncMessages, configuredCatalog);
+
+    final List<AirbyteMessage> secondSyncMessages = Lists.newArrayList(new AirbyteMessage()
+        .withRecord(new AirbyteRecordMessage()
+            .withStream(catalog.getStreams().get(0).getName())
+            .withEmittedAt(Instant.now().toEpochMilli())
+            .withData(Jsons.jsonNode(ImmutableMap.builder()
+                .put("date", "2020-09-01T00:00:00Z")
+                .put("HKD", 10)
+                .put("NZD", 700)
+                .build()))));
+    runSync(config, secondSyncMessages, configuredCatalog);
+
+    final List<AirbyteMessage> expectedMessagesAfterSecondSync = new ArrayList<>();
+    expectedMessagesAfterSecondSync.addAll(firstSyncMessages);
+    expectedMessagesAfterSecondSync.addAll(secondSyncMessages);
+
+    final Map<String, AirbyteMessage> latestMessagesOnly = expectedMessagesAfterSecondSync
+        .stream()
+        .filter(message -> message.getType() == Type.RECORD && message.getRecord() != null)
+        .collect(Collectors.toMap(
+            message -> message.getRecord().getData().get("date").asText(),
+            message -> message,
+            // keep only latest emitted record message per primary key/cursor
+            (a, b) -> a.getRecord().getEmittedAt() > b.getRecord().getEmittedAt() ? a : b));
+    // Filter expectedMessagesAfterSecondSync and keep latest messages only (keep same message order)
+    final List<AirbyteMessage> expectedMessages = expectedMessagesAfterSecondSync
+        .stream()
+        .filter(message -> message.getType() == Type.RECORD && message.getRecord() != null)
+        .filter(message -> {
+          final String key = message.getRecord().getData().get("date").asText();
+          return message.getRecord().getEmittedAt().equals(latestMessagesOnly.get(key).getRecord().getEmittedAt());
+        }).collect(Collectors.toList());
+
+    final String defaultSchema = getDefaultSchema(config);
+    retrieveRawRecordsAndAssertSameMessages(catalog, expectedMessagesAfterSecondSync, defaultSchema);
+    final List<AirbyteRecordMessage> actualMessages = retrieveNormalizedRecords(catalog, defaultSchema);
+    assertSameMessages(expectedMessages, actualMessages, true);
   }
 
   @Test

--- a/airbyte-integrations/bases/standard-destination-test/src/main/resources/exchange_rate_catalog.json
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/resources/exchange_rate_catalog.json
@@ -4,6 +4,9 @@
       "name": "exchange_rate",
       "json_schema": {
         "properties": {
+          "currency": {
+            "type": "string"
+          },
           "date": {
             "type": "string"
           },

--- a/airbyte-integrations/bases/standard-destination-test/src/main/resources/exchange_rate_messages.txt
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/resources/exchange_rate_messages.txt
@@ -1,8 +1,8 @@
-{"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602637589000, "data": { "date": "2020-08-29T00:00:00Z", "NZD": 0.12, "HKD": 2.13}}}
+{"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602637589000, "data": { "currency": "USD", "date": "2020-08-29T00:00:00Z", "NZD": 0.12, "HKD": 2.13}}}
 {"type": "STATE", "state": { "data": {"start_date": "2020-08-31"}}}
-{"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602637689100, "data": { "date": "2020-08-30T00:00:00Z", "NZD": 1.14, "HKD": 7.15}}}
+{"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602637689100, "data": { "currency": "USD", "date": "2020-08-30T00:00:00Z", "NZD": 1.14, "HKD": 7.15}}}
 {"type": "STATE", "state": { "data": {"start_date": "2020-09-01"}}}
-{"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602637789200, "data": { "date": "2020-08-31T00:00:00Z", "NZD": 1.14, "HKD": 7.15, "USD": 10.16}}}
-{"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602637889300, "data": { "date": "2020-08-31T00:00:00Z", "NZD": 1.99, "HKD": 7.99, "USD": 10.99}}}
-{"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602637989400, "data": { "date": "2020-09-01T00:00:00Z", "NZD": 1.14, "HKD": 7.15, "USD": 10.16}}}
+{"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602637789200, "data": { "currency": "EUR", "date": "2020-08-31T00:00:00Z", "NZD": 1.14, "HKD": 7.15, "USD": 10.16}}}
+{"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602637889300, "data": { "currency": "EUR", "date": "2020-08-31T00:00:00Z", "NZD": 1.14, "HKD": 7.99, "USD": 10.99}}}
+{"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602637989400, "data": { "currency": "EUR", "date": "2020-09-01T00:00:00Z", "NZD": 1.14, "HKD": 7.15, "USD": 10.16}}}
 {"type": "STATE", "state": { "data": {"start_date": "2020-09-02"}}}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
@@ -43,7 +43,7 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNormalizationRunner.class);
 
-  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.17";
+  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.18";
 
   private final DestinationType destinationType;
   private final ProcessBuilderFactory pbf;


### PR DESCRIPTION
## What
Closes #2749 
Relates to #2683
Closes #2684

## How
*Describe the solution*
For the test case, I also used the scenario where we would want to deduplicate using as the cursor the column `_airbyte_emitted_at` column as described in https://github.com/airbytehq/airbyte/issues/2683

This is because exchange rate API could have the "date" column as the primary key but we can have multiple rows for the same day and there isn't another date column in the data. By doing so, the cursor field is now optional for normalization.

This is also handling a column with type float as described in #2684 as the primary key.

(normalization should now be able to handle the empty/airbyte generated column use case as cursor and is a matter of handling that option in the UI too)

## Pre-merge Checklist
- [x] *Run integration tests*
- [x] *Publish Docker images*

## Recommended reading order
1. `airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/TestDestination.java`
1. `airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py`
1. the rest
