### PR TITLE
fix: 🔧 - Fix envs map in kube overlays

### DIFF
--- a/kube/overlays/dev/kustomization.yaml
+++ b/kube/overlays/dev/kustomization.yaml
@@ -18,4 +18,5 @@ images:
 
 configMapGenerator:
   - name: airbyte-env
-    env: .env
+    envs: 
+      - .env

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -18,4 +18,5 @@ images:
 
 configMapGenerator:
   - name: airbyte-env
-    env: .env
+    envs: 
+      - .env


### PR DESCRIPTION
## What
This PR aims to solve the Kustomization issue with the `env` field since it should be `envs`.

## How
- Update Kustomization overlays.

## Links of Interest
- https://github.com/kubeflow/metadata/issues/202