### PR TITLE
🎉 improvement: speed up mongodb schema discovery

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb/Dockerfile
+++ b/airbyte-integrations/connectors/source-mongodb/Dockerfile
@@ -13,4 +13,4 @@ RUN bundle install
 ENTRYPOINT ["ruby", "/airbyte/source.rb"]
 
 LABEL io.airbyte.name=airbyte/source-mongodb
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.3.0

--- a/airbyte-integrations/connectors/source-mongodb/lib/mongodb_configured_stream/incremental.rb
+++ b/airbyte-integrations/connectors/source-mongodb/lib/mongodb_configured_stream/incremental.rb
@@ -71,15 +71,13 @@ class MongodbConfiguredStream::Incremental < MongodbConfiguredStream::Base
   private
 
   def determine_cursor_field_type
-    explorer = MongodbTypesExplorer.new(collection: @client[stream_name], field: cursor_field) do |type|
+    MongodbTypesExplorer.run(collection: @client[stream_name], field: cursor_field) do |type|
       if DATETIME_TYPES.include?(type)
         CURSOR_TYPES[:datetime]
       else
         CURSOR_TYPES[:integer]
       end
     end
-
-    explorer.field_type
   end
 
   def convert_cursor(value)

--- a/airbyte-integrations/connectors/source-mongodb/lib/mongodb_source.rb
+++ b/airbyte-integrations/connectors/source-mongodb/lib/mongodb_source.rb
@@ -40,6 +40,7 @@ class MongodbSource
     @config = JSON.parse(File.read(config))
 
     streams = client.collections.map do |collection|
+      AirbyteLogger.log("Discovering stream #{collection.name}")
       MongodbStream.new(collection: collection).discover
     end
 

--- a/airbyte-integrations/connectors/source-mongodb/lib/mongodb_types_explorer.rb
+++ b/airbyte-integrations/connectors/source-mongodb/lib/mongodb_types_explorer.rb
@@ -5,30 +5,36 @@ require_relative './mongodb_stream.rb'
 class MongodbTypesExplorer
   EXPLORE_LIMIT = 1_000
 
-  attr_reader :field_type
+  @@cache = {}
 
-  def initialize(collection:, field:, limit: EXPLORE_LIMIT, &type_mapping_block)
-    @collection = collection
-    @field = field
-    @limit = limit
-    @type_mapping_block = type_mapping_block
+  def self.run(collection:, field:, limit: EXPLORE_LIMIT, &type_mapping_block)
+    determine_field_types_for_collection(collection: collection, limit: limit, &type_mapping_block)
 
-    @field_type = determine_field_type
+    @@cache[collection.name][field]
   end
 
   private
 
-  def determine_field_type
-    airbyte_types = Set[]
+  def self.determine_field_types_for_collection(collection:, limit:, &type_mapping_block)
+    return if @@cache[collection.name]
 
-    @collection.find(@field => { "$nin": [nil] }).limit(@limit).each do |item|
-      mapped_value = @type_mapping_block[item[@field].class]
-      airbyte_types.add(mapped_value)
+    airbyte_types = {}
+
+    collection.find.limit(limit).each do |item|
+      item.each_pair do |key, value|
+        mapped_value = type_mapping_block[value.class]
+
+        airbyte_types[key] ||= Set[]
+        airbyte_types[key].add(mapped_value)
+      end
     end
 
-    # Has one specific type
-    if airbyte_types.count == 1
-      airbyte_types.first
+    @@cache[collection.name] = {}
+    airbyte_types.each_pair do |field, types|
+      # Has one specific type
+      if types.count == 1
+        @@cache[collection.name][field] = types.first
+      end
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: fut <fut.wrk@gmail.com>

## What
Speed up the discovery phase for MongoDB source. 

## How
Full DB scan takes huge amount of time for large DBs. Thus we take only 10k documents to search for props and 1k documents to determine prop types. 

## Pre-merge Checklist
- [x] *Run integration tests*
- [x] *Publish Docker images* (`docker pull narrativebi/airbyte-source-mongodb:0.3.0`)