### PR TITLE
Add missing prefix and icon fields in migration v0.20.0

### DIFF
--- a/airbyte-migration/README.md
+++ b/airbyte-migration/README.md
@@ -3,18 +3,25 @@
 This module migrates configs specified in `airbyte-config` to new versions.
 
 ## Run production migration in docker
+
 ```sh
-docker run --rm -v ~/Downloads:/config airbyte/migration:0.23.0-alpha -- \
+BUILD_VERSION=$(cat .env | grep VERSION | awk -F"=" '{print $2}')
+INPUT_PATH=<path to directory containing downloaded airbyte_archive.tar.gz>
+OUTPUT_PATH=<path to where migrated archive will be written (should end in .tar.gz)>
+TARGET_VERSION=<version you are migrating to or empty for latest>
+
+docker run --rm -v ${INPUT_PATH}:/config airbyte/migration:${BUILD_VERSION} -- \
   --input /config/airbyte_archive.tar.gz \
-  --output ~/Downloads/new_airbyte_archive.tar.gz
+  --output ${OUTPUT_PATH} \
+  [ --target-version ${TARGET_VERSION} ]
 ```
 
 See [Upgrading Airbyte](https://docs.airbyte.io/tutorials/upgrading-airbyte) for details.
 
 ## Run dev migration in IDE
-Run `MigrationRunner.java` with arguments.
+Run `MigrationRunner.java` with arguments (`--input`, `--output`, `--target-version`).
 
-## Run dev migration locally
+## Run dev migration in command line
 
 Run the following command in project root:
 

--- a/airbyte-migration/README.md
+++ b/airbyte-migration/README.md
@@ -1,0 +1,37 @@
+# Airbyte Config Migration
+
+This module migrates configs specified in `airbyte-config` to new versions.
+
+## Run production migration in docker
+```sh
+docker run --rm -v ~/Downloads:/config airbyte/migration:0.23.0-alpha -- \
+  --input /config/airbyte_archive.tar.gz \
+  --output ~/Downloads/new_airbyte_archive.tar.gz
+```
+
+See [Upgrading Airbyte](https://docs.airbyte.io/tutorials/upgrading-airbyte) for details.
+
+## Run dev migration in IDE
+Run `MigrationRunner.java` with arguments.
+
+## Run dev migration locally
+
+Run the following command in project root:
+
+```sh
+# Get the current version
+BUILD_VERSION=$(cat .env | grep VERSION | awk -F"=" '{print $2}')
+
+# Build the migration bundle file
+./gradlew airbyte-migration:build
+
+# Extract the bundle file
+tar xf ./airbyte-migration/build/distributions/airbyte-migration-${BUILD_VERSION}.tar --strip-components=1
+
+# Run the migration
+bin/airbyte-migration \
+  --input <input_config_archive.tar.gz> \
+  --output <output_config_archive.tar.gz>
+```
+
+See [MigrationRunner](./src/main/java/io/airbyte/migrate/MigrationRunner.java) for details.

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/Migrate.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/Migrate.java
@@ -136,7 +136,7 @@ public class Migrate {
                   try {
                     jsonSchemaValidator.ensure(migration.getInputSchema().get(entry.getKey()), r);
                   } catch (JsonValidationException e) {
-                    throw new IllegalArgumentException("Input data schema does not match declared input schema.", e);
+                    throw new IllegalArgumentException(String.format("Input data schema does not match declared input schema %s.", entry.getKey().getName()), e);
                   }
                 })));
 

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/Migrate.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/Migrate.java
@@ -136,7 +136,8 @@ public class Migrate {
                   try {
                     jsonSchemaValidator.ensure(migration.getInputSchema().get(entry.getKey()), r);
                   } catch (JsonValidationException e) {
-                    throw new IllegalArgumentException(String.format("Input data schema does not match declared input schema %s.", entry.getKey().getName()), e);
+                    throw new IllegalArgumentException(
+                        String.format("Input data schema does not match declared input schema %s.", entry.getKey().getName()), e);
                   }
                 })));
 

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_20_0.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_20_0.java
@@ -45,9 +45,10 @@ import org.slf4j.LoggerFactory;
  */
 public class MigrationV0_20_0 extends BaseMigration implements Migration {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(MigrationV0_20_0.class);
-
   private static final ResourceId STANDARD_WORKSPACE_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_WORKSPACE");
+  private static final ResourceId STANDARD_SOURCE_DEFINITION_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_SOURCE_DEFINITION");
+  private static final ResourceId STANDARD_DESTINATION_DEFINITION_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_DESTINATION_DEFINITION");
+  private static final ResourceId STANDARD_SYNC_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_SYNC");
 
   private static final String MIGRATION_VERSION = "0.20.0-alpha";
 
@@ -69,6 +70,15 @@ public class MigrationV0_20_0 extends BaseMigration implements Migration {
     outputSchema.put(
         STANDARD_WORKSPACE_RESOURCE_ID,
         MigrationUtils.getSchemaFromResourcePath(Path.of("migrations/migrationV0_20_0"), STANDARD_WORKSPACE_RESOURCE_ID));
+    outputSchema.put(
+        STANDARD_SOURCE_DEFINITION_RESOURCE_ID,
+        MigrationUtils.getSchemaFromResourcePath(Path.of("migrations/migrationV0_20_0"), STANDARD_SOURCE_DEFINITION_RESOURCE_ID));
+    outputSchema.put(
+        STANDARD_DESTINATION_DEFINITION_RESOURCE_ID,
+        MigrationUtils.getSchemaFromResourcePath(Path.of("migrations/migrationV0_20_0"), STANDARD_DESTINATION_DEFINITION_RESOURCE_ID));
+    outputSchema.put(
+        STANDARD_SYNC_RESOURCE_ID,
+        MigrationUtils.getSchemaFromResourcePath(Path.of("migrations/migrationV0_20_0"), STANDARD_SYNC_RESOURCE_ID));
     return outputSchema;
   }
 

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_20_0.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_20_0.java
@@ -34,8 +34,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This migration is currently empty and is a placeholder for migrations for the next 0.19.0 release
@@ -46,8 +44,10 @@ import org.slf4j.LoggerFactory;
 public class MigrationV0_20_0 extends BaseMigration implements Migration {
 
   private static final ResourceId STANDARD_WORKSPACE_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_WORKSPACE");
-  private static final ResourceId STANDARD_SOURCE_DEFINITION_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_SOURCE_DEFINITION");
-  private static final ResourceId STANDARD_DESTINATION_DEFINITION_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_DESTINATION_DEFINITION");
+  private static final ResourceId STANDARD_SOURCE_DEFINITION_RESOURCE_ID =
+      ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_SOURCE_DEFINITION");
+  private static final ResourceId STANDARD_DESTINATION_DEFINITION_RESOURCE_ID =
+      ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_DESTINATION_DEFINITION");
   private static final ResourceId STANDARD_SYNC_RESOURCE_ID = ResourceId.fromConstantCase(ResourceType.CONFIG, "STANDARD_SYNC");
 
   private static final String MIGRATION_VERSION = "0.20.0-alpha";

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_20_0/StandardDestinationDefinition.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_20_0/StandardDestinationDefinition.yaml
@@ -1,0 +1,27 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
+title: StandardDestinationDefinition
+description: describes a destination
+type: object
+required:
+  - destinationDefinitionId
+  - name
+  - dockerRepository
+  - dockerImageTag
+  - documentationUrl
+additionalProperties: false
+properties:
+  destinationDefinitionId:
+    type: string
+    format: uuid
+  name:
+    type: string
+  dockerRepository:
+    type: string
+  dockerImageTag:
+    type: string
+  documentationUrl:
+    type: string
+  icon:
+    type: string

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_20_0/StandardSourceDefinition.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_20_0/StandardSourceDefinition.yaml
@@ -1,0 +1,27 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/Source.yaml
+title: StandardSourceDefinition
+description: describes a source
+type: object
+required:
+  - sourceDefinitionId
+  - name
+  - dockerRepository
+  - dockerImageTag
+  - documentationUrl
+additionalProperties: false
+properties:
+  sourceDefinitionId:
+    type: string
+    format: uuid
+  name:
+    type: string
+  dockerRepository:
+    type: string
+  dockerImageTag:
+    type: string
+  documentationUrl:
+    type: string
+  icon:
+    type: string

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_20_0/StandardSync.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_20_0/StandardSync.yaml
@@ -1,0 +1,40 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSync.yaml
+title: StandardSync
+description: configuration required for sync for ALL taps
+type: object
+required:
+  - sourceId
+  - destinationId
+  - name
+  - catalog
+additionalProperties: false
+properties:
+  prefix:
+    description: Prefix that will be prepended to the name of each stream when it is written to the destination.
+    type: string
+  sourceId:
+    type: string
+    format: uuid
+  destinationId:
+    type: string
+    format: uuid
+  operationIds:
+    type: array
+    items:
+      type: string
+      format: uuid
+  connectionId:
+    type: string
+    format: uuid
+  name:
+    type: string
+  catalog:
+    existingJavaType: io.airbyte.protocol.models.ConfiguredAirbyteCatalog
+  status:
+    type: string
+    enum:
+      - active
+      - inactive
+      - deprecated


### PR DESCRIPTION
## What
- Two new fields `prefix` and `icon` were added in the v0.20.0 config schema. However, they were not specified in the relevant migration file.
- Consequently, when users run any migration after v0.20.0, the migration runner will consider the input configs as invalid since they contain the two new fields undefined in the schema defined in migration resource, which is the source of truth for schema validation during migration.

<details>
<summary>Click to expand sample logs</summary>

```
2021-05-19 23:12:51 INFO i.a.m.MigrationRunner(parse):78 - {} - args: [--input, /config/airbyte_archive.tar.gz, --output, /Users/lirentu/Downloads/new_airbyte_archive.tar.gz]
2021-05-19 23:12:51 INFO i.a.m.MigrationRunner(run):50 - {} - Unpacking tarball
2021-05-19 23:12:51 INFO i.a.m.MigrationRunner(run):67 - {} - Running migrations...
2021-05-19 23:12:51 INFO i.a.m.MigrationRunner(run):68 - {} - MigrateConfig{inputPath=/tmp/airbyte_migrate7703568884416841818/uncompressed, outputPath=/tmp/airbyte_migrate7703568884416841818/output, targetVersion='null'}
2021-05-19 23:12:51 INFO i.a.m.Migrate(run):88 - {} - Starting migrations. Current version: 0.22.3-alpha, Target version: null
2021-05-19 23:12:51 INFO i.a.m.Migrate(run):112 - {} - Migrating from version: 0.22.0-alpha to version 0.23.0-alpha.
Exception in thread "main" java.lang.IllegalArgumentException: Input data schema does not match declared input schema.
	at io.airbyte.migrate.Migrate.lambda$runMigration$1(Migrate.java:139)
	at java.base/java.util.stream.ReferencePipeline$11$1.accept(ReferencePipeline.java:441)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at io.airbyte.migrate.migrations.MigrationV0_23_0.migrate(MigrationV0_23_0.java:94)
	at io.airbyte.migrate.MigrateWithMetadata.migrate(MigrateWithMetadata.java:52)
	at io.airbyte.migrate.Migrate.runMigration(Migrate.java:149)
	at io.airbyte.migrate.Migrate.run(Migrate.java:113)
	at io.airbyte.migrate.MigrationRunner.run(MigrationRunner.java:70)
	at io.airbyte.migrate.MigrationRunner.main(MigrationRunner.java:108)
Caused by: io.airbyte.validation.json.JsonValidationException: json schema validation failed.
errors: $.icon: is not defined in the schema and the schema does not allow additional properties
schema:
{
  "$schema" : "http://json-schema.org/draft-07/schema#",
  "$id" : "https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml",
  "title" : "StandardDestinationDefinition",
  "description" : "describes a destination",
  "type" : "object",
  "required" : [ "destinationDefinitionId", "name", "dockerRepository", "dockerImageTag", "documentationUrl" ],
  "additionalProperties" : false,
  "properties" : {
    "destinationDefinitionId" : {
      "type" : "string",
      "format" : "uuid"
    },
    "name" : {
      "type" : "string"
    },
    "dockerRepository" : {
      "type" : "string"
    },
    "dockerImageTag" : {
      "type" : "string"
    },
    "documentationUrl" : {
      "type" : "string"
    }
  }
}
object:
{
  "destinationDefinitionId" : "f7a7d195-377f-cf5b-70a5-be6b819019dc",
  "name" : "Redshift",
  "dockerRepository" : "airbyte/destination-redshift",
  "dockerImageTag" : "0.3.7",
  "documentationUrl" : "https://docs.airbyte.io/integrations/destinations/redshift",
  "icon" : "redshift.svg"
}
	at io.airbyte.validation.json.JsonSchemaValidator.ensure(JsonSchemaValidator.java:88)
	at io.airbyte.migrate.Migrate.lambda$runMigration$1(Migrate.java:137)
	... 15 more
```

</details>

## How
- This PR fixes this issue by adding the updated schemas to migration 0.20.0.

## Questions
- [ ] The same updated schemas (standard sync, source definition, and destination definition) also exist in migration resource for v0.23.0. I think they can be removed, since the schema change actually happened in 0.20.0.
- [x] The resource directory for migration 0.20.0 also contains a few other updated schemas (notification, notification type, and slack notification config). But these files are not referenced in migration 0.20.0. Is this expected? I think they should either be referenced there, or removed. @ChristopheDuong, can you confirm?

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `MigrationV0_20_0.java`
1. The rest
