### PR TITLE
Simplify normalization dedup in bigquery

### DIFF
--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/bigquery/test_primary_key_streams/models/generated/airbyte_tables/test_normalization/test_normalization_dedup_exchange_rate_scd.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/bigquery/test_primary_key_streams/models/generated/airbyte_tables/test_normalization/test_normalization_dedup_exchange_rate_scd.sql
@@ -9,11 +9,11 @@ select
     USD,
     date as _airbyte_start_at,
     lag(date) over (
-        partition by id, currency, cast({{ 'NZD' }} as {{ dbt_utils.type_string() }})
+        partition by id, currency, cast(NZD as {{ dbt_utils.type_string() }})
         order by date desc, _airbyte_emitted_at desc
     ) as _airbyte_end_at,
     lag(date) over (
-        partition by id, currency, cast({{ 'NZD' }} as {{ dbt_utils.type_string() }})
+        partition by id, currency, cast(NZD as {{ dbt_utils.type_string() }})
         order by date desc, _airbyte_emitted_at desc
     ) is null as _airbyte_active_row,
     _airbyte_emitted_at,

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/postgres/test_primary_key_streams/models/generated/airbyte_tables/test_normalization/test_normalization_dedup_exchange_rate_scd.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/postgres/test_primary_key_streams/models/generated/airbyte_tables/test_normalization/test_normalization_dedup_exchange_rate_scd.sql
@@ -9,11 +9,11 @@ select
     usd,
     {{ adapter.quote('date') }} as _airbyte_start_at,
     lag({{ adapter.quote('date') }}) over (
-        partition by {{ adapter.quote('id') }}, currency, cast({{ 'nzd' }} as {{ dbt_utils.type_string() }})
+        partition by {{ adapter.quote('id') }}, currency, cast(nzd as {{ dbt_utils.type_string() }})
         order by {{ adapter.quote('date') }} desc, _airbyte_emitted_at desc
     ) as _airbyte_end_at,
     lag({{ adapter.quote('date') }}) over (
-        partition by {{ adapter.quote('id') }}, currency, cast({{ 'nzd' }} as {{ dbt_utils.type_string() }})
+        partition by {{ adapter.quote('id') }}, currency, cast(nzd as {{ dbt_utils.type_string() }})
         order by {{ adapter.quote('date') }} desc, _airbyte_emitted_at desc
     ) is null as _airbyte_active_row,
     _airbyte_emitted_at,

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/redshift/test_primary_key_streams/models/generated/airbyte_tables/test_normalization/test_normalization_dedup_exchange_rate_scd.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/redshift/test_primary_key_streams/models/generated/airbyte_tables/test_normalization/test_normalization_dedup_exchange_rate_scd.sql
@@ -9,11 +9,11 @@ select
     usd,
     date as _airbyte_start_at,
     lag(date) over (
-        partition by id, currency, cast({{ 'nzd' }} as {{ dbt_utils.type_string() }})
+        partition by id, currency, cast(nzd as {{ dbt_utils.type_string() }})
         order by date desc, _airbyte_emitted_at desc
     ) as _airbyte_end_at,
     lag(date) over (
-        partition by id, currency, cast({{ 'nzd' }} as {{ dbt_utils.type_string() }})
+        partition by id, currency, cast(nzd as {{ dbt_utils.type_string() }})
         order by date desc, _airbyte_emitted_at desc
     ) is null as _airbyte_active_row,
     _airbyte_emitted_at,

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/snowflake/test_primary_key_streams/models/generated/airbyte_tables/TEST_NORMALIZATION/TEST_NORMALIZATION_DEDUP_EXCHANGE_RATE_SCD.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/snowflake/test_primary_key_streams/models/generated/airbyte_tables/TEST_NORMALIZATION/TEST_NORMALIZATION_DEDUP_EXCHANGE_RATE_SCD.sql
@@ -9,11 +9,11 @@ select
     USD,
     DATE as _airbyte_start_at,
     lag(DATE) over (
-        partition by ID, CURRENCY, cast({{ 'NZD' }} as {{ dbt_utils.type_string() }})
+        partition by ID, CURRENCY, cast(NZD as {{ dbt_utils.type_string() }})
         order by DATE desc, _airbyte_emitted_at desc
     ) as _airbyte_end_at,
     lag(DATE) over (
-        partition by ID, CURRENCY, cast({{ 'NZD' }} as {{ dbt_utils.type_string() }})
+        partition by ID, CURRENCY, cast(NZD as {{ dbt_utils.type_string() }})
         order by DATE desc, _airbyte_emitted_at desc
     ) is null as _airbyte_active_row,
     _airbyte_emitted_at,

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/snowflake/test_primary_key_streams/models/generated/sources.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/snowflake/test_primary_key_streams/models/generated/sources.yml
@@ -5,6 +5,6 @@ sources:
     identifier: false
     schema: false
   tables:
