### PR TITLE
Release CDK 0.1.1.

### DIFF
--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -33,7 +33,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.0",
+    version="0.1.1",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -33,7 +33,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.0rc5",
+    version="0.1.0",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/374ebc65-6636-4ea0-925c-7d35999a8ffc.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/374ebc65-6636-4ea0-925c-7d35999a8ffc.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "374ebc65-6636-4ea0-925c-7d35999a8ffc",
   "name": "Smartsheets",
   "dockerRepository": "airbyte/source-smartsheets",
-  "dockerImageTag": "0.1.3",
+  "dockerImageTag": "0.1.4",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-smartsheets"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/374ebc65-6636-4ea0-925c-7d35999a8ffc.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/374ebc65-6636-4ea0-925c-7d35999a8ffc.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "374ebc65-6636-4ea0-925c-7d35999a8ffc",
   "name": "Smartsheets",
   "dockerRepository": "airbyte/source-smartsheets",
-  "dockerImageTag": "0.1.2",
+  "dockerImageTag": "0.1.3",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-smartsheets"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ef69ef6e-aa7f-4af1-a01d-ef775033524e.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ef69ef6e-aa7f-4af1-a01d-ef775033524e.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "ef69ef6e-aa7f-4af1-a01d-ef775033524e",
   "name": "GitHub",
   "dockerRepository": "airbyte/source-github-singer",
-  "dockerImageTag": "0.2.3",
+  "dockerImageTag": "0.2.5",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-github-singer",
   "icon": "github.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -248,7 +248,7 @@
 - sourceDefinitionId: 374ebc65-6636-4ea0-925c-7d35999a8ffc
   name: Smartsheets
   dockerRepository: airbyte/source-smartsheets
-  dockerImageTag: 0.1.3
+  dockerImageTag: 0.1.4
   documentationUrl: https://hub.docker.com/r/airbyte/source-smartsheets
 - sourceDefinitionId: b39a7370-74c3-45a6-ac3a-380d48520a83
   name: Oracle DB

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -19,7 +19,7 @@
 - sourceDefinitionId: ef69ef6e-aa7f-4af1-a01d-ef775033524e
   name: GitHub
   dockerRepository: airbyte/source-github-singer
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.2.5
   documentationUrl: https://hub.docker.com/r/airbyte/source-github-singer
   icon: github.svg
 - sourceDefinitionId: b5ea17b1-f170-46dc-bc31-cc744ca984c1
@@ -248,7 +248,7 @@
 - sourceDefinitionId: 374ebc65-6636-4ea0-925c-7d35999a8ffc
   name: Smartsheets
   dockerRepository: airbyte/source-smartsheets
-  dockerImageTag: 0.1.2
+  dockerImageTag: 0.1.3
   documentationUrl: https://hub.docker.com/r/airbyte/source-smartsheets
 - sourceDefinitionId: b39a7370-74c3-45a6-ac3a-380d48520a83
   name: Oracle DB

--- a/airbyte-integrations/bases/source-acceptance-test/setup.py
+++ b/airbyte-integrations/bases/source-acceptance-test/setup.py
@@ -24,7 +24,7 @@
 import setuptools
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk==0.1.0rc5",
+    "airbyte-cdk==0.1.1",
     "docker==4.4.4",
     "PyYAML==5.4.0",
     "inflection==0.5.1",

--- a/airbyte-integrations/connectors/source-exchange-rates/Dockerfile
+++ b/airbyte-integrations/connectors/source-exchange-rates/Dockerfile
@@ -15,5 +15,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.3
+LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/source-exchange-rates

--- a/airbyte-integrations/connectors/source-exchange-rates/setup.py
+++ b/airbyte-integrations/connectors/source-exchange-rates/setup.py
@@ -30,5 +30,5 @@ setup(
     author_email="contact@airbyte.io",
     packages=find_packages(),
     package_data={"": ["*.json", "schemas/*.json"]},
-    install_requires=["airbyte-cdk-test", "pendulum>=2,<3"],
+    install_requires=["airbyte-cdk==0.1.1", "pendulum>=2,<3"],
 )

--- a/airbyte-integrations/connectors/source-github-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-github-singer/Dockerfile
@@ -15,7 +15,7 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.4
+LABEL io.airbyte.version=0.2.5
 LABEL io.airbyte.name=airbyte/source-github-singer
 
 WORKDIR /airbyte

--- a/airbyte-integrations/connectors/source-github-singer/setup.py
+++ b/airbyte-integrations/connectors/source-github-singer/setup.py
@@ -32,7 +32,7 @@ setup(
     install_requires=[
         "tap-github @ https://github.com/airbytehq/tap-github/tarball/v1.9.4-airbyte",
         "requests==2.20.0",
-        "airbyte-cdk-test==0.1.0rc3",
+        "airbyte-cdk==0.1.1",
     ],
     package_data={"": ["*.json"]},
 )

--- a/airbyte-integrations/connectors/source-slack/Dockerfile
+++ b/airbyte-integrations/connectors/source-slack/Dockerfile
@@ -15,5 +15,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/source-slack

--- a/airbyte-integrations/connectors/source-slack/setup.py
+++ b/airbyte-integrations/connectors/source-slack/setup.py
@@ -29,6 +29,6 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=["airbyte-cdk-test", "pytest==6.1.2", "slack_sdk==3.4.2", "pendulum>=2,<3"],
+    install_requires=["airbyte-cdk==0.1.1", "pytest==6.1.2", "slack_sdk==3.4.2", "pendulum>=2,<3"],
     package_data={"": ["*.json"]},
 )

--- a/airbyte-integrations/connectors/source-smartsheets/Dockerfile
+++ b/airbyte-integrations/connectors/source-smartsheets/Dockerfile
@@ -14,5 +14,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.3
+LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/source-smartsheets

--- a/airbyte-integrations/connectors/source-smartsheets/Dockerfile
+++ b/airbyte-integrations/connectors/source-smartsheets/Dockerfile
@@ -14,5 +14,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/source-smartsheets

--- a/airbyte-integrations/connectors/source-stripe/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe/Dockerfile
@@ -11,5 +11,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.6
+LABEL io.airbyte.version=0.1.7
 LABEL io.airbyte.name=airbyte/source-stripe

--- a/airbyte-integrations/connectors/source-stripe/setup.py
+++ b/airbyte-integrations/connectors/source-stripe/setup.py
@@ -30,5 +30,5 @@ setup(
     author_email="contact@airbyte.io",
     packages=find_packages(),
     package_data={"": ["*.json", "schemas/*.json", "schemas/shared/*.json"]},
-    install_requires=["airbyte-cdk==0.1.0rc5", "stripe"],
+    install_requires=["airbyte-cdk==0.1.1", "stripe"],
 )


### PR DESCRIPTION
## What
Release CDK 0.1.1. Unfortunately I can't release 0.1.0 because we previously released it while testing and I didn't realise once a package is released on PyPi, a package with the same name/version cannot be released regardless of whether it's deleted or not.

Updated:
- source-exchange-rates
- source-github-singer
- source-slack
- source-smartsheets (this is at 0.1.4 since someone published 0.1.3 but the change was not checked in)
- source-stripe

Only `source-github-singer` and `source-smartsheets` need to be updated. The rest are either not already published or have singer equivalents present. 

## Pre-merge Checklist
- [x] *Publish CDK 0.1.1.*
- [ ] *Update and publish all relevant sources.*
