### PR TITLE
Add prefix to unnested field

### DIFF
--- a/airbyte-integrations/bases/base-normalization/dbt-project-template/macros/cross_db_utils/array.sql
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template/macros/cross_db_utils/array.sql
@@ -25,7 +25,7 @@
         case jsonb_typeof({{ array_col }})
         when 'array' then {{ array_col }}
         else '[]' end
-    ) as {{ array_col }}
+    ) as _{{ array_col }}
 {%- endmacro %}
 
 {% macro redshift__cross_join_unnest(stream_name, array_col) -%}

--- a/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_primary_key_streams/data_input/catalog.json
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_primary_key_streams/data_input/catalog.json
@@ -68,6 +68,39 @@
       "cursor_field": ["date"],
       "destination_sync_mode": "append_dedup",
       "primary_key": [["id"], ["currency"], ["NZD"]]
+    },
+    {
+      "stream": {
+        "name": "exchange_rate_nested_currencies",
+        "json_schema": {
+          "type": ["null", "object"],
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "currencies": { 
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "short_name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            "date": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": []
+      }
     }
   ]
 }

--- a/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_primary_key_streams/data_input/messages.txt
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_primary_key_streams/data_input/messages.txt
@@ -13,3 +13,8 @@
 {"type": "RECORD", "record": {"stream": "dedup_exchange_rate", "emitted_at": 1602637989400, "data": { "id": 2, "currency": "EUR", "date": "2020-09-01T00:00:00Z", "NZD": 2.43, "HKD": 8, "USD": 10.16}}}
 {"type": "RECORD", "record": {"stream": "dedup_exchange_rate", "emitted_at": 1602637990700, "data": { "id": 1, "currency": "USD", "date": "2020-09-01T00:00:00Z", "NZD": 1.14, "HKD": 10.5}}}
 {"type": "RECORD", "record": {"stream": "dedup_exchange_rate", "emitted_at": 1602637990800, "data": { "id": 2, "currency": "EUR", "date": "2020-09-01T00:00:00Z", "NZD": 2.43, "HKD": 5.4}}}
+
+
+{"type": "RECORD", "record": {"stream": "exchange_rate_nested_currencies", "emitted_at": 1602637589000, "data": { "id": 1, "currencies": [{"short_name": "NZD", "value": 1.14},{"short_name": "HKD", "value": 2.13}], "date": "2020-08-29T00:00:00Z"}}}
+{"type": "RECORD", "record": {"stream": "exchange_rate_nested_currencies", "emitted_at": 1602637689100, "data": { "id": 1, "currencies": [{"short_name": "NZD", "value": 1.14},{"short_name": "HKD", "value": 7.15}], "date": "2020-08-30T00:00:00Z"}}}
+{"type": "RECORD", "record": {"stream": "exchange_rate_nested_currencies", "emitted_at": 1602637789200, "data": { "id": 2, "currencies": [{"short_name": "NZD", "value": 3.89},{"short_name": "HKD", "value": 7.12}], "date": "2020-08-31T00:00:00Z"}}}

--- a/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_primary_key_streams/dbt_schema_tests/schema_test.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_primary_key_streams/dbt_schema_tests/schema_test.yml
@@ -21,7 +21,7 @@ models:
           description: check_raw_and_normalized_rowcounts
             Raw and normalized tables should be equal.
           compare_model: source('test_normalization', '_airbyte_raw_exchange_rate')
-
+          
   - name: test_normalization_dedup_exchange_rate
     tests:
       - dbt_utils.unique_combination_of_columns:
@@ -31,3 +31,12 @@ models:
             - id
             - currency
             - NZD
+
+  - name: test_normalization_e__urrenc_f41_currencies
+    columns:
+      - name: short_name
+        tests:
+          - not_null
+      - name: value
+        tests:
+          - not_null

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
@@ -268,10 +268,10 @@ class StreamProcessor(object):
                 is_nested_array = False
                 json_column_name = column_names[field][1]
             elif is_array(properties[field]["type"]) and "items" in properties[field]:
-                quoted_field = column_names[field][1]
+                unquoted_field = column_names[field][0]
                 children_properties = find_properties_object([], field, properties[field]["items"])
                 is_nested_array = True
-                json_column_name = f"unnested_column_value({quoted_field})"
+                json_column_name = f"unnested_column_value('_{unquoted_field}')"
             if children_properties:
                 for child_key in children_properties:
                     stream_processor = StreamProcessor.create_from_parent(


### PR DESCRIPTION
## What
This pr solves https://github.com/airbytehq/airbyte/issues/3108

## How
Adds a prefix to the unnested field so the extracted json fields wont come out empty.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## ps
- I'm not sure how to run all integration tests
- The dedup base normalization integration tests didn't work for me, but the rest including the one I've added did.
