### PR TITLE
cdc standard tests

### DIFF
--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/StandardSourceTest.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/StandardSourceTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Sets;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.JobGetSpecConfig;
@@ -74,6 +75,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class StandardSourceTest {
+
+  public static final String CDC_LSN = "_ab_cdc_lsn";
+  public static final String CDC_UPDATED_AT = "_ab_cdc_updated_at";
+  public static final String CDC_DELETED_AT = "_ab_cdc_deleted_at";
 
   private static final long JOB_ID = 0L;
   private static final int JOB_ATTEMPT = 0;
@@ -445,7 +450,11 @@ public abstract class StandardSourceTest {
 
   private void assertSameRecords(List<AirbyteRecordMessage> expected, List<AirbyteRecordMessage> actual, String message) {
     final List<AirbyteRecordMessage> prunedExpected = expected.stream().map(this::pruneEmittedAt).collect(Collectors.toList());
-    final List<AirbyteRecordMessage> prunedActual = actual.stream().map(this::pruneEmittedAt).collect(Collectors.toList());
+    final List<AirbyteRecordMessage> prunedActual = actual
+        .stream()
+        .map(this::pruneEmittedAt)
+        .map(this::pruneCdcMetadata)
+        .collect(Collectors.toList());
     assertEquals(prunedExpected.size(), prunedActual.size(), message);
     assertTrue(prunedExpected.containsAll(prunedActual), message);
     assertTrue(prunedActual.containsAll(prunedExpected), message);
@@ -453,6 +462,14 @@ public abstract class StandardSourceTest {
 
   private AirbyteRecordMessage pruneEmittedAt(AirbyteRecordMessage m) {
     return Jsons.clone(m).withEmittedAt(null);
+  }
+
+  private AirbyteRecordMessage pruneCdcMetadata(AirbyteRecordMessage m) {
+    final AirbyteRecordMessage clone = Jsons.clone(m);
+    ((ObjectNode) clone.getData()).remove(CDC_LSN);
+    ((ObjectNode) clone.getData()).remove(CDC_UPDATED_AT);
+    ((ObjectNode) clone.getData()).remove(CDC_DELETED_AT);
+    return clone;
   }
 
   public static class TestDestinationEnv {

--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -81,6 +81,10 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractJdbcSource.class);
 
+  public static final String CDC_LSN = "_ab_cdc_lsn";
+  public static final String CDC_UPDATED_AT = "_ab_cdc_updated_at";
+  public static final String CDC_DELETED_AT = "_ab_cdc_deleted_at";
+
   private static final String JDBC_COLUMN_DATABASE_NAME = "TABLE_CAT";
   private static final String JDBC_COLUMN_SCHEMA_NAME = "TABLE_SCHEM";
   private static final String JDBC_COLUMN_TABLE_NAME = "TABLE_NAME";

--- a/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceStandardTest.java
@@ -43,7 +43,6 @@ import io.airbyte.db.Databases;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
-import io.airbyte.integrations.source.jdbc.models.CdcState;
 import io.airbyte.integrations.source.jdbc.models.JdbcState;
 import io.airbyte.integrations.source.jdbc.models.JdbcStreamState;
 import io.airbyte.protocol.models.AirbyteCatalog;
@@ -548,23 +547,24 @@ public abstract class JdbcSourceStandardTest {
     expectedMessages.add(new AirbyteMessage().withType(Type.RECORD)
         .withRecord(new AirbyteRecordMessage().withStream(streamName)
             .withData(Jsons.jsonNode(ImmutableMap
-                .of(COL_ID, ID_VALUE_4, COL_NAME, "riker", COL_UPDATED_AT,
-                    "2006-10-19T00:00:00Z")))));
+                .of(COL_ID, ID_VALUE_4,
+                    COL_NAME, "riker",
+                    COL_UPDATED_AT, "2006-10-19T00:00:00Z")))));
     expectedMessages.add(new AirbyteMessage().withType(Type.RECORD)
         .withRecord(new AirbyteRecordMessage().withStream(streamName)
             .withData(Jsons.jsonNode(ImmutableMap
-                .of(COL_ID, ID_VALUE_5, COL_NAME, "data", COL_UPDATED_AT,
-                    "2006-10-19T00:00:00Z")))));
+                .of(COL_ID, ID_VALUE_5,
+                    COL_NAME, "data",
+                    COL_UPDATED_AT, "2006-10-19T00:00:00Z")))));
     expectedMessages.add(new AirbyteMessage()
         .withType(Type.STATE)
         .withState(new AirbyteStateMessage()
             .withData(Jsons.jsonNode(new JdbcState()
+                .withCdc(false)
                 .withStreams(Lists.newArrayList(new JdbcStreamState()
                     .withStreamName(streamName)
                     .withCursorField(ImmutableList.of(COL_ID))
-                    .withCursor("5")))
-                .withCdc(false)
-                .withCdcState(new CdcState())))));
+                    .withCursor("5")))))));
 
     setEmittedAtToNull(actualMessagesSecondSync);
 
