### PR TITLE
🐛 Destination MSSQL: fix issue with unicode symbols handling (ex.\u2028 showed as ?)

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/d4353156-9217-4cad-8dd7-c108fd4f74cf.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/d4353156-9217-4cad-8dd7-c108fd4f74cf.json
@@ -2,6 +2,6 @@
   "destinationDefinitionId": "d4353156-9217-4cad-8dd7-c108fd4f74cf",
   "name": "MS SQL Server",
   "dockerRepository": "airbyte/destination-mssql",
-  "dockerImageTag": "0.1.1",
+  "dockerImageTag": "0.1.2",
   "documentationUrl": "https://docs.airbyte.io/integrations/destinations/mssql"
 }

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -43,5 +43,5 @@
 - destinationDefinitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
   name: MS SQL Server
   dockerRepository: airbyte/destination-mssql
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   documentationUrl: https://docs.airbyte.io/integrations/destinations/mssql

--- a/airbyte-integrations/connectors/destination-mssql/Dockerfile
+++ b/airbyte-integrations/connectors/destination-mssql/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/destination-mssql

--- a/airbyte-integrations/connectors/destination-mssql/src/main/java/io/airbyte/integrations/destination/mssql/SqlServerOperations.java
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/java/io/airbyte/integrations/destination/mssql/SqlServerOperations.java
@@ -53,7 +53,7 @@ public class SqlServerOperations implements SqlOperations {
             + "WHERE s.name = '%s' AND t.name = '%s') "
             + "CREATE TABLE %s.%s ( \n"
             + "%s VARCHAR(64) PRIMARY KEY,\n"
-            + "%s VARCHAR(MAX),\n"
+            + "%s NVARCHAR(MAX),\n"
             + "%s DATETIMEOFFSET(7) DEFAULT SYSDATETIMEOFFSET()\n"
             + ");\n",
         schemaName, tableName, schemaName, tableName, JavaBaseConstants.COLUMN_NAME_AB_ID, JavaBaseConstants.COLUMN_NAME_DATA,

--- a/airbyte-integrations/connectors/destination-mssql/src/main/java/io/airbyte/integrations/destination/mssql/SqlServerOperations.java
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/java/io/airbyte/integrations/destination/mssql/SqlServerOperations.java
@@ -53,7 +53,7 @@ public class SqlServerOperations implements SqlOperations {
             + "WHERE s.name = '%s' AND t.name = '%s') "
             + "CREATE TABLE %s.%s ( \n"
             + "%s VARCHAR(64) PRIMARY KEY,\n"
-            + "%s NVARCHAR(MAX),\n" //Microsoft SQL Server specific: NVARCHAR can store Unicode meanwhile VARCHAR - not
+            + "%s NVARCHAR(MAX),\n" // Microsoft SQL Server specific: NVARCHAR can store Unicode meanwhile VARCHAR - not
             + "%s DATETIMEOFFSET(7) DEFAULT SYSDATETIMEOFFSET()\n"
             + ");\n",
         schemaName, tableName, schemaName, tableName, JavaBaseConstants.COLUMN_NAME_AB_ID, JavaBaseConstants.COLUMN_NAME_DATA,

--- a/airbyte-integrations/connectors/destination-mssql/src/main/java/io/airbyte/integrations/destination/mssql/SqlServerOperations.java
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/java/io/airbyte/integrations/destination/mssql/SqlServerOperations.java
@@ -53,7 +53,7 @@ public class SqlServerOperations implements SqlOperations {
             + "WHERE s.name = '%s' AND t.name = '%s') "
             + "CREATE TABLE %s.%s ( \n"
             + "%s VARCHAR(64) PRIMARY KEY,\n"
-            + "%s NVARCHAR(MAX),\n"
+            + "%s NVARCHAR(MAX),\n" //Microsoft SQL Server specific: NVARCHAR can store Unicode meanwhile VARCHAR - not
             + "%s DATETIMEOFFSET(7) DEFAULT SYSDATETIMEOFFSET()\n"
             + ");\n",
         schemaName, tableName, schemaName, tableName, JavaBaseConstants.COLUMN_NAME_AB_ID, JavaBaseConstants.COLUMN_NAME_DATA,

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -14,6 +14,10 @@ Each stream will be output into its own table in SQL Server. Each table will con
 * `_airbyte_emitted_at`: a timestamp representing when the event was pulled from the data source. The column type in SQL Server is `DATETIMEOFFSET(7)`.
 * `_airbyte_data`: a JSON blob representing with the event data. The column type in SQL Server is `NVARCHAR(MAX)`.
 
+#####  Microsoft SQL Server specifics or why NVARCHAR type is used here:
+* NVARCHAR is Unicode - 2 bytes per character, therefore max. of 1 billion characters; will handle East Asian, Arabic, Hebrew, Cyrillic etc. characters just fine.
+* VARCHAR is non-Unicode - 1 byte per character, max. capacity is 2 billion characters, but limited to the character set you're SQL Server is using, basically - no support for those languages mentioned before
+
 #### Features
 
 | Feature | Supported?\(Yes/No\) | Notes |

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -12,7 +12,7 @@ Each stream will be output into its own table in SQL Server. Each table will con
 
 * `_airbyte_ab_id`: a uuid assigned by Airbyte to each event that is processed. The column type in SQL Server is `VARCHAR(64)`.
 * `_airbyte_emitted_at`: a timestamp representing when the event was pulled from the data source. The column type in SQL Server is `DATETIMEOFFSET(7)`.
-* `_airbyte_data`: a JSON blob representing with the event data. The column type in SQL Server is `VARCHAR(MAX)`.
+* `_airbyte_data`: a JSON blob representing with the event data. The column type in SQL Server is `NVARCHAR(MAX)`.
 
 #### Features
 


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/issues/3552 MSSQL Destination: Fix newline handling

## How
Fixed MSSQL _airbyte_data field's type to support unicode.

This is for Microsoft SQL Server:
**NVARCHAR** is Unicode - 2 bytes per character, therefore max. of 1 billion characters; will handle East Asian, Arabic, Hebrew, Cyrillic etc. characters just fine.
**VARCHAR** is non-Unicode - 1 byte per character, max. capacity is 2 billion characters, but limited to the character set you're SQL Server is using, basically - no support for those languages mentioned before


## Pre-merge Checklist
- [x] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `test.java`
1. `component.ts`
1. the rest
