### PR TITLE
Productionise Kube

### DIFF
--- a/airbyte-commons/build.gradle
+++ b/airbyte-commons/build.gradle
@@ -3,7 +3,9 @@ plugins {
 }
 
 dependencies {
-    testImplementation 'org.apache.commons:commons-lang3:3.11'
+    implementation 'org.apache.commons:commons-compress:1.20'
+    implementation 'com.github.docker-java:docker-java:3.2.8'
+    implementation 'com.github.docker-java:docker-java-transport-httpclient5:3.2.8'
 
-    implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.20'
+    testImplementation 'org.apache.commons:commons-lang3:3.11'
 }

--- a/airbyte-commons/src/main/java/io/airbyte/commons/docker/DockerUtils.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/docker/DockerUtils.java
@@ -24,10 +24,36 @@
 
 package io.airbyte.commons.docker;
 
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.BuildImageResultCallback;
+import com.github.dockerjava.core.DefaultDockerClientConfig;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.core.DockerClientImpl;
+import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
+import com.github.dockerjava.transport.DockerHttpClient;
+import java.io.File;
+import java.util.Set;
+
 public class DockerUtils {
+
+  private static final DockerClientConfig CONFIG = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
+  private static final DockerHttpClient HTTP_CLIENT = new ApacheDockerHttpClient.Builder()
+      .dockerHost(CONFIG.getDockerHost())
+      .sslConfig(CONFIG.getSSLConfig())
+      .maxConnections(100)
+      .build();
+  private static final DockerClient DOCKER_CLIENT = DockerClientImpl.getInstance(CONFIG, HTTP_CLIENT);
 
   public static String getTaggedImageName(String dockerRepository, String tag) {
     return String.join(":", dockerRepository, tag);
+  }
+
+  public static String buildImage(String dockerFilePath, String tag) {
+    return DOCKER_CLIENT.buildImageCmd()
+        .withDockerfile(new File(dockerFilePath))
+        .withTags(Set.of(tag))
+        .exec(new BuildImageResultCallback())
+        .awaitImageId();
   }
 
 }

--- a/airbyte-commons/src/main/java/io/airbyte/commons/docker/DockerUtils.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/docker/DockerUtils.java
@@ -34,6 +34,7 @@ import com.github.dockerjava.transport.DockerHttpClient;
 import java.io.File;
 import java.util.Set;
 
