### PR TITLE
Allow the user to enter a comma-separated list of Google Adwords customer IDs

### DIFF
--- a/airbyte-integrations/connectors/source-google-adwords-singer/source_google_adwords_singer/spec.json
+++ b/airbyte-integrations/connectors/source-google-adwords-singer/source_google_adwords_singer/spec.json
@@ -47,7 +47,7 @@
       },
       "customer_ids": {
         "type": "string",
-        "pattern": "^[0-9]{10}$",
+        "pattern": "^[0-9]{10}(,[0-9]{10})*$",
         "description": "Comma-separated list of a customer ids. Each customer id must be specified  as a 10-digit number without dashes. More instruction on how to find this value in our <a href=\"https://docs.airbyte.io/integrations/sources/google-adwords#setup-guide\">docs</a>"
       }
     }


### PR DESCRIPTION
## What
The Google Adwords source connector has a field named `customer_ids`, which is presented in the UI like this:

![image](https://user-images.githubusercontent.com/236086/118566364-99181800-b728-11eb-86f0-6433c7757885.png)

But if I try to enter multiple IDs separated by commas, the UI refuses to accept them:

![image](https://user-images.githubusercontent.com/236086/118566431-b351f600-b728-11eb-9ad0-4ef4e468e2b4.png)

## How
It looks like the connector really does accept a comma-separated list of IDs; in `source.py` I see the line:

```
            customer_ids = config["customer_ids"].split(",")
```

So I think this is just a matter of changing the regular expression in `spec.json` to allow multiple customer IDs, and that's what this PR does.

Note that I haven't actually tried out this change with multiple customer IDs because I haven't figured out how to make changes to the code of a running Airbyte instance yet.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*
