### PR TITLE
Update link in docs so they open in the same page (faster UX)

### DIFF
--- a/docs/contributing-to-airbyte/using-the-airbyte-cdk/README.md
+++ b/docs/contributing-to-airbyte/using-the-airbyte-cdk/README.md
@@ -2,4 +2,4 @@
 
 Airbyte Connector Development Kits (CDK) significantly accelerate connector development. We currently provide a Python CDK, and a Java one is in development.
 
-Navigate here for more information on the [Python CDK](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector/using-the-airbyte-cdk/python)
+Navigate here for more information on the [Python CDK](./contributing-to-airbyte/building-new-connector/using-the-airbyte-cdk/python)


### PR DESCRIPTION
To use links within the docs so they don't open a new page, we need to use ./
I thought this link would apply.