### PR TITLE
Print docker process command being executed as INFO instead of DEBUG

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessBuilderFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessBuilderFactory.java
@@ -108,7 +108,7 @@ public class DockerProcessBuilderFactory implements ProcessBuilderFactory {
     cmd.add(imageName);
     cmd.addAll(Arrays.asList(args));
 
-    LOGGER.debug("Preparing command: {}", Joiner.on(" ").join(cmd));
+    LOGGER.info("Preparing command: {}", Joiner.on(" ").join(cmd));
 
     return new ProcessBuilder(cmd);
   }


### PR DESCRIPTION
## What
we use to see what docker commands were being run in the logs but we don't see debug level anymore.
It's useful to point to users and run the docker commands independently from a sync worker for debugging.

## How
Move that print to INFO level instead.

