### PR TITLE
Tweak webbackend API to handle operations with connections

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -924,7 +924,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OperationRead"
+                $ref: "#/components/schemas/CheckOperationRead"
         "422":
           $ref: "#/components/responses/InvalidInput"
   /v1/operations/create:
@@ -966,7 +966,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OperationRead"
+                $ref: "#/components/schemas/CheckOperationRead"
         "422":
           $ref: "#/components/responses/InvalidInput"
   /v1/operations/update:
@@ -1992,7 +1992,7 @@ components:
         - $ref: "#/components/schemas/ConnectionCreate"
         - type: object
           properties:
-            withCreatedOperations:
+            withOperations:
               type: array
               items:
                 $ref: "#/components/schemas/OperationCreate"
@@ -2025,11 +2025,7 @@ components:
           properties:
             withRefreshedCatalog:
               type: boolean
-            withCreatedOperations:
-              type: array
-              items:
-                $ref: "#/components/schemas/OperationCreate"
-            withUpdatedOperations:
+            withOperations:
               type: array
               items:
                 $ref: "#/components/schemas/OperationUpdate"
@@ -2196,6 +2192,20 @@ components:
           type: string
         dbtArguments:
           type: string
+    CheckOperationRead:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - succeeded
+            - failed
+        message:
+          type: string
+        logs:
+          $ref: "#/components/schemas/LogRead"
     # LOGS
     LogType:
       type: string

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -960,15 +960,15 @@ paths:
             schema:
               $ref: "#/components/schemas/OperationUpdate"
         required: true
-        responses:
-          "200":
-            description: Successful operation
-            content:
-              application/json:
-                schema:
-                  $ref: "#/components/schemas/OperationRead"
-          "422":
-            $ref: "#/components/responses/InvalidInput"
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OperationRead"
+        "422":
+          $ref: "#/components/responses/InvalidInput"
   /v1/operations/update:
     post:
       tags:
@@ -1012,22 +1012,6 @@ paths:
                 $ref: "#/components/schemas/OperationReadList"
         "404":
           description: Connection not found
-        "422":
-          $ref: "#/components/responses/InvalidInput"
-  /v1/operations/list_unassigned:
-    post:
-      tags:
-        - operation
-      summary: Returns all operations not assigned to a connection.
-      description: List operations not assigned to a connection
-      operationId: listUnassignedOperations
-      responses:
-        "200":
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/OperationReadList"
         "422":
           $ref: "#/components/responses/InvalidInput"
   /v1/operations/get:
@@ -1179,6 +1163,27 @@ paths:
                 $ref: "#/components/schemas/WbConnectionRead"
         "404":
           description: Connection not found
+        "422":
+          $ref: "#/components/responses/InvalidInput"
+  /v1/web_backend/connections/create:
+    post:
+      tags:
+        - web_backend
+      summary: Create a connection
+      operationId: webBackendCreateConnection
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebBackendConnectionCreate"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectionRead"
         "422":
           $ref: "#/components/responses/InvalidInput"
   /v1/web_backend/connections/update:
@@ -1982,6 +1987,15 @@ components:
           $ref: "#/components/schemas/ConnectionSchedule"
         status:
           $ref: "#/components/schemas/ConnectionStatus"
+    WebBackendConnectionCreate:
+      allOf:
+        - $ref: "#/components/schemas/ConnectionCreate"
+        - type: object
+          properties:
+            withCreatedOperations:
+              type: array
+              items:
+                $ref: "#/components/schemas/OperationCreate"
     ConnectionUpdate:
       type: object
       required:
@@ -2011,7 +2025,11 @@ components:
           properties:
             withRefreshedCatalog:
               type: boolean
-            withOperations:
+            withCreatedOperations:
+              type: array
+              items:
+                $ref: "#/components/schemas/OperationCreate"
+            withUpdatedOperations:
               type: array
               items:
                 $ref: "#/components/schemas/OperationUpdate"

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -906,6 +906,27 @@ paths:
           description: Connection not found
         "422":
           $ref: "#/components/responses/InvalidInput"
+  /v1/operations/check:
+    post:
+      tags:
+        - operation
+      summary: Check if an operation to be created is valid
+      operationId: checkOperationCreate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OperationCreate"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OperationRead"
+        "422":
+          $ref: "#/components/responses/InvalidInput"
   /v1/operations/create:
     post:
       tags:
@@ -927,6 +948,27 @@ paths:
                 $ref: "#/components/schemas/OperationRead"
         "422":
           $ref: "#/components/responses/InvalidInput"
+  /v1/operations/check_for_update:
+    post:
+      tags:
+        - operation
+      summary: Check if an operation to be updated is valid
+      operationId: checkOperationUpdate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OperationUpdate"
+        required: true
+        responses:
+          "200":
+            description: Successful operation
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/OperationRead"
+          "422":
+            $ref: "#/components/responses/InvalidInput"
   /v1/operations/update:
     post:
       tags:
@@ -970,6 +1012,22 @@ paths:
                 $ref: "#/components/schemas/OperationReadList"
         "404":
           description: Connection not found
