### PR TITLE
 🎉 Python CDK: change minimum python version to 3.7.0

### DIFF
--- a/.github/workflows/publish-cdk-command.yml
+++ b/.github/workflows/publish-cdk-command.yml
@@ -13,9 +13,9 @@ jobs:
   publish-cdk:
     runs-on: ubuntu-latest
     steps:
-      - uses: "gabrielfalcao/pyenv-action@v5"
+      - uses: actions/setup-python@v1
         with:
-          default: 3.7.0
+          python-version: '3.7.0'
       - uses: actions/setup-java@v1
         with:
           java-version: '14'
@@ -35,10 +35,11 @@ jobs:
           echo "pypi_url=https://test.pypi.org/legacy/" >> $GITHUB_ENV
       - name: Checkout Airbyte
         uses: actions/checkout@v2
-      - name: Setup py-version
-        run: pyenv local 3.7.0 && pyenv global 3.7.0
       - name: Build CDK Package
         run: ./gradlew --no-daemon :airbyte-cdk:python:build
+      - name: Setup version 3.7.0 for CDK
+        working-directory: 'airbyte-cdk/python/'
+        run: echo "3.7.0" > .python-version
       - name: Publish Python Package
         if: success()
         uses: mariamrf/py-package-publish-action@v1.1.0

--- a/.github/workflows/publish-cdk-command.yml
+++ b/.github/workflows/publish-cdk-command.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: gabrielfalcao/pyenv-action@v7
         with:
           default: 3.7.0
-          command: pyenv local 3.7.0
       - uses: actions/setup-java@v1
         with:
           java-version: '14'
@@ -37,7 +36,8 @@ jobs:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
       - name: Build CDK Package
-        run: ./gradlew --no-daemon :airbyte-cdk:python:build
+        # By default .python-version is 3.7.9
+        run: pyenv local 3.7.0 && ./gradlew --no-daemon :airbyte-cdk:python:build
       - name: Publish Python Package
         if: success()
         uses: mariamrf/py-package-publish-action@v1.1.0

--- a/.github/workflows/publish-cdk-command.yml
+++ b/.github/workflows/publish-cdk-command.yml
@@ -13,9 +13,9 @@ jobs:
   publish-cdk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v1
+      - uses: gabrielfalcao/pyenv-action@v7
         with:
-          python-version: '3.7.0'
+          default: 3.7.0
       - uses: actions/setup-java@v1
         with:
           java-version: '14'

--- a/.github/workflows/publish-cdk-command.yml
+++ b/.github/workflows/publish-cdk-command.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.7.0'
       - uses: actions/setup-java@v1
         with:
           java-version: '14'
@@ -41,7 +41,7 @@ jobs:
         if: success()
         uses: mariamrf/py-package-publish-action@v1.1.0
         with:
-          python_version: '3.7.9'
+          python_version: '3.7.0'
           pip_version: '21.1'
           subdir: 'airbyte-cdk/python/'
         env:

--- a/.github/workflows/publish-cdk-command.yml
+++ b/.github/workflows/publish-cdk-command.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7.0'
+          python-version: '3.7'
       - uses: actions/setup-java@v1
         with:
           java-version: '14'

--- a/.github/workflows/publish-cdk-command.yml
+++ b/.github/workflows/publish-cdk-command.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: gabrielfalcao/pyenv-action@v7
         with:
           default: 3.7.0
+          command: pyenv local 3.7.0
       - uses: actions/setup-java@v1
         with:
           java-version: '14'
@@ -37,9 +38,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Build CDK Package
         run: ./gradlew --no-daemon :airbyte-cdk:python:build
-      - name: Setup version 3.7.0 for CDK
-        working-directory: 'airbyte-cdk/python/'
-        run: echo "3.7.0" > .python-version
       - name: Publish Python Package
         if: success()
         uses: mariamrf/py-package-publish-action@v1.1.0

--- a/.github/workflows/publish-cdk-command.yml
+++ b/.github/workflows/publish-cdk-command.yml
@@ -13,9 +13,9 @@ jobs:
   publish-cdk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v2
+      - uses: "gabrielfalcao/pyenv-action@v5"
         with:
-          python-version: '3.7'
+          default: 3.7.0
       - uses: actions/setup-java@v1
         with:
           java-version: '14'
@@ -35,6 +35,8 @@ jobs:
           echo "pypi_url=https://test.pypi.org/legacy/" >> $GITHUB_ENV
       - name: Checkout Airbyte
         uses: actions/checkout@v2
+      - name: Setup py-version
+        run: pyenv local 3.7.0 && pyenv global 3.7.0
       - name: Build CDK Package
         run: ./gradlew --no-daemon :airbyte-cdk:python:build
       - name: Publish Python Package

--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.4
+Allow to use Python 3.7.0: https://github.com/airbytehq/airbyte/pull/3566
+
 ## 0.1.2
 Fix an issue that caused infinite pagination: https://github.com/airbytehq/airbyte/pull/3366
 

--- a/airbyte-cdk/python/docs/tutorials/cdk-tutorial-python-http/0-getting-started.md
+++ b/airbyte-cdk/python/docs/tutorials/cdk-tutorial-python-http/0-getting-started.md
@@ -10,7 +10,7 @@ This is a step-by-step guide for how to create an Airbyte source in Python to re
 * Docker
 * NodeJS \(only used to generate the connector\). We'll remove the NodeJS dependency soon.
 
-All the commands below assume that `python` points to a version of python &gt;=3.7.9. On some systems, `python` points to a Python2 installation and `python3` points to Python3. If this is the case on your machine, substitute all `python` commands in this guide with `python3`.
+All the commands below assume that `python` points to a version of python &gt;=3.7.0. On some systems, `python` points to a Python2 installation and `python3` points to Python3. If this is the case on your machine, substitute all `python` commands in this guide with `python3`.
 
 ## Checklist
 

--- a/airbyte-cdk/python/docs/tutorials/http_api_source.md
+++ b/airbyte-cdk/python/docs/tutorials/http_api_source.md
@@ -11,7 +11,7 @@ Exchangerates API as an example since it is both simple but demonstrates a lot o
 * Docker
 * NodeJS (only used to generate the connector). We'll remove the NodeJS dependency soon.
 
-All the commands below assume that `python` points to a version of python >=3.7.9. On some systems, `python` points to a Python2 installation and `python3` points to Python3. If this is the case on your machine, substitute all `python` commands in this guide with `python3`.
+All the commands below assume that `python` points to a version of python >=3.7.0. On some systems, `python` points to a Python2 installation and `python3` points to Python3. If this is the case on your machine, substitute all `python` commands in this guide with `python3`.
 
 ## Checklist
 * Step 1: Create the source using the template

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -35,7 +35,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.3",
+    version="0.1.4",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -72,7 +72,7 @@ setup(
         "PyYAML==5.4",
         "requests",
     ],
-    python_requires=">=3.7.9",
+    python_requires=">=3.7.0",
     extras_require={
         "dev": [
             "MyPy==0.812",


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/issues/3578  Allow Python CDK to work with Python 3.7.X

## How
Updated python version in `setup.py`

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `setup.py`
