### PR TITLE
Revert "Make email a required field in the onboarding flow"

### DIFF
--- a/airbyte-e2e-testing/cypress/integration/onboarding.spec.js
+++ b/airbyte-e2e-testing/cypress/integration/onboarding.spec.js
@@ -3,9 +3,7 @@ describe("Onboarding actions", () => {
     cy.visit("/");
     cy.url().should("include", `${Cypress.config().baseUrl}/preferences`);
 
-    cy.fillEmail("test-email-onboarding@test-onboarding-domain.com");
-    cy.get("input[name=securityUpdates]").parent().click();
-
+    // cy.fillEmail("");
     cy.submit();
 
     cy.url().should("include", `${Cypress.config().baseUrl}/onboarding`);

--- a/airbyte-webapp/src/components/PreferencesForm/PreferencesForm.tsx
+++ b/airbyte-webapp/src/components/PreferencesForm/PreferencesForm.tsx
@@ -57,7 +57,7 @@ const Text = styled.div`
 `;
 
 const preferencesValidationSchema = yup.object().shape({
-  email: yup.string().email("form.email.error").required("form.empty.error"),
+  email: yup.string().email("form.email.error"),
 });
 
 const PreferencesForm: React.FC<PreferencesFormProps> = ({
@@ -100,7 +100,7 @@ const PreferencesForm: React.FC<PreferencesFormProps> = ({
               {({ field, meta }: FieldProps<string>) => (
                 <LabeledInput
                   {...field}
-                  label={<FormattedMessage id="form.yourEmail" />}
+                  label={<FormattedMessage id="form.emailOptional" />}
                   placeholder={formatMessage({
                     id: "form.email.placeholder",
                   })}
@@ -113,9 +113,6 @@ const PreferencesForm: React.FC<PreferencesFormProps> = ({
                   }
                   onChange={(event) => {
                     handleChange(event);
-                    if (isEdit) {
-                      return;
-                    }
                     if (
                       field.value.length === 0 &&
                       event.target.value.length > 0

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -11,7 +11,7 @@
   "sidebar.settings": "Settings",
 
   "form.continue": "Continue",
-  "form.yourEmail": "Your email",
+  "form.emailOptional": "Your email (optional)",
   "form.email.placeholder": "you@company.com",
   "form.email.error": "This email address doesn’t seem correct.",
   "form.empty.error": "Empty field",


### PR DESCRIPTION
Reverts airbytehq/airbyte#2814

@Jamakase fyi. We decided to revert this before the release. We'll likely include this in a different way when we introduce accounts.