### PR TITLE
Fix speedrun tutorial link.

### DIFF
--- a/docs/contributing-to-airbyte/python/tutorials/cdk-speedrun.md
+++ b/docs/contributing-to-airbyte/python/tutorials/cdk-speedrun.md
@@ -2,7 +2,7 @@
 
 ## CDK Speedrun \(HTTP API Source Creation [Any%](https://en.wikipedia.org/wiki/Speedrun#:~:text=Any%25%2C%20or%20fastest%20completion%2C,the%20game%20to%20its%20fullest.&text=Specific%20requirements%20for%20a%20100,different%20depending%20on%20the%20game.) Route\)
 
-This is a blazing fast guide to building an HTTP source connector. Think of it as the TL;DR version of [this tutorial.](https://github.com/airbytehq/airbyte/tree/576d932ddbd748713ad5cbeabebd3c21cd0148ad/airbyte-cdk/python/docs/cdk-tutorial-python-http.md)
+This is a blazing fast guide to building an HTTP source connector. Think of it as the TL;DR version of [this tutorial.](./cdk-tutorial-python-http/0-getting-started.md)
 
 ## Dependencies
 


### PR DESCRIPTION
## Main Changes
- A link was broken in the speedrun tutorial, this fixes that.
