### PR TITLE
Add support of Custom Transformations to API

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2097,6 +2097,12 @@ components:
       # - webhook
     OperatorNormalization:
       type: object
+      properties:
+        option:
+          type: string
+          enum:
+            - basic
+            #- unnesting
     OperatorDbt:
       type: object
       required:

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -777,7 +777,7 @@ paths:
     post:
       tags:
         - connection
-      summary: Updated a connection status
+      summary: Update a connection
       operationId: updateConnection
       requestBody:
         content:
@@ -904,6 +904,114 @@ paths:
                 $ref: "#/components/schemas/JobInfoRead"
         "404":
           description: Connection not found
+        "422":
+          $ref: "#/components/responses/InvalidInput"
+  /v1/operations/create:
+    post:
+      tags:
+        - operation
+      summary: Create an operation to be applied as part of a connection pipeline
+      operationId: createOperation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OperationCreate"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OperationRead"
+        "422":
+          $ref: "#/components/responses/InvalidInput"
+  /v1/operations/update:
+    post:
+      tags:
+        - operation
+      summary: Update an operation
+      operationId: updateOperation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OperationUpdate"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OperationRead"
+        "422":
+          $ref: "#/components/responses/InvalidInput"
+  /v1/operations/list:
+    post:
+      tags:
+        - operation
+      summary: Returns all operations for a connection.
+      description: List operations for connection.
+      operationId: listOperationsForConnection
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionIdRequestBody"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OperationReadList"
+        "404":
+          description: Connection not found
+        "422":
+          $ref: "#/components/responses/InvalidInput"
+  /v1/operations/get:
+    post:
+      tags:
+        - operation
+      summary: Returns an operation
+      operationId: getOperation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OperationIdRequestBody"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OperationRead"
+        "404":
+          description: Operation not found
+        "422":
+          $ref: "#/components/responses/InvalidInput"
+  /v1/operations/delete:
+    post:
+      tags:
+        - operation
+      summary: Delete an operation
+      operationId: deleteOperation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OperationIdRequestBody"
+        required: true
+      responses:
+        "204":
+          description: The resource was deleted successfully.
+        "404":
+          description: Operation not found
         "422":
           $ref: "#/components/responses/InvalidInput"
   /v1/scheduler/sources/check_connection:
@@ -1806,6 +1914,10 @@ components:
           $ref: "#/components/schemas/SourceId"
         destinationId:
           $ref: "#/components/schemas/DestinationId"
+        operationIds:
+          type: array
+          items:
+            $ref: "#/components/schemas/OperationId"
         syncCatalog:
           $ref: "#/components/schemas/AirbyteCatalog"
         schedule:
@@ -1824,6 +1936,10 @@ components:
         prefix:
           type: string
           description: Prefix that will be prepended to the name of each stream when it is written to the destination.
+        operationIds:
+          type: array
+          items:
+            $ref: "#/components/schemas/OperationId"
         syncCatalog:
           $ref: "#/components/schemas/AirbyteCatalog"
         schedule:
@@ -1858,6 +1974,10 @@ components:
           $ref: "#/components/schemas/SourceId"
         destinationId:
           $ref: "#/components/schemas/DestinationId"
+        operationIds:
+          type: array
+          items:
+            $ref: "#/components/schemas/OperationId"
         syncCatalog:
           $ref: "#/components/schemas/AirbyteCatalog"
         schedule:
@@ -1898,6 +2018,117 @@ components:
             - days
             - weeks
             - months
+    # Operations
+    OperationId:
+      type: string
+      format: uuid
+    OperationIdRequestBody:
+      type: object
+      required:
+        - OperationId
+      properties:
+        OperationId:
+          $ref: "#/components/schemas/OperationId"
+    OperationCreate:
+      type: object
+      required:
+        - name
+        - operatorConfiguration
+        - status
+      properties:
+        name:
+          type: string
+        operatorConfiguration:
+          $ref: "#/components/schemas/OperatorConfiguration"
+        status:
+          $ref: "#/components/schemas/OperationStatus"
+    OperationUpdate:
+      type: object
+      required:
+        - operationId
+        - name
+        - operatorConfiguration
+        - status
+      properties:
+        operationId:
+          $ref: "#/components/schemas/OperationId"
+        name:
+          type: string
+        operatorConfiguration:
+          $ref: "#/components/schemas/OperatorConfiguration"
+        status:
+          $ref: "#/components/schemas/OperationStatus"
+    OperationRead:
+      type: object
+      required:
+        - operationId
+        - name
+        - operatorConfiguration
+        - status
+      properties:
+        operationId:
+          $ref: "#/components/schemas/OperationId"
+        name:
+          type: string
+        operatorConfiguration:
+          $ref: "#/components/schemas/OperatorConfiguration"
+        status:
+          $ref: "#/components/schemas/OperationStatus"
+    OperationReadList:
+      type: object
+      required:
+        - operations
+      properties:
+        operations:
+          type: array
+          items:
+            $ref: "#/components/schemas/OperationRead"
+    OperationStatus:
+      type: string
+      description: Active means that data is flowing through the operator. Inactive means it is not. Deprecated means the operator is off and cannot be re-activated.
+      enum:
+        - active
+        - inactive
+        - deprecated
+    OperatorConfiguration:
+      type: object
+      required:
+        - OperatorType
+      properties:
+        # Instead of this type field, we would prefer a json schema "oneOf" but unfortunately,
+        # the jsonschema2pojo does not seem to support it yet: https://github.com/joelittlejohn/jsonschema2pojo/issues/392
+        operatorType:
+          $ref: "#/components/schemas/OperatorType"
+        normalization:
+          $ref: "#/components/schemas/OperatorNormalization"
+        dbt:
+          $ref: "#/components/schemas/OperatorDbt"
+    OperatorType:
+      type: string
+      enum:
+        # - destination
+        - normalization
+        - dbt
+      # - docker
+      # - webhook
+    OperatorNormalization:
+      type: object
+      required:
+        - enabled
+      properties:
+        enabled:
+          type: boolean
+    OperatorDbt:
+      type: object
+      required:
+        - gitRepoUrl
+      properties:
+        gitRepoUrl:
+          type: string
+        dockerImage:
+          type: string
+        dbtArguments:
+          type: string
     # LOGS
     LogType:
       type: string
@@ -2238,10 +2469,16 @@ components:
           $ref: "#/components/schemas/ConnectionSchedule"
         status:
           $ref: "#/components/schemas/ConnectionStatus"
+        operationIds:
+          type: array
+          items:
+            $ref: "#/components/schemas/OperationId"
         source:
           $ref: "#/components/schemas/SourceRead"
         destination:
           $ref: "#/components/schemas/DestinationRead"
+        operations:
+          $ref: "#/components/schemas/OperationReadList"
         latestSyncJobCreatedAt:
           description: epoch time of the latest sync job. null if no sync job has taken place.
           type: integer

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2093,7 +2093,7 @@ components:
     OperatorConfiguration:
       type: object
       required:
-        - OperatorType
+        - operatorType
       properties:
         # Instead of this type field, we would prefer a json schema "oneOf" but unfortunately,
         # the jsonschema2pojo does not seem to support it yet: https://github.com/joelittlejohn/jsonschema2pojo/issues/392

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2034,21 +2034,17 @@ components:
       required:
         - name
         - operatorConfiguration
-        - status
       properties:
         name:
           type: string
         operatorConfiguration:
           $ref: "#/components/schemas/OperatorConfiguration"
-        status:
-          $ref: "#/components/schemas/OperationStatus"
     OperationUpdate:
       type: object
       required:
         - operationId
         - name
         - operatorConfiguration
-        - status
       properties:
         operationId:
           $ref: "#/components/schemas/OperationId"
@@ -2056,15 +2052,12 @@ components:
           type: string
         operatorConfiguration:
           $ref: "#/components/schemas/OperatorConfiguration"
-        status:
-          $ref: "#/components/schemas/OperationStatus"
     OperationRead:
       type: object
       required:
         - operationId
         - name
         - operatorConfiguration
-        - status
       properties:
         operationId:
           $ref: "#/components/schemas/OperationId"
@@ -2072,8 +2065,6 @@ components:
           type: string
         operatorConfiguration:
           $ref: "#/components/schemas/OperatorConfiguration"
-        status:
-          $ref: "#/components/schemas/OperationStatus"
     OperationReadList:
       type: object
       required:
@@ -2083,13 +2074,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/OperationRead"
-    OperationStatus:
-      type: string
-      description: Active means that data is flowing through the operator. Inactive means it is not. Deprecated means the operator is off and cannot be re-activated.
-      enum:
-        - active
-        - inactive
-        - deprecated
     OperatorConfiguration:
       type: object
       required:
@@ -2113,11 +2097,6 @@ components:
       # - webhook
     OperatorNormalization:
       type: object
-      required:
-        - enabled
-      properties:
-        enabled:
-          type: boolean
     OperatorDbt:
       type: object
       required:

