### PR TITLE
Upload test reports (from integration test slash commands) as GitHub artifacts

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -101,6 +101,12 @@ jobs:
           ACTION_RUN_ID: ${{github.run_id}}
           # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
           TZ: UTC
+      - name: Archive test reports artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: integration-test-reports
+          path: |
+            **/${{ github.event.inputs.connector }}/build/reports/tests/**/**
       - name: Report Status
         if: github.ref == 'refs/heads/master' && always()
         run: ./tools/status/report.sh ${{ github.event.inputs.connector }} ${{github.repository}} ${{github.run_id}} ${{steps.test.outcome}}

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -102,9 +102,10 @@ jobs:
           # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
           TZ: UTC
       - name: Archive test reports artifacts
+        if: github.event.inputs.comment-id && !success()
         uses: actions/upload-artifact@v2
         with:
-          name: integration-test-reports
+          name: test-reports
           path: |
             **/${{ github.event.inputs.connector }}/build/reports/tests/**/**
       - name: Report Status


### PR DESCRIPTION
## What
When integration tests are failing on GitHub test commands, it'd be helpful to have access to more logs...

## How
Implement [storing workflow data as artifacts](https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts) in order to upload `<connectors>/build/reports/tests` files that can then be downloaded and browsed for more investigations afterward when tests are failing.

You can browse on the summary tab to the bottom of the integration test to download a zip of `test-reports.zip`:

![Screenshot 2021-05-14 at 18 30 58](https://user-images.githubusercontent.com/7718175/118300751-93c98c00-b4e2-11eb-892f-c4cf760f476b.png)

In the test reports, when you select a particular test, you can then view the standard output to get more details on test failures!
(See an example in the comment below)

## Pre-merge Checklist
- [x] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `.github/workflows/test-command.yml`
1. the rest
