### PR TITLE
safer icon retrieval

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -85,7 +85,7 @@ public class DestinationDefinitionsHandler {
           .dockerImageTag(standardDestinationDefinition.getDockerImageTag())
           .documentationUrl(new URI(standardDestinationDefinition.getDocumentationUrl()))
           .icon(loadIcon(standardDestinationDefinition.getIcon()));
-    } catch (URISyntaxException | NullPointerException | IOException e) {
+    } catch (URISyntaxException | NullPointerException e) {
       throw new KnownException(500, "Unable to process retrieved latest destination definitions list", e);
     }
   }
@@ -161,8 +161,12 @@ public class DestinationDefinitionsHandler {
     return buildDestinationDefinitionRead(newDestination);
   }
 
-  public static String loadIcon(String name) throws IOException {
-    return name == null ? null : MoreResources.readResource("icons/" + name);
+  public static String loadIcon(String name) {
+    try {
+      return name == null ? null : MoreResources.readResource("icons/" + name);
+    } catch (IOException e) {
+      return null;
+    }
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -86,7 +86,7 @@ public class SourceDefinitionsHandler {
           .dockerImageTag(standardSourceDefinition.getDockerImageTag())
           .documentationUrl(new URI(standardSourceDefinition.getDocumentationUrl()))
           .icon(loadIcon(standardSourceDefinition.getIcon()));
-    } catch (URISyntaxException | NullPointerException | IOException e) {
+    } catch (URISyntaxException | NullPointerException e) {
       throw new KnownException(500, "Unable to process retrieved latest source definitions list", e);
     }
   }
@@ -158,8 +158,12 @@ public class SourceDefinitionsHandler {
     return buildSourceDefinitionRead(newSource);
   }
 
-  public static String loadIcon(String name) throws IOException {
-    return name == null ? null : MoreResources.readResource("icons/" + name);
+  public static String loadIcon(String name) {
+    try {
+      return name == null ? null : MoreResources.readResource("icons/" + name);
+    } catch (IOException e) {
+      return null;
+    }
   }
 
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
@@ -102,7 +102,7 @@ class DestinationDefinitionsHandlerTest {
         .dockerRepository(destination.getDockerRepository())
         .dockerImageTag(destination.getDockerImageTag())
         .documentationUrl(new URI(destination.getDocumentationUrl()))
-        .icon(loadIcon(destination.getIcon()));
+        .icon(DestinationDefinitionsHandler.loadIcon(destination.getIcon()));
 
     final DestinationDefinitionRead expectedDestinationDefinitionRead2 = new DestinationDefinitionRead()
         .destinationDefinitionId(destination2.getDestinationDefinitionId())
@@ -110,7 +110,7 @@ class DestinationDefinitionsHandlerTest {
         .dockerRepository(destination2.getDockerRepository())
         .dockerImageTag(destination2.getDockerImageTag())
         .documentationUrl(new URI(destination2.getDocumentationUrl()))
-        .icon(loadIcon(destination2.getIcon()));
+        .icon(DestinationDefinitionsHandler.loadIcon(destination2.getIcon()));
 
     final DestinationDefinitionReadList actualDestinationDefinitionReadList = destinationHandler.listDestinationDefinitions();
 
@@ -131,7 +131,7 @@ class DestinationDefinitionsHandlerTest {
         .dockerRepository(destination.getDockerRepository())
         .dockerImageTag(destination.getDockerImageTag())
         .documentationUrl(new URI(destination.getDocumentationUrl()))
-        .icon(loadIcon(destination.getIcon()));
+        .icon(DestinationDefinitionsHandler.loadIcon(destination.getIcon()));
 
     final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody = new DestinationDefinitionIdRequestBody()
         .destinationDefinitionId(destination.getDestinationDefinitionId());
@@ -159,7 +159,7 @@ class DestinationDefinitionsHandlerTest {
         .dockerImageTag(destination.getDockerImageTag())
         .documentationUrl(new URI(destination.getDocumentationUrl()))
         .destinationDefinitionId(destination.getDestinationDefinitionId())
-        .icon(loadIcon(destination.getIcon()));
+        .icon(DestinationDefinitionsHandler.loadIcon(destination.getIcon()));
 
     final DestinationDefinitionRead actualRead = destinationHandler.createDestinationDefinition(create);
 
@@ -210,14 +210,6 @@ class DestinationDefinitionsHandlerTest {
       assertEquals(0, destinationHandler.listLatestDestinationDefinitions().getDestinationDefinitions().size());
     }
 
-  }
-
-  private static String loadIcon(String name) {
-    try {
-      return DestinationDefinitionsHandler.loadIcon(name);
-    } catch (IOException e) {
-      return "Error";
-    }
   }
 
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -105,7 +105,7 @@ class SourceDefinitionsHandlerTest {
         .dockerRepository(source.getDockerRepository())
         .dockerImageTag(source.getDockerImageTag())
         .documentationUrl(new URI(source.getDocumentationUrl()))
-        .icon(loadIcon(source.getIcon()));
+        .icon(SourceDefinitionsHandler.loadIcon(source.getIcon()));
 
     SourceDefinitionRead expectedSourceDefinitionRead2 = new SourceDefinitionRead()
         .sourceDefinitionId(source2.getSourceDefinitionId())
@@ -113,7 +113,7 @@ class SourceDefinitionsHandlerTest {
         .dockerRepository(source.getDockerRepository())
         .dockerImageTag(source.getDockerImageTag())
         .documentationUrl(new URI(source.getDocumentationUrl()))
-        .icon(loadIcon(source.getIcon()));
+        .icon(SourceDefinitionsHandler.loadIcon(source.getIcon()));
 
     final SourceDefinitionReadList actualSourceDefinitionReadList = sourceHandler.listSourceDefinitions();
 
@@ -133,7 +133,7 @@ class SourceDefinitionsHandlerTest {
         .dockerRepository(source.getDockerRepository())
         .dockerImageTag(source.getDockerImageTag())
         .documentationUrl(new URI(source.getDocumentationUrl()))
-        .icon(loadIcon(source.getIcon()));
+        .icon(SourceDefinitionsHandler.loadIcon(source.getIcon()));
 
     final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody =
         new SourceDefinitionIdRequestBody().sourceDefinitionId(source.getSourceDefinitionId());
@@ -161,7 +161,7 @@ class SourceDefinitionsHandlerTest {
         .dockerImageTag(source.getDockerImageTag())
         .documentationUrl(new URI(source.getDocumentationUrl()))
         .sourceDefinitionId(source.getSourceDefinitionId())
-        .icon(loadIcon(source.getIcon()));
+        .icon(SourceDefinitionsHandler.loadIcon(source.getIcon()));
 
     final SourceDefinitionRead actualRead = sourceHandler.createSourceDefinition(create);
 
@@ -215,20 +215,12 @@ class SourceDefinitionsHandlerTest {
     @Test
     @DisplayName("Icon should contain data")
     void testIconHoldsData() {
-      final String icon = loadIcon(source.getIcon());
+      final String icon = SourceDefinitionsHandler.loadIcon(source.getIcon());
       assertNotNull(icon);
       assert (icon.length() > 3000);
       assert (icon.length() < 6000);
     }
 
-  }
-
-  private static String loadIcon(String name) {
-    try {
-      return SourceDefinitionsHandler.loadIcon(name);
-    } catch (IOException e) {
-      return "Error";
-    }
   }
 
 }


### PR DESCRIPTION
In order to fix https://github.com/airbytehq/airbyte/issues/3588 we really just need to release a version because the Asana icon is included on master as of today.

This change (via @cgardens) fixes future cases of this issue.

We need to do the 0.24.0 release since there are other changes on master that require migrations.