### PR TITLE
🎉  restart core containers if they fail automatically

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
   db:
     image: airbyte/db:${VERSION}
     container_name: airbyte-db
+    restart: unless-stopped
     environment:
       - POSTGRES_USER=${DATABASE_USER}
       - POSTGRES_PASSWORD=${DATABASE_PASSWORD}
@@ -30,6 +31,7 @@ services:
   scheduler:
     image: airbyte/scheduler:${VERSION}
     container_name: airbyte-scheduler
+    restart: unless-stopped
     environment:
       - WEBAPP_URL=${WEBAPP_URL}
       - WAIT_BEFORE_HOSTS=5
@@ -55,6 +57,7 @@ services:
   server:
     image: airbyte/server:${VERSION}
     container_name: airbyte-server
+    restart: unless-stopped
     environment:
       - WEBAPP_URL=${WEBAPP_URL}
       - WAIT_BEFORE_HOSTS=5
@@ -77,6 +80,7 @@ services:
   webapp:
     image: airbyte/webapp:${VERSION}
     container_name: airbyte-webapp
+    restart: unless-stopped
     ports:
       - 8000:80
     environment:
@@ -89,6 +93,7 @@ services:
   airbyte-temporal:
     image: temporalio/auto-setup:1.7.0
     container_name: airbyte-temporal
+    restart: unless-stopped
     ports:
       - 7233:7233
     environment:


### PR DESCRIPTION
see https://docs.docker.com/compose/compose-file/compose-file-v3/#restart for docs on restart

This adds restarts for all long-running containers. I allowed `unless-stopped` instead of `always` so we can still manually control services.

We've seen a couple of issues on Slack where users were confused because some container (like temporal or the server) died and never restarted. This should fix that problem.

**Manual Testing**
I tested this by running `docker-compose up` in one window, and in the other running this sequence of commands:
```
→ docker exec -it airbyte-server /bin/bash
root@9365322a100e:/app# apt-get install ps
...
root@9365322a100e:/app# ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  7.2  8.1 3392784 250900 ?      Ssl  18:38   0:16 /usr/local/open
root        63  0.0  0.1   5624  3576 pts/0    Ss   18:41   0:00 /bin/bash
root       391  0.0  0.0   9396  2988 pts/0    R+   18:42   0:00 ps aux
root@9365322a100e:/app# kill 1
root@9365322a100e:/app# %
```

which killed the server. Then I could see it restarted successfully in the docker-compose logs/UI interactions. 