### PR TITLE
add bumpversion to .env kube

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -12,4 +12,6 @@ serialize =
 
 [bumpversion:file:docs/tutorials/upgrading-airbyte.md]
 
+[bumpversion:file:kube/overlays/stable/.env]
+
 [bumpversion:file:kube/overlays/stable/kustomization.yaml]


### PR DESCRIPTION
## What
We need to change the version in the .env inside `/kube/stable` too.
The files inside resources use the .env version to pull the version and create PODs.

## How
*Describe the solution*

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `.bumpversion.cfg`
