### PR TITLE
testing PR 3646

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/client/common.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/client/common.py
@@ -25,7 +25,7 @@
 import json
 import sys
 from time import sleep
-from typing import Sequence
+from typing import Iterable, Sequence
 
 import backoff
 import pendulum
@@ -83,6 +83,11 @@ def retry_pattern(backoff_type, exception, **wait_gen_kwargs):
             if exc.api_error_code() in FACEBOOK_API_CALL_LIMIT_ERROR_CODES:
                 return handle_call_rate_response(exc)
             return exc.api_transient_error() or exc.api_error_subcode() == FACEBOOK_UNKNOWN_ERROR_CODE
+        else:
+            exception_list = exception if isinstance(exception, Iterable) else [exception]
+            for exception_type in exception_list:
+                if isinstance(exc, exception_type):
+                    return True
         return False
 
     return backoff.on_exception(

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -1,168 +1,69 @@
 {
   "properties": {
-    "account_currency": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "account_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "account_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "action_values": {
       "$ref": "ads_action_stats.json"
     },
-    "actions": {
-      "$ref": "ads_action_stats.json"
-    },
-    "activity_recency": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "ad_click_actions": {
-      "$ref": "ads_action_stats.json"
-    },
-    "ad_format_asset": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "ad_id": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
+    "actions": { "$ref": "ads_action_stats.json" },
+    "ad_click_actions": { "$ref": "ads_action_stats.json" },
+    "ad_id": { "type": ["null", "string"] },
     "ad_impression_actions": {
       "$ref": "ads_action_stats.json"
     },
     "ad_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "adset_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "adset_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "age_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "attribution_setting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "auction_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "auction_competitiveness": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "auction_max_competitor_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "buying_type": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaign_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaign_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "canvas_avg_view_percent": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "canvas_avg_view_time": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
-    "catalog_segment_actions": {
-      "$ref": "ads_action_stats.json"
+      "type": ["null", "number"]
     },
     "catalog_segment_value": {
       "$ref": "ads_action_stats.json"
     },
-    "catalog_segment_value_mobile_purchase_roas": {
-      "$ref": "ads_action_stats.json"
-    },
-    "catalog_segment_value_omni_purchase_roas": {
-      "$ref": "ads_action_stats.json"
-    },
-    "catalog_segment_value_website_purchase_roas": {
-      "$ref": "ads_action_stats.json"
-    },
     "clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "conversion_rate_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "conversion_values": {
       "$ref": "ads_action_stats.json"
     },
     "conversions": {
-      "$ref": "ads_action_stats.json"
-    },
-    "converted_product_quantity": {
-      "$ref": "ads_action_stats.json"
-    },
-    "converted_product_value": {
       "$ref": "ads_action_stats.json"
     },
     "cost_per_15_sec_video_view": {
@@ -180,26 +81,11 @@
     "cost_per_conversion": {
       "$ref": "ads_action_stats.json"
     },
-    "cost_per_dda_countby_convs": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
     "cost_per_inline_link_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_inline_post_engagement": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
-    "cost_per_one_thousand_ad_impression": {
-      "$ref": "ads_action_stats.json"
+      "type": ["null", "number"]
     },
     "cost_per_outbound_click": {
       "$ref": "ads_action_stats.json"
@@ -214,241 +100,88 @@
       "$ref": "ads_action_stats.json"
     },
     "cost_per_unique_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_unique_conversion": {
       "$ref": "ads_action_stats.json"
     },
     "cost_per_unique_inline_link_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_unique_outbound_click": {
       "$ref": "ads_action_stats.json"
     },
-    "country": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "cpc": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cpm": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cpp": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "created_time": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "date_start": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "date_stop": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "dda_countby_convs": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
-    "device_platform": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "dma": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "engagement_rate_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "estimated_ad_recall_rate_lower_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recall_rate_upper_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers_lower_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers_upper_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "frequency": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
-    "frequency_value": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "number"]
     },
     "full_view_impressions": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "full_view_reach": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "gender_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "hourly_stats_aggregated_by_advertiser_time_zone": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "hourly_stats_aggregated_by_audience_time_zone": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "impression_device": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "impressions": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "inline_link_click_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "inline_link_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "inline_post_engagement": {
-      "type": [
-        "null",
-        "integer"
-      ]
-    },
-    "instant_experience_clicks_to_open": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
-    "instant_experience_clicks_to_start": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
-    "instant_experience_outbound_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
-    },
-    "interactive_component_tap": {
-      "$ref": "ads_action_stats.json"
+      "type": ["null", "integer"]
     },
     "labels": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "location": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "mobile_app_purchase_roas": {
-      "$ref": "ads_action_stats.json"
+      "type": ["null", "string"]
     },
     "objective": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "optimization_goal": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "outbound_clicks": {
       "$ref": "ads_action_stats.json"
@@ -456,107 +189,38 @@
     "outbound_clicks_ctr": {
       "$ref": "ads_action_stats.json"
     },
-    "place_page_id": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "place_page_name": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "platform_position": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "product_id": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "publisher_platform": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "purchase_roas": {
-      "$ref": "ads_action_stats.json"
-    },
-    "qualifying_question_qualify_answer_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
     "quality_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "reach": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "social_spend": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "spend": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
-    "store_visit_actions": {
-      "$ref": "ads_action_stats.json"
+      "type": ["null", "number"]
     },
     "unique_actions": {
       "$ref": "ads_action_stats.json"
     },
     "unique_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "unique_conversions": {
       "$ref": "ads_action_stats.json"
     },
     "unique_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_inline_link_click_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_inline_link_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "unique_link_clicks_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_outbound_clicks": {
       "$ref": "ads_action_stats.json"
