### PR TITLE
Self-hosted EC2 Runners

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,9 +16,11 @@ jobs:
         run: ./tools/bin/ci_integration_workflow_launcher.sh
         env:
           GITHUB_TOKEN: ${{ secrets.SLASH_COMMAND_PAT }}
+
+  ## Gradle Build
   # In case of self-hosted EC2 errors, remove the `start-build-runner` block.
   start-build-runner:
-    name: Start Build EC2 runner
+    name: Start Build EC2 Runner
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
@@ -30,7 +32,7 @@ jobs:
           aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-      - name: Start EC2 runner
+      - name: Start EC2 Runner
         id: start-ec2-runner
         uses: machulav/ec2-github-runner@v2.1.0
         with:
@@ -158,7 +160,7 @@ jobs:
           SLACK_FOOTER: ""
   # In case of self-hosted EC2 errors, remove the `stop-build-runner` block.
   stop-build-runner:
-    name: Stop Build EC2 runner
+    name: Stop Build EC2 Runner
     needs:
       - start-build-runner # required to get output from the start-runner job
       - build # required to wait when the main job is done
@@ -178,8 +180,37 @@ jobs:
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
           label: ${{ needs.start-build-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-build-runner.outputs.ec2-instance-id }}
-  acceptance_test:
+
+  ## Acceptance Test
+  # In case of self-hosted EC2 errors, remove the next two lines and uncomment the currently commented out `runs-on` line.
+  start-acceptance-test-runner:
+    name: Start Acceptance Test EC2 Runner
     runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@v2.1.0
+        with:
+          mode: start
+          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
+          ec2-image-id: ami-0b39c2b1b65f75ca8
+          ec2-instance-type: c5.2xlarge
+          subnet-id: subnet-01d35f948346c05bd
+          security-group-id: sg-04399aaf4d51a35f9
+  acceptance-test:
+    # In case of self-hosted EC2 errors, remove the next two lines and uncomment the currently commented out `runs-on` line.
+    needs: start-acceptance-test-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.start-acceptance-test-runner.outputs.label }} # run the job on the newly created runner
+    # runs-on: ubuntu-latest
     name: Run Acceptance Tests
     steps:
       - name: Checkout Airbyte
@@ -206,10 +237,59 @@ jobs:
       - name: Run Docker End-to-End Acceptance Tests
         run: |
           ./tools/bin/acceptance_test.sh
-
-  launch_e2e_frontend_tests:
+  # In case of self-hosted EC2 errors, remove the `stop-build-runner` block.
+  stop-acceptance-test-runner:
+    name: Stop Acceptance Test EC2 Runner
+    needs:
+      - start-acceptance-test-runner # required to get output from the start-runner job
+      - acceptance-test # required to wait when the main job is done
     runs-on: ubuntu-latest
-    name: Run Front-end Tests
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@v2.1.0
+        with:
+          mode: stop
+          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
+          label: ${{ needs.start-acceptance-test-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-acceptance-test-runner.outputs.ec2-instance-id }}
+
+  ## Frontend Test
+  start-frontend-test-runner:
+    name: Start Frontend Test EC2 Runner
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@v2.1.0
+        with:
+          mode: start
+          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
+          ec2-image-id: ami-0b39c2b1b65f75ca8
+          ec2-instance-type: c5.2xlarge
+          subnet-id: subnet-01d35f948346c05bd
+          security-group-id: sg-04399aaf4d51a35f9
+  frontend-test:
+    # In case of self-hosted EC2 errors, remove the next two lines and uncomment the currently commented out `runs-on` line.
+    needs: start-frontend-test-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.start-frontend-test-runner.outputs.label }} # run the job on the newly created runner
+    # runs-on: ubuntu-latest
+    name: Run Frontend Test
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
@@ -231,6 +311,29 @@ jobs:
 
       - name: Run End-to-End Frontend Tests
         run: ./tools/bin/e2e_test.sh
+    # In case of self-hosted EC2 errors, remove the `stop-build-runner` block.
+  stop-frontend-test-runner:
+    name: Stop Frontend Test EC2 Runner
+    needs:
+      - start-frontend-test-runner # required to get output from the start-runner job
+      - frontend-test # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@v2.1.0
+        with:
+          mode: stop
+          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
+          label: ${{ needs.start-frontend-test-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-frontend-test-runner.outputs.ec2-instance-id }}
+
 # DISABLED UNTIL WE HAVE TEMPORAL ON KUBE
 #  test_kube:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,8 +16,36 @@ jobs:
         run: ./tools/bin/ci_integration_workflow_launcher.sh
         env:
           GITHUB_TOKEN: ${{ secrets.SLASH_COMMAND_PAT }}
