### PR TITLE
fix feed handling when feeds are unavailable

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/services/AirbyteGithubStore.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/services/AirbyteGithubStore.java
@@ -25,12 +25,16 @@
 package io.airbyte.server.services;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.airbyte.config.StandardDestinationDefinition;
+import io.airbyte.config.StandardSourceDefinition;
+import io.airbyte.config.helpers.YamlListToStandardDefinitions;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
+import java.util.List;
 
 /**
  * Convenience class for retrieving files checked into the Airbyte Github repo.
@@ -59,12 +63,12 @@ public class AirbyteGithubStore {
     this.baseUrl = baseUrl;
   }
 
-  public String getLatestDestinations() throws IOException, InterruptedException {
-    return getFile(DESTINATION_DEFINITION_LIST_LOCATION_PATH);
+  public List<StandardDestinationDefinition> getLatestDestinations() throws IOException, InterruptedException {
+    return YamlListToStandardDefinitions.toStandardDestinationDefinitions(getFile(DESTINATION_DEFINITION_LIST_LOCATION_PATH));
   }
 
-  public String getLatestSources() throws IOException, InterruptedException {
-    return getFile(SOURCE_DEFINITION_LIST_LOCATION_PATH);
+  public List<StandardSourceDefinition> getLatestSources() throws IOException, InterruptedException {
+    return YamlListToStandardDefinitions.toStandardSourceDefinitions(getFile(SOURCE_DEFINITION_LIST_LOCATION_PATH));
   }
 
   @VisibleForTesting

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
@@ -26,7 +26,6 @@ package io.airbyte.server.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -43,13 +42,13 @@ import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.scheduler.client.CachingSynchronousSchedulerClient;
-import io.airbyte.server.errors.KnownException;
 import io.airbyte.server.services.AirbyteGithubStore;
 import io.airbyte.server.validators.DockerImageValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -93,7 +92,7 @@ class DestinationDefinitionsHandlerTest {
 
   @Test
   @DisplayName("listDestinationDefinition should return the right list")
-  void testListDestinations() throws JsonValidationException, IOException, ConfigNotFoundException, URISyntaxException {
+  void testListDestinations() throws JsonValidationException, IOException, URISyntaxException {
     final StandardDestinationDefinition destination2 = generateDestination();
 
     when(configRepository.listStandardDestinationDefinitions()).thenReturn(Lists.newArrayList(destination, destination2));
@@ -145,7 +144,7 @@ class DestinationDefinitionsHandlerTest {
 
   @Test
   @DisplayName("createDestinationDefinition should correctly create a destinationDefinition")
-  void testCreateDestinationDefinition() throws URISyntaxException, ConfigNotFoundException, IOException, JsonValidationException {
+  void testCreateDestinationDefinition() throws URISyntaxException, IOException, JsonValidationException {
     final StandardDestinationDefinition destination = generateDestination();
     when(uuidSupplier.get()).thenReturn(destination.getDestinationDefinitionId());
     final DestinationDefinitionCreate create = new DestinationDefinitionCreate()
@@ -194,45 +193,22 @@ class DestinationDefinitionsHandlerTest {
 
     @Test
     @DisplayName("should return the latest list")
-    void testCorrect() throws JsonValidationException, IOException, ConfigNotFoundException, InterruptedException {
-      final var goodYamlString = "- destinationDefinitionId: a625d593-bba5-4a1c-a53d-2d246268a816\n"
-          + "  name: Local JSON\n"
-          + "  dockerRepository: airbyte/destination-local-json\n"
-          + "  dockerImageTag: 0.1.4\n"
-          + "  documentationUrl: https://docs.airbyte.io/integrations/destinations/local-json";
-      when(githubStore.getLatestDestinations()).thenReturn(goodYamlString);
+    void testCorrect() throws IOException, InterruptedException {
+      final StandardDestinationDefinition destinationDefinition = generateDestination();
+      when(githubStore.getLatestDestinations()).thenReturn(Collections.singletonList(destinationDefinition));
 
       final var destinationDefinitionReadList = destinationHandler.listLatestDestinationDefinitions().getDestinationDefinitions();
       assertEquals(1, destinationDefinitionReadList.size());
 
-      final var localJsonDefinition = destinationDefinitionReadList.get(0);
-      assertEquals("Local JSON", localJsonDefinition.getName());
+      final var destinationDefinitionRead = destinationDefinitionReadList.get(0);
+      assertEquals(DestinationDefinitionsHandler.buildDestinationDefinitionRead(destinationDefinition), destinationDefinitionRead);
     }
 
     @Test
-    @DisplayName("should fail if http method times out")
-    void testHttpTimeout() throws JsonValidationException, IOException, ConfigNotFoundException, InterruptedException {
+    @DisplayName("returns empty collection if cannot find latest definitions")
+    void testHttpTimeout() throws IOException, InterruptedException {
       when(githubStore.getLatestDestinations()).thenThrow(new IOException());
-      assertThrows(KnownException.class, () -> destinationHandler.listLatestDestinationDefinitions().getDestinationDefinitions());
-    }
-
-    @Test
-    @DisplayName("should fail if no data is received")
-    void testEmptyFileReceived() throws JsonValidationException, IOException, ConfigNotFoundException, InterruptedException {
-      when(githubStore.getLatestDestinations()).thenReturn("");
-      assertThrows(KnownException.class, () -> destinationHandler.listLatestDestinationDefinitions());
-    }
-
-    @Test
-    @DisplayName("should fail if bad data is received")
-    void testBadFileReceived() throws JsonValidationException, IOException, ConfigNotFoundException, InterruptedException {
-      final var badYamlString = "- sourceDefinitionid: a625d593-bba5-4a1c-a53d-2d246268a816\n"
-          + "  name: Local JSON\n"
-          + "  dockerRepository: airbyte/destination-local-json\n"
-          + "  dockerImage";
-      when(githubStore.getLatestDestinations()).thenReturn(badYamlString);
-
-      assertThrows(KnownException.class, () -> destinationHandler.listLatestDestinationDefinitions());
+      assertEquals(0, destinationHandler.listLatestDestinationDefinitions().getDestinationDefinitions().size());
     }
 
   }


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/2782
## What
* when definition feeds aren't available the web app breaks.
* the common case for this is when the instance doesn't have access to the internet.

## How
* if there is a failure fetching feeds, return empty feeds.
* this _mostly_ just works in the ui (see screenshot). optionally we should remove the word latest if we don't have info on what the latest version is.

![Screen Shot 2021-04-19 at 4 08 34 PM](https://user-images.githubusercontent.com/9092207/115314161-85799180-a129-11eb-84a3-40dde8e68b14.png)
