### PR TITLE
Source FB marketing: add test (#2829)

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/integration_test.py
@@ -92,6 +92,19 @@ class TestFacebookMarketingSource:
 
         assert len(deleted_records) == deleted_num, f"{stream_name} should have {deleted_num} deleted records returned"
 
+    def test_campaign_stream_specific_deleted_id_pulled(self, stream_config_with_include_deleted, configured_catalog):
+        specific_campaign_id = "23846541919710398"
+        catalog = self.slice_catalog(configured_catalog, {"campaigns"})
+        records, _ = self._read_records(stream_config_with_include_deleted, catalog)
+
+        is_specific_campaign_pulled = False
+        for record in records:
+            if record.record.data["id"] == specific_campaign_id:
+                is_specific_campaign_pulled = True
+                break
+
+        assert is_specific_campaign_pulled is True, f"campaigns stream should have a deleted campaign with id={specific_campaign_id}"
+
     @pytest.mark.parametrize("stream_name, deleted_num", [("ads", 2), ("campaigns", 3), ("adsets", 1)])
     def test_streams_with_include_deleted_and_state(
         self, stream_name, deleted_num, stream_config_with_include_deleted, configured_catalog, state


### PR DESCRIPTION
Add test for pulling specific deleted campaign when `include_deleted=true`.

## What
Add test as was requested in [this](https://github.com/airbytehq/airbyte/issues/2829#issuecomment-823399570) comment.

## Pre-merge Checklist
- [x] *Run integration tests*
- [ ] *Publish Docker images* (no need in publishing new docker image because only tests were affected)

