### PR TITLE
Add Rust as a connector specific dependency to source-file

### DIFF
--- a/airbyte-integrations/connectors/source-file/README.md
+++ b/airbyte-integrations/connectors/source-file/README.md
@@ -8,6 +8,10 @@ For information about how to use this connector within Airbyte, see [the documen
 ### Prerequisites
 **To iterate on this connector, make sure to complete this prerequisites section.**
 
+#### Connector-Specific Dependencies
+
+For this connector, you will need Rust, as it is a prerequisite for running `pip install cryptography`.
+
 #### Build & Activate Virtual Environment and install dependencies
 From this connector directory, create a virtual environment:
 ```

--- a/airbyte-integrations/connectors/source-file/README.md
+++ b/airbyte-integrations/connectors/source-file/README.md
@@ -10,8 +10,7 @@ For information about how to use this connector within Airbyte, see [the documen
 
 #### Connector-Specific Dependencies
 
-For this connector, you will need Rust, as it is a prerequisite for running `pip install cryptography`. You can do this with the recommended
-installation pattern noted [here](https://www.rust-lang.org/tools/install) on the Rust website.
+For this connector, you will need Rust, as it is a prerequisite for running `pip install cryptography`. You can do this with the recommended installation pattern noted [here](https://www.rust-lang.org/tools/install) on the Rust website.
 
 #### Build & Activate Virtual Environment and install dependencies
 From this connector directory, create a virtual environment:

--- a/airbyte-integrations/connectors/source-file/README.md
+++ b/airbyte-integrations/connectors/source-file/README.md
@@ -10,7 +10,8 @@ For information about how to use this connector within Airbyte, see [the documen
 
 #### Connector-Specific Dependencies
 
-For this connector, you will need Rust, as it is a prerequisite for running `pip install cryptography`.
+For this connector, you will need Rust, as it is a prerequisite for running `pip install cryptography`. You can do this with the recommended
+installation pattern noted [here](https://www.rust-lang.org/tools/install) on the Rust website.
 
 #### Build & Activate Virtual Environment and install dependencies
 From this connector directory, create a virtual environment:


### PR DESCRIPTION
## Main Changes
- Weirdly enough, Rust is specifically required as a dependency for the `source-file` connector, as mentioned in this PR: #2340, so this PR adds the dependency to the specific connector README file. 

## Notes
- Cleans up some outstanding doc updates mentioned here: https://github.com/airbytehq/airbyte/pull/2340#issuecomment-818341062

