### PR TITLE
Source Zoom: fix version bumping

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9845d17a-45f1-4070-8a60-50914b1c8e2b.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9845d17a-45f1-4070-8a60-50914b1c8e2b.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "9845d17a-45f1-4070-8a60-50914b1c8e2b",
   "name": "HTTP Request",
   "dockerRepository": "airbyte/source-http-request",
-  "dockerImageTag": "0.2.2",
+  "dockerImageTag": "0.2.3",
   "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-http-request",
   "icon": "http.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/aea2fd0d-377d-465e-86c0-4fdc4f688e51.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/aea2fd0d-377d-465e-86c0-4fdc4f688e51.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "aea2fd0d-377d-465e-86c0-4fdc4f688e51",
   "name": "Zoom",
   "dockerRepository": "airbyte/source-zoom-singer",
-  "dockerImageTag": "0.2.2",
+  "dockerImageTag": "0.2.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-zoom-singer",
   "icon": "zoom.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -109,7 +109,7 @@
 - sourceDefinitionId: 9845d17a-45f1-4070-8a60-50914b1c8e2b
   name: HTTP Request
   dockerRepository: airbyte/source-http-request
-  dockerImageTag: 0.2.2
+  dockerImageTag: 0.2.3
   documentationUrl: https://hub.docker.com/repository/docker/airbyte/source-http-request
   icon: http.svg
 - sourceDefinitionId: e87ffa8e-a3b5-f69c-9076-6011339de1f6

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -175,7 +175,7 @@
 - sourceDefinitionId: aea2fd0d-377d-465e-86c0-4fdc4f688e51
   name: Zoom
   dockerRepository: airbyte/source-zoom-singer
-  dockerImageTag: 0.2.2
+  dockerImageTag: 0.2.1
   documentationUrl: https://hub.docker.com/r/airbyte/source-zoom-singer
   icon: zoom.svg
 - sourceDefinitionId: eaf50f04-21dd-4620-913b-2a83f5635227

--- a/airbyte-integrations/connectors/source-http-request/Dockerfile
+++ b/airbyte-integrations/connectors/source-http-request/Dockerfile
@@ -11,5 +11,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.2
+LABEL io.airbyte.version=0.2.3
 LABEL io.airbyte.name=airbyte/source-http-request

--- a/airbyte-integrations/connectors/source-zoom-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-zoom-singer/Dockerfile
@@ -11,7 +11,7 @@ ENV CODE_PATH="source_zoom_singer"
 ENV AIRBYTE_IMPL_MODULE="source_zoom_singer"
 ENV AIRBYTE_IMPL_PATH="SourceZoomSinger"
 
-LABEL io.airbyte.version=0.2.2
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-zoom-singer
 
 WORKDIR /airbyte/integration_code


### PR DESCRIPTION
Its version was accidentally bumped instead of HTTP source
## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `test.java`
1. `component.ts`
1. the rest