--- a/airbyte-config/models/src/main/java/io/airbyte/config/ConfigSchema.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/ConfigSchema.java
@@ -50,6 +50,7 @@ public enum ConfigSchema {
   // worker
   STANDARD_SYNC_INPUT("StandardSyncInput.yaml"),
   NORMALIZATION_INPUT("NormalizationInput.yaml"),
+  OPERATOR_DBT_INPUT("OperatorDbtInput.yaml"),
 
   STANDARD_SYNC_OUTPUT("StandardSyncOutput.yaml"),
 

--- a/airbyte-config/models/src/main/java/io/airbyte/config/ConfigSchema.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/ConfigSchema.java
@@ -43,8 +43,9 @@ public enum ConfigSchema {
 
   // sync
   STANDARD_SYNC("StandardSync.yaml"),
-  STANDARD_SYNC_SUMMARY("StandardSyncSummary.yaml"),
+  STANDARD_SYNC_OPERATION("StandardSyncOperation.yaml"),
   STANDARD_SYNC_SCHEDULE("StandardSyncSchedule.yaml"),
+  STANDARD_SYNC_SUMMARY("StandardSyncSummary.yaml"),
 
   // worker
   STANDARD_SYNC_INPUT("StandardSyncInput.yaml"),

--- a/airbyte-config/models/src/main/resources/types/JobResetConnectionConfig.yaml
+++ b/airbyte-config/models/src/main/resources/types/JobResetConnectionConfig.yaml
@@ -24,3 +24,8 @@ properties:
   destinationDockerImage:
     description: Image name of the destination with tag.
     type: string
+  operationSequence:
+    description: Sequence of configurations of operations to apply as part of the sync
+    type: array
+    items:
+      "$ref": StandardSyncOperation.yaml

--- a/airbyte-config/models/src/main/resources/types/JobSyncConfig.yaml
+++ b/airbyte-config/models/src/main/resources/types/JobSyncConfig.yaml
@@ -33,6 +33,11 @@ properties:
   destinationDockerImage:
     description: Image name of the destination with tag.
     type: string
+  operationSequence:
+    description: Sequence of configurations of operations to apply as part of the sync
+    type: array
+    items:
+      "$ref": StandardSyncOperation.yaml
   state:
     description: optional state of the previous run. this object is defined per integration.
     "$ref": State.yaml

--- a/airbyte-config/models/src/main/resources/types/OperatorDbt.yaml
+++ b/airbyte-config/models/src/main/resources/types/OperatorDbt.yaml
@@ -1,0 +1,16 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/OperatorDbt.yaml
+title: OperatorDbt
+description: Settings for a DBT operator
+type: object
+required:
+  - gitRepoUrl
+additionalProperties: false
+properties:
+  gitRepoUrl:
+    type: string
+  dockerImage:
+    type: string
+  dbtArguments:
+    type: string

--- a/airbyte-config/models/src/main/resources/types/OperatorDbtInput.yaml
+++ b/airbyte-config/models/src/main/resources/types/OperatorDbtInput.yaml
@@ -1,0 +1,17 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/OperatorDbtInput.yaml
+title: Operator Dbt Input
+description: Input configuration for DBT Transformation operator
+type: object
+additionalProperties: false
+required:
+  - destinationConfiguration
+  - operatorDbt
+properties:
+  destinationConfiguration:
+    description: Integration specific blob. Must be a valid JSON string.
+    type: object
+    existingJavaType: com.fasterxml.jackson.databind.JsonNode
+  operatorDbt:
+    "$ref": OperatorDbt.yaml

--- a/airbyte-config/models/src/main/resources/types/OperatorNormalization.yaml
+++ b/airbyte-config/models/src/main/resources/types/OperatorNormalization.yaml
@@ -1,0 +1,13 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/OperatorNormalization.yaml
+title: OperatorNormalization
+description: Settings for a normalization operator
+type: object
+additionalProperties: false
+properties:
+  option:
+    type: string
+    enum:
+      - basic
+      #- unnesting

--- a/airbyte-config/models/src/main/resources/types/OperatorType.yaml
+++ b/airbyte-config/models/src/main/resources/types/OperatorType.yaml
@@ -1,0 +1,10 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/OperatorType.yaml
+title: OperatorType
+description: Type of Operator
+type: string
+enum:
+  # - destination
+  - normalization
+  - dbt

--- a/airbyte-config/models/src/main/resources/types/StandardSync.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSync.yaml
@@ -20,6 +20,11 @@ properties:
   destinationId:
     type: string
     format: uuid
+  operationIds:
+    type: array
+    items:
+      type: string
+      format: uuid
   connectionId:
     type: string
     format: uuid

--- a/airbyte-config/models/src/main/resources/types/StandardSyncInput.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSyncInput.yaml
@@ -21,6 +21,11 @@ properties:
     description: Integration specific blob. Must be a valid JSON string.
     type: object
     existingJavaType: com.fasterxml.jackson.databind.JsonNode
+  operationSequence:
+    description: Sequence of configurations of operations to apply as part of the sync
+    type: array
+    items:
+      "$ref": StandardSyncOperation.yaml
   catalog:
     description: the configured airbyte catalog
     type: object

--- a/airbyte-config/models/src/main/resources/types/StandardSyncOperation.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSyncOperation.yaml
@@ -19,9 +19,9 @@ properties:
   # the jsonschema2pojo does not seem to support it yet: https://github.com/joelittlejohn/jsonschema2pojo/issues/392
   operatorType:
     "$ref": OperatorType.yaml
-  OperatorNormalization:
+  operatorNormalization:
     "$ref": OperatorNormalization.yaml
-  OperatorDbt:
+  operatorDbt:
     "$ref": OperatorDbt.yaml
   tombstone:
     description:

--- a/airbyte-config/models/src/main/resources/types/StandardSyncOperation.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSyncOperation.yaml
@@ -1,0 +1,30 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSyncOperation.yaml
+title: StandardSyncOperation
+description: Configuration of an operation to apply during a sync
+type: object
+required:
+  - operationId
+  - name
+  - operatorType
+additionalProperties: false
+properties:
+  operationId:
+    type: string
+    format: uuid
+  name:
+    type: string
+  # Instead of this type field, we would prefer a json schema "oneOf" but unfortunately,
+  # the jsonschema2pojo does not seem to support it yet: https://github.com/joelittlejohn/jsonschema2pojo/issues/392
+  operatorType:
+    "$ref": OperatorType.yaml
+  OperatorNormalization:
+    "$ref": OperatorNormalization.yaml
+  OperatorDbt:
+    "$ref": OperatorDbt.yaml
+  tombstone:
+    description:
+      if not set or false, the configuration is active. if true, then this
+      configuration is permanently off.
+    type: boolean

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -31,6 +31,7 @@ import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncSchedule;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.validation.json.JsonValidationException;
@@ -197,6 +198,18 @@ public class ConfigRepository {
 
   public void writeStandardSchedule(final StandardSyncSchedule schedule) throws JsonValidationException, IOException {
     persistence.writeConfig(ConfigSchema.STANDARD_SYNC_SCHEDULE, schedule.getConnectionId().toString(), schedule);
+  }
+
+  public StandardSyncOperation getStandardSyncOperation(final UUID operationId) throws JsonValidationException, IOException, ConfigNotFoundException {
+    return persistence.getConfig(ConfigSchema.STANDARD_SYNC_OPERATION, operationId.toString(), StandardSyncOperation.class);
+  }
+
+  public void writeStandardSyncOperation(final StandardSyncOperation standardSyncOperation) throws JsonValidationException, IOException {
+    persistence.writeConfig(ConfigSchema.STANDARD_SYNC_OPERATION, standardSyncOperation.getOperationId().toString(), standardSyncOperation);
+  }
+
+  public List<StandardSyncOperation> listStandardSyncOperations() throws IOException, JsonValidationException {
+    return persistence.listConfigs(ConfigSchema.STANDARD_SYNC_OPERATION, StandardSyncOperation.class);
   }
 
 }

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DefaultConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DefaultConfigPersistenceTest.java
@@ -38,6 +38,7 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -104,7 +105,7 @@ class DefaultConfigPersistenceTest {
         .withConnectionId(UUID_1)
         .withSourceId(UUID.randomUUID())
         .withDestinationId(UUID.randomUUID())
-        .withStatus(StandardSync.Status.ACTIVE);
+        .withOperationIds(List.of(UUID.randomUUID()));
 
     configPersistence.writeConfig(ConfigSchema.STANDARD_SYNC, UUID_1.toString(), standardSync);
 

--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/worker_run/TemporalWorkerRunFactory.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/worker_run/TemporalWorkerRunFactory.java
@@ -70,7 +70,8 @@ public class TemporalWorkerRunFactory {
             .withDestinationDockerImage(resetConnection.getDestinationDockerImage())
             .withSourceConfiguration(Jsons.emptyObject())
             .withDestinationConfiguration(resetConnection.getDestinationConfiguration())
-            .withConfiguredAirbyteCatalog(resetConnection.getConfiguredAirbyteCatalog());
+            .withConfiguredAirbyteCatalog(resetConnection.getConfiguredAirbyteCatalog())
+            .withOperationSequence(resetConnection.getOperationSequence());
 
         final TemporalResponse<StandardSyncOutput> output = temporalClient.submitSync(job.getId(), attemptId, config);
         return toOutputAndStatus(output);

--- a/airbyte-scheduler/app/src/test/java/io/airbyte/scheduler/app/JobSchedulerTest.java
+++ b/airbyte-scheduler/app/src/test/java/io/airbyte/scheduler/app/JobSchedulerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSync.Status;
+import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncSchedule;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
@@ -46,6 +47,7 @@ import io.airbyte.scheduler.persistence.job_factory.SyncJobFactory;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,6 +57,7 @@ class JobSchedulerTest {
 
   private static final StandardSync STANDARD_SYNC;
   private static final StandardSyncSchedule STANDARD_SYNC_SCHEDULE;
+  private static final List<StandardSyncOperation> STANDARD_SYNC_OPERATIONS;
   private static final long JOB_ID = 12L;
   private Job previousJob;
 
@@ -71,6 +74,7 @@ class JobSchedulerTest {
     final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(Collections.singletonList(stream));
 
     final UUID connectionId = UUID.randomUUID();
+    final UUID operationId = UUID.randomUUID();
 
     STANDARD_SYNC = new StandardSync()
         .withConnectionId(connectionId)
@@ -79,10 +83,12 @@ class JobSchedulerTest {
         .withStatus(StandardSync.Status.ACTIVE)
         .withCatalog(catalog)
         .withSourceId(sourceId)
-        .withDestinationId(destinationId);
+        .withDestinationId(destinationId)
+        .withOperationIds(List.of(operationId));
 
     // empty. contents not needed for any of these unit tests.
     STANDARD_SYNC_SCHEDULE = new StandardSyncSchedule();
+    STANDARD_SYNC_OPERATIONS = List.of(new StandardSyncOperation().withOperationId(operationId));
   }
 
   private ConfigRepository configRepository;

--- a/airbyte-scheduler/app/src/test/java/io/airbyte/scheduler/app/worker_run/TemporalWorkerRunFactoryTest.java
+++ b/airbyte-scheduler/app/src/test/java/io/airbyte/scheduler/app/worker_run/TemporalWorkerRunFactoryTest.java
@@ -36,6 +36,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.JobResetConnectionConfig;
 import io.airbyte.config.JobSyncConfig;
+import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.scheduler.models.Job;
@@ -45,6 +46,7 @@ import io.airbyte.workers.temporal.TemporalResponse;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -89,11 +91,13 @@ class TemporalWorkerRunFactoryTest {
     final JobResetConnectionConfig resetConfig = new JobResetConnectionConfig()
         .withDestinationDockerImage("airbyte/fusion_reactor")
         .withDestinationConfiguration(Jsons.jsonNode(ImmutableMap.of("a", 1)))
+        .withOperationSequence(List.of(new StandardSyncOperation().withName("b")))
         .withConfiguredAirbyteCatalog(new ConfiguredAirbyteCatalog());
     final JobSyncConfig syncConfig = new JobSyncConfig()
         .withSourceDockerImage(WorkerConstants.RESET_JOB_SOURCE_DOCKER_IMAGE_STUB)
         .withDestinationDockerImage(resetConfig.getDestinationDockerImage())
         .withDestinationConfiguration(resetConfig.getDestinationConfiguration())
+        .withOperationSequence(List.of(new StandardSyncOperation().withName("b")))
         .withSourceConfiguration(Jsons.emptyObject())
         .withConfiguredAirbyteCatalog(resetConfig.getConfiguredAirbyteCatalog());
     when(job.getConfigType()).thenReturn(ConfigType.RESET_CONNECTION);

--- a/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/DefaultSchedulerJobClient.java
+++ b/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/DefaultSchedulerJobClient.java
@@ -27,11 +27,13 @@ package io.airbyte.scheduler.client;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.scheduler.models.Job;
 import io.airbyte.scheduler.persistence.JobCreator;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,14 +56,16 @@ public class DefaultSchedulerJobClient implements SchedulerJobClient {
                                       DestinationConnection destination,
                                       StandardSync standardSync,
                                       String sourceDockerImage,
-                                      String destinationDockerImage)
+                                      String destinationDockerImage,
+                                      List<StandardSyncOperation> standardSyncOperations)
       throws IOException {
     final Optional<Long> jobIdOptional = jobCreator.createSyncJob(
         source,
         destination,
         standardSync,
         sourceDockerImage,
-        destinationDockerImage);
+        destinationDockerImage,
+        standardSyncOperations);
 
     long jobId = jobIdOptional.isEmpty()
         ? jobPersistence.getLastReplicationJob(standardSync.getConnectionId()).orElseThrow(() -> new RuntimeException("No job available")).getId()
@@ -73,9 +77,11 @@ public class DefaultSchedulerJobClient implements SchedulerJobClient {
   @Override
   public Job createOrGetActiveResetConnectionJob(DestinationConnection destination,
                                                  StandardSync standardSync,
-                                                 String destinationDockerImage)
+                                                 String destinationDockerImage,
+                                                 List<StandardSyncOperation> standardSyncOperations)
       throws IOException {
-    final Optional<Long> jobIdOptional = jobCreator.createResetConnectionJob(destination, standardSync, destinationDockerImage);
+    final Optional<Long> jobIdOptional =
+        jobCreator.createResetConnectionJob(destination, standardSync, destinationDockerImage, standardSyncOperations);
 
     long jobId = jobIdOptional.isEmpty()
         ? jobPersistence.getLastReplicationJob(standardSync.getConnectionId()).orElseThrow(() -> new RuntimeException("No job available")).getId()

--- a/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/SchedulerJobClient.java
+++ b/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/SchedulerJobClient.java
@@ -27,8 +27,10 @@ package io.airbyte.scheduler.client;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.scheduler.models.Job;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Exposes a way of executing short-lived jobs as RPC calls. If it returns successfully, it
@@ -41,12 +43,14 @@ public interface SchedulerJobClient {
                                DestinationConnection destination,
                                StandardSync standardSync,
                                String sourceDockerImage,
-                               String destinationDockerImage)
+                               String destinationDockerImage,
+                               List<StandardSyncOperation> standardSyncOperations)
       throws IOException;
 
   Job createOrGetActiveResetConnectionJob(DestinationConnection destination,
                                           StandardSync standardSync,
-                                          String destinationDockerImage)
+                                          String destinationDockerImage,
+                                          List<StandardSyncOperation> standardSyncOperations)
       throws IOException;
 
 }

--- a/airbyte-scheduler/client/src/test/java/io/airbyte/scheduler/client/DefaultSchedulerJobClientTest.java
+++ b/airbyte-scheduler/client/src/test/java/io/airbyte/scheduler/client/DefaultSchedulerJobClientTest.java
@@ -36,6 +36,7 @@ import io.airbyte.scheduler.models.Job;
 import io.airbyte.scheduler.persistence.JobCreator;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,10 +66,11 @@ class DefaultSchedulerJobClientTest {
     final DestinationConnection destination = mock(DestinationConnection.class);
     final StandardSync standardSync = mock(StandardSync.class);
     final String destinationDockerImage = "airbyte/spaceport";
-    when(jobCreator.createSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage)).thenReturn(Optional.of(JOB_ID));
+    when(jobCreator.createSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage, List.of()))
+        .thenReturn(Optional.of(JOB_ID));
     when(jobPersistence.getJob(JOB_ID)).thenReturn(job);
 
-    assertEquals(job, client.createOrGetActiveSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage));
+    assertEquals(job, client.createOrGetActiveSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage, List.of()));
   }
 
   @Test
