### PR TITLE
🐛 bugfix: parsing Mysql jdbc params

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/435bb9a5-7887-4809-aa58-28c27df0d7ad.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/435bb9a5-7887-4809-aa58-28c27df0d7ad.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "435bb9a5-7887-4809-aa58-28c27df0d7ad",
   "name": "MySQL",
   "dockerRepository": "airbyte/source-mysql",
-  "dockerImageTag": "0.2.4",
+  "dockerImageTag": "0.2.5",
   "documentationUrl": "https://docs.airbyte.io/integrations/sources/mysql"
 }

--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -133,7 +133,7 @@ public abstract class AbstractJdbcSource extends BaseConnector implements Source
       LOGGER.info("Exception while checking connection: ", e);
       return new AirbyteConnectionStatus()
           .withStatus(Status.FAILED)
-          .withMessage("Could not connect with provided configuration.");
+          .withMessage("Could not connect with provided configuration. Error: " + e.getMessage());
     }
   }
 

--- a/airbyte-integrations/connectors/source-mysql/Dockerfile
+++ b/airbyte-integrations/connectors/source-mysql/Dockerfile
@@ -8,6 +8,6 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.2.4
+LABEL io.airbyte.version=0.2.5
 
 LABEL io.airbyte.name=airbyte/source-mysql

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
@@ -52,8 +52,8 @@ public class MySqlSource extends AbstractJdbcSource implements Source {
         config.get("database").asText()));
     // see MySqlJdbcStreamingQueryConfiguration for more context on why useCursorFetch=true is needed.
     jdbc_url.append("?useCursorFetch=true");
-    if (config.get("jdbc_url_params") != null && !config.get("jdbc_url_params").isEmpty()) {
-      jdbc_url.append("&").append(config.get("jdbc_url_params"));
+    if (config.get("jdbc_url_params") != null && !config.get("jdbc_url_params").asText().isEmpty()) {
+      jdbc_url.append("&").append(config.get("jdbc_url_params").asText());
     }
     ImmutableMap.Builder<Object, Object> configBuilder = ImmutableMap.builder()
         .put("username", config.get("username").asText())

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlJdbcStandardTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlJdbcStandardTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.MySQLContainer;
 
 class MySqlJdbcStandardTest extends JdbcSourceStandardTest {
@@ -123,5 +124,4 @@ class MySqlJdbcStandardTest extends JdbcSourceStandardTest {
   public JsonNode getConfig() {
     return Jsons.clone(config);
   }
-
 }

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlSourceTests.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlSourceTests.java
@@ -1,0 +1,71 @@
+package io.airbyte.integrations.source.mysql;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.db.Database;
+import io.airbyte.db.Databases;
+import io.airbyte.protocol.models.AirbyteConnectionStatus;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.jooq.SQLDialect;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MySqlSourceTests {
+
+  private static final String TEST_USER = "test";
+  private static final String TEST_PASSWORD = "test";
+  private static MySQLContainer<?> container;
+
+  private JsonNode config;
+  private Database database;
+
+  @Test
+  public void testSettingTimezones() throws Exception {
+    // start DB
+    container = new MySQLContainer<>("mysql:8.0")
+        .withUsername(TEST_USER)
+        .withPassword(TEST_PASSWORD)
+        .withEnv("MYSQL_ROOT_HOST", "%")
+        .withEnv("MYSQL_ROOT_PASSWORD", TEST_PASSWORD)
+        .withEnv("TZ", "Europe/Moscow");
+    container.start();
+    Properties properties = new Properties();
+    properties.putAll(ImmutableMap.of("user", "root", "password", TEST_PASSWORD, "serverTimezone", "Europe/Moscow"));
+    DriverManager.getConnection(container.getJdbcUrl(), properties);
+    String dbName = "db_" + RandomStringUtils.randomAlphabetic(10);
+    config = getConfig(container, dbName, "serverTimezone=Europe/Moscow");
+
+    try(Connection connection = DriverManager.getConnection(container.getJdbcUrl(), properties)){
+      connection.createStatement().execute("GRANT ALL PRIVILEGES ON *.* TO '" + TEST_USER + "'@'%';\n");
+      connection.createStatement().execute("CREATE DATABASE " + config.get("database").asText());
+    }
+    AirbyteConnectionStatus check = new MySqlSource().check(config);
+    assertEquals(AirbyteConnectionStatus.Status.SUCCEEDED, check.getStatus());
+
+    // cleanup
+    container.close();
+  }
+
+  private static JsonNode getConfig(MySQLContainer dbContainer, String dbName, String jdbcParams) {
+    return Jsons.jsonNode(ImmutableMap.builder()
+        .put("host", dbContainer.getHost())
+        .put("port", dbContainer.getFirstMappedPort())
+        .put("database", dbName)
+        .put("username", TEST_USER)
+        .put("password", TEST_PASSWORD)
+        .put("jdbc_url_params", jdbcParams)
+        .build());
+  }
+}


### PR DESCRIPTION
Added small fix with for correct parse jdbc params in source-mysql connector:
- correct condition at https://github.com/airbytehq/airbyte/blob/cf45cc6be27257abc832432d9aa0d32742a96d19/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java#L55
- correct appending param to jdbc url at https://github.com/airbytehq/airbyte/blob/cf45cc6be27257abc832432d9aa0d32742a96d19/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java#L56
- bump version of source-mysql connector to 0.2.5
