### PR TITLE
Revert default value for API_URL

### DIFF
--- a/.env
+++ b/.env
@@ -18,5 +18,6 @@ TRACKING_STRATEGY=segment
 # Issue: https://github.com/airbytehq/airbyte/issues/577
 HACK_LOCAL_ROOT_PARENT=/tmp
 WEBAPP_URL=http://localhost:8000/
-API_URL=http://localhost:8001/api/v1/
+# todo - Migrate to a way to define a better default API_URL
+# API_URL=http://localhost:8001/api/v1/
 TEMPORAL_HOST=airbyte-temporal:7233

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -82,7 +82,7 @@ services:
     environment:
       - AIRBYTE_ROLE=${AIRBYTE_ROLE:-}
       - AIRBYTE_VERSION=${VERSION}
-      - API_URL=${API_URL}
+      - API_URL=${API_URL:-}
       - IS_DEMO=${IS_DEMO:-}
       - PAPERCUPS_STORYTIME=${PAPERCUPS_STORYTIME:-}
       - TRACKING_STRATEGY=${TRACKING_STRATEGY}


### PR DESCRIPTION
## What
Following up on https://github.com/airbytehq/airbyte/pull/2808 which seems to break many installations by defining the API_URL instead of leaving it empty.

## How
Revert back to an empty Variable 
