### PR TITLE
Document usage of `./gradlew format` and workaround for files without import statements

### DIFF
--- a/airbyte-integrations/connectors/source-pokeapi/source_pokeapi/pokemon_list.py
+++ b/airbyte-integrations/connectors/source-pokeapi/source_pokeapi/pokemon_list.py
@@ -21,9 +21,8 @@
 # SOFTWARE.
 
 
-from . import pokemon_list
+# startfile
 
-# Store large list of all known Pokemon.
 POKEMON_LIST = [
     "bulbasaur",
     "ivysaur",
@@ -924,6 +923,3 @@ POKEMON_LIST = [
     "spectrier",
     "calyrex",
 ]
-
-# Use the import so flakeCheck doesn't get mad at us.
-no_op_list = pokemon_list.POKEMON_LIST

--- a/airbyte-integrations/connectors/source-pokeapi/source_pokeapi/pokemon_list.py
+++ b/airbyte-integrations/connectors/source-pokeapi/source_pokeapi/pokemon_list.py
@@ -21,7 +21,9 @@
 # SOFTWARE.
 
 
-# startfile
+"""
+pokemon_list.py includes a list of all known pokemon for config validation in source.py.
+"""
 
 POKEMON_LIST = [
     "bulbasaur",

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ spotless {
         // Many __init__.py files are blank which makes it hard to write a regex to know where to add a license
         targetExclude createSpotlessTarget('**/__init__.py')
 
-        licenseHeaderFile createPythonLicenseWith(rootProject.file('LICENSE')), '(from|import|def|""")'
+        licenseHeaderFile createPythonLicenseWith(rootProject.file('LICENSE')), '(from|import|def|^[a-z]+(?:_+[a-z]+)*$|""")'
         trimTrailingWhitespace()
     }
     format 'styling', {

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ spotless {
         // Many __init__.py files are blank which makes it hard to write a regex to know where to add a license
         targetExclude createSpotlessTarget('**/__init__.py')
 
-        licenseHeaderFile createPythonLicenseWith(rootProject.file('LICENSE')), '(from|import|def|^[a-z]+(?:_+[a-z]+)*$|""")'
+        licenseHeaderFile createPythonLicenseWith(rootProject.file('LICENSE')), '(from|import|def|# startfile|""")'
         trimTrailingWhitespace()
     }
     format 'styling', {

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ spotless {
         // Many __init__.py files are blank which makes it hard to write a regex to know where to add a license
         targetExclude createSpotlessTarget('**/__init__.py')
 
-        licenseHeaderFile createPythonLicenseWith(rootProject.file('LICENSE')), '(from|import|def|# startfile|""")'
+        licenseHeaderFile createPythonLicenseWith(rootProject.file('LICENSE')), '(from|import|def|""")'
         trimTrailingWhitespace()
     }
     format 'styling', {

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -82,6 +82,18 @@ VERSION=dev docker-compose up
 ./gradlew :airbyte-tests:acceptanceTests
 ```
 
+## Run formatting automation/tests
+
+To run our formatting scripts, simply run `./gradlew format` at the base of the repo. 
+
+Note: If you are contributing a Python file without imports or function definitions, place the following comment at the top of your file:
+
+```python
+"""
+[FILENAME] includes [INSERT DESCRIPTION OF CONTENTS HERE]
+"""
+```
+
 ### Develop on `airbyte-webapp`
 
 * Spin up Airbyte locally so the UI can make requests against the local API.

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -84,7 +84,7 @@ VERSION=dev docker-compose up
 
 ## Run formatting automation/tests
 
-To run our formatting scripts, simply run `./gradlew format` at the base of the repo. 
+To format code in the repo, simply run `./gradlew format` at the base of the repo. 
 
 Note: If you are contributing a Python file without imports or function definitions, place the following comment at the top of your file:
 


### PR DESCRIPTION
## Main Changes
- To allow the license check for a file without imports or function definitions to succeed, you must include a block comment at the top of your Python file. This documents that behavior in our contribution docs.

## Misc Changes
- Clean up old workaround for this

## Notes
- Closes #3221