@@ -79,14 +81,14 @@ class DefaultSchedulerJobClientTest {
     final UUID connectionUuid = UUID.randomUUID();
     when(standardSync.getConnectionId()).thenReturn(connectionUuid);
     final String destinationDockerImage = "airbyte/spaceport";
-    when(jobCreator.createSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage)).thenReturn(Optional.empty());
+    when(jobCreator.createSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage, List.of())).thenReturn(Optional.empty());
 
     final Job currentJob = mock(Job.class);
     when(currentJob.getId()).thenReturn(42L);
     when(jobPersistence.getLastReplicationJob(connectionUuid)).thenReturn(Optional.of(currentJob));
     when(jobPersistence.getJob(42L)).thenReturn(currentJob);
 
-    assertEquals(currentJob, client.createOrGetActiveSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage));
+    assertEquals(currentJob, client.createOrGetActiveSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage, List.of()));
   }
 
   @Test
@@ -94,10 +96,10 @@ class DefaultSchedulerJobClientTest {
     final DestinationConnection destination = mock(DestinationConnection.class);
     final StandardSync standardSync = mock(StandardSync.class);
     final String destinationDockerImage = "airbyte/spaceport";
-    when(jobCreator.createResetConnectionJob(destination, standardSync, destinationDockerImage)).thenReturn(Optional.of(JOB_ID));
+    when(jobCreator.createResetConnectionJob(destination, standardSync, destinationDockerImage, List.of())).thenReturn(Optional.of(JOB_ID));
     when(jobPersistence.getJob(JOB_ID)).thenReturn(job);
 
-    assertEquals(job, client.createOrGetActiveResetConnectionJob(destination, standardSync, destinationDockerImage));
+    assertEquals(job, client.createOrGetActiveResetConnectionJob(destination, standardSync, destinationDockerImage, List.of()));
   }
 
   @Test
