### PR TITLE
Upgrade normalization to use dbt from docker images

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -1,7 +1,5 @@
-FROM airbyte/base-airbyte-protocol-python:0.1.1
-
-# dbt needs git in order to run.
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+FROM fishtownanalytics/dbt:0.19.1
+COPY --from=airbyte/base-airbyte-protocol-python:0.1.1 /airbyte /airbyte
 
 WORKDIR /airbyte
 COPY entrypoint.sh .
@@ -9,15 +7,20 @@ COPY entrypoint.sh .
 WORKDIR /airbyte/normalization_code
 COPY normalization ./normalization
 COPY setup.py .
-RUN pip install .
 COPY dbt-project-template/ ./dbt-template/
+
+WORKDIR /airbyte/base_python_structs
+RUN pip install .
+
+WORKDIR /airbyte/normalization_code
+RUN pip install .
+
 WORKDIR /airbyte/normalization_code/dbt-template/
 # Download external dbt dependencies
 RUN dbt deps
 
 WORKDIR /airbyte
-
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.27
+LABEL io.airbyte.version=0.1.28
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template/packages.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template/packages.yml
@@ -2,4 +2,4 @@
 
 packages:
   - git: "https://github.com/fishtown-analytics/dbt-utils.git"
-    revision: 0.6.2
+    revision: 0.6.4

--- a/airbyte-integrations/bases/base-normalization/setup.py
+++ b/airbyte-integrations/bases/base-normalization/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     author_email="contact@airbyte.io",
     url="https://github.com/airbytehq/airbyte",
     packages=setuptools.find_packages(),
-    install_requires=["airbyte-protocol", "dbt==0.18.2rc1", "pyyaml"],
+    install_requires=["airbyte-protocol", "pyyaml", "jinja2"],
     package_data={"": ["*.yml"]},
     setup_requires=["pytest-runner"],
     entry_points={

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
@@ -43,7 +43,7 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNormalizationRunner.class);
 
-  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.27";
+  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.28";
 
   private final DestinationType destinationType;
   private final ProcessBuilderFactory pbf;


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/3075

## How
Normalization python package does not depend on dbt anymore.

However, normalization airbyte docker image inherits from dbt docker image, so we should not need to `pip install dbt` either (just change docker image tag) and thus, we won't need to install all dbt dependencies in our virtualenv.

To implement this, I had to tweak the normalization integration test to invoke dbt through docker images of normalization instead of directly from the virtualenv binaries (since dbt should not get installed there anymore)

## Pre-merge Checklist
- [x] *Run integration tests*
- [x] *Publish Docker images*

## Recommended reading order
1. `airbyte-integrations/bases/base-normalization/Dockerfile`
1. the rest
