### PR TITLE
Add view when connection list is empty

### DIFF
--- a/airbyte-webapp/src/components/index.tsx
+++ b/airbyte-webapp/src/components/index.tsx
@@ -21,3 +21,4 @@ export * from "./RadioButton";
 export * from "./ArrayOfObjectsEditor";
 export * from "./ContentCard";
 export * from "./PreferencesForm";
+export * from "./ContentCard";

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -192,6 +192,7 @@
   "connection.updateSchemaText": "WARNING! Updating the schema will delete all the data for this connection in your destination and start syncing from scratch. Are you sure you want to do this?",
   "connection.newConnection": "+ new connection",
   "connection.newConnectionTitle": "New connection",
+  "connection.noConnections": "Connection list is empty",
 
   "tables.sourceIsValidating": "Validating the source",
   "tables.sourceIsValidatingBefore": "before you add a new destination",

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/AllConnectionsPage/AllConnectionsPage.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/AllConnectionsPage/AllConnectionsPage.tsx
@@ -1,13 +1,25 @@
 import React, { Suspense } from "react";
 import { FormattedMessage } from "react-intl";
 import { useResource } from "rest-hooks";
+import styled from "styled-components";
 
-import { Button, MainPageWithScroll, PageTitle, LoadingPage } from "components";
+import {
+  Button,
+  MainPageWithScroll,
+  PageTitle,
+  LoadingPage,
+  ContentCard,
+} from "components";
 import ConnectionResource from "core/resources/Connection";
 import config from "config";
 import ConnectionsTable from "./components/ConnectionsTable";
 import { Routes } from "pages/routes";
 import useRouter from "components/hooks/useRouterHook";
+import EmptyResource from "components/EmptyResourceBlock";
+
+const Content = styled(ContentCard)`
+  margin: 0 32px 0 27px;
+`;
 
 const AllConnectionsPage: React.FC = () => {
   const { push } = useRouter();
@@ -32,7 +44,15 @@ const AllConnectionsPage: React.FC = () => {
       }
     >
       <Suspense fallback={<LoadingPage />}>
-        <ConnectionsTable connections={connections} />
+        {connections.length ? (
+          <ConnectionsTable connections={connections} />
+        ) : (
+          <Content>
+            <EmptyResource
+              text={<FormattedMessage id="connection.noConnections" />}
+            />
+          </Content>
+        )}
       </Suspense>
     </MainPageWithScroll>
   );


### PR DESCRIPTION
## What
Show empty message when user doesn't create connection yet (the same as for Source and Destination pages)


<img width="1193" alt="Снимок экрана 2021-04-09 в 01 32 16" src="https://user-images.githubusercontent.com/3767150/114104600-d68cb880-98d3-11eb-9db3-b91b9470a6d1.png">
