### PR TITLE
🎉 Source Stripe: fix date property name, only add connected account header when set, and set primary key

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/fullschema.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/fullschema.json
@@ -2066,7 +2066,7 @@
     "json_schema": {
       "type": ["null", "object"],
       "properties": {
-        "date": {
+        "created": {
           "type": ["null", "string"],
           "format": "date-time"
         },

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoices.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoices.json
@@ -1,7 +1,7 @@
 {
   "type": ["null", "object"],
   "properties": {
-    "date": {
+    "created": {
       "type": ["null", "string"],
       "format": "date-time"
     },

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
@@ -33,6 +33,7 @@ from base_python import AbstractSource, HttpStream, Stream, TokenAuthenticator
 
 class StripeStream(HttpStream, ABC):
     url_base = "https://api.stripe.com/v1/"
+    primary_key = "id"
 
     def __init__(self, account_id: str, **kwargs):
         super().__init__(**kwargs)
@@ -61,7 +62,10 @@ class StripeStream(HttpStream, ABC):
         return params
 
     def request_headers(self, **kwargs) -> Mapping[str, Any]:
-        return {"Stripe-Account": self.account_id}
+        if self.account_id:
+            return {"Stripe-Account": self.account_id}
+
+        return {}
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
         response_json = response.json()


### PR DESCRIPTION
## What
This allows the stream to be used with the "default" account ID for the key, without worrying about Stripe Connect.

Additionally, set a reasonable `primary_key` for Stripe streams, which seems to be required.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `test.java`
1. `component.ts`
1. the rest
