### PR TITLE
change ProcessBuilderFactory into ProcessFactory

### DIFF
--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAcceptanceTest.java
@@ -56,8 +56,8 @@ import io.airbyte.workers.DefaultDiscoverCatalogWorker;
 import io.airbyte.workers.DefaultGetSpecWorker;
 import io.airbyte.workers.WorkerException;
 import io.airbyte.workers.process.AirbyteIntegrationLauncher;
-import io.airbyte.workers.process.DockerProcessBuilderFactory;
-import io.airbyte.workers.process.ProcessBuilderFactory;
+import io.airbyte.workers.process.DockerProcessFactory;
+import io.airbyte.workers.process.ProcessFactory;
 import io.airbyte.workers.protocols.airbyte.AirbyteSource;
 import io.airbyte.workers.protocols.airbyte.DefaultAirbyteSource;
 import java.nio.file.Files;
@@ -91,7 +91,7 @@ public abstract class SourceAcceptanceTest {
 
   private Path jobRoot;
   protected Path localRoot;
-  private ProcessBuilderFactory pbf;
+  private ProcessFactory processFactory;
 
   /**
    * TODO hack: Various Singer integrations use cursor fields inclusively i.e: they output records
@@ -207,7 +207,7 @@ public abstract class SourceAcceptanceTest {
 
     setup(testEnv);
 
-    pbf = new DockerProcessBuilderFactory(
+    processFactory = new DockerProcessFactory(
         workspaceRoot,
         workspaceRoot.toString(),
         localRoot.toString(),
@@ -419,17 +419,17 @@ public abstract class SourceAcceptanceTest {
   }
 
   private ConnectorSpecification runSpec() throws WorkerException {
-    return new DefaultGetSpecWorker(new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), pbf))
+    return new DefaultGetSpecWorker(new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory))
         .run(new JobGetSpecConfig().withDockerImage(getImageName()), jobRoot);
   }
 
   private StandardCheckConnectionOutput runCheck() throws Exception {
-    return new DefaultCheckConnectionWorker(new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), pbf))
+    return new DefaultCheckConnectionWorker(new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory))
         .run(new StandardCheckConnectionInput().withConnectionConfiguration(getConfig()), jobRoot);
   }
 
   private AirbyteCatalog runDiscover() throws Exception {
-    return new DefaultDiscoverCatalogWorker(new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), pbf))
+    return new DefaultDiscoverCatalogWorker(new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory))
         .run(new StandardDiscoverCatalogInput().withConnectionConfiguration(getConfig()), jobRoot);
   }
 
@@ -444,7 +444,7 @@ public abstract class SourceAcceptanceTest {
         .withState(state == null ? null : new State().withState(state))
         .withCatalog(catalog);
 
-    final AirbyteSource source = new DefaultAirbyteSource(new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), pbf));
+    final AirbyteSource source = new DefaultAirbyteSource(new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory));
     final List<AirbyteMessage> messages = new ArrayList<>();
     source.start(sourceConfig, jobRoot);
     while (!source.isFinished()) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DbtTransformationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DbtTransformationRunner.java
@@ -30,7 +30,7 @@ import io.airbyte.commons.io.LineGobbler;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.config.OperatorDbt;
 import io.airbyte.workers.normalization.NormalizationRunner;
-import io.airbyte.workers.process.ProcessBuilderFactory;
+import io.airbyte.workers.process.ProcessFactory;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,12 +45,12 @@ public class DbtTransformationRunner implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(DbtTransformationRunner.class);
   private static final String DBT_ENTRYPOINT_SH = "entrypoint.sh";
 
-  private final ProcessBuilderFactory pbf;
+  private final ProcessFactory processFactory;
   private final NormalizationRunner normalizationRunner;
   private Process process = null;
 
-  public DbtTransformationRunner(final ProcessBuilderFactory pbf, NormalizationRunner normalizationRunner) {
-    this.pbf = pbf;
+  public DbtTransformationRunner(final ProcessFactory processFactory, NormalizationRunner normalizationRunner) {
+    this.processFactory = processFactory;
     this.normalizationRunner = normalizationRunner;
   }
 
@@ -87,7 +87,7 @@ public class DbtTransformationRunner implements AutoCloseable {
       if (!dbtConfig.getDbtArguments().contains("--project-dir=")) {
         dbtArguments.add("--project-dir=/data/job/transform/git_repo/");
       }
-      process = pbf.create(jobId, attempt, jobRoot, dbtConfig.getDockerImage(), "/bin/bash", dbtArguments).start();
+      process = processFactory.create(jobId, attempt, jobRoot, dbtConfig.getDockerImage(), "/bin/bash", dbtArguments);
 
       LineGobbler.gobble(process.getInputStream(), LOGGER::info);
       LineGobbler.gobble(process.getErrorStream(), LOGGER::error);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultCheckConnectionWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultCheckConnectionWorker.java
@@ -70,7 +70,7 @@ public class DefaultCheckConnectionWorker implements CheckConnectionWorker {
     IOs.writeFile(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
 
     try {
-      process = integrationLauncher.check(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME).start();
+      process = integrationLauncher.check(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME);
 
       LineGobbler.gobble(process.getErrorStream(), LOGGER::error);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultDiscoverCatalogWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultDiscoverCatalogWorker.java
@@ -67,8 +67,7 @@ public class DefaultDiscoverCatalogWorker implements DiscoverCatalogWorker {
     IOs.writeFile(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
 
     try {
-      process = integrationLauncher.discover(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME)
-          .start();
+      process = integrationLauncher.discover(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME);
 
       LineGobbler.gobble(process.getErrorStream(), LOGGER::error);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultGetSpecWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultGetSpecWorker.java
@@ -61,7 +61,7 @@ public class DefaultGetSpecWorker implements GetSpecWorker {
   @Override
   public ConnectorSpecification run(JobGetSpecConfig config, Path jobRoot) throws WorkerException {
     try {
-      process = integrationLauncher.spec(jobRoot).start();
+      process = integrationLauncher.spec(jobRoot);
 
       LineGobbler.gobble(process.getErrorStream(), LOGGER::error);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -32,7 +32,7 @@ import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.process.AirbyteIntegrationLauncher;
 import io.airbyte.workers.process.IntegrationLauncher;
-import io.airbyte.workers.process.ProcessBuilderFactory;
+import io.airbyte.workers.process.ProcessFactory;
 import io.airbyte.workers.protocols.airbyte.HeartbeatMonitor;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -220,10 +220,10 @@ public class WorkerUtils {
     MDC.put("job_log_filename", WorkerConstants.LOG_FILENAME);
   }
 
-  // todo (cgardens) can we get this down to just passing pbf and docker image and not job id and
-  // attempt
-  public static IntegrationLauncher getIntegrationLauncher(IntegrationLauncherConfig config, ProcessBuilderFactory pbf) {
-    return new AirbyteIntegrationLauncher(config.getJobId(), Math.toIntExact(config.getAttemptId()), config.getDockerImage(), pbf);
+  // todo (cgardens) can we get this down to just passing the process factory and image and not job id
+  // and attempt
+  public static IntegrationLauncher getIntegrationLauncher(IntegrationLauncherConfig config, ProcessFactory processFactory) {
+    return new AirbyteIntegrationLauncher(config.getJobId(), Math.toIntExact(config.getAttemptId()), config.getDockerImage(), processFactory);
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
@@ -34,7 +34,7 @@ import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.workers.WorkerConstants;
 import io.airbyte.workers.WorkerException;
 import io.airbyte.workers.WorkerUtils;
-import io.airbyte.workers.process.ProcessBuilderFactory;
+import io.airbyte.workers.process.ProcessFactory;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -47,7 +47,7 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
   public static final String NORMALIZATION_IMAGE_NAME = "airbyte/normalization:0.1.30";
 
   private final DestinationType destinationType;
-  private final ProcessBuilderFactory pbf;
+  private final ProcessFactory processFactory;
 
   private Process process = null;
 
@@ -58,9 +58,9 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
     SNOWFLAKE
   }
 
-  public DefaultNormalizationRunner(final DestinationType destinationType, final ProcessBuilderFactory pbf) {
+  public DefaultNormalizationRunner(final DestinationType destinationType, final ProcessFactory processFactory) {
     this.destinationType = destinationType;
-    this.pbf = pbf;
+    this.processFactory = processFactory;
   }
 
   @Override
@@ -86,7 +86,7 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
 
   private boolean runProcess(String jobId, int attempt, Path jobRoot, final String... args) throws Exception {
     try {
-      process = pbf.create(jobId, attempt, jobRoot, NORMALIZATION_IMAGE_NAME, null, args).start();
+      process = processFactory.create(jobId, attempt, jobRoot, NORMALIZATION_IMAGE_NAME, null, args);
 
       LineGobbler.gobble(process.getInputStream(), LOGGER::info);
       LineGobbler.gobble(process.getErrorStream(), LOGGER::error);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.workers.WorkerConstants;
 import io.airbyte.workers.normalization.NormalizationRunner.NoOpNormalizationRunner;
-import io.airbyte.workers.process.ProcessBuilderFactory;
+import io.airbyte.workers.process.ProcessFactory;
 import java.util.Map;
 import java.util.Optional;
 
@@ -42,7 +42,7 @@ public class NormalizationRunnerFactory {
           .put("airbyte/destination-snowflake", DefaultNormalizationRunner.DestinationType.SNOWFLAKE)
           .build();
 
-  public static NormalizationRunner create(String imageName, ProcessBuilderFactory pbf, JsonNode config) {
+  public static NormalizationRunner create(String imageName, ProcessFactory processFactory, JsonNode config) {
     if (!shouldNormalize(config)) {
       return new NoOpNormalizationRunner();
     }
@@ -50,7 +50,7 @@ public class NormalizationRunnerFactory {
     final String imageNameWithoutTag = imageName.split(":")[0];
 
     if (NORMALIZATION_MAPPING.containsKey(imageNameWithoutTag)) {
-      return new DefaultNormalizationRunner(NORMALIZATION_MAPPING.get(imageNameWithoutTag), pbf);
+      return new DefaultNormalizationRunner(NORMALIZATION_MAPPING.get(imageNameWithoutTag), processFactory);
     } else {
       throw new IllegalStateException(
           String.format("Requested normalization for %s, but it is not included in the normalization mapping.", imageName));

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/AirbyteIntegrationLauncher.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/AirbyteIntegrationLauncher.java
@@ -38,22 +38,22 @@ public class AirbyteIntegrationLauncher implements IntegrationLauncher {
   private final String jobId;
   private final int attempt;
   private final String imageName;
-  private final ProcessBuilderFactory pbf;
+  private final ProcessFactory processFactory;
 
-  public AirbyteIntegrationLauncher(long jobId, int attempt, final String imageName, final ProcessBuilderFactory pbf) {
-    this(String.valueOf(jobId), attempt, imageName, pbf);
+  public AirbyteIntegrationLauncher(long jobId, int attempt, final String imageName, final ProcessFactory processFactory) {
+    this(String.valueOf(jobId), attempt, imageName, processFactory);
   }
 
-  public AirbyteIntegrationLauncher(String jobId, int attempt, final String imageName, final ProcessBuilderFactory pbf) {
+  public AirbyteIntegrationLauncher(String jobId, int attempt, final String imageName, final ProcessFactory processFactory) {
     this.jobId = jobId;
     this.attempt = attempt;
     this.imageName = imageName;
-    this.pbf = pbf;
+    this.processFactory = processFactory;
   }
 
   @Override
-  public ProcessBuilder spec(final Path jobRoot) throws WorkerException {
-    return pbf.create(
+  public Process spec(final Path jobRoot) throws WorkerException {
+    return processFactory.create(
         jobId,
         attempt,
         jobRoot,
@@ -63,8 +63,8 @@ public class AirbyteIntegrationLauncher implements IntegrationLauncher {
   }
 
   @Override
-  public ProcessBuilder check(final Path jobRoot, final String configFilename) throws WorkerException {
-    return pbf.create(
+  public Process check(final Path jobRoot, final String configFilename) throws WorkerException {
+    return processFactory.create(
         jobId,
         attempt,
         jobRoot,
@@ -75,8 +75,8 @@ public class AirbyteIntegrationLauncher implements IntegrationLauncher {
   }
 
   @Override
-  public ProcessBuilder discover(final Path jobRoot, final String configFilename) throws WorkerException {
-    return pbf.create(
+  public Process discover(final Path jobRoot, final String configFilename) throws WorkerException {
+    return processFactory.create(
         jobId,
         attempt,
         jobRoot,
@@ -87,10 +87,10 @@ public class AirbyteIntegrationLauncher implements IntegrationLauncher {
   }
 
   @Override
-  public ProcessBuilder read(final Path jobRoot,
-                             final String configFilename,
-                             final String catalogFilename,
-                             final String stateFilename)
+  public Process read(final Path jobRoot,
+                      final String configFilename,
+                      final String catalogFilename,
+                      final String stateFilename)
       throws WorkerException {
     final List<String> arguments = Lists.newArrayList(
         "read",
@@ -102,7 +102,7 @@ public class AirbyteIntegrationLauncher implements IntegrationLauncher {
       arguments.add(stateFilename);
     }
 
-    return pbf.create(
+    return processFactory.create(
         jobId,
         attempt,
         jobRoot,
@@ -112,8 +112,8 @@ public class AirbyteIntegrationLauncher implements IntegrationLauncher {
   }
 
   @Override
-  public ProcessBuilder write(Path jobRoot, String configFilename, String catalogFilename) throws WorkerException {
-    return pbf.create(
+  public Process write(Path jobRoot, String configFilename, String catalogFilename) throws WorkerException {
+    return processFactory.create(
         jobId,
         attempt,
         jobRoot,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
@@ -42,9 +42,9 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DockerProcessBuilderFactory implements ProcessBuilderFactory {
+public class DockerProcessFactory implements ProcessFactory {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(DockerProcessBuilderFactory.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DockerProcessFactory.class);
 
   private static final Path DATA_MOUNT_DESTINATION = Path.of("/data");
   private static final Path LOCAL_MOUNT_DESTINATION = Path.of("/local");
@@ -56,7 +56,7 @@ public class DockerProcessBuilderFactory implements ProcessBuilderFactory {
   private final String networkName;
   private final Path imageExistsScriptPath;
 
-  public DockerProcessBuilderFactory(Path workspaceRoot, String workspaceMountSource, String localMountSource, String networkName) {
+  public DockerProcessFactory(Path workspaceRoot, String workspaceMountSource, String localMountSource, String networkName) {
     this.workspaceRoot = workspaceRoot;
     this.workspaceMountSource = workspaceMountSource;
     this.localMountSource = localMountSource;
@@ -79,7 +79,7 @@ public class DockerProcessBuilderFactory implements ProcessBuilderFactory {
   }
 
   @Override
-  public ProcessBuilder create(String jobId, int attempt, final Path jobRoot, final String imageName, final String entrypoint, final String... args)
+  public Process create(String jobId, int attempt, final Path jobRoot, final String imageName, final String entrypoint, final String... args)
       throws WorkerException {
 
     if (!checkImageExists(imageName)) {
@@ -110,7 +110,11 @@ public class DockerProcessBuilderFactory implements ProcessBuilderFactory {
 
     LOGGER.info("Preparing command: {}", Joiner.on(" ").join(cmd));
 
-    return new ProcessBuilder(cmd);
+    try {
+      return new ProcessBuilder(cmd).start();
+    } catch (IOException e) {
+      throw new WorkerException(e.getMessage(), e);
+    }
   }
 
   private Path rebasePath(final Path jobRoot) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/IntegrationLauncher.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/IntegrationLauncher.java
@@ -29,33 +29,33 @@ import java.nio.file.Path;
 
 public interface IntegrationLauncher {
 
-  ProcessBuilder spec(final Path jobRoot) throws WorkerException;
+  Process spec(final Path jobRoot) throws WorkerException;
 
-  ProcessBuilder check(final Path jobRoot, final String configFilename) throws WorkerException;
+  Process check(final Path jobRoot, final String configFilename) throws WorkerException;
 
-  ProcessBuilder discover(final Path jobRoot, final String configFilename) throws WorkerException;
+  Process discover(final Path jobRoot, final String configFilename) throws WorkerException;
 
-  ProcessBuilder read(final Path jobRoot,
-                      final String configFilename,
-                      final String catalogFilename,
-                      final String stateFilename)
+  Process read(final Path jobRoot,
+               final String configFilename,
+               final String catalogFilename,
+               final String stateFilename)
       throws WorkerException;
 
-  default ProcessBuilder read(final Path jobRoot,
-                              final String configFilename,
-                              final String catalogFilename)
+  default Process read(final Path jobRoot,
+                       final String configFilename,
+                       final String catalogFilename)
       throws WorkerException {
     return read(jobRoot, configFilename, catalogFilename, null);
   }
 
-  ProcessBuilder write(final Path jobRoot,
-                       final String configFilename,
-                       final String catalogFilename)
+  Process write(final Path jobRoot,
+                final String configFilename,
+                final String catalogFilename)
       throws WorkerException;
 
   // TODO: this version should be removed once we've moved away from singer protocol
-  default ProcessBuilder write(final Path jobRoot,
-                               final String configFilename)
+  default Process write(final Path jobRoot,
+                        final String configFilename)
       throws WorkerException {
     return write(jobRoot, configFilename, null);
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
@@ -39,20 +39,20 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class KubeProcessBuilderFactory implements ProcessBuilderFactory {
+public class KubeProcessFactory implements ProcessFactory {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(KubeProcessBuilderFactory.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(KubeProcessFactory.class);
 
   private static final Path WORKSPACE_MOUNT_DESTINATION = Path.of("/workspace");
 
   private final Path workspaceRoot;
 
-  public KubeProcessBuilderFactory(Path workspaceRoot) {
+  public KubeProcessFactory(Path workspaceRoot) {
     this.workspaceRoot = workspaceRoot;
   }
 
   @Override
-  public ProcessBuilder create(String jobId, int attempt, final Path jobRoot, final String imageName, final String entrypoint, final String... args)
+  public Process create(String jobId, int attempt, final Path jobRoot, final String imageName, final String entrypoint, final String... args)
       throws WorkerException {
 
     try {
@@ -90,7 +90,7 @@ public class KubeProcessBuilderFactory implements ProcessBuilderFactory {
       // TODO handle entrypoint override (to run DbtTransformationRunner for example)
       LOGGER.debug("Preparing command: {}", Joiner.on(" ").join(cmd));
 
-      return new ProcessBuilder(cmd);
+      return new ProcessBuilder(cmd).start();
     } catch (Exception e) {
       throw new WorkerException(e.getMessage());
     }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/ProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/ProcessFactory.java
@@ -28,7 +28,7 @@ import io.airbyte.workers.WorkerException;
 import java.nio.file.Path;
 import java.util.List;
 
-public interface ProcessBuilderFactory {
+public interface ProcessFactory {
 
   /**
    * Creates a ProcessBuilder to run a program in a new Process.
@@ -43,25 +43,25 @@ public interface ProcessBuilderFactory {
    * @return the ProcessBuilder object to run the process
    * @throws WorkerException
    */
-  ProcessBuilder create(String jobId, int attempt, final Path jobPath, final String imageName, final String entrypoint, final String... args)
+  Process create(String jobId, int attempt, final Path jobPath, final String imageName, final String entrypoint, final String... args)
       throws WorkerException;
 
-  default ProcessBuilder create(long jobId, int attempt, final Path jobPath, final String imageName, final String entrypoint, final String... args)
+  default Process create(long jobId, int attempt, final Path jobPath, final String imageName, final String entrypoint, final String... args)
       throws WorkerException {
     return create(String.valueOf(jobId), attempt, jobPath, imageName, entrypoint, args);
   }
 
-  default ProcessBuilder create(String jobId,
-                                int attempt,
-                                final Path jobPath,
-                                final String imageName,
-                                final String entrypoint,
-                                final List<String> args)
+  default Process create(String jobId,
+                         int attempt,
+                         final Path jobPath,
+                         final String imageName,
+                         final String entrypoint,
+                         final List<String> args)
       throws WorkerException {
     return create(jobId, attempt, jobPath, imageName, entrypoint, args.toArray(new String[0]));
   }
 
-  default ProcessBuilder create(long jobId, int attempt, final Path jobPath, final String imageName, final String entrypoint, final List<String> args)
+  default Process create(long jobId, int attempt, final Path jobPath, final String imageName, final String entrypoint, final List<String> args)
       throws WorkerException {
     return create(String.valueOf(jobId), attempt, jobPath, imageName, entrypoint, args);
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -82,7 +82,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
     destinationProcess = integrationLauncher.write(
         jobRoot,
         WorkerConstants.DESTINATION_CONFIG_JSON_FILENAME,
-        WorkerConstants.DESTINATION_CATALOG_JSON_FILENAME).start();
+        WorkerConstants.DESTINATION_CATALOG_JSON_FILENAME);
     // stdout logs are logged elsewhere since stdout also contains data
     LineGobbler.gobble(destinationProcess.getErrorStream(), LOGGER::error);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
@@ -88,7 +88,7 @@ public class DefaultAirbyteSource implements AirbyteSource {
     sourceProcess = integrationLauncher.read(jobRoot,
         WorkerConstants.SOURCE_CONFIG_JSON_FILENAME,
         WorkerConstants.SOURCE_CATALOG_JSON_FILENAME,
-        input.getState() == null ? null : WorkerConstants.INPUT_STATE_JSON_FILENAME).start();
+        input.getState() == null ? null : WorkerConstants.INPUT_STATE_JSON_FILENAME);
     // stdout logs are logged elsewhere since stdout also contains data
     LineGobbler.gobble(sourceProcess.getErrorStream(), LOGGER::error);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CheckConnectionWorkflow.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CheckConnectionWorkflow.java
@@ -33,7 +33,7 @@ import io.airbyte.workers.DefaultCheckConnectionWorker;
 import io.airbyte.workers.Worker;
 import io.airbyte.workers.process.AirbyteIntegrationLauncher;
 import io.airbyte.workers.process.IntegrationLauncher;
-import io.airbyte.workers.process.ProcessBuilderFactory;
+import io.airbyte.workers.process.ProcessFactory;
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
 import io.temporal.activity.ActivityOptions;
@@ -81,11 +81,11 @@ public interface CheckConnectionWorkflow {
 
   class CheckConnectionActivityImpl implements CheckConnectionActivity {
 
-    private final ProcessBuilderFactory pbf;
+    private final ProcessFactory processFactory;
     private final Path workspaceRoot;
 
-    public CheckConnectionActivityImpl(ProcessBuilderFactory pbf, Path workspaceRoot) {
-      this.pbf = pbf;
+    public CheckConnectionActivityImpl(ProcessFactory processFactory, Path workspaceRoot) {
+      this.processFactory = processFactory;
       this.workspaceRoot = workspaceRoot;
     }
 
@@ -112,7 +112,7 @@ public interface CheckConnectionWorkflow {
             launcherConfig.getJobId(),
             Math.toIntExact(launcherConfig.getAttemptId()),
             launcherConfig.getDockerImage(),
-            pbf);
+            processFactory);
 
         return new DefaultCheckConnectionWorker(integrationLauncher);
       };

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/DiscoverCatalogWorkflow.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/DiscoverCatalogWorkflow.java
@@ -33,7 +33,7 @@ import io.airbyte.workers.DefaultDiscoverCatalogWorker;
 import io.airbyte.workers.Worker;
 import io.airbyte.workers.process.AirbyteIntegrationLauncher;
 import io.airbyte.workers.process.IntegrationLauncher;
-import io.airbyte.workers.process.ProcessBuilderFactory;
+import io.airbyte.workers.process.ProcessFactory;
 import io.airbyte.workers.protocols.airbyte.AirbyteStreamFactory;
 import io.airbyte.workers.protocols.airbyte.DefaultAirbyteStreamFactory;
 import io.temporal.activity.ActivityInterface;
@@ -83,11 +83,11 @@ public interface DiscoverCatalogWorkflow {
 
   class DiscoverCatalogActivityImpl implements DiscoverCatalogActivity {
 
-    private final ProcessBuilderFactory pbf;
+    private final ProcessFactory processFactory;
     private final Path workspaceRoot;
 
-    public DiscoverCatalogActivityImpl(ProcessBuilderFactory pbf, Path workspaceRoot) {
-      this.pbf = pbf;
+    public DiscoverCatalogActivityImpl(ProcessFactory processFactory, Path workspaceRoot) {
+      this.processFactory = processFactory;
       this.workspaceRoot = workspaceRoot;
     }
 
@@ -110,7 +110,7 @@ public interface DiscoverCatalogWorkflow {
       return () -> {
         final IntegrationLauncher integrationLauncher =
             new AirbyteIntegrationLauncher(launcherConfig.getJobId(), launcherConfig.getAttemptId().intValue(), launcherConfig.getDockerImage(),
-                pbf);
+                processFactory);
         final AirbyteStreamFactory streamFactory = new DefaultAirbyteStreamFactory();
 
         return new DefaultDiscoverCatalogWorker(integrationLauncher, streamFactory);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/SpecWorkflow.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/SpecWorkflow.java
@@ -33,7 +33,7 @@ import io.airbyte.workers.DefaultGetSpecWorker;
 import io.airbyte.workers.Worker;
 import io.airbyte.workers.process.AirbyteIntegrationLauncher;
 import io.airbyte.workers.process.IntegrationLauncher;
-import io.airbyte.workers.process.ProcessBuilderFactory;
+import io.airbyte.workers.process.ProcessFactory;
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
 import io.temporal.activity.ActivityOptions;
@@ -75,11 +75,11 @@ public interface SpecWorkflow {
 
   class SpecActivityImpl implements SpecActivity {
 
-    private final ProcessBuilderFactory pbf;
+    private final ProcessFactory processFactory;
     private final Path workspaceRoot;
 
-    public SpecActivityImpl(ProcessBuilderFactory pbf, Path workspaceRoot) {
-      this.pbf = pbf;
+    public SpecActivityImpl(ProcessFactory processFactory, Path workspaceRoot) {
+      this.processFactory = processFactory;
       this.workspaceRoot = workspaceRoot;
     }
 
@@ -102,7 +102,7 @@ public interface SpecWorkflow {
             launcherConfig.getJobId(),
             launcherConfig.getAttemptId().intValue(),
             launcherConfig.getDockerImage(),
-            pbf);
+            processFactory);
 
         return new DefaultGetSpecWorker(integrationLauncher);
       };

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/SyncWorkflow.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/SyncWorkflow.java
@@ -51,7 +51,7 @@ import io.airbyte.workers.WorkerConstants;
 import io.airbyte.workers.normalization.NormalizationRunnerFactory;
 import io.airbyte.workers.process.AirbyteIntegrationLauncher;
 import io.airbyte.workers.process.IntegrationLauncher;
-import io.airbyte.workers.process.ProcessBuilderFactory;
+import io.airbyte.workers.process.ProcessFactory;
 import io.airbyte.workers.protocols.airbyte.AirbyteMessageTracker;
 import io.airbyte.workers.protocols.airbyte.AirbyteSource;
 import io.airbyte.workers.protocols.airbyte.DefaultAirbyteDestination;
@@ -157,17 +157,17 @@ public interface SyncWorkflow {
 
     private static final int MAX_RETRIES = 3;
 
-    private final ProcessBuilderFactory pbf;
+    private final ProcessFactory processFactory;
     private final Path workspaceRoot;
     private final AirbyteConfigValidator validator;
 
-    public ReplicationActivityImpl(ProcessBuilderFactory pbf, Path workspaceRoot) {
-      this(pbf, workspaceRoot, new AirbyteConfigValidator());
+    public ReplicationActivityImpl(ProcessFactory processFactory, Path workspaceRoot) {
+      this(processFactory, workspaceRoot, new AirbyteConfigValidator());
     }
 
     @VisibleForTesting
-    ReplicationActivityImpl(ProcessBuilderFactory pbf, Path workspaceRoot, AirbyteConfigValidator validator) {
-      this.pbf = pbf;
+    ReplicationActivityImpl(ProcessFactory processFactory, Path workspaceRoot, AirbyteConfigValidator validator) {
+      this.processFactory = processFactory;
       this.workspaceRoot = workspaceRoot;
       this.validator = validator;
     }
@@ -252,12 +252,12 @@ public interface SyncWorkflow {
             sourceLauncherConfig.getJobId(),
             Math.toIntExact(sourceLauncherConfig.getAttemptId()),
             sourceLauncherConfig.getDockerImage(),
-            pbf);
+            processFactory);
         final IntegrationLauncher destinationLauncher = new AirbyteIntegrationLauncher(
             destinationLauncherConfig.getJobId(),
             Math.toIntExact(destinationLauncherConfig.getAttemptId()),
             destinationLauncherConfig.getDockerImage(),
-            pbf);
+            processFactory);
 
         // reset jobs use an empty source to induce resetting all data in destination.
         final AirbyteSource airbyteSource =
@@ -291,17 +291,17 @@ public interface SyncWorkflow {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NormalizationActivityImpl.class);
 
-    private final ProcessBuilderFactory pbf;
+    private final ProcessFactory processFactory;
     private final Path workspaceRoot;
     private final AirbyteConfigValidator validator;
 
-    public NormalizationActivityImpl(ProcessBuilderFactory pbf, Path workspaceRoot) {
-      this(pbf, workspaceRoot, new AirbyteConfigValidator());
+    public NormalizationActivityImpl(ProcessFactory processFactory, Path workspaceRoot) {
+      this(processFactory, workspaceRoot, new AirbyteConfigValidator());
     }
 
     @VisibleForTesting
-    NormalizationActivityImpl(ProcessBuilderFactory pbf, Path workspaceRoot, AirbyteConfigValidator validator) {
-      this.pbf = pbf;
+    NormalizationActivityImpl(ProcessFactory processFactory, Path workspaceRoot, AirbyteConfigValidator validator) {
+      this.processFactory = processFactory;
       this.workspaceRoot = workspaceRoot;
       this.validator = validator;
     }
@@ -334,7 +334,7 @@ public interface SyncWorkflow {
           Math.toIntExact(jobRunConfig.getAttemptId()),
           NormalizationRunnerFactory.create(
               destinationLauncherConfig.getDockerImage(),
-              pbf,
+              processFactory,
               normalizationInput.getDestinationConfiguration()));
     }
 
@@ -354,17 +354,17 @@ public interface SyncWorkflow {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DbtTransformationActivityImpl.class);
 
-    private final ProcessBuilderFactory pbf;
+    private final ProcessFactory processFactory;
     private final Path workspaceRoot;
     private final AirbyteConfigValidator validator;
 
-    public DbtTransformationActivityImpl(ProcessBuilderFactory pbf, Path workspaceRoot) {
-      this(pbf, workspaceRoot, new AirbyteConfigValidator());
+    public DbtTransformationActivityImpl(ProcessFactory processFactory, Path workspaceRoot) {
+      this(processFactory, workspaceRoot, new AirbyteConfigValidator());
     }
 
     @VisibleForTesting
-    DbtTransformationActivityImpl(ProcessBuilderFactory pbf, Path workspaceRoot, AirbyteConfigValidator validator) {
-      this.pbf = pbf;
+    DbtTransformationActivityImpl(ProcessFactory processFactory, Path workspaceRoot, AirbyteConfigValidator validator) {
+      this.processFactory = processFactory;
       this.workspaceRoot = workspaceRoot;
       this.validator = validator;
     }
@@ -393,10 +393,11 @@ public interface SyncWorkflow {
       return () -> new DbtTransformationWorker(
           jobRunConfig.getJobId(),
           Math.toIntExact(jobRunConfig.getAttemptId()),
-          new DbtTransformationRunner(pbf, NormalizationRunnerFactory.create(
-              destinationLauncherConfig.getDockerImage(),
-              pbf,
-              operatorDbtInput.getDestinationConfiguration())));
+          new DbtTransformationRunner(
+              processFactory, NormalizationRunnerFactory.create(
+                  destinationLauncherConfig.getDockerImage(),
+                  processFactory,
+                  operatorDbtInput.getDestinationConfiguration())));
     }
 
   }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultCheckConnectionWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultCheckConnectionWorkerTest.java
@@ -74,7 +74,7 @@ public class DefaultCheckConnectionWorkerTest {
     integrationLauncher = mock(IntegrationLauncher.class, RETURNS_DEEP_STUBS);
     process = mock(Process.class);
 
-    when(integrationLauncher.check(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME).start()).thenReturn(process);
+    when(integrationLauncher.check(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME)).thenReturn(process);
     final InputStream inputStream = mock(InputStream.class);
     when(process.getInputStream()).thenReturn(inputStream);
     when(process.getErrorStream()).thenReturn(new ByteArrayInputStream(new byte[0]));

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultDiscoverCatalogWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultDiscoverCatalogWorkerTest.java
@@ -83,7 +83,7 @@ public class DefaultDiscoverCatalogWorkerTest {
     integrationLauncher = mock(IntegrationLauncher.class, RETURNS_DEEP_STUBS);
     process = mock(Process.class);
 
-    when(integrationLauncher.discover(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME).start()).thenReturn(process);
+    when(integrationLauncher.discover(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME)).thenReturn(process);
     final InputStream inputStream = mock(InputStream.class);
     when(process.getInputStream()).thenReturn(inputStream);
     when(process.getErrorStream()).thenReturn(new ByteArrayInputStream(new byte[0]));

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultGetSpecWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultGetSpecWorkerTest.java
@@ -65,7 +65,7 @@ class DefaultGetSpecWorkerTest {
     integrationLauncher = mock(IntegrationLauncher.class, RETURNS_DEEP_STUBS);
     process = mock(Process.class);
     when(process.getErrorStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
-    when(integrationLauncher.spec(jobRoot).start()).thenReturn(process);
+    when(integrationLauncher.spec(jobRoot)).thenReturn(process);
 
     worker = new DefaultGetSpecWorker(integrationLauncher);
   }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/normalization/DefaultNormalizationRunnerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/normalization/DefaultNormalizationRunnerTest.java
@@ -35,7 +35,7 @@ import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.workers.WorkerConstants;
 import io.airbyte.workers.WorkerException;
 import io.airbyte.workers.normalization.DefaultNormalizationRunner.DestinationType;
-import io.airbyte.workers.process.ProcessBuilderFactory;
+import io.airbyte.workers.process.ProcessFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -49,7 +49,7 @@ class DefaultNormalizationRunnerTest {
   private static final int JOB_ATTEMPT = 0;
 
   private Path jobRoot;
-  private ProcessBuilderFactory pbf;
+  private ProcessFactory processFactory;
   private Process process;
   private JsonNode config;
   private ConfiguredAirbyteCatalog catalog;
@@ -57,26 +57,24 @@ class DefaultNormalizationRunnerTest {
   @BeforeEach
   void setup() throws IOException, WorkerException {
     jobRoot = Files.createDirectories(Files.createTempDirectory("test"));
-    pbf = mock(ProcessBuilderFactory.class);
-    final ProcessBuilder processBuilder = mock(ProcessBuilder.class);
+    processFactory = mock(ProcessFactory.class);
     process = mock(Process.class);
 
     config = mock(JsonNode.class);
     catalog = mock(ConfiguredAirbyteCatalog.class);
 
-    when(pbf.create(JOB_ID, JOB_ATTEMPT, jobRoot, DefaultNormalizationRunner.NORMALIZATION_IMAGE_NAME, null, "run",
+    when(processFactory.create(JOB_ID, JOB_ATTEMPT, jobRoot, DefaultNormalizationRunner.NORMALIZATION_IMAGE_NAME, null, "run",
         "--integration-type", "bigquery",
         "--config", WorkerConstants.DESTINATION_CONFIG_JSON_FILENAME,
         "--catalog", WorkerConstants.DESTINATION_CATALOG_JSON_FILENAME))
-            .thenReturn(processBuilder);
-    when(processBuilder.start()).thenReturn(process);
+            .thenReturn(process);
     when(process.getInputStream()).thenReturn(new ByteArrayInputStream("hello".getBytes()));
     when(process.getErrorStream()).thenReturn(new ByteArrayInputStream("hello".getBytes()));
   }
 
   @Test
   void test() throws Exception {
-    final NormalizationRunner runner = new DefaultNormalizationRunner(DestinationType.BIGQUERY, pbf);
+    final NormalizationRunner runner = new DefaultNormalizationRunner(DestinationType.BIGQUERY, processFactory);
 
     when(process.exitValue()).thenReturn(0);
 
@@ -87,7 +85,7 @@ class DefaultNormalizationRunnerTest {
   public void testClose() throws Exception {
     when(process.isAlive()).thenReturn(true).thenReturn(false);
 
-    final NormalizationRunner runner = new DefaultNormalizationRunner(DestinationType.BIGQUERY, pbf);
+    final NormalizationRunner runner = new DefaultNormalizationRunner(DestinationType.BIGQUERY, processFactory);
     runner.normalize(JOB_ID, JOB_ATTEMPT, jobRoot, config, catalog);
     runner.close();
 
@@ -98,7 +96,7 @@ class DefaultNormalizationRunnerTest {
   public void testFailure() {
     doThrow(new RuntimeException()).when(process).exitValue();
 
-    final NormalizationRunner runner = new DefaultNormalizationRunner(DestinationType.BIGQUERY, pbf);
+    final NormalizationRunner runner = new DefaultNormalizationRunner(DestinationType.BIGQUERY, processFactory);
     assertThrows(RuntimeException.class, () -> runner.normalize(JOB_ID, JOB_ATTEMPT, jobRoot, config, catalog));
 
     verify(process).destroy();

--- a/airbyte-workers/src/test/java/io/airbyte/workers/normalization/NormalizationRunnerFactoryTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/normalization/NormalizationRunnerFactoryTest.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.workers.normalization.DefaultNormalizationRunner.DestinationType;
 import io.airbyte.workers.normalization.NormalizationRunner.NoOpNormalizationRunner;
-import io.airbyte.workers.process.ProcessBuilderFactory;
+import io.airbyte.workers.process.ProcessFactory;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,31 +42,31 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 class NormalizationRunnerFactoryTest {
 
   private static final JsonNode CONFIG_WITH_NORMALIZATION = Jsons.jsonNode(ImmutableMap.of("basic_normalization", true));
-  private ProcessBuilderFactory pbf;
+  private ProcessFactory processFactory;
 
   @BeforeEach
   void setup() {
-    pbf = mock(ProcessBuilderFactory.class);
+    processFactory = mock(ProcessFactory.class);
   }
 
   @Test
   void testMappings() {
     assertEquals(DestinationType.BIGQUERY,
         ((DefaultNormalizationRunner) NormalizationRunnerFactory.create(
-            "airbyte/destination-bigquery:0.1.0", pbf, CONFIG_WITH_NORMALIZATION)).getDestinationType());
+            "airbyte/destination-bigquery:0.1.0", processFactory, CONFIG_WITH_NORMALIZATION)).getDestinationType());
     assertEquals(DestinationType.POSTGRES,
         ((DefaultNormalizationRunner) NormalizationRunnerFactory.create(
-            "airbyte/destination-postgres:0.1.0", pbf, CONFIG_WITH_NORMALIZATION)).getDestinationType());
+            "airbyte/destination-postgres:0.1.0", processFactory, CONFIG_WITH_NORMALIZATION)).getDestinationType());
     assertEquals(DestinationType.SNOWFLAKE,
         ((DefaultNormalizationRunner) NormalizationRunnerFactory.create(
-            "airbyte/destination-snowflake:0.1.0", pbf, CONFIG_WITH_NORMALIZATION)).getDestinationType());
+            "airbyte/destination-snowflake:0.1.0", processFactory, CONFIG_WITH_NORMALIZATION)).getDestinationType());
     assertThrows(IllegalStateException.class,
-        () -> NormalizationRunnerFactory.create("airbyte/destination-csv:0.1.0", pbf, CONFIG_WITH_NORMALIZATION));
+        () -> NormalizationRunnerFactory.create("airbyte/destination-csv:0.1.0", processFactory, CONFIG_WITH_NORMALIZATION));
   }
 
   @Test
   void testShouldNotNormalize() {
-    assertTrue(NormalizationRunnerFactory.create("airbyte/destination-bigquery:0.1.0", pbf,
+    assertTrue(NormalizationRunnerFactory.create("airbyte/destination-bigquery:0.1.0", processFactory,
         Jsons.jsonNode(Collections.emptyMap())) instanceof NoOpNormalizationRunner);
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/AirbyteIntegrationLauncherTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/AirbyteIntegrationLauncherTest.java
@@ -38,27 +38,27 @@ class AirbyteIntegrationLauncherTest {
   private static final Path JOB_ROOT = Path.of("abc");
   public static final String FAKE_IMAGE = "fake_image";
 
-  private ProcessBuilderFactory pbf;
+  private ProcessFactory processFactory;
   private AirbyteIntegrationLauncher launcher;
 
   @BeforeEach
   void setUp() {
-    pbf = Mockito.mock(ProcessBuilderFactory.class);
-    launcher = new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, FAKE_IMAGE, pbf);
+    processFactory = Mockito.mock(ProcessFactory.class);
+    launcher = new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, FAKE_IMAGE, processFactory);
   }
 
   @Test
   void spec() throws WorkerException {
     launcher.spec(JOB_ROOT);
 
-    Mockito.verify(pbf).create(JOB_ID, JOB_ATTEMPT, JOB_ROOT, FAKE_IMAGE, null, "spec");
+    Mockito.verify(processFactory).create(JOB_ID, JOB_ATTEMPT, JOB_ROOT, FAKE_IMAGE, null, "spec");
   }
 
   @Test
   void check() throws WorkerException {
     launcher.check(JOB_ROOT, "config");
 
-    Mockito.verify(pbf).create(JOB_ID, JOB_ATTEMPT, JOB_ROOT, FAKE_IMAGE, null,
+    Mockito.verify(processFactory).create(JOB_ID, JOB_ATTEMPT, JOB_ROOT, FAKE_IMAGE, null,
         "check",
         "--config", "config");
   }
@@ -67,7 +67,7 @@ class AirbyteIntegrationLauncherTest {
   void discover() throws WorkerException {
     launcher.discover(JOB_ROOT, "config");
 
-    Mockito.verify(pbf).create(JOB_ID, JOB_ATTEMPT, JOB_ROOT, FAKE_IMAGE, null,
+    Mockito.verify(processFactory).create(JOB_ID, JOB_ATTEMPT, JOB_ROOT, FAKE_IMAGE, null,
         "discover",
         "--config", "config");
   }
@@ -76,7 +76,7 @@ class AirbyteIntegrationLauncherTest {
   void read() throws WorkerException {
     launcher.read(JOB_ROOT, "config", "catalog", "state");
 
-    Mockito.verify(pbf).create(JOB_ID, JOB_ATTEMPT, JOB_ROOT, FAKE_IMAGE, null,
+    Mockito.verify(processFactory).create(JOB_ID, JOB_ATTEMPT, JOB_ROOT, FAKE_IMAGE, null,
         Lists.newArrayList(
             "read",
             "--config", "config",
@@ -88,7 +88,7 @@ class AirbyteIntegrationLauncherTest {
   void write() throws WorkerException {
     launcher.write(JOB_ROOT, "config", "catalog");
 
-    Mockito.verify(pbf).create(JOB_ID, JOB_ATTEMPT, JOB_ROOT, FAKE_IMAGE, null,
+    Mockito.verify(processFactory).create(JOB_ID, JOB_ATTEMPT, JOB_ROOT, FAKE_IMAGE, null,
         "write",
         "--config", "config",
         "--catalog", "catalog");

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
@@ -34,24 +34,24 @@ import org.junit.jupiter.api.Test;
 
 // todo (cgardens) - these are not truly "unit" tests as they are check resources on the internet.
 // we should move them to "integration" tests, when we have facility to do so.
-class DockerProcessBuilderFactoryTest {
+class DockerProcessFactoryTest {
 
   private static final Path TEST_ROOT = Path.of("/tmp/airbyte_tests");
 
   @Test
   public void testImageExists() throws IOException, WorkerException {
-    Path workspaceRoot = Files.createTempDirectory(Files.createDirectories(TEST_ROOT), "pbf");
+    Path workspaceRoot = Files.createTempDirectory(Files.createDirectories(TEST_ROOT), "process_factory");
 
-    final DockerProcessBuilderFactory pbf = new DockerProcessBuilderFactory(workspaceRoot, "", "", "");
-    assertTrue(pbf.checkImageExists("airbyte/scheduler:dev"));
+    final DockerProcessFactory processFactory = new DockerProcessFactory(workspaceRoot, "", "", "");
+    assertTrue(processFactory.checkImageExists("airbyte/scheduler:dev"));
   }
 
   @Test
   public void testImageDoesNotExist() throws IOException, WorkerException {
-    Path workspaceRoot = Files.createTempDirectory(Files.createDirectories(TEST_ROOT), "pbf");
+    Path workspaceRoot = Files.createTempDirectory(Files.createDirectories(TEST_ROOT), "process_factory");
 
-    final DockerProcessBuilderFactory pbf = new DockerProcessBuilderFactory(workspaceRoot, "", "", "");
-    assertFalse(pbf.checkImageExists("airbyte/fake:0.1.2"));
+    final DockerProcessFactory processFactory = new DockerProcessFactory(workspaceRoot, "", "", "");
+    assertFalse(processFactory.checkImageExists("airbyte/fake:0.1.2"));
   }
 
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
@@ -87,9 +87,8 @@ class DefaultAirbyteDestinationTest {
 
     integrationLauncher = mock(IntegrationLauncher.class, RETURNS_DEEP_STUBS);
     final InputStream inputStream = mock(InputStream.class);
-    when(integrationLauncher.write(jobRoot, WorkerConstants.DESTINATION_CONFIG_JSON_FILENAME, WorkerConstants.DESTINATION_CATALOG_JSON_FILENAME)
-        .start())
-            .thenReturn(process);
+    when(integrationLauncher.write(jobRoot, WorkerConstants.DESTINATION_CONFIG_JSON_FILENAME, WorkerConstants.DESTINATION_CATALOG_JSON_FILENAME))
+        .thenReturn(process);
 
     when(process.isAlive()).thenReturn(true);
     when(process.getInputStream()).thenReturn(inputStream);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
@@ -101,8 +101,7 @@ class DefaultAirbyteSourceTest {
         jobRoot,
         WorkerConstants.SOURCE_CONFIG_JSON_FILENAME,
         WorkerConstants.SOURCE_CATALOG_JSON_FILENAME,
-        WorkerConstants.INPUT_STATE_JSON_FILENAME)
-        .start()).thenReturn(process);
+        WorkerConstants.INPUT_STATE_JSON_FILENAME)).thenReturn(process);
     when(process.isAlive()).thenReturn(true);
     when(process.getInputStream()).thenReturn(inputStream);
     when(process.getErrorStream()).thenReturn(new ByteArrayInputStream("qwer".getBytes(StandardCharsets.UTF_8)));

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalPoolTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalPoolTest.java
@@ -24,12 +24,11 @@
 
 package io.airbyte.workers.temporal;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.airbyte.workers.process.ProcessBuilderFactory;
+import io.airbyte.workers.process.ProcessFactory;
 import io.temporal.api.namespace.v1.NamespaceInfo;
 import io.temporal.api.workflowservice.v1.DescribeNamespaceResponse;
 import io.temporal.serviceclient.WorkflowServiceStubs;
@@ -44,8 +43,8 @@ class TemporalPoolTest {
   public void testWaitForTemporalServerOnLogThrowsException() {
     WorkflowServiceStubs workflowServiceStubs = mock(WorkflowServiceStubs.class, Mockito.RETURNS_DEEP_STUBS);
     Path path = mock(Path.class);
-    ProcessBuilderFactory processBuilderFactory = mock(ProcessBuilderFactory.class);
-    TemporalPool testPool = new TemporalPool(workflowServiceStubs, path, processBuilderFactory);
+    ProcessFactory processFactory = mock(ProcessFactory.class);
+    TemporalPool testPool = new TemporalPool(workflowServiceStubs, path, processFactory);
     DescribeNamespaceResponse describeNamespaceResponse = mock(DescribeNamespaceResponse.class);
     NamespaceInfo namespaceInfo = mock(NamespaceInfo.class);
 


### PR DESCRIPTION
For the Kubernetes work, we're going to be generating a `Process`, not a `ProcessBuilder`. The various options for interacting with the `ProcessBuilder` won't be available so it seems to make more sense to do this in general.

Should be a straightforward refactor.