@@ -107,14 +109,14 @@ class DefaultSchedulerJobClientTest {
     final UUID connectionUuid = UUID.randomUUID();
     when(standardSync.getConnectionId()).thenReturn(connectionUuid);
     final String destinationDockerImage = "airbyte/spaceport";
-    when(jobCreator.createResetConnectionJob(destination, standardSync, destinationDockerImage)).thenReturn(Optional.empty());
+    when(jobCreator.createResetConnectionJob(destination, standardSync, destinationDockerImage, List.of())).thenReturn(Optional.empty());
 
     final Job currentJob = mock(Job.class);
     when(currentJob.getId()).thenReturn(42L);
     when(jobPersistence.getLastReplicationJob(connectionUuid)).thenReturn(Optional.of(currentJob));
     when(jobPersistence.getJob(42L)).thenReturn(currentJob);
 
-    assertEquals(currentJob, client.createOrGetActiveResetConnectionJob(destination, standardSync, destinationDockerImage));
+    assertEquals(currentJob, client.createOrGetActiveResetConnectionJob(destination, standardSync, destinationDockerImage, List.of()));
   }
 
 }

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
@@ -34,10 +34,12 @@ import io.airbyte.config.JobResetConnectionConfig;
 import io.airbyte.config.JobSyncConfig;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.DestinationSyncMode;
 import io.airbyte.protocol.models.SyncMode;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 public class DefaultJobCreator implements JobCreator {
@@ -104,7 +106,8 @@ public class DefaultJobCreator implements JobCreator {
                                       DestinationConnection destination,
                                       StandardSync standardSync,
                                       String sourceDockerImageName,
-                                      String destinationDockerImageName)
+                                      String destinationDockerImageName,
+                                      List<StandardSyncOperation> standardSyncOperations)
       throws IOException {
     // reusing this isn't going to quite work.
     final JobSyncConfig jobSyncConfig = new JobSyncConfig()
@@ -113,6 +116,7 @@ public class DefaultJobCreator implements JobCreator {
         .withSourceConfiguration(source.getConfiguration())
         .withDestinationDockerImage(destinationDockerImageName)
         .withDestinationConfiguration(destination.getConfiguration())
+        .withOperationSequence(standardSyncOperations)
         .withConfiguredAirbyteCatalog(standardSync.getCatalog())
         .withState(null);
 
@@ -132,7 +136,10 @@ public class DefaultJobCreator implements JobCreator {
   // 4. The Empty source emits no state message, so state will start at null (i.e. start from the
   // beginning on the next sync).
   @Override
-  public Optional<Long> createResetConnectionJob(DestinationConnection destination, StandardSync standardSync, String destinationDockerImage)
+  public Optional<Long> createResetConnectionJob(DestinationConnection destination,
+                                                 StandardSync standardSync,
+                                                 String destinationDockerImage,
+                                                 List<StandardSyncOperation> standardSyncOperations)
       throws IOException {
     final ConfiguredAirbyteCatalog configuredAirbyteCatalog = standardSync.getCatalog();
     configuredAirbyteCatalog.getStreams().forEach(configuredAirbyteStream -> {
@@ -144,6 +151,7 @@ public class DefaultJobCreator implements JobCreator {
         .withPrefix(standardSync.getPrefix())
         .withDestinationDockerImage(destinationDockerImage)
         .withDestinationConfiguration(destination.getConfiguration())
+        .withOperationSequence(standardSyncOperations)
         .withConfiguredAirbyteCatalog(configuredAirbyteCatalog);
 
     final JobConfig jobConfig = new JobConfig()

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobCreator.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobCreator.java
@@ -27,7 +27,9 @@ package io.airbyte.scheduler.persistence;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSyncOperation;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 public interface JobCreator {
@@ -54,7 +56,8 @@ public interface JobCreator {
                                DestinationConnection destination,
                                StandardSync standardSync,
                                String sourceDockerImage,
-                               String destinationDockerImage)
+                               String destinationDockerImage,
+                               List<StandardSyncOperation> standardSyncOperations)
       throws IOException;
 
   /**
@@ -65,7 +68,10 @@ public interface JobCreator {
    * @return the new job if no other conflicting job was running, otherwise empty
    * @throws IOException if something wrong happens
    */
-  Optional<Long> createResetConnectionJob(DestinationConnection destination, StandardSync standardSync, String destinationDockerImage)
+  Optional<Long> createResetConnectionJob(DestinationConnection destination,
+                                          StandardSync standardSync,
+                                          String destinationDockerImage,
+                                          List<StandardSyncOperation> standardSyncOperations)
       throws IOException;
 
 }

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/DefaultSyncJobFactory.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/DefaultSyncJobFactory.java
@@ -24,17 +24,20 @@
 
 package io.airbyte.scheduler.persistence.job_factory;
 
+import com.google.common.collect.Lists;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.scheduler.persistence.DefaultJobCreator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 
 public class DefaultSyncJobFactory implements SyncJobFactory {
@@ -63,12 +66,19 @@ public class DefaultSyncJobFactory implements SyncJobFactory {
       final String destinationImageName =
           DockerUtils.getTaggedImageName(destinationDefinition.getDockerRepository(), destinationDefinition.getDockerImageTag());
 
+      final List<StandardSyncOperation> standardSyncOperations = Lists.newArrayList();
+      for (var operationId : standardSync.getOperationIds()) {
+        final StandardSyncOperation standardSyncOperation = configRepository.getStandardSyncOperation(operationId);
+        standardSyncOperations.add(standardSyncOperation);
+      }
+
       return jobCreator.createSyncJob(
           sourceConnection,
           destinationConnection,
           standardSync,
           sourceImageName,
-          destinationImageName)
+          destinationImageName,
+          standardSyncOperations)
           .orElseThrow(() -> new IllegalStateException("We shouldn't be trying to create a new sync job if there is one running already."));
 
     } catch (IOException | JsonValidationException | ConfigNotFoundException e) {

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
@@ -40,8 +40,12 @@ import io.airbyte.config.JobDiscoverCatalogConfig;
 import io.airbyte.config.JobGetSpecConfig;
 import io.airbyte.config.JobResetConnectionConfig;
 import io.airbyte.config.JobSyncConfig;
+import io.airbyte.config.OperatorNormalization;
+import io.airbyte.config.OperatorNormalization.Option;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSyncOperation;
+import io.airbyte.config.StandardSyncOperation.OperatorType;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
@@ -50,6 +54,7 @@ import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,6 +70,7 @@ public class DefaultJobCreatorTest {
   private static final SourceConnection SOURCE_CONNECTION;
   private static final DestinationConnection DESTINATION_CONNECTION;
   private static final StandardSync STANDARD_SYNC;
+  private static final StandardSyncOperation STANDARD_SYNC_OPERATION;
   private static final long JOB_ID = 12L;
 
   private JobPersistence jobPersistence;
@@ -102,6 +108,7 @@ public class DefaultJobCreatorTest {
     final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(Collections.singletonList(stream));
 
     final UUID connectionId = UUID.randomUUID();
+    final UUID operationId = UUID.randomUUID();
 
     STANDARD_SYNC = new StandardSync()
         .withConnectionId(connectionId)
@@ -110,7 +117,15 @@ public class DefaultJobCreatorTest {
         .withStatus(StandardSync.Status.ACTIVE)
         .withCatalog(catalog)
         .withSourceId(sourceId)
-        .withDestinationId(destinationId);
+        .withDestinationId(destinationId)
+        .withOperationIds(List.of(operationId));
+
+    STANDARD_SYNC_OPERATION = new StandardSyncOperation()
+        .withOperationId(operationId)
+        .withName("normalize")
+        .withTombstone(false)
+        .withOperatorType(OperatorType.NORMALIZATION)
+        .withOperatorNormalization(new OperatorNormalization().withOption(Option.BASIC));
   }
 
   @BeforeEach
@@ -192,7 +207,8 @@ public class DefaultJobCreatorTest {
         .withSourceDockerImage(SOURCE_IMAGE_NAME)
         .withDestinationConfiguration(DESTINATION_CONNECTION.getConfiguration())
         .withDestinationDockerImage(DESTINATION_IMAGE_NAME)
-        .withConfiguredAirbyteCatalog(STANDARD_SYNC.getCatalog());
+        .withConfiguredAirbyteCatalog(STANDARD_SYNC.getCatalog())
+        .withOperationSequence(List.of(STANDARD_SYNC_OPERATION));
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(JobConfig.ConfigType.SYNC)
@@ -206,7 +222,8 @@ public class DefaultJobCreatorTest {
         DESTINATION_CONNECTION,
         STANDARD_SYNC,
         SOURCE_IMAGE_NAME,
-        DESTINATION_IMAGE_NAME).orElseThrow();
+        DESTINATION_IMAGE_NAME,
+        List.of(STANDARD_SYNC_OPERATION)).orElseThrow();
     assertEquals(JOB_ID, jobId);
   }
 
@@ -218,7 +235,8 @@ public class DefaultJobCreatorTest {
         .withSourceDockerImage(SOURCE_IMAGE_NAME)
         .withDestinationConfiguration(DESTINATION_CONNECTION.getConfiguration())
         .withDestinationDockerImage(DESTINATION_IMAGE_NAME)
-        .withConfiguredAirbyteCatalog(STANDARD_SYNC.getCatalog());
+        .withConfiguredAirbyteCatalog(STANDARD_SYNC.getCatalog())
+        .withOperationSequence(List.of(STANDARD_SYNC_OPERATION));
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(JobConfig.ConfigType.SYNC)
@@ -232,7 +250,8 @@ public class DefaultJobCreatorTest {
         DESTINATION_CONNECTION,
         STANDARD_SYNC,
         SOURCE_IMAGE_NAME,
-        DESTINATION_IMAGE_NAME).isEmpty());
+        DESTINATION_IMAGE_NAME,
+        List.of(STANDARD_SYNC_OPERATION)).isEmpty());
   }
 
   @Test
@@ -248,7 +267,8 @@ public class DefaultJobCreatorTest {
         .withPrefix(STANDARD_SYNC.getPrefix())
         .withDestinationConfiguration(DESTINATION_CONNECTION.getConfiguration())
         .withDestinationDockerImage(DESTINATION_IMAGE_NAME)
-        .withConfiguredAirbyteCatalog(expectedCatalog);
+        .withConfiguredAirbyteCatalog(expectedCatalog)
+        .withOperationSequence(List.of(STANDARD_SYNC_OPERATION));
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(ConfigType.RESET_CONNECTION)
@@ -260,7 +280,8 @@ public class DefaultJobCreatorTest {
     final long jobId = jobCreator.createResetConnectionJob(
         DESTINATION_CONNECTION,
         STANDARD_SYNC,
-        DESTINATION_IMAGE_NAME).orElseThrow();
+        DESTINATION_IMAGE_NAME,
+        List.of(STANDARD_SYNC_OPERATION)).orElseThrow();
     assertEquals(JOB_ID, jobId);
   }
 
@@ -277,7 +298,8 @@ public class DefaultJobCreatorTest {
         .withPrefix(STANDARD_SYNC.getPrefix())
         .withDestinationConfiguration(DESTINATION_CONNECTION.getConfiguration())
         .withDestinationDockerImage(DESTINATION_IMAGE_NAME)
-        .withConfiguredAirbyteCatalog(expectedCatalog);
+        .withConfiguredAirbyteCatalog(expectedCatalog)
+        .withOperationSequence(List.of(STANDARD_SYNC_OPERATION));
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(ConfigType.RESET_CONNECTION)
@@ -289,7 +311,8 @@ public class DefaultJobCreatorTest {
     assertTrue(jobCreator.createResetConnectionJob(
         DESTINATION_CONNECTION,
         STANDARD_SYNC,
-        DESTINATION_IMAGE_NAME).isEmpty());
+        DESTINATION_IMAGE_NAME,
+        List.of(STANDARD_SYNC_OPERATION)).isEmpty());
   }
 
 }

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_factory/DefaultSyncJobFactoryTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_factory/DefaultSyncJobFactoryTest.java
@@ -35,11 +35,13 @@ import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.scheduler.persistence.DefaultJobCreator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -53,13 +55,17 @@ class DefaultSyncJobFactoryTest {
     final UUID connectionId = UUID.randomUUID();
     final UUID sourceId = UUID.randomUUID();
     final UUID destinationId = UUID.randomUUID();
+    final UUID operationId = UUID.randomUUID();
     final DefaultJobCreator jobCreator = mock(DefaultJobCreator.class);
     final ConfigRepository configRepository = mock(ConfigRepository.class);
     final long jobId = 11L;
 
+    final StandardSyncOperation operation = new StandardSyncOperation().withOperationId(operationId);
+    final List<StandardSyncOperation> operations = List.of(operation);
     final StandardSync standardSync = new StandardSync()
         .withSourceId(sourceId)
-        .withDestinationId(destinationId);
+        .withDestinationId(destinationId)
+        .withOperationIds(List.of(operationId));
 
     final SourceConnection sourceConnection = new SourceConnection().withSourceDefinitionId(sourceDefinitionId);
     final DestinationConnection destinationConnection =
@@ -75,7 +81,8 @@ class DefaultSyncJobFactoryTest {
     when(configRepository.getStandardSync(connectionId)).thenReturn(standardSync);
     when(configRepository.getSourceConnection(sourceId)).thenReturn(sourceConnection);
     when(configRepository.getDestinationConnection(destinationId)).thenReturn(destinationConnection);
-    when(jobCreator.createSyncJob(sourceConnection, destinationConnection, standardSync, srcDockerImage, dstDockerImage))
+    when(configRepository.getStandardSyncOperation(operationId)).thenReturn(operation);
+    when(jobCreator.createSyncJob(sourceConnection, destinationConnection, standardSync, srcDockerImage, dstDockerImage, operations))
         .thenReturn(Optional.of(jobId));
     when(configRepository.getStandardSourceDefinition(sourceDefinitionId))
         .thenReturn(new StandardSourceDefinition().withSourceDefinitionId(sourceDefinitionId).withDockerRepository(srcDockerRepo)
@@ -90,7 +97,7 @@ class DefaultSyncJobFactoryTest {
     assertEquals(jobId, actualJobId);
 
     verify(jobCreator)
-        .createSyncJob(sourceConnection, destinationConnection, standardSync, srcDockerImage, dstDockerImage);
+        .createSyncJob(sourceConnection, destinationConnection, standardSync, srcDockerImage, dstDockerImage, operations);
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -52,6 +52,11 @@ import io.airbyte.api.model.JobReadList;
 import io.airbyte.api.model.LogsRequestBody;
 import io.airbyte.api.model.Notification;
 import io.airbyte.api.model.NotificationRead;
+import io.airbyte.api.model.OperationCreate;
+import io.airbyte.api.model.OperationIdRequestBody;
+import io.airbyte.api.model.OperationRead;
+import io.airbyte.api.model.OperationReadList;
+import io.airbyte.api.model.OperationUpdate;
 import io.airbyte.api.model.SlugRequestBody;
 import io.airbyte.api.model.SourceCoreConfig;
 import io.airbyte.api.model.SourceCreate;
@@ -93,6 +98,7 @@ import io.airbyte.server.handlers.HealthCheckHandler;
 import io.airbyte.server.handlers.JobHistoryHandler;
 import io.airbyte.server.handlers.LogsHandler;
 import io.airbyte.server.handlers.OpenApiConfigHandler;
+import io.airbyte.server.handlers.OperationsHandler;
 import io.airbyte.server.handlers.SchedulerHandler;
 import io.airbyte.server.handlers.SourceDefinitionsHandler;
 import io.airbyte.server.handlers.SourceHandler;
@@ -118,6 +124,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   private final DestinationDefinitionsHandler destinationDefinitionsHandler;
   private final DestinationHandler destinationHandler;
   private final ConnectionsHandler connectionsHandler;
+  private final OperationsHandler operationsHandler;
   private final SchedulerHandler schedulerHandler;
   private final JobHistoryHandler jobHistoryHandler;
   private final WebBackendConnectionsHandler webBackendConnectionsHandler;
@@ -152,6 +159,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
     final DockerImageValidator dockerImageValidator = new DockerImageValidator(synchronousSchedulerClient);
     sourceDefinitionsHandler = new SourceDefinitionsHandler(configRepository, dockerImageValidator, synchronousSchedulerClient);
     connectionsHandler = new ConnectionsHandler(configRepository);
+    operationsHandler = new OperationsHandler(configRepository);
     destinationDefinitionsHandler = new DestinationDefinitionsHandler(configRepository, dockerImageValidator, synchronousSchedulerClient);
     destinationHandler = new DestinationHandler(configRepository, schemaValidator, specFetcher, connectionsHandler);
     sourceHandler = new SourceHandler(configRepository, schemaValidator, specFetcher, connectionsHandler);
@@ -162,7 +170,8 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
         sourceHandler,
         destinationHandler,
         jobHistoryHandler,
-        schedulerHandler);
+        schedulerHandler,
+        operationsHandler);
     webBackendSourceHandler = new WebBackendSourceHandler(sourceHandler, schedulerHandler);
     webBackendDestinationHandler = new WebBackendDestinationHandler(destinationHandler, schedulerHandler);
     healthCheckHandler = new HealthCheckHandler(configRepository);
@@ -240,6 +249,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   public SourceDefinitionSpecificationRead getSourceDefinitionSpecification(@Valid SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody) {
     return execute(() -> schedulerHandler.getSourceDefinitionSpecification(sourceDefinitionIdRequestBody));
   }
+
   // SOURCE IMPLEMENTATION
 
   @Override
@@ -387,7 +397,6 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
       connectionsHandler.deleteConnection(connectionIdRequestBody);
       return null;
     });
-
   }
 
   @Override
@@ -398,6 +407,36 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   @Override
   public JobInfoRead resetConnection(@Valid ConnectionIdRequestBody connectionIdRequestBody) {
     return execute(() -> schedulerHandler.resetConnection(connectionIdRequestBody));
+  }
+
+  // Operations
+
+  @Override
+  public OperationRead createOperation(@Valid OperationCreate operationCreate) {
+    return execute(() -> operationsHandler.createOperation(operationCreate));
+  }
+
+  @Override
+  public void deleteOperation(OperationIdRequestBody operationIdRequestBody) {
+    execute(() -> {
+      operationsHandler.deleteOperation(operationIdRequestBody);
+      return null;
+    });
+  }
+
+  @Override
+  public OperationReadList listOperationsForConnection(ConnectionIdRequestBody connectionIdRequestBody) {
+    return execute(() -> operationsHandler.listOperationsForConnection(connectionIdRequestBody));
+  }
+
+  @Override
+  public OperationRead getOperation(OperationIdRequestBody operationIdRequestBody) {
+    return execute(() -> operationsHandler.getOperation(operationIdRequestBody));
+  }
+
+  @Override
+  public OperationRead updateOperation(OperationUpdate operationUpdate) {
+    return execute(() -> operationsHandler.updateOperation(operationUpdate));
   }
 
   // SCHEDULER

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -86,6 +86,7 @@ public class ConnectionsHandler {
         .withPrefix(connectionCreate.getPrefix())
         .withSourceId(connectionCreate.getSourceId())
         .withDestinationId(connectionCreate.getDestinationId())
+        .withOperationIds(connectionCreate.getOperationIds())
         .withStatus(toPersistenceStatus(connectionCreate.getStatus()));
 
     // TODO Undesirable behavior: sending a null configured catalog should not be valid?
@@ -155,6 +156,7 @@ public class ConnectionsHandler {
     // retrieve sync
     final StandardSync persistedSync = configRepository.getStandardSync(connectionUpdate.getConnectionId())
         .withPrefix(connectionUpdate.getPrefix())
+        .withOperationIds(connectionUpdate.getOperationIds())
         .withCatalog(CatalogConverter.toProtocol(connectionUpdate.getSyncCatalog()))
         .withStatus(toPersistenceStatus(connectionUpdate.getStatus()));
 
@@ -257,6 +259,7 @@ public class ConnectionsHandler {
         .connectionId(standardSync.getConnectionId())
         .sourceId(standardSync.getSourceId())
         .destinationId(standardSync.getDestinationId())
+        .operationIds(standardSync.getOperationIds())
         .status(toApiStatus(standardSync.getStatus()))
         .schedule(apiSchedule)
         .name(standardSync.getName())

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -219,6 +219,7 @@ public class ConnectionsHandler {
     final ConnectionUpdate connectionUpdate = new ConnectionUpdate()
         .prefix(connectionRead.getPrefix())
         .connectionId(connectionRead.getConnectionId())
+        .operationIds(connectionRead.getOperationIds())
         .syncCatalog(connectionRead.getSyncCatalog())
         .schedule(connectionRead.getSchedule())
         .status(ConnectionStatus.DEPRECATED);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/OperationsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/OperationsHandler.java
@@ -31,7 +31,6 @@ import io.airbyte.api.model.OperationCreate;
 import io.airbyte.api.model.OperationIdRequestBody;
 import io.airbyte.api.model.OperationRead;
 import io.airbyte.api.model.OperationReadList;
-import io.airbyte.api.model.OperationStatus;
 import io.airbyte.api.model.OperationUpdate;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
@@ -88,12 +87,7 @@ public class OperationsHandler {
   }
 
   public void deleteOperation(OperationRead operationRead) throws ConfigNotFoundException, IOException, JsonValidationException {
-    final OperationUpdate operationUpdate = new OperationUpdate()
-        .operationId(operationRead.getOperationId())
-        .name(operationRead.getName())
-        .operatorConfiguration(operationRead.getOperatorConfiguration())
-        .status(OperationStatus.DEPRECATED);
-    updateOperation(operationUpdate);
+    // TODO chris: to implement in next PR on custom-dbt-config
   }
 
   private OperationRead buildOperationRead(UUID operationId)

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/OperationsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/OperationsHandler.java
@@ -1,0 +1,105 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.server.handlers;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import io.airbyte.api.model.ConnectionIdRequestBody;
+import io.airbyte.api.model.OperationCreate;
+import io.airbyte.api.model.OperationIdRequestBody;
+import io.airbyte.api.model.OperationRead;
+import io.airbyte.api.model.OperationReadList;
+import io.airbyte.api.model.OperationStatus;
+import io.airbyte.api.model.OperationUpdate;
+import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.validation.json.JsonValidationException;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+public class OperationsHandler {
+
+  private final ConfigRepository configRepository;
+  private final Supplier<UUID> uuidGenerator;
+
+  @VisibleForTesting
+  OperationsHandler(final ConfigRepository configRepository, final Supplier<UUID> uuidGenerator) {
+    this.configRepository = configRepository;
+    this.uuidGenerator = uuidGenerator;
+  }
+
+  public OperationsHandler(final ConfigRepository configRepository) {
+    this(configRepository, UUID::randomUUID);
+  }
+
+  public OperationRead createOperation(OperationCreate operationCreate)
+      throws JsonValidationException, IOException, ConfigNotFoundException {
+    final UUID operationId = uuidGenerator.get();
+    // TODO chris: to implement in next PR on custom-dbt-config
+    return buildOperationRead(operationId);
+  }
+
+  public OperationRead updateOperation(OperationUpdate operationUpdate)
+      throws ConfigNotFoundException, IOException, JsonValidationException {
+    // TODO chris: to implement in next PR on custom-dbt-config
+    return new OperationRead();
+  }
+
+  public OperationReadList listOperationsForConnection(ConnectionIdRequestBody connectionIdRequestBody)
+      throws JsonValidationException, ConfigNotFoundException, IOException {
+    final List<OperationRead> operationReads = Lists.newArrayList();
+    // TODO chris: to implement in next PR on custom-dbt-config
+    return new OperationReadList().operations(operationReads);
+  }
+
+  public OperationRead getOperation(OperationIdRequestBody operationIdRequestBody)
+      throws JsonValidationException, IOException, ConfigNotFoundException {
+    return buildOperationRead(operationIdRequestBody.getOperationId());
+  }
+
+  public void deleteOperation(OperationIdRequestBody operationIdRequestBody)
+      throws ConfigNotFoundException, IOException, JsonValidationException {
+    final OperationRead OperationRead = getOperation(operationIdRequestBody);
+    deleteOperation(OperationRead);
+  }
+
+  public void deleteOperation(OperationRead operationRead) throws ConfigNotFoundException, IOException, JsonValidationException {
+    final OperationUpdate operationUpdate = new OperationUpdate()
+        .operationId(operationRead.getOperationId())
+        .name(operationRead.getName())
+        .operatorConfiguration(operationRead.getOperatorConfiguration())
+        .status(OperationStatus.DEPRECATED);
+    updateOperation(operationUpdate);
+  }
+
+  private OperationRead buildOperationRead(UUID operationId)
+      throws ConfigNotFoundException, IOException, JsonValidationException {
+    // TODO chris: to implement in next PR on custom-dbt-config
+    return new OperationRead();
+  }
+
+}

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -58,6 +58,7 @@ public class ArchiveHandlerTest {
     verify(configRepository, never()).writeDestinationConnection(any());
     verify(configRepository, never()).writeStandardSync(any());
     verify(configRepository, never()).writeStandardSchedule(any());
+    verify(configRepository, never()).writeStandardSyncOperation(any());
   }
 
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -97,6 +97,7 @@ class ConnectionsHandlerTest {
     final ConnectionCreate connectionCreate = new ConnectionCreate()
         .sourceId(standardSync.getSourceId())
         .destinationId(standardSync.getDestinationId())
+        .operationIds(standardSync.getOperationIds())
         .name("presto to hudi")
         .prefix("presto_to_hudi")
         .status(ConnectionStatus.ACTIVE)
@@ -108,7 +109,8 @@ class ConnectionsHandlerTest {
     final ConnectionRead expectedConnectionRead = ConnectionHelpers.generateExpectedConnectionRead(
         standardSync.getConnectionId(),
         standardSync.getSourceId(),
-        standardSync.getDestinationId());
+        standardSync.getDestinationId(),
+        standardSync.getOperationIds());
 
     assertEquals(expectedConnectionRead, actualConnectionRead);
 
@@ -158,7 +160,8 @@ class ConnectionsHandlerTest {
     final ConnectionRead expectedConnectionRead = ConnectionHelpers.generateExpectedConnectionRead(
         standardSync.getConnectionId(),
         standardSync.getSourceId(),
-        standardSync.getDestinationId())
+        standardSync.getDestinationId(),
+        standardSync.getOperationIds())
         .schedule(null)
         .syncCatalog(catalog)
         .status(ConnectionStatus.INACTIVE);
@@ -209,11 +212,13 @@ class ConnectionsHandlerTest {
     final ConnectionRead connectionRead = ConnectionHelpers.generateExpectedConnectionRead(
         standardSync.getConnectionId(),
         standardSync.getSourceId(),
-        standardSync.getDestinationId());
+        standardSync.getDestinationId(),
+        standardSync.getOperationIds());
 
     final ConnectionUpdate expectedConnectionUpdate = new ConnectionUpdate()
         .prefix(connectionRead.getPrefix())
         .connectionId(connectionRead.getConnectionId())
+        .operationIds(connectionRead.getOperationIds())
         .status(ConnectionStatus.DEPRECATED)
         .syncCatalog(connectionRead.getSyncCatalog())
         .schedule(connectionRead.getSchedule());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/OperationsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/OperationsHandlerTest.java
@@ -1,0 +1,211 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.server.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.airbyte.api.model.ConnectionIdRequestBody;
+import io.airbyte.api.model.OperationCreate;
+import io.airbyte.api.model.OperationIdRequestBody;
+import io.airbyte.api.model.OperationRead;
+import io.airbyte.api.model.OperationReadList;
+import io.airbyte.api.model.OperationUpdate;
+import io.airbyte.api.model.OperatorConfiguration;
+import io.airbyte.api.model.OperatorDbt;
+import io.airbyte.api.model.OperatorNormalization;
+import io.airbyte.api.model.OperatorNormalization.OptionEnum;
+import io.airbyte.api.model.OperatorType;
+import io.airbyte.commons.enums.Enums;
+import io.airbyte.config.OperatorNormalization.Option;
+import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSyncOperation;
+import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.validation.json.JsonValidationException;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OperationsHandlerTest {
+
+  private ConfigRepository configRepository;
+  private Supplier<UUID> uuidGenerator;
+
+  private OperationsHandler operationsHandler;
+  private StandardSyncOperation standardSyncOperation;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() throws IOException {
+    configRepository = mock(ConfigRepository.class);
+    uuidGenerator = mock(Supplier.class);
+
+    operationsHandler = new OperationsHandler(configRepository, uuidGenerator);
+    standardSyncOperation = new StandardSyncOperation()
+        .withOperationId(UUID.randomUUID())
+        .withName("presto to hudi")
+        .withOperatorType(io.airbyte.config.StandardSyncOperation.OperatorType.NORMALIZATION)
+        .withOperatorNormalization(new io.airbyte.config.OperatorNormalization().withOption(Option.BASIC))
+        .withOperatorDbt(null)
+        .withTombstone(false);
+  }
+
+  @Test
+  void testCreateOperation() throws JsonValidationException, ConfigNotFoundException, IOException {
+    when(uuidGenerator.get()).thenReturn(standardSyncOperation.getOperationId());
+
+    when(configRepository.getStandardSyncOperation(standardSyncOperation.getOperationId())).thenReturn(standardSyncOperation);
+
+    final OperationCreate operationCreate = new OperationCreate()
+        .name(standardSyncOperation.getName())
+        .operatorConfiguration(new OperatorConfiguration()
+            .operatorType(OperatorType.NORMALIZATION)
+            .normalization(new OperatorNormalization().option(OptionEnum.BASIC)));
+
+    final OperationRead actualOperationRead = operationsHandler.createOperation(operationCreate);
+
+    final OperationRead expectedOperationRead = new OperationRead()
+        .operationId(standardSyncOperation.getOperationId())
+        .name(standardSyncOperation.getName())
+        .operatorConfiguration(new OperatorConfiguration()
+            .operatorType(OperatorType.NORMALIZATION)
+            .normalization(new OperatorNormalization().option(OptionEnum.BASIC)));
+
+    assertEquals(expectedOperationRead, actualOperationRead);
+
+    verify(configRepository).writeStandardSyncOperation(standardSyncOperation);
+  }
+
+  @Test
+  void testUpdateOperation() throws JsonValidationException, ConfigNotFoundException, IOException {
+    final OperationUpdate operationUpdate = new OperationUpdate()
+        .operationId(standardSyncOperation.getOperationId())
+        .name(standardSyncOperation.getName())
+        .operatorConfiguration(new OperatorConfiguration()
+            .operatorType(OperatorType.DBT)
+            .dbt(new OperatorDbt()
+                .gitRepoUrl("git_repo")
+                .dockerImage("docker")
+                .dbtArguments("--full-refresh")));
+
+    final StandardSyncOperation updatedStandardSyncOperation = new StandardSyncOperation()
+        .withOperationId(standardSyncOperation.getOperationId())
+        .withName(standardSyncOperation.getName())
+        .withOperatorType(io.airbyte.config.StandardSyncOperation.OperatorType.DBT)
+        .withOperatorDbt(new io.airbyte.config.OperatorDbt()
+            .withGitRepoUrl("git_repo")
+            .withDockerImage("docker")
+            .withDbtArguments("--full-refresh"))
+        .withOperatorNormalization(null)
+        .withTombstone(false);
+
+    when(configRepository.getStandardSyncOperation(standardSyncOperation.getOperationId())).thenReturn(standardSyncOperation)
+        .thenReturn(updatedStandardSyncOperation);
+
+    final OperationRead actualOperationRead = operationsHandler.updateOperation(operationUpdate);
+
+    final OperationRead expectedOperationRead = new OperationRead()
+        .operationId(standardSyncOperation.getOperationId())
+        .name(standardSyncOperation.getName())
+        .operatorConfiguration(new OperatorConfiguration()
+            .operatorType(OperatorType.DBT)
+            .dbt(new OperatorDbt()
+                .gitRepoUrl("git_repo")
+                .dockerImage("docker")
+                .dbtArguments("--full-refresh")));
+
+    assertEquals(expectedOperationRead, actualOperationRead);
+
+    verify(configRepository).writeStandardSyncOperation(updatedStandardSyncOperation);
+  }
+
+  @Test
+  void testGetOperation() throws JsonValidationException, ConfigNotFoundException, IOException {
+    when(configRepository.getStandardSyncOperation(standardSyncOperation.getOperationId())).thenReturn(standardSyncOperation);
+
+    final OperationIdRequestBody operationIdRequestBody = new OperationIdRequestBody().operationId(standardSyncOperation.getOperationId());
+    final OperationRead actualOperationRead = operationsHandler.getOperation(operationIdRequestBody);
+
+    final OperationRead expectedOperationRead = generateOperationRead();
+
+    assertEquals(expectedOperationRead, actualOperationRead);
+  }
+
+  private OperationRead generateOperationRead() {
+    return new OperationRead()
+        .operationId(standardSyncOperation.getOperationId())
+        .name(standardSyncOperation.getName())
+        .operatorConfiguration(new OperatorConfiguration()
+            .operatorType(OperatorType.NORMALIZATION)
+            .normalization(new OperatorNormalization().option(OptionEnum.BASIC)));
+  }
+
+  @Test
+  void testListOperationsForConnection() throws JsonValidationException, ConfigNotFoundException, IOException {
+    UUID connectionId = UUID.randomUUID();
+
+    when(configRepository.getStandardSync(connectionId))
+        .thenReturn(new StandardSync()
+            .withOperationIds(List.of(standardSyncOperation.getOperationId())));
+
+    when(configRepository.getStandardSyncOperation(standardSyncOperation.getOperationId()))
+        .thenReturn(standardSyncOperation);
+
+    when(configRepository.listStandardSyncOperations())
+        .thenReturn(List.of(standardSyncOperation));
+
+    final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody().connectionId(connectionId);
+    final OperationReadList actualOperationReadList = operationsHandler.listOperationsForConnection(connectionIdRequestBody);
+
+    assertEquals(generateOperationRead(), actualOperationReadList.getOperations().get(0));
+  }
+
+  @Test
+  void testDeleteOperation() throws JsonValidationException, IOException, ConfigNotFoundException {
+    final OperationIdRequestBody operationIdRequestBody = new OperationIdRequestBody().operationId(standardSyncOperation.getOperationId());
+
+    final OperationsHandler spiedOperationsHandler = spy(operationsHandler);
+    when(configRepository.getStandardSyncOperation(standardSyncOperation.getOperationId())).thenReturn(standardSyncOperation);
+
+    spiedOperationsHandler.deleteOperation(operationIdRequestBody);
+
+    verify(configRepository).writeStandardSyncOperation(standardSyncOperation.withTombstone(true));
+  }
+
+  @Test
+  void testEnumConversion() {
+    assertTrue(Enums.isCompatible(io.airbyte.api.model.OperatorType.class, io.airbyte.config.StandardSyncOperation.OperatorType.class));
+    assertTrue(Enums.isCompatible(io.airbyte.api.model.OperatorNormalization.OptionEnum.class, io.airbyte.config.OperatorNormalization.Option.class));
+  }
+
+}

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -53,7 +53,6 @@ import io.airbyte.api.model.JobRead;
 import io.airbyte.api.model.JobReadList;
 import io.airbyte.api.model.JobStatus;
 import io.airbyte.api.model.JobWithAttemptsRead;
-import io.airbyte.api.model.OperationRead;
 import io.airbyte.api.model.OperationReadList;
 import io.airbyte.api.model.SourceDiscoverSchemaRead;
 import io.airbyte.api.model.SourceIdRequestBody;
@@ -126,10 +125,7 @@ class WebBackendConnectionsHandlerTest {
 
     final StandardSync standardSync = ConnectionHelpers.generateSyncWithSourceId(source.getSourceId());
     connectionRead = ConnectionHelpers.generateExpectedConnectionRead(standardSync);
-    operationReadList = new OperationReadList()
-        .operations(List.of(new OperationRead()
-            .operationId(connectionRead.getOperationIds().get(0))
-            .name("Test Operation")));
+    operationReadList = new OperationReadList().operations(List.of());
 
     final SourceIdRequestBody sourceIdRequestBody = new SourceIdRequestBody();
     sourceIdRequestBody.setSourceId(connectionRead.getSourceId());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -53,6 +53,7 @@ import io.airbyte.api.model.JobRead;
 import io.airbyte.api.model.JobReadList;
 import io.airbyte.api.model.JobStatus;
 import io.airbyte.api.model.JobWithAttemptsRead;
+import io.airbyte.api.model.OperationRead;
 import io.airbyte.api.model.OperationReadList;
 import io.airbyte.api.model.SourceDiscoverSchemaRead;
 import io.airbyte.api.model.SourceIdRequestBody;
@@ -125,7 +126,10 @@ class WebBackendConnectionsHandlerTest {
 
     final StandardSync standardSync = ConnectionHelpers.generateSyncWithSourceId(source.getSourceId());
     connectionRead = ConnectionHelpers.generateExpectedConnectionRead(standardSync);
-    operationReadList = new OperationReadList().operations(List.of());
+    operationReadList = new OperationReadList()
+        .operations(List.of(new OperationRead()
+            .operationId(connectionRead.getOperationIds().get(0))
+            .name("Test Operation")));
 
     final SourceIdRequestBody sourceIdRequestBody = new SourceIdRequestBody();
     sourceIdRequestBody.setSourceId(connectionRead.getSourceId());

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
@@ -63,7 +63,8 @@ public class ConnectionHelpers {
         .withStatus(StandardSync.Status.ACTIVE)
         .withCatalog(generateBasicConfiguredAirbyteCatalog())
         .withSourceId(sourceId)
-        .withDestinationId(UUID.randomUUID());
+        .withDestinationId(UUID.randomUUID())
+        .withOperationIds(List.of(UUID.randomUUID()));
   }
 
   public static StandardSync generateSyncWithDestinationId(UUID destinationId) {
@@ -76,7 +77,8 @@ public class ConnectionHelpers {
         .withStatus(StandardSync.Status.ACTIVE)
         .withCatalog(generateBasicConfiguredAirbyteCatalog())
         .withSourceId(UUID.randomUUID())
-        .withDestinationId(destinationId);
+        .withDestinationId(destinationId)
+        .withOperationIds(List.of(UUID.randomUUID()));
   }
 
   public static ConnectionSchedule generateBasicSchedule() {
@@ -87,12 +89,14 @@ public class ConnectionHelpers {
 
   public static ConnectionRead generateExpectedConnectionRead(UUID connectionId,
                                                               UUID sourceId,
-                                                              UUID destinationId) {
+                                                              UUID destinationId,
+                                                              List<UUID> operationIds) {
 
     return new ConnectionRead()
         .connectionId(connectionId)
         .sourceId(sourceId)
         .destinationId(destinationId)
+        .operationIds(operationIds)
         .name("presto to hudi")
         .prefix("presto_to_hudi")
         .status(ConnectionStatus.ACTIVE)
@@ -104,7 +108,8 @@ public class ConnectionHelpers {
     return generateExpectedConnectionRead(
         standardSync.getConnectionId(),
         standardSync.getSourceId(),
-        standardSync.getDestinationId());
+        standardSync.getDestinationId(),
+        standardSync.getOperationIds());
   }
 
   public static StandardSyncSchedule generateSchedule(UUID connectionId) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -113,6 +113,7 @@ public class TemporalClient {
         .withPrefix(config.getPrefix())
         .withSourceConfiguration(config.getSourceConfiguration())
         .withDestinationConfiguration(config.getDestinationConfiguration())
+        .withOperationSequence(config.getOperationSequence())
         .withCatalog(config.getConfiguredAirbyteCatalog())
         .withState(config.getState());
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/TestConfigHelpers.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/TestConfigHelpers.java
@@ -38,6 +38,7 @@ import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -56,6 +57,7 @@ public class TestConfigHelpers {
     final UUID destinationDefinitionId = UUID.randomUUID();
     final UUID destinationId = UUID.randomUUID();
     final UUID connectionId = UUID.randomUUID();
+    final UUID operationId = UUID.randomUUID();
 
     final JsonNode sourceConnection =
         Jsons.jsonNode(
@@ -94,7 +96,8 @@ public class TestConfigHelpers {
         .withStatus(Status.ACTIVE)
         .withName(CONNECTION_NAME)
         .withPrefix(CONNECTION_NAME)
-        .withCatalog(catalog);
+        .withCatalog(catalog)
+        .withOperationIds(List.of(operationId));
 
     final String stateValue = Jsons.serialize(Map.of("lastSync", String.valueOf(LAST_SYNC_TIME)));
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
@@ -48,6 +48,7 @@ import io.temporal.client.WorkflowClient;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -178,11 +179,13 @@ class TemporalClientTest {
           .withSourceDockerImage(IMAGE_NAME2)
           .withSourceConfiguration(Jsons.emptyObject())
           .withDestinationConfiguration(Jsons.emptyObject())
+          .withOperationSequence(List.of())
           .withConfiguredAirbyteCatalog(new ConfiguredAirbyteCatalog());
       final StandardSyncInput input = new StandardSyncInput()
           .withPrefix(syncConfig.getPrefix())
           .withSourceConfiguration(syncConfig.getSourceConfiguration())
           .withDestinationConfiguration(syncConfig.getDestinationConfiguration())
+          .withOperationSequence(syncConfig.getOperationSequence())
           .withCatalog(syncConfig.getConfiguredAirbyteCatalog())
           .withState(syncConfig.getState());
 

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -2406,7 +2406,9 @@ font-style: italic;
   "name" : "name",
   "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "operatorConfiguration" : {
-    "normalization" : "{}",
+    "normalization" : {
+      "option" : "basic"
+    },
     "dbt" : {
       "dockerImage" : "dockerImage",
       "dbtArguments" : "dbtArguments",
@@ -2512,7 +2514,9 @@ font-style: italic;
   "name" : "name",
   "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "operatorConfiguration" : {
-    "normalization" : "{}",
+    "normalization" : {
+      "option" : "basic"
+    },
     "dbt" : {
       "dockerImage" : "dockerImage",
       "dbtArguments" : "dbtArguments",
@@ -2580,7 +2584,9 @@ font-style: italic;
     "name" : "name",
     "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     "operatorConfiguration" : {
-      "normalization" : "{}",
+      "normalization" : {
+        "option" : "basic"
+      },
       "dbt" : {
         "dockerImage" : "dockerImage",
         "dbtArguments" : "dbtArguments",
@@ -2591,7 +2597,9 @@ font-style: italic;
     "name" : "name",
     "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     "operatorConfiguration" : {
-      "normalization" : "{}",
+      "normalization" : {
+        "option" : "basic"
+      },
       "dbt" : {
         "dockerImage" : "dockerImage",
         "dbtArguments" : "dbtArguments",
@@ -2659,7 +2667,9 @@ font-style: italic;
   "name" : "name",
   "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "operatorConfiguration" : {
-    "normalization" : "{}",
+    "normalization" : {
+      "option" : "basic"
+    },
     "dbt" : {
       "dockerImage" : "dockerImage",
       "dbtArguments" : "dbtArguments",
@@ -3904,7 +3914,9 @@ font-style: italic;
       "name" : "name",
       "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
       "operatorConfiguration" : {
-        "normalization" : "{}",
+        "normalization" : {
+          "option" : "basic"
+        },
         "dbt" : {
           "dockerImage" : "dockerImage",
           "dbtArguments" : "dbtArguments",
@@ -3915,7 +3927,9 @@ font-style: italic;
       "name" : "name",
       "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
       "operatorConfiguration" : {
-        "normalization" : "{}",
+        "normalization" : {
+          "option" : "basic"
+        },
         "dbt" : {
           "dockerImage" : "dockerImage",
           "dbtArguments" : "dbtArguments",
@@ -4052,7 +4066,9 @@ font-style: italic;
         "name" : "name",
         "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
         "operatorConfiguration" : {
-          "normalization" : "{}",
+          "normalization" : {
+            "option" : "basic"
+          },
           "dbt" : {
             "dockerImage" : "dockerImage",
             "dbtArguments" : "dbtArguments",
@@ -4063,7 +4079,9 @@ font-style: italic;
         "name" : "name",
         "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
         "operatorConfiguration" : {
-          "normalization" : "{}",
+          "normalization" : {
+            "option" : "basic"
+          },
           "dbt" : {
             "dockerImage" : "dockerImage",
             "dbtArguments" : "dbtArguments",
@@ -4143,7 +4161,9 @@ font-style: italic;
         "name" : "name",
         "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
         "operatorConfiguration" : {
-          "normalization" : "{}",
+          "normalization" : {
+            "option" : "basic"
+          },
           "dbt" : {
             "dockerImage" : "dockerImage",
             "dbtArguments" : "dbtArguments",
@@ -4154,7 +4174,9 @@ font-style: italic;
         "name" : "name",
         "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
         "operatorConfiguration" : {
-          "normalization" : "{}",
+          "normalization" : {
+            "option" : "basic"
+          },
           "dbt" : {
             "dockerImage" : "dockerImage",
             "dbtArguments" : "dbtArguments",
@@ -4845,6 +4867,7 @@ font-style: italic;
     <li><a href="#OperationUpdate"><code>OperationUpdate</code> - </a></li>
     <li><a href="#OperatorConfiguration"><code>OperatorConfiguration</code> - </a></li>
     <li><a href="#OperatorDbt"><code>OperatorDbt</code> - </a></li>
+    <li><a href="#OperatorNormalization"><code>OperatorNormalization</code> - </a></li>
     <li><a href="#OperatorType"><code>OperatorType</code> - </a></li>
     <li><a href="#SlackNotificationConfiguration"><code>SlackNotificationConfiguration</code> - </a></li>
     <li><a href="#SlugRequestBody"><code>SlugRequestBody</code> - </a></li>
@@ -5325,7 +5348,7 @@ font-style: italic;
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">operatorType </div><div class="param-desc"><span class="param-type"><a href="#OperatorType">OperatorType</a></span>  </div>
-<div class="param">normalization (optional)</div><div class="param-desc"><span class="param-type"><a href="#">Object</a></span>  </div>
+<div class="param">normalization (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperatorNormalization">OperatorNormalization</a></span>  </div>
 <div class="param">dbt (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperatorDbt">OperatorDbt</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
@@ -5336,6 +5359,15 @@ font-style: italic;
       <div class="param">gitRepoUrl </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dockerImage (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dbtArguments (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="OperatorNormalization"><code>OperatorNormalization</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">option (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+        <div class="param-enum-header">Enum:</div>
+        <div class="param-enum">basic</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -277,6 +277,14 @@ font-style: italic;
   <ul>
   <li><a href="#getOpenApiSpec"><code><span class="http-method">get</span> /v1/openapi</code></a></li>
   </ul>
+  <h4><a href="#Operation">Operation</a></h4>
+  <ul>
+  <li><a href="#createOperation"><code><span class="http-method">post</span> /v1/operations/create</code></a></li>
+  <li><a href="#deleteOperation"><code><span class="http-method">post</span> /v1/operations/delete</code></a></li>
+  <li><a href="#getOperation"><code><span class="http-method">post</span> /v1/operations/get</code></a></li>
+  <li><a href="#listOperationsForConnection"><code><span class="http-method">post</span> /v1/operations/list</code></a></li>
+  <li><a href="#updateOperation"><code><span class="http-method">post</span> /v1/operations/update</code></a></li>
+  </ul>
   <h4><a href="#Scheduler">Scheduler</a></h4>
   <ul>
   <li><a href="#executeDestinationCheckConnection"><code><span class="http-method">post</span> /v1/scheduler/destinations/check_connection</code></a></li>
@@ -401,6 +409,7 @@ font-style: italic;
     } ]
   },
   "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+  "operationIds" : [ null, null ],
   "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
 }</code></pre>
 
@@ -539,6 +548,7 @@ font-style: italic;
     } ]
   },
   "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+  "operationIds" : [ null, null ],
   "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
 }</code></pre>
 
@@ -639,6 +649,7 @@ font-style: italic;
       } ]
     },
     "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+    "operationIds" : [ null, null ],
     "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
   }, {
     "sourceId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
@@ -682,6 +693,7 @@ font-style: italic;
       } ]
     },
     "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+    "operationIds" : [ null, null ],
     "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
   } ]
 }</code></pre>
@@ -885,7 +897,7 @@ font-style: italic;
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
     <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/connections/update</code></pre></div>
-    <div class="method-summary">Updated a connection status (<span class="nickname">updateConnection</span>)</div>
+    <div class="method-summary">Update a connection (<span class="nickname">updateConnection</span>)</div>
     <div class="method-notes"></div>
 
 
@@ -958,6 +970,7 @@ font-style: italic;
     } ]
   },
   "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+  "operationIds" : [ null, null ],
   "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
 }</code></pre>
 
@@ -2353,6 +2366,334 @@ font-style: italic;
         <a href="#File">File</a>
   </div> <!-- method -->
   <hr/>
+  <h1><a name="Operation">Operation</a></h1>
+  <div class="method"><a name="createOperation"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/operations/create</code></pre></div>
+    <div class="method-summary">Create an operation to be applied as part of a connection pipeline (<span class="nickname">createOperation</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">OperationCreate <a href="#OperationCreate">OperationCreate</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#OperationRead">OperationRead</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "name" : "name",
+  "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+  "operatorConfiguration" : {
+    "normalization" : {
+      "enabled" : true
+    },
+    "dbt" : {
+      "dockerImage" : "dockerImage",
+      "dbtArguments" : "dbtArguments",
+      "gitRepoUrl" : "gitRepoUrl"
+    }
+  }
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#OperationRead">OperationRead</a>
+    <h4 class="field-label">422</h4>
+    Invalid Input
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="deleteOperation"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/operations/delete</code></pre></div>
+    <div class="method-summary">Delete an operation (<span class="nickname">deleteOperation</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">OperationIdRequestBody <a href="#OperationIdRequestBody">OperationIdRequestBody</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">204</h4>
+    The resource was deleted successfully.
+        <a href="#"></a>
+    <h4 class="field-label">404</h4>
+    Operation not found
+        <a href="#"></a>
+    <h4 class="field-label">422</h4>
+    Invalid Input
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="getOperation"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/operations/get</code></pre></div>
+    <div class="method-summary">Returns an operation (<span class="nickname">getOperation</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">OperationIdRequestBody <a href="#OperationIdRequestBody">OperationIdRequestBody</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#OperationRead">OperationRead</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "name" : "name",
+  "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+  "operatorConfiguration" : {
+    "normalization" : {
+      "enabled" : true
+    },
+    "dbt" : {
+      "dockerImage" : "dockerImage",
+      "dbtArguments" : "dbtArguments",
+      "gitRepoUrl" : "gitRepoUrl"
+    }
+  }
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#OperationRead">OperationRead</a>
+    <h4 class="field-label">404</h4>
+    Operation not found
+        <a href="#"></a>
+    <h4 class="field-label">422</h4>
+    Invalid Input
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="listOperationsForConnection"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/operations/list</code></pre></div>
+    <div class="method-summary">Returns all operations for a connection. (<span class="nickname">listOperationsForConnection</span>)</div>
+    <div class="method-notes">List operations for connection.</div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">ConnectionIdRequestBody <a href="#ConnectionIdRequestBody">ConnectionIdRequestBody</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#OperationReadList">OperationReadList</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "operations" : [ {
+    "name" : "name",
+    "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+    "operatorConfiguration" : {
+      "normalization" : {
+        "enabled" : true
+      },
+      "dbt" : {
+        "dockerImage" : "dockerImage",
+        "dbtArguments" : "dbtArguments",
+        "gitRepoUrl" : "gitRepoUrl"
+      }
+    }
+  }, {
+    "name" : "name",
+    "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+    "operatorConfiguration" : {
+      "normalization" : {
+        "enabled" : true
+      },
+      "dbt" : {
+        "dockerImage" : "dockerImage",
+        "dbtArguments" : "dbtArguments",
+        "gitRepoUrl" : "gitRepoUrl"
+      }
+    }
+  } ]
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#OperationReadList">OperationReadList</a>
+    <h4 class="field-label">404</h4>
+    Connection not found
+        <a href="#"></a>
+    <h4 class="field-label">422</h4>
+    Invalid Input
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="updateOperation"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/operations/update</code></pre></div>
+    <div class="method-summary">Update an operation (<span class="nickname">updateOperation</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">OperationUpdate <a href="#OperationUpdate">OperationUpdate</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#OperationRead">OperationRead</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "name" : "name",
+  "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+  "operatorConfiguration" : {
+    "normalization" : {
+      "enabled" : true
+    },
+    "dbt" : {
+      "dockerImage" : "dockerImage",
+      "dbtArguments" : "dbtArguments",
+      "gitRepoUrl" : "gitRepoUrl"
+    }
+  }
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#OperationRead">OperationRead</a>
+    <h4 class="field-label">422</h4>
+    Invalid Input
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
   <h1><a name="Scheduler">Scheduler</a></h1>
   <div class="method"><a name="executeDestinationCheckConnection"/>
     <div class="method-path">
@@ -3568,6 +3909,35 @@ font-style: italic;
     "units" : 0,
     "timeUnit" : "minutes"
   },
+  "operations" : {
+    "operations" : [ {
+      "name" : "name",
+      "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+      "operatorConfiguration" : {
+        "normalization" : {
+          "enabled" : true
+        },
+        "dbt" : {
+          "dockerImage" : "dockerImage",
+          "dbtArguments" : "dbtArguments",
+          "gitRepoUrl" : "gitRepoUrl"
+        }
+      }
+    }, {
+      "name" : "name",
+      "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+      "operatorConfiguration" : {
+        "normalization" : {
+          "enabled" : true
+        },
+        "dbt" : {
+          "dockerImage" : "dockerImage",
+          "dbtArguments" : "dbtArguments",
+          "gitRepoUrl" : "gitRepoUrl"
+        }
+      }
+    } ]
+  },
   "name" : "name",
   "syncCatalog" : {
     "streams" : [ {
@@ -3602,7 +3972,8 @@ font-style: italic;
       }
     } ]
   },
-  "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
+  "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+  "operationIds" : [ null, null ]
 }</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -3690,6 +4061,35 @@ font-style: italic;
       "units" : 0,
       "timeUnit" : "minutes"
     },
+    "operations" : {
+      "operations" : [ {
+        "name" : "name",
+        "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+        "operatorConfiguration" : {
+          "normalization" : {
+            "enabled" : true
+          },
+          "dbt" : {
+            "dockerImage" : "dockerImage",
+            "dbtArguments" : "dbtArguments",
+            "gitRepoUrl" : "gitRepoUrl"
+          }
+        }
+      }, {
+        "name" : "name",
+        "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+        "operatorConfiguration" : {
+          "normalization" : {
+            "enabled" : true
+          },
+          "dbt" : {
+            "dockerImage" : "dockerImage",
+            "dbtArguments" : "dbtArguments",
+            "gitRepoUrl" : "gitRepoUrl"
+          }
+        }
+      } ]
+    },
     "name" : "name",
     "syncCatalog" : {
       "streams" : [ {
@@ -3724,7 +4124,8 @@ font-style: italic;
         }
       } ]
     },
-    "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
+    "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+    "operationIds" : [ null, null ]
   }, {
     "sourceId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     "latestSyncJobCreatedAt" : 0,
@@ -3755,6 +4156,35 @@ font-style: italic;
       "units" : 0,
       "timeUnit" : "minutes"
     },
+    "operations" : {
+      "operations" : [ {
+        "name" : "name",
+        "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+        "operatorConfiguration" : {
+          "normalization" : {
+            "enabled" : true
+          },
+          "dbt" : {
+            "dockerImage" : "dockerImage",
+            "dbtArguments" : "dbtArguments",
+            "gitRepoUrl" : "gitRepoUrl"
+          }
+        }
+      }, {
+        "name" : "name",
+        "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+        "operatorConfiguration" : {
+          "normalization" : {
+            "enabled" : true
+          },
+          "dbt" : {
+            "dockerImage" : "dockerImage",
+            "dbtArguments" : "dbtArguments",
+            "gitRepoUrl" : "gitRepoUrl"
+          }
+        }
+      } ]
+    },
     "name" : "name",
     "syncCatalog" : {
       "streams" : [ {
@@ -3789,7 +4219,8 @@ font-style: italic;
         }
       } ]
     },
-    "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
+    "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+    "operationIds" : [ null, null ]
   } ]
 }</code></pre>
 