-  - name: _AIRBYTE_RAW_EXCHANGE_RATE
   - name: _AIRBYTE_RAW_DEDUP_EXCHANGE_RATE
+  - name: _AIRBYTE_RAW_EXCHANGE_RATE
 version: 2

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
@@ -523,9 +523,9 @@ from {{ from_table }}
                     property_type = self.properties[field]["type"]
                 else:
                     property_type = "object"
-                if is_number(property_type) or is_boolean(property_type) or is_array(property_type) or is_object(property_type):
-                    # some destinations don't handle float columns (or other types) as primary keys, turn everything to string
-                    return f"cast({jinja_call(self.safe_cast_to_string(self.properties[field], column_names[field][1]))} as {jinja_call('dbt_utils.type_string()')})"
+                if is_number(property_type) or is_object(property_type):
+                    # some destinations don't handle float columns (or complex types) as primary keys, turn them to string
+                    return f"cast({column_names[field][0]} as {jinja_call('dbt_utils.type_string()')})"
                 else:
                     return column_names[field][0]
             else:

--- a/airbyte-integrations/bases/base-normalization/unit_tests/test_stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/unit_tests/test_stream_processor.py
@@ -335,8 +335,9 @@ def test_cursor_field(cursor_field: List[str], expecting_exception: bool, expect
     "primary_key, column_type, expecting_exception, expected_primary_keys, expected_final_primary_key_string",
     [
         ([["id"]], "string", False, ["id"], "{{ adapter.quote('id') }}"),
+        ([["id"]], "number", False, ["id"], "cast({{ adapter.quote('id') }} as {{ dbt_utils.type_string() }})"),
         ([["first_name"], ["last_name"]], "string", False, ["first_name", "last_name"], "first_name, last_name"),
-        ([["float_id"]], "number", False, ["float_id"], "cast({{ 'float_id' }} as {{ dbt_utils.type_string() }})"),
+        ([["float_id"]], "number", False, ["float_id"], "cast(float_id as {{ dbt_utils.type_string() }})"),
         ([["_airbyte_emitted_at"]], "string", False, [], "cast(_airbyte_emitted_at as {{ dbt_utils.type_string() }})"),
         (None, "string", True, [], ""),
         ([["parent", "nested_field"]], "string", True, [], ""),


### PR DESCRIPTION
## What
This is follow-up to #3025 with an example of bugfix on normalization code and how integration tests would be showing up in a PR 

## How
Dedup DBT models for bigquery where adding extra quotes around the column name when generating the `partition by` clause. This resulted in using a constant literal string value as a primary key, which results in a deduped table of only 1 row in BigQuery when we hit this test case!

Previous normalization Unit tests were all passing and normalization would successfully run but the end result would not be as expected...

Thanks to integration tests, we can now better visualize the impact of code changes on the final SQL queries

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `test.java`
1. `component.ts`
1. the rest
