### PR TITLE
Source hubspot: Fix argument error in log call

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/api.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/api.py
@@ -118,7 +118,7 @@ class API:
         self._credentials["access_token"] = auth["access_token"]
         self._credentials["refresh_token"] = auth["refresh_token"]
         self._credentials["token_expires"] = datetime.utcnow() + timedelta(seconds=auth["expires_in"] - 600)
-        logger.info("Token refreshed. Expires at %s", self._credentials["token_expires"])
+        logger.info(f"Token refreshed. Expires at {self._credentials['token_expires']}")
 
     @property
     def api_key(self) -> Optional[str]:


### PR DESCRIPTION
## What

When attempting to use an OAuth access token with the Hubspot source,
the logging call would cause the process to crash with an error:

```
TypeError: info() takes 2 positional arguments but 3 were given
```

## How

Convert log message to proper Python `f` string.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