+// TODO(Davin): This should be split out into an Docker commons to minimise dependency pollution.
 public class DockerUtils {
 
   private static final DockerClientConfig CONFIG = DefaultDockerClientConfig.createDefaultConfigBuilder().build();

--- a/airbyte-commons/src/main/java/io/airbyte/commons/string/Strings.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/string/Strings.java
@@ -36,8 +36,8 @@ public class Strings {
         .collect(Collectors.joining(separator));
   }
 
-  public static String addRandomSuffix(String base, int suffixLength) {
-    return base + "-" + RandomStringUtils.randomAlphabetic(suffixLength).toLowerCase();
+  public static String addRandomSuffix(String base, String separator, int suffixLength) {
+    return base + separator + RandomStringUtils.randomAlphabetic(suffixLength).toLowerCase();
   }
 
 }

--- a/airbyte-commons/src/main/java/io/airbyte/commons/string/Strings.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/string/Strings.java
@@ -26,6 +26,7 @@ package io.airbyte.commons.string;
 
 import com.google.common.collect.Streams;
 import java.util.stream.Collectors;
+import org.apache.commons.lang.RandomStringUtils;
 
 public class Strings {
 
@@ -33,6 +34,10 @@ public class Strings {
     return Streams.stream(iterable)
         .map(Object::toString)
         .collect(Collectors.joining(separator));
+  }
+
+  public static String addRandomSuffix(String base, int suffixLength) {
+    return base + "-" + RandomStringUtils.randomAlphabetic(suffixLength).toLowerCase();
   }
 
 }

--- a/airbyte-db/src/test/java/io/airbyte/db/PostgresUtilsTest.java
+++ b/airbyte-db/src/test/java/io/airbyte/db/PostgresUtilsTest.java
@@ -31,12 +31,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.jdbc.DefaultJdbcDatabase;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.sql.SQLException;
 import org.apache.commons.dbcp2.BasicDataSource;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,7 +58,7 @@ class PostgresUtilsTest {
 
   @BeforeEach
   void setup() throws Exception {
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10);
 
     final JsonNode config = getConfig(PSQL_DB, dbName);
 

--- a/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestDefaultJdbcDatabase.java
+++ b/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestDefaultJdbcDatabase.java
@@ -31,13 +31,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Databases;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,7 +65,7 @@ public class TestDefaultJdbcDatabase {
 
   @BeforeEach
   void setup() throws Exception {
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10);
 
     config = getConfig(PSQL_DB, dbName);
 

--- a/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestJdbcUtils.java
+++ b/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestJdbcUtils.java
@@ -34,6 +34,7 @@ import com.google.common.collect.Lists;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.stream.MoreStreams;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.math.BigDecimal;
@@ -48,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.dbcp2.BasicDataSource;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,7 +75,7 @@ public class TestJdbcUtils {
 
   @BeforeEach
   void setup() throws Exception {
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10);
 
     final JsonNode config = getConfig(PSQL_DB, dbName);
 

--- a/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestStreamingJdbcDatabase.java
+++ b/airbyte-db/src/test/java/io/airbyte/db/jdbc/TestStreamingJdbcDatabase.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Lists;
 import io.airbyte.commons.functional.CheckedConsumer;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -47,7 +48,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.dbcp2.BasicDataSource;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -79,7 +79,7 @@ public class TestStreamingJdbcDatabase {
   void setup() throws Exception {
     jdbcStreamingQueryConfiguration = mock(JdbcStreamingQueryConfiguration.class);
 
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10);
 
     final JsonNode config = getConfig(PSQL_DB, dbName);
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationAcceptanceTest.java
@@ -43,6 +43,7 @@ import com.google.cloud.bigquery.TableResult;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.integrations.base.JavaBaseConstants;
 import io.airbyte.integrations.destination.StandardNameTransformer;
 import io.airbyte.integrations.standardtest.destination.DestinationAcceptanceTest;
@@ -55,7 +56,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -184,7 +184,8 @@ public class BigQueryDestinationAcceptanceTest extends DestinationAcceptanceTest
     final JsonNode credentialsJson = Jsons.deserialize(credentialsJsonString);
     final String projectId = credentialsJson.get(CONFIG_PROJECT_ID).asText();
 
-    final String datasetId = "airbyte_tests_" + RandomStringUtils.randomAlphanumeric(8);
+    final String datasetId = Strings.addRandomSuffix("airbyte_tests", "_", 8);
+
     config = Jsons.jsonNode(ImmutableMap.builder()
         .put(CONFIG_PROJECT_ID, projectId)
         .put(CONFIG_CREDS, credentialsJsonString)

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/java/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTest.java
@@ -43,6 +43,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
 import io.airbyte.integrations.base.Destination;
 import io.airbyte.integrations.base.JavaBaseConstants;
@@ -69,7 +70,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -136,7 +136,7 @@ class BigQueryDestinationTest {
         .build()
         .getService();
 
-    final String datasetId = "airbyte_tests_" + RandomStringUtils.randomAlphanumeric(8);
+    final String datasetId = Strings.addRandomSuffix("airbyte_tests", "_", 8);
     MESSAGE_USERS1.getRecord().setNamespace(datasetId);
     MESSAGE_USERS2.getRecord().setNamespace(datasetId);
     MESSAGE_TASKS1.getRecord().setNamespace(datasetId);

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/java/io/airbyte/integrations/destination/mssql/MSSQLDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/java/io/airbyte/integrations/destination/mssql/MSSQLDestinationAcceptanceTest.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
 import io.airbyte.integrations.base.JavaBaseConstants;
@@ -37,7 +38,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.jooq.JSONFormat;
 import org.jooq.JSONFormat.RecordFormat;
 import org.junit.jupiter.api.AfterAll;
@@ -162,7 +162,7 @@ public class MSSQLDestinationAcceptanceTest extends DestinationAcceptanceTest {
   @Override
   protected void setup(TestDestinationEnv testEnv) throws SQLException {
     configWithoutDbName = getConfig(db);
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10);
 
     final Database database = getDatabase(configWithoutDbName);
     database.query(ctx -> {

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/java/io/airbyte/integrations/destination/mssql/MSSQLDestinationAcceptanceTestSSL.java
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/java/io/airbyte/integrations/destination/mssql/MSSQLDestinationAcceptanceTestSSL.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
 import io.airbyte.integrations.base.JavaBaseConstants;
@@ -37,7 +38,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.jooq.JSONFormat;
 import org.jooq.JSONFormat.RecordFormat;
 import org.junit.jupiter.api.AfterAll;
@@ -171,7 +171,7 @@ public class MSSQLDestinationAcceptanceTestSSL extends DestinationAcceptanceTest
   @Override
   protected void setup(TestDestinationEnv testEnv) throws SQLException {
     configWithoutDbName = getConfig(db);
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10);
 
     final Database database = getDatabase(configWithoutDbName);
     database.query(ctx -> {

--- a/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftCopyDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftCopyDestinationAcceptanceTest.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
 import io.airbyte.integrations.base.JavaBaseConstants;
@@ -37,7 +38,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.jooq.JSONFormat;
 import org.jooq.JSONFormat.RecordFormat;
 
@@ -129,7 +129,7 @@ public class RedshiftCopyDestinationAcceptanceTest extends DestinationAcceptance
   // for each test we create a new schema in the database. run the test in there and then remove it.
   @Override
   protected void setup(TestDestinationEnv testEnv) throws Exception {
-    final String schemaName = ("integration_test_" + RandomStringUtils.randomAlphanumeric(5));
+    final String schemaName = Strings.addRandomSuffix("integration_test", "_", 5);
     final String createSchemaQuery = String.format("CREATE SCHEMA %s", schemaName);
     baseConfig = getStaticConfig();
     getDatabase().query(ctx -> ctx.execute(createSchemaQuery));

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.base.JavaBaseConstants;
 import io.airbyte.integrations.destination.ExtendedNameTransformer;

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
@@ -38,7 +38,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.RandomStringUtils;
 
 public class SnowflakeInsertDestinationAcceptanceTest extends DestinationAcceptanceTest {
 
@@ -126,7 +125,7 @@ public class SnowflakeInsertDestinationAcceptanceTest extends DestinationAccepta
   // for each test we create a new schema in the database. run the test in there and then remove it.
   @Override
   protected void setup(TestDestinationEnv testEnv) throws Exception {
-    final String schemaName = ("integration_test_" + RandomStringUtils.randomAlphanumeric(5));
+    final String schemaName = Strings.addRandomSuffix("integration_test", "_", 5);
     final String createSchemaQuery = String.format("CREATE SCHEMA %s", schemaName);
 
     baseConfig = getStaticConfig();

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceAcceptanceTest.java
@@ -28,13 +28,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.jdbc.PostgresJdbcStreamingQueryConfiguration;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.source.jdbc.test.JdbcSourceAcceptanceTest;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.util.Set;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +62,7 @@ class AbstractJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest {
 
   @BeforeEach
   public void setup() throws Exception {
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
 
     config = Jsons.jsonNode(ImmutableMap.builder()
         .put("host", PSQL_DB.getHost())

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/DefaultJdbcStressTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/DefaultJdbcStressTest.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.jdbc.PostgresJdbcStreamingQueryConfiguration;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
@@ -35,7 +36,6 @@ import io.airbyte.integrations.source.jdbc.test.JdbcStressTest;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,7 +65,7 @@ class DefaultJdbcStressTest extends JdbcStressTest {
 
   @BeforeEach
   public void setup() throws Exception {
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10);
 
     config = Jsons.jsonNode(ImmutableMap.of("host", "localhost", "port", 5432, "database", "charles", "username", "postgres", "password", ""));
 

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/JdbcSourceStressTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/JdbcSourceStressTest.java
@@ -35,7 +35,6 @@ import io.airbyte.integrations.source.jdbc.test.JdbcStressTest;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,7 +64,7 @@ class JdbcSourceStressTest extends JdbcStressTest {
 
   @BeforeEach
   public void setup() throws Exception {
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String schemaName = Strings.addRandomSuffix("db", "_", 10);;
 
     config = Jsons.jsonNode(ImmutableMap.builder()
         .put("host", PSQL_DB.getHost())

--- a/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/MssqlSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/MssqlSourceAcceptanceTest.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
 import io.airbyte.integrations.standardtest.source.SourceAcceptanceTest;
@@ -41,7 +42,6 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.testcontainers.containers.MSSQLServerContainer;
 
 public class MssqlSourceAcceptanceTest extends SourceAcceptanceTest {
@@ -62,7 +62,7 @@ public class MssqlSourceAcceptanceTest extends SourceAcceptanceTest {
         .put("username", db.getUsername())
         .put("password", db.getPassword())
         .build());
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
 
     final Database database = getDatabase(configWithoutDbName);
     database.query(ctx -> {

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlJdbcSourceAcceptanceTest.java
@@ -28,11 +28,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Databases;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
 import io.airbyte.integrations.source.jdbc.test.JdbcSourceAcceptanceTest;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,7 +67,7 @@ public class MssqlJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest {
             configWithoutDbName.get("port").asInt()),
         "com.microsoft.sqlserver.jdbc.SQLServerDriver");
 
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
 
     database.execute(ctx -> ctx.createStatement().execute(String.format("CREATE DATABASE %s;", dbName)));
 

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlSourceTest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
 import io.airbyte.protocol.models.AirbyteCatalog;
@@ -40,7 +41,6 @@ import io.airbyte.protocol.models.Field.JsonSchemaPrimitive;
 import io.airbyte.protocol.models.SyncMode;
 import java.sql.SQLException;
 import java.util.List;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,7 +77,7 @@ class MssqlSourceTest {
   @BeforeEach
   void setup() throws SQLException {
     configWithoutDbName = getConfig(db);
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
 
     final Database database = getDatabase(configWithoutDbName);
     database.query(ctx -> {

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlStressTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/MssqlStressTest.java
@@ -28,12 +28,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Databases;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
 import io.airbyte.integrations.source.jdbc.test.JdbcStressTest;
 import java.util.Optional;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,7 +70,7 @@ public class MssqlStressTest extends JdbcStressTest {
             configWithoutDbName.get("port").asInt()),
         "com.microsoft.sqlserver.jdbc.SQLServerDriver");
 
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
 
     database.execute(ctx -> ctx.createStatement().execute(String.format("CREATE DATABASE %s;", dbName)));
 

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlJdbcSourceAcceptanceTest.java
@@ -27,6 +27,7 @@ package io.airbyte.integrations.source.mysql;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
@@ -34,7 +35,6 @@ import io.airbyte.integrations.source.jdbc.test.JdbcSourceAcceptanceTest;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.jooq.SQLDialect;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -68,7 +68,7 @@ class MySqlJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest {
     config = Jsons.jsonNode(ImmutableMap.builder()
         .put("host", container.getHost())
         .put("port", container.getFirstMappedPort())
-        .put("database", "db_" + RandomStringUtils.randomAlphabetic(10))
+        .put("database", Strings.addRandomSuffix("db", "_", 10))
         .put("username", TEST_USER)
         .put("password", TEST_PASSWORD)
         .build());

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlSourceTests.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlSourceTests.java
@@ -29,12 +29,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Database;
 import io.airbyte.protocol.models.AirbyteConnectionStatus;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.util.Properties;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.MySQLContainer;
 
@@ -60,7 +60,7 @@ public class MySqlSourceTests {
     Properties properties = new Properties();
     properties.putAll(ImmutableMap.of("user", "root", "password", TEST_PASSWORD, "serverTimezone", "Europe/Moscow"));
     DriverManager.getConnection(container.getJdbcUrl(), properties);
-    String dbName = "db_" + RandomStringUtils.randomAlphabetic(10);
+    final String dbName = Strings.addRandomSuffix("db", "_", 10);
     config = getConfig(container, dbName, "serverTimezone=Europe/Moscow");
 
     try (Connection connection = DriverManager.getConnection(container.getJdbcUrl(), properties)) {

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlStressTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlStressTest.java
@@ -27,6 +27,7 @@ package io.airbyte.integrations.source.mysql;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
@@ -35,7 +36,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Optional;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.jooq.SQLDialect;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -71,7 +71,7 @@ class MySqlStressTest extends JdbcStressTest {
     config = Jsons.jsonNode(ImmutableMap.builder()
         .put("host", container.getHost())
         .put("port", container.getFirstMappedPort())
-        .put("database", "db_" + RandomStringUtils.randomAlphabetic(10))
+        .put("database", Strings.addRandomSuffix("db", "_", 10))
         .put("username", TEST_USER)
         .put("password", TEST_PASSWORD)
         .build());

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
@@ -41,6 +41,7 @@ import com.google.common.collect.Streams;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.Exceptions;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.commons.util.AutoCloseableIterator;
 import io.airbyte.commons.util.AutoCloseableIterators;
 import io.airbyte.db.Database;
@@ -72,7 +73,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.junit.jupiter.api.AfterAll;
@@ -159,7 +159,7 @@ class CdcPostgresSourceTest {
   void setup() throws Exception {
     source = new PostgresSource();
 
-    dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
 
     final String initScriptName = "init_" + dbName.concat(".sql");
     final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresJdbcSourceAcceptanceTest.java
@@ -28,10 +28,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
 import io.airbyte.integrations.source.jdbc.test.JdbcSourceAcceptanceTest;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,7 +52,7 @@ class PostgresJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest {
 
   @BeforeEach
   public void setup() throws Exception {
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
 
     config = Jsons.jsonNode(ImmutableMap.builder()
         .put("host", PSQL_DB.getHost())

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceSSLTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceSSLTest.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.commons.util.MoreIterators;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
@@ -56,7 +57,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.jooq.SQLDialect;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -113,7 +113,7 @@ class PostgresSourceSSLTest {
 
   @BeforeEach
   void setup() throws Exception {
-    dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
 
     final String initScriptName = "init_" + dbName.concat(".sql");
     final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.commons.util.MoreIterators;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
@@ -56,7 +57,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.jooq.SQLDialect;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -115,7 +115,7 @@ class PostgresSourceTest {
 
   @BeforeEach
   void setup() throws Exception {
-    dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
 
     final String initScriptName = "init_" + dbName.concat(".sql");
     final String tmpFilePath = IOs.writeFileToRandomTmpDir(initScriptName, "CREATE DATABASE " + dbName + ";");

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresStressTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresStressTest.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.jdbc.PostgresJdbcStreamingQueryConfiguration;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
@@ -36,7 +37,6 @@ import io.airbyte.integrations.source.jdbc.test.JdbcStressTest;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,7 +66,7 @@ class PostgresStressTest extends JdbcStressTest {
 
   @BeforeEach
   public void setup() throws Exception {
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
 
     config = Jsons.jsonNode(ImmutableMap.builder()
         .put("host", PSQL_DB.getHost())

--- a/airbyte-integrations/connectors/source-redshift/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/RedshiftSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-redshift/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/RedshiftSourceAcceptanceTest.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Databases;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.db.jdbc.JdbcUtils;
@@ -42,7 +43,6 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import org.apache.commons.lang3.RandomStringUtils;
 
 public class RedshiftSourceAcceptanceTest extends SourceAcceptanceTest {
 
@@ -69,7 +69,7 @@ public class RedshiftSourceAcceptanceTest extends SourceAcceptanceTest {
             config.get("database").asText()),
         RedshiftSource.DRIVER_CLASS);
 
-    schemaName = ("integration_test_" + RandomStringUtils.randomAlphanumeric(5)).toLowerCase();
+    schemaName = Strings.addRandomSuffix("integration_test", "_", 5).toLowerCase();
     final String createSchemaQuery = String.format("CREATE SCHEMA %s", schemaName);
     database.execute(connection -> {
       connection.createStatement().execute(createSchemaQuery);

--- a/airbyte-test-utils/src/main/java/io/airbyte/test/utils/PostgreSQLContainerHelper.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/utils/PostgreSQLContainerHelper.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
 import io.airbyte.db.jdbc.JdbcDatabase;
@@ -35,7 +36,6 @@ import java.io.IOException;
 import java.util.UUID;
 import org.jooq.SQLDialect;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
 import org.testcontainers.utility.MountableFile;
 
 public class PostgreSQLContainerHelper {
@@ -53,7 +53,7 @@ public class PostgreSQLContainerHelper {
   }
 
   public static JsonNode createDatabaseWithRandomNameAndGetPostgresConfig(PostgreSQLContainer<?> psqlDb) {
-    final String dbName = "db_" + RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    final String dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
     return createDatabaseAndGetPostgresConfig(psqlDb, dbName);
   }
 

--- a/airbyte-workers/named_pipes/np_source/Dockerfile
+++ b/airbyte-workers/named_pipes/np_source/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:latest
 COPY run.sh /tmp/run.sh
-ENV AIRBYTE_ENTRYPOINT="/tmp/run.sh"
-ENTRYPOINT /tmp/run.sh
+ENV AIRBYTE_ENTRYPOINT=">&2 /tmp/run.sh"
+ENTRYPOINT [">&2", "/tmp/run.sh"]

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -73,6 +73,8 @@ import org.slf4j.LoggerFactory;
  *
  * See the constructor for more information.
  */
+
+// TODO(Davin): Better test for this. See https://github.com/airbytehq/airbyte/issues/3700.
 public class KubePodProcess extends Process {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(KubePodProcess.class);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -69,7 +69,7 @@ public class KubePodProcess extends Process {
 
   // TODO(Davin): Cache this result.
   public static String getCommandFromImage(KubernetesClient client, String imageName, String namespace) throws InterruptedException {
-    final String podName = Strings.addRandomSuffix("airbyte-command-fetcher", 5);
+    final String podName = Strings.addRandomSuffix("airbyte-command-fetcher", "-", 5);
 
     Container commandFetcher = new ContainerBuilder()
         .withName("airbyte-command-fetcher")

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -93,7 +93,8 @@ public class KubePodProcess extends Process {
 
     var logs = client.pods().inNamespace(namespace).withName(podName).getLog();
     if (!logs.contains("AIRBYTE_ENTRYPOINT")) {
-      throw new RuntimeException("Missing AIRBYTE_ENTRYPOINT from command fetcher logs. This should not happen. Check the echo command has not been changed.");
+      throw new RuntimeException(
+          "Missing AIRBYTE_ENTRYPOINT from command fetcher logs. This should not happen. Check the echo command has not been changed.");
     }
 
     var envVal = logs.split("=")[1].strip();

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -51,25 +51,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A Process abstraction backed by a Kube Pod running in a Kubernetes cluster 'somewhere'. The parent process starting a Kube Pod Process needs
- * to exist within the Kube networking space. This is so the parent process can forward data into the child's stdin and read the child's stdout
- * and stderr streams.
+ * A Process abstraction backed by a Kube Pod running in a Kubernetes cluster 'somewhere'. The
+ * parent process starting a Kube Pod Process needs to exist within the Kube networking space. This
+ * is so the parent process can forward data into the child's stdin and read the child's stdout and
+ * stderr streams.
  *
  * This is made possible by:
- * <li>
- *   1) An init container that creates 3 named pipes corresponding to stdin, stdout and std err.
+ * <li>1) An init container that creates 3 named pipes corresponding to stdin, stdout and std err.
  * </li>
- * <li>
- *   2) Redirecting the stdin named pipe to the original image's entrypoint and it's output into the respective named pipes for stdout and stderr.
- * </li>
- * <li>
- *   3) Each named pipe has a corresponding side car. Each side car forwards its stream accordingly using socat. e.g. stderr/stdout is forwarded to
- *      parent process while input from the parent process is forwarded into stdin.
- * </li>
- * <li>
- *   4) The parent process listens on the stdout and stederr sockets for an incoming TCP connection. It also initiates a TCP connection to the child
- *   process aka the Kube pod on the specified stdin socket.
- * </li>
+ * <li>2) Redirecting the stdin named pipe to the original image's entrypoint and it's output into
+ * the respective named pipes for stdout and stderr.</li>
+ * <li>3) Each named pipe has a corresponding side car. Each side car forwards its stream
+ * accordingly using socat. e.g. stderr/stdout is forwarded to parent process while input from the
+ * parent process is forwarded into stdin.</li>
+ * <li>4) The parent process listens on the stdout and stederr sockets for an incoming TCP
+ * connection. It also initiates a TCP connection to the child process aka the Kube pod on the
+ * specified stdin socket.</li>
  *
  * See the constructor for more information.
  */

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -89,6 +89,8 @@ public class KubePodProcess extends Process {
     LOGGER.info("Creating pod...");
     Pod podDefinition = client.pods().inNamespace(namespace).createOrReplace(pod);
     LOGGER.info("Waiting until command fetcher pod completes...");
+    // TODO(Davin): If a pod is not missing, this will wait for up to 2 minutes before erroring out.
+    // Figure out a better way.
     client.resource(podDefinition).waitUntilCondition(p -> p.getStatus().getPhase().equals("Succeeded"), 2, TimeUnit.MINUTES);
 
     var logs = client.pods().inNamespace(namespace).withName(podName).getLog();

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -25,6 +25,7 @@
 package io.airbyte.workers.process;
 
 import com.google.common.base.Preconditions;
+import io.airbyte.commons.string.Strings;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
@@ -46,7 +47,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.output.NullOutputStream;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,9 +69,7 @@ public class KubePodProcess extends Process {
 
   // TODO(Davin): Cache this result.
   public static String getCommandFromImage(KubernetesClient client, String imageName, String namespace) throws InterruptedException {
-    final String suffix = RandomStringUtils.randomAlphabetic(5).toLowerCase();
-
-    final String podName = "airbyte-command-fetcher-" + suffix;
+    final String podName = Strings.addRandomSuffix("airbyte-command-fetcher", 5);
 
     Container commandFetcher = new ContainerBuilder()
         .withName("airbyte-command-fetcher")
@@ -159,7 +157,7 @@ public class KubePodProcess extends Process {
         .withName("main")
         .withImage(image)
         .withCommand("sh", "-c",
-            usesStdin ? "cat /pipes/stdin | " + entrypoint + "2> /pipes/stderr > /pipes/stdout" : entrypoint + "2> /pipes/stderr > /pipes/stdout")
+            usesStdin ? "cat /pipes/stdin | " + entrypoint + " 2> /pipes/stderr > /pipes/stdout" : entrypoint + "   2> /pipes/stderr > /pipes/stdout")
         .withVolumeMounts(volumeMount)
         .build();
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessBuilderFactoryPOC.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessBuilderFactoryPOC.java
@@ -25,18 +25,14 @@
 package io.airbyte.workers.process;
 
 import io.airbyte.commons.io.IOs;
-import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.utils.HttpClientUtils;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import okhttp3.OkHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,14 +81,16 @@ public class KubeProcessBuilderFactoryPOC {
     LOGGER.info("Closing sync worker resources...");
     listenTask.cancel(true);
     executor.shutdownNow();
-    // TODO(Davin, issue-3611): Figure out why these commands are not effectively shutting down OkHTTP even though documentation suggests so. See
-    //  https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/#shutdown-isnt-necessary
-    //  Instead, the pod shuts down after 5 minutes as the pool reaps the remaining idle connection after
-    //  5 minutes of inactivity, as per the default configuration.
-    //  OK_HTTP_CLIENT.dispatcher().executorService().shutdownNow();
-    //  OK_HTTP_CLIENT.connectionPool().evictAll();
-    //  The Kube client has issues with closing the client. Since manually injecting the OkHttp client also doesn't work, it is not clear whether it's OkHTTP or the Fabric client at fault.
-    //  See https://github.com/fabric8io/kubernetes-client/issues/2403.
+    // TODO(Davin, issue-3611): Figure out why these commands are not effectively shutting down OkHTTP
+    // even though documentation suggests so. See
+    // https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/#shutdown-isnt-necessary
+    // Instead, the pod shuts down after 5 minutes as the pool reaps the remaining idle connection after
+    // 5 minutes of inactivity, as per the default configuration.
+    // OK_HTTP_CLIENT.dispatcher().executorService().shutdownNow();
+    // OK_HTTP_CLIENT.connectionPool().evictAll();
+    // The Kube client has issues with closing the client. Since manually injecting the OkHttp client
+    // also doesn't work, it is not clear whether it's OkHTTP or the Fabric client at fault.
+    // See https://github.com/fabric8io/kubernetes-client/issues/2403.
     KUBE_CLIENT.close();
     LOGGER.info("Done!");
     // Manually exit for the time being.

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessBuilderFactoryPOC.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessBuilderFactoryPOC.java
@@ -24,13 +24,11 @@
 
 package io.airbyte.workers.process;
 
-import io.airbyte.commons.io.IOs;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.PrintWriter;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.slf4j.Logger;
@@ -46,12 +44,13 @@ public class KubeProcessBuilderFactoryPOC {
     Process src = new KubePodProcess(KUBE_CLIENT, "src", "default", "np_source:dev", 9002, 9003, false);
 
     LOGGER.info("Launching destination process...");
-    Process dest = new KubePodProcess(KUBE_CLIENT, "dest", "default", "np_dest:dev", 9004, 9005, true);
+    // Process dest = new KubePodProcess(KUBE_CLIENT, "dest", "default", "worker-test:print-to-stdout",
+    // 9004, 9005, true);
 
     LOGGER.info("Launching background thread to read destination lines...");
     ExecutorService executor = Executors.newSingleThreadExecutor();
     var listenTask = executor.submit(() -> {
-      BufferedReader reader = new BufferedReader(new InputStreamReader(dest.getInputStream()));
+      BufferedReader reader = new BufferedReader(new InputStreamReader(src.getErrorStream()));
       try {
         String line;
         while ((line = reader.readLine()) != null) {
@@ -64,19 +63,19 @@ public class KubeProcessBuilderFactoryPOC {
 
     LOGGER.info("Copying source stdout to destination stdin...");
 
-    try (BufferedReader reader = IOs.newBufferedReader(src.getInputStream())) {
-      try (PrintWriter writer = new PrintWriter(dest.getOutputStream(), true)) {
-        String line;
-        while ((line = reader.readLine()) != null) {
-          writer.println(line);
-        }
-      }
-    }
+    // try (BufferedReader reader = IOs.newBufferedReader(src.getInputStream())) {
+    // try (PrintWriter writer = new PrintWriter(dest.getOutputStream(), true)) {
+    // String line;
+    // while ((line = reader.readLine()) != null) {
+    // writer.println(line);
+    // }
+    // }
+    // }
 
     LOGGER.info("Waiting for source process to terminate...");
-    src.waitFor();
+    // src.waitFor();
     LOGGER.info("Waiting for destination process to terminate...");
-    dest.waitFor();
+    src.waitFor();
 
     LOGGER.info("Closing sync worker resources...");
     listenTask.cancel(true);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessBuilderFactoryPOC.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessBuilderFactoryPOC.java
@@ -43,10 +43,10 @@ public class KubeProcessBuilderFactoryPOC {
 
   public static void main(String[] args) throws InterruptedException, IOException {
     LOGGER.info("Launching source process...");
-    Process src = new KubePodProcess(KUBE_CLIENT, "src", "default", "np_source:dev", 9002, false);
+    Process src = new KubePodProcess(KUBE_CLIENT, "src", "default", "np_source:dev", 9002, 9003, false);
 
     LOGGER.info("Launching destination process...");
-    Process dest = new KubePodProcess(KUBE_CLIENT, "dest", "default", "np_dest:dev", 9003, true);
+    Process dest = new KubePodProcess(KUBE_CLIENT, "dest", "default", "np_dest:dev", 9004, 9005, true);
 
     LOGGER.info("Launching background thread to read destination lines...");
     ExecutorService executor = Executors.newSingleThreadExecutor();

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/KubePodProcessTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/KubePodProcessTest.java
@@ -36,7 +36,6 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -100,14 +99,13 @@ public class KubePodProcessTest {
     @Test
     @DisplayName("Should return the correct pod ip.")
     public void testGetPodIpGoodPod() throws InterruptedException {
-      final String suffix = RandomStringUtils.randomAlphabetic(5).toLowerCase();
       var sleep = new ContainerBuilder()
           .withImage("busybox")
           .withName("sleep")
           .withCommand("sleep", "100000")
           .build();
 
-      var podName = "test-get-pod-good-pod-" + suffix;
+      var podName = Strings.addRandomSuffix("test-get-pod-good-pod", "-", 5);
       Pod podDef = new PodBuilder()
           .withApiVersion("v1")
           .withNewMetadata()

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/KubePodProcessTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/KubePodProcessTest.java
@@ -37,11 +37,14 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.com.google.common.io.Resources;
 
+// Disabled until we start minikube on the node.
+@Disabled
 public class KubePodProcessTest {
 
   private static final KubernetesClient K8s = new DefaultKubernetesClient();

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/KubePodProcessTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/KubePodProcessTest.java
@@ -129,4 +129,9 @@ public class KubePodProcessTest {
 
   }
 
+  @Test
+  public void testGetStdOutLogs() {
+
+  }
+
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/KubePodProcessTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/KubePodProcessTest.java
@@ -135,27 +135,4 @@ public class KubePodProcessTest {
 
   }
 
-  @Test
-  public void testGetStdOutLogs() throws IOException, InterruptedException {
-    // we need to create an image from a java class
-    var podName = Strings.addRandomSuffix("worker-test-stdout", "-", 5);
-    var printStdoutDockerfile = Resources.getResource(TEST_IMAGE_PRINT_STDOUT_PATH);
-    DockerUtils.buildImage(printStdoutDockerfile.getPath(), TEST_IMAGE_PRINT_STDOUT_NAME);
-
-    // this needs to be run as a Kube pod so networking lines up
-    var b = new KubePodProcess(K8s, podName, "default", TEST_IMAGE_PRINT_STDOUT_NAME, 9000, 9001, false);
-    var c = b.getInputStream();
-    var d = c.readAllBytes();
-
-    System.out.println(new String(d));
-
-    b.waitFor();
-  }
-
-  @Test
-  public void portforwardTest() {
-
-    K8s.pods().inNamespace("default").withName("").portForward();
-  }
-
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/KubePodProcessTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/KubePodProcessTest.java
@@ -55,9 +55,6 @@ public class KubePodProcessTest {
   private static final String TEST_IMAGE_NO_VAR_PATH = "Dockerfile.no_var";
   private static final String TEST_IMAGE_NO_VAR_NAME = "worker-test:no-var";
 
-  private static final String TEST_IMAGE_PRINT_STDOUT_PATH = "Dockerfile.print_to_stdout";
-  private static final String TEST_IMAGE_PRINT_STDOUT_NAME = "worker-test:print-to-stdout";
-
   @BeforeAll
   public static void setup() {
     var varDockerfile = Resources.getResource(TEST_IMAGE_WITH_VAR_PATH);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/KubePodProcessTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/KubePodProcessTest.java
@@ -27,6 +27,7 @@ package io.airbyte.workers.process;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.airbyte.commons.docker.DockerUtils;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
@@ -39,24 +40,25 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.io.Resources;
 
 public class KubePodProcessTest {
 
   private static final KubernetesClient CLIENT = new DefaultKubernetesClient();
-  private static final String ENTRYPOINT = "/tmp/run.sh";
-  private static final String TEST_IMAGE_NAME = "np_dest:dev";
+
+  private static final String ENTRYPOINT = "sh";
+  private static final String TEST_IMAGE_WITH_VAR_PATH = "Dockerfile.with_var";
+  private static final String TEST_IMAGE_WITH_VAR_NAME = "worker-test:with-var";
+  private static final String TEST_IMAGE_NO_VAR_PATH = "Dockerfile.no_var";
+  private static final String TEST_IMAGE_NO_VAR_NAME = "worker-test:no-var";
 
   @BeforeAll
   public static void setup() {
-    // TODO(Davin): Why does building the container ahead doesn't work?
-    // new GenericContainer(
-    // new ImageFromDockerfile(TEST_IMAGE_NAME, false)
-    // .withDockerfileFromBuilder(builder -> {
-    // builder
-    // .from("debian")
-    // .env(Map.of("AIRBYTE_ENTRYPOINT", ENTRYPOINT))
-    // .entryPoint(ENTRYPOINT)
-    // .build();})).withEnv("AIRBYTE_ENTRYPOINT", ENTRYPOINT);
+    var varDockerFile = Resources.getResource(TEST_IMAGE_WITH_VAR_PATH);
+    DockerUtils.buildImage(varDockerFile.getPath(), TEST_IMAGE_WITH_VAR_NAME);
+
+    var noVarDockerFile = Resources.getResource(TEST_IMAGE_NO_VAR_PATH);
+    DockerUtils.buildImage(noVarDockerFile.getPath(), TEST_IMAGE_NO_VAR_NAME);
   }
 
   @Nested
@@ -65,7 +67,7 @@ public class KubePodProcessTest {
     @Test
     @DisplayName("Should error if image does not have the right env var set.")
     public void testGetCommandFromImageNoCommand() {
-      assertThrows(RuntimeException.class, () -> KubePodProcess.getCommandFromImage(CLIENT, "debian", "default"));
+      assertThrows(RuntimeException.class, () -> KubePodProcess.getCommandFromImage(CLIENT, TEST_IMAGE_NO_VAR_NAME, "default"));
     }
 
     @Test
@@ -77,7 +79,7 @@ public class KubePodProcessTest {
     @Test
     @DisplayName("Should retrieve the right command if image has the right env var set.")
     public void testGetCommandFromImageCommandPresent() throws IOException, InterruptedException {
-      var command = KubePodProcess.getCommandFromImage(CLIENT, TEST_IMAGE_NAME, "default");
+      var command = KubePodProcess.getCommandFromImage(CLIENT, TEST_IMAGE_WITH_VAR_NAME, "default");
       assertEquals(ENTRYPOINT, command);
     }
 

--- a/airbyte-workers/src/test/resources/Dockerfile.no_var
+++ b/airbyte-workers/src/test/resources/Dockerfile.no_var
@@ -1,0 +1,3 @@
+FROM alpine:3
+
+ENTRYPOINT "sh"

--- a/airbyte-workers/src/test/resources/Dockerfile.print_to_stdout
+++ b/airbyte-workers/src/test/resources/Dockerfile.print_to_stdout
@@ -1,0 +1,6 @@
+FROM alpine:3
+
+ENV AIRBYTE_ENTRYPOINT="sh -c echo testing-log && sleep 60"
+
+ENTRYPOINT ["sh", "-c", "echo 'testing-log'"]
+

--- a/airbyte-workers/src/test/resources/Dockerfile.print_to_stdout
+++ b/airbyte-workers/src/test/resources/Dockerfile.print_to_stdout
@@ -1,6 +1,0 @@
-FROM alpine:3
-
-ENV AIRBYTE_ENTRYPOINT="sh -c echo testing-log && sleep 60"
-
-ENTRYPOINT ["sh", "-c", "echo 'testing-log'"]
-

--- a/airbyte-workers/src/test/resources/Dockerfile.with_var
+++ b/airbyte-workers/src/test/resources/Dockerfile.with_var
@@ -1,0 +1,5 @@
+FROM alpine:3
+
+ENV AIRBYTE_ENTRYPOINT="sh"
+
+ENTRYPOINT "sh"


### PR DESCRIPTION
## What
Implements redirecting standard error as well.

## How
This uses the same approach we previously had with redirecting stdin and stdout.

The interesting part of this PR is some of the bits where I'm starting to automate the tests around the `KubePodProcess`.

In particular, testing images are now automatically built from Dockerfiles in test/resource. I trying to test the stdout/stderr pipes and realising we currently assume the calling process is reachable from Kube namespace. 


## Pre-merge Checklist
- [ ] *Finish test testing stdout and stderr correctly output data.*

## Recommended reading order
1. `KubePodProcess`
2. `KubePodProcessTest`
3. the rest
