### PR TITLE
MongoDB Source Connection String Fix

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb/lib/mongodb_source.rb
+++ b/airbyte-integrations/connectors/source-mongodb/lib/mongodb_source.rb
@@ -70,7 +70,7 @@ class MongodbSource
 
   def client
     @client ||= begin
-                  uri = "mongodb://#{@config['user']}:#{@config['password']}@#{@config['host']}:#{@config['port']}/#{@config['database']}?authSource=#{@config['auth_source']}"
+                  uri = "mongodb+srv://#{@config['user']}:#{@config['password']}@#{@config['host']}:/#{@config['database']}?authSource=#{@config['auth_source']}"
                   if !@config.fetch(:"replica_set", "").strip.empty?
                     uri += "&replicaSet=#{@config['replica_set']}&ssl=true"
                   elsif ["true", true].include?(@config.fetch("ssl", false))

--- a/airbyte-integrations/connectors/source-mongodb/lib/mongodb_source.rb
+++ b/airbyte-integrations/connectors/source-mongodb/lib/mongodb_source.rb
@@ -70,7 +70,7 @@ class MongodbSource
 
   def client
     @client ||= begin
-                  uri = "mongodb+srv://#{@config['user']}:#{@config['password']}@#{@config['host']}:/#{@config['database']}?authSource=#{@config['auth_source']}"
+                  uri = "mongodb+srv://#{@config['user']}:#{@config['password']}@#{@config['host']}/#{@config['database']}?authSource=#{@config['auth_source']}"
                   if !@config.fetch(:"replica_set", "").strip.empty?
                     uri += "&replicaSet=#{@config['replica_set']}&ssl=true"
                   elsif ["true", true].include?(@config.fetch("ssl", false))


### PR DESCRIPTION
## What
When using MongoDB atlas, the connection was failing with the following error

```DefaultAirbyteStreamFactory(lambda$create$0):73 - W, [2021-05-14T16:07:49.870271 #8] WARN -- : MONGODB | Error running ismaster on <redacted server name>.mongodb.net:27017: SocketError: getaddrinfo: Name does not resolve
2021-05-14 16:08:50 INFO (/tmp/workspace/c0bdcfee-0a4d-48c0-8de1-560e9908d59b/0) DefaultAirbyteStreamFactory(internalLog):110 - [2021-05-14 16:07:50 +0000] WARN : | "MONGODB | Error running ismaster on <redacted server name>.mongodb.net:27017: SocketError: getaddrinfo: Name does not resolve"
2021-05-14 16:08:50 INFO (/tmp/workspace/c0bdcfee-0a4d-48c0-8de1-560e9908d59b/0) TemporalAttemptExecution(get):134 - Stopping cancellation check scheduling...
```

## How
Solution was achieved modifying the connection string by adding the  suffix to  and removing the port number.

This is a hack and a better solution would be to give the users option to provide the connection string
    directly, without having to enter their hostname, user, password, port, etc.

## Pre-merge Checklist
* [ ] _Run integration tests_
* [ ] _Publish Docker images_

## Recommended reading order
1. `test.java`
1. `component.ts`
1. the rest



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200367912513076/1200368070239349) by [Unito](https://www.unito.io)
