### PR TITLE
Add redirect to cdk tutorial page

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -35,3 +35,4 @@ redirects:
   tutorials/building-a-python-source: ./tutorials/tutorials/building-a-python-source.md
   tutorials/transformations-with-sql: ./tutorials/transformation-and-normalization/transformations-with-sql.md
   tutorials/transformations-with-dbt: ./tutorials/transformation-and-normalization/transformations-with-dbt.md
+  contributing-to-airbyte/cdk-tutorial-alpha: ./contributing-to-airbyte/python/tutorials/cdk-tutorial-python-http/0-getting-started.md

--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -35,4 +35,4 @@ redirects:
   tutorials/building-a-python-source: ./tutorials/tutorials/building-a-python-source.md
   tutorials/transformations-with-sql: ./tutorials/transformation-and-normalization/transformations-with-sql.md
   tutorials/transformations-with-dbt: ./tutorials/transformation-and-normalization/transformations-with-dbt.md
-  contributing-to-airbyte/cdk-tutorial-alpha: ./contributing-to-airbyte/python/tutorials/cdk-tutorial-python-http/0-getting-started.md
+  contributing-to-airbyte/cdk-tutorial-alpha: ./contributing-to-airbyte/python/README.md


### PR DESCRIPTION
## What
Add redirect to top page return searching: `airbyte cdk`

## How
Added a link to the markdown page to get started CDK tutorial, I read Gitbook docs and it's not clear if I can redirect to a folder. So I did it in the simplest way, does anyone know how to answer if it is possible?

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `test.java`
1. `component.ts`
1. the rest
