### PR TITLE
add metrics for sync-level configs

### DIFF
--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -228,10 +228,10 @@ public class JobTracker {
   }
 
   /**
-   * The CheckConnection jobs (both source and destination) of the SynchronousSchedulerClient
-   * interface can have a successful job with a failed check. Because of this, tracking just the job
-   * attempt status does not capture the whole picture. The `check_connection_outcome` field tracks
-   * this.
+   * The CheckConnection jobs (both source and destination) of the
+   * {@link io.airbyte.scheduler.client.SynchronousSchedulerClient} interface can have a successful
+   * job with a failed check. Because of this, tracking just the job attempt status does not capture
+   * the whole picture. The `check_connection_outcome` field tracks this.
    */
   private ImmutableMap<String, Object> generateCheckConnectionMetadata(StandardCheckConnectionOutput output) {
     if (output == null) {

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -72,6 +72,7 @@ public class JobTracker {
   public static final String MESSAGE_NAME = "Connector Jobs";
   public static final String CONFIG = "config";
   public static final String CATALOG = "catalog";
+  public static final String SET = "set";
 
   private final ConfigRepository configRepository;
   private final JobPersistence jobPersistence;
@@ -169,8 +170,8 @@ public class JobTracker {
     final Map<String, Object> output = new HashMap<>();
 
     for (ConfiguredAirbyteStream stream : catalog.getStreams()) {
-      output.put(CATALOG + ".sync_mode." + stream.getSyncMode().name().toLowerCase(), true);
-      output.put(CATALOG + ".destination_sync_mode." + stream.getDestinationSyncMode().name().toLowerCase(), true);
+      output.put(CATALOG + ".sync_mode." + stream.getSyncMode().name().toLowerCase(), SET);
+      output.put(CATALOG + ".destination_sync_mode." + stream.getDestinationSyncMode().name().toLowerCase(), SET);
     }
 
     return output;
@@ -193,7 +194,7 @@ public class JobTracker {
           if (child.isObject()) {
             output.putAll(configToMetadata(fieldJsonPath, child));
           } else if (!child.isTextual() || (child.isTextual() && !child.asText().isEmpty())) {
-            output.put(fieldJsonPath, true);
+            output.put(fieldJsonPath, SET);
           }
         }
       }

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -139,7 +139,13 @@ public class JobTracker {
       final ImmutableMap<String, Object> stateMetadata = generateStateMetadata(jobState);
       final Map<String, Object> syncConfigMetadata = generateSyncConfigMetadata(job.getConfig());
 
-      track(MoreMaps.merge(jobMetadata, jobAttemptMetadata, sourceDefMetadata, destinationDefMetadata, syncMetadata, stateMetadata,
+      track(MoreMaps.merge(
+          jobMetadata,
+          jobAttemptMetadata,
+          sourceDefMetadata,
+          destinationDefMetadata,
+          syncMetadata,
+          stateMetadata,
           syncConfigMetadata));
     });
   }
@@ -183,10 +189,12 @@ public class JobTracker {
 
         if (child.isBoolean()) {
           output.put(fieldJsonPath, child.asBoolean());
-        } else if (child.isObject()) {
-          output.putAll(configToMetadata(fieldJsonPath, child));
-        } else {
-          output.put(fieldJsonPath, true);
+        } else if (!child.isNull()) {
+          if (child.isObject()) {
+            output.putAll(configToMetadata(fieldJsonPath, child));
+          } else if (!child.isTextual() || (child.isTextual() && !child.asText().isEmpty())) {
+            output.put(fieldJsonPath, true);
+          }
         }
       }
     }

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -24,6 +24,8 @@
 
 package io.airbyte.scheduler.persistence.job_tracker;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -32,6 +34,7 @@ import io.airbyte.analytics.TrackingClient;
 import io.airbyte.analytics.TrackingClientSingleton;
 import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.commons.map.MoreMaps;
+import io.airbyte.config.JobConfig;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.JobOutput;
 import io.airbyte.config.StandardCheckConnectionOutput;
@@ -42,11 +45,16 @@ import io.airbyte.config.StandardSyncSummary;
 import io.airbyte.config.helpers.ScheduleHelpers;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.scheduler.models.Attempt;
 import io.airbyte.scheduler.models.Job;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -62,6 +70,8 @@ public class JobTracker {
   }
 
   public static final String MESSAGE_NAME = "Connector Jobs";
+  public static final String CONFIG = "config";
+  public static final String CATALOG = "catalog";
 
   private final ConfigRepository configRepository;
   private final JobPersistence jobPersistence;
@@ -127,9 +137,61 @@ public class JobTracker {
       final ImmutableMap<String, Object> destinationDefMetadata = generateDestinationDefinitionMetadata(destinationDefinitionId);
       final ImmutableMap<String, Object> syncMetadata = generateSyncMetadata(connectionId);
       final ImmutableMap<String, Object> stateMetadata = generateStateMetadata(jobState);
+      final Map<String, Object> syncConfigMetadata = generateSyncConfigMetadata(job.getConfig());
 
-      track(MoreMaps.merge(jobMetadata, jobAttemptMetadata, sourceDefMetadata, destinationDefMetadata, syncMetadata, stateMetadata));
+      track(MoreMaps.merge(jobMetadata, jobAttemptMetadata, sourceDefMetadata, destinationDefMetadata, syncMetadata, stateMetadata,
+          syncConfigMetadata));
     });
+  }
+
+  private Map<String, Object> generateSyncConfigMetadata(JobConfig config) {
+    if (config.getConfigType() == ConfigType.SYNC) {
+      JsonNode sourceConfiguration = config.getSync().getSourceConfiguration();
+      JsonNode destinationConfiguration = config.getSync().getDestinationConfiguration();
+
+      Map<String, Object> sourceMetadata = configToMetadata(CONFIG + ".source", sourceConfiguration);
+      Map<String, Object> destinationMetadata = configToMetadata(CONFIG + ".destination", destinationConfiguration);
+      Map<String, Object> catalogMetadata = getCatalogMetadata(config.getSync().getConfiguredAirbyteCatalog());
+
+      return MoreMaps.merge(sourceMetadata, destinationMetadata, catalogMetadata);
+    } else {
+      return Collections.emptyMap();
+    }
+  }
+
+  private Map<String, Object> getCatalogMetadata(ConfiguredAirbyteCatalog catalog) {
+    final Map<String, Object> output = new HashMap<>();
+
+    for (ConfiguredAirbyteStream stream : catalog.getStreams()) {
+      output.put(CATALOG + ".sync_mode." + stream.getSyncMode().name().toLowerCase(), true);
+      output.put(CATALOG + ".destination_sync_mode." + stream.getDestinationSyncMode().name().toLowerCase(), true);
+    }
+
+    return output;
+  }
+
+  protected static Map<String, Object> configToMetadata(String jsonPath, JsonNode config) {
+    final Map<String, Object> output = new HashMap<>();
+
+    if (config.isObject()) {
+      final ObjectNode node = (ObjectNode) config;
+      for (Iterator<Map.Entry<String, JsonNode>> it = node.fields(); it.hasNext();) {
+        var entry = it.next();
+        var field = entry.getKey();
+        var fieldJsonPath = jsonPath + "." + field;
+        var child = entry.getValue();
+
+        if (child.isBoolean()) {
+          output.put(fieldJsonPath, child.asBoolean());
+        } else if (child.isObject()) {
+          output.putAll(configToMetadata(fieldJsonPath, child));
+        } else {
+          output.put(fieldJsonPath, true);
+        }
+      }
+    }
+
+    return output;
   }
 
   private ImmutableMap<String, Object> generateSyncMetadata(UUID connectionId) throws ConfigNotFoundException, IOException, JsonValidationException {
@@ -166,10 +228,10 @@ public class JobTracker {
   }
 
   /**
-   * The CheckConnection jobs (both source and destination) of the
-   * {@link io.airbyte.scheduler.client.SynchronousSchedulerClient} interface can have a successful
-   * job with a failed check. Because of this, tracking just the job attempt status does not capture
-   * the whole picture. The `check_connection_outcome` field tracks this.
+   * The CheckConnection jobs (both source and destination) of the SynchronousSchedulerClient
+   * interface can have a successful job with a failed check. Because of this, tracking just the job
+   * attempt status does not capture the whole picture. The `check_connection_outcome` field tracks
+   * this.
    */
   private ImmutableMap<String, Object> generateCheckConnectionMetadata(StandardCheckConnectionOutput output) {
     if (output == null) {

--- a/airbyte-scheduler/persistence/src/main/resources/example_config.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config.json
@@ -2,6 +2,8 @@
   "username": "some_user",
   "password": "hunter2",
   "has_ssl": false,
+  "empty_string": "",
+  "null_value": null,
   "one_of": {
     "some_key": 100
   }

--- a/airbyte-scheduler/persistence/src/main/resources/example_config.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config.json
@@ -1,0 +1,8 @@
+{
+  "username": "some_user",
+  "password": "hunter2",
+  "has_ssl": false,
+  "one_of": {
+    "some_key": 100
+  }
+}

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
@@ -234,7 +234,7 @@ class JobTrackerTest {
 
   @Test
   void testConfigToMetadata() throws IOException {
-    String configJson = MoreResources.readResource("config.json");
+    String configJson = MoreResources.readResource("example_config.json");
     JsonNode config = Jsons.deserialize(configJson);
 
     Map<String, Object> expected = ImmutableMap.of(

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
@@ -101,10 +101,10 @@ class JobTrackerTest {
       .put("volume_mb", SYNC_BYTES_SYNC)
       .build();
   private static final ImmutableMap<String, Object> SYNC_CONFIG_METADATA = ImmutableMap.<String, Object>builder()
-      .put(JobTracker.CONFIG + ".source.key", true)
+      .put(JobTracker.CONFIG + ".source.key", JobTracker.SET)
       .put(JobTracker.CONFIG + ".destination.key", false)
-      .put(JobTracker.CATALOG + ".sync_mode.full_refresh", true)
-      .put(JobTracker.CATALOG + ".destination_sync_mode.append", true)
+      .put(JobTracker.CATALOG + ".sync_mode.full_refresh", JobTracker.SET)
+      .put(JobTracker.CATALOG + ".destination_sync_mode.append", JobTracker.SET)
       .build();
 
   private ConfigRepository configRepository;
@@ -238,10 +238,10 @@ class JobTrackerTest {
     JsonNode config = Jsons.deserialize(configJson);
 
     Map<String, Object> expected = ImmutableMap.of(
-        JobTracker.CONFIG + ".username", true,
+        JobTracker.CONFIG + ".username", JobTracker.SET,
         JobTracker.CONFIG + ".has_ssl", false,
-        JobTracker.CONFIG + ".password", true,
-        JobTracker.CONFIG + ".one_of.some_key", true);
+        JobTracker.CONFIG + ".password", JobTracker.SET,
+        JobTracker.CONFIG + ".one_of.some_key", JobTracker.SET);
 
     Map<String, Object> actual = JobTracker.configToMetadata(JobTracker.CONFIG, config);
 
@@ -303,7 +303,7 @@ class JobTrackerTest {
             .withDestinationSyncMode(DestinationSyncMode.APPEND)));
 
     final JobSyncConfig jobSyncConfig = new JobSyncConfig()
-        .withSourceConfiguration(Jsons.jsonNode(ImmutableMap.of("key", true)))
+        .withSourceConfiguration(Jsons.jsonNode(ImmutableMap.of("key", "some_value")))
         .withDestinationConfiguration(Jsons.jsonNode(ImmutableMap.of("key", false)))
         .withConfiguredAirbyteCatalog(catalog);
 

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
@@ -24,15 +24,21 @@
 
 package io.airbyte.scheduler.persistence.job_tracker;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.analytics.TrackingClient;
+import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.map.MoreMaps;
+import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.config.JobConfig;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.JobOutput;
+import io.airbyte.config.JobSyncConfig;
 import io.airbyte.config.Schedule;
 import io.airbyte.config.Schedule.TimeUnit;
 import io.airbyte.config.StandardCheckConnectionOutput;
@@ -44,12 +50,17 @@ import io.airbyte.config.StandardSyncSchedule;
 import io.airbyte.config.StandardSyncSummary;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.ConfiguredAirbyteStream;
+import io.airbyte.protocol.models.DestinationSyncMode;
+import io.airbyte.protocol.models.SyncMode;
 import io.airbyte.scheduler.models.Attempt;
 import io.airbyte.scheduler.models.Job;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.scheduler.persistence.job_tracker.JobTracker.JobState;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -88,6 +99,12 @@ class JobTrackerTest {
       .put("duration", SYNC_DURATION)
       .put("volume_rows", SYNC_RECORDS_SYNC)
       .put("volume_mb", SYNC_BYTES_SYNC)
+      .build();
+  private static final ImmutableMap<String, Object> SYNC_CONFIG_METADATA = ImmutableMap.<String, Object>builder()
+      .put(JobTracker.CONFIG + ".source.key", true)
+      .put(JobTracker.CONFIG + ".destination.key", false)
+      .put(JobTracker.CATALOG + ".sync_mode.full_refresh", true)
+      .put(JobTracker.CATALOG + ".destination_sync_mode.append", true)
       .build();
 
   private ConfigRepository configRepository;
@@ -167,7 +184,7 @@ class JobTrackerTest {
 
   @Test
   void testTrackSync() throws ConfigNotFoundException, IOException, JsonValidationException {
-    testAsynchronous(ConfigType.SYNC);
+    testAsynchronous(ConfigType.SYNC, SYNC_CONFIG_METADATA);
   }
 
   @Test
@@ -176,6 +193,12 @@ class JobTrackerTest {
   }
 
   void testAsynchronous(ConfigType configType) throws ConfigNotFoundException, IOException, JsonValidationException {
+    testAsynchronous(configType, Collections.emptyMap());
+  }
+
+  // todo update with connection-specific test
+  void testAsynchronous(ConfigType configType, Map<String, Object> additionalExpectedMetadata)
+      throws ConfigNotFoundException, IOException, JsonValidationException {
     // for sync the job id is a long not a uuid.
     final long jobId = 10L;
 
@@ -183,19 +206,25 @@ class JobTrackerTest {
     final Job job = getJobMock(configType, jobId);
     // test when frequency is manual.
     when(configRepository.getStandardSyncSchedule(CONNECTION_ID)).thenReturn(new StandardSyncSchedule().withManual(true));
-    final Map<String, Object> manualMetadata = MoreMaps.merge(metadata, ImmutableMap.of("frequency", "manual"));
+    final Map<String, Object> manualMetadata = MoreMaps.merge(
+        metadata,
+        ImmutableMap.of("frequency", "manual"),
+        additionalExpectedMetadata);
     assertCorrectMessageForEachState((jobState) -> jobTracker.trackSync(job, jobState), manualMetadata);
 
     // test when frequency is scheduled.
     when(configRepository.getStandardSyncSchedule(CONNECTION_ID))
         .thenReturn(new StandardSyncSchedule().withManual(false).withSchedule(new Schedule().withUnits(1L).withTimeUnit(TimeUnit.MINUTES)));
-    final Map<String, Object> scheduledMetadata = MoreMaps.merge(metadata, ImmutableMap.of("frequency", "1 min"));
+    final Map<String, Object> scheduledMetadata = MoreMaps.merge(
+        metadata,
+        ImmutableMap.of("frequency", "1 min"),
+        additionalExpectedMetadata);
     assertCorrectMessageForEachState((jobState) -> jobTracker.trackSync(job, jobState), scheduledMetadata);
   }
 
   @Test
   void testTrackSyncAttempt() throws ConfigNotFoundException, IOException, JsonValidationException {
-    testAsynchronousAttempt(ConfigType.SYNC);
+    testAsynchronousAttempt(ConfigType.SYNC, SYNC_CONFIG_METADATA);
   }
 
   @Test
@@ -203,7 +232,28 @@ class JobTrackerTest {
     testAsynchronousAttempt(ConfigType.RESET_CONNECTION);
   }
 
+  @Test
+  void testConfigToMetadata() throws IOException {
+    String configJson = MoreResources.readResource("config.json");
+    JsonNode config = Jsons.deserialize(configJson);
+
+    Map<String, Object> expected = ImmutableMap.of(
+        JobTracker.CONFIG + ".username", true,
+        JobTracker.CONFIG + ".has_ssl", false,
+        JobTracker.CONFIG + ".password", true,
+        JobTracker.CONFIG + ".one_of.some_key", true);
+
+    Map<String, Object> actual = JobTracker.configToMetadata(JobTracker.CONFIG, config);
+
+    assertEquals(expected, actual);
+  }
+
   void testAsynchronousAttempt(ConfigType configType) throws ConfigNotFoundException, IOException, JsonValidationException {
+    testAsynchronousAttempt(configType, Collections.emptyMap());
+  }
+
+  void testAsynchronousAttempt(ConfigType configType, Map<String, Object> additionalExpectedMetadata)
+      throws ConfigNotFoundException, IOException, JsonValidationException {
     // for sync the job id is a long not a uuid.
     final long jobId = 10L;
 
@@ -211,7 +261,11 @@ class JobTrackerTest {
     final Job job = getJobWithAttemptsMock(configType, jobId);
     // test when frequency is manual.
     when(configRepository.getStandardSyncSchedule(CONNECTION_ID)).thenReturn(new StandardSyncSchedule().withManual(true));
-    final Map<String, Object> manualMetadata = MoreMaps.merge(ATTEMPT_METADATA, metadata, ImmutableMap.of("frequency", "manual"));
+    final Map<String, Object> manualMetadata = MoreMaps.merge(
+        ATTEMPT_METADATA,
+        metadata,
+        ImmutableMap.of("frequency", "manual"),
+        additionalExpectedMetadata);
 
     jobTracker.trackSync(job, JobState.SUCCEEDED);
     assertCorrectMessageForSucceededState(manualMetadata);
@@ -243,8 +297,26 @@ class JobTrackerTest {
             .withName(DESTINATION_DEF_NAME)
             .withDockerImageTag(CONNECTOR_VERSION));
 
+    final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(List.of(
+        new ConfiguredAirbyteStream()
+            .withSyncMode(SyncMode.FULL_REFRESH)
+            .withDestinationSyncMode(DestinationSyncMode.APPEND)));
+
+    final JobSyncConfig jobSyncConfig = new JobSyncConfig()
+        .withSourceConfiguration(Jsons.jsonNode(ImmutableMap.of("key", true)))
+        .withDestinationConfiguration(Jsons.jsonNode(ImmutableMap.of("key", false)))
+        .withConfiguredAirbyteCatalog(catalog);
+
+    final JobConfig jobConfig = mock(JobConfig.class);
+    when(jobConfig.getConfigType()).thenReturn(configType);
+
+    if (configType == ConfigType.SYNC) {
+      when(jobConfig.getSync()).thenReturn(jobSyncConfig);
+    }
+
     final Job job = mock(Job.class);
     when(job.getId()).thenReturn(jobId);
+    when(job.getConfig()).thenReturn(jobConfig);
     when(job.getConfigType()).thenReturn(configType);
     when(job.getScope()).thenReturn(CONNECTION_ID.toString());
     when(job.getAttemptsCount()).thenReturn(700);


### PR DESCRIPTION
Resolves:
* https://github.com/airbytehq/airbyte/issues/3015
* https://github.com/airbytehq/airbyte/issues/3016

I ended up tracking more than I expected for the source/destination configs and less for the sync-level configuration.

For the source/destinations, I initially tried using a scheduler client (which depends on a job tracker) to fetch the specs and figure out which fields are required. I ended up doing it the current method, which was much easier to implement (no circular job tracker dep) at the expense of reporting some additional metrics.

For the sync-level configs, it looks like the cursor/pk setting is tied pretty closely to the modes, so it doesn't seem to add much more information. It's also not clear to me how to identify if a custom namespace is being used or not at this level, so I'm not tracking that here.