### PR TITLE
DNM: Record Data POC to simplify BufferedStreamConsumer.

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/FailureTrackingAirbyteMessageConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/FailureTrackingAirbyteMessageConsumer.java
@@ -33,9 +33,11 @@ import org.slf4j.LoggerFactory;
  * the {@link AirbyteMessageConsumer} interface. The original interface methods are wrapped in
  * generic exception handlers - any exception is caught and logged.
  *
- * Two methods are intended for extension: - startTracked: Wraps set up of necessary
- * infrastructure/configuration before message consumption. - acceptTracked: Wraps actual processing
- * of each {@link io.airbyte.protocol.models.AirbyteMessage}.
+ * Two methods are intended for extension:
+ * <li>- startTracked: Wraps set up of necessary infrastructure/configuration before message
+ * consumption.</li>
+ * <li>- acceptTracked: Wraps actual processing of each
+ * {@link io.airbyte.protocol.models.AirbyteMessage}.</li>
  *
  * Though not necessary, we highly encourage using this class when implementing destinations. See
  * child classes for examples.
@@ -58,6 +60,12 @@ public abstract class FailureTrackingAirbyteMessageConsumer implements AirbyteMe
     }
   }
 
+  /**
+   * This function's general pattern is to 1) Check the data can be written to the destination (e.g.
+   * some records might be too big) 2) Unwrap the
+   * {@link io.airbyte.protocol.models.AirbyteRecordMessage} and extracting and passing the data and
+   * emittedAt fields to other secondary functions to be written.
+   */
   protected abstract void acceptTracked(AirbyteMessage msg) throws Exception;
 
   @Override

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/RecordData.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/RecordData.java
@@ -1,0 +1,75 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.integrations.destination;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airbyte.commons.json.Jsons;
+import java.sql.Timestamp;
+import java.time.Instant;
+
+/**
+ * This class is an immutable POJO containing all data necessary to write an
+ * {@link io.airbyte.protocol.models.AirbyteRecordMessage} to a Destination.
+ *
+ * This removes the need to pass the entire AirbyteRecordMessage around internally, which make syncs
+ * slightly more efficient.
+ *
+ * It's immutable nature - there are no method to allow internal state modification - help with
+ * readability.
+ *
+ * Internal Destination interfaces should use this when necessary.
+ */
+public class RecordData {
+
+  @JsonProperty("jsonData")
+  private final String jsonData;
+
+  @JsonProperty("emittedAt")
+  private final Timestamp emittedAt;
+
+  public RecordData(String jsonData, Timestamp emittedAt) {
+    this.jsonData = jsonData;
+    this.emittedAt = emittedAt;
+  }
+
+  public String getJsonData() {
+    return jsonData;
+  }
+
+  public Timestamp getEmittedAt() {
+    return emittedAt;
+  }
+
+  public static void main(String[] args) {
+    var r = new RecordData("her her", Timestamp.from(Instant.now()));
+    var str = Jsons.serialize(r);
+    System.out.println(str);
+
+    var o = Jsons.deserialize(str, RecordData.class);
+    System.out.println(o.getEmittedAt());
+    System.out.println(o.getJsonData());
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/RecordWriter.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/RecordWriter.java
@@ -26,12 +26,12 @@ package io.airbyte.integrations.destination.buffered_stream_consumer;
 
 import io.airbyte.commons.functional.CheckedBiConsumer;
 import io.airbyte.integrations.base.AirbyteStreamNameNamespacePair;
-import io.airbyte.protocol.models.AirbyteRecordMessage;
+import io.airbyte.integrations.destination.RecordData;
 import java.util.List;
 
-public interface RecordWriter extends CheckedBiConsumer<AirbyteStreamNameNamespacePair, List<AirbyteRecordMessage>, Exception> {
+public interface RecordWriter extends CheckedBiConsumer<AirbyteStreamNameNamespacePair, List<RecordData>, Exception> {
 
   @Override
-  void accept(AirbyteStreamNameNamespacePair pair, List<AirbyteRecordMessage> recordStream) throws Exception;
+  void accept(AirbyteStreamNameNamespacePair pair, List<RecordData> recordStream) throws Exception;
 
 }

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/DefaultSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/DefaultSqlOperations.java
@@ -24,10 +24,9 @@
 
 package io.airbyte.integrations.destination.jdbc;
 
-import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.base.JavaBaseConstants;
-import io.airbyte.protocol.models.AirbyteRecordMessage;
+import io.airbyte.integrations.destination.RecordData;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -36,8 +35,6 @@ import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.csv.CSVFormat;
@@ -77,7 +74,7 @@ public class DefaultSqlOperations implements SqlOperations {
   }
 
   @Override
-  public void insertRecords(JdbcDatabase database, List<AirbyteRecordMessage> records, String schemaName, String tmpTableName) throws SQLException {
+  public void insertRecords(JdbcDatabase database, List<RecordData> records, String schemaName, String tmpTableName) throws SQLException {
     if (records.isEmpty()) {
       return;
     }
@@ -107,17 +104,15 @@ public class DefaultSqlOperations implements SqlOperations {
     });
   }
 
-  private void writeBatchToFile(File tmpFile, List<AirbyteRecordMessage> records) throws Exception {
+  private void writeBatchToFile(File tmpFile, List<RecordData> records) throws Exception {
     PrintWriter writer = null;
     try {
       writer = new PrintWriter(tmpFile, StandardCharsets.UTF_8);
       var csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT);
 
-      for (AirbyteRecordMessage record : records) {
+      for (RecordData record : records) {
         var uuid = UUID.randomUUID().toString();
-        var jsonData = Jsons.serialize(record.getData());
-        var emittedAt = Timestamp.from(Instant.ofEpochMilli(record.getEmittedAt()));
-        csvPrinter.printRecord(uuid, jsonData, emittedAt);
+        csvPrinter.printRecord(uuid, "", record.getEmittedAt());
       }
     } finally {
       if (writer != null) {

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/SqlOperations.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/SqlOperations.java
@@ -25,7 +25,7 @@
 package io.airbyte.integrations.destination.jdbc;
 
 import io.airbyte.db.jdbc.JdbcDatabase;
-import io.airbyte.protocol.models.AirbyteRecordMessage;
+import io.airbyte.integrations.destination.RecordData;
 import java.util.List;
 
 // todo (cgardens) - is it necessary to expose so much configurability in this interface. review if
@@ -79,12 +79,12 @@ public interface SqlOperations {
   /**
    * Insert records into table. Assumes the table exists.
    *
-   * @param records records to insert.
+   * @param records each entry in this list is a serialised record from the source.
    * @param schemaName name of schema
    * @param tableName name of table
    * @throws Exception exception
    */
-  void insertRecords(JdbcDatabase database, List<AirbyteRecordMessage> records, String schemaName, String tableName) throws Exception;
+  void insertRecords(JdbcDatabase database, List<RecordData> records, String schemaName, String tableName) throws Exception;
 
   /**
    * Query to copy all records from source table to destination table. Both tables must be in the

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/SqlOperationsUtils.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/SqlOperationsUtils.java
@@ -25,13 +25,10 @@
 package io.airbyte.integrations.destination.jdbc;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.jdbc.JdbcDatabase;
-import io.airbyte.protocol.models.AirbyteRecordMessage;
+import io.airbyte.integrations.destination.RecordData;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -52,7 +49,7 @@ public class SqlOperationsUtils {
   public static void insertRawRecordsInSingleQuery(String insertQueryComponent,
                                                    String recordQueryComponent,
                                                    JdbcDatabase jdbcDatabase,
-                                                   List<AirbyteRecordMessage> records)
+                                                   List<RecordData> records)
       throws SQLException {
     insertRawRecordsInSingleQuery(insertQueryComponent, recordQueryComponent, jdbcDatabase, records, UUID::randomUUID);
 
@@ -62,7 +59,7 @@ public class SqlOperationsUtils {
   static void insertRawRecordsInSingleQuery(String insertQueryComponent,
                                             String recordQueryComponent,
                                             JdbcDatabase jdbcDatabase,
-                                            List<AirbyteRecordMessage> records,
+                                            List<RecordData> records,
                                             Supplier<UUID> uuidSupplier)
       throws SQLException {
     if (records.isEmpty()) {
@@ -85,11 +82,11 @@ public class SqlOperationsUtils {
       try (final PreparedStatement statement = connection.prepareStatement(s1)) {
         // second loop: bind values to the SQL string.
         int i = 1;
-        for (final AirbyteRecordMessage message : records) {
+        for (final RecordData record : records) {
           // 1-indexed
           statement.setString(i, uuidSupplier.get().toString());
-          statement.setString(i + 1, Jsons.serialize(message.getData()));
-          statement.setTimestamp(i + 2, Timestamp.from(Instant.ofEpochMilli(message.getEmittedAt())));
+          statement.setString(i + 1, record.getJsonData());
+          statement.setTimestamp(i + 2, record.getEmittedAt());
           i += 3;
         }
 

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftSqlOperations.java
@@ -26,10 +26,10 @@ package io.airbyte.integrations.destination.redshift;
 
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.base.JavaBaseConstants;
+import io.airbyte.integrations.destination.RecordData;
 import io.airbyte.integrations.destination.jdbc.DefaultSqlOperations;
 import io.airbyte.integrations.destination.jdbc.SqlOperations;
 import io.airbyte.integrations.destination.jdbc.SqlOperationsUtils;
-import io.airbyte.protocol.models.AirbyteRecordMessage;
 import java.sql.SQLException;
 import java.util.List;
 import org.slf4j.Logger;
@@ -52,7 +52,7 @@ public class RedshiftSqlOperations extends DefaultSqlOperations implements SqlOp
   }
 
   @Override
-  public void insertRecords(JdbcDatabase database, List<AirbyteRecordMessage> records, String schemaName, String tmpTableName) throws SQLException {
+  public void insertRecords(JdbcDatabase database, List<RecordData> records, String schemaName, String tmpTableName) throws SQLException {
     LOGGER.info("actual size of batch: {}", records.size());
 
     // query syntax:

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeSqlOperations.java
@@ -26,10 +26,10 @@ package io.airbyte.integrations.destination.snowflake;
 
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.base.JavaBaseConstants;
+import io.airbyte.integrations.destination.RecordData;
 import io.airbyte.integrations.destination.jdbc.DefaultSqlOperations;
 import io.airbyte.integrations.destination.jdbc.SqlOperations;
 import io.airbyte.integrations.destination.jdbc.SqlOperationsUtils;
-import io.airbyte.protocol.models.AirbyteRecordMessage;
 import java.sql.SQLException;
 import java.util.List;
 import org.slf4j.Logger;
@@ -52,7 +52,7 @@ class SnowflakeSqlOperations extends DefaultSqlOperations implements SqlOperatio
   }
 
   @Override
-  public void insertRecords(JdbcDatabase database, List<AirbyteRecordMessage> records, String schemaName, String tableName) throws SQLException {
+  public void insertRecords(JdbcDatabase database, List<RecordData> records, String schemaName, String tableName) throws SQLException {
     LOGGER.info("actual size of batch: {}", records.size());
 
     // snowflake query syntax:


### PR DESCRIPTION
## What
I fixed a Redshift bug yesterday that made me realise the BufferedStreamConsumer has some divergence from all the other consumers in the way it handles the AirbyteRecordMessage, notably the CopyConsumer.

Current behaviour:
* All the other consumers extract and format the required data from the AirbyteRecordMessage and write it to the destination in the `accept_tracked` function. 
* The `BufferedStreamConsumer` passes the AirbyteRecordMessage into the OnDisk stream. This is fed into the `RecordWriter` and all the various `YSqlOperations` classes downstream to be written to the Destination.

Here, I've tried to mirror what other consumers are doing in the BufferedStreamConsumer. Instead of passing the entire record around, I'm extracting relevant data into an immutable internal only data structure. This data structure is what is passed along and eventually written.

I like this because:
- All processing of the Airbyte Record's data is centralised in `accept_tracked`.  The bug yesterday was related to the data length and I found myself looking through all the possible points at which the data could be modified. This simplifies that.
- RecordData is a POJO with no modify methods. This in theory makes downstream logic easier to reason about.

This PR is somewhat rough right now. If people think this is an approach worth pursuing, I can clean it up and present a proper PR (including addressing Michel's comments).

Also open to other thoughts about this - this PR isn't useful and we shouldn't bother is also a valid answer!

Charles, does the backpressure work invalidate this PR?

## Recommended reading order
* RecordData.java
* RecordWriter.java
* BufferedStreamConsumer.java