@@ -4013,6 +4444,7 @@ font-style: italic;
     } ]
   },
   "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+  "operationIds" : [ null, null ],
   "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
 }</code></pre>
 
@@ -4428,6 +4860,16 @@ font-style: italic;
     <li><a href="#Notification"><code>Notification</code> - </a></li>
     <li><a href="#NotificationRead"><code>NotificationRead</code> - </a></li>
     <li><a href="#NotificationType"><code>NotificationType</code> - </a></li>
+    <li><a href="#OperationCreate"><code>OperationCreate</code> - </a></li>
+    <li><a href="#OperationIdRequestBody"><code>OperationIdRequestBody</code> - </a></li>
+    <li><a href="#OperationRead"><code>OperationRead</code> - </a></li>
+    <li><a href="#OperationReadList"><code>OperationReadList</code> - </a></li>
+    <li><a href="#OperationStatus"><code>OperationStatus</code> - </a></li>
+    <li><a href="#OperationUpdate"><code>OperationUpdate</code> - </a></li>
+    <li><a href="#OperatorConfiguration"><code>OperatorConfiguration</code> - </a></li>
+    <li><a href="#OperatorDbt"><code>OperatorDbt</code> - </a></li>
+    <li><a href="#OperatorNormalization"><code>OperatorNormalization</code> - </a></li>
+    <li><a href="#OperatorType"><code>OperatorType</code> - </a></li>
     <li><a href="#SlackNotificationConfiguration"><code>SlackNotificationConfiguration</code> - </a></li>
     <li><a href="#SlugRequestBody"><code>SlugRequestBody</code> - </a></li>
     <li><a href="#SourceCoreConfig"><code>SourceCoreConfig</code> - </a></li>
