### PR TITLE
bug: set cdc flag in state

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -220,6 +220,10 @@ public class PostgresSource extends AbstractJdbcSource implements Source {
                                                                              JdbcStateManager stateManager,
                                                                              Instant emittedAt) {
     if (isCdc(config)) {
+      // todo (cgardens) - this is a hack to make sure this flag get set properly. when we consolidate our
+      // CDC logic, we should figure out a way to add this more ergonomically into the AbstractJdbcSource.
+      stateManager.setIsCdc(true);
+
       // State works differently in CDC than it does in convention incremental. The state is written to an
       // offset file that debezium reads from. Then once all records are replicated, we read back that
       // offset file (which will have been updated by debezium) and set it in the state. There is no


### PR DESCRIPTION
## What
* subodh1810 pointed out that we never actually set the `cdc` flag in the jdbc state. While this omission hasn't caused an actual bug (yet), it is super confusing. This PR adds a change to make sure that this flag gets set. It's definitely a stopgap until we consolidate our CDC code a little bit more intelligently into the rest of our jdbc abstraction.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200367912513076/1200368130330552) by [Unito](https://www.unito.io)
