### PR TITLE
Checkpointing: migrate remaining destinations

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/CommitOnStateAirbyteMessageConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/CommitOnStateAirbyteMessageConsumer.java
@@ -31,27 +31,29 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Minimal abstract class intended to handle the case where a destination commits record messages as
- * it receives them. In these cases, the destination can simply emit the the state message
- * immediately.
+ * Minimal abstract class intended to handle the case where the destination can commit records every
+ * time a state message appears. This class does that commit and then immediately emits the state
+ * message. This should only be used in cases when the commit is relatively cheap. immediately.
  */
-public abstract class ImmediateStateAirbyteMessageConsumer extends FailureTrackingAirbyteMessageConsumer implements AirbyteMessageConsumer {
+public abstract class CommitOnStateAirbyteMessageConsumer extends FailureTrackingAirbyteMessageConsumer implements AirbyteMessageConsumer {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ImmediateStateAirbyteMessageConsumer.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CommitOnStateAirbyteMessageConsumer.class);
+
   private final Consumer<AirbyteMessage> outputRecordCollector;
 
-  public ImmediateStateAirbyteMessageConsumer(Consumer<AirbyteMessage> outputRecordCollector) {
+  public CommitOnStateAirbyteMessageConsumer(Consumer<AirbyteMessage> outputRecordCollector) {
     this.outputRecordCollector = outputRecordCollector;
   }
 
   @Override
   public void accept(AirbyteMessage message) throws Exception {
     if (message.getType() == Type.STATE) {
+      commit();
       outputRecordCollector.accept(message);
     }
     super.accept(message);
   }
 
-  public abstract void onState() throws Exception;
+  public abstract void commit() throws Exception;
 
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ImmediateStateAirbyteMessageConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ImmediateStateAirbyteMessageConsumer.java
@@ -44,8 +44,6 @@ public abstract class ImmediateStateAirbyteMessageConsumer extends FailureTracki
     this.outputRecordCollector = outputRecordCollector;
   }
 
-  protected abstract void acceptTracked(AirbyteMessage msg) throws Exception;
-
   @Override
   public void accept(AirbyteMessage message) throws Exception {
     if (message.getType() == Type.STATE) {
@@ -53,5 +51,7 @@ public abstract class ImmediateStateAirbyteMessageConsumer extends FailureTracki
     }
     super.accept(message);
   }
+
+  public abstract void onState() throws Exception;
 
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ImmediateStateAirbyteMessageConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ImmediateStateAirbyteMessageConsumer.java
@@ -1,0 +1,57 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.integrations.base;
+
+import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteMessage.Type;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Minimal abstract class intended to handle the case where a destination commits record messages as
+ * it receives them. In these cases, the destination can simply emit the the state message
+ * immediately.
+ */
+public abstract class ImmediateStateAirbyteMessageConsumer extends FailureTrackingAirbyteMessageConsumer implements AirbyteMessageConsumer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ImmediateStateAirbyteMessageConsumer.class);
+  private final Consumer<AirbyteMessage> outputRecordCollector;
+
+  public ImmediateStateAirbyteMessageConsumer(Consumer<AirbyteMessage> outputRecordCollector) {
+    this.outputRecordCollector = outputRecordCollector;
+  }
+
+  protected abstract void acceptTracked(AirbyteMessage msg) throws Exception;
+
+  @Override
+  public void accept(AirbyteMessage message) throws Exception {
+    if (message.getType() == Type.STATE) {
+      outputRecordCollector.accept(message);
+    }
+    super.accept(message);
+  }
+
+}

--- a/airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
+++ b/airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
@@ -224,6 +224,13 @@ public class CsvDestination implements Destination {
       }
     }
 
+    @Override
+    public void onState() throws Exception {
+      for (WriteConfig writeConfig : writeConfigs.values()) {
+        writeConfig.getWriter().flush();
+      }
+    }
+
   }
 
   private static class WriteConfig {

--- a/airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
+++ b/airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java
@@ -30,7 +30,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
 import io.airbyte.integrations.base.Destination;
-import io.airbyte.integrations.base.FailureTrackingAirbyteMessageConsumer;
+import io.airbyte.integrations.base.ImmediateStateAirbyteMessageConsumer;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.JavaBaseConstants;
 import io.airbyte.integrations.destination.StandardNameTransformer;
@@ -125,7 +125,7 @@ public class CsvDestination implements Destination {
       writeConfigs.put(stream.getStream().getName(), new WriteConfig(printer, tmpPath, finalPath));
     }
 
-    return new CsvConsumer(writeConfigs, catalog);
+    return new CsvConsumer(writeConfigs, catalog, outputRecordCollector);
   }
 
   /**
@@ -153,12 +153,13 @@ public class CsvDestination implements Destination {
    * successfully, it moves the tmp files to files named by their respective stream. If there are any
    * failures, nothing is written.
    */