@@ -629,6 +629,7 @@ public abstract class JdbcSourceStandardTest {
         .withType(Type.STATE)
         .withState(new AirbyteStateMessage()
             .withData(Jsons.jsonNode(new JdbcState()
+                .withCdc(false)
                 .withStreams(Lists.newArrayList(
                     new JdbcStreamState()
                         .withStreamName(streamName)
@@ -636,15 +637,14 @@ public abstract class JdbcSourceStandardTest {
                         .withCursor("3"),
                     new JdbcStreamState()
                         .withStreamName(streamName2)
-                        .withCursorField(ImmutableList.of(COL_ID))))
-                .withCdc(false)
-                .withCdcState(new CdcState())))));
+                        .withCursorField(ImmutableList.of(COL_ID))))))));
 
     expectedMessagesFirstSync.addAll(secondStreamExpectedMessages);
     expectedMessagesFirstSync.add(new AirbyteMessage()
         .withType(Type.STATE)
         .withState(new AirbyteStateMessage()
             .withData(Jsons.jsonNode(new JdbcState()
+                .withCdc(false)
                 .withStreams(Lists.newArrayList(
                     new JdbcStreamState()
                         .withStreamName(streamName)
@@ -653,9 +653,7 @@ public abstract class JdbcSourceStandardTest {
                     new JdbcStreamState()
                         .withStreamName(streamName2)
                         .withCursorField(ImmutableList.of(COL_ID))
-                        .withCursor("3")))
-                .withCdc(false)
-                .withCdcState(new CdcState())))));
+                        .withCursor("3")))))));
 
     setEmittedAtToNull(actualMessagesFirstSync);
 
@@ -716,12 +714,11 @@ public abstract class JdbcSourceStandardTest {
         .withType(Type.STATE)
         .withState(new AirbyteStateMessage()
             .withData(Jsons.jsonNode(new JdbcState()
+                .withCdc(false)
                 .withStreams(Lists.newArrayList(new JdbcStreamState()
                     .withStreamName(airbyteStream.getStream().getName())
                     .withCursorField(ImmutableList.of(cursorField))
-                    .withCursor(endCursorValue)))
-                .withCdc(false)
-                .withCdcState(new CdcState())))));
+                    .withCursor(endCursorValue)))))));
 
     assertEquals(expectedMessages, actualMessages);
   }
