### PR TITLE
in docs, ./gradlew build => CORE_ONLY=1 ...

### DIFF
--- a/docs/contributing-to-airbyte/building-new-connector/monorepo-python-development.md
+++ b/docs/contributing-to-airbyte/building-new-connector/monorepo-python-development.md
@@ -4,7 +4,7 @@ This guide contains instructions on how to setup Python with Gradle within the A
 
 ## Python Connector Development
 
-Before working with connectors written in Python, we recommend running `./gradlew build` from the root project directory. This will create a `virtualenv` for every connector and helper project and install dependencies locally.
+Before working with connectors written in Python, we recommend running `./gradlew :airbyte-integrations:connectors:<connector directory name>:build` (e.g. `./gradlew :airbyte-integrations:connectors:source-postgres:build`) from the root project directory. This will create a `virtualenv` and install dependencies for the connector you want to work on as well as any internal Airbyte python packages it depends on.
 
 When iterating on a single connector, you will often iterate by running
 

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -64,7 +64,7 @@ export CPPFLAGS="-I/usr/local/opt/openssl/include"
 ## Run in `dev` mode with `docker-compose`
 
 ```bash
-./gradlew build
+CORE_ONLY=1 ./gradlew build
 VERSION=dev docker-compose up
 ```
 
@@ -77,7 +77,7 @@ In `dev` mode, all data will be persisted in `/tmp/dev_root`.
 To run acceptance \(end-to-end\) tests, you must have the Airbyte running locally.
 
 ```bash
-./gradlew build
+CORE_ONLY=1 ./gradlew build
 VERSION=dev docker-compose up
 ./gradlew :airbyte-tests:acceptanceTests
 ```
@@ -130,7 +130,7 @@ Sometimes you'll want to reset the data in your local environment. One common ca
 * Rebuild the project
 
   ```bash
-   ./gradlew build
+   CORE_ONLY=1 ./gradlew build
    VERSION=dev docker-compose up -V
   ```
 


### PR DESCRIPTION
## What
* It's a bit sadistic to ask a contributor to `./gradlew build`. 

## How
* In the docs replace instructions to `./gradlew build` with `CORE_ONLY=1 ./gradlew build` or whatever is appropriate in the context of the docs.