@@ -564,15 +228,9 @@
     "unique_outbound_clicks_ctr": {
       "$ref": "ads_action_stats.json"
     },
-    "unique_video_view_15_sec": {
-      "$ref": "ads_action_stats.json"
-    },
     "updated_time": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "video_15_sec_watched_actions": {
       "$ref": "ads_action_stats.json"
@@ -613,27 +271,15 @@
     "video_play_retention_20_to_60s_actions": {
       "$ref": "ads_histogram_stats.json"
     },
-    "video_play_retention_graph_actions": {
-      "$ref": "ads_histogram_stats.json"
-    },
     "video_time_watched_actions": {
       "$ref": "ads_action_stats.json"
     },
     "website_ctr": {
       "$ref": "ads_action_stats.json"
     },
-    "website_purchase_roas": {
-      "$ref": "ads_action_stats.json"
-    },
     "wish_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     }
   },
-  "type": [
-    "null",
-    "object"
-  ]
+  "type": ["null", "object"]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -21,26 +21,6 @@
     "ad_id": {
       "type": ["null", "string"]
     },
-    "website_ctr": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "number"]
-          },
-          "action_destination": {
-            "type": ["null", "string"]
-          },
-          "action_target_id": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
     "unique_inline_link_click_ctr": {
       "type": ["null", "number"]
     },
@@ -106,20 +86,6 @@
     "cpp": {
       "type": ["null", "number"]
     },
-    "cost_per_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
     "unique_link_clicks_ctr": {
       "type": ["null", "number"]
     },
@@ -172,8 +138,92 @@
     "cost_per_inline_link_click": {
       "type": ["null", "number"]
     },
