### PR TITLE
correct typo in mysql source docs

### DIFF
--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -19,7 +19,12 @@ MySQL data types are mapped to the following data types when synchronizing data:
 | `date` | string |  |
 | `datetime` | string |  |
 | `enum` | string |  |
-| `numeric` | string | includes integer, etc |
+| `tinyint` | number | |
+| `smallint` | number | |
+| `mediumint` | number | |
+| `int` | number | |
+| `numeric` | number | |
+| `bigint` | number | |
 | `string` | string |  |
 
 If you do not see a type in this list, assume that it is coerced into a string. We are happy to take feedback on preferred mappings.

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -23,8 +23,8 @@ MySQL data types are mapped to the following data types when synchronizing data:
 | `smallint` | number | |
 | `mediumint` | number | |
 | `int` | number | |
-| `numeric` | number | |
 | `bigint` | number | |
+| `numeric` | number | |
 | `string` | string |  |
 
 If you do not see a type in this list, assume that it is coerced into a string. We are happy to take feedback on preferred mappings.


### PR DESCRIPTION
## What
Correct typo in MySQL docs.
airbytehq/airbyte#2908 had tested int types and I'll work to improve data types mapping in airbytehq/airbyte-internal-issues#61


## How
Correct doc

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `mysql.md`
