### PR TITLE
Source FreshDesk  bugfix: fixing data types in JSON schema to match data from API

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ec4b9503-13cb-48ab-a4ab-6ade4be46567.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ec4b9503-13cb-48ab-a4ab-6ade4be46567.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "ec4b9503-13cb-48ab-a4ab-6ade4be46567",
   "name": "Freshdesk",
   "dockerRepository": "airbyte/source-freshdesk",
-  "dockerImageTag": "0.2.1",
+  "dockerImageTag": "0.2.2",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-freshdesk",
   "icon": "freshdesk.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -127,7 +127,7 @@
 - sourceDefinitionId: ec4b9503-13cb-48ab-a4ab-6ade4be46567
   name: Freshdesk
   dockerRepository: airbyte/source-freshdesk
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2
   documentationUrl: https://hub.docker.com/r/airbyte/source-freshdesk
   icon: freshdesk.svg
 - sourceDefinitionId: 396e4ca3-8a97-4b85-aa4e-c9d8c2d5f992

--- a/airbyte-integrations/connectors/source-freshdesk/Dockerfile
+++ b/airbyte-integrations/connectors/source-freshdesk/Dockerfile
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.1
+LABEL io.airbyte.version=0.2.2
 LABEL io.airbyte.name=airbyte/source-freshdesk

--- a/airbyte-integrations/connectors/source-freshdesk/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-freshdesk/sample_files/configured_catalog.json
@@ -120,7 +120,7 @@
               "type": "object"
             },
             "health_score": {
-              "type": ["number", "null"]
+              "type": ["string", "null"]
             },
             "account_tier": {
               "type": "string"
@@ -324,7 +324,7 @@
               "type": "string"
             },
             "auto_ticket_assign": {
-              "type": "boolean"
+              "type": ["string", "null"]
             }
           }
         },

--- a/airbyte-integrations/connectors/source-freshdesk/source_freshdesk/schemas/companies.json
+++ b/airbyte-integrations/connectors/source-freshdesk/source_freshdesk/schemas/companies.json
@@ -30,7 +30,7 @@
       "type": "object"
     },
     "health_score": {
-      "type": ["number", "null"]
+      "type": ["string", "null"]
     },
     "account_tier": {
       "type": "string"

--- a/airbyte-integrations/connectors/source-freshdesk/source_freshdesk/schemas/groups.json
+++ b/airbyte-integrations/connectors/source-freshdesk/source_freshdesk/schemas/groups.json
@@ -30,7 +30,7 @@
       "type": "string"
     },
     "auto_ticket_assign": {
-      "type": "boolean"
+      "type": ["string", "null"]
     }
   }
 }


### PR DESCRIPTION
## What
Closes #3252 

## How
The web responces from API (both fields and data types) in some cases does not match the FreshDesk API documentation. Solution is to set correct data types manually, accordinately to recieved web-responces.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `test.java`
1. `component.ts`
1. the rest
