### PR TITLE
make postgres ssl optional in spec

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/decd338e-5647-4c0b-adf4-da0e75f5a750.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/decd338e-5647-4c0b-adf4-da0e75f5a750.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "decd338e-5647-4c0b-adf4-da0e75f5a750",
   "name": "Postgres",
   "dockerRepository": "airbyte/source-postgres",
-  "dockerImageTag": "0.2.6",
+  "dockerImageTag": "0.2.7",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-postgres"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -26,7 +26,7 @@
 - sourceDefinitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
   name: Postgres
   dockerRepository: airbyte/source-postgres
-  dockerImageTag: 0.2.6
+  dockerImageTag: 0.2.7
   documentationUrl: https://hub.docker.com/r/airbyte/source-postgres
 - sourceDefinitionId: cd42861b-01fc-4658-a8ab-5d11d0510f01
   name: Recurly

--- a/airbyte-integrations/connectors/source-postgres/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.2.6
+LABEL io.airbyte.version=0.2.7
 LABEL io.airbyte.name=airbyte/source-postgres

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -91,7 +91,7 @@ public class PostgresSource extends AbstractJdbcSource implements Source {
         config.get("port").asText(),
         config.get("database").asText()));
 
-    if (config.get("ssl").asBoolean()) {
+    if (config.has("ssl") && config.get("ssl").asBoolean()) {
       additionalParameters.add("ssl=true");
       additionalParameters.add("sslmode=require");
     }

--- a/airbyte-integrations/connectors/source-postgres/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-postgres/src/main/resources/spec.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Postgres Source Spec",
     "type": "object",
-    "required": ["host", "port", "database", "username", "ssl"],
+    "required": ["host", "port", "database", "username"],
     "additionalProperties": false,
     "properties": {
       "host": {

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcPostgresSourceStandardTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcPostgresSourceStandardTest.java
@@ -72,7 +72,6 @@ public class CdcPostgresSourceStandardTest extends StandardSourceTest {
         .put("database", container.getDatabaseName())
         .put("username", container.getUsername())
         .put("password", container.getPassword())
-        .put("ssl", false)
         .put("replication_method", ImmutableMap.of("replication_slot", SLOT_NAME_BASE))
         .build());
 


### PR DESCRIPTION
@marcosmarxm I missed this in my review for https://github.com/airbytehq/airbyte/pull/2757. We aim to make the connector specifications backwards compatible if possible. If SSL is required, then existing `source-postgres` users wouldn't be able to update without modifying their source config.