### PR TITLE
Add the new Facebook API v10.0 fields to the ads_insights schema.

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -21,26 +21,6 @@
     "ad_id": {
       "type": ["null", "string"]
     },
-    "website_ctr": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "number"]
-          },
-          "action_destination": {
-            "type": ["null", "string"]
-          },
-          "action_target_id": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
     "unique_inline_link_click_ctr": {
       "type": ["null", "number"]
     },
@@ -106,20 +86,6 @@
     "cpp": {
       "type": ["null", "number"]
     },
-    "cost_per_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
     "unique_link_clicks_ctr": {
       "type": ["null", "number"]
     },
@@ -172,8 +138,92 @@
     "cost_per_inline_link_click": {
       "type": ["null", "number"]
     },
-    "ctr": {
-      "type": ["null", "number"]
-    }
+    "ctr": { "type": ["null", "number"] },
+    "account_currency": { "type": ["null", "string"] },
+    "activity_recency": { "type": ["null", "string"] },
+    "ad_click_actions": { "$ref": "ads_action_stats.json" },
+    "ad_format_asset": { "type": ["null", "string"] },
+    "ad_impression_actions": { "$ref": "ads_action_stats.json" },
+    "age_targeting": { "type": ["null", "string"] },
+    "attribution_setting": { "type": ["null", "string"] },
+    "auction_bid": { "type": ["null", "number"] },
+    "auction_competitiveness": { "type": ["null", "number"] },
+    "auction_max_competitor_bid": { "type": ["null", "number"] },
+    "buying_type": { "type": ["null", "string"] },
+    "catalog_segment_actions": { "$ref": "ads_action_stats.json" },
+    "catalog_segment_value": { "$ref": "ads_action_stats.json" },
+    "catalog_segment_value_mobile_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "catalog_segment_value_omni_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "catalog_segment_value_website_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "conversion_values": { "$ref": "ads_action_stats.json" },
+    "conversions": { "$ref": "ads_action_stats.json" },
+    "converted_product_quantity": { "$ref": "ads_action_stats.json" },
+    "converted_product_value": { "$ref": "ads_action_stats.json" },
+    "cost_per_15_sec_video_view": { "$ref": "ads_action_stats.json" },
+    "cost_per_2_sec_continuous_video_view": { "$ref": "ads_action_stats.json" },
+    "cost_per_action_type": { "$ref": "ads_action_stats.json" },
+    "cost_per_ad_click": { "$ref": "ads_action_stats.json" },
+    "cost_per_conversion": { "$ref": "ads_action_stats.json" },
+    "cost_per_dda_countby_convs": { "type": ["null", "number"] },
+    "cost_per_one_thousand_ad_impression": { "$ref": "ads_action_stats.json" },
+    "cost_per_outbound_click": { "$ref": "ads_action_stats.json" },
+    "cost_per_store_visit_action": { "$ref": "ads_action_stats.json" },
+    "cost_per_thruplay": { "$ref": "ads_action_stats.json" },
+    "cost_per_unique_action_type": { "$ref": "ads_action_stats.json" },
+    "cost_per_unique_conversion": { "$ref": "ads_action_stats.json" },
+    "cost_per_unique_outbound_click": { "$ref": "ads_action_stats.json" },
+    "country": { "type": ["null", "string"] },
+    "created_time": { "type": ["null", "string"], "format": "date-time" },
+    "country": { "type": ["null", "string"] },
+    "dda_countby_convs": { "type": ["null", "number"] },
+    "device_platform": { "type": ["null", "string"] },
+    "dma": { "type": ["null", "string"] },
+    "estimated_ad_recall_rate_lower_bound": { "type": ["null", "number"] },
+    "estimated_ad_recall_rate_upper_bound": { "type": ["null", "number"] },
+    "estimated_ad_recallers_lower_bound": { "type": ["null", "number"] },
+    "estimated_ad_recallers_upper_bound": { "type": ["null", "number"] },
+    "frequency_value": { "type": ["null", "string"] },
+    "full_view_impressions": { "type": ["null", "number"] },
+    "full_view_reach": { "type": ["null", "number"] },
+    "gender_targeting": { "type": ["null", "string"] },
+    "hourly_stats_aggregated_by_advertiser_time_zone": { "type": ["null", "string"] },
+    "hourly_stats_aggregated_by_audience_time_zone": { "type": ["null", "string"] },
+    "impression_device": { "type": ["null", "string"] },
+    "instant_experience_clicks_to_open": { "type": ["null", "number"] },
+    "instant_experience_clicks_to_start": { "type": ["null", "number"] },
+    "instant_experience_outbound_clicks": { "type": ["null", "integer"] },
+    "interactive_component_tap": { "$ref": "ads_action_stats.json" },
+    "labels": { "type": ["null", "string"] },
+    "location": { "type": ["null", "string"] },
+    "mobile_app_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "optimization_goal": { "type": ["null", "string"] },
+    "outbound_clicks_ctr": { "$ref": "ads_action_stats.json" },
+    "place_page_id": { "type": ["null", "string"] },
+    "place_page_name": { "type": ["null", "string"] },
+    "platform_position": { "type": ["null", "string"] },
+    "product_id": { "type": ["null", "string"] },
+    "publisher_platform": { "type": ["null", "string"] },
+    "purchase_roas": { "$ref": "ads_action_stats.json" },
+    "qualifying_question_qualify_answer_rate": { "type": ["null", "number"] },
+    "store_visit_actions": { "$ref": "ads_action_stats.json" },
+    "unique_conversions": { "$ref": "ads_action_stats.json" },
+    "unique_outbound_clicks": { "$ref": "ads_action_stats.json" },
+    "unique_outbound_clicks_ctr": { "$ref": "ads_action_stats.json" },
+    "unique_video_view_15_sec": { "$ref": "ads_action_stats.json" },
+    "updated_time": { "type": ["null", "string"], "format": "date-time" },
+    "video_15_sec_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_avg_time_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_continuous_2_sec_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_play_actions": { "$ref": "ads_histogram_stats.json" },
+    "video_play_retention_0_to_15s_actions": { "$ref": "ads_histogram_stats.json" },
+    "video_play_retention_20_to_60s_actions": { "$ref": "ads_histogram_stats.json" },
+    "video_play_retention_graph_actions": { "$ref": "ads_histogram_stats.json" },
+    "video_time_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
+    "website_ctr": { "$ref": "ads_action_stats.json" },
+    "website_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "wish_bid": { "type": ["null", "number"] }
   }
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -1,5 +1,11 @@
 {
   "properties": {
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "account_id": {
       "type": [
         "null",
@@ -54,6 +60,12 @@
         "string"
       ]
     },
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "auction_bid": {
       "type": [
         "null",
@@ -102,7 +114,19 @@
         "number"
       ]
     },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
     "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "clicks": {
@@ -123,6 +147,12 @@
     "conversions": {
       "$ref": "ads_action_stats.json"
     },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
     "cost_per_15_sec_video_view": {
       "$ref": "ads_action_stats.json"
     },
@@ -137,6 +167,12 @@
     },
     "cost_per_conversion": {
       "$ref": "ads_action_stats.json"
+    },
+    "cost_per_estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
     },
     "cost_per_inline_link_click": {
       "type": [
@@ -167,9 +203,6 @@
         "null",
         "number"
       ]
-    },
-    "cost_per_unique_conversion": {
-      "$ref": "ads_action_stats.json"
     },
     "cost_per_unique_inline_link_click": {
       "type": [
@@ -231,6 +264,12 @@
         "string"
       ]
     },
