### PR TITLE
🎉 Source Google Adwords: support selecting the lookback window for determining conversions

### DIFF
--- a/airbyte-integrations/connectors/source-google-adwords-singer/source_google_adwords_singer/spec.json
+++ b/airbyte-integrations/connectors/source-google-adwords-singer/source_google_adwords_singer/spec.json
@@ -39,6 +39,12 @@
         "description": "UTC date and time in the format 2017-01-25T00:00:00Z. Any data before this date will not be replicated.",
         "examples": ["2017-01-25T00:00:00Z"]
       },
+      "conversion_window_days": {
+        "type": "string",
+        "description": "Define the historical replication start date. Change this setting if you want to replicate data beyond Google Ads’s default setting of 30 days.",
+        "examples": ["-30"],
+        "pattern": "^(-)?[0-9]+"
+      },
       "customer_ids": {
         "type": "string",
         "pattern": "^[0-9]{10}$",


### PR DESCRIPTION
## What
*Describe what the change is solving*
It helps the user to define the historical replication start date

## How
*Describe the solution*
As the singer already supports it adding it in the schema will let airbyte api configure it
