### PR TITLE
Replace Timeouts for Sources

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultSyncWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultSyncWorker.java
@@ -90,6 +90,8 @@ public class DefaultSyncWorker implements SyncWorker {
     final StandardTargetConfig targetConfig = WorkerUtils.syncToTargetConfig(syncInput);
     targetConfig.setCatalog(mapper.mapCatalog(targetConfig.getCatalog()));
 
+    // note: resources are closed in the opposite order in which they are declared. thus source will be
+    // closed first (which is what we want).
     try (destination; source) {
       destination.start(targetConfig, jobRoot);
       source.start(tapConfig, jobRoot);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -108,11 +108,9 @@ public class WorkerUtils {
     }
 
     // if we have closed gracefully exit...
-    if (!process.isAlive()) {
-      return;
+    if (process.isAlive()) {
+      forceShutdown.accept(process, forcedShutdownMagnitude, forcedShutdownTimeUnit);
     }
-
-    forceShutdown.accept(process, forcedShutdownMagnitude, forcedShutdownTimeUnit);
   }
 
   @VisibleForTesting

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
@@ -47,6 +47,8 @@ public class DefaultAirbyteSource implements AirbyteSource {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAirbyteSource.class);
 
+  private static final long HEART_BEAT_FRESH_TIME_MAGNITUDE = 1;
+  private static final TimeUnit HEART_BEAT_FRESH_TIME_UNIT = TimeUnit.SECONDS;
   private static final long CHECK_HEARTBEAT_TIME_MAGNITUDE = 1;
   private static final TimeUnit CHECK_HEARTBEAT_TIME_UNIT = TimeUnit.SECONDS;
   private static final long GRACEFUL_SHUTDOWN_TIME_MAGNITUDE = 10;
@@ -62,7 +64,7 @@ public class DefaultAirbyteSource implements AirbyteSource {
   private Iterator<AirbyteMessage> messageIterator = null;
 
   public DefaultAirbyteSource(final IntegrationLauncher integrationLauncher) {
-    this(integrationLauncher, new DefaultAirbyteStreamFactory(), new HeartbeatMonitor());
+    this(integrationLauncher, new DefaultAirbyteStreamFactory(), new HeartbeatMonitor(HEART_BEAT_FRESH_TIME_MAGNITUDE, HEART_BEAT_FRESH_TIME_UNIT));
   }
 
   @VisibleForTesting

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/HeartbeatMonitor.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/HeartbeatMonitor.java
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.workers.protocols.airbyte;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+public class HeartbeatMonitor {
+
+  public static final int TIME_MAGNITUDE = 30;
+  public static final TemporalUnit TIME_UNIT = ChronoUnit.SECONDS;
+
+  private final Supplier<Instant> instantSupplier;
+  private final AtomicReference<Instant> lastBeat;
+
+  public HeartbeatMonitor() {
+    this(Instant::now);
+  }
+
+  @VisibleForTesting
+  public HeartbeatMonitor(Supplier<Instant> instantSupplier) {
+    this.instantSupplier = instantSupplier;
+    this.lastBeat = new AtomicReference<>(null);
+  }
+
+  public void beat() {
+    lastBeat.set(instantSupplier.get());
+  }
+
+  public boolean isBeating() {
+    final Instant instantFetched = lastBeat.get();
+    final Instant now = instantSupplier.get();
+    return instantFetched != null && instantFetched.plus(TIME_MAGNITUDE, TIME_UNIT).isAfter(now);
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/WorkerUtilsTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/WorkerUtilsTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.when;
 
 import io.airbyte.workers.protocols.airbyte.HeartbeatMonitor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.util.TriConsumer;
 import org.junit.jupiter.api.BeforeEach;

--- a/airbyte-workers/src/test/java/io/airbyte/workers/WorkerUtilsTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/WorkerUtilsTest.java
@@ -1,0 +1,160 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.workers;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.airbyte.workers.protocols.airbyte.HeartbeatMonitor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.logging.log4j.util.TriConsumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class WorkerUtilsTest {
+
+  @Nested
+  class GentleCloseWithHeartbeat {
+
+    private final long CHECK_HEARTBEAT_TIME_MAGNITUDE = 10;
+    private final TimeUnit CHECK_HEARTBEAT_TIME_UNIT = TimeUnit.MILLISECONDS;
+
+    private final long SHUTDOWN_TIME_MAGNITUDE = 100;
+    private final TimeUnit SHUTDOWN_TIME_UNIT = TimeUnit.MILLISECONDS;
+
+    private Process process;
+    private HeartbeatMonitor heartbeatMonitor;
+    private AtomicBoolean hasCompleted;
+    private AtomicBoolean threwException;
+    private Thread gentleCloseThread;
+    private TriConsumer<Process, Long, TimeUnit> forceShutdown;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setup() throws InterruptedException {
+      process = mock(Process.class);
+      heartbeatMonitor = mock(HeartbeatMonitor.class);
+      forceShutdown = mock(TriConsumer.class);
+      threwException = new AtomicBoolean(false);
+      hasCompleted = new AtomicBoolean(false);
+      gentleCloseThread = start(process, heartbeatMonitor, hasCompleted, forceShutdown);
+    }
+
+    @SuppressWarnings("BusyWait")
+    private Thread start(final Process process,
+                         final HeartbeatMonitor heartbeatMonitor,
+                         final AtomicBoolean hasCompleted,
+                         final TriConsumer<Process, Long, TimeUnit> forceShutdown)
+        throws InterruptedException {
+      when(process.isAlive()).thenReturn(true);
+      final AtomicInteger recordedBeats = new AtomicInteger(0);
+      doAnswer((ignored) -> {
+        recordedBeats.incrementAndGet();
+        return true;
+      }).when(heartbeatMonitor).isBeating();
+
+      final Thread thread = new Thread(() -> {
+        try {
+
+          WorkerUtils.gentleCloseWithHeartbeat(
+              process,
+              heartbeatMonitor,
+              SHUTDOWN_TIME_MAGNITUDE * 10,
+              SHUTDOWN_TIME_UNIT,
+              CHECK_HEARTBEAT_TIME_MAGNITUDE,
+              CHECK_HEARTBEAT_TIME_UNIT,
+              SHUTDOWN_TIME_MAGNITUDE,
+              SHUTDOWN_TIME_UNIT,
+              forceShutdown);
+
+          hasCompleted.set(true);
+        } catch (Throwable e) {
+          threwException.set(true);
+        }
+      });
+
+      thread.start();
+
+      // block until the loop is running.
+      while (recordedBeats.get() == 0) {
+        Thread.sleep(10);
+      }
+
+      return thread;
+    }
+
+    @Test
+    @DisplayName("Test heartbeat ends and graceful shutdown.")
+    void testGracefulShutdown() throws InterruptedException {
+      when(heartbeatMonitor.isBeating()).thenReturn(false);
+      when(process.isAlive()).thenReturn(false);
+
+      gentleCloseThread.join(0);
+
+      assertFalse(threwException.get());
+      assertTrue(hasCompleted.get());
+      assertFalse(gentleCloseThread.isAlive());
+      verifyNoInteractions(forceShutdown);
+    }
+
+    @Test
+    @DisplayName("Test heartbeat ends and shutdown is forced.")
+    void testForcedShutdown() throws InterruptedException {
+      when(heartbeatMonitor.isBeating()).thenReturn(false);
+      when(process.isAlive()).thenReturn(true);
+
+      gentleCloseThread.join(0);
+
+      assertFalse(threwException.get());
+      assertTrue(hasCompleted.get());
+      assertFalse(gentleCloseThread.isAlive());
+      verify(forceShutdown).accept(process, SHUTDOWN_TIME_MAGNITUDE, SHUTDOWN_TIME_UNIT);
+    }
+
+    @Test
+    @DisplayName("Test process dies.")
+    void testProcessDies() throws InterruptedException {
+      when(process.isAlive()).thenReturn(false);
+
+      gentleCloseThread.join(0);
+
+      assertFalse(threwException.get());
+      assertTrue(hasCompleted.get());
+      assertFalse(gentleCloseThread.isAlive());
+      verifyNoInteractions(forceShutdown);
+    }
+
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
@@ -88,6 +88,7 @@ class DefaultAirbyteSourceTest {
   private IntegrationLauncher integrationLauncher;
   private Process process;
   private AirbyteStreamFactory streamFactory;
+  private HeartbeatMonitor heartbeatMonitor;
 
   @BeforeEach
   public void setup() throws IOException, WorkerException {
@@ -95,6 +96,7 @@ class DefaultAirbyteSourceTest {
 
     integrationLauncher = mock(IntegrationLauncher.class, RETURNS_DEEP_STUBS);
     process = mock(Process.class, RETURNS_DEEP_STUBS);
+    heartbeatMonitor = mock(HeartbeatMonitor.class);
     final InputStream inputStream = mock(InputStream.class);
     when(integrationLauncher.read(
         jobRoot,
@@ -112,7 +114,7 @@ class DefaultAirbyteSourceTest {
   @SuppressWarnings({"OptionalGetWithoutIsPresent", "BusyWait"})
   @Test
   public void testSuccessfulLifecycle() throws Exception {
-    final AirbyteSource tap = new DefaultAirbyteSource(integrationLauncher, streamFactory);
+    final AirbyteSource tap = new DefaultAirbyteSource(integrationLauncher, streamFactory, heartbeatMonitor);
     tap.start(TAP_CONFIG, jobRoot);
 
     final List<AirbyteMessage> messages = Lists.newArrayList();
@@ -151,7 +153,7 @@ class DefaultAirbyteSourceTest {
 
   @Test
   public void testProcessFail() throws Exception {
-    final AirbyteSource tap = new DefaultAirbyteSource(integrationLauncher, streamFactory);
+    final AirbyteSource tap = new DefaultAirbyteSource(integrationLauncher, streamFactory, heartbeatMonitor);
     tap.start(TAP_CONFIG, jobRoot);
 
     when(process.exitValue()).thenReturn(1);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
@@ -24,13 +24,12 @@
 
 package io.airbyte.workers.protocols.airbyte;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -114,6 +113,8 @@ class DefaultAirbyteSourceTest {
   @SuppressWarnings({"OptionalGetWithoutIsPresent", "BusyWait"})
   @Test
   public void testSuccessfulLifecycle() throws Exception {
+    when(heartbeatMonitor.isBeating()).thenReturn(true).thenReturn(false);
+
     final AirbyteSource tap = new DefaultAirbyteSource(integrationLauncher, streamFactory, heartbeatMonitor);
     tap.start(TAP_CONFIG, jobRoot);
 
@@ -127,6 +128,7 @@ class DefaultAirbyteSourceTest {
 
     when(process.isAlive()).thenReturn(false);
     assertTrue(tap.isFinished());
+    verify(heartbeatMonitor, times(2)).beat();
 
     tap.close();
 
@@ -148,7 +150,7 @@ class DefaultAirbyteSourceTest {
       }
     });
 
-    verify(process).waitFor(anyLong(), any());
+    verify(process).exitValue();
   }
 
   @Test

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/HeartbeatMonitorTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/HeartbeatMonitorTest.java
@@ -1,0 +1,71 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.workers.protocols.airbyte;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HeartbeatMonitorTest {
+
+  private static final Instant NOW = Instant.now();
+  private static final Instant FIVE_SECONDS_BEFORE = NOW.minus(5, ChronoUnit.SECONDS);
+  private static final Instant THIRTY_ONE_SECONDS_BEFORE = NOW.minus(30, ChronoUnit.SECONDS);
+
+  private Supplier<Instant> instantSupplier;
+  private HeartbeatMonitor heartbeatMonitor;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setup() {
+    instantSupplier = mock(Supplier.class);
+    heartbeatMonitor = new HeartbeatMonitor(instantSupplier);
+  }
+
+  @Test
+  void testNeverBeat() {
+    assertFalse(heartbeatMonitor.isBeating());
+  }
+
+  @Test
+  void testRecentBeat() {
+    when(instantSupplier.get()).thenReturn(FIVE_SECONDS_BEFORE).thenReturn(NOW);
+    assertTrue(heartbeatMonitor.isBeating());
+  }
+
+  @Test
+  void testStaleBeat() {
+    when(instantSupplier.get()).thenReturn(THIRTY_ONE_SECONDS_BEFORE).thenReturn(NOW);
+    assertFalse(heartbeatMonitor.isBeating());
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/HeartbeatMonitorTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/HeartbeatMonitorTest.java
@@ -29,30 +29,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class HeartbeatMonitorTest {
 
-  private static final long HEART_BEAT_FRESH_MAGNITUDE = 30;
-  private static final TimeUnit HEART_BEAT_FRESH_TIME_UNIT = TimeUnit.SECONDS;
+  private static final Duration HEART_BEAT_FRESH_DURATION = Duration.of(30, ChronoUnit.SECONDS);
 
   private static final Instant NOW = Instant.now();
   private static final Instant FIVE_SECONDS_BEFORE = NOW.minus(5, ChronoUnit.SECONDS);
   private static final Instant THIRTY_SECONDS_BEFORE = NOW.minus(30, ChronoUnit.SECONDS);
 
-  private Supplier<Instant> instantSupplier;
+  private Supplier<Instant> nowSupplier;
   private HeartbeatMonitor heartbeatMonitor;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
   void setup() {
-    instantSupplier = mock(Supplier.class);
-    heartbeatMonitor = new HeartbeatMonitor(HEART_BEAT_FRESH_MAGNITUDE, HEART_BEAT_FRESH_TIME_UNIT, instantSupplier);
+    nowSupplier = mock(Supplier.class);
+    heartbeatMonitor = new HeartbeatMonitor(HEART_BEAT_FRESH_DURATION, nowSupplier);
   }
 
   @Test
@@ -62,14 +61,14 @@ class HeartbeatMonitorTest {
 
   @Test
   void testFreshBeat() {
-    when(instantSupplier.get()).thenReturn(FIVE_SECONDS_BEFORE).thenReturn(NOW);
+    when(nowSupplier.get()).thenReturn(FIVE_SECONDS_BEFORE).thenReturn(NOW);
     heartbeatMonitor.beat();
     assertTrue(heartbeatMonitor.isBeating());
   }
 
   @Test
   void testStaleBeat() {
-    when(instantSupplier.get()).thenReturn(THIRTY_SECONDS_BEFORE).thenReturn(NOW);
+    when(nowSupplier.get()).thenReturn(THIRTY_SECONDS_BEFORE).thenReturn(NOW);
     heartbeatMonitor.beat();
     assertFalse(heartbeatMonitor.isBeating());
   }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/HeartbeatMonitorTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/HeartbeatMonitorTest.java
@@ -31,15 +31,19 @@ import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class HeartbeatMonitorTest {
 
+  private static final long HEART_BEAT_FRESH_MAGNITUDE = 30;
+  private static final TimeUnit HEART_BEAT_FRESH_TIME_UNIT = TimeUnit.SECONDS;
+
   private static final Instant NOW = Instant.now();
   private static final Instant FIVE_SECONDS_BEFORE = NOW.minus(5, ChronoUnit.SECONDS);
-  private static final Instant THIRTY_ONE_SECONDS_BEFORE = NOW.minus(30, ChronoUnit.SECONDS);
+  private static final Instant THIRTY_SECONDS_BEFORE = NOW.minus(30, ChronoUnit.SECONDS);
 
   private Supplier<Instant> instantSupplier;
   private HeartbeatMonitor heartbeatMonitor;
@@ -48,7 +52,7 @@ class HeartbeatMonitorTest {
   @BeforeEach
   void setup() {
     instantSupplier = mock(Supplier.class);
-    heartbeatMonitor = new HeartbeatMonitor(instantSupplier);
+    heartbeatMonitor = new HeartbeatMonitor(HEART_BEAT_FRESH_MAGNITUDE, HEART_BEAT_FRESH_TIME_UNIT, instantSupplier);
   }
 
   @Test
@@ -57,14 +61,16 @@ class HeartbeatMonitorTest {
   }
 
   @Test
-  void testRecentBeat() {
+  void testFreshBeat() {
     when(instantSupplier.get()).thenReturn(FIVE_SECONDS_BEFORE).thenReturn(NOW);
+    heartbeatMonitor.beat();
     assertTrue(heartbeatMonitor.isBeating());
   }
 
   @Test
   void testStaleBeat() {
-    when(instantSupplier.get()).thenReturn(THIRTY_ONE_SECONDS_BEFORE).thenReturn(NOW);
+    when(instantSupplier.get()).thenReturn(THIRTY_SECONDS_BEFORE).thenReturn(NOW);
+    heartbeatMonitor.beat();
     assertFalse(heartbeatMonitor.isBeating());
   }
 


### PR DESCRIPTION
## What
* I started yesterday on a project just to understand what would be needed to get rid of the timeouts in our workers (for all jobs and for both sources and destinations). As I did this, I realized there might be some low hanging fruit here where we could solve all of the problems we've had supported by the community without investing into alot of inter-process / inter-docker heart beating.
* Essentially if we heart beat whenever we receive a new record from the input stream, we can reasonably say that we should wait a little longer to kill the process. This isn't perfect. In cases, where a long query prevents data from arriving for a long time, it means we could still kill the process prematurely. It should allow us to avoid the case where data is flowing (e.g. the case of the guy who has 80% of his data replicated after 10 hours). We can configure the solution in this PR to be strictly better than what we have now.

## How
* Every time a new record is received, emit a heartbeat.
* In the logic for killing a source, only kill the source if the process is already dead or if the process is alive but we haven't received a record in a long time.

## Follow up
* I've tuned this such that the numbers are relatively low. This may be a mistake. Need to think a little more about how this should be tuned when it rolls out. 

## Thought Process
* I was trying to get the most bang for our buck without having to make contributors of connectors have to do anything. There are however categories of problems that cannot be solved with this approach however. e.g. If the initial query in a source takes a really long time, and no data is sent until that query completes on the server side of the source. With this approach we would continue to kill the process prematurely. In order to solve this, we would have to have the source itself emitting a heartbeat message. (Perhaps adding a new type of message to the protocol).
* This approach doesn't work at all with destinations as they are implemented now. If we did want to add to destinations logic for this, we would need some way to get the heartbeat messages out of the destination. We could read STDOUT of the destination and detect emitted heartbeat messages (assuming we added heartbeat messages to the protocol).

Anyway, I think this solves the problem as it is reported now, so I think we should move forward with this. Then based on future complaints around timeouts and heart beating we can decide if we want to introduce a more invasive approach where **connectors are responsible for doing their own heart beating** and / or **adding heartbeat messages to the protocol**.