### PR TITLE
destination: mysql implementation

### DIFF
--- a/airbyte-db/src/main/java/io/airbyte/db/Databases.java
+++ b/airbyte-db/src/main/java/io/airbyte/db/Databases.java
@@ -28,6 +28,7 @@ import io.airbyte.db.jdbc.DefaultJdbcDatabase;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.db.jdbc.JdbcStreamingQueryConfiguration;
 import io.airbyte.db.jdbc.StreamingJdbcDatabase;
+import java.util.Optional;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.jooq.SQLDialect;
 
@@ -60,6 +61,16 @@ public class Databases {
     return new DefaultJdbcDatabase(connectionPool);
   }
 
+  public static JdbcDatabase createJdbcDatabase(final String username,
+      final String password,
+      final String jdbcConnectionString,
+      final String driverClassName,
+      final String connectionProperties) {
+    final BasicDataSource connectionPool = createBasicDataSource(username, password, jdbcConnectionString, driverClassName,Optional.of(connectionProperties));
+
+    return new DefaultJdbcDatabase(connectionPool);
+  }
+
   public static JdbcDatabase createStreamingJdbcDatabase(final String username,
                                                          final String password,
                                                          final String jdbcConnectionString,
@@ -72,14 +83,24 @@ public class Databases {
   }
 
   private static BasicDataSource createBasicDataSource(final String username,
+      final String password,
+      final String jdbcConnectionString,
+      final String driverClassName) {
+    return createBasicDataSource(username, password, jdbcConnectionString, driverClassName,
+        Optional.empty());
+  }
+
+  private static BasicDataSource createBasicDataSource(final String username,
                                                        final String password,
                                                        final String jdbcConnectionString,
-                                                       final String driverClassName) {
+                                                       final String driverClassName,
+                                                       final Optional<String> connectionProperties) {
     final BasicDataSource connectionPool = new BasicDataSource();
     connectionPool.setDriverClassName(driverClassName);
     connectionPool.setUsername(username);
     connectionPool.setPassword(password);
     connectionPool.setUrl(jdbcConnectionString);
+    connectionProperties.ifPresent(connectionPool::setConnectionProperties);
     return connectionPool;
   }
 

--- a/airbyte-db/src/main/java/io/airbyte/db/jdbc/JdbcDatabase.java
+++ b/airbyte-db/src/main/java/io/airbyte/db/jdbc/JdbcDatabase.java
@@ -50,6 +50,18 @@ public interface JdbcDatabase extends AutoCloseable {
     execute(connection -> connection.createStatement().execute(sql));
   }
 
+  default void executeWithinTransaction(List<String> queries) throws SQLException {
+    execute(connection -> {
+          connection.setAutoCommit(false);
+          for (String s : queries) {
+            connection.createStatement().execute(s);
+          }
+          connection.commit();
+          connection.setAutoCommit(true);
+        }
+    );
+  }
+
   /**
    * Use a connection to create a {@link ResultSet} and map it into a list. The entire
    * {@link ResultSet} will be buffered in memory before the list is returned. The caller does not

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
@@ -79,7 +79,7 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
 
   private static final long GRACEFUL_SHUTDOWN_MINUTES = 5L;
   private static final int MIN_RECORDS = 500;
-  private static final int BATCH_SIZE = 10000;
+  private static final int BATCH_SIZE = 500_000;
 
   private final VoidCallable onStart;
   private final RecordWriter recordWriter;

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/AbstractJdbcDestination.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/AbstractJdbcDestination.java
@@ -43,9 +43,9 @@ public abstract class AbstractJdbcDestination extends BaseConnector implements D
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractJdbcDestination.class);
 
-  private final String driverClass;
-  private final NamingConventionTransformer namingResolver;
-  private final SqlOperations sqlOperations;
+  protected final String driverClass;
+  protected final NamingConventionTransformer namingResolver;
+  protected final SqlOperations sqlOperations;
 
   public AbstractJdbcDestination(final String driverClass,
                                  final NamingConventionTransformer namingResolver,

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/DefaultSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/DefaultSqlOperations.java
@@ -107,7 +107,7 @@ public class DefaultSqlOperations implements SqlOperations {
     });
   }
 
-  private void writeBatchToFile(File tmpFile, List<AirbyteRecordMessage> records) throws Exception {
+  protected void writeBatchToFile(File tmpFile, List<AirbyteRecordMessage> records) throws Exception {
     PrintWriter writer = null;
     try {
       writer = new PrintWriter(tmpFile, StandardCharsets.UTF_8);
@@ -138,8 +138,14 @@ public class DefaultSqlOperations implements SqlOperations {
   }
 
   @Override
-  public void executeTransaction(JdbcDatabase database, String queries) throws Exception {
-    database.execute("BEGIN;\n" + queries + "COMMIT;");
+  public void executeTransaction(JdbcDatabase database, List<String> queries) throws Exception {
+    final StringBuilder appendedQueries = new StringBuilder();
+    appendedQueries.append("BEGIN;\n");
+    for (String query : queries) {
+      appendedQueries.append(query);
+    }
+    appendedQueries.append("COMMIT;");
+    database.execute(appendedQueries.toString());
   }
 
   @Override
@@ -149,6 +155,11 @@ public class DefaultSqlOperations implements SqlOperations {
 
   private String dropTableIfExistsQuery(String schemaName, String tableName) {
     return String.format("DROP TABLE IF EXISTS %s.%s;\n", schemaName, tableName);
+  }
+
+  @Override
+  public boolean isSchemaRequired() {
+    return true;
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/JdbcBufferedConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/JdbcBufferedConsumerFactory.java
@@ -41,6 +41,7 @@ import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.DestinationSyncMode;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -66,7 +67,7 @@ public class JdbcBufferedConsumerFactory {
                                               NamingConventionTransformer namingResolver,
                                               JsonNode config,
                                               ConfiguredAirbyteCatalog catalog) {
-    final List<WriteConfig> writeConfigs = createWriteConfigs(namingResolver, config, catalog);
+    final List<WriteConfig> writeConfigs = createWriteConfigs(namingResolver, config, catalog, sqlOperations.isSchemaRequired());
 
     return new BufferedStreamConsumer(
         onStartFunction(database, sqlOperations, writeConfigs),
@@ -77,25 +78,37 @@ public class JdbcBufferedConsumerFactory {
         sqlOperations::isValidData);
   }
 
-  private static List<WriteConfig> createWriteConfigs(NamingConventionTransformer namingResolver, JsonNode config, ConfiguredAirbyteCatalog catalog) {
-    Preconditions.checkState(config.has("schema"), "jdbc destinations must specify a schema.");
+  private static List<WriteConfig> createWriteConfigs(NamingConventionTransformer namingResolver, JsonNode config, ConfiguredAirbyteCatalog catalog, boolean schemaRequired) {
+    if (schemaRequired) {
+      Preconditions.checkState(config.has("schema"), "jdbc destinations must specify a schema.");
+    }
     final Instant now = Instant.now();
-    return catalog.getStreams().stream().map(toWriteConfig(namingResolver, config, now)).collect(Collectors.toList());
+    return catalog.getStreams().stream().map(toWriteConfig(namingResolver, config, now, schemaRequired)).collect(Collectors.toList());
   }
 
-  private static Function<ConfiguredAirbyteStream, WriteConfig> toWriteConfig(NamingConventionTransformer namingResolver,
-                                                                              JsonNode config,
-                                                                              Instant now) {
+  private static Function<ConfiguredAirbyteStream, WriteConfig> toWriteConfig(
+      NamingConventionTransformer namingResolver,
+      JsonNode config,
+      Instant now, boolean schemaRequired) {
     return stream -> {
       Preconditions.checkNotNull(stream.getDestinationSyncMode(), "Undefined destination sync mode");
       final AirbyteStream abStream = stream.getStream();
 
-      final String defaultSchemaName = namingResolver.getIdentifier(config.get("schema").asText());
+      final String defaultSchemaName = schemaRequired ? namingResolver.getIdentifier(config.get("schema").asText()) : namingResolver.getIdentifier(config.get("database").asText());
       final String outputSchema = getOutputSchema(abStream, defaultSchemaName);
 
       final String streamName = abStream.getName();
       final String tableName = Names.concatQuotedNames("_airbyte_raw_", namingResolver.getIdentifier(streamName));
-      final String tmpTableName = Names.concatQuotedNames("_airbyte_" + now.toEpochMilli() + "_", tableName);
+      String tmpTableName = Names.concatQuotedNames("_airbyte_" + now.toEpochMilli() + "_", tableName);
+
+      //This is for MySQL destination, the table names cant have more than 64 characters.
+      if (tmpTableName.length() > 64) {
+        String prefix = tmpTableName.substring(0, 31); //31
+        String suffix = tmpTableName.substring(32, 63); //31
+        tmpTableName = prefix + "__" + suffix;
+        System.out.println(tmpTableName + " LENGTH IS " + tmpTableName.length());
+      }
+
       final DestinationSyncMode syncMode = stream.getDestinationSyncMode();
 
       return new WriteConfig(streamName, abStream.getNamespace(), outputSchema, tmpTableName, tableName, syncMode);
@@ -155,7 +168,7 @@ public class JdbcBufferedConsumerFactory {
     return (hasFailed) -> {
       // copy data
       if (!hasFailed) {
-        final StringBuilder queries = new StringBuilder();
+        List<String> queryList = new ArrayList<>();
         LOGGER.info("Finalizing tables in destination started for {} streams", writeConfigs.size());
         for (WriteConfig writeConfig : writeConfigs) {
           final String schemaName = writeConfig.getOutputSchemaName();
@@ -166,16 +179,16 @@ public class JdbcBufferedConsumerFactory {
 
           sqlOperations.createTableIfNotExists(database, schemaName, dstTableName);
           switch (writeConfig.getSyncMode()) {
-            case OVERWRITE -> queries.append(sqlOperations.truncateTableQuery(schemaName, dstTableName));
+            case OVERWRITE -> queryList.add(sqlOperations.truncateTableQuery(schemaName, dstTableName));
             case APPEND -> {}
             case APPEND_DEDUP -> {}
             default -> throw new IllegalStateException("Unrecognized sync mode: " + writeConfig.getSyncMode());
           }
-          queries.append(sqlOperations.copyTableQuery(schemaName, srcTableName, dstTableName));
+          queryList.add(sqlOperations.copyTableQuery(schemaName, srcTableName, dstTableName));
         }
 
         LOGGER.info("Executing finalization of tables.");
-        sqlOperations.executeTransaction(database, queries.toString());
+        sqlOperations.executeTransaction(database, queryList);
         LOGGER.info("Finalizing tables in destination completed.");
       }
       // clean up

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/SqlOperations.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/SqlOperations.java
@@ -103,11 +103,13 @@ public interface SqlOperations {
    * @param queries queries to execute
    * @throws Exception exception
    */
-  void executeTransaction(JdbcDatabase database, String queries) throws Exception;
+  void executeTransaction(JdbcDatabase database, List<String> queries) throws Exception;
 
   /**
    * Check if the data record is valid and ok to be written to destination
    */
   boolean isValidData(final String data);
+
+  boolean isSchemaRequired();
 
 }

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/CopyConsumer.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/CopyConsumer.java
@@ -39,6 +39,7 @@ import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -161,7 +162,7 @@ public class CopyConsumer<T> extends FailureTrackingAirbyteMessageConsumer {
         }
       }
       if (!hasFailed) {
-        sqlOperations.executeTransaction(db, mergeCopiersToFinalTableQuery.toString());
+        sqlOperations.executeTransaction(db, Collections.singletonList(mergeCopiersToFinalTableQuery.toString()));
       }
     } finally {
       for (var copier : streamCopiers) {

--- a/airbyte-integrations/connectors/destination-mysql/.dockerignore
+++ b/airbyte-integrations/connectors/destination-mysql/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!build

--- a/airbyte-integrations/connectors/destination-mysql/Dockerfile
+++ b/airbyte-integrations/connectors/destination-mysql/Dockerfile
@@ -1,0 +1,12 @@
+FROM airbyte/integration-base-java:dev
+
+WORKDIR /airbyte
+
+ENV APPLICATION destination-mysql
+
+COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
+
+RUN tar xf ${APPLICATION}.tar --strip-components=1
+
+LABEL io.airbyte.version=0.3.0
+LABEL io.airbyte.name=airbyte/destination-mysql

--- a/airbyte-integrations/connectors/destination-mysql/build.gradle
+++ b/airbyte-integrations/connectors/destination-mysql/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'application'
+    id 'airbyte-docker'
+    id 'airbyte-integration-test-java'
+}
+
+application {
+    mainClass = 'io.airbyte.integrations.destination.mysql.MySQLDestination'
+}
+
+dependencies {
+    implementation project(':airbyte-db')
+    implementation project(':airbyte-integrations:bases:base-java')
+    implementation project(':airbyte-protocol:models')
+    implementation project(':airbyte-integrations:connectors:destination-jdbc')
+
+    // https://mvnrepository.com/artifact/mysql/mysql-connector-java
+    implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.22'
+
+    integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
+    integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-mysql')
+    integrationTestJavaImplementation "org.testcontainers:mysql:1.15.1"
+
+    implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
+    integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
+}
+

--- a/airbyte-integrations/connectors/destination-mysql/src/main/java/io/airbyte/integrations/destination/mysql/MySQLDestination.java
+++ b/airbyte-integrations/connectors/destination-mysql/src/main/java/io/airbyte/integrations/destination/mysql/MySQLDestination.java
@@ -1,0 +1,81 @@
+package io.airbyte.integrations.destination.mysql;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.db.Databases;
+import io.airbyte.db.jdbc.JdbcDatabase;
+import io.airbyte.integrations.base.Destination;
+import io.airbyte.integrations.base.IntegrationRunner;
+import io.airbyte.integrations.destination.jdbc.AbstractJdbcDestination;
+import io.airbyte.protocol.models.AirbyteConnectionStatus;
+import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MySQLDestination extends AbstractJdbcDestination implements Destination {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MySQLDestination.class);
+
+  public static final String DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
+
+  @Override
+  public AirbyteConnectionStatus check(JsonNode config) {
+    try (final JdbcDatabase database = getDatabase(config)) {
+      String outputSchema = namingResolver.getIdentifier(config.get("database").asText());
+      attemptSQLCreateAndDropTableOperations(outputSchema, database, namingResolver, sqlOperations);
+      boolean localFileEnabled = ((MySQLSqlOperations) sqlOperations)
+          .checkIfLocalFileIsEnabled(database);
+      if (!localFileEnabled) {
+        ((MySQLSqlOperations) sqlOperations).tryEnableLocalFile(database);
+      }
+      return new AirbyteConnectionStatus().withStatus(Status.SUCCEEDED);
+    } catch (Exception e) {
+      LOGGER.error("Exception while checking connection: ", e);
+      return new AirbyteConnectionStatus()
+          .withStatus(Status.FAILED)
+          .withMessage("Could not connect with provided configuration. \n" + e.getMessage());
+    }
+  }
+
+  public MySQLDestination() {
+    super(DRIVER_CLASS, new MySQLNameTransformer(), new MySQLSqlOperations());
+  }
+
+  @Override
+  protected JdbcDatabase getDatabase(JsonNode config) {
+    final JsonNode jdbcConfig = toJdbcConfig(config);
+
+    return Databases.createJdbcDatabase(
+        jdbcConfig.get("username").asText(),
+        jdbcConfig.has("password") ? jdbcConfig.get("password").asText() : null,
+        jdbcConfig.get("jdbc_url").asText(),
+        driverClass,
+        "allowLoadLocalInfile=true");
+  }
+
+  @Override
+  public JsonNode toJdbcConfig(JsonNode config) {
+    final StringBuilder jdbcUrl = new StringBuilder(String.format("jdbc:mysql://%s:%s/%s",
+        config.get("host").asText(),
+        config.get("port").asText(),
+        config.get("database").asText()));
+
+    ImmutableMap.Builder<Object, Object> configBuilder = ImmutableMap.builder()
+        .put("username", config.get("username").asText())
+        .put("jdbc_url", jdbcUrl.toString());
+
+    if (config.has("password")) {
+      configBuilder.put("password", config.get("password").asText());
+    }
+
+    return Jsons.jsonNode(configBuilder.build());
+  }
+
+  public static void main(String[] args) throws Exception {
+    final Destination destination = new MySQLDestination();
+    LOGGER.info("starting destination: {}", MySQLDestination.class);
+    new IntegrationRunner(destination).run(args);
+    LOGGER.info("completed destination: {}", MySQLDestination.class);
+  }
+}

