### PR TITLE
Basic paginate for connection list page.

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -799,8 +799,21 @@ paths:
       tags:
         - connection
       summary: Returns all connections for a workspace.
-      description: List connections for workspace. Does not return deleted connections.
+      description: List connections for workspace. Does not return deleted connections. Returns the first 25 connections by default.
       operationId: listConnectionsForWorkspace
+      parameters:
+        - name: limit
+          in: path
+          description: Number of connections to return.
+          required: false
+          schema:
+            type: integer
+        - name: offset
+          in: path
+          description: Number of connections to start from when listing.
+          required: false
+          schema:
+            type: integer
       requestBody:
         content:
           application/json:
@@ -1993,6 +2006,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ConnectionRead"
+        offset:
+          type: integer
+        limit:
+          type: integer
     ConnectionStatus:
       type: string
       description: Active means that data is flowing through the connection. Inactive means it is not. Deprecated means the connection is off and cannot be re-activated. the schema field describes the elements of the schema that will be synced.

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2008,8 +2008,6 @@ components:
             $ref: "#/components/schemas/ConnectionRead"
         offset:
           type: integer
-        limit:
-          type: integer
     ConnectionStatus:
       type: string
       description: Active means that data is flowing through the connection. Inactive means it is not. Deprecated means the connection is off and cannot be re-activated. the schema field describes the elements of the schema that will be synced.

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -576,8 +576,16 @@ font-style: italic;
     <a class="up" href="#__Methods">Up</a>
     <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/connections/list</code></pre></div>
     <div class="method-summary">Returns all connections for a workspace. (<span class="nickname">listConnectionsForWorkspace</span>)</div>
-    <div class="method-notes">List connections for workspace. Does not return deleted connections.</div>
+    <div class="method-notes">List connections for workspace. Does not return deleted connections. Returns the first 25 connections by default.</div>
 
+    <h3 class="field-label">Path parameters</h3>
+    <div class="field-items">
+      <div class="param">limit (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; Number of connections to return. default: null </div><div class="param">offset (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; Number of connections to start from when listing. default: null </div>
+    </div>  <!-- field-items -->
 
     <h3 class="field-label">Consumes</h3>
     This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
@@ -607,6 +615,8 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
+  "offset" : 0,
+  "limit" : 6,
   "connections" : [ {
     "sourceId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     "schedule" : {
@@ -5018,6 +5028,8 @@ font-style: italic;
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">connections </div><div class="param-desc"><span class="param-type"><a href="#ConnectionRead">array[ConnectionRead]</a></span>  </div>
+<div class="param">offset (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span>  </div>
+<div class="param">limit (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What
Prototype connections paginate.

## How
* Use a simple limit-offset strategy with default 25. 
* Api accepts limit-offset as parameters for the connection list route.
* Response body contains the current offset, so users know what offset to pass into the next request.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200367912513076/1200368073603289) by [Unito](https://www.unito.io)