+    "estimated_ad_recall_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
     "estimated_ad_recall_rate_lower_bound": {
       "type": [
         "null",
@@ -238,6 +277,12 @@
       ]
     },
     "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers": {
       "type": [
         "null",
         "number"
@@ -303,6 +348,24 @@
         "integer"
       ]
     },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
     "labels": {
       "type": [
         "null",
@@ -315,7 +378,16 @@
         "string"
       ]
     },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
     "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
       "type": [
         "null",
         "string"
@@ -326,6 +398,15 @@
     },
     "outbound_clicks_ctr": {
       "$ref": "ads_action_stats.json"
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
     },
     "quality_ranking": {
       "type": [
@@ -351,6 +432,9 @@
         "number"
       ]
     },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
     "unique_actions": {
       "$ref": "ads_action_stats.json"
     },
@@ -359,9 +443,6 @@
         "null",
         "integer"
       ]
-    },
-    "unique_conversions": {
-      "$ref": "ads_action_stats.json"
     },
     "unique_ctr": {
       "type": [
@@ -439,10 +520,16 @@
     "video_play_retention_20_to_60s_actions": {
       "$ref": "ads_histogram_stats.json"
     },
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
     "video_time_watched_actions": {
       "$ref": "ads_action_stats.json"
     },
     "website_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "wish_bid": {

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -1,229 +1,639 @@
 {
-  "type": ["null", "object"],
   "properties": {
-    "unique_actions": { "$ref": "ads_action_stats.json" },
-    "actions": { "$ref": "ads_action_stats.json" },
-    "action_values": { "$ref": "ads_action_stats.json" },
-    "outbound_clicks": { "$ref": "ads_action_stats.json" },
-    "video_30_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p25_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p50_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p75_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p100_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_play_curve_actions": { "$ref": "ads_histogram_stats.json" },
-    "clicks": {
-      "type": ["null", "integer"]
-    },
-    "date_stop": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "ad_id": {
-      "type": ["null", "string"]
-    },
-    "unique_inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "adset_id": {
-      "type": ["null", "string"]
-    },
-    "frequency": {
-      "type": ["null", "number"]
-    },
-    "account_name": {
-      "type": ["null", "string"]
-    },
-    "canvas_avg_view_time": {
-      "type": ["null", "number"]
-    },
-    "unique_inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "cost_per_unique_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "inline_post_engagement": {
-      "type": ["null", "integer"]
-    },
-    "campaign_name": {
-      "type": ["null", "string"]
-    },
-    "inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "campaign_id": {
-      "type": ["null", "string"]
-    },
-    "cpc": {
-      "type": ["null", "number"]
-    },
-    "ad_name": {
-      "type": ["null", "string"]
-    },
-    "cost_per_unique_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "cpm": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_post_engagement": {
-      "type": ["null", "number"]
-    },
-    "inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "cpp": {
-      "type": ["null", "number"]
-    },
-    "unique_link_clicks_ctr": {
-      "type": ["null", "number"]
-    },
-    "spend": {
-      "type": ["null", "number"]
-    },
-    "cost_per_unique_click": {
-      "type": ["null", "number"]
-    },
-    "adset_name": {
-      "type": ["null", "string"]
-    },
-    "unique_clicks": {
-      "type": ["null", "integer"]
-    },
-    "social_spend": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "canvas_avg_view_percent": {
-      "type": ["null", "number"]
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "account_id": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "date_start": {
-      "type": ["null", "string"],
-      "format": "date-time"
+    "account_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "objective": {
-      "type": ["null", "string"]
+    "action_values": {
+      "$ref": "ads_action_stats.json"
     },
-    "quality_ranking": {
-      "type": ["null", "string"]
+    "actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "engagement_rate_ranking": {
-      "type": ["null", "string"]
+    "activity_recency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_click_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "ad_format_asset": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_impression_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "ad_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "age_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "auction_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_competitiveness": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_max_competitor_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "buying_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_percent": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "canvas_avg_view_time": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "conversion_rate_ranking": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "impressions": {
-      "type": ["null", "integer"]
+    "conversion_values": {
+      "$ref": "ads_action_stats.json"
     },
-    "unique_ctr": {
-      "type": ["null", "number"]
+    "conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_15_sec_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_2_sec_continuous_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_ad_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_dda_countby_convs": {
+      "type": [
+        "null",
+        "number"
+      ]
     },
     "cost_per_inline_link_click": {
-      "type": ["null", "number"]
+      "type": [
+        "null",
+        "number"
+      ]
     },
-    "ctr": { "type": ["null", "number"] },
-    "account_currency": { "type": ["null", "string"] },
-    "activity_recency": { "type": ["null", "string"] },
-    "ad_click_actions": { "$ref": "ads_action_stats.json" },
-    "ad_format_asset": { "type": ["null", "string"] },
-    "ad_impression_actions": { "$ref": "ads_action_stats.json" },
-    "age_targeting": { "type": ["null", "string"] },
-    "attribution_setting": { "type": ["null", "string"] },
-    "auction_bid": { "type": ["null", "number"] },
-    "auction_competitiveness": { "type": ["null", "number"] },
-    "auction_max_competitor_bid": { "type": ["null", "number"] },
-    "buying_type": { "type": ["null", "string"] },
-    "catalog_segment_actions": { "$ref": "ads_action_stats.json" },
-    "catalog_segment_value": { "$ref": "ads_action_stats.json" },
-    "catalog_segment_value_mobile_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "catalog_segment_value_omni_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "catalog_segment_value_website_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "conversion_values": { "$ref": "ads_action_stats.json" },
-    "conversions": { "$ref": "ads_action_stats.json" },
-    "converted_product_quantity": { "$ref": "ads_action_stats.json" },
-    "converted_product_value": { "$ref": "ads_action_stats.json" },
-    "cost_per_15_sec_video_view": { "$ref": "ads_action_stats.json" },
-    "cost_per_2_sec_continuous_video_view": { "$ref": "ads_action_stats.json" },
-    "cost_per_action_type": { "$ref": "ads_action_stats.json" },
-    "cost_per_ad_click": { "$ref": "ads_action_stats.json" },
-    "cost_per_conversion": { "$ref": "ads_action_stats.json" },
-    "cost_per_dda_countby_convs": { "type": ["null", "number"] },
-    "cost_per_one_thousand_ad_impression": { "$ref": "ads_action_stats.json" },
-    "cost_per_outbound_click": { "$ref": "ads_action_stats.json" },
-    "cost_per_store_visit_action": { "$ref": "ads_action_stats.json" },
-    "cost_per_thruplay": { "$ref": "ads_action_stats.json" },
-    "cost_per_unique_action_type": { "$ref": "ads_action_stats.json" },
-    "cost_per_unique_conversion": { "$ref": "ads_action_stats.json" },
-    "cost_per_unique_outbound_click": { "$ref": "ads_action_stats.json" },
-    "country": { "type": ["null", "string"] },
-    "created_time": { "type": ["null", "string"], "format": "date-time" },
-    "country": { "type": ["null", "string"] },
-    "dda_countby_convs": { "type": ["null", "number"] },
-    "device_platform": { "type": ["null", "string"] },
-    "dma": { "type": ["null", "string"] },
-    "estimated_ad_recall_rate_lower_bound": { "type": ["null", "number"] },
-    "estimated_ad_recall_rate_upper_bound": { "type": ["null", "number"] },
-    "estimated_ad_recallers_lower_bound": { "type": ["null", "number"] },
-    "estimated_ad_recallers_upper_bound": { "type": ["null", "number"] },
-    "frequency_value": { "type": ["null", "string"] },
-    "full_view_impressions": { "type": ["null", "number"] },
-    "full_view_reach": { "type": ["null", "number"] },
-    "gender_targeting": { "type": ["null", "string"] },
-    "hourly_stats_aggregated_by_advertiser_time_zone": { "type": ["null", "string"] },
-    "hourly_stats_aggregated_by_audience_time_zone": { "type": ["null", "string"] },
-    "impression_device": { "type": ["null", "string"] },
-    "instant_experience_clicks_to_open": { "type": ["null", "number"] },
-    "instant_experience_clicks_to_start": { "type": ["null", "number"] },
-    "instant_experience_outbound_clicks": { "type": ["null", "integer"] },
-    "interactive_component_tap": { "$ref": "ads_action_stats.json" },
-    "labels": { "type": ["null", "string"] },
-    "location": { "type": ["null", "string"] },
-    "mobile_app_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "optimization_goal": { "type": ["null", "string"] },
-    "outbound_clicks_ctr": { "$ref": "ads_action_stats.json" },
-    "place_page_id": { "type": ["null", "string"] },
-    "place_page_name": { "type": ["null", "string"] },
-    "platform_position": { "type": ["null", "string"] },
-    "product_id": { "type": ["null", "string"] },
-    "publisher_platform": { "type": ["null", "string"] },
-    "purchase_roas": { "$ref": "ads_action_stats.json" },
-    "qualifying_question_qualify_answer_rate": { "type": ["null", "number"] },
-    "store_visit_actions": { "$ref": "ads_action_stats.json" },
-    "unique_conversions": { "$ref": "ads_action_stats.json" },
-    "unique_outbound_clicks": { "$ref": "ads_action_stats.json" },
-    "unique_outbound_clicks_ctr": { "$ref": "ads_action_stats.json" },
-    "unique_video_view_15_sec": { "$ref": "ads_action_stats.json" },
-    "updated_time": { "type": ["null", "string"], "format": "date-time" },
-    "video_15_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_avg_time_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_continuous_2_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_play_actions": { "$ref": "ads_histogram_stats.json" },
-    "video_play_retention_0_to_15s_actions": { "$ref": "ads_histogram_stats.json" },
-    "video_play_retention_20_to_60s_actions": { "$ref": "ads_histogram_stats.json" },
-    "video_play_retention_graph_actions": { "$ref": "ads_histogram_stats.json" },
-    "video_time_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
-    "website_ctr": { "$ref": "ads_action_stats.json" },
-    "website_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "wish_bid": { "type": ["null", "number"] }
-  }
+    "cost_per_inline_post_engagement": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_one_thousand_ad_impression": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_store_visit_action": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_thruplay": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "country": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "cpc": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpm": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpp": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "created_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "date_start": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_stop": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "dda_countby_convs": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "device_platform": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "dma": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "engagement_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recall_rate_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency_value": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "full_view_impressions": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_reach": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "gender_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "hourly_stats_aggregated_by_advertiser_time_zone": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "hourly_stats_aggregated_by_audience_time_zone": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impression_device": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_post_engagement": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "interactive_component_tap": {
+      "$ref": "ads_action_stats.json"
+    },
+    "labels": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "location": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "place_page_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "place_page_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "platform_position": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "product_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "publisher_platform": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "quality_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reach": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "social_spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_link_clicks_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_video_view_15_sec": {
+      "$ref": "ads_action_stats.json"
+    },
+    "updated_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "video_15_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_30_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_avg_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_continuous_2_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p100_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p25_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p50_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p75_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p95_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_play_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_curve_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_0_to_15s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_20_to_60s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "wish_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    }
+  },
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -1,11 +1,5 @@
 {
   "properties": {
-    "account_currency": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "account_id": {
       "type": [
         "null",
@@ -24,20 +18,8 @@
     "actions": {
       "$ref": "ads_action_stats.json"
     },
-    "activity_recency": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "ad_click_actions": {
       "$ref": "ads_action_stats.json"
-    },
-    "ad_format_asset": {
-      "type": [
-        "null",
-        "string"
-      ]
     },
     "ad_id": {
       "type": [
@@ -67,12 +49,6 @@
       ]
     },
     "age_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "attribution_setting": {
       "type": [
         "null",
         "string"
@@ -126,19 +102,7 @@
         "number"
       ]
     },
-    "catalog_segment_actions": {
-      "$ref": "ads_action_stats.json"
-    },
     "catalog_segment_value": {
-      "$ref": "ads_action_stats.json"
-    },
-    "catalog_segment_value_mobile_purchase_roas": {
-      "$ref": "ads_action_stats.json"
-    },
-    "catalog_segment_value_omni_purchase_roas": {
-      "$ref": "ads_action_stats.json"
-    },
-    "catalog_segment_value_website_purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "clicks": {
@@ -159,12 +123,6 @@
     "conversions": {
       "$ref": "ads_action_stats.json"
     },
-    "converted_product_quantity": {
-      "$ref": "ads_action_stats.json"
-    },
-    "converted_product_value": {
-      "$ref": "ads_action_stats.json"
-    },
     "cost_per_15_sec_video_view": {
       "$ref": "ads_action_stats.json"
     },
@@ -180,12 +138,6 @@
     "cost_per_conversion": {
       "$ref": "ads_action_stats.json"
     },
-    "cost_per_dda_countby_convs": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
     "cost_per_inline_link_click": {
       "type": [
         "null",
@@ -197,9 +149,6 @@
         "null",
         "number"
       ]
-    },
-    "cost_per_one_thousand_ad_impression": {
-      "$ref": "ads_action_stats.json"
     },
     "cost_per_outbound_click": {
       "$ref": "ads_action_stats.json"
@@ -230,12 +179,6 @@
     },
     "cost_per_unique_outbound_click": {
       "$ref": "ads_action_stats.json"
-    },
-    "country": {
-      "type": [
-        "null",
-        "string"
-      ]
     },
     "cpc": {
       "type": [
@@ -282,24 +225,6 @@
         "string"
       ]
     },
-    "dda_countby_convs": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
-    "device_platform": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "dma": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "engagement_rate_ranking": {
       "type": [
         "null",
@@ -336,12 +261,6 @@
         "number"
       ]
     },
-    "frequency_value": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "full_view_impressions": {
       "type": [
         "null",
@@ -355,24 +274,6 @@
       ]
     },
     "gender_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "hourly_stats_aggregated_by_advertiser_time_zone": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "hourly_stats_aggregated_by_audience_time_zone": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "impression_device": {
       "type": [
         "null",
         "string"
@@ -402,27 +303,6 @@
         "integer"
       ]
     },
-    "instant_experience_clicks_to_open": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
-    "instant_experience_clicks_to_start": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
-    "instant_experience_outbound_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
-    },
-    "interactive_component_tap": {
-      "$ref": "ads_action_stats.json"
-    },
     "labels": {
       "type": [
         "null",
@@ -435,16 +315,7 @@
         "string"
       ]
     },
-    "mobile_app_purchase_roas": {
-      "$ref": "ads_action_stats.json"
-    },
     "objective": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "optimization_goal": {
       "type": [
         "null",
         "string"
@@ -455,45 +326,6 @@
     },
     "outbound_clicks_ctr": {
       "$ref": "ads_action_stats.json"
-    },
-    "place_page_id": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "place_page_name": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "platform_position": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "product_id": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "publisher_platform": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "purchase_roas": {
-      "$ref": "ads_action_stats.json"
-    },
-    "qualifying_question_qualify_answer_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
     },
     "quality_ranking": {
       "type": [
@@ -518,9 +350,6 @@
         "null",
         "number"
       ]
-    },
-    "store_visit_actions": {
-      "$ref": "ads_action_stats.json"
     },
     "unique_actions": {
       "$ref": "ads_action_stats.json"
@@ -562,9 +391,6 @@
       "$ref": "ads_action_stats.json"
     },
     "unique_outbound_clicks_ctr": {
-      "$ref": "ads_action_stats.json"
-    },
-    "unique_video_view_15_sec": {
       "$ref": "ads_action_stats.json"
     },
     "updated_time": {
@@ -613,16 +439,10 @@
     "video_play_retention_20_to_60s_actions": {
       "$ref": "ads_histogram_stats.json"
     },
-    "video_play_retention_graph_actions": {
-      "$ref": "ads_histogram_stats.json"
-    },
     "video_time_watched_actions": {
       "$ref": "ads_action_stats.json"
     },
     "website_ctr": {
-      "$ref": "ads_action_stats.json"
-    },
-    "website_purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "wish_bid": {

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_age_and_gender.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_age_and_gender.json
@@ -1,186 +1,559 @@
 {
-  "type": ["null", "object"],
   "properties": {
-    "unique_actions": { "$ref": "ads_action_stats.json" },
-    "actions": { "$ref": "ads_action_stats.json" },
-    "action_values": { "$ref": "ads_action_stats.json" },
-    "outbound_clicks": { "$ref": "ads_action_stats.json" },
-    "video_30_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p25_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p50_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p75_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p100_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_play_curve_actions": { "$ref": "ads_histogram_stats.json" },
-    "clicks": {
-      "type": ["null", "integer"]
-    },
-    "date_stop": {
-      "type": ["null", "string"]
-    },
-    "ad_id": {
-      "type": ["null", "string"]
-    },
-    "website_ctr": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "number"]
-          },
-          "action_destination": {
-            "type": ["null", "string"]
-          },
-          "action_target_id": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "adset_id": {
-      "type": ["null", "string"]
-    },
-    "frequency": {
-      "type": ["null", "number"]
-    },
-    "account_name": {
-      "type": ["null", "string"]
-    },
-    "canvas_avg_view_time": {
-      "type": ["null", "number"]
-    },
-    "unique_inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "cost_per_unique_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "inline_post_engagement": {
-      "type": ["null", "integer"]
-    },
-    "campaign_name": {
-      "type": ["null", "string"]
-    },
-    "inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "campaign_id": {
-      "type": ["null", "string"]
-    },
-    "cpc": {
-      "type": ["null", "number"]
-    },
-    "ad_name": {
-      "type": ["null", "string"]
-    },
-    "cost_per_unique_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "cpm": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_post_engagement": {
-      "type": ["null", "number"]
-    },
-    "inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "cpp": {
-      "type": ["null", "number"]
-    },
-    "cost_per_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_link_clicks_ctr": {
-      "type": ["null", "number"]
-    },
-    "spend": {
-      "type": ["null", "number"]
-    },
-    "cost_per_unique_click": {
-      "type": ["null", "number"]
-    },
-    "adset_name": {
-      "type": ["null", "string"]
-    },
-    "unique_clicks": {
-      "type": ["null", "integer"]
-    },
-    "social_spend": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "canvas_avg_view_percent": {
-      "type": ["null", "number"]
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "account_id": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "date_start": {
-      "type": ["null", "string"]
+    "account_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "objective": {
-      "type": ["null", "string"]
+    "action_values": {
+      "$ref": "ads_action_stats.json"
     },
-    "impressions": {
-      "type": ["null", "integer"]
+    "actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "unique_ctr": {
-      "type": ["null", "number"]
+    "ad_click_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "cost_per_inline_link_click": {
-      "type": ["null", "number"]
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "ctr": {
-      "type": ["null", "number"]
+    "ad_impression_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "reach": {
-      "type": ["null", "integer"]
+    "ad_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "age": {
-      "type": ["null", "integer", "string"]
+      "type": [
+        "null",
+        "integer",
+        "string"
+      ]
     },
-    "gender": {
-      "type": ["null", "string"]
+    "age_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "quality_ranking": {
-      "type": ["null", "string"]
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "engagement_rate_ranking": {
-      "type": ["null", "string"]
+    "auction_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_competitiveness": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_max_competitor_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "buying_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_percent": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "canvas_avg_view_time": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "conversion_rate_ranking": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "conversion_values": {
+      "$ref": "ads_action_stats.json"
+    },
+    "conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_15_sec_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_2_sec_continuous_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_ad_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_post_engagement": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_store_visit_action": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_thruplay": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cpc": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpm": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpp": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "created_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "date_start": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_stop": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "engagement_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recall_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_impressions": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_reach": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "gender": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "gender_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_post_engagement": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "labels": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "location": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "quality_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reach": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "social_spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_link_clicks_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "updated_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "video_15_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_30_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_avg_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_continuous_2_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p100_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p25_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p50_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p75_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p95_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_play_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_curve_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_0_to_15s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_20_to_60s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "wish_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
     }
-  }
+  },
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_country.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_country.json
@@ -1,185 +1,552 @@
 {
-  "type": ["null", "object"],
   "properties": {
-    "unique_actions": { "$ref": "ads_action_stats.json" },
-    "actions": { "$ref": "ads_action_stats.json" },
-    "action_values": { "$ref": "ads_action_stats.json" },
-    "outbound_clicks": { "$ref": "ads_action_stats.json" },
-    "video_30_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p25_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p50_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p75_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p100_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_play_curve_actions": { "$ref": "ads_histogram_stats.json" },
-    "clicks": {
-      "type": ["null", "integer"]
-    },
-    "date_stop": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "ad_id": {
-      "type": ["null", "string"]
-    },
-    "website_ctr": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "number"]
-          },
-          "action_destination": {
-            "type": ["null", "string"]
-          },
-          "action_target_id": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "adset_id": {
-      "type": ["null", "string"]
-    },
-    "frequency": {
-      "type": ["null", "number"]
-    },
-    "account_name": {
-      "type": ["null", "string"]
-    },
-    "canvas_avg_view_time": {
-      "type": ["null", "number"]
-    },
-    "unique_inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "cost_per_unique_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "inline_post_engagement": {
-      "type": ["null", "integer"]
-    },
-    "campaign_name": {
-      "type": ["null", "string"]
-    },
-    "inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "campaign_id": {
-      "type": ["null", "string"]
-    },
-    "cpc": {
-      "type": ["null", "number"]
-    },
-    "ad_name": {
-      "type": ["null", "string"]
-    },
-    "cost_per_unique_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "cpm": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_post_engagement": {
-      "type": ["null", "number"]
-    },
-    "inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "cpp": {
-      "type": ["null", "number"]
-    },
-    "cost_per_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_link_clicks_ctr": {
-      "type": ["null", "number"]
-    },
-    "spend": {
-      "type": ["null", "number"]
-    },
-    "cost_per_unique_click": {
-      "type": ["null", "number"]
-    },
-    "adset_name": {
-      "type": ["null", "string"]
-    },
-    "unique_clicks": {
-      "type": ["null", "integer"]
-    },
-    "social_spend": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "canvas_avg_view_percent": {
-      "type": ["null", "number"]
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "account_id": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "date_start": {
-      "type": ["null", "string"],
-      "format": "date-time"
+    "account_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "objective": {
-      "type": ["null", "string"]
+    "action_values": {
+      "$ref": "ads_action_stats.json"
     },
-    "impressions": {
-      "type": ["null", "integer"]
+    "actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "unique_ctr": {
-      "type": ["null", "number"]
+    "ad_click_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "cost_per_inline_link_click": {
-      "type": ["null", "number"]
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "ctr": {
-      "type": ["null", "number"]
+    "ad_impression_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "reach": {
-      "type": ["null", "integer"]
+    "ad_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "country": {
-      "type": ["null", "string"]
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "quality_ranking": {
-      "type": ["null", "string"]
+    "adset_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "engagement_rate_ranking": {
-      "type": ["null", "string"]
+    "age_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "auction_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_competitiveness": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_max_competitor_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "buying_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_percent": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "canvas_avg_view_time": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "conversion_rate_ranking": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "conversion_values": {
+      "$ref": "ads_action_stats.json"
+    },
+    "conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_15_sec_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_2_sec_continuous_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_ad_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_post_engagement": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_store_visit_action": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_thruplay": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "country": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "cpc": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpm": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpp": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "created_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "date_start": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_stop": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "engagement_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recall_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_impressions": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_reach": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "gender_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_post_engagement": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "labels": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "location": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "quality_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reach": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "social_spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_link_clicks_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "updated_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "video_15_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_30_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_avg_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_continuous_2_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p100_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p25_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p50_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p75_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p95_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_play_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_curve_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_0_to_15s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_20_to_60s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "wish_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
     }
-  }
+  },
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_dma.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_dma.json
@@ -1,185 +1,552 @@
 {
-  "type": ["null", "object"],
   "properties": {
-    "unique_actions": { "$ref": "ads_action_stats.json" },
-    "actions": { "$ref": "ads_action_stats.json" },
-    "action_values": { "$ref": "ads_action_stats.json" },
-    "outbound_clicks": { "$ref": "ads_action_stats.json" },
-    "video_30_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p25_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p50_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p75_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p100_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_play_curve_actions": { "$ref": "ads_histogram_stats.json" },
-    "clicks": {
-      "type": ["null", "integer"]
-    },
-    "date_stop": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "ad_id": {
-      "type": ["null", "string"]
-    },
-    "website_ctr": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "number"]
-          },
-          "action_destination": {
-            "type": ["null", "string"]
-          },
-          "action_target_id": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "adset_id": {
-      "type": ["null", "string"]
-    },
-    "frequency": {
-      "type": ["null", "number"]
-    },
-    "account_name": {
-      "type": ["null", "string"]
-    },
-    "canvas_avg_view_time": {
-      "type": ["null", "number"]
-    },
-    "unique_inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "cost_per_unique_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "inline_post_engagement": {
-      "type": ["null", "integer"]
-    },
-    "campaign_name": {
-      "type": ["null", "string"]
-    },
-    "inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "campaign_id": {
-      "type": ["null", "string"]
-    },
-    "cpc": {
-      "type": ["null", "number"]
-    },
-    "ad_name": {
-      "type": ["null", "string"]
-    },
-    "cost_per_unique_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "cpm": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_post_engagement": {
-      "type": ["null", "number"]
-    },
-    "inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "cpp": {
-      "type": ["null", "number"]
-    },
-    "cost_per_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_link_clicks_ctr": {
-      "type": ["null", "number"]
-    },
-    "spend": {
-      "type": ["null", "number"]
-    },
-    "cost_per_unique_click": {
-      "type": ["null", "number"]
-    },
-    "adset_name": {
-      "type": ["null", "string"]
-    },
-    "unique_clicks": {
-      "type": ["null", "integer"]
-    },
-    "social_spend": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "canvas_avg_view_percent": {
-      "type": ["null", "number"]
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "account_id": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "date_start": {
-      "type": ["null", "string"],
-      "format": "date-time"
+    "account_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "objective": {
-      "type": ["null", "string"]
+    "action_values": {
+      "$ref": "ads_action_stats.json"
     },
-    "impressions": {
-      "type": ["null", "integer"]
+    "actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "unique_ctr": {
-      "type": ["null", "number"]
+    "ad_click_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "cost_per_inline_link_click": {
-      "type": ["null", "number"]
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "ctr": {
-      "type": ["null", "number"]
+    "ad_impression_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "reach": {
-      "type": ["null", "integer"]
+    "ad_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "dma": {
-      "type": ["null", "string"]
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "quality_ranking": {
-      "type": ["null", "string"]
+    "adset_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "engagement_rate_ranking": {
-      "type": ["null", "string"]
+    "age_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "auction_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_competitiveness": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_max_competitor_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "buying_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_percent": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "canvas_avg_view_time": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "conversion_rate_ranking": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "conversion_values": {
+      "$ref": "ads_action_stats.json"
+    },
+    "conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_15_sec_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_2_sec_continuous_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_ad_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_post_engagement": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_store_visit_action": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_thruplay": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cpc": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpm": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpp": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "created_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "date_start": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_stop": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "dma": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "engagement_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recall_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_impressions": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_reach": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "gender_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_post_engagement": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "labels": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "location": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "quality_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reach": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "social_spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_link_clicks_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "updated_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "video_15_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_30_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_avg_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_continuous_2_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p100_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p25_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p50_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p75_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p95_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_play_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_curve_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_0_to_15s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_20_to_60s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "wish_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
     }
-  }
+  },
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_platform_and_device.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_platform_and_device.json
@@ -1,19 +1,523 @@
 {
-  "type": ["null", "object"],
   "properties": {
-    "unique_actions": {
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "account_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "account_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "action_values": {
       "$ref": "ads_action_stats.json"
     },
     "actions": {
       "$ref": "ads_action_stats.json"
     },
-    "action_values": {
+    "ad_click_actions": {
       "$ref": "ads_action_stats.json"
+    },
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_impression_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "ad_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "age_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "auction_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_competitiveness": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_max_competitor_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "buying_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_percent": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "canvas_avg_view_time": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "conversion_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "conversion_values": {
+      "$ref": "ads_action_stats.json"
+    },
+    "conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_15_sec_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_2_sec_continuous_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_ad_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_post_engagement": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_store_visit_action": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_thruplay": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cpc": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpm": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpp": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "created_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "date_start": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_stop": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "engagement_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recall_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_impressions": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_reach": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "gender_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impression_device": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_post_engagement": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "labels": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "location": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "outbound_clicks": {
       "$ref": "ads_action_stats.json"
     },
+    "outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "placement": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "platform_position": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "publisher_platform": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "quality_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reach": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "social_spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_link_clicks_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "updated_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "video_15_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
     "video_30_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_avg_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_continuous_2_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p100_watched_actions": {
       "$ref": "ads_action_stats.json"
     },
     "video_p25_watched_actions": {
@@ -25,190 +529,42 @@
     "video_p75_watched_actions": {
       "$ref": "ads_action_stats.json"
     },
-    "video_p100_watched_actions": {
+    "video_p95_watched_actions": {
       "$ref": "ads_action_stats.json"
+    },
+    "video_play_actions": {
+      "$ref": "ads_histogram_stats.json"
     },
     "video_play_curve_actions": {
       "$ref": "ads_histogram_stats.json"
     },
-    "impression_device": {
-      "type": ["null", "string"]
+    "video_play_retention_0_to_15s_actions": {
+      "$ref": "ads_histogram_stats.json"
     },
-    "platform_position": {
-      "type": ["null", "string"]
+    "video_play_retention_20_to_60s_actions": {
+      "$ref": "ads_histogram_stats.json"
     },
-    "publisher_platform": {
-      "type": ["null", "string"]
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
     },
-    "clicks": {
-      "type": ["null", "integer"]
-    },
-    "date_stop": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "ad_id": {
-      "type": ["null", "string"]
+    "video_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
     },
     "website_ctr": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "number"]
-          },
-          "action_destination": {
-            "type": ["null", "string"]
-          },
-          "action_target_id": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
+      "$ref": "ads_action_stats.json"
     },
-    "unique_inline_link_click_ctr": {
-      "type": ["null", "number"]
+    "website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
     },
-    "adset_id": {
-      "type": ["null", "string"]
-    },
-    "frequency": {
-      "type": ["null", "number"]
-    },
-    "account_name": {
-      "type": ["null", "string"]
-    },
-    "canvas_avg_view_time": {
-      "type": ["null", "number"]
-    },
-    "unique_inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "cost_per_unique_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "inline_post_engagement": {
-      "type": ["null", "integer"]
-    },
-    "campaign_name": {
-      "type": ["null", "string"]
-    },
-    "inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "campaign_id": {
-      "type": ["null", "string"]
-    },
-    "cpc": {
-      "type": ["null", "number"]
-    },
-    "ad_name": {
-      "type": ["null", "string"]
-    },
-    "cost_per_unique_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "cpm": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_post_engagement": {
-      "type": ["null", "number"]
-    },
-    "inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "cpp": {
-      "type": ["null", "number"]
-    },
-    "cost_per_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_link_clicks_ctr": {
-      "type": ["null", "number"]
-    },
-    "spend": {
-      "type": ["null", "number"]
-    },
-    "cost_per_unique_click": {
-      "type": ["null", "number"]
-    },
-    "adset_name": {
-      "type": ["null", "string"]
-    },
-    "unique_clicks": {
-      "type": ["null", "integer"]
-    },
-    "social_spend": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "canvas_avg_view_percent": {
-      "type": ["null", "number"]
-    },
-    "account_id": {
-      "type": ["null", "string"]
-    },
-    "date_start": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "objective": {
-      "type": ["null", "string"]
-    },
-    "impressions": {
-      "type": ["null", "integer"]
-    },
-    "unique_ctr": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "ctr": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "placement": {
-      "type": ["null", "string"]
-    },
-    "quality_ranking": {
-      "type": ["null", "string"]
-    },
-    "engagement_rate_ranking": {
-      "type": ["null", "string"]
-    },
-    "conversion_rate_ranking": {
-      "type": ["null", "string"]
+    "wish_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
     }
-  }
+  },
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_region.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_region.json
@@ -1,185 +1,552 @@
 {
-  "type": ["null", "object"],
   "properties": {
-    "unique_actions": { "$ref": "ads_action_stats.json" },
-    "actions": { "$ref": "ads_action_stats.json" },
-    "action_values": { "$ref": "ads_action_stats.json" },
-    "outbound_clicks": { "$ref": "ads_action_stats.json" },
-    "video_30_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p25_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p50_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p75_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p100_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_play_curve_actions": { "$ref": "ads_histogram_stats.json" },
-    "clicks": {
-      "type": ["null", "integer"]
-    },
-    "date_stop": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "ad_id": {
-      "type": ["null", "string"]
-    },
-    "website_ctr": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "number"]
-          },
-          "action_destination": {
-            "type": ["null", "string"]
-          },
-          "action_target_id": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "adset_id": {
-      "type": ["null", "string"]
-    },
-    "frequency": {
-      "type": ["null", "number"]
-    },
-    "account_name": {
-      "type": ["null", "string"]
-    },
-    "canvas_avg_view_time": {
-      "type": ["null", "number"]
-    },
-    "unique_inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "cost_per_unique_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "inline_post_engagement": {
-      "type": ["null", "integer"]
-    },
-    "campaign_name": {
-      "type": ["null", "string"]
-    },
-    "inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "campaign_id": {
-      "type": ["null", "string"]
-    },
-    "cpc": {
-      "type": ["null", "number"]
-    },
-    "ad_name": {
-      "type": ["null", "string"]
-    },
-    "cost_per_unique_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "cpm": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_post_engagement": {
-      "type": ["null", "number"]
-    },
-    "inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "cpp": {
-      "type": ["null", "number"]
-    },
-    "cost_per_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_link_clicks_ctr": {
-      "type": ["null", "number"]
-    },
-    "spend": {
-      "type": ["null", "number"]
-    },
-    "cost_per_unique_click": {
-      "type": ["null", "number"]
-    },
-    "adset_name": {
-      "type": ["null", "string"]
-    },
-    "unique_clicks": {
-      "type": ["null", "integer"]
-    },
-    "social_spend": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "canvas_avg_view_percent": {
-      "type": ["null", "number"]
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "account_id": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "date_start": {
-      "type": ["null", "string"],
-      "format": "date-time"
+    "account_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "objective": {
-      "type": ["null", "string"]
+    "action_values": {
+      "$ref": "ads_action_stats.json"
     },
-    "impressions": {
-      "type": ["null", "integer"]
+    "actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "unique_ctr": {
-      "type": ["null", "number"]
+    "ad_click_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "cost_per_inline_link_click": {
-      "type": ["null", "number"]
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "ctr": {
-      "type": ["null", "number"]
+    "ad_impression_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "reach": {
-      "type": ["null", "integer"]
+    "ad_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "region": {
-      "type": ["null", "string"]
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "quality_ranking": {
-      "type": ["null", "string"]
+    "adset_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "engagement_rate_ranking": {
-      "type": ["null", "string"]
+    "age_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "auction_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_competitiveness": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_max_competitor_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "buying_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_percent": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "canvas_avg_view_time": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "conversion_rate_ranking": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "conversion_values": {
+      "$ref": "ads_action_stats.json"
+    },
+    "conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_15_sec_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_2_sec_continuous_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_ad_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_post_engagement": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_store_visit_action": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_thruplay": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cpc": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpm": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpp": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "created_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "date_start": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_stop": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "engagement_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recall_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_impressions": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_reach": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "gender_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_post_engagement": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "labels": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "location": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "quality_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reach": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "region": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "social_spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_link_clicks_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "updated_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "video_15_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_30_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_avg_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_continuous_2_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p100_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p25_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p50_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p75_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p95_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_play_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_curve_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_0_to_15s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_20_to_60s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "wish_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
     }
-  }
+  },
+  "type": [
+    "null",
+    "object"
+  ]
 }