+        "422":
+          $ref: "#/components/responses/InvalidInput"
+  /v1/operations/list_unassigned:
+    post:
+      tags:
+        - operation
+      summary: Returns all operations not assigned to a connection.
+      description: List operations not assigned to a connection
+      operationId: listUnassignedOperations
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OperationReadList"
         "422":
           $ref: "#/components/responses/InvalidInput"
   /v1/operations/get:
@@ -1953,6 +2011,10 @@ components:
           properties:
             withRefreshedCatalog:
               type: boolean
+            withOperations:
+              type: array
+              items:
+                $ref: "#/components/schemas/OperationUpdate"
     ConnectionRead:
       type: object
       required:

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -911,12 +911,12 @@ paths:
       tags:
         - operation
       summary: Check if an operation to be created is valid
-      operationId: checkOperationCreate
+      operationId: checkOperation
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OperationCreate"
+              $ref: "#/components/schemas/OperationCreateOrUpdate"
         required: true
       responses:
         "200":
@@ -946,27 +946,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OperationRead"
-        "422":
-          $ref: "#/components/responses/InvalidInput"
-  /v1/operations/check_for_update:
-    post:
-      tags:
-        - operation
-      summary: Check if an operation to be updated is valid
-      operationId: checkOperationUpdate
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/OperationUpdate"
-        required: true
-      responses:
-        "200":
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CheckOperationRead"
         "422":
           $ref: "#/components/responses/InvalidInput"
   /v1/operations/update:
@@ -2025,10 +2004,10 @@ components:
           properties:
             withRefreshedCatalog:
               type: boolean
-            withOperations:
+            operations:
               type: array
               items:
-                $ref: "#/components/schemas/OperationUpdate"
+                $ref: "#/components/schemas/OperationCreateOrUpdate"
     ConnectionRead:
       type: object
       required:
@@ -2119,6 +2098,18 @@ components:
       type: object
       required:
         - operationId
+        - name
+        - operatorConfiguration
+      properties:
+        operationId:
+          $ref: "#/components/schemas/OperationId"
+        name:
+          type: string
+        operatorConfiguration:
+          $ref: "#/components/schemas/OperatorConfiguration"
+    OperationCreateOrUpdate:
+      type: object
+      required:
         - name
         - operatorConfiguration
       properties:

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2204,8 +2204,6 @@ components:
             - failed
         message:
           type: string
-        logs:
-          $ref: "#/components/schemas/LogRead"
     # LOGS
     LogType:
       type: string

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -54,6 +54,7 @@ import io.airbyte.api.model.LogsRequestBody;
 import io.airbyte.api.model.Notification;
 import io.airbyte.api.model.NotificationRead;
 import io.airbyte.api.model.OperationCreate;
+import io.airbyte.api.model.OperationCreateOrUpdate;
 import io.airbyte.api.model.OperationIdRequestBody;
 import io.airbyte.api.model.OperationRead;
 import io.airbyte.api.model.OperationReadList;
@@ -415,8 +416,8 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   // Operations
 
   @Override