--- a/airbyte-integrations/connectors/destination-mysql/src/main/java/io/airbyte/integrations/destination/mysql/MySQLNameTransformer.java
+++ b/airbyte-integrations/connectors/destination-mysql/src/main/java/io/airbyte/integrations/destination/mysql/MySQLNameTransformer.java
@@ -1,0 +1,11 @@
+package io.airbyte.integrations.destination.mysql;
+
+import io.airbyte.integrations.destination.ExtendedNameTransformer;
+
+public class MySQLNameTransformer extends ExtendedNameTransformer {
+
+  @Override
+  protected String applyDefaultCase(String input) {
+    return input.toLowerCase();
+  }
+}

--- a/airbyte-integrations/connectors/destination-mysql/src/main/java/io/airbyte/integrations/destination/mysql/MySQLSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-mysql/src/main/java/io/airbyte/integrations/destination/mysql/MySQLSqlOperations.java
@@ -1,0 +1,105 @@
+package io.airbyte.integrations.destination.mysql;
+
+import io.airbyte.db.jdbc.JdbcDatabase;
+import io.airbyte.integrations.base.JavaBaseConstants;
+import io.airbyte.integrations.destination.jdbc.DefaultSqlOperations;
+import io.airbyte.protocol.models.AirbyteRecordMessage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MySQLSqlOperations extends DefaultSqlOperations {
+  private boolean isLocalFileEnabled = false;
+
+  @Override
+  public void executeTransaction(JdbcDatabase database, List<String> queries) throws Exception {
+    database.executeWithinTransaction(queries);
+  }
+
+  @Override
+  public void insertRecords(JdbcDatabase database, List<AirbyteRecordMessage> records,
+      String schemaName, String tmpTableName) throws SQLException {
+    if (records.isEmpty()) {
+      return;
+    }
+
+    boolean localFileEnabled = isLocalFileEnabled || checkIfLocalFileIsEnabled(database);
+
+    if(!localFileEnabled) {
+      tryEnableLocalFile(database);
+    }
+    isLocalFileEnabled = true;
+    loadDataIntoTable(database, records, schemaName, tmpTableName);
+  }
+
+  private void loadDataIntoTable(JdbcDatabase database, List<AirbyteRecordMessage> records,
+      String schemaName, String tmpTableName) throws SQLException {
+    database.execute(connection -> {
+      File tmpFile = null;
+      try {
+        tmpFile = Files.createTempFile(tmpTableName + "-", ".tmp").toFile();
+        writeBatchToFile(tmpFile, records);
+
+        String absoluteFile = "'" + tmpFile.getAbsolutePath() + "'";
+
+        String query = String.format(
+            "LOAD DATA LOCAL INFILE %s INTO TABLE %s.%s FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\\r\\n'",
+            absoluteFile, schemaName, tmpTableName);
+
+        try (Statement stmt = connection.createStatement()) {
+          stmt.execute(query);
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      } finally {
+        try {
+          if (tmpFile != null) {
+            Files.delete(tmpFile.toPath());
+          }
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    });
+  }
+
+  void tryEnableLocalFile(JdbcDatabase database) throws SQLException {
+    database.execute(connection -> {
+      try (Statement statement = connection.createStatement()) {
+        statement.execute("set global local_infile=true");
+      } catch (Exception e) {
+        throw new RuntimeException("local_infile attribute could not be enabled", e);
+      }
+    });
+  }
+
+  @Override
+  public boolean isSchemaRequired() {
+    return false;
+  }
+
+  boolean checkIfLocalFileIsEnabled(JdbcDatabase database) throws SQLException {
+    List<String> value = database.resultSetQuery(connection ->
+            connection.createStatement().executeQuery("SHOW GLOBAL VARIABLES LIKE 'local_infile'"),
+        resultSet -> resultSet.getString("Value")
+    ).collect(Collectors.toList());
+
+    return value.get(0).equalsIgnoreCase("on");
+  }
+
+  @Override
+  public String createTableQuery(String schemaName, String tableName) {
+    //MySQL requires byte information with VARCHAR. Since we are using uuid as value for the column, 256 is enough
+    return String.format(
+        "CREATE TABLE IF NOT EXISTS %s.%s ( \n"
+            + "%s VARCHAR(256) PRIMARY KEY,\n"
+            + "%s JSON,\n"
+            + "%s TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n"
+            + ");\n",
+        schemaName, tableName, JavaBaseConstants.COLUMN_NAME_AB_ID, JavaBaseConstants.COLUMN_NAME_DATA, JavaBaseConstants.COLUMN_NAME_EMITTED_AT);
+  }
+}

--- a/airbyte-integrations/connectors/destination-mysql/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-mysql/src/main/resources/spec.json
@@ -1,0 +1,49 @@
+{
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/mysql",
+  "supportsIncremental": true,
+  "supported_destination_sync_modes": ["overwrite", "append"],
+  "connectionSpecification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MySQL Destination Spec",
+    "type": "object",
+    "required": ["host", "port", "username", "database", "password"],
+    "additionalProperties": false,
+    "properties": {
+      "host": {
+        "title": "Host",
+        "description": "Hostname of the database.",
+        "type": "string",
+        "order": 0
+      },
+      "port": {
+        "title": "Port",
+        "description": "Port of the database.",
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 65536,
+        "default": 3306,
+        "examples": ["3306"],
+        "order": 1
+      },
+      "database": {
+        "title": "DB Name",
+        "description": "Name of the database.",
+        "type": "string",
+        "order": 2
+      },
+      "username": {
+        "title": "User",
+        "description": "Username to use to access the database.",
+        "type": "string",
+        "order": 3
+      },
+      "password": {
+        "title": "Password",
+        "description": "Password associated with the username.",
+        "type": "string",
+        "airbyte_secret": true,
+        "order": 4
+      }
+    }
+  }
+}

--- a/airbyte-integrations/connectors/destination-mysql/src/test-integration/java/io.airbyte.integrations.destination.mysql/MySQLIntegrationTest.java
+++ b/airbyte-integrations/connectors/destination-mysql/src/test-integration/java/io.airbyte.integrations.destination.mysql/MySQLIntegrationTest.java
@@ -1,0 +1,99 @@
+package io.airbyte.integrations.destination.mysql;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.db.Databases;
+import io.airbyte.integrations.base.JavaBaseConstants;
+import io.airbyte.integrations.destination.ExtendedNameTransformer;
+import io.airbyte.integrations.standardtest.destination.TestDestination;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jooq.JSONFormat;
+import org.jooq.JSONFormat.RecordFormat;
+import org.jooq.SQLDialect;
+import org.testcontainers.containers.MySQLContainer;
+
+public class MySQLIntegrationTest extends TestDestination {
+  private static final JSONFormat JSON_FORMAT = new JSONFormat().recordFormat(RecordFormat.OBJECT);
+
+  private MySQLContainer<?> db;
+  private ExtendedNameTransformer namingResolver = new MySQLNameTransformer();
+  @Override
+  protected String getImageName() {
+    return "airbyte/destination-mysql:dev";
+  }
+
+  @Override
+  protected JsonNode getConfig() {
+    //root user is required cause by default the server value for local_infile is OFF and we need to turn it ON for loading data and the normal user doesn't have permission to switch it on
+    return Jsons.jsonNode(ImmutableMap.builder()
+        .put("host", db.getHost())
+        .put("username", "root")
+        .put("password", "test")
+        .put("database", db.getDatabaseName())
+        .put("port", db.getFirstMappedPort())
+        .build());
+  }
+
+  @Override
+  protected JsonNode getFailCheckConfig() {
+    return Jsons.jsonNode(ImmutableMap.builder()
+        .put("host", db.getHost())
+        .put("username", db.getUsername())
+        .put("password", "wrong password")
+        .put("database", db.getDatabaseName())
+        .put("port", db.getFirstMappedPort())
+        .build());
+  }
+
+  @Override
+  protected String getDefaultSchema(JsonNode config) {
+    if (config.get("database") == null) {
+      return null;
+    }
+    return config.get("database").asText();
+  }
+
+  @Override
+  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv, String streamName,
+      String namespace) throws Exception {
+    return retrieveRecordsFromTable(namingResolver.getRawTableName(streamName), namespace)
+        .stream()
+        .map(r -> Jsons.deserialize(r.get(JavaBaseConstants.COLUMN_NAME_DATA).asText()))
+        .collect(Collectors.toList());
+  }
+
+  private List<JsonNode> retrieveRecordsFromTable(String tableName, String schemaName) throws SQLException {
+    return Databases.createDatabase(
+        db.getUsername(),
+        db.getPassword(),
+        String.format("jdbc:mysql://%s:%s/%s",
+            db.getHost(),
+            db.getFirstMappedPort(),
+            db.getDatabaseName()),
+        "com.mysql.cj.jdbc.Driver",
+        SQLDialect.MYSQL).query(
+        ctx -> ctx
+            .fetch(String.format("SELECT * FROM %s.%s ORDER BY %s ASC;", schemaName, tableName,
+                JavaBaseConstants.COLUMN_NAME_EMITTED_AT))
+            .stream()
+            .map(r -> r.formatJSON(JSON_FORMAT))
+            .map(Jsons::deserialize)
+            .collect(Collectors.toList()));
+  }
+
+
+  @Override
+  protected void setup(TestDestinationEnv testEnv) {
+    db = new MySQLContainer<>("mysql:8.0");
+    db.start();
+  }
+
+  @Override
+  protected void tearDown(TestDestinationEnv testEnv) {
+    db.stop();
+    db.close();
+  }
+}


### PR DESCRIPTION
## What
Issue : https://github.com/airbytehq/airbyte/issues/1483

## How
The PR introduces module for mysql-destination. This mainly tackles loading data into the mysql tables without making too many changes to the existing architecture/code. We are using `LOAD DATA INFILE` mechanism to load data into mysql. This is the recommended way of doing it. Ref : https://dev.mysql.com/doc/refman/8.0/en/load-data.html

This implementation is not compatible with normalization. The MySQL integration tests pass locally.

## Pre-merge Checklist
- [x] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `test.java`
1. `component.ts`
1. the rest
