### PR TITLE
csv discovery takes too much memory (#2089)

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/778daa7c-feaf-4db6-96f3-70fd645acc77.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/778daa7c-feaf-4db6-96f3-70fd645acc77.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "778daa7c-feaf-4db6-96f3-70fd645acc77",
   "name": "File",
   "dockerRepository": "airbyte/source-file",
-  "dockerImageTag": "0.2.1",
+  "dockerImageTag": "0.2.2",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-file"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -6,7 +6,7 @@
 - sourceDefinitionId: 778daa7c-feaf-4db6-96f3-70fd645acc77
   name: File
   dockerRepository: airbyte/source-file
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2
   documentationUrl: https://hub.docker.com/r/airbyte/source-file
 - sourceDefinitionId: fdc8b827-3257-4b33-83cc-106d234c34d4
   name: Google Adwords

--- a/airbyte-integrations/connectors/source-file/Dockerfile
+++ b/airbyte-integrations/connectors/source-file/Dockerfile
@@ -11,5 +11,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.1
+LABEL io.airbyte.version=0.2.2
 LABEL io.airbyte.name=airbyte/source-file

--- a/airbyte-integrations/connectors/source-file/source_file/client.py
+++ b/airbyte-integrations/connectors/source-file/source_file/client.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 import json
 import traceback
-from typing import Iterable, List
+from typing import Iterable
 from urllib.parse import urlparse
 
 import google

--- a/airbyte-integrations/connectors/source-file/source_file/client.py
+++ b/airbyte-integrations/connectors/source-file/source_file/client.py
@@ -256,7 +256,7 @@ class Client:
                 result = [result]
         return result
 
-    def load_dataframes(self, fp, skip_data=False) -> List:
+    def load_dataframes(self, fp, skip_data=False) -> Iterable:
         """load and return the appropriate pandas dataframe.
 
         :param fp: file-like object to read from

--- a/airbyte-integrations/connectors/source-file/source_file/client.py
+++ b/airbyte-integrations/connectors/source-file/source_file/client.py
@@ -324,15 +324,15 @@ class Client:
             if self._reader_format == "json" or self._reader_format == "jsonl":
                 yield from self.load_nested_json(fp)
             else:
-                fields = list(fields)
+                fields = set(fields) if fields else None
                 for df in self.load_dataframes(fp):
                     if self._reader_format == "csv" and isinstance(df, pd.io.parsers.TextFileReader):
                         for chunk in df:
-                            columns = set(fields).intersection(set(chunk.columns)) if fields else chunk.columns
+                            columns = fields.intersection(set(chunk.columns)) if fields else chunk.columns
                             chunk = chunk.replace(np.nan, "NaN", regex=True)
                             yield from chunk[columns].to_dict(orient="records")
                     else:
-                        columns = set(fields).intersection(set(df.columns)) if fields else df.columns
+                        columns = fields.intersection(set(df.columns)) if fields else df.columns
                         df = df.replace(np.nan, "NaN", regex=True)
                         yield from df[columns].to_dict(orient="records")
 

--- a/airbyte-integrations/connectors/source-file/source_file/client.py
+++ b/airbyte-integrations/connectors/source-file/source_file/client.py
@@ -326,15 +326,15 @@ class Client:
             else:
                 fields = set(fields) if fields else None
                 for df in self.load_dataframes(fp):
+                    chunks = [df]
+
                     if self._reader_format == "csv" and isinstance(df, pd.io.parsers.TextFileReader):
-                        for chunk in df:
-                            columns = fields.intersection(set(chunk.columns)) if fields else chunk.columns
-                            chunk = chunk.replace(np.nan, "NaN", regex=True)
-                            yield from chunk[columns].to_dict(orient="records")
-                    else:
-                        columns = fields.intersection(set(df.columns)) if fields else df.columns
-                        df = df.replace(np.nan, "NaN", regex=True)
-                        yield from df[columns].to_dict(orient="records")
+                        chunks = df
+
+                    for chunk in chunks:
+                        columns = fields.intersection(set(chunk.columns)) if fields else chunk.columns
+                        chunk = chunk.replace(np.nan, "NaN", regex=True)
+                        yield from chunk[columns].to_dict(orient="records")
 
     def _stream_properties(self):
         with self.reader.open(binary=self.binary_source) as fp:


### PR DESCRIPTION
Use `chunksize` parameter when reading csv files.

## What
This PR is for https://github.com/airbytehq/airbyte/issues/2089 issue.

## How
*Describe the solution*
Use `chunksize` parameter when reading csv files. It'll load not all the file but its chunks one at a time. Each chunk has 10000 lines.

## Pre-merge Checklist
- [x] *Run integration tests*
- [x] *Publish Docker images*

## Recommended reading order
1. `airbyte-integrations/connectors/source-file/source_file/client.py`

