### PR TITLE
Hotfix: Fix migration tests.

### DIFF
--- a/airbyte-migration/src/main/resources/migrations/migrationV0_23_0/StandardSync.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_23_0/StandardSync.yaml
@@ -20,6 +20,11 @@ properties:
   destinationId:
     type: string
     format: uuid
+  operationIds:
+    type: array
+    items:
+      type: string
+      format: uuid
   connectionId:
     type: string
     format: uuid


### PR DESCRIPTION
## What
Update migration schema to include recent changes to the StandardSync.

From timestamps, I believe what happened is the migration test branch build passed before Chris merged in his change. One way to avoid this is to build the branch just before merging, but it's still possible to mistime this. Not a big deal.
