### PR TITLE
stop creating two databases

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
     environment:
       - POSTGRES_USER=${DATABASE_USER}
       - POSTGRES_PASSWORD=${DATABASE_PASSWORD}
-      - POSTGRES_DB=db-${DATABASE_DB}
+      - POSTGRES_DB=${DATABASE_DB}
     volumes:
       - db:/var/lib/postgresql/data
   seed:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,6 @@ services:
     environment:
       - POSTGRES_USER=${DATABASE_USER}
       - POSTGRES_PASSWORD=${DATABASE_PASSWORD}
-      - POSTGRES_DB=${DATABASE_DB}
     volumes:
       - db:/var/lib/postgresql/data
   seed:


### PR DESCRIPTION
We're creating two databases on startup. One is with `schema.sql` and is called `airbyte`. The other is `db-airbyte` from `docker-compose.yaml` which isn't used by anything:

```
# jrhizor in ~/code/airbyte on git:master ● [17:14:29]
→ docker exec -it airbyte-db psql -U docker db-airbyte
psql (13.2)
Type "help" for help.

db-airbyte=# \dt
Did not find any relations.
```

```
# jrhizor in ~/code/airbyte on git:master ● [17:14:48]
→ docker exec -it airbyte-db psql -U docker airbyte
psql (13.2)
Type "help" for help.

airbyte=# \dt
             List of relations
 Schema |       Name       | Type  | Owner
--------+------------------+-------+--------
 public | airbyte_metadata | table | docker
 public | attempts         | table | docker
 public | jobs             | table | docker
(3 rows)

```

If we fix the name for `db-airbyte` in `docker-compose.yaml` we run into an error on startup:
```
airbyte-db          | psql:/docker-entrypoint-initdb.d/000_init.sql:3: ERROR:  database "airbyte" already exists
```

However, if we remove the line completely, it only initializes a DB from the config script, which prevents any extraneous database creation.