-    "ctr": {
-      "type": ["null", "number"]
-    }
+    "ctr": { "type": ["null", "number"] },
+    "account_currency": { "type": ["null", "string"] },
+    "activity_recency": { "type": ["null", "string"] },
+    "ad_click_actions": { "$ref": "ads_action_stats.json" },
+    "ad_format_asset": { "type": ["null", "string"] },
+    "ad_impression_actions": { "$ref": "ads_action_stats.json" },
+    "age_targeting": { "type": ["null", "string"] },
+    "attribution_setting": { "type": ["null", "string"] },
+    "auction_bid": { "type": ["null", "number"] },
+    "auction_competitiveness": { "type": ["null", "number"] },
+    "auction_max_competitor_bid": { "type": ["null", "number"] },
+    "buying_type": { "type": ["null", "string"] },
+    "catalog_segment_actions": { "$ref": "ads_action_stats.json" },
+    "catalog_segment_value": { "$ref": "ads_action_stats.json" },
+    "catalog_segment_value_mobile_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "catalog_segment_value_omni_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "catalog_segment_value_website_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "conversion_values": { "$ref": "ads_action_stats.json" },
+    "conversions": { "$ref": "ads_action_stats.json" },
+    "converted_product_quantity": { "$ref": "ads_action_stats.json" },
+    "converted_product_value": { "$ref": "ads_action_stats.json" },
+    "cost_per_15_sec_video_view": { "$ref": "ads_action_stats.json" },
+    "cost_per_2_sec_continuous_video_view": { "$ref": "ads_action_stats.json" },
+    "cost_per_action_type": { "$ref": "ads_action_stats.json" },
+    "cost_per_ad_click": { "$ref": "ads_action_stats.json" },
+    "cost_per_conversion": { "$ref": "ads_action_stats.json" },
+    "cost_per_dda_countby_convs": { "type": ["null", "number"] },
+    "cost_per_one_thousand_ad_impression": { "$ref": "ads_action_stats.json" },
+    "cost_per_outbound_click": { "$ref": "ads_action_stats.json" },
+    "cost_per_store_visit_action": { "$ref": "ads_action_stats.json" },
+    "cost_per_thruplay": { "$ref": "ads_action_stats.json" },
+    "cost_per_unique_action_type": { "$ref": "ads_action_stats.json" },
+    "cost_per_unique_conversion": { "$ref": "ads_action_stats.json" },
+    "cost_per_unique_outbound_click": { "$ref": "ads_action_stats.json" },
+    "country": { "type": ["null", "string"] },
+    "created_time": { "type": ["null", "string"], "format": "date-time" },
+    "country": { "type": ["null", "string"] },
+    "dda_countby_convs": { "type": ["null", "number"] },
+    "device_platform": { "type": ["null", "string"] },
+    "dma": { "type": ["null", "string"] },
+    "estimated_ad_recall_rate_lower_bound": { "type": ["null", "number"] },
+    "estimated_ad_recall_rate_upper_bound": { "type": ["null", "number"] },
+    "estimated_ad_recallers_lower_bound": { "type": ["null", "number"] },
+    "estimated_ad_recallers_upper_bound": { "type": ["null", "number"] },
+    "frequency_value": { "type": ["null", "string"] },
+    "full_view_impressions": { "type": ["null", "number"] },
+    "full_view_reach": { "type": ["null", "number"] },
+    "gender_targeting": { "type": ["null", "string"] },
+    "hourly_stats_aggregated_by_advertiser_time_zone": { "type": ["null", "string"] },
+    "hourly_stats_aggregated_by_audience_time_zone": { "type": ["null", "string"] },
+    "impression_device": { "type": ["null", "string"] },
+    "instant_experience_clicks_to_open": { "type": ["null", "number"] },
+    "instant_experience_clicks_to_start": { "type": ["null", "number"] },
+    "instant_experience_outbound_clicks": { "type": ["null", "integer"] },
+    "interactive_component_tap": { "$ref": "ads_action_stats.json" },
+    "labels": { "type": ["null", "string"] },
+    "location": { "type": ["null", "string"] },
+    "mobile_app_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "optimization_goal": { "type": ["null", "string"] },
+    "outbound_clicks_ctr": { "$ref": "ads_action_stats.json" },
+    "place_page_id": { "type": ["null", "string"] },
+    "place_page_name": { "type": ["null", "string"] },
+    "platform_position": { "type": ["null", "string"] },
+    "product_id": { "type": ["null", "string"] },
+    "publisher_platform": { "type": ["null", "string"] },
+    "purchase_roas": { "$ref": "ads_action_stats.json" },
+    "qualifying_question_qualify_answer_rate": { "type": ["null", "number"] },
+    "store_visit_actions": { "$ref": "ads_action_stats.json" },
+    "unique_conversions": { "$ref": "ads_action_stats.json" },
+    "unique_outbound_clicks": { "$ref": "ads_action_stats.json" },
+    "unique_outbound_clicks_ctr": { "$ref": "ads_action_stats.json" },
+    "unique_video_view_15_sec": { "$ref": "ads_action_stats.json" },
+    "updated_time": { "type": ["null", "string"], "format": "date-time" },
+    "video_15_sec_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_avg_time_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_continuous_2_sec_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_play_actions": { "$ref": "ads_histogram_stats.json" },
+    "video_play_retention_0_to_15s_actions": { "$ref": "ads_histogram_stats.json" },
+    "video_play_retention_20_to_60s_actions": { "$ref": "ads_histogram_stats.json" },
+    "video_play_retention_graph_actions": { "$ref": "ads_histogram_stats.json" },
+    "video_time_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
+    "website_ctr": { "$ref": "ads_action_stats.json" },
+    "website_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "wish_bid": { "type": ["null", "number"] }
   }
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -1,229 +1,639 @@
 {
-  "type": ["null", "object"],
   "properties": {
-    "unique_actions": { "$ref": "ads_action_stats.json" },
-    "actions": { "$ref": "ads_action_stats.json" },
-    "action_values": { "$ref": "ads_action_stats.json" },
-    "outbound_clicks": { "$ref": "ads_action_stats.json" },
-    "video_30_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p25_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p50_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p75_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p100_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_play_curve_actions": { "$ref": "ads_histogram_stats.json" },
-    "clicks": {
-      "type": ["null", "integer"]
-    },
-    "date_stop": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "ad_id": {
-      "type": ["null", "string"]
-    },
-    "unique_inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "adset_id": {
-      "type": ["null", "string"]
-    },
-    "frequency": {
-      "type": ["null", "number"]
-    },
-    "account_name": {
-      "type": ["null", "string"]
-    },
-    "canvas_avg_view_time": {
-      "type": ["null", "number"]
-    },
-    "unique_inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "cost_per_unique_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "inline_post_engagement": {
-      "type": ["null", "integer"]
-    },
-    "campaign_name": {
-      "type": ["null", "string"]
-    },
-    "inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "campaign_id": {
-      "type": ["null", "string"]
-    },
-    "cpc": {
-      "type": ["null", "number"]
-    },
-    "ad_name": {
-      "type": ["null", "string"]
-    },
-    "cost_per_unique_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "cpm": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_post_engagement": {
-      "type": ["null", "number"]
-    },
-    "inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "cpp": {
-      "type": ["null", "number"]
-    },
-    "unique_link_clicks_ctr": {
-      "type": ["null", "number"]
-    },
-    "spend": {
-      "type": ["null", "number"]
-    },
-    "cost_per_unique_click": {
-      "type": ["null", "number"]
-    },
-    "adset_name": {
-      "type": ["null", "string"]
-    },
-    "unique_clicks": {
-      "type": ["null", "integer"]
-    },
-    "social_spend": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "canvas_avg_view_percent": {
-      "type": ["null", "number"]
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "account_id": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "date_start": {
-      "type": ["null", "string"],
-      "format": "date-time"
+    "account_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "objective": {
-      "type": ["null", "string"]
+    "action_values": {
+      "$ref": "ads_action_stats.json"
     },
-    "quality_ranking": {
-      "type": ["null", "string"]
+    "actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "engagement_rate_ranking": {
-      "type": ["null", "string"]
+    "activity_recency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_click_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "ad_format_asset": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_impression_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "ad_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "age_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "auction_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_competitiveness": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_max_competitor_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "buying_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_percent": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "canvas_avg_view_time": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "conversion_rate_ranking": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "impressions": {
-      "type": ["null", "integer"]
+    "conversion_values": {
+      "$ref": "ads_action_stats.json"
     },
-    "unique_ctr": {
-      "type": ["null", "number"]
+    "conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_15_sec_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_2_sec_continuous_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_ad_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_dda_countby_convs": {
+      "type": [
+        "null",
+        "number"
+      ]
     },
     "cost_per_inline_link_click": {
-      "type": ["null", "number"]
+      "type": [
+        "null",
+        "number"
+      ]
     },
-    "ctr": { "type": ["null", "number"] },
-    "account_currency": { "type": ["null", "string"] },
-    "activity_recency": { "type": ["null", "string"] },
-    "ad_click_actions": { "$ref": "ads_action_stats.json" },
-    "ad_format_asset": { "type": ["null", "string"] },
-    "ad_impression_actions": { "$ref": "ads_action_stats.json" },
-    "age_targeting": { "type": ["null", "string"] },
-    "attribution_setting": { "type": ["null", "string"] },
-    "auction_bid": { "type": ["null", "number"] },
-    "auction_competitiveness": { "type": ["null", "number"] },
-    "auction_max_competitor_bid": { "type": ["null", "number"] },
-    "buying_type": { "type": ["null", "string"] },
-    "catalog_segment_actions": { "$ref": "ads_action_stats.json" },
-    "catalog_segment_value": { "$ref": "ads_action_stats.json" },
-    "catalog_segment_value_mobile_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "catalog_segment_value_omni_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "catalog_segment_value_website_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "conversion_values": { "$ref": "ads_action_stats.json" },
-    "conversions": { "$ref": "ads_action_stats.json" },
-    "converted_product_quantity": { "$ref": "ads_action_stats.json" },
-    "converted_product_value": { "$ref": "ads_action_stats.json" },
-    "cost_per_15_sec_video_view": { "$ref": "ads_action_stats.json" },
-    "cost_per_2_sec_continuous_video_view": { "$ref": "ads_action_stats.json" },
-    "cost_per_action_type": { "$ref": "ads_action_stats.json" },
-    "cost_per_ad_click": { "$ref": "ads_action_stats.json" },
-    "cost_per_conversion": { "$ref": "ads_action_stats.json" },
-    "cost_per_dda_countby_convs": { "type": ["null", "number"] },
-    "cost_per_one_thousand_ad_impression": { "$ref": "ads_action_stats.json" },
-    "cost_per_outbound_click": { "$ref": "ads_action_stats.json" },
-    "cost_per_store_visit_action": { "$ref": "ads_action_stats.json" },
-    "cost_per_thruplay": { "$ref": "ads_action_stats.json" },
-    "cost_per_unique_action_type": { "$ref": "ads_action_stats.json" },
-    "cost_per_unique_conversion": { "$ref": "ads_action_stats.json" },
-    "cost_per_unique_outbound_click": { "$ref": "ads_action_stats.json" },
-    "country": { "type": ["null", "string"] },
-    "created_time": { "type": ["null", "string"], "format": "date-time" },
-    "country": { "type": ["null", "string"] },
-    "dda_countby_convs": { "type": ["null", "number"] },
-    "device_platform": { "type": ["null", "string"] },
-    "dma": { "type": ["null", "string"] },
-    "estimated_ad_recall_rate_lower_bound": { "type": ["null", "number"] },
-    "estimated_ad_recall_rate_upper_bound": { "type": ["null", "number"] },
-    "estimated_ad_recallers_lower_bound": { "type": ["null", "number"] },
-    "estimated_ad_recallers_upper_bound": { "type": ["null", "number"] },
-    "frequency_value": { "type": ["null", "string"] },
-    "full_view_impressions": { "type": ["null", "number"] },
-    "full_view_reach": { "type": ["null", "number"] },
-    "gender_targeting": { "type": ["null", "string"] },
-    "hourly_stats_aggregated_by_advertiser_time_zone": { "type": ["null", "string"] },
-    "hourly_stats_aggregated_by_audience_time_zone": { "type": ["null", "string"] },
-    "impression_device": { "type": ["null", "string"] },
-    "instant_experience_clicks_to_open": { "type": ["null", "number"] },
-    "instant_experience_clicks_to_start": { "type": ["null", "number"] },
-    "instant_experience_outbound_clicks": { "type": ["null", "integer"] },
-    "interactive_component_tap": { "$ref": "ads_action_stats.json" },
-    "labels": { "type": ["null", "string"] },
-    "location": { "type": ["null", "string"] },
-    "mobile_app_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "optimization_goal": { "type": ["null", "string"] },
-    "outbound_clicks_ctr": { "$ref": "ads_action_stats.json" },
-    "place_page_id": { "type": ["null", "string"] },
-    "place_page_name": { "type": ["null", "string"] },
-    "platform_position": { "type": ["null", "string"] },
-    "product_id": { "type": ["null", "string"] },
-    "publisher_platform": { "type": ["null", "string"] },
-    "purchase_roas": { "$ref": "ads_action_stats.json" },
-    "qualifying_question_qualify_answer_rate": { "type": ["null", "number"] },
-    "store_visit_actions": { "$ref": "ads_action_stats.json" },
-    "unique_conversions": { "$ref": "ads_action_stats.json" },
-    "unique_outbound_clicks": { "$ref": "ads_action_stats.json" },
-    "unique_outbound_clicks_ctr": { "$ref": "ads_action_stats.json" },
-    "unique_video_view_15_sec": { "$ref": "ads_action_stats.json" },
-    "updated_time": { "type": ["null", "string"], "format": "date-time" },
-    "video_15_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_avg_time_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_continuous_2_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_play_actions": { "$ref": "ads_histogram_stats.json" },
-    "video_play_retention_0_to_15s_actions": { "$ref": "ads_histogram_stats.json" },
-    "video_play_retention_20_to_60s_actions": { "$ref": "ads_histogram_stats.json" },
-    "video_play_retention_graph_actions": { "$ref": "ads_histogram_stats.json" },
-    "video_time_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
-    "website_ctr": { "$ref": "ads_action_stats.json" },
-    "website_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "wish_bid": { "type": ["null", "number"] }
-  }
+    "cost_per_inline_post_engagement": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_one_thousand_ad_impression": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_store_visit_action": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_thruplay": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "country": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "cpc": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpm": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpp": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "created_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "date_start": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_stop": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "dda_countby_convs": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "device_platform": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "dma": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "engagement_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recall_rate_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency_value": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "full_view_impressions": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_reach": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "gender_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "hourly_stats_aggregated_by_advertiser_time_zone": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "hourly_stats_aggregated_by_audience_time_zone": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impression_device": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_post_engagement": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "interactive_component_tap": {
+      "$ref": "ads_action_stats.json"
+    },
+    "labels": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "location": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "place_page_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "place_page_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "platform_position": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "product_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "publisher_platform": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "quality_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reach": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "social_spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_link_clicks_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_video_view_15_sec": {
+      "$ref": "ads_action_stats.json"
+    },
+    "updated_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "video_15_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_30_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_avg_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_continuous_2_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p100_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p25_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p50_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p75_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p95_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_play_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_curve_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_0_to_15s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_20_to_60s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "wish_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    }
+  },
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-file/main_dev.py
+++ b/airbyte-integrations/connectors/source-file/main_dev.py
@@ -22,7 +22,6 @@
 # SOFTWARE.
 #
 
-
 import sys
 
 from base_python.entrypoint import launch


### PR DESCRIPTION
1. Introduces better retries for jobs on top of #3646  -- I added this while testing that PR. 
2. Updates the configured catalog used for testing with the new fields introduced in #3646 

The current state is that FB API is consistently failing when we request these additional fields, and not failing when we don't (i.e: FB version on master). I spent some time fiddling with removing some of the new fields to see if I can get a sync to succeed to no avail. We should pick this up later. 