### PR TITLE
Fix argument error in log call (#3087)

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/36c891d9-4bd9-43ac-bad2-10e12756272c.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/36c891d9-4bd9-43ac-bad2-10e12756272c.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "36c891d9-4bd9-43ac-bad2-10e12756272c",
   "name": "Hubspot",
   "dockerRepository": "airbyte/source-hubspot",
-  "dockerImageTag": "0.1.2",
+  "dockerImageTag": "0.1.3",
   "documentationUrl": "https://https://docs.airbyte.io/integrations/sources/hubspot",
   "icon": "hubspot.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -97,7 +97,7 @@
 - sourceDefinitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
   name: Hubspot
   dockerRepository: airbyte/source-hubspot
-  dockerImageTag: 0.1.2
+  dockerImageTag: 0.1.3
   documentationUrl: https://https://docs.airbyte.io/integrations/sources/hubspot
   icon: hubspot.svg
 - sourceDefinitionId: b1892b11-788d-44bd-b9ec-3a436f7b54ce

--- a/airbyte-integrations/connectors/source-hubspot/Dockerfile
+++ b/airbyte-integrations/connectors/source-hubspot/Dockerfile
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/source-hubspot

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/api.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/api.py
@@ -118,7 +118,7 @@ class API:
         self._credentials["access_token"] = auth["access_token"]
         self._credentials["refresh_token"] = auth["refresh_token"]
         self._credentials["token_expires"] = datetime.utcnow() + timedelta(seconds=auth["expires_in"] - 600)
-        logger.info("Token refreshed. Expires at %s", self._credentials["token_expires"])
+        logger.info(f"Token refreshed. Expires at {self._credentials['token_expires']}")
 
     @property
     def api_key(self) -> Optional[str]:


### PR DESCRIPTION
When attempting to use an OAuth access token with the Hubspot source,
the logging call would cause the process to crash with an error:

```
TypeError: info() takes 2 positional arguments but 3 were given
```