-  public CheckOperationRead checkOperationCreate(OperationCreate operationCreate) {
-    return execute(() -> operationsHandler.checkCreateOperation(operationCreate));
+  public CheckOperationRead checkOperation(OperationCreateOrUpdate operationCreateOrUpdate) {
+    return execute(() -> operationsHandler.checkOperation(operationCreateOrUpdate));
   }
 
   @Override
@@ -440,11 +441,6 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   @Override
   public OperationRead getOperation(OperationIdRequestBody operationIdRequestBody) {
     return execute(() -> operationsHandler.getOperation(operationIdRequestBody));
-  }
-
-  @Override
-  public CheckOperationRead checkOperationUpdate(OperationUpdate operationUpdate) {
-    return execute(() -> operationsHandler.checkUpdateOperation(operationUpdate));
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -25,6 +25,7 @@
 package io.airbyte.server.apis;
 
 import io.airbyte.api.model.CheckConnectionRead;
+import io.airbyte.api.model.CheckOperationRead;
 import io.airbyte.api.model.ConnectionCreate;
 import io.airbyte.api.model.ConnectionIdRequestBody;
 import io.airbyte.api.model.ConnectionRead;
@@ -74,6 +75,7 @@ import io.airbyte.api.model.SourceRecreate;
 import io.airbyte.api.model.SourceUpdate;
 import io.airbyte.api.model.WbConnectionRead;
 import io.airbyte.api.model.WbConnectionReadList;
+import io.airbyte.api.model.WebBackendConnectionCreate;
 import io.airbyte.api.model.WebBackendConnectionRequestBody;
 import io.airbyte.api.model.WebBackendConnectionUpdate;
 import io.airbyte.api.model.WorkspaceCreate;
@@ -394,6 +396,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   @Override
   public void deleteConnection(@Valid ConnectionIdRequestBody connectionIdRequestBody) {
     execute(() -> {
+      operationsHandler.deleteOperationsForConnection(connectionIdRequestBody);
       connectionsHandler.deleteConnection(connectionIdRequestBody);
       return null;
     });
@@ -410,6 +413,11 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   }
 
   // Operations
+
+  @Override
+  public CheckOperationRead checkOperationCreate(OperationCreate operationCreate) {
+    return execute(() -> operationsHandler.checkCreateOperation(operationCreate));
+  }
 
   @Override
   public OperationRead createOperation(@Valid OperationCreate operationCreate) {
@@ -432,6 +440,11 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   @Override
   public OperationRead getOperation(OperationIdRequestBody operationIdRequestBody) {
     return execute(() -> operationsHandler.getOperation(operationIdRequestBody));
+  }
+
+  @Override
+  public CheckOperationRead checkOperationUpdate(OperationUpdate operationUpdate) {
+    return execute(() -> operationsHandler.checkUpdateOperation(operationUpdate));
   }
 
   @Override
@@ -509,6 +522,11 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   @Override
   public WbConnectionRead webBackendGetConnection(@Valid WebBackendConnectionRequestBody webBackendConnectionRequestBody) {
     return execute(() -> webBackendConnectionsHandler.webBackendGetConnection(webBackendConnectionRequestBody));
+  }
+
+  @Override
+  public ConnectionRead webBackendCreateConnection(WebBackendConnectionCreate webBackendConnectionCreate) {
+    return execute(() -> webBackendConnectionsHandler.webBackendCreateConnection(webBackendConnectionCreate));
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/OperationsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/OperationsHandler.java
@@ -27,6 +27,8 @@ package io.airbyte.server.handlers;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import io.airbyte.api.model.CheckOperationRead;
+import io.airbyte.api.model.CheckOperationRead.StatusEnum;
 import io.airbyte.api.model.ConnectionIdRequestBody;
 import io.airbyte.api.model.OperationCreate;
 import io.airbyte.api.model.OperationIdRequestBody;
@@ -66,11 +68,25 @@ public class OperationsHandler {
     this(configRepository, UUID::randomUUID);
   }
 
+  public CheckOperationRead checkCreateOperation(OperationCreate operationCreate) {
+    try {
+      toStandardSyncOperation(operationCreate);
+    } catch (IllegalArgumentException e) {
+      return new CheckOperationRead().status(StatusEnum.FAILED);
+    }
+    return new CheckOperationRead().status(StatusEnum.SUCCEEDED);
+  }
+
   public OperationRead createOperation(OperationCreate operationCreate)
       throws JsonValidationException, IOException, ConfigNotFoundException {
     final UUID operationId = uuidGenerator.get();
+    final StandardSyncOperation standardSyncOperation = toStandardSyncOperation(operationCreate)
+        .withOperationId(operationId);
+    return persistOperation(standardSyncOperation);
+  }
+
+  private static StandardSyncOperation toStandardSyncOperation(OperationCreate operationCreate) {
     final StandardSyncOperation standardSyncOperation = new StandardSyncOperation()
-        .withOperationId(operationId)
         .withName(operationCreate.getName())
         .withOperatorType(Enums.convertTo(operationCreate.getOperatorConfiguration().getOperatorType(), OperatorType.class))
         .withTombstone(false);
@@ -87,40 +103,53 @@ public class OperationsHandler {
           .withDockerImage(operationCreate.getOperatorConfiguration().getDbt().getDockerImage())
           .withDbtArguments(operationCreate.getOperatorConfiguration().getDbt().getDbtArguments()));
     }
-    configRepository.writeStandardSyncOperation(standardSyncOperation);
-    return buildOperationRead(operationId);
+    return standardSyncOperation;
+  }
+
+  public CheckOperationRead checkUpdateOperation(OperationUpdate operationUpdate) {
+    try {
+      final StandardSyncOperation standardSyncOperation = configRepository.getStandardSyncOperation(operationUpdate.getOperationId());
+      updateOperation(operationUpdate, standardSyncOperation);
+    } catch (IllegalArgumentException | JsonValidationException | ConfigNotFoundException | IOException e) {
+      return new CheckOperationRead().status(StatusEnum.FAILED);
+    }
+    return new CheckOperationRead().status(StatusEnum.SUCCEEDED);
   }
 
   public OperationRead updateOperation(OperationUpdate operationUpdate)
       throws ConfigNotFoundException, IOException, JsonValidationException {
-    final StandardSyncOperation persistedSync = configRepository.getStandardSyncOperation(operationUpdate.getOperationId())
+    final StandardSyncOperation standardSyncOperation = configRepository.getStandardSyncOperation(operationUpdate.getOperationId());
+    return persistOperation(updateOperation(operationUpdate, standardSyncOperation));
+  }
+
+  private OperationRead persistOperation(StandardSyncOperation standardSyncOperation)
+      throws ConfigNotFoundException, IOException, JsonValidationException {
+    configRepository.writeStandardSyncOperation(standardSyncOperation);
+    return buildOperationRead(standardSyncOperation.getOperationId());
+  }
+
+  public static StandardSyncOperation updateOperation(OperationUpdate operationUpdate, StandardSyncOperation standardSyncOperation) {
+    standardSyncOperation
         .withName(operationUpdate.getName())
         .withOperatorType(Enums.convertTo(operationUpdate.getOperatorConfiguration().getOperatorType(), OperatorType.class));
     if (operationUpdate.getOperatorConfiguration().getOperatorType() == io.airbyte.api.model.OperatorType.NORMALIZATION) {
       Preconditions.checkArgument(operationUpdate.getOperatorConfiguration().getNormalization() != null);
-      persistedSync.withOperatorNormalization(new OperatorNormalization()
+      standardSyncOperation.withOperatorNormalization(new OperatorNormalization()
           .withOption(Enums.convertTo(operationUpdate.getOperatorConfiguration().getNormalization().getOption(), Option.class)));
     } else {
-      persistedSync.withOperatorNormalization(null);
+      standardSyncOperation.withOperatorNormalization(null);
     }
     if (operationUpdate.getOperatorConfiguration().getOperatorType() == io.airbyte.api.model.OperatorType.DBT) {
       Preconditions.checkArgument(operationUpdate.getOperatorConfiguration().getDbt() != null);
-      persistedSync.withOperatorDbt(new OperatorDbt()
+      standardSyncOperation.withOperatorDbt(new OperatorDbt()
           .withGitRepoUrl(operationUpdate.getOperatorConfiguration().getDbt().getGitRepoUrl())
           .withGitRepoBranch(operationUpdate.getOperatorConfiguration().getDbt().getGitRepoBranch())
           .withDockerImage(operationUpdate.getOperatorConfiguration().getDbt().getDockerImage())
           .withDbtArguments(operationUpdate.getOperatorConfiguration().getDbt().getDbtArguments()));
     } else {
-      persistedSync.withOperatorDbt(null);
+      standardSyncOperation.withOperatorDbt(null);
     }
-    return updateOperation(operationUpdate, persistedSync);
-  }
-
-  public OperationRead updateOperation(OperationUpdate operationUpdate, StandardSyncOperation persistedSync)
-      throws ConfigNotFoundException, IOException, JsonValidationException {
-    final UUID operationId = operationUpdate.getOperationId();
-    configRepository.writeStandardSyncOperation(persistedSync);
-    return buildOperationRead(operationId);
+    return standardSyncOperation;
   }
 
   public OperationReadList listOperationsForConnection(ConnectionIdRequestBody connectionIdRequestBody)
@@ -144,6 +173,40 @@ public class OperationsHandler {
     return buildOperationRead(operationIdRequestBody.getOperationId());
   }
 
+  public void deleteOperationsForConnection(ConnectionIdRequestBody connectionIdRequestBody)
+      throws JsonValidationException, ConfigNotFoundException, IOException {
+    final StandardSync standardSync = configRepository.getStandardSync(connectionIdRequestBody.getConnectionId());
+    deleteOperationsForConnection(standardSync, standardSync.getOperationIds());
+  }
+
+  public void deleteOperationsForConnection(UUID connectionId, List<UUID> deleteOperationIds)
+      throws JsonValidationException, ConfigNotFoundException, IOException {
+    final StandardSync standardSync = configRepository.getStandardSync(connectionId);
+    deleteOperationsForConnection(standardSync, deleteOperationIds);
+  }
+
+  public void deleteOperationsForConnection(StandardSync standardSync, List<UUID> deleteOperationIds)
+      throws JsonValidationException, ConfigNotFoundException, IOException {
+    final List<StandardSync> allStandardSyncs = configRepository.listStandardSyncs();
+    final List<UUID> operationIds = standardSync.getOperationIds();
+    for (UUID operationId : deleteOperationIds) {
+      operationIds.remove(operationId);
+      boolean sharedOperation = false;
+      for (StandardSync sync : allStandardSyncs) {
+        // Check if other connections are using the same operation
+        if (sync.getConnectionId() != standardSync.getConnectionId() && sync.getOperationIds().contains(operationId)) {
+          sharedOperation = true;
+          break;
+        }
+      }
+      if (!sharedOperation) {
+        removeOperation(operationId);
+      }
+    }
+    standardSync.withOperationIds(operationIds);
+    configRepository.writeStandardSync(standardSync);
+  }
+
   public void deleteOperation(OperationIdRequestBody operationIdRequestBody)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final UUID operationId = operationIdRequestBody.getOperationId();
@@ -153,10 +216,14 @@ public class OperationsHandler {
         configRepository.writeStandardSync(standardSync);
       }
     }
+    removeOperation(operationId);
+  }
+
+  private void removeOperation(UUID operationId) throws JsonValidationException, ConfigNotFoundException, IOException {
     final StandardSyncOperation standardSyncOperation = configRepository.getStandardSyncOperation(operationId);
     if (standardSyncOperation != null) {
       standardSyncOperation.withTombstone(true);
-      configRepository.writeStandardSyncOperation(standardSyncOperation);
+      persistOperation(standardSyncOperation);
     } else {
       throw new ConfigNotFoundException(ConfigSchema.STANDARD_SYNC_OPERATION, operationId.toString());
     }
@@ -172,7 +239,7 @@ public class OperationsHandler {
     }
   }
 
-  private OperationRead buildOperationRead(StandardSyncOperation standardSyncOperation) {
+  private static OperationRead buildOperationRead(StandardSyncOperation standardSyncOperation) {
     final OperatorConfiguration operatorConfiguration = new OperatorConfiguration()
         .operatorType(Enums.convertTo(standardSyncOperation.getOperatorType(), io.airbyte.api.model.OperatorType.class));
     if (standardSyncOperation.getOperatorType() == OperatorType.NORMALIZATION) {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/OperationsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/OperationsHandler.java
@@ -72,7 +72,8 @@ public class OperationsHandler {
     try {
       toStandardSyncOperation(operationCreate);
     } catch (IllegalArgumentException e) {
-      return new CheckOperationRead().status(StatusEnum.FAILED);
+      return new CheckOperationRead().status(StatusEnum.FAILED)
+          .message(e.getMessage());
     }
     return new CheckOperationRead().status(StatusEnum.SUCCEEDED);
   }
@@ -111,7 +112,8 @@ public class OperationsHandler {
       final StandardSyncOperation standardSyncOperation = configRepository.getStandardSyncOperation(operationUpdate.getOperationId());
       updateOperation(operationUpdate, standardSyncOperation);
     } catch (IllegalArgumentException | JsonValidationException | ConfigNotFoundException | IOException e) {
-      return new CheckOperationRead().status(StatusEnum.FAILED);
+      return new CheckOperationRead().status(StatusEnum.FAILED)
+          .message(e.getMessage());
     }
     return new CheckOperationRead().status(StatusEnum.SUCCEEDED);
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -277,7 +277,7 @@ public class WebBackendConnectionsHandler {
       throws JsonValidationException, ConfigNotFoundException, IOException {
     final ConnectionRead connectionRead =
         connectionsHandler.getConnection(new ConnectionIdRequestBody().connectionId(webBackendConnectionUpdate.getConnectionId()));
-    final List<UUID> originalOperationIds = connectionRead.getOperationIds();
+    final List<UUID> originalOperationIds = new ArrayList<>(connectionRead.getOperationIds());
     final List<UUID> operationIds = new ArrayList<>();
     for (var operationUpdate : webBackendConnectionUpdate.getWithOperations()) {
       if (!originalOperationIds.contains(operationUpdate.getOperationId())) {

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -54,6 +54,7 @@ import io.airbyte.api.model.JobRead;
 import io.airbyte.api.model.JobReadList;
 import io.airbyte.api.model.JobStatus;
 import io.airbyte.api.model.JobWithAttemptsRead;
+import io.airbyte.api.model.OperationCreateOrUpdate;
 import io.airbyte.api.model.OperationRead;
 import io.airbyte.api.model.OperationReadList;
 import io.airbyte.api.model.OperationUpdate;
@@ -378,16 +379,17 @@ class WebBackendConnectionsHandlerTest {
 
   @Test
   void testUpdateConnectionWithOperations() throws JsonValidationException, ConfigNotFoundException, IOException {
-    final OperationUpdate operationUpdate = new OperationUpdate()
+    final OperationCreateOrUpdate operationCreateOrUpdate = new OperationCreateOrUpdate()
         .name("Test Operation")
         .operationId(connectionRead.getOperationIds().get(0));
+    final OperationUpdate operationUpdate = WebBackendConnectionsHandler.toOperationUpdate(operationCreateOrUpdate);
     WebBackendConnectionUpdate updateBody = new WebBackendConnectionUpdate()
         .prefix(expected.getPrefix())
         .connectionId(expected.getConnectionId())
         .schedule(expected.getSchedule())
         .status(expected.getStatus())
         .syncCatalog(expected.getSyncCatalog())
-        .withOperations(List.of(operationUpdate));
+        .operations(List.of(operationCreateOrUpdate));
 
     when(connectionsHandler.getConnection(new ConnectionIdRequestBody().connectionId(expected.getConnectionId()))).thenReturn(
         new ConnectionRead()

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -2407,9 +2407,6 @@ font-style: italic;
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
   "message" : "message",
-  "logs" : {
-    "logLines" : [ "logLines", "logLines" ]
-  },
   "status" : "succeeded"
 }</code></pre>
 
@@ -2466,9 +2463,6 @@ font-style: italic;
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
   "message" : "message",
-  "logs" : {
-    "logLines" : [ "logLines", "logLines" ]
-  },
   "status" : "succeeded"
 }</code></pre>
 
@@ -5217,7 +5211,6 @@ font-style: italic;
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">succeeded</div><div class="param-enum">failed</div>
 <div class="param">message (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">logs (optional)</div><div class="param-desc"><span class="param-type"><a href="#LogRead">LogRead</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -279,8 +279,7 @@ font-style: italic;
   </ul>
   <h4><a href="#Operation">Operation</a></h4>
   <ul>
-  <li><a href="#checkOperationCreate"><code><span class="http-method">post</span> /v1/operations/check</code></a></li>
-  <li><a href="#checkOperationUpdate"><code><span class="http-method">post</span> /v1/operations/check_for_update</code></a></li>
+  <li><a href="#checkOperation"><code><span class="http-method">post</span> /v1/operations/check</code></a></li>
   <li><a href="#createOperation"><code><span class="http-method">post</span> /v1/operations/create</code></a></li>
   <li><a href="#deleteOperation"><code><span class="http-method">post</span> /v1/operations/delete</code></a></li>
   <li><a href="#getOperation"><code><span class="http-method">post</span> /v1/operations/get</code></a></li>
@@ -2370,11 +2369,11 @@ font-style: italic;
   </div> <!-- method -->
   <hr/>
   <h1><a name="Operation">Operation</a></h1>
-  <div class="method"><a name="checkOperationCreate"/>
+  <div class="method"><a name="checkOperation"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
     <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/operations/check</code></pre></div>
-    <div class="method-summary">Check if an operation to be created is valid (<span class="nickname">checkOperationCreate</span>)</div>
+    <div class="method-summary">Check if an operation to be created is valid (<span class="nickname">checkOperation</span>)</div>
     <div class="method-notes"></div>
 
 
@@ -2386,63 +2385,7 @@ font-style: italic;
 
     <h3 class="field-label">Request body</h3>
     <div class="field-items">
-      <div class="param">OperationCreate <a href="#OperationCreate">OperationCreate</a> (required)</div>
-
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
-
-    </div>  <!-- field-items -->
-
-
-
-
-    <h3 class="field-label">Return type</h3>
-    <div class="return-type">
-      <a href="#CheckOperationRead">CheckOperationRead</a>
-      
-    </div>
-
-    <!--Todo: process Response Object and its headers, schema, examples -->
-
-    <h3 class="field-label">Example data</h3>
-    <div class="example-data-content-type">Content-Type: application/json</div>
-    <pre class="example"><code>{
-  "message" : "message",
-  "status" : "succeeded"
-}</code></pre>
-
-    <h3 class="field-label">Produces</h3>
-    This API call produces the following media types according to the <span class="header">Accept</span> request header;
-    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
-    <ul>
-      <li><code>application/json</code></li>
-    </ul>
-
-    <h3 class="field-label">Responses</h3>
-    <h4 class="field-label">200</h4>
-    Successful operation
-        <a href="#CheckOperationRead">CheckOperationRead</a>
-    <h4 class="field-label">422</h4>
-    Invalid Input
-        <a href="#"></a>
-  </div> <!-- method -->
-  <hr/>
-  <div class="method"><a name="checkOperationUpdate"/>
-    <div class="method-path">
-    <a class="up" href="#__Methods">Up</a>
-    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/operations/check_for_update</code></pre></div>
-    <div class="method-summary">Check if an operation to be updated is valid (<span class="nickname">checkOperationUpdate</span>)</div>
-    <div class="method-notes"></div>
-
-
-    <h3 class="field-label">Consumes</h3>
-    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
-    <ul>
-      <li><code>application/json</code></li>
-    </ul>
-
-    <h3 class="field-label">Request body</h3>
-    <div class="field-items">
-      <div class="param">OperationUpdate <a href="#OperationUpdate">OperationUpdate</a> (required)</div>
+      <div class="param">OperationCreateOrUpdate <a href="#OperationCreateOrUpdate">OperationCreateOrUpdate</a> (required)</div>
 
       <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
 
@@ -5085,6 +5028,7 @@ font-style: italic;
     <li><a href="#NotificationRead"><code>NotificationRead</code> - </a></li>
     <li><a href="#NotificationType"><code>NotificationType</code> - </a></li>
     <li><a href="#OperationCreate"><code>OperationCreate</code> - </a></li>
+    <li><a href="#OperationCreateOrUpdate"><code>OperationCreateOrUpdate</code> - </a></li>
     <li><a href="#OperationIdRequestBody"><code>OperationIdRequestBody</code> - </a></li>
     <li><a href="#OperationRead"><code>OperationRead</code> - </a></li>
     <li><a href="#OperationReadList"><code>OperationReadList</code> - </a></li>
@@ -5548,6 +5492,15 @@ font-style: italic;
     </div>  <!-- field-items -->
   </div>
   <div class="model">
+    <h3><a name="OperationCreateOrUpdate"><code>OperationCreateOrUpdate</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">operationId (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">operatorConfiguration </div><div class="param-desc"><span class="param-type"><a href="#OperatorConfiguration">OperatorConfiguration</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
     <h3><a name="OperationIdRequestBody"><code>OperationIdRequestBody</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
@@ -5850,7 +5803,7 @@ font-style: italic;
 <div class="param">schedule (optional)</div><div class="param-desc"><span class="param-type"><a href="#ConnectionSchedule">ConnectionSchedule</a></span>  </div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
 <div class="param">withRefreshedCatalog (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
-<div class="param">withOperations (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperationUpdate">array[OperationUpdate]</a></span>  </div>
+<div class="param">operations (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperationCreateOrUpdate">array[OperationCreateOrUpdate]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -5858,7 +5811,7 @@ font-style: italic;
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">withRefreshedCatalog (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
-<div class="param">withOperations (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperationUpdate">array[OperationUpdate]</a></span>  </div>
+<div class="param">operations (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperationCreateOrUpdate">array[OperationCreateOrUpdate]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -279,6 +279,8 @@ font-style: italic;
   </ul>
   <h4><a href="#Operation">Operation</a></h4>
   <ul>
+  <li><a href="#checkOperationCreate"><code><span class="http-method">post</span> /v1/operations/check</code></a></li>
+  <li><a href="#checkOperationUpdate"><code><span class="http-method">post</span> /v1/operations/check_for_update</code></a></li>
   <li><a href="#createOperation"><code><span class="http-method">post</span> /v1/operations/create</code></a></li>
   <li><a href="#deleteOperation"><code><span class="http-method">post</span> /v1/operations/delete</code></a></li>
   <li><a href="#getOperation"><code><span class="http-method">post</span> /v1/operations/get</code></a></li>
@@ -316,6 +318,7 @@ font-style: italic;
   </ul>
   <h4><a href="#WebBackend">WebBackend</a></h4>
   <ul>
+  <li><a href="#webBackendCreateConnection"><code><span class="http-method">post</span> /v1/web_backend/connections/create</code></a></li>
   <li><a href="#webBackendGetConnection"><code><span class="http-method">post</span> /v1/web_backend/connections/get</code></a></li>
   <li><a href="#webBackendListConnectionsForWorkspace"><code><span class="http-method">post</span> /v1/web_backend/connections/list</code></a></li>
   <li><a href="#webBackendRecreateDestination"><code><span class="http-method">post</span> /v1/web_backend/destinations/recreate</code></a></li>
@@ -2367,6 +2370,124 @@ font-style: italic;
   </div> <!-- method -->
   <hr/>
   <h1><a name="Operation">Operation</a></h1>
+  <div class="method"><a name="checkOperationCreate"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/operations/check</code></pre></div>
+    <div class="method-summary">Check if an operation to be created is valid (<span class="nickname">checkOperationCreate</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">OperationCreate <a href="#OperationCreate">OperationCreate</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#CheckOperationRead">CheckOperationRead</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "message" : "message",
+  "logs" : {
+    "logLines" : [ "logLines", "logLines" ]
+  },
+  "status" : "succeeded"
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#CheckOperationRead">CheckOperationRead</a>
+    <h4 class="field-label">422</h4>
+    Invalid Input
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="checkOperationUpdate"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/operations/check_for_update</code></pre></div>
+    <div class="method-summary">Check if an operation to be updated is valid (<span class="nickname">checkOperationUpdate</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">OperationUpdate <a href="#OperationUpdate">OperationUpdate</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#CheckOperationRead">CheckOperationRead</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "message" : "message",
+  "logs" : {
+    "logLines" : [ "logLines", "logLines" ]
+  },
+  "status" : "succeeded"
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#CheckOperationRead">CheckOperationRead</a>
+    <h4 class="field-label">422</h4>
+    Invalid Input
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
   <div class="method"><a name="createOperation"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -3849,6 +3970,103 @@ font-style: italic;
   </div> <!-- method -->
   <hr/>
   <h1><a name="WebBackend">WebBackend</a></h1>
+  <div class="method"><a name="webBackendCreateConnection"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/web_backend/connections/create</code></pre></div>
+    <div class="method-summary">Create a connection (<span class="nickname">webBackendCreateConnection</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">WebBackendConnectionCreate <a href="#WebBackendConnectionCreate">WebBackendConnectionCreate</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#ConnectionRead">ConnectionRead</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "sourceId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+  "schedule" : {
+    "units" : 0,
+    "timeUnit" : "minutes"
+  },
+  "prefix" : "prefix",
+  "name" : "name",
+  "syncCatalog" : {
+    "streams" : [ {
+      "stream" : {
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
+        "supportedSyncModes" : [ null, null ],
+        "sourceDefinedCursor" : true,
+        "name" : "name",
+        "namespace" : "namespace",
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+      },
+      "config" : {
+        "aliasName" : "aliasName",
+        "cursorField" : [ "cursorField", "cursorField" ],
+        "selected" : true,
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
+      }
+    }, {
+      "stream" : {
+        "sourceDefinedPrimaryKey" : [ [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ], [ "sourceDefinedPrimaryKey", "sourceDefinedPrimaryKey" ] ],
+        "supportedSyncModes" : [ null, null ],
+        "sourceDefinedCursor" : true,
+        "name" : "name",
+        "namespace" : "namespace",
+        "defaultCursorField" : [ "defaultCursorField", "defaultCursorField" ]
+      },
+      "config" : {
+        "aliasName" : "aliasName",
+        "cursorField" : [ "cursorField", "cursorField" ],
+        "selected" : true,
+        "primaryKey" : [ [ "primaryKey", "primaryKey" ], [ "primaryKey", "primaryKey" ] ]
+      }
+    } ]
+  },
+  "connectionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+  "operationIds" : [ null, null ],
+  "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#ConnectionRead">ConnectionRead</a>
+    <h4 class="field-label">422</h4>
+    Invalid Input
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
   <div class="method"><a name="webBackendGetConnection"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -4833,6 +5051,7 @@ font-style: italic;
     <li><a href="#AttemptRead"><code>AttemptRead</code> - </a></li>
     <li><a href="#AttemptStatus"><code>AttemptStatus</code> - </a></li>
     <li><a href="#CheckConnectionRead"><code>CheckConnectionRead</code> - </a></li>
+    <li><a href="#CheckOperationRead"><code>CheckOperationRead</code> - </a></li>
     <li><a href="#ConnectionCreate"><code>ConnectionCreate</code> - </a></li>
     <li><a href="#ConnectionIdRequestBody"><code>ConnectionIdRequestBody</code> - </a></li>
     <li><a href="#ConnectionRead"><code>ConnectionRead</code> - </a></li>
@@ -4901,6 +5120,8 @@ font-style: italic;
     <li><a href="#SynchronousJobRead"><code>SynchronousJobRead</code> - </a></li>
     <li><a href="#WbConnectionRead"><code>WbConnectionRead</code> - </a></li>
     <li><a href="#WbConnectionReadList"><code>WbConnectionReadList</code> - </a></li>
+    <li><a href="#WebBackendConnectionCreate"><code>WebBackendConnectionCreate</code> - </a></li>
+    <li><a href="#WebBackendConnectionCreate_allOf"><code>WebBackendConnectionCreate_allOf</code> - </a></li>
     <li><a href="#WebBackendConnectionRequestBody"><code>WebBackendConnectionRequestBody</code> - </a></li>
     <li><a href="#WebBackendConnectionUpdate"><code>WebBackendConnectionUpdate</code> - </a></li>
     <li><a href="#WebBackendConnectionUpdate_allOf"><code>WebBackendConnectionUpdate_allOf</code> - </a></li>
@@ -4986,6 +5207,17 @@ font-style: italic;
         <div class="param-enum">succeeded</div><div class="param-enum">failed</div>
 <div class="param">message (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">jobInfo </div><div class="param-desc"><span class="param-type"><a href="#SynchronousJobRead">SynchronousJobRead</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="CheckOperationRead"><code>CheckOperationRead</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+        <div class="param-enum-header">Enum:</div>
+        <div class="param-enum">succeeded</div><div class="param-enum">failed</div>
+<div class="param">message (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">logs (optional)</div><div class="param-desc"><span class="param-type"><a href="#LogRead">LogRead</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -5585,6 +5817,28 @@ font-style: italic;
     </div>  <!-- field-items -->
   </div>
   <div class="model">
+    <h3><a name="WebBackendConnectionCreate"><code>WebBackendConnectionCreate</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Optional name of the connection </div>
+<div class="param">prefix (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Prefix that will be prepended to the name of each stream when it is written to the destination. </div>
+<div class="param">sourceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">destinationId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">operationIds (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">array[UUID]</a></span>  format: uuid</div>
+<div class="param">syncCatalog (optional)</div><div class="param-desc"><span class="param-type"><a href="#AirbyteCatalog">AirbyteCatalog</a></span>  </div>
+<div class="param">schedule (optional)</div><div class="param-desc"><span class="param-type"><a href="#ConnectionSchedule">ConnectionSchedule</a></span>  </div>
+<div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
+<div class="param">withOperations (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperationCreate">array[OperationCreate]</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="WebBackendConnectionCreate_allOf"><code>WebBackendConnectionCreate_allOf</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">withOperations (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperationCreate">array[OperationCreate]</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
     <h3><a name="WebBackendConnectionRequestBody"><code>WebBackendConnectionRequestBody</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
@@ -5603,6 +5857,7 @@ font-style: italic;
 <div class="param">schedule (optional)</div><div class="param-desc"><span class="param-type"><a href="#ConnectionSchedule">ConnectionSchedule</a></span>  </div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
 <div class="param">withRefreshedCatalog (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+<div class="param">withOperations (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperationUpdate">array[OperationUpdate]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -5610,6 +5865,7 @@ font-style: italic;
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">withRefreshedCatalog (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+<div class="param">withOperations (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperationUpdate">array[OperationUpdate]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What
From discussions with @Jamakase, we probably need to tweak the web backend API to provide a better UI/UX flow when implementing #3235.

Connections and Operations API calls should be bundled more together using the web backend routes.

## How
*Describe the solution*
- Add check and check_for_update on the operations route to validate if operation configurations are somehow valid before actually creating/updating them
- Bundle updates to connection and operations in a single API route with the WebBackEndConnectionUpdate (needed when we want to attach operations to a connection)
- Mirror and make a WebBackEndConnectionCreate route too

## Pre-merge Checklist
- [x] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `airbyte-api/src/main/openapi/config.yaml`
1. `airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java`
1. `airbyte-server/src/main/java/io/airbyte/server/handlers/OperationsHandler.java`
1. the rest
