### PR TITLE
add docs explaining (lack of) ECS support

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -79,6 +79,7 @@
   * [On AWS \(EC2\)](deploying-airbyte/on-aws-ec2.md)
   * [On GCP \(Compute Engine\)](deploying-airbyte/on-gcp-compute-engine.md)
   * [On Kubernetes \(Alpha\)](deploying-airbyte/on-kubernetes.md)
+  * [On AWS ECS \(Coming Soon\)](deploying-airbyte/on-aws-ecs.md)
 * [API documentation](api-documentation.md)
 * [Architecture](architecture/README.md)
   * [AirbyteCatalog & ConfiguredAirbyteCatalog](architecture/catalog.md)

--- a/docs/deploying-airbyte/on-aws-ecs.md
+++ b/docs/deploying-airbyte/on-aws-ecs.md
@@ -1,0 +1,7 @@
+# On AWS \(ECS\)
+
+{% hint style="warn" %}
+We do not currently support deployment on ECS.
+{% endhint %}
+
+The current iteration is not compatible with ECS. Airbyte currently relies on docker containers being able to create other docker containers. ECS does not permit containers to do this. We will be revising this strategy soon, so that we can be compatible with ECS and other container services.


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/2901

## What
* We get questions about ECS (and other container services) support.

## How
* Explain why we don't support it for now but say it is coming soon.

Maybe this should be in an FAQ instead? Happy to adjust.