@@ -4544,6 +4986,7 @@ font-style: italic;
 <div class="param">prefix (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Prefix that will be prepended to the name of each stream when it is written to the destination. </div>
 <div class="param">sourceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">destinationId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">operationIds (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">array[UUID]</a></span>  format: uuid</div>
 <div class="param">syncCatalog (optional)</div><div class="param-desc"><span class="param-type"><a href="#AirbyteCatalog">AirbyteCatalog</a></span>  </div>
 <div class="param">schedule (optional)</div><div class="param-desc"><span class="param-type"><a href="#ConnectionSchedule">ConnectionSchedule</a></span>  </div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
@@ -4565,6 +5008,7 @@ font-style: italic;
 <div class="param">prefix (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Prefix that will be prepended to the name of each stream when it is written to the destination. </div>
 <div class="param">sourceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">destinationId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">operationIds (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">array[UUID]</a></span>  format: uuid</div>
 <div class="param">syncCatalog </div><div class="param-desc"><span class="param-type"><a href="#AirbyteCatalog">AirbyteCatalog</a></span>  </div>
 <div class="param">schedule (optional)</div><div class="param-desc"><span class="param-type"><a href="#ConnectionSchedule">ConnectionSchedule</a></span>  </div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
@@ -4599,6 +5043,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">connectionId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">prefix (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Prefix that will be prepended to the name of each stream when it is written to the destination. </div>
+<div class="param">operationIds (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">array[UUID]</a></span>  format: uuid</div>
 <div class="param">syncCatalog </div><div class="param-desc"><span class="param-type"><a href="#AirbyteCatalog">AirbyteCatalog</a></span>  </div>
 <div class="param">schedule (optional)</div><div class="param-desc"><span class="param-type"><a href="#ConnectionSchedule">ConnectionSchedule</a></span>  </div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
@@ -4860,6 +5305,86 @@ font-style: italic;
           </div>  <!-- field-items -->
   </div>
   <div class="model">
+    <h3><a name="OperationCreate"><code>OperationCreate</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">operatorConfiguration </div><div class="param-desc"><span class="param-type"><a href="#OperatorConfiguration">OperatorConfiguration</a></span>  </div>
+<div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#OperationStatus">OperationStatus</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="OperationIdRequestBody"><code>OperationIdRequestBody</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">OperationId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="OperationRead"><code>OperationRead</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">operationId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">operatorConfiguration </div><div class="param-desc"><span class="param-type"><a href="#OperatorConfiguration">OperatorConfiguration</a></span>  </div>
+<div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#OperationStatus">OperationStatus</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="OperationReadList"><code>OperationReadList</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">operations </div><div class="param-desc"><span class="param-type"><a href="#OperationRead">array[OperationRead]</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="OperationStatus"><code>OperationStatus</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'>Active means that data is flowing through the operator. Inactive means it is not. Deprecated means the operator is off and cannot be re-activated.</div>
+    <div class="field-items">
+          </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="OperationUpdate"><code>OperationUpdate</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">operationId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">operatorConfiguration </div><div class="param-desc"><span class="param-type"><a href="#OperatorConfiguration">OperatorConfiguration</a></span>  </div>
+<div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#OperationStatus">OperationStatus</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="OperatorConfiguration"><code>OperatorConfiguration</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">operatorType (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperatorType">OperatorType</a></span>  </div>
+<div class="param">normalization (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperatorNormalization">OperatorNormalization</a></span>  </div>
+<div class="param">dbt (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperatorDbt">OperatorDbt</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="OperatorDbt"><code>OperatorDbt</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">gitRepoUrl </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">dockerImage (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">dbtArguments (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="OperatorNormalization"><code>OperatorNormalization</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">enabled </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="OperatorType"><code>OperatorType</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+          </div>  <!-- field-items -->
+  </div>
+  <div class="model">
     <h3><a name="SlackNotificationConfiguration"><code>SlackNotificationConfiguration</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
@@ -5039,8 +5564,10 @@ font-style: italic;
 <div class="param">syncCatalog </div><div class="param-desc"><span class="param-type"><a href="#AirbyteCatalog">AirbyteCatalog</a></span>  </div>
 <div class="param">schedule (optional)</div><div class="param-desc"><span class="param-type"><a href="#ConnectionSchedule">ConnectionSchedule</a></span>  </div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
+<div class="param">operationIds (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">array[UUID]</a></span>  format: uuid</div>
 <div class="param">source </div><div class="param-desc"><span class="param-type"><a href="#SourceRead">SourceRead</a></span>  </div>
 <div class="param">destination </div><div class="param-desc"><span class="param-type"><a href="#DestinationRead">DestinationRead</a></span>  </div>
+<div class="param">operations (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperationReadList">OperationReadList</a></span>  </div>
 <div class="param">latestSyncJobCreatedAt (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> epoch time of the latest sync job. null if no sync job has taken place. format: int64</div>
 <div class="param">latestSyncJobStatus (optional)</div><div class="param-desc"><span class="param-type"><a href="#JobStatus">JobStatus</a></span>  </div>
 <div class="param">isSyncing </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
@@ -5067,6 +5594,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">connectionId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">prefix (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Prefix that will be prepended to the name of each stream when it is written to the destination. </div>
+<div class="param">operationIds (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">array[UUID]</a></span>  format: uuid</div>
 <div class="param">syncCatalog </div><div class="param-desc"><span class="param-type"><a href="#AirbyteCatalog">AirbyteCatalog</a></span>  </div>
 <div class="param">schedule (optional)</div><div class="param-desc"><span class="param-type"><a href="#ConnectionSchedule">ConnectionSchedule</a></span>  </div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -2406,9 +2406,7 @@ font-style: italic;
   "name" : "name",
   "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "operatorConfiguration" : {
-    "normalization" : {
-      "enabled" : true
-    },
+    "normalization" : "{}",
     "dbt" : {
       "dockerImage" : "dockerImage",
       "dbtArguments" : "dbtArguments",
@@ -2514,9 +2512,7 @@ font-style: italic;
   "name" : "name",
   "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "operatorConfiguration" : {
-    "normalization" : {
-      "enabled" : true
-    },
+    "normalization" : "{}",
     "dbt" : {
       "dockerImage" : "dockerImage",
       "dbtArguments" : "dbtArguments",
@@ -2584,9 +2580,7 @@ font-style: italic;
     "name" : "name",
     "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     "operatorConfiguration" : {
-      "normalization" : {
-        "enabled" : true
-      },
+      "normalization" : "{}",
       "dbt" : {
         "dockerImage" : "dockerImage",
         "dbtArguments" : "dbtArguments",
@@ -2597,9 +2591,7 @@ font-style: italic;
     "name" : "name",
     "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     "operatorConfiguration" : {
-      "normalization" : {
-        "enabled" : true
-      },
+      "normalization" : "{}",
       "dbt" : {
         "dockerImage" : "dockerImage",
         "dbtArguments" : "dbtArguments",
@@ -2667,9 +2659,7 @@ font-style: italic;
   "name" : "name",
   "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "operatorConfiguration" : {
-    "normalization" : {
-      "enabled" : true
-    },
+    "normalization" : "{}",
     "dbt" : {
       "dockerImage" : "dockerImage",
       "dbtArguments" : "dbtArguments",
@@ -3914,9 +3904,7 @@ font-style: italic;
       "name" : "name",
       "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
       "operatorConfiguration" : {
-        "normalization" : {
-          "enabled" : true
-        },
+        "normalization" : "{}",
         "dbt" : {
           "dockerImage" : "dockerImage",
           "dbtArguments" : "dbtArguments",
@@ -3927,9 +3915,7 @@ font-style: italic;
       "name" : "name",
       "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
       "operatorConfiguration" : {
-        "normalization" : {
-          "enabled" : true
-        },
+        "normalization" : "{}",
         "dbt" : {
           "dockerImage" : "dockerImage",
           "dbtArguments" : "dbtArguments",
@@ -4066,9 +4052,7 @@ font-style: italic;
         "name" : "name",
         "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
         "operatorConfiguration" : {
-          "normalization" : {
-            "enabled" : true
-          },
+          "normalization" : "{}",
           "dbt" : {
             "dockerImage" : "dockerImage",
             "dbtArguments" : "dbtArguments",
@@ -4079,9 +4063,7 @@ font-style: italic;
         "name" : "name",
         "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
         "operatorConfiguration" : {
-          "normalization" : {
-            "enabled" : true
-          },
+          "normalization" : "{}",
           "dbt" : {
             "dockerImage" : "dockerImage",
             "dbtArguments" : "dbtArguments",
@@ -4161,9 +4143,7 @@ font-style: italic;
         "name" : "name",
         "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
         "operatorConfiguration" : {
-          "normalization" : {
-            "enabled" : true
-          },
+          "normalization" : "{}",
           "dbt" : {
             "dockerImage" : "dockerImage",
             "dbtArguments" : "dbtArguments",
@@ -4174,9 +4154,7 @@ font-style: italic;
         "name" : "name",
         "operationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
         "operatorConfiguration" : {
-          "normalization" : {
-            "enabled" : true
-          },
+          "normalization" : "{}",
           "dbt" : {
             "dockerImage" : "dockerImage",
             "dbtArguments" : "dbtArguments",
@@ -4864,11 +4842,9 @@ font-style: italic;
     <li><a href="#OperationIdRequestBody"><code>OperationIdRequestBody</code> - </a></li>
     <li><a href="#OperationRead"><code>OperationRead</code> - </a></li>
     <li><a href="#OperationReadList"><code>OperationReadList</code> - </a></li>
-    <li><a href="#OperationStatus"><code>OperationStatus</code> - </a></li>
     <li><a href="#OperationUpdate"><code>OperationUpdate</code> - </a></li>
     <li><a href="#OperatorConfiguration"><code>OperatorConfiguration</code> - </a></li>
     <li><a href="#OperatorDbt"><code>OperatorDbt</code> - </a></li>
-    <li><a href="#OperatorNormalization"><code>OperatorNormalization</code> - </a></li>
     <li><a href="#OperatorType"><code>OperatorType</code> - </a></li>
     <li><a href="#SlackNotificationConfiguration"><code>SlackNotificationConfiguration</code> - </a></li>
     <li><a href="#SlugRequestBody"><code>SlugRequestBody</code> - </a></li>
@@ -5310,7 +5286,6 @@ font-style: italic;
     <div class="field-items">
       <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">operatorConfiguration </div><div class="param-desc"><span class="param-type"><a href="#OperatorConfiguration">OperatorConfiguration</a></span>  </div>
-<div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#OperationStatus">OperationStatus</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -5327,7 +5302,6 @@ font-style: italic;
       <div class="param">operationId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">operatorConfiguration </div><div class="param-desc"><span class="param-type"><a href="#OperatorConfiguration">OperatorConfiguration</a></span>  </div>
-<div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#OperationStatus">OperationStatus</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -5338,27 +5312,20 @@ font-style: italic;
     </div>  <!-- field-items -->
   </div>
   <div class="model">
-    <h3><a name="OperationStatus"><code>OperationStatus</code> - </a> <a class="up" href="#__Models">Up</a></h3>
-    <div class='model-description'>Active means that data is flowing through the operator. Inactive means it is not. Deprecated means the operator is off and cannot be re-activated.</div>
-    <div class="field-items">
-          </div>  <!-- field-items -->
-  </div>
-  <div class="model">
     <h3><a name="OperationUpdate"><code>OperationUpdate</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">operationId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">operatorConfiguration </div><div class="param-desc"><span class="param-type"><a href="#OperatorConfiguration">OperatorConfiguration</a></span>  </div>
-<div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#OperationStatus">OperationStatus</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
     <h3><a name="OperatorConfiguration"><code>OperatorConfiguration</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">operatorType (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperatorType">OperatorType</a></span>  </div>
-<div class="param">normalization (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperatorNormalization">OperatorNormalization</a></span>  </div>
+      <div class="param">operatorType </div><div class="param-desc"><span class="param-type"><a href="#OperatorType">OperatorType</a></span>  </div>
+<div class="param">normalization (optional)</div><div class="param-desc"><span class="param-type"><a href="#">Object</a></span>  </div>
 <div class="param">dbt (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperatorDbt">OperatorDbt</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
@@ -5369,13 +5336,6 @@ font-style: italic;
       <div class="param">gitRepoUrl </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dockerImage (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dbtArguments (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-    </div>  <!-- field-items -->
-  </div>
-  <div class="model">
-    <h3><a name="OperatorNormalization"><code>OperatorNormalization</code> - </a> <a class="up" href="#__Models">Up</a></h3>
-    <div class='model-description'></div>
-    <div class="field-items">
-      <div class="param">enabled </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What
Implements the API part of https://github.com/airbytehq/airbyte/issues/3233

## How
- Add new routes to API to create Operations configuration objects.
- Persist a sequence of operationIds in the Connection* configuration objects that point to associated Operations

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `airbyte-api/src/main/openapi/config.yaml`
1. the rest