-  private static class CsvConsumer extends FailureTrackingAirbyteMessageConsumer {
+  private static class CsvConsumer extends ImmediateStateAirbyteMessageConsumer {
 
     private final Map<String, WriteConfig> writeConfigs;
     private final ConfiguredAirbyteCatalog catalog;
 
-    public CsvConsumer(Map<String, WriteConfig> writeConfigs, ConfiguredAirbyteCatalog catalog) {
+    public CsvConsumer(Map<String, WriteConfig> writeConfigs, ConfiguredAirbyteCatalog catalog, Consumer<AirbyteMessage> outputRecordCollector) {
+      super(outputRecordCollector);
       this.catalog = catalog;
       LOGGER.info("initializing consumer.");
 

--- a/airbyte-integrations/connectors/destination-local-json/src/main/java/io/airbyte/integrations/destination/local_json/LocalJsonDestination.java
+++ b/airbyte-integrations/connectors/destination-local-json/src/main/java/io/airbyte/integrations/destination/local_json/LocalJsonDestination.java
@@ -30,8 +30,8 @@ import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
+import io.airbyte.integrations.base.CommitOnStateAirbyteMessageConsumer;
 import io.airbyte.integrations.base.Destination;
-import io.airbyte.integrations.base.ImmediateStateAirbyteMessageConsumer;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.JavaBaseConstants;
 import io.airbyte.integrations.destination.StandardNameTransformer;
@@ -148,7 +148,7 @@ public class LocalJsonDestination implements Destination {
    * successfully, it moves the tmp files to files named by their respective stream. If there are any
    * failures, nothing is written.
    */
-  private static class JsonConsumer extends ImmediateStateAirbyteMessageConsumer {
+  private static class JsonConsumer extends CommitOnStateAirbyteMessageConsumer {
 
     private final Map<String, WriteConfig> writeConfigs;
     private final ConfiguredAirbyteCatalog catalog;
@@ -185,6 +185,13 @@ public class LocalJsonDestination implements Destination {
           JavaBaseConstants.COLUMN_NAME_EMITTED_AT, recordMessage.getEmittedAt(),
           JavaBaseConstants.COLUMN_NAME_DATA, recordMessage.getData())));
       writer.write(System.lineSeparator());
+    }
+
+    @Override
+    public void commit() throws Exception {
+      for (WriteConfig writeConfig : writeConfigs.values()) {
+        writeConfig.getWriter().flush();
+      }
     }
 
     @Override

--- a/airbyte-integrations/connectors/destination-local-json/src/main/java/io/airbyte/integrations/destination/local_json/LocalJsonDestination.java
+++ b/airbyte-integrations/connectors/destination-local-json/src/main/java/io/airbyte/integrations/destination/local_json/LocalJsonDestination.java
@@ -31,7 +31,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
 import io.airbyte.integrations.base.Destination;
-import io.airbyte.integrations.base.FailureTrackingAirbyteMessageConsumer;
+import io.airbyte.integrations.base.ImmediateStateAirbyteMessageConsumer;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.JavaBaseConstants;
 import io.airbyte.integrations.destination.StandardNameTransformer;
@@ -120,7 +120,7 @@ public class LocalJsonDestination implements Destination {
       writeConfigs.put(stream.getStream().getName(), new WriteConfig(writer, tmpPath, finalPath));
     }
 
-    return new JsonConsumer(writeConfigs, catalog);
+    return new JsonConsumer(writeConfigs, catalog, outputRecordCollector);
   }
 
   /**
@@ -148,12 +148,13 @@ public class LocalJsonDestination implements Destination {
    * successfully, it moves the tmp files to files named by their respective stream. If there are any
    * failures, nothing is written.
    */
-  private static class JsonConsumer extends FailureTrackingAirbyteMessageConsumer {
+  private static class JsonConsumer extends ImmediateStateAirbyteMessageConsumer {
 
     private final Map<String, WriteConfig> writeConfigs;
     private final ConfiguredAirbyteCatalog catalog;
 
-    public JsonConsumer(Map<String, WriteConfig> writeConfigs, ConfiguredAirbyteCatalog catalog) {
+    public JsonConsumer(Map<String, WriteConfig> writeConfigs, ConfiguredAirbyteCatalog catalog, Consumer<AirbyteMessage> outputRecordCollector) {
+      super(outputRecordCollector);
       LOGGER.info("initializing consumer.");
       this.catalog = catalog;
       this.writeConfigs = writeConfigs;

--- a/airbyte-integrations/connectors/destination-meilisearch/src/main/java/io/airbyte/integrations/destination/meilisearch/MeiliSearchDestination.java
+++ b/airbyte-integrations/connectors/destination-meilisearch/src/main/java/io/airbyte/integrations/destination/meilisearch/MeiliSearchDestination.java
@@ -82,6 +82,7 @@ public class MeiliSearchDestination extends BaseConnector implements Destination
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MeiliSearchDestination.class);
 
+  private static final int MAX_BATCH_SIZE = 10000;
   public static final String AB_PK_COLUMN = "_ab_pk";
 
   @Override
@@ -115,7 +116,8 @@ public class MeiliSearchDestination extends BaseConnector implements Destination
         recordWriterFunction(indexNameToIndex),
         (hasFailed) -> LOGGER.info("Completed writing to MeiliSearch. Status: {}", hasFailed ? "FAILED" : "SUCCEEDED"),
         catalog,
-        (data) -> true);
+        (data) -> true,
+        MAX_BATCH_SIZE);
   }
 
   private static Map<String, Index> createIndices(ConfiguredAirbyteCatalog catalog, Client client) throws Exception {

--- a/airbyte-integrations/connectors/destination-meilisearch/src/main/java/io/airbyte/integrations/destination/meilisearch/MeiliSearchDestination.java
+++ b/airbyte-integrations/connectors/destination-meilisearch/src/main/java/io/airbyte/integrations/destination/meilisearch/MeiliSearchDestination.java
@@ -83,6 +83,7 @@ public class MeiliSearchDestination extends BaseConnector implements Destination
   private static final Logger LOGGER = LoggerFactory.getLogger(MeiliSearchDestination.class);
 
   private static final int MAX_BATCH_SIZE = 10000;
+
   public static final String AB_PK_COLUMN = "_ab_pk";
 
   @Override


### PR DESCRIPTION
## What
* Migrates CSV and Json destinations using a new abstraction `CommitOnStateAirbyteMessageConsumer`. The idea here is that every time the consumer sees a state message it "commits" immediately and then emits the state message.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200368060087111/1200369139865113) by [Unito](https://www.unito.io)
