### PR TITLE
optionally remove normalization hashing

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
@@ -62,6 +62,8 @@ public interface Configs {
 
   String getTemporalHost();
 
+  String getBasicNormalizationHashMethod();
+
   enum TrackingStrategy {
     SEGMENT,
     LOGGING

--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -53,6 +53,7 @@ public class EnvConfigs implements Configs {
   private static final String MAXIMUM_WORKSPACE_RETENTION_DAYS = "MAXIMUM_WORKSPACE_RETENTION_DAYS";
   private static final String MAXIMUM_WORKSPACE_SIZE_MB = "MAXIMUM_WORKSPACE_SIZE_MB";
   private static final String TEMPORAL_HOST = "TEMPORAL_HOST";
+  public static final String BASIC_NORMALIZATION_HASH_METHOD = "BASIC_NORMALIZATION_HASH_METHOD";
 
   private static final long DEFAULT_MINIMUM_WORKSPACE_RETENTION_DAYS = 1;
   private static final long DEFAULT_MAXIMUM_WORKSPACE_RETENTION_DAYS = 60;
@@ -164,6 +165,11 @@ public class EnvConfigs implements Configs {
   @Override
   public String getTemporalHost() {
     return getEnvOrDefault(TEMPORAL_HOST, "airbyte-temporal:7233");
+  }
+
+  @Override
+  public String getBasicNormalizationHashMethod() {
+    return getEnvOrDefault(BASIC_NORMALIZATION_HASH_METHOD, "sha1-3");
   }
 
   private String getEnvOrDefault(String key, String defaultValue) {

--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -22,5 +22,5 @@ RUN dbt deps
 WORKDIR /airbyte
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.29
+LABEL io.airbyte.version=0.1.30
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
@@ -779,9 +779,12 @@ def hash_json_path(json_path: List[str]) -> str:
 
 
 def hash_name(input: str) -> str:
-    h = hashlib.sha1()
-    h.update(input.encode("utf-8"))
-    return h.hexdigest()[:3]
+    if os.getenv("BASIC_NORMALIZATION_HASH_METHOD") == "none":
+        return ""
+    else:
+        h = hashlib.sha1()
+        h.update(input.encode("utf-8"))
+        return h.hexdigest()[:3]
 
 
 def get_table_name(name_transformer: DestinationNameTransformer, parent: str, child: str, suffix: str, json_path: List[str]) -> str:

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
@@ -26,9 +26,12 @@ package io.airbyte.workers.normalization;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.io.LineGobbler;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.Configs;
+import io.airbyte.config.EnvConfigs;
 import io.airbyte.config.OperatorDbt;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.workers.WorkerConstants;
@@ -36,6 +39,8 @@ import io.airbyte.workers.WorkerException;
 import io.airbyte.workers.WorkerUtils;
 import io.airbyte.workers.process.ProcessBuilderFactory;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,10 +49,11 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNormalizationRunner.class);
 
-  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.29";
+  public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.30";
 
   private final DestinationType destinationType;
   private final ProcessBuilderFactory pbf;
+  private final Map<String, String> envVars;
 
   private Process process = null;
 
@@ -58,15 +64,16 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
     SNOWFLAKE
   }
 
-  public DefaultNormalizationRunner(final DestinationType destinationType, final ProcessBuilderFactory pbf) {
+  public DefaultNormalizationRunner(final DestinationType destinationType, final ProcessBuilderFactory pbf, Configs configs) {
     this.destinationType = destinationType;
     this.pbf = pbf;
+    this.envVars = ImmutableMap.of(EnvConfigs.BASIC_NORMALIZATION_HASH_METHOD, configs.getBasicNormalizationHashMethod());
   }
 
   @Override
   public boolean configureDbt(String jobId, int attempt, Path jobRoot, JsonNode config, OperatorDbt dbtConfig) throws Exception {
     IOs.writeFile(jobRoot, WorkerConstants.DESTINATION_CONFIG_JSON_FILENAME, Jsons.serialize(config));
-    return runProcess(jobId, attempt, jobRoot, "configure-dbt",
+    return runProcess(jobId, attempt, jobRoot, Collections.emptyMap(), "configure-dbt",
         "--integration-type", destinationType.toString().toLowerCase(),
         "--config", WorkerConstants.DESTINATION_CONFIG_JSON_FILENAME,
         "--git-repo", dbtConfig.getGitRepoUrl(),
@@ -78,15 +85,15 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
     IOs.writeFile(jobRoot, WorkerConstants.DESTINATION_CONFIG_JSON_FILENAME, Jsons.serialize(config));
     IOs.writeFile(jobRoot, WorkerConstants.DESTINATION_CATALOG_JSON_FILENAME, Jsons.serialize(catalog));
 
-    return runProcess(jobId, attempt, jobRoot, "run",
+    return runProcess(jobId, attempt, jobRoot, envVars, "run",
         "--integration-type", destinationType.toString().toLowerCase(),
         "--config", WorkerConstants.DESTINATION_CONFIG_JSON_FILENAME,
         "--catalog", WorkerConstants.DESTINATION_CATALOG_JSON_FILENAME);
   }
 
-  private boolean runProcess(String jobId, int attempt, Path jobRoot, final String... args) throws Exception {
+  private boolean runProcess(String jobId, int attempt, Path jobRoot, Map<String, String> envVars, final String... args) throws Exception {
     try {
-      process = pbf.create(jobId, attempt, jobRoot, NORMALIZATION_IMAGE_NAME, null, args).start();
+      process = pbf.create(jobId, attempt, jobRoot, NORMALIZATION_IMAGE_NAME, null, envVars, args).start();
 
       LineGobbler.gobble(process.getInputStream(), LOGGER::info);
       LineGobbler.gobble(process.getErrorStream(), LOGGER::error);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
@@ -26,6 +26,7 @@ package io.airbyte.workers.normalization;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
+import io.airbyte.config.EnvConfigs;
 import io.airbyte.workers.WorkerConstants;
 import io.airbyte.workers.normalization.NormalizationRunner.NoOpNormalizationRunner;
 import io.airbyte.workers.process.ProcessBuilderFactory;
@@ -50,7 +51,7 @@ public class NormalizationRunnerFactory {
     final String imageNameWithoutTag = imageName.split(":")[0];
 
     if (NORMALIZATION_MAPPING.containsKey(imageNameWithoutTag)) {
-      return new DefaultNormalizationRunner(NORMALIZATION_MAPPING.get(imageNameWithoutTag), pbf);
+      return new DefaultNormalizationRunner(NORMALIZATION_MAPPING.get(imageNameWithoutTag), pbf, new EnvConfigs());
     } else {
       throw new IllegalStateException(
           String.format("Requested normalization for %s, but it is not included in the normalization mapping.", imageName));

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessBuilderFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessBuilderFactory.java
@@ -38,6 +38,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,7 +80,13 @@ public class DockerProcessBuilderFactory implements ProcessBuilderFactory {
   }
 
   @Override
-  public ProcessBuilder create(String jobId, int attempt, final Path jobRoot, final String imageName, final String entrypoint, final String... args)
+  public ProcessBuilder create(String jobId,
+                               int attempt,
+                               final Path jobRoot,
+                               final String imageName,
+                               final String entrypoint,
+                               final Map<String, String> envVars,
+                               final String... args)
       throws WorkerException {
 
     if (!checkImageExists(imageName)) {
@@ -105,6 +112,12 @@ public class DockerProcessBuilderFactory implements ProcessBuilderFactory {
       cmd.add("--entrypoint");
       cmd.add(entrypoint);
     }
+
+    for (Map.Entry<String, String> entry : envVars.entrySet()) {
+      cmd.add("-e");
+      cmd.add(entry.getKey() + "=" + entry.getValue());
+    }
+
     cmd.add(imageName);
     cmd.addAll(Arrays.asList(args));
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessBuilderFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessBuilderFactory.java
@@ -35,6 +35,7 @@ import io.airbyte.workers.WorkerException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,8 +52,15 @@ public class KubeProcessBuilderFactory implements ProcessBuilderFactory {
     this.workspaceRoot = workspaceRoot;
   }
 
+  // todo: support env var passthrough
   @Override
-  public ProcessBuilder create(String jobId, int attempt, final Path jobRoot, final String imageName, final String entrypoint, final String... args)
+  public ProcessBuilder create(String jobId,
+                               int attempt,
+                               final Path jobRoot,
+                               final String imageName,
+                               final String entrypoint,
+                               final Map<String, String> envVars,
+                               final String... args)
       throws WorkerException {
 
     try {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/ProcessBuilderFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/ProcessBuilderFactory.java
@@ -26,7 +26,9 @@ package io.airbyte.workers.process;
 
 import io.airbyte.workers.WorkerException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public interface ProcessBuilderFactory {
 
@@ -43,8 +45,19 @@ public interface ProcessBuilderFactory {
    * @return the ProcessBuilder object to run the process
    * @throws WorkerException
    */
-  ProcessBuilder create(String jobId, int attempt, final Path jobPath, final String imageName, final String entrypoint, final String... args)
+  ProcessBuilder create(String jobId,
+                        int attempt,
+                        final Path jobPath,
+                        final String imageName,
+                        final String entrypoint,
+                        final Map<String, String> envVars,
+                        final String... args)
       throws WorkerException;
+
+  default ProcessBuilder create(String jobId, int attempt, final Path jobPath, final String imageName, final String entrypoint, final String... args)
+      throws WorkerException {
+    return create(jobId, attempt, jobPath, imageName, entrypoint, Collections.emptyMap(), args);
+  }
 
   default ProcessBuilder create(long jobId, int attempt, final Path jobPath, final String imageName, final String entrypoint, final String... args)
       throws WorkerException {


### PR DESCRIPTION
We spent some time the last few days debating how to approach normalization.

It sounds like we haven't reached a definitive conclusion on a long-term "correct" solution. However, we do know that we will need [configurable normalization](#3522) and [the ability to turn off normalization hashing](#3523). 

The "correct" way to allow turning off normalization hashing is to allow it to be configured at the sync level. However, we can hack our way to 90% of the benefit by allowing this setting at the Airbyte instance level. This definitely isn't the cleanest way to do it, but if we are committed to allowing the configuration of this option medium/long term, it seems like a reasonable option to roll out something like this and do slightly more migration work later on if it's going to save the larger effort of [general configurable normalization](#3522) or a bunch of throwaway source specific work.

If this is something we end up wanting to do, we need to:


* [ ] potentially still use the default hashing method for Postgres/limited dbs <-- would appreciate input on this
* [ ] remove the extra underscore in the empty case
* [ ] test this



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200367912513076/1200368071117271) by [Unito](https://www.unito.io)