-  build:
+  # In case of self-hosted EC2 errors, remove the `start-build-runner` block.
+  start-build-runner:
+    name: Start Build EC2 runner
     runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@v2.1.0
+        with:
+          mode: start
+          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
+          ec2-image-id: ami-0b39c2b1b65f75ca8
+          ec2-instance-type: c5.2xlarge
+          subnet-id: subnet-01d35f948346c05bd
+          security-group-id: sg-04399aaf4d51a35f9
+  build:
+    # In case of self-hosted EC2 errors, remove the next two lines and uncomment the currently commented out `runs-on` line.
+    needs: start-build-runner # required to start the main job when the runner is ready
+    runs-on: ${{ needs.start-build-runner.outputs.label }} # run the job on the newly created runner
+    # runs-on: ubuntu-latest
+    name: Build Airbyte
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
@@ -128,8 +156,31 @@ jobs:
           SLACK_USERNAME: Buildbot
           SLACK_TITLE: "Build Success"
           SLACK_FOOTER: ""
-  test_docker:
+  # In case of self-hosted EC2 errors, remove the `stop-build-runner` block.
+  stop-build-runner:
+    name: Stop Build EC2 runner
+    needs:
+      - start-build-runner # required to get output from the start-runner job
+      - build # required to wait when the main job is done
     runs-on: ubuntu-latest
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@v2.1.0
+        with:
+          mode: stop
+          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
+          label: ${{ needs.start-build-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-build-runner.outputs.ec2-instance-id }}
+  acceptance_test:
+    runs-on: ubuntu-latest
+    name: Run Acceptance Tests
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
@@ -158,6 +209,7 @@ jobs:
 
   launch_e2e_frontend_tests:
     runs-on: ubuntu-latest
+    name: Run Front-end Tests
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -261,34 +261,8 @@ jobs:
           ec2-instance-id: ${{ needs.start-acceptance-test-runner.outputs.ec2-instance-id }}
 
   ## Frontend Test
-  start-frontend-test-runner:
-    name: Start Frontend Test EC2 Runner
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: Start EC2 runner
-        id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.1.0
-        with:
-          mode: start
-          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
-          ec2-image-id: ami-0b39c2b1b65f75ca8
-          ec2-instance-type: c5.2xlarge
-          subnet-id: subnet-01d35f948346c05bd
-          security-group-id: sg-04399aaf4d51a35f9
   frontend-test:
-    # In case of self-hosted EC2 errors, remove the next two lines and uncomment the currently commented out `runs-on` line.
-    needs: start-frontend-test-runner # required to start the main job when the runner is ready
-    runs-on: ${{ needs.start-frontend-test-runner.outputs.label }} # run the job on the newly created runner
-    # runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
     name: Run Frontend Test
     steps:
       - name: Checkout Airbyte
@@ -311,28 +285,6 @@ jobs:
 
       - name: Run End-to-End Frontend Tests
         run: ./tools/bin/e2e_test.sh
-    # In case of self-hosted EC2 errors, remove the `stop-build-runner` block.
-  stop-frontend-test-runner:
-    name: Stop Frontend Test EC2 Runner
-    needs:
-      - start-frontend-test-runner # required to get output from the start-runner job
-      - frontend-test # required to wait when the main job is done
-    runs-on: ubuntu-latest
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.1.0
-        with:
-          mode: stop
-          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
-          label: ${{ needs.start-frontend-test-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-frontend-test-runner.outputs.ec2-instance-id }}
 
 # DISABLED UNTIL WE HAVE TEMPORAL ON KUBE
 #  test_kube:


### PR DESCRIPTION
## What
Use self-hosted ec2 runners for the main Airbyte build as discussed today. Will bring this up for evaluation after a week. Anecdotal testing shows builds generally finish in 9 - 10 mins vs 15 - 20 mins on the regular runner, even after accounting for the time taken to spin up the instance (about 1 min).

Removed this from the frontend tests since Cypress is running into an [issue](https://github.com/cypress-io/cypress/issues/5110) that seems to be related to how the tests are structured and I don't think we need to debug now.

The slash commands will continue running on the github runner.

## How
* Use https://github.com/machulav/ec2-github-runner to start and stop an individual instance per job we ran as part of the build.
* This uses an 8 core EC2 machine (c5.2xlarge). This instance is cost/performance sweet spot from my testing. Cost is 0.34 cents an hour, which gives us `1000 USD / 0.34 USD * 60 mins  ~= 177k mins/month` of build time.

## Recommended reading order