@@ -772,18 +769,22 @@ public abstract class JdbcSourceStandardTest {
         new AirbyteMessage().withType(Type.RECORD)
             .withRecord(new AirbyteRecordMessage().withStream(streamName)
                 .withData(Jsons.jsonNode(ImmutableMap
-                    .of(COL_ID, ID_VALUE_1, COL_NAME, "picard", COL_UPDATED_AT,
-                        "2004-10-19T00:00:00Z")))),
+                    .of(COL_ID, ID_VALUE_1,
+                        COL_NAME, "picard",
+                        COL_UPDATED_AT, "2004-10-19T00:00:00Z")))),
         new AirbyteMessage().withType(Type.RECORD)
             .withRecord(new AirbyteRecordMessage().withStream(streamName)
                 .withData(Jsons.jsonNode(ImmutableMap
-                    .of(COL_ID, ID_VALUE_2, COL_NAME, "crusher", COL_UPDATED_AT,
+                    .of(COL_ID, ID_VALUE_2,
+                        COL_NAME, "crusher",
+                        COL_UPDATED_AT,
                         "2005-10-19T00:00:00Z")))),
         new AirbyteMessage().withType(Type.RECORD)
             .withRecord(new AirbyteRecordMessage().withStream(streamName)
                 .withData(Jsons.jsonNode(ImmutableMap
-                    .of(COL_ID, ID_VALUE_3, COL_NAME, "vash", COL_UPDATED_AT,
-                        "2006-10-19T00:00:00Z")))));
+                    .of(COL_ID, ID_VALUE_3,
+                        COL_NAME, "vash",
+                        COL_UPDATED_AT, "2006-10-19T00:00:00Z")))));
   }
 
   private ConfiguredAirbyteStream createTableWithSpaces() throws SQLException {

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -76,10 +76,6 @@ public class PostgresSource extends AbstractJdbcSource implements Source {
 
   static final String DRIVER_CLASS = "org.postgresql.Driver";
 
-  public static final String CDC_LSN = "_ab_cdc_lsn";
-  public static final String CDC_UPDATED_AT = "_ab_cdc_updated_at";
-  public static final String CDC_DELETED_AT = "_ab_cdc_deleted_at";
-
   public PostgresSource() {
     super(DRIVER_CLASS, new PostgresJdbcStreamingQueryConfiguration());
   }

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -189,6 +189,8 @@ public class PostgresSource extends AbstractJdbcSource implements Source {
                                                                              JdbcStateManager stateManager,
                                                                              Instant emittedAt) {
     if (isCdc(config)) {
+      LOGGER.info("Using CDC");
+
       // State works differently in CDC than it does in convention incremental. The state is written to an
       // offset file that debezium reads from. Then once all records are replicated, we read back that
       // offset file (which will have been updated by debezium) and set it in the state. There is no

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcPostgresSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcPostgresSourceStandardTest.java
@@ -1,0 +1,153 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.integrations.io.airbyte.integration_tests.sources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.db.Database;
+import io.airbyte.db.Databases;
+import io.airbyte.integrations.standardtest.source.StandardSourceTest;
+import io.airbyte.protocol.models.CatalogHelpers;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.ConfiguredAirbyteStream;
+import io.airbyte.protocol.models.ConnectorSpecification;
+import io.airbyte.protocol.models.DestinationSyncMode;
+import io.airbyte.protocol.models.Field;
+import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
+import io.airbyte.protocol.models.SyncMode;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import org.jooq.SQLDialect;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.MountableFile;
+
+// todo (cgardens) - Sanity check that when configured for CDC that postgres performs like any other
+// incremental source. As we have more sources support CDC we will find a more reusable way of doing
+// this, but for now this is a solid sanity check.
+public class CdcPostgresSourceStandardTest extends StandardSourceTest {
+
+  private static final String SLOT_NAME_BASE = "debezium_slot";
+  private static final String STREAM_NAME = "public.id_and_name";
+  private static final String STREAM_NAME2 = "public.starships";
+
+  private PostgreSQLContainer<?> container;
+  private JsonNode config;
+
+  @Override
+  protected void setup(TestDestinationEnv testEnv) throws Exception {
+    container = new PostgreSQLContainer<>("postgres:13-alpine")
+        .withCopyFileToContainer(MountableFile.forClasspathResource("postgresql.conf"), "/etc/postgresql/postgresql.conf")
+        .withCommand("postgres -c config_file=/etc/postgresql/postgresql.conf");
+    container.start();
+
+    config = Jsons.jsonNode(ImmutableMap.builder()
+        .put("host", container.getHost())
+        .put("port", container.getFirstMappedPort())
+        .put("database", container.getDatabaseName())
+        .put("username", container.getUsername())
+        .put("password", container.getPassword())
+        .put("replication_slot", SLOT_NAME_BASE)
+        .build());
+
+    final Database database = Databases.createDatabase(
+        config.get("username").asText(),
+        config.get("password").asText(),
+        String.format("jdbc:postgresql://%s:%s/%s",
+            config.get("host").asText(),
+            config.get("port").asText(),
+            config.get("database").asText()),
+        "org.postgresql.Driver",
+        SQLDialect.POSTGRES);
+
+    database.query(ctx -> {
+      ctx.execute("SELECT pg_create_logical_replication_slot('" + SLOT_NAME_BASE + "', 'pgoutput');");
+      ctx.execute("CREATE TABLE id_and_name(id INTEGER, name VARCHAR(200));");
+      ctx.execute("INSERT INTO id_and_name (id, name) VALUES (1,'picard'),  (2, 'crusher'), (3, 'vash');");
+      ctx.execute("CREATE TABLE starships(id INTEGER, name VARCHAR(200));");
+      ctx.execute("INSERT INTO starships (id, name) VALUES (1,'enterprise-d'),  (2, 'defiant'), (3, 'yamato');");
+      return null;
+    });
+
+    database.close();
+  }
+
+  @Override
+  protected void tearDown(TestDestinationEnv testEnv) {
+    container.close();
+  }
+
+  @Override
+  protected String getImageName() {
+    return "airbyte/source-postgres:dev";
+  }
+
+  @Override
+  protected ConnectorSpecification getSpec() throws Exception {
+    return Jsons.deserialize(MoreResources.readResource("spec.json"), ConnectorSpecification.class);
+  }
+
+  @Override
+  protected JsonNode getConfig() {
+    return config;
+  }
+
+  @Override
+  protected ConfiguredAirbyteCatalog getConfiguredCatalog() {
+    return new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(
+        new ConfiguredAirbyteStream()
+            .withSyncMode(SyncMode.INCREMENTAL)
+            .withCursorField(Lists.newArrayList("id"))
+            .withDestinationSyncMode(DestinationSyncMode.APPEND)
+            .withStream(CatalogHelpers.createAirbyteStream(
+                STREAM_NAME,
+                Field.of("id", JsonSchemaPrimitive.NUMBER),
+                Field.of("name", JsonSchemaPrimitive.STRING))
+                .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))),
+        new ConfiguredAirbyteStream()
+            .withSyncMode(SyncMode.INCREMENTAL)
+            .withCursorField(Lists.newArrayList("id"))
+            .withDestinationSyncMode(DestinationSyncMode.APPEND)
+            .withStream(CatalogHelpers.createAirbyteStream(
+                STREAM_NAME2,
+                Field.of("id", JsonSchemaPrimitive.NUMBER),
+                Field.of("name", JsonSchemaPrimitive.STRING))
+                .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL)))));
+  }
+
+  @Override
+  protected List<String> getRegexTests() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected JsonNode getState() {
+    return Jsons.jsonNode(new HashMap<>());
+  }
+
+}

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
@@ -41,11 +41,11 @@ import com.google.common.collect.Streams;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.Exceptions;
-import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.util.AutoCloseableIterator;
 import io.airbyte.commons.util.AutoCloseableIterators;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
