### PR TITLE
Fix Postgres replication tutorial command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,7 +87,7 @@ And there you have it. You've pulled data from an API directly into a file and a
 
 ## That's it!
 
-This is just the beginning of using Airbyte. We support a large collection of sources and destination. You can even contribute your own.
+This is just the beginning of using Airbyte. We support a large collection of sources and destinations. You can even contribute your own.
 
 If you have any questions at all, please reach out to us on [Slack](https://slack.airbyte.io/). We’re still in alpha, so if you see any rough edges or want to request a connector you need, please create an issue on our [Github](https://github.com/airbytehq/airbyte) or leave a thumbs up on an existing issue.
 

--- a/docs/tutorials/postgres-replication.md
+++ b/docs/tutorials/postgres-replication.md
@@ -96,7 +96,7 @@ One of biggest problems we've seen in tools like Fivetran is the lack of visibil
 Now let's verify that this worked. Let's output the contents of the destination db:
 
 ```text
-docker exec airbyte-destination psql -U postgres -c "SELECT * FROM public.public_users;"
+docker exec airbyte-destination psql -U postgres -c "SELECT * FROM public.users;"
 ```
 
 {% hint style="info" %}


### PR DESCRIPTION
## Main Changes
- Updating the Postgres tutorial `docker exec` command to work correctly.
- Previously referenced `public.public_users` which I think was changed at some point to `public.users`

## Misc Changes
- Small grammar fix in Getting Started guide.
