### PR TITLE
add test that migration output schema same as source schema

### DIFF
--- a/airbyte-migration/build.gradle
+++ b/airbyte-migration/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     implementation project(':airbyte-json-validation')
 
     implementation 'net.sourceforge.argparse4j:argparse4j:0.8.1'
+
+    testImplementation project(':airbyte-config:models')
 }
 
 application {

--- a/airbyte-migration/build.gradle
+++ b/airbyte-migration/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation 'net.sourceforge.argparse4j:argparse4j:0.8.1'
 
     testImplementation project(':airbyte-config:models')
+    testImplementation project(':airbyte-db')
 }
 
 application {

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/Migrations.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/Migrations.java
@@ -30,6 +30,7 @@ import io.airbyte.migrate.migrations.MigrationV0_14_3;
 import io.airbyte.migrate.migrations.MigrationV0_17_0;
 import io.airbyte.migrate.migrations.MigrationV0_18_0;
 import io.airbyte.migrate.migrations.MigrationV0_20_0;
+import io.airbyte.migrate.migrations.MigrationV0_23_0;
 import io.airbyte.migrate.migrations.NoOpMigration;
 import java.util.List;
 
@@ -45,6 +46,7 @@ public class Migrations {
   private static final Migration MIGRATION_V_0_20_0 = new MigrationV0_20_0(MIGRATION_V_0_19_0);
   private static final Migration MIGRATION_V_0_21_0 = new NoOpMigration(MIGRATION_V_0_20_0, "0.21.0-alpha");
   private static final Migration MIGRATION_V_0_22_0 = new NoOpMigration(MIGRATION_V_0_21_0, "0.22.0-alpha");
+  private static final Migration MIGRATION_V_0_23_0 = new MigrationV0_23_0(MIGRATION_V_0_22_0);
 
   // all migrations must be added to the list in the order that they should be applied.
   public static final List<Migration> MIGRATIONS = ImmutableList.of(
@@ -57,6 +59,7 @@ public class Migrations {
       MIGRATION_V_0_19_0,
       MIGRATION_V_0_20_0,
       MIGRATION_V_0_21_0,
-      MIGRATION_V_0_22_0);
+      MIGRATION_V_0_22_0,
+      MIGRATION_V_0_23_0);
 
 }

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/ResourceId.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/ResourceId.java
@@ -84,6 +84,10 @@ public class ResourceId {
     return type.getDirectoryName().resolve(name + ".yaml");
   }
 
+  public String getName() {
+    return name;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_14_3.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_14_3.java
@@ -29,12 +29,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.util.MoreIterators;
 import io.airbyte.migrate.Migration;
+import io.airbyte.migrate.MigrationUtils;
 import io.airbyte.migrate.ResourceId;
 import io.airbyte.migrate.ResourceType;
-import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,14 +65,9 @@ public class MigrationV0_14_3 extends BaseMigration implements Migration {
   @Override
   public Map<ResourceId, JsonNode> getOutputSchema() {
     final Map<ResourceId, JsonNode> outputSchema = new HashMap<>(new MigrationV0_14_0().getOutputSchema());
-
-    try {
-      outputSchema.put(STANDARD_SYNC_RESOURCE_ID,
-          Jsons.jsonNode(MoreResources.readResource("migrations/migrationV0_14_0/airbyte_config/StandardSync.yaml")));
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-
+    outputSchema.put(
+        STANDARD_SYNC_RESOURCE_ID,
+        MigrationUtils.getSchemaFromResourcePath(Path.of("migrations/migrationV0_14_3/airbyte_config"), STANDARD_SYNC_RESOURCE_ID));
     return outputSchema;
   }
 

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_18_0.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_18_0.java
@@ -28,12 +28,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.util.MoreIterators;
 import io.airbyte.migrate.Migration;
+import io.airbyte.migrate.MigrationUtils;
 import io.airbyte.migrate.ResourceId;
 import io.airbyte.migrate.ResourceType;
-import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -78,12 +78,9 @@ public class MigrationV0_18_0 extends BaseMigration implements Migration {
   @Override
   public Map<ResourceId, JsonNode> getInputSchema() {
     final Map<ResourceId, JsonNode> outputSchema = new HashMap<>(previousMigration.getOutputSchema());
-    try {
-      outputSchema.put(STANDARD_WORKSPACE_RESOURCE_ID,
-          Jsons.jsonNode(MoreResources.readResource("migrations/migrationV0_18_0/StandardWorkspace.yaml")));
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    outputSchema.put(
+        STANDARD_WORKSPACE_RESOURCE_ID,
+        MigrationUtils.getSchemaFromResourcePath(Path.of("migrations/migrationV0_18_0"), STANDARD_WORKSPACE_RESOURCE_ID));
     return outputSchema;
   }
 

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_23_0.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_23_0.java
@@ -43,17 +43,20 @@ import org.slf4j.LoggerFactory;
  * Additionally, this migration updates the JSON Schema for StandardWorkspace with a new optional
  * field 'failureNotificationsWebhook' introduced in issue #1689
  */
-public class MigrationV0_20_0 extends BaseMigration implements Migration {
+public class MigrationV0_23_0 extends BaseMigration implements Migration {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(MigrationV0_20_0.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(MigrationV0_23_0.class);
 
-  private static final ResourceId STANDARD_WORKSPACE_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_WORKSPACE");
+  private static final ResourceId SOURCE_DEFINITION_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_SOURCE_DEFINITION");
+  private static final ResourceId DESTINATION_DEFINITION_RESOURCE_ID =
+      ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_DESTINATION_DEFINITION");
+  private static final ResourceId STANDARD_SYNC_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_SYNC");
 
-  private static final String MIGRATION_VERSION = "0.20.0-alpha";
+  private static final String MIGRATION_VERSION = "0.23.0-alpha";
 
   private final Migration previousMigration;
 
-  public MigrationV0_20_0(Migration previousMigration) {
+  public MigrationV0_23_0(Migration previousMigration) {
     super(previousMigration);
     this.previousMigration = previousMigration;
   }
@@ -65,16 +68,22 @@ public class MigrationV0_20_0 extends BaseMigration implements Migration {
 
   @Override
   public Map<ResourceId, JsonNode> getInputSchema() {
-    final Map<ResourceId, JsonNode> outputSchema = new HashMap<>(previousMigration.getOutputSchema());
-    outputSchema.put(
-        STANDARD_WORKSPACE_RESOURCE_ID,
-        MigrationUtils.getSchemaFromResourcePath(Path.of("migrations/migrationV0_20_0"), STANDARD_WORKSPACE_RESOURCE_ID));
-    return outputSchema;
+    return new HashMap<>(previousMigration.getOutputSchema());
   }
 
   @Override
   public Map<ResourceId, JsonNode> getOutputSchema() {
-    return getInputSchema();
+    final Map<ResourceId, JsonNode> outputSchema = new HashMap<>(previousMigration.getOutputSchema());
+    outputSchema.put(
+        SOURCE_DEFINITION_RESOURCE_ID,
+        MigrationUtils.getSchemaFromResourcePath(Path.of("migrations/migrationV0_23_0"), SOURCE_DEFINITION_RESOURCE_ID));
+    outputSchema.put(
+        DESTINATION_DEFINITION_RESOURCE_ID,
+        MigrationUtils.getSchemaFromResourcePath(Path.of("migrations/migrationV0_23_0"), DESTINATION_DEFINITION_RESOURCE_ID));
+    outputSchema.put(
+        STANDARD_SYNC_RESOURCE_ID,
+        MigrationUtils.getSchemaFromResourcePath(Path.of("migrations/migrationV0_23_0"), STANDARD_SYNC_RESOURCE_ID));
+    return outputSchema;
   }
 
   @Override

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_23_0/StandardDestinationDefinition.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_23_0/StandardDestinationDefinition.yaml
@@ -1,0 +1,27 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
+title: StandardDestinationDefinition
+description: describes a destination
+type: object
+required:
+  - destinationDefinitionId
+  - name
+  - dockerRepository
+  - dockerImageTag
+  - documentationUrl
+additionalProperties: false
+properties:
+  destinationDefinitionId:
+    type: string
+    format: uuid
+  name:
+    type: string
+  dockerRepository:
+    type: string
+  dockerImageTag:
+    type: string
+  documentationUrl:
+    type: string
+  icon:
+    type: string

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_23_0/StandardSourceDefinition.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_23_0/StandardSourceDefinition.yaml
@@ -1,0 +1,27 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/Source.yaml
+title: StandardSourceDefinition
+description: describes a source
+type: object
+required:
+  - sourceDefinitionId
+  - name
+  - dockerRepository
+  - dockerImageTag
+  - documentationUrl
+additionalProperties: false
+properties:
+  sourceDefinitionId:
+    type: string
+    format: uuid
+  name:
+    type: string
+  dockerRepository:
+    type: string
+  dockerImageTag:
+    type: string
+  documentationUrl:
+    type: string
+  icon:
+    type: string

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_23_0/StandardSync.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_23_0/StandardSync.yaml
@@ -1,0 +1,35 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSync.yaml
+title: StandardSync
+description: configuration required for sync for ALL taps
+type: object
+required:
+  - sourceId
+  - destinationId
+  - name
+  - catalog
+additionalProperties: false
+properties:
+  prefix:
+    description: Prefix that will be prepended to the name of each stream when it is written to the destination.
+    type: string
+  sourceId:
+    type: string
+    format: uuid
+  destinationId:
+    type: string
+    format: uuid
+  connectionId:
+    type: string
+    format: uuid
+  name:
+    type: string
+  catalog:
+    existingJavaType: io.airbyte.protocol.models.ConfiguredAirbyteCatalog
+  status:
+    type: string
+    enum:
+      - active
+      - inactive
+      - deprecated

--- a/airbyte-migration/src/test/java/io/airbyte/migrate/MigrationCurrentSchemaTest.java
+++ b/airbyte-migration/src/test/java/io/airbyte/migrate/MigrationCurrentSchemaTest.java
@@ -1,0 +1,72 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.migrate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.commons.enums.Enums;
+import io.airbyte.migrate.migrations.MigrationV0_14_0.ConfigKeys;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+public class MigrationCurrentSchemaTest {
+
+  // get all of the "current" configs (in other words the one airbyte-config). get all of the configs
+  // from the output schema of the last migration. make sure they match.
+  @Test
+  void testConfigsOfLastMigrationMatchSource() {
+    final Migration lastMigration = Migrations.MIGRATIONS.get(Migrations.MIGRATIONS.size() - 1);
+    System.out.println("lastMigration.getVersion() = " + lastMigration.getVersion());
+    final Map<ResourceId, JsonNode> lastMigrationOutputSchema = lastMigration.getOutputSchema();
+    final Map<ResourceId, JsonNode> currentSchema = MigrationUtils.getNameToSchemasFromResourcePath(
+        Path.of("types"),
+        ResourceType.CONFIG,
+        Enums.valuesAsStrings(ConfigKeys.class));
+
+    final Map<ResourceId, JsonNode> lastMigrationOutputSchemaCleaned = lastMigrationOutputSchema.entrySet()
+        .stream()
+        .filter(entry -> entry.getKey().getType() == ResourceType.CONFIG)
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+    assertEquals(currentSchema.size(), lastMigrationOutputSchemaCleaned.size());
+
+    final List<Entry<ResourceId, JsonNode>> lastMigrationOutputSchemaCleanedSorted = lastMigrationOutputSchemaCleaned.entrySet()
+        .stream()
+        .sorted(Comparator.comparing((v) -> v.getKey().getType()))
+        .collect(Collectors.toList());
+
+    // break out element-wise assertion so it is easier to read any failed tests.
+    for (Map.Entry<ResourceId, JsonNode> lastMigrationEntry : lastMigrationOutputSchemaCleanedSorted) {
+      assertEquals(lastMigrationEntry.getValue(), currentSchema.get(lastMigrationEntry.getKey()));
+    }
+  }
+
+}

--- a/airbyte-migration/src/test/java/io/airbyte/migrate/MigrationCurrentSchemaTest.java
+++ b/airbyte-migration/src/test/java/io/airbyte/migrate/MigrationCurrentSchemaTest.java
@@ -44,7 +44,6 @@ public class MigrationCurrentSchemaTest {
   @Test
   void testConfigsOfLastMigrationMatchSource() {
     final Migration lastMigration = Migrations.MIGRATIONS.get(Migrations.MIGRATIONS.size() - 1);
-    System.out.println("lastMigration.getVersion() = " + lastMigration.getVersion());
     final Map<ResourceId, JsonNode> lastMigrationOutputSchema = lastMigration.getOutputSchema();
     final Map<ResourceId, JsonNode> currentSchema = MigrationUtils.getNameToSchemasFromResourcePath(
         Path.of("types"),


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/1862

## What
* Fix issue in migrations where output schemas were only using part of the schema. The problem is that the way the schemas were being pulled in was not following references. Now they do.
* Add a test that checks that the configs in `airbyte-config` and `airbyte-db` match the configs in the output schema of the last migration
* Going to stop iterating here. I think this hits the main case that's been biting us. We can add more coverage for other cases as they arise. I describe below what is and is not tested.

## What this will catch
* configs that are removed to `airbyte-config` & `airbyte-db` but not added to the migrations schema.
* configs that are edited in `airbyte-config` & `airbyte-db` but not in the migrations schema. (i think this is the most common case)

## What this will NOT catch
* ~~changes to the postgres database schema.~~ (Update: Added dbs to this PR)
* configs that are added to `airbyte-config` & `airbyte-db` but not added to the migrations schema.
* when the schema.sql is updated but the json schema objects that define it are not updated.