### PR TITLE
🎉  allow users to access both the api and webapp from the same port

### DIFF
--- a/.env
+++ b/.env
@@ -21,3 +21,4 @@ WEBAPP_URL=http://localhost:8000/
 # todo - Migrate to a way to define a better default API_URL
 # API_URL=http://localhost:8001/api/v1/
 TEMPORAL_HOST=airbyte-temporal:7233
+INTERNAL_API_URL=http://airbyte-server:8001/api/

--- a/.env
+++ b/.env
@@ -21,4 +21,4 @@ WEBAPP_URL=http://localhost:8000/
 # todo - Migrate to a way to define a better default API_URL
 # API_URL=http://localhost:8001/api/v1/
 TEMPORAL_HOST=airbyte-temporal:7233
-INTERNAL_API_URL=http://airbyte-server:8001/api/
+INTERNAL_API_HOST=airbyte-server:8001

--- a/.env.dev
+++ b/.env.dev
@@ -19,4 +19,4 @@ TRACKING_STRATEGY=logging
 HACK_LOCAL_ROOT_PARENT=/tmp
 WEBAPP_URL=http://localhost:8000/
 API_URL=http://localhost:8001/api/v1/
-INTERNAL_API_URL=http://airbyte-server:8001/api/
+INTERNAL_API_HOST=airbyte-server:8001

--- a/.env.dev
+++ b/.env.dev
@@ -19,3 +19,4 @@ TRACKING_STRATEGY=logging
 HACK_LOCAL_ROOT_PARENT=/tmp
 WEBAPP_URL=http://localhost:8000/
 API_URL=http://localhost:8001/api/v1/
+INTERNAL_API_URL=http://airbyte-server:8001/api/

--- a/airbyte-webapp/nginx/default.conf.template
+++ b/airbyte-webapp/nginx/default.conf.template
@@ -6,6 +6,10 @@ server {
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;
 
+    upstream api-server {
+        server $INTERNAL_API_URL;
+    }
+
     location / {
         root   /usr/share/nginx/html;
         try_files $uri $uri/ /index.html;
@@ -28,5 +32,9 @@ server {
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
         root   /usr/share/nginx/html;
+    }
+
+    location /api/ {
+        proxy_pass http://api-server;
     }
 }

--- a/airbyte-webapp/nginx/default.conf.template
+++ b/airbyte-webapp/nginx/default.conf.template
@@ -1,3 +1,7 @@
+upstream api-server {
+    server $INTERNAL_API_HOST;
+}
+
 server {
     listen       80;
     listen  [::]:80;
@@ -5,10 +9,6 @@ server {
 
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;
-
-    upstream api-server {
-        server $INTERNAL_API_URL;
-    }
 
     location / {
         root   /usr/share/nginx/html;
@@ -35,6 +35,6 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://api-server;
+        proxy_pass http://api-server/api/;
     }
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -90,6 +90,7 @@ services:
       - IS_DEMO=${IS_DEMO:-}
       - PAPERCUPS_STORYTIME=${PAPERCUPS_STORYTIME:-}
       - TRACKING_STRATEGY=${TRACKING_STRATEGY}
+      - INTERNAL_API_HOST=${INTERNAL_API_HOST}
   airbyte-temporal:
     image: temporalio/auto-setup:1.7.0
     container_name: airbyte-temporal

--- a/kube/overlays/dev/.env
+++ b/kube/overlays/dev/.env
@@ -16,3 +16,4 @@ LOCAL_ROOT=/tmp/airbyte_local
 PAPERCUPS_STORYTIME=disabled
 IS_DEMO=false
 TEMPORAL_HOST=airbyte-temporal-svc:7233
+INTERNAL_API_HOST=http://airbyte-server-svc:8001/api/

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -16,3 +16,4 @@ LOCAL_ROOT=/tmp/airbyte_local
 PAPERCUPS_STORYTIME=enabled
 IS_DEMO=false
 TEMPORAL_HOST=airbyte-temporal-svc:7233
+INTERNAL_API_HOST=http://airbyte-server-svc:8001/api/

--- a/kube/resources/webapp.yaml
+++ b/kube/resources/webapp.yaml
@@ -53,5 +53,10 @@ spec:
                 configMapKeyRef:
                   name: airbyte-env
                   key: IS_DEMO
+            - name: INTERNAL_API_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: airbyte-env
+                  key: INTERNAL_API_HOST
           ports:
             - containerPort: 80


### PR DESCRIPTION
In https://github.com/airbytehq/airbyte/pull/3422 I was trying to make a single port the only method of using Airbyte.

In this PR, I'm simply allowing the usage. It always forwards /api to an upstream (which is more resilient to server problems than the original PR as well).

To "enable" this, all you need is to set `API_URL=/api/v1/` in your `.env` file.

There's one downside, which is that on startup instead of showing the server is starting message it fails until the server starts. We'll need to add 502 errors as an allowed error that causes the network boundary error.

I'll create issues to update our defaults/docs and for the 502 error handling.
