### PR TITLE
Move build to us-east-2.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
-          ec2-image-id: ami-0b39c2b1b65f75ca8
+          ec2-image-id: ami-04bd6e81239f4f3fb
           ec2-instance-type: c5.2xlarge
           subnet-id: subnet-01d35f948346c05bd
           security-group-id: sg-04399aaf4d51a35f9
@@ -172,7 +172,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
+          aws-region: us-east-2
       - name: Stop EC2 runner
         uses: machulav/ec2-github-runner@v2.1.0
         with:
@@ -202,7 +202,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
-          ec2-image-id: ami-0b39c2b1b65f75ca8
+          ec2-image-id: ami-04bd6e81239f4f3fb
           ec2-instance-type: c5.2xlarge
           subnet-id: subnet-01d35f948346c05bd
           security-group-id: sg-04399aaf4d51a35f9

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -40,8 +40,8 @@ jobs:
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
           ec2-image-id: ami-04bd6e81239f4f3fb
           ec2-instance-type: c5.2xlarge
-          subnet-id: subnet-01d35f948346c05bd
-          security-group-id: sg-04399aaf4d51a35f9
+          subnet-id: subnet-0469a9e68a379c1d3
+          security-group-id: sg-0793f3c9413f21970
   build:
     # In case of self-hosted EC2 errors, remove the next two lines and uncomment the currently commented out `runs-on` line.
     needs: start-build-runner # required to start the main job when the runner is ready
@@ -204,8 +204,8 @@ jobs:
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
           ec2-image-id: ami-04bd6e81239f4f3fb
           ec2-instance-type: c5.2xlarge
-          subnet-id: subnet-01d35f948346c05bd
-          security-group-id: sg-04399aaf4d51a35f9
+          subnet-id: subnet-0469a9e68a379c1d3
+          security-group-id: sg-0793f3c9413f21970
   acceptance-test:
     # In case of self-hosted EC2 errors, remove the next two lines and uncomment the currently commented out `runs-on` line.
     needs: start-acceptance-test-runner # required to start the main job when the runner is ready

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
+          aws-region: us-east-2
       - name: Start EC2 Runner
         id: start-ec2-runner
         uses: machulav/ec2-github-runner@v2.1.0
@@ -195,7 +195,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
+          aws-region: us-east-2
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: machulav/ec2-github-runner@v2.1.0
@@ -251,7 +251,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
+          aws-region: us-east-2
       - name: Stop EC2 runner
         uses: machulav/ec2-github-runner@v2.1.0
         with:


### PR DESCRIPTION
## What
Move our builds to us-east-2, where we have 640 CPU limit, allowing us to run a total of 80 concurrent builds.