+import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
@@ -82,9 +82,9 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.MountableFile;
 
-class PostgresSourceCdcTest {
+class CdcPostgresSourceTest {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(PostgresSourceCdcTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CdcPostgresSourceTest.class);
 
   private static final String SLOT_NAME_BASE = "debezium_slot";
   private static final String MAKES_STREAM_NAME = "public.makes";
@@ -162,8 +162,8 @@ class PostgresSourceCdcTest {
     database = getDatabaseFromConfig(config);
     database.query(ctx -> {
       ctx.execute("SELECT pg_create_logical_replication_slot('" + fullReplicationSlot + "', 'pgoutput');");
-      ctx.fetch(String.format("CREATE TABLE %s(%s INTEGER, %s VARCHAR(200), PRIMARY KEY (%s));", MAKES_STREAM_NAME, COL_ID, COL_MAKE, COL_ID));
-      ctx.fetch(String.format("CREATE TABLE %s(%s INTEGER, %s INTEGER, %s VARCHAR(200), PRIMARY KEY (%s));",
+      ctx.execute(String.format("CREATE TABLE %s(%s INTEGER, %s VARCHAR(200), PRIMARY KEY (%s));", MAKES_STREAM_NAME, COL_ID, COL_MAKE, COL_ID));
+      ctx.execute(String.format("CREATE TABLE %s(%s INTEGER, %s INTEGER, %s VARCHAR(200), PRIMARY KEY (%s));",
           MODELS_STREAM_NAME, COL_ID, COL_MAKE_ID, COL_MODEL, COL_ID));
 
       for (JsonNode recordJson : MAKE_RECORDS) {
@@ -237,9 +237,9 @@ class PostgresSourceCdcTest {
     assertExpectedStateMessages(stateMessages2);
     assertEquals(1, recordMessages2.size());
     assertEquals(11, recordMessages2.get(0).getData().get(COL_ID).asInt());
-    assertNotNull(recordMessages2.get(0).getData().get(PostgresSource.CDC_LSN));
-    assertNotNull(recordMessages2.get(0).getData().get(PostgresSource.CDC_UPDATED_AT));
-    assertNotNull(recordMessages2.get(0).getData().get(PostgresSource.CDC_DELETED_AT));
+    assertNotNull(recordMessages2.get(0).getData().get(AbstractJdbcSource.CDC_LSN));
+    assertNotNull(recordMessages2.get(0).getData().get(AbstractJdbcSource.CDC_UPDATED_AT));
+    assertNotNull(recordMessages2.get(0).getData().get(AbstractJdbcSource.CDC_DELETED_AT));
   }
 
   @Test
@@ -267,9 +267,9 @@ class PostgresSourceCdcTest {
     assertEquals(1, recordMessages2.size());
     assertEquals(11, recordMessages2.get(0).getData().get(COL_ID).asInt());
     assertEquals(updatedModel, recordMessages2.get(0).getData().get(COL_MODEL).asText());
-    assertNotNull(recordMessages2.get(0).getData().get(PostgresSource.CDC_LSN));
-    assertNotNull(recordMessages2.get(0).getData().get(PostgresSource.CDC_UPDATED_AT));
-    assertTrue(recordMessages2.get(0).getData().get(PostgresSource.CDC_DELETED_AT).isNull());
+    assertNotNull(recordMessages2.get(0).getData().get(AbstractJdbcSource.CDC_LSN));
+    assertNotNull(recordMessages2.get(0).getData().get(AbstractJdbcSource.CDC_UPDATED_AT));
+    assertTrue(recordMessages2.get(0).getData().get(AbstractJdbcSource.CDC_DELETED_AT).isNull());
   }
 
   @SuppressWarnings({"BusyWait", "CodeBlock2Expr"})
@@ -458,17 +458,17 @@ class PostgresSourceCdcTest {
           final JsonNode data = recordMessage.getData();
 
           if (cdcStreams.contains(recordMessage.getStream())) {
-            assertNotNull(data.get(PostgresSource.CDC_LSN));
-            assertNotNull(data.get(PostgresSource.CDC_UPDATED_AT));
+            assertNotNull(data.get(AbstractJdbcSource.CDC_LSN));
+            assertNotNull(data.get(AbstractJdbcSource.CDC_UPDATED_AT));
           } else {
-            assertNull(data.get(PostgresSource.CDC_LSN));
-            assertNull(data.get(PostgresSource.CDC_UPDATED_AT));
-            assertNull(data.get(PostgresSource.CDC_DELETED_AT));
+            assertNull(data.get(AbstractJdbcSource.CDC_LSN));
+            assertNull(data.get(AbstractJdbcSource.CDC_UPDATED_AT));
+            assertNull(data.get(AbstractJdbcSource.CDC_DELETED_AT));
           }
 
-          ((ObjectNode) data).remove(PostgresSource.CDC_LSN);
-          ((ObjectNode) data).remove(PostgresSource.CDC_UPDATED_AT);
-          ((ObjectNode) data).remove(PostgresSource.CDC_DELETED_AT);
+          ((ObjectNode) data).remove(AbstractJdbcSource.CDC_LSN);
+          ((ObjectNode) data).remove(AbstractJdbcSource.CDC_UPDATED_AT);
+          ((ObjectNode) data).remove(AbstractJdbcSource.CDC_DELETED_AT);
 
           return data;
         })


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/2747
closes https://github.com/airbytehq/airbyte/issues/2746

## What
* Fix JdbcStandardTests to work with CDC
* Add another invocation of the standard tests for postgres with the source set to CDC to sanity check that the CDC version of postgres passes standard tests.