### PR DESCRIPTION
## What
This adds almost all of the missing fields to the ads_insights schema, to match the list of fields documented here:
https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights/#fields

## How
I edited the JSON file by hand, then sorted the keys and reviewed it by comparing it to the documentation page by hand.  Note that I made these edits only by pattern-matching; I don't actually have a deeper understanding of the syntax.

I applied the following heuristics:
  - I used the type `["null", "integer"]` for all fields described as "numeric string" whose name ended in "clicks"
  - I used the type `["null", "number"]` for all other fields described as "numeric string" 
  - I used the type `["null", "string"]` for all other fields described as "string"
  - For a couple of fields that are documented as type `List<AdsActionStats>` but had nested types declared in the original file, I replaced the nested type with a reference to `ads_action_stats.json` (consistent with the rest of the `List<AdsActionStats>` fields.

I did not add the following fields, which are of types that haven't been defined in the `shared` directory yet:
- `comparison_node` (AdsInsightsComparison)
- `dda_results` (List\<AdsInsightsResult\>)
- `description_asset` (AdAssetDescription)
- `image_asset` (AdAssetImage)
- `rule_asset` (AdAssetRule)
- `title_asset` (AdAssetTitle)
- `video_asset` (AdAssetVideo)

## Pre-merge Checklist
I have not tested anything.

- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Reviewer notes
This change is divided into two commits.  The first commit has the new fields added, while preserving the rest of the original file so you can see a minimal diff.  The second commit has the whole file sorted by `json.dumps` (completely automated, with no manual edits), so you can review it against the [API documentation](https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights/#fields
).