### PR TITLE
Upgraded normalization DBT to 0.19.1

### DIFF
--- a/airbyte-integrations/bases/base-normalization/dbt-project-template/packages.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template/packages.yml
@@ -2,4 +2,4 @@
 
 packages:
   - git: "https://github.com/fishtown-analytics/dbt-utils.git"
-    revision: 0.6.2
+    revision: 0.6.4

--- a/airbyte-integrations/bases/base-normalization/setup.py
+++ b/airbyte-integrations/bases/base-normalization/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     author_email="contact@airbyte.io",
     url="https://github.com/airbytehq/airbyte",
     packages=setuptools.find_packages(),
-    install_requires=["airbyte-protocol", "dbt==0.18.2rc1", "pyyaml"],
+    install_requires=["airbyte-protocol", "dbt==0.19.1", "pyyaml"],
     package_data={"": ["*.yml"]},
     setup_requires=["pytest-runner"],
     entry_points={


### PR DESCRIPTION
## What
Solves #2931 

## How
- Changed the required DBT version in airbyte-integrations/bases/base-normalization/setup.py

## Pre-merge Checklist
- [x] *Run integration tests*
- [x] *Publish Docker images*

## Recommended reading order
