### PR TITLE
Remove smartsheets from connector index until CI is setup

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -203,11 +203,12 @@
   dockerRepository: airbyte/source-tempo
   dockerImageTag: 0.2.2
   documentationUrl: https://hub.docker.com/r/airbyte/source-tempo
-- sourceDefinitionId: 374ebc65-6636-4ea0-925c-7d35999a8ffc
-  name: Smartsheets
-  dockerRepository: airbyte/source-smartsheets
-  dockerImageTag: 0.1.1
-  documentationUrl: https://hub.docker.com/r/airbyte/source-smartsheets
+# bring this back once https://github.com/airbytehq/airbyte/issues/2902 is done
+#- sourceDefinitionId: 374ebc65-6636-4ea0-925c-7d35999a8ffc
+#  name: Smartsheets
+#  dockerRepository: airbyte/source-smartsheets
+#  dockerImageTag: 0.1.1
+#  documentationUrl: https://hub.docker.com/r/airbyte/source-smartsheets
 - sourceDefinitionId: b39a7370-74c3-45a6-ac3a-380d48520a83
   name: Oracle
   dockerRepository: airbyte/source-oracle

--- a/airbyte-integrations/connectors/source-appsflyer-singer/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-appsflyer-singer/unit_tests/unit_test.py
@@ -22,5 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+
 def test_example_method():
     assert True

--- a/airbyte-integrations/connectors/source-gitlab-singer/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-gitlab-singer/unit_tests/unit_test.py
@@ -22,5 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+
 def test_example_method():
     assert True

--- a/airbyte-integrations/connectors/source-google-directory/source_google_directory/utils.py
+++ b/airbyte-integrations/connectors/source-google-directory/source_google_directory/utils.py
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+
 def rate_limit_handling(error):
     retried_cases = [
         (403, "quotaExceeded"),

--- a/airbyte-integrations/connectors/source-instagram/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-instagram/unit_tests/unit_test.py
@@ -22,5 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+
 def test_example_method():
     assert True

--- a/airbyte-integrations/connectors/source-smartsheets/source_smartsheets/source.py
+++ b/airbyte-integrations/connectors/source-smartsheets/source_smartsheets/source.py
@@ -38,7 +38,6 @@ from airbyte_protocol import (
     Type,
 )
 from base_python import AirbyteLogger, Source
-from smartsheet.smartsheet import Smartsheet
 
 
 # helpers


### PR DESCRIPTION
removing smartsheets from shipping with Airbyte until we setup CI for it. See #2902 