### PR TITLE
Add the new Facebook API v10.0 fields to the ads_insights schema. #3646

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e7778cfc-e97c-4458-9ecb-b4f2bba8946c.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e7778cfc-e97c-4458-9ecb-b4f2bba8946c.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "e7778cfc-e97c-4458-9ecb-b4f2bba8946c",
   "name": "Facebook Marketing",
   "dockerRepository": "airbyte/source-facebook-marketing",
-  "dockerImageTag": "0.2.6",
+  "dockerImageTag": "0.2.7",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-facebook-marketing",
   "icon": "facebook.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -96,7 +96,7 @@
 - sourceDefinitionId: e7778cfc-e97c-4458-9ecb-b4f2bba8946c
   name: Facebook Marketing
   dockerRepository: airbyte/source-facebook-marketing
-  dockerImageTag: 0.2.6
+  dockerImageTag: 0.2.7
   documentationUrl: https://hub.docker.com/r/airbyte/source-facebook-marketing
   icon: facebook.svg
 - sourceDefinitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c

--- a/airbyte-integrations/connectors/source-facebook-marketing/.dockerignore
+++ b/airbyte-integrations/connectors/source-facebook-marketing/.dockerignore
@@ -1,5 +1,4 @@
 *
-!Dockerfile
 !source_facebook_marketing
 !setup.py
 !main.py

--- a/airbyte-integrations/connectors/source-facebook-marketing/.dockerignore
+++ b/airbyte-integrations/connectors/source-facebook-marketing/.dockerignore
@@ -1,0 +1,5 @@
+*
+!Dockerfile
+!source_facebook_marketing
+!setup.py
+!main.py

--- a/airbyte-integrations/connectors/source-facebook-marketing/CHANGELOG.md
+++ b/airbyte-integrations/connectors/source-facebook-marketing/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## 0.2.4
-Fix an issue that caused losing Insights data from the past 28 days while incremental sync: https://github.com/airbytehq/airbyte/pull/3395
-
-## 0.2.5
-Allow configuring insights lookback window (#3396)
+## 0.2.7
+Add missing fields to AdInsights streams (#3693) 
 
 ## 0.2.6
 Fix handling call rate limit (#3525) 
 
-## 0.2.7
-Add missing fields to AdInsights streams (#3693) 
+## 0.2.5
+Allow configuring insights lookback window (#3396)
+
+## 0.2.4
+Fix an issue that caused losing Insights data from the past 28 days while incremental sync: https://github.com/airbytehq/airbyte/pull/3395

--- a/airbyte-integrations/connectors/source-facebook-marketing/CHANGELOG.md
+++ b/airbyte-integrations/connectors/source-facebook-marketing/CHANGELOG.md
@@ -8,3 +8,6 @@ Allow configuring insights lookback window (#3396)
 
 ## 0.2.6
 Fix handling call rate limit (#3525) 
+
+## 0.2.7
+Add missing fields to AdInsights streams (#3693) 

--- a/airbyte-integrations/connectors/source-facebook-marketing/Dockerfile
+++ b/airbyte-integrations/connectors/source-facebook-marketing/Dockerfile
@@ -11,5 +11,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.6
+LABEL io.airbyte.version=0.2.7
 LABEL io.airbyte.name=airbyte/source-facebook-marketing

--- a/airbyte-integrations/connectors/source-facebook-marketing/sample_files/configured_catalog_adsinsights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/sample_files/configured_catalog_adsinsights.json
@@ -540,7 +540,7 @@
     },
     {
       "stream": {
-        "name": "ads_insights_platform_and_device",
+        "name": "ads_insights_age_and_gender",
         "json_schema": {
           "properties": {
             "account_currency": {
@@ -575,6 +575,9 @@
             },
             "adset_name": {
               "type": ["null", "string"]
+            },
+            "age": {
+              "type": ["null", "integer", "string"]
             },
             "age_targeting": {
               "type": ["null", "string"]
@@ -737,6 +740,9 @@
             },
             "full_view_reach": {
               "type": ["null", "number"]
+            },
+            "gender": {
+              "type": ["null", "string"]
             },
             "gender_targeting": {
               "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-facebook-marketing/sample_files/configured_catalog_adsinsights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/sample_files/configured_catalog_adsinsights.json
@@ -542,544 +542,352 @@
       "stream": {
         "name": "ads_insights_platform_and_device",
         "json_schema": {
-          "type": ["null", "object"],
           "properties": {
-            "unique_actions": {
-              "type": ["null", "array"],
-              "items": {
-                "type": ["null", "object"],
-                "properties": {
-                  "1d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "1d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "action_destination": {
-                    "type": ["null", "string"]
-                  },
-                  "action_target_id": {
-                    "type": ["null", "string"]
-                  },
-                  "action_type": {
-                    "type": ["null", "string"]
-                  },
-                  "value": {
-                    "type": ["null", "number"]
-                  }
-                }
-              }
-            },
-            "actions": {
-              "type": ["null", "array"],
-              "items": {
-                "type": ["null", "object"],
-                "properties": {
-                  "1d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "1d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "action_destination": {
-                    "type": ["null", "string"]
-                  },
-                  "action_target_id": {
-                    "type": ["null", "string"]
-                  },
-                  "action_type": {
-                    "type": ["null", "string"]
-                  },
-                  "value": {
-                    "type": ["null", "number"]
-                  }
-                }
-              }
-            },
-            "action_values": {
-              "type": ["null", "array"],
-              "items": {
-                "type": ["null", "object"],
-                "properties": {
-                  "1d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "1d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "action_destination": {
-                    "type": ["null", "string"]
-                  },
-                  "action_target_id": {
-                    "type": ["null", "string"]
-                  },
-                  "action_type": {
-                    "type": ["null", "string"]
-                  },
-                  "value": {
-                    "type": ["null", "number"]
-                  }
-                }
-              }
-            },
-            "outbound_clicks": {
-              "type": ["null", "array"],
-              "items": {
-                "type": ["null", "object"],
-                "properties": {
-                  "1d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "1d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "action_destination": {
-                    "type": ["null", "string"]
-                  },
-                  "action_target_id": {
-                    "type": ["null", "string"]
-                  },
-                  "action_type": {
-                    "type": ["null", "string"]
-                  },
-                  "value": {
-                    "type": ["null", "number"]
-                  }
-                }
-              }
-            },
-            "video_30_sec_watched_actions": {
-              "type": ["null", "array"],
-              "items": {
-                "type": ["null", "object"],
-                "properties": {
-                  "1d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "1d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "action_destination": {
-                    "type": ["null", "string"]
-                  },
-                  "action_target_id": {
-                    "type": ["null", "string"]
-                  },
-                  "action_type": {
-                    "type": ["null", "string"]
-                  },
-                  "value": {
-                    "type": ["null", "number"]
-                  }
-                }
-              }
-            },
-            "video_p25_watched_actions": {
-              "type": ["null", "array"],
-              "items": {
-                "type": ["null", "object"],
-                "properties": {
-                  "1d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "1d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "action_destination": {
-                    "type": ["null", "string"]
-                  },
-                  "action_target_id": {
-                    "type": ["null", "string"]
-                  },
-                  "action_type": {
-                    "type": ["null", "string"]
-                  },
-                  "value": {
-                    "type": ["null", "number"]
-                  }
-                }
-              }
-            },
-            "video_p50_watched_actions": {
-              "type": ["null", "array"],
-              "items": {
-                "type": ["null", "object"],
-                "properties": {
-                  "1d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "1d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "action_destination": {
-                    "type": ["null", "string"]
-                  },
-                  "action_target_id": {
-                    "type": ["null", "string"]
-                  },
-                  "action_type": {
-                    "type": ["null", "string"]
-                  },
-                  "value": {
-                    "type": ["null", "number"]
-                  }
-                }
-              }
-            },
-            "video_p75_watched_actions": {
-              "type": ["null", "array"],
-              "items": {
-                "type": ["null", "object"],
-                "properties": {
-                  "1d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "1d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "action_destination": {
-                    "type": ["null", "string"]
-                  },
-                  "action_target_id": {
-                    "type": ["null", "string"]
-                  },
-                  "action_type": {
-                    "type": ["null", "string"]
-                  },
-                  "value": {
-                    "type": ["null", "number"]
-                  }
-                }
-              }
-            },
-            "video_p100_watched_actions": {
-              "type": ["null", "array"],
-              "items": {
-                "type": ["null", "object"],
-                "properties": {
-                  "1d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_click": {
-                    "type": ["null", "number"]
-                  },
-                  "1d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "7d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "28d_view": {
-                    "type": ["null", "number"]
-                  },
-                  "action_destination": {
-                    "type": ["null", "string"]
-                  },
-                  "action_target_id": {
-                    "type": ["null", "string"]
-                  },
-                  "action_type": {
-                    "type": ["null", "string"]
-                  },
-                  "value": {
-                    "type": ["null", "number"]
-                  }
-                }
-              }
-            },
-            "video_play_curve_actions": {
-              "type": ["null", "array"],
-              "items": {
-                "type": ["null", "object"],
-                "properties": {
-                  "action_type": {
-                    "type": ["null", "string"]
-                  },
-                  "value": {
-                    "type": ["null", "array"],
-                    "items": {
-                      "type": ["null", "integer"]
-                    }
-                  }
-                }
-              }
-            },
-            "impression_device": {
+            "account_currency": {
               "type": ["null", "string"]
-            },
-            "platform_position": {
-              "type": ["null", "string"]
-            },
-            "publisher_platform": {
-              "type": ["null", "string"]
-            },
-            "clicks": {
-              "type": ["null", "integer"]
-            },
-            "date_stop": {
-              "type": ["null", "string"],
-              "format": "date-time"
-            },
-            "ad_id": {
-              "type": ["null", "string"]
-            },
-            "website_ctr": {
-              "type": ["null", "array"],
-              "items": {
-                "type": ["null", "object"],
-                "properties": {
-                  "value": {
-                    "type": ["null", "number"]
-                  },
-                  "action_destination": {
-                    "type": ["null", "string"]
-                  },
-                  "action_target_id": {
-                    "type": ["null", "string"]
-                  },
-                  "action_type": {
-                    "type": ["null", "string"]
-                  }
-                }
-              }
-            },
-            "unique_inline_link_click_ctr": {
-              "type": ["null", "number"]
-            },
-            "adset_id": {
-              "type": ["null", "string"]
-            },
-            "frequency": {
-              "type": ["null", "number"]
-            },
-            "account_name": {
-              "type": ["null", "string"]
-            },
-            "canvas_avg_view_time": {
-              "type": ["null", "number"]
-            },
-            "unique_inline_link_clicks": {
-              "type": ["null", "integer"]
-            },
-            "cost_per_unique_action_type": {
-              "type": ["null", "array"],
-              "items": {
-                "type": ["null", "object"],
-                "properties": {
-                  "value": {
-                    "type": ["null", "string"]
-                  },
-                  "action_type": {
-                    "type": ["null", "string"]
-                  }
-                }
-              }
-            },
-            "inline_post_engagement": {
-              "type": ["null", "integer"]
-            },
-            "campaign_name": {
-              "type": ["null", "string"]
-            },
-            "inline_link_clicks": {
-              "type": ["null", "integer"]
-            },
-            "campaign_id": {
-              "type": ["null", "string"]
-            },
-            "cpc": {
-              "type": ["null", "number"]
-            },
-            "ad_name": {
-              "type": ["null", "string"]
-            },
-            "cost_per_unique_inline_link_click": {
-              "type": ["null", "number"]
-            },
-            "cpm": {
-              "type": ["null", "number"]
-            },
-            "cost_per_inline_post_engagement": {
-              "type": ["null", "number"]
-            },
-            "inline_link_click_ctr": {
-              "type": ["null", "number"]
-            },
-            "cpp": {
-              "type": ["null", "number"]
-            },
-            "cost_per_action_type": {
-              "type": ["null", "array"],
-              "items": {
-                "type": ["null", "object"],
-                "properties": {
-                  "value": {
-                    "type": ["null", "string"]
-                  },
-                  "action_type": {
-                    "type": ["null", "string"]
-                  }
-                }
-              }
-            },
-            "unique_link_clicks_ctr": {
-              "type": ["null", "number"]
-            },
-            "spend": {
-              "type": ["null", "number"]
-            },
-            "cost_per_unique_click": {
-              "type": ["null", "number"]
-            },
-            "adset_name": {
-              "type": ["null", "string"]
-            },
-            "unique_clicks": {
-              "type": ["null", "integer"]
-            },
-            "social_spend": {
-              "type": ["null", "number"]
-            },
-            "reach": {
-              "type": ["null", "integer"]
-            },
-            "canvas_avg_view_percent": {
-              "type": ["null", "number"]
             },
             "account_id": {
               "type": ["null", "string"]
             },
-            "date_start": {
-              "type": ["null", "string"],
-              "format": "date-time"
-            },
-            "objective": {
+            "account_name": {
               "type": ["null", "string"]
             },
-            "impressions": {
+            "action_values": {
+              "$ref": "ads_action_stats.json"
+            },
+            "actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "ad_click_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "ad_id": {
+              "type": ["null", "string"]
+            },
+            "ad_impression_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "ad_name": {
+              "type": ["null", "string"]
+            },
+            "adset_id": {
+              "type": ["null", "string"]
+            },
+            "adset_name": {
+              "type": ["null", "string"]
+            },
+            "age_targeting": {
+              "type": ["null", "string"]
+            },
+            "attribution_setting": {
+              "type": ["null", "string"]
+            },
+            "auction_bid": {
+              "type": ["null", "number"]
+            },
+            "auction_competitiveness": {
+              "type": ["null", "number"]
+            },
+            "auction_max_competitor_bid": {
+              "type": ["null", "number"]
+            },
+            "buying_type": {
+              "type": ["null", "string"]
+            },
+            "campaign_id": {
+              "type": ["null", "string"]
+            },
+            "campaign_name": {
+              "type": ["null", "string"]
+            },
+            "canvas_avg_view_percent": {
+              "type": ["null", "number"]
+            },
+            "canvas_avg_view_time": {
+              "type": ["null", "number"]
+            },
+            "catalog_segment_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "catalog_segment_value": {
+              "$ref": "ads_action_stats.json"
+            },
+            "catalog_segment_value_mobile_purchase_roas": {
+              "$ref": "ads_action_stats.json"
+            },
+            "catalog_segment_value_omni_purchase_roas": {
+              "$ref": "ads_action_stats.json"
+            },
+            "catalog_segment_value_website_purchase_roas": {
+              "$ref": "ads_action_stats.json"
+            },
+            "clicks": {
               "type": ["null", "integer"]
             },
-            "unique_ctr": {
+            "conversion_rate_ranking": {
+              "type": ["null", "string"]
+            },
+            "conversion_values": {
+              "$ref": "ads_action_stats.json"
+            },
+            "conversions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "converted_product_quantity": {
+              "$ref": "ads_action_stats.json"
+            },
+            "converted_product_value": {
+              "$ref": "ads_action_stats.json"
+            },
+            "cost_per_15_sec_video_view": {
+              "$ref": "ads_action_stats.json"
+            },
+            "cost_per_2_sec_continuous_video_view": {
+              "$ref": "ads_action_stats.json"
+            },
+            "cost_per_action_type": {
+              "$ref": "ads_action_stats.json"
+            },
+            "cost_per_ad_click": {
+              "$ref": "ads_action_stats.json"
+            },
+            "cost_per_conversion": {
+              "$ref": "ads_action_stats.json"
+            },
+            "cost_per_estimated_ad_recallers": {
               "type": ["null", "number"]
             },
             "cost_per_inline_link_click": {
               "type": ["null", "number"]
             },
+            "cost_per_inline_post_engagement": {
+              "type": ["null", "number"]
+            },
+            "cost_per_outbound_click": {
+              "$ref": "ads_action_stats.json"
+            },
+            "cost_per_store_visit_action": {
+              "$ref": "ads_action_stats.json"
+            },
+            "cost_per_thruplay": {
+              "$ref": "ads_action_stats.json"
+            },
+            "cost_per_unique_action_type": {
+              "$ref": "ads_action_stats.json"
+            },
+            "cost_per_unique_click": {
+              "type": ["null", "number"]
+            },
+            "cost_per_unique_inline_link_click": {
+              "type": ["null", "number"]
+            },
+            "cost_per_unique_outbound_click": {
+              "$ref": "ads_action_stats.json"
+            },
+            "cpc": {
+              "type": ["null", "number"]
+            },
+            "cpm": {
+              "type": ["null", "number"]
+            },
+            "cpp": {
+              "type": ["null", "number"]
+            },
+            "created_time": {
+              "format": "date-time",
+              "type": ["null", "string"]
+            },
             "ctr": {
               "type": ["null", "number"]
             },
-            "placement": {
+            "date_start": {
+              "format": "date-time",
               "type": ["null", "string"]
             },
-            "quality_ranking": {
+            "date_stop": {
+              "format": "date-time",
               "type": ["null", "string"]
             },
             "engagement_rate_ranking": {
               "type": ["null", "string"]
             },
-            "conversion_rate_ranking": {
+            "estimated_ad_recall_rate": {
+              "type": ["null", "number"]
+            },
+            "estimated_ad_recall_rate_lower_bound": {
+              "type": ["null", "number"]
+            },
+            "estimated_ad_recall_rate_upper_bound": {
+              "type": ["null", "number"]
+            },
+            "estimated_ad_recallers": {
+              "type": ["null", "number"]
+            },
+            "estimated_ad_recallers_lower_bound": {
+              "type": ["null", "number"]
+            },
+            "estimated_ad_recallers_upper_bound": {
+              "type": ["null", "number"]
+            },
+            "frequency": {
+              "type": ["null", "number"]
+            },
+            "full_view_impressions": {
+              "type": ["null", "number"]
+            },
+            "full_view_reach": {
+              "type": ["null", "number"]
+            },
+            "gender_targeting": {
               "type": ["null", "string"]
+            },
+            "impressions": {
+              "type": ["null", "integer"]
+            },
+            "inline_link_click_ctr": {
+              "type": ["null", "number"]
+            },
+            "inline_link_clicks": {
+              "type": ["null", "integer"]
+            },
+            "inline_post_engagement": {
+              "type": ["null", "integer"]
+            },
+            "instant_experience_clicks_to_open": {
+              "type": ["null", "number"]
+            },
+            "instant_experience_clicks_to_start": {
+              "type": ["null", "number"]
+            },
+            "instant_experience_outbound_clicks": {
+              "type": ["null", "integer"]
+            },
+            "labels": {
+              "type": ["null", "string"]
+            },
+            "location": {
+              "type": ["null", "string"]
+            },
+            "mobile_app_purchase_roas": {
+              "$ref": "ads_action_stats.json"
+            },
+            "objective": {
+              "type": ["null", "string"]
+            },
+            "optimization_goal": {
+              "type": ["null", "string"]
+            },
+            "outbound_clicks": {
+              "$ref": "ads_action_stats.json"
+            },
+            "outbound_clicks_ctr": {
+              "$ref": "ads_action_stats.json"
+            },
+            "purchase_roas": {
+              "$ref": "ads_action_stats.json"
+            },
+            "qualifying_question_qualify_answer_rate": {
+              "type": ["null", "number"]
+            },
+            "quality_ranking": {
+              "type": ["null", "string"]
+            },
+            "reach": {
+              "type": ["null", "integer"]
+            },
+            "social_spend": {
+              "type": ["null", "number"]
+            },
+            "spend": {
+              "type": ["null", "number"]
+            },
+            "store_visit_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "unique_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "unique_clicks": {
+              "type": ["null", "integer"]
+            },
+            "unique_ctr": {
+              "type": ["null", "number"]
+            },
+            "unique_inline_link_click_ctr": {
+              "type": ["null", "number"]
+            },
+            "unique_inline_link_clicks": {
+              "type": ["null", "integer"]
+            },
+            "unique_link_clicks_ctr": {
+              "type": ["null", "number"]
+            },
+            "unique_outbound_clicks": {
+              "$ref": "ads_action_stats.json"
+            },
+            "unique_outbound_clicks_ctr": {
+              "$ref": "ads_action_stats.json"
+            },
+            "updated_time": {
+              "format": "date-time",
+              "type": ["null", "string"]
+            },
+            "video_15_sec_watched_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "video_30_sec_watched_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "video_avg_time_watched_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "video_continuous_2_sec_watched_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "video_p100_watched_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "video_p25_watched_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "video_p50_watched_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "video_p75_watched_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "video_p95_watched_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "video_play_actions": {
+              "$ref": "ads_histogram_stats.json"
+            },
+            "video_play_curve_actions": {
+              "$ref": "ads_histogram_stats.json"
+            },
+            "video_play_retention_0_to_15s_actions": {
+              "$ref": "ads_histogram_stats.json"
+            },
+            "video_play_retention_20_to_60s_actions": {
+              "$ref": "ads_histogram_stats.json"
+            },
+            "video_play_retention_graph_actions": {
+              "$ref": "ads_histogram_stats.json"
+            },
+            "video_time_watched_actions": {
+              "$ref": "ads_action_stats.json"
+            },
+            "website_ctr": {
+              "$ref": "ads_action_stats.json"
+            },
+            "website_purchase_roas": {
+              "$ref": "ads_action_stats.json"
+            },
+            "wish_bid": {
+              "type": ["null", "number"]
             }
-          }
+          },
+          "type": ["null", "object"]
         },
         "supported_sync_modes": ["incremental"],
         "source_defined_cursor": true

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/client/api.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/client/api.py
@@ -359,11 +359,15 @@ class AdsInsightAPI(IncrementalStreamAPI):
             job = job.api_get()
             job_progress_pct = job["async_percent_completion"]
             logger.info(f"ReportRunId {job['report_run_id']} is {job_progress_pct}% complete")
+            runtime = pendulum.now() - start_time
 
             if job["async_status"] == "Job Completed":
                 return job
+            elif job["async_status"] == "Job Failed":
+                raise JobTimeoutException(f"AdReportRun {job} failed after {runtime.in_seconds()} seconds.")
+            elif job["async_status"] == "Job Skipped":
+                raise JobTimeoutException(f"AdReportRun {job} skipped after {runtime.in_seconds()} seconds.")
 
-            runtime = pendulum.now() - start_time
             if runtime > self.MAX_WAIT_TO_START and job_progress_pct == 0:
                 raise JobTimeoutException(
                     f"AdReportRun {job} did not start after {runtime.in_seconds()} seconds. This is an intermittent error which may be fixed by retrying the job. Aborting."

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/client/common.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/client/common.py
@@ -83,7 +83,7 @@ def retry_pattern(backoff_type, exception, **wait_gen_kwargs):
             if exc.api_error_code() in FACEBOOK_API_CALL_LIMIT_ERROR_CODES:
                 return handle_call_rate_response(exc)
             return exc.api_transient_error() or exc.api_error_subcode() == FACEBOOK_UNKNOWN_ERROR_CODE
-        return False
+        return True
 
     return backoff.on_exception(
         backoff_type,

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -1,22 +1,13 @@
 {
   "properties": {
     "account_currency": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "account_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "account_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "action_values": {
       "$ref": "ads_action_stats.json"
@@ -28,91 +19,49 @@
       "$ref": "ads_action_stats.json"
     },
     "ad_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "ad_impression_actions": {
       "$ref": "ads_action_stats.json"
     },
     "ad_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "adset_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "adset_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "age_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "attribution_setting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "auction_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "auction_competitiveness": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "auction_max_competitor_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "buying_type": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaign_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaign_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "canvas_avg_view_percent": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "canvas_avg_view_time": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "catalog_segment_actions": {
       "$ref": "ads_action_stats.json"
@@ -130,16 +79,10 @@
       "$ref": "ads_action_stats.json"
     },
     "clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "conversion_rate_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "conversion_values": {
       "$ref": "ads_action_stats.json"
@@ -169,22 +112,13 @@
       "$ref": "ads_action_stats.json"
     },
     "cost_per_estimated_ad_recallers": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_inline_link_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_inline_post_engagement": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_outbound_click": {
       "$ref": "ads_action_stats.json"
@@ -199,199 +133,106 @@
       "$ref": "ads_action_stats.json"
     },
     "cost_per_unique_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_unique_inline_link_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_unique_outbound_click": {
       "$ref": "ads_action_stats.json"
     },
     "cpc": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cpm": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cpp": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "created_time": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "date_start": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "date_stop": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "engagement_rate_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "estimated_ad_recall_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recall_rate_lower_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recall_rate_upper_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers_lower_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers_upper_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "frequency": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "full_view_impressions": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "full_view_reach": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "gender_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "impressions": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "inline_link_click_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "inline_link_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "inline_post_engagement": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "instant_experience_clicks_to_open": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "instant_experience_clicks_to_start": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "instant_experience_outbound_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "labels": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "location": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "mobile_app_purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "objective": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "optimization_goal": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "outbound_clicks": {
       "$ref": "ads_action_stats.json"
@@ -403,34 +244,19 @@
       "$ref": "ads_action_stats.json"
     },
     "qualifying_question_qualify_answer_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "quality_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "reach": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "social_spend": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "spend": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "store_visit_actions": {
       "$ref": "ads_action_stats.json"
@@ -439,34 +265,19 @@
       "$ref": "ads_action_stats.json"
     },
     "unique_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "unique_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_inline_link_click_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_inline_link_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "unique_link_clicks_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_outbound_clicks": {
       "$ref": "ads_action_stats.json"
@@ -476,10 +287,7 @@
     },
     "updated_time": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "video_15_sec_watched_actions": {
       "$ref": "ads_action_stats.json"
@@ -533,14 +341,8 @@
       "$ref": "ads_action_stats.json"
     },
     "wish_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     }
   },
-  "type": [
-    "null",
-    "object"
-  ]
+  "type": ["null", "object"]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -21,26 +21,6 @@
     "ad_id": {
       "type": ["null", "string"]
     },
-    "website_ctr": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "number"]
-          },
-          "action_destination": {
-            "type": ["null", "string"]
-          },
-          "action_target_id": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
     "unique_inline_link_click_ctr": {
       "type": ["null", "number"]
     },
@@ -106,20 +86,6 @@
     "cpp": {
       "type": ["null", "number"]
     },
-    "cost_per_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
     "unique_link_clicks_ctr": {
       "type": ["null", "number"]
     },
@@ -172,8 +138,92 @@
     "cost_per_inline_link_click": {
       "type": ["null", "number"]
     },
-    "ctr": {
-      "type": ["null", "number"]
-    }
+    "ctr": { "type": ["null", "number"] },
+    "account_currency": { "type": ["null", "string"] },
+    "activity_recency": { "type": ["null", "string"] },
+    "ad_click_actions": { "$ref": "ads_action_stats.json" },
+    "ad_format_asset": { "type": ["null", "string"] },
+    "ad_impression_actions": { "$ref": "ads_action_stats.json" },
+    "age_targeting": { "type": ["null", "string"] },
+    "attribution_setting": { "type": ["null", "string"] },
+    "auction_bid": { "type": ["null", "number"] },
+    "auction_competitiveness": { "type": ["null", "number"] },
+    "auction_max_competitor_bid": { "type": ["null", "number"] },
+    "buying_type": { "type": ["null", "string"] },
+    "catalog_segment_actions": { "$ref": "ads_action_stats.json" },
+    "catalog_segment_value": { "$ref": "ads_action_stats.json" },
+    "catalog_segment_value_mobile_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "catalog_segment_value_omni_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "catalog_segment_value_website_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "conversion_values": { "$ref": "ads_action_stats.json" },
+    "conversions": { "$ref": "ads_action_stats.json" },
+    "converted_product_quantity": { "$ref": "ads_action_stats.json" },
+    "converted_product_value": { "$ref": "ads_action_stats.json" },
+    "cost_per_15_sec_video_view": { "$ref": "ads_action_stats.json" },
+    "cost_per_2_sec_continuous_video_view": { "$ref": "ads_action_stats.json" },
+    "cost_per_action_type": { "$ref": "ads_action_stats.json" },
+    "cost_per_ad_click": { "$ref": "ads_action_stats.json" },
+    "cost_per_conversion": { "$ref": "ads_action_stats.json" },
+    "cost_per_dda_countby_convs": { "type": ["null", "number"] },
+    "cost_per_one_thousand_ad_impression": { "$ref": "ads_action_stats.json" },
+    "cost_per_outbound_click": { "$ref": "ads_action_stats.json" },
+    "cost_per_store_visit_action": { "$ref": "ads_action_stats.json" },
+    "cost_per_thruplay": { "$ref": "ads_action_stats.json" },
+    "cost_per_unique_action_type": { "$ref": "ads_action_stats.json" },
+    "cost_per_unique_conversion": { "$ref": "ads_action_stats.json" },
+    "cost_per_unique_outbound_click": { "$ref": "ads_action_stats.json" },
+    "country": { "type": ["null", "string"] },
+    "created_time": { "type": ["null", "string"], "format": "date-time" },
+    "country": { "type": ["null", "string"] },
+    "dda_countby_convs": { "type": ["null", "number"] },
+    "device_platform": { "type": ["null", "string"] },
+    "dma": { "type": ["null", "string"] },
+    "estimated_ad_recall_rate_lower_bound": { "type": ["null", "number"] },
+    "estimated_ad_recall_rate_upper_bound": { "type": ["null", "number"] },
+    "estimated_ad_recallers_lower_bound": { "type": ["null", "number"] },
+    "estimated_ad_recallers_upper_bound": { "type": ["null", "number"] },
+    "frequency_value": { "type": ["null", "string"] },
+    "full_view_impressions": { "type": ["null", "number"] },
+    "full_view_reach": { "type": ["null", "number"] },
+    "gender_targeting": { "type": ["null", "string"] },
+    "hourly_stats_aggregated_by_advertiser_time_zone": { "type": ["null", "string"] },
+    "hourly_stats_aggregated_by_audience_time_zone": { "type": ["null", "string"] },
+    "impression_device": { "type": ["null", "string"] },
+    "instant_experience_clicks_to_open": { "type": ["null", "number"] },
+    "instant_experience_clicks_to_start": { "type": ["null", "number"] },
+    "instant_experience_outbound_clicks": { "type": ["null", "integer"] },
+    "interactive_component_tap": { "$ref": "ads_action_stats.json" },
+    "labels": { "type": ["null", "string"] },
+    "location": { "type": ["null", "string"] },
+    "mobile_app_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "optimization_goal": { "type": ["null", "string"] },
+    "outbound_clicks_ctr": { "$ref": "ads_action_stats.json" },
+    "place_page_id": { "type": ["null", "string"] },
+    "place_page_name": { "type": ["null", "string"] },
+    "platform_position": { "type": ["null", "string"] },
+    "product_id": { "type": ["null", "string"] },
+    "publisher_platform": { "type": ["null", "string"] },
+    "purchase_roas": { "$ref": "ads_action_stats.json" },
+    "qualifying_question_qualify_answer_rate": { "type": ["null", "number"] },
+    "store_visit_actions": { "$ref": "ads_action_stats.json" },
+    "unique_conversions": { "$ref": "ads_action_stats.json" },
+    "unique_outbound_clicks": { "$ref": "ads_action_stats.json" },
+    "unique_outbound_clicks_ctr": { "$ref": "ads_action_stats.json" },
+    "unique_video_view_15_sec": { "$ref": "ads_action_stats.json" },
+    "updated_time": { "type": ["null", "string"], "format": "date-time" },
+    "video_15_sec_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_avg_time_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_continuous_2_sec_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_play_actions": { "$ref": "ads_histogram_stats.json" },
+    "video_play_retention_0_to_15s_actions": { "$ref": "ads_histogram_stats.json" },
+    "video_play_retention_20_to_60s_actions": { "$ref": "ads_histogram_stats.json" },
+    "video_play_retention_graph_actions": { "$ref": "ads_histogram_stats.json" },
+    "video_time_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
+    "website_ctr": { "$ref": "ads_action_stats.json" },
+    "website_purchase_roas": { "$ref": "ads_action_stats.json" },
+    "wish_bid": { "type": ["null", "number"] }
   }
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -1,5 +1,11 @@
 {
   "properties": {
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "account_id": {
       "type": [
         "null",
@@ -54,6 +60,12 @@
         "string"
       ]
     },
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "auction_bid": {
       "type": [
         "null",
@@ -102,7 +114,19 @@
         "number"
       ]
     },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
     "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "clicks": {
@@ -123,6 +147,12 @@
     "conversions": {
       "$ref": "ads_action_stats.json"
     },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
     "cost_per_15_sec_video_view": {
       "$ref": "ads_action_stats.json"
     },
@@ -137,6 +167,12 @@
     },
     "cost_per_conversion": {
       "$ref": "ads_action_stats.json"
+    },
+    "cost_per_estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
     },
     "cost_per_inline_link_click": {
       "type": [
@@ -167,9 +203,6 @@
         "null",
         "number"
       ]
-    },
-    "cost_per_unique_conversion": {
-      "$ref": "ads_action_stats.json"
     },
     "cost_per_unique_inline_link_click": {
       "type": [
@@ -231,6 +264,12 @@
         "string"
       ]
     },
+    "estimated_ad_recall_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
     "estimated_ad_recall_rate_lower_bound": {
       "type": [
         "null",
@@ -238,6 +277,12 @@
       ]
     },
     "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers": {
       "type": [
         "null",
         "number"
@@ -303,6 +348,24 @@
         "integer"
       ]
     },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
     "labels": {
       "type": [
         "null",
@@ -315,7 +378,16 @@
         "string"
       ]
     },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
     "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
       "type": [
         "null",
         "string"
@@ -326,6 +398,15 @@
     },
     "outbound_clicks_ctr": {
       "$ref": "ads_action_stats.json"
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
     },
     "quality_ranking": {
       "type": [
@@ -351,6 +432,9 @@
         "number"
       ]
     },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
     "unique_actions": {
       "$ref": "ads_action_stats.json"
     },
@@ -359,9 +443,6 @@
         "null",
         "integer"
       ]
-    },
-    "unique_conversions": {
-      "$ref": "ads_action_stats.json"
     },
     "unique_ctr": {
       "type": [
@@ -439,10 +520,16 @@
     "video_play_retention_20_to_60s_actions": {
       "$ref": "ads_histogram_stats.json"
     },
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
     "video_time_watched_actions": {
       "$ref": "ads_action_stats.json"
     },
     "website_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "wish_bid": {

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -1,229 +1,639 @@
 {
-  "type": ["null", "object"],
   "properties": {
-    "unique_actions": { "$ref": "ads_action_stats.json" },
-    "actions": { "$ref": "ads_action_stats.json" },
-    "action_values": { "$ref": "ads_action_stats.json" },
-    "outbound_clicks": { "$ref": "ads_action_stats.json" },
-    "video_30_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p25_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p50_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p75_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p100_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_play_curve_actions": { "$ref": "ads_histogram_stats.json" },
-    "clicks": {
-      "type": ["null", "integer"]
-    },
-    "date_stop": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "ad_id": {
-      "type": ["null", "string"]
-    },
-    "unique_inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "adset_id": {
-      "type": ["null", "string"]
-    },
-    "frequency": {
-      "type": ["null", "number"]
-    },
-    "account_name": {
-      "type": ["null", "string"]
-    },
-    "canvas_avg_view_time": {
-      "type": ["null", "number"]
-    },
-    "unique_inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "cost_per_unique_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "inline_post_engagement": {
-      "type": ["null", "integer"]
-    },
-    "campaign_name": {
-      "type": ["null", "string"]
-    },
-    "inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "campaign_id": {
-      "type": ["null", "string"]
-    },
-    "cpc": {
-      "type": ["null", "number"]
-    },
-    "ad_name": {
-      "type": ["null", "string"]
-    },
-    "cost_per_unique_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "cpm": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_post_engagement": {
-      "type": ["null", "number"]
-    },
-    "inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "cpp": {
-      "type": ["null", "number"]
-    },
-    "unique_link_clicks_ctr": {
-      "type": ["null", "number"]
-    },
-    "spend": {
-      "type": ["null", "number"]
-    },
-    "cost_per_unique_click": {
-      "type": ["null", "number"]
-    },
-    "adset_name": {
-      "type": ["null", "string"]
-    },
-    "unique_clicks": {
-      "type": ["null", "integer"]
-    },
-    "social_spend": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "canvas_avg_view_percent": {
-      "type": ["null", "number"]
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "account_id": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "date_start": {
-      "type": ["null", "string"],
-      "format": "date-time"
+    "account_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "objective": {
-      "type": ["null", "string"]
+    "action_values": {
+      "$ref": "ads_action_stats.json"
     },
-    "quality_ranking": {
-      "type": ["null", "string"]
+    "actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "engagement_rate_ranking": {
-      "type": ["null", "string"]
+    "activity_recency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_click_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "ad_format_asset": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_impression_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "ad_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "age_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "auction_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_competitiveness": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_max_competitor_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "buying_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_percent": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "canvas_avg_view_time": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "conversion_rate_ranking": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "impressions": {
-      "type": ["null", "integer"]
+    "conversion_values": {
+      "$ref": "ads_action_stats.json"
     },
-    "unique_ctr": {
-      "type": ["null", "number"]
+    "conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_15_sec_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_2_sec_continuous_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_ad_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_dda_countby_convs": {
+      "type": [
+        "null",
+        "number"
+      ]
     },
     "cost_per_inline_link_click": {
-      "type": ["null", "number"]
+      "type": [
+        "null",
+        "number"
+      ]
     },
-    "ctr": { "type": ["null", "number"] },
-    "account_currency": { "type": ["null", "string"] },
-    "activity_recency": { "type": ["null", "string"] },
-    "ad_click_actions": { "$ref": "ads_action_stats.json" },
-    "ad_format_asset": { "type": ["null", "string"] },
-    "ad_impression_actions": { "$ref": "ads_action_stats.json" },
-    "age_targeting": { "type": ["null", "string"] },
-    "attribution_setting": { "type": ["null", "string"] },
-    "auction_bid": { "type": ["null", "number"] },
-    "auction_competitiveness": { "type": ["null", "number"] },
-    "auction_max_competitor_bid": { "type": ["null", "number"] },
-    "buying_type": { "type": ["null", "string"] },
-    "catalog_segment_actions": { "$ref": "ads_action_stats.json" },
-    "catalog_segment_value": { "$ref": "ads_action_stats.json" },
-    "catalog_segment_value_mobile_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "catalog_segment_value_omni_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "catalog_segment_value_website_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "conversion_values": { "$ref": "ads_action_stats.json" },
-    "conversions": { "$ref": "ads_action_stats.json" },
-    "converted_product_quantity": { "$ref": "ads_action_stats.json" },
-    "converted_product_value": { "$ref": "ads_action_stats.json" },
-    "cost_per_15_sec_video_view": { "$ref": "ads_action_stats.json" },
-    "cost_per_2_sec_continuous_video_view": { "$ref": "ads_action_stats.json" },
-    "cost_per_action_type": { "$ref": "ads_action_stats.json" },
-    "cost_per_ad_click": { "$ref": "ads_action_stats.json" },
-    "cost_per_conversion": { "$ref": "ads_action_stats.json" },
-    "cost_per_dda_countby_convs": { "type": ["null", "number"] },
-    "cost_per_one_thousand_ad_impression": { "$ref": "ads_action_stats.json" },
-    "cost_per_outbound_click": { "$ref": "ads_action_stats.json" },
-    "cost_per_store_visit_action": { "$ref": "ads_action_stats.json" },
-    "cost_per_thruplay": { "$ref": "ads_action_stats.json" },
-    "cost_per_unique_action_type": { "$ref": "ads_action_stats.json" },
-    "cost_per_unique_conversion": { "$ref": "ads_action_stats.json" },
-    "cost_per_unique_outbound_click": { "$ref": "ads_action_stats.json" },
-    "country": { "type": ["null", "string"] },
-    "created_time": { "type": ["null", "string"], "format": "date-time" },
-    "country": { "type": ["null", "string"] },
-    "dda_countby_convs": { "type": ["null", "number"] },
-    "device_platform": { "type": ["null", "string"] },
-    "dma": { "type": ["null", "string"] },
-    "estimated_ad_recall_rate_lower_bound": { "type": ["null", "number"] },
-    "estimated_ad_recall_rate_upper_bound": { "type": ["null", "number"] },
-    "estimated_ad_recallers_lower_bound": { "type": ["null", "number"] },
-    "estimated_ad_recallers_upper_bound": { "type": ["null", "number"] },
-    "frequency_value": { "type": ["null", "string"] },
-    "full_view_impressions": { "type": ["null", "number"] },
-    "full_view_reach": { "type": ["null", "number"] },
-    "gender_targeting": { "type": ["null", "string"] },
-    "hourly_stats_aggregated_by_advertiser_time_zone": { "type": ["null", "string"] },
-    "hourly_stats_aggregated_by_audience_time_zone": { "type": ["null", "string"] },
-    "impression_device": { "type": ["null", "string"] },
-    "instant_experience_clicks_to_open": { "type": ["null", "number"] },
-    "instant_experience_clicks_to_start": { "type": ["null", "number"] },
-    "instant_experience_outbound_clicks": { "type": ["null", "integer"] },
-    "interactive_component_tap": { "$ref": "ads_action_stats.json" },
-    "labels": { "type": ["null", "string"] },
-    "location": { "type": ["null", "string"] },
-    "mobile_app_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "optimization_goal": { "type": ["null", "string"] },
-    "outbound_clicks_ctr": { "$ref": "ads_action_stats.json" },
-    "place_page_id": { "type": ["null", "string"] },
-    "place_page_name": { "type": ["null", "string"] },
-    "platform_position": { "type": ["null", "string"] },
-    "product_id": { "type": ["null", "string"] },
-    "publisher_platform": { "type": ["null", "string"] },
-    "purchase_roas": { "$ref": "ads_action_stats.json" },
-    "qualifying_question_qualify_answer_rate": { "type": ["null", "number"] },
-    "store_visit_actions": { "$ref": "ads_action_stats.json" },
-    "unique_conversions": { "$ref": "ads_action_stats.json" },
-    "unique_outbound_clicks": { "$ref": "ads_action_stats.json" },
-    "unique_outbound_clicks_ctr": { "$ref": "ads_action_stats.json" },
-    "unique_video_view_15_sec": { "$ref": "ads_action_stats.json" },
-    "updated_time": { "type": ["null", "string"], "format": "date-time" },
-    "video_15_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_avg_time_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_continuous_2_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_play_actions": { "$ref": "ads_histogram_stats.json" },
-    "video_play_retention_0_to_15s_actions": { "$ref": "ads_histogram_stats.json" },
-    "video_play_retention_20_to_60s_actions": { "$ref": "ads_histogram_stats.json" },
-    "video_play_retention_graph_actions": { "$ref": "ads_histogram_stats.json" },
-    "video_time_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p95_watched_actions": { "$ref": "ads_action_stats.json" },
-    "website_ctr": { "$ref": "ads_action_stats.json" },
-    "website_purchase_roas": { "$ref": "ads_action_stats.json" },
-    "wish_bid": { "type": ["null", "number"] }
-  }
+    "cost_per_inline_post_engagement": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_one_thousand_ad_impression": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_store_visit_action": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_thruplay": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "country": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "cpc": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpm": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpp": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "created_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "date_start": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_stop": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "dda_countby_convs": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "device_platform": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "dma": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "engagement_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recall_rate_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency_value": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "full_view_impressions": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_reach": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "gender_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "hourly_stats_aggregated_by_advertiser_time_zone": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "hourly_stats_aggregated_by_audience_time_zone": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impression_device": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_post_engagement": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "interactive_component_tap": {
+      "$ref": "ads_action_stats.json"
+    },
+    "labels": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "location": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "place_page_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "place_page_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "platform_position": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "product_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "publisher_platform": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "quality_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reach": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "social_spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_link_clicks_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_video_view_15_sec": {
+      "$ref": "ads_action_stats.json"
+    },
+    "updated_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "video_15_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_30_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_avg_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_continuous_2_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p100_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p25_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p50_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p75_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p95_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_play_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_curve_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_0_to_15s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_20_to_60s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "wish_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    }
+  },
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights.json
@@ -1,11 +1,5 @@
 {
   "properties": {
-    "account_currency": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "account_id": {
       "type": [
         "null",
@@ -24,20 +18,8 @@
     "actions": {
       "$ref": "ads_action_stats.json"
     },
-    "activity_recency": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "ad_click_actions": {
       "$ref": "ads_action_stats.json"
-    },
-    "ad_format_asset": {
-      "type": [
-        "null",
-        "string"
-      ]
     },
     "ad_id": {
       "type": [
@@ -67,12 +49,6 @@
       ]
     },
     "age_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "attribution_setting": {
       "type": [
         "null",
         "string"
@@ -126,19 +102,7 @@
         "number"
       ]
     },
-    "catalog_segment_actions": {
-      "$ref": "ads_action_stats.json"
-    },
     "catalog_segment_value": {
-      "$ref": "ads_action_stats.json"
-    },
-    "catalog_segment_value_mobile_purchase_roas": {
-      "$ref": "ads_action_stats.json"
-    },
-    "catalog_segment_value_omni_purchase_roas": {
-      "$ref": "ads_action_stats.json"
-    },
-    "catalog_segment_value_website_purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "clicks": {
@@ -159,12 +123,6 @@
     "conversions": {
       "$ref": "ads_action_stats.json"
     },
-    "converted_product_quantity": {
-      "$ref": "ads_action_stats.json"
-    },
-    "converted_product_value": {
-      "$ref": "ads_action_stats.json"
-    },
     "cost_per_15_sec_video_view": {
       "$ref": "ads_action_stats.json"
     },
@@ -180,12 +138,6 @@
     "cost_per_conversion": {
       "$ref": "ads_action_stats.json"
     },
-    "cost_per_dda_countby_convs": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
     "cost_per_inline_link_click": {
       "type": [
         "null",
@@ -197,9 +149,6 @@
         "null",
         "number"
       ]
-    },
-    "cost_per_one_thousand_ad_impression": {
-      "$ref": "ads_action_stats.json"
     },
     "cost_per_outbound_click": {
       "$ref": "ads_action_stats.json"
@@ -230,12 +179,6 @@
     },
     "cost_per_unique_outbound_click": {
       "$ref": "ads_action_stats.json"
-    },
-    "country": {
-      "type": [
-        "null",
-        "string"
-      ]
     },
     "cpc": {
       "type": [
@@ -282,24 +225,6 @@
         "string"
       ]
     },
-    "dda_countby_convs": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
-    "device_platform": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "dma": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "engagement_rate_ranking": {
       "type": [
         "null",
@@ -336,12 +261,6 @@
         "number"
       ]
     },
-    "frequency_value": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "full_view_impressions": {
       "type": [
         "null",
@@ -355,24 +274,6 @@
       ]
     },
     "gender_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "hourly_stats_aggregated_by_advertiser_time_zone": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "hourly_stats_aggregated_by_audience_time_zone": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "impression_device": {
       "type": [
         "null",
         "string"
@@ -402,27 +303,6 @@
         "integer"
       ]
     },
-    "instant_experience_clicks_to_open": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
-    "instant_experience_clicks_to_start": {
-      "type": [
-        "null",
-        "number"
-      ]
-    },
-    "instant_experience_outbound_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
-    },
-    "interactive_component_tap": {
-      "$ref": "ads_action_stats.json"
-    },
     "labels": {
       "type": [
         "null",
@@ -435,16 +315,7 @@
         "string"
       ]
     },
-    "mobile_app_purchase_roas": {
-      "$ref": "ads_action_stats.json"
-    },
     "objective": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "optimization_goal": {
       "type": [
         "null",
         "string"
@@ -455,45 +326,6 @@
     },
     "outbound_clicks_ctr": {
       "$ref": "ads_action_stats.json"
-    },
-    "place_page_id": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "place_page_name": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "platform_position": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "product_id": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "publisher_platform": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "purchase_roas": {
-      "$ref": "ads_action_stats.json"
-    },
-    "qualifying_question_qualify_answer_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
     },
     "quality_ranking": {
       "type": [
@@ -518,9 +350,6 @@
         "null",
         "number"
       ]
-    },
-    "store_visit_actions": {
-      "$ref": "ads_action_stats.json"
     },
     "unique_actions": {
       "$ref": "ads_action_stats.json"
@@ -562,9 +391,6 @@
       "$ref": "ads_action_stats.json"
     },
     "unique_outbound_clicks_ctr": {
-      "$ref": "ads_action_stats.json"
-    },
-    "unique_video_view_15_sec": {
       "$ref": "ads_action_stats.json"
     },
     "updated_time": {
@@ -613,16 +439,10 @@
     "video_play_retention_20_to_60s_actions": {
       "$ref": "ads_histogram_stats.json"
     },
-    "video_play_retention_graph_actions": {
-      "$ref": "ads_histogram_stats.json"
-    },
     "video_time_watched_actions": {
       "$ref": "ads_action_stats.json"
     },
     "website_ctr": {
-      "$ref": "ads_action_stats.json"
-    },
-    "website_purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "wish_bid": {

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_age_and_gender.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_age_and_gender.json
@@ -1,186 +1,559 @@
 {
-  "type": ["null", "object"],
   "properties": {
-    "unique_actions": { "$ref": "ads_action_stats.json" },
-    "actions": { "$ref": "ads_action_stats.json" },
-    "action_values": { "$ref": "ads_action_stats.json" },
-    "outbound_clicks": { "$ref": "ads_action_stats.json" },
-    "video_30_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p25_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p50_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p75_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p100_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_play_curve_actions": { "$ref": "ads_histogram_stats.json" },
-    "clicks": {
-      "type": ["null", "integer"]
-    },
-    "date_stop": {
-      "type": ["null", "string"]
-    },
-    "ad_id": {
-      "type": ["null", "string"]
-    },
-    "website_ctr": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "number"]
-          },
-          "action_destination": {
-            "type": ["null", "string"]
-          },
-          "action_target_id": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "adset_id": {
-      "type": ["null", "string"]
-    },
-    "frequency": {
-      "type": ["null", "number"]
-    },
-    "account_name": {
-      "type": ["null", "string"]
-    },
-    "canvas_avg_view_time": {
-      "type": ["null", "number"]
-    },
-    "unique_inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "cost_per_unique_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "inline_post_engagement": {
-      "type": ["null", "integer"]
-    },
-    "campaign_name": {
-      "type": ["null", "string"]
-    },
-    "inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "campaign_id": {
-      "type": ["null", "string"]
-    },
-    "cpc": {
-      "type": ["null", "number"]
-    },
-    "ad_name": {
-      "type": ["null", "string"]
-    },
-    "cost_per_unique_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "cpm": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_post_engagement": {
-      "type": ["null", "number"]
-    },
-    "inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "cpp": {
-      "type": ["null", "number"]
-    },
-    "cost_per_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_link_clicks_ctr": {
-      "type": ["null", "number"]
-    },
-    "spend": {
-      "type": ["null", "number"]
-    },
-    "cost_per_unique_click": {
-      "type": ["null", "number"]
-    },
-    "adset_name": {
-      "type": ["null", "string"]
-    },
-    "unique_clicks": {
-      "type": ["null", "integer"]
-    },
-    "social_spend": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "canvas_avg_view_percent": {
-      "type": ["null", "number"]
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "account_id": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "date_start": {
-      "type": ["null", "string"]
+    "account_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "objective": {
-      "type": ["null", "string"]
+    "action_values": {
+      "$ref": "ads_action_stats.json"
     },
-    "impressions": {
-      "type": ["null", "integer"]
+    "actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "unique_ctr": {
-      "type": ["null", "number"]
+    "ad_click_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "cost_per_inline_link_click": {
-      "type": ["null", "number"]
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "ctr": {
-      "type": ["null", "number"]
+    "ad_impression_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "reach": {
-      "type": ["null", "integer"]
+    "ad_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "age": {
-      "type": ["null", "integer", "string"]
+      "type": [
+        "null",
+        "integer",
+        "string"
+      ]
     },
-    "gender": {
-      "type": ["null", "string"]
+    "age_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "quality_ranking": {
-      "type": ["null", "string"]
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "engagement_rate_ranking": {
-      "type": ["null", "string"]
+    "auction_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_competitiveness": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_max_competitor_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "buying_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_percent": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "canvas_avg_view_time": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "conversion_rate_ranking": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "conversion_values": {
+      "$ref": "ads_action_stats.json"
+    },
+    "conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_15_sec_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_2_sec_continuous_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_ad_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_post_engagement": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_store_visit_action": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_thruplay": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cpc": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpm": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpp": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "created_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "date_start": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_stop": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "engagement_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recall_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_impressions": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_reach": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "gender": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "gender_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_post_engagement": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "labels": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "location": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "quality_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reach": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "social_spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_link_clicks_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "updated_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "video_15_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_30_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_avg_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_continuous_2_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p100_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p25_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p50_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p75_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p95_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_play_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_curve_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_0_to_15s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_20_to_60s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "wish_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
     }
-  }
+  },
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_age_and_gender.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_age_and_gender.json
@@ -1,22 +1,13 @@
 {
   "properties": {
     "account_currency": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "account_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "account_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "action_values": {
       "$ref": "ads_action_stats.json"
@@ -28,98 +19,52 @@
       "$ref": "ads_action_stats.json"
     },
     "ad_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "ad_impression_actions": {
       "$ref": "ads_action_stats.json"
     },
     "ad_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "adset_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "adset_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "age": {
-      "type": [
-        "null",
-        "integer",
-        "string"
-      ]
+      "type": ["null", "integer", "string"]
     },
     "age_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "attribution_setting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "auction_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "auction_competitiveness": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "auction_max_competitor_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "buying_type": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaign_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaign_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "canvas_avg_view_percent": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "canvas_avg_view_time": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "catalog_segment_actions": {
       "$ref": "ads_action_stats.json"
@@ -137,16 +82,10 @@
       "$ref": "ads_action_stats.json"
     },
     "clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "conversion_rate_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "conversion_values": {
       "$ref": "ads_action_stats.json"
@@ -176,22 +115,13 @@
       "$ref": "ads_action_stats.json"
     },
     "cost_per_estimated_ad_recallers": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_inline_link_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_inline_post_engagement": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_outbound_click": {
       "$ref": "ads_action_stats.json"
@@ -206,205 +136,109 @@
       "$ref": "ads_action_stats.json"
     },
     "cost_per_unique_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_unique_inline_link_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_unique_outbound_click": {
       "$ref": "ads_action_stats.json"
     },
     "cpc": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cpm": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cpp": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "created_time": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "date_start": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "date_stop": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "engagement_rate_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "estimated_ad_recall_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recall_rate_lower_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recall_rate_upper_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers_lower_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers_upper_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "frequency": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "full_view_impressions": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "full_view_reach": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "gender": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "gender_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "impressions": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "inline_link_click_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "inline_link_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "inline_post_engagement": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "instant_experience_clicks_to_open": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "instant_experience_clicks_to_start": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "instant_experience_outbound_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "labels": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "location": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "mobile_app_purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "objective": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "optimization_goal": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "outbound_clicks": {
       "$ref": "ads_action_stats.json"
@@ -416,34 +250,19 @@
       "$ref": "ads_action_stats.json"
     },
     "qualifying_question_qualify_answer_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "quality_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "reach": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "social_spend": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "spend": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "store_visit_actions": {
       "$ref": "ads_action_stats.json"
@@ -452,34 +271,19 @@
       "$ref": "ads_action_stats.json"
     },
     "unique_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "unique_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_inline_link_click_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_inline_link_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "unique_link_clicks_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_outbound_clicks": {
       "$ref": "ads_action_stats.json"
@@ -489,10 +293,7 @@
     },
     "updated_time": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "video_15_sec_watched_actions": {
       "$ref": "ads_action_stats.json"
@@ -546,14 +347,8 @@
       "$ref": "ads_action_stats.json"
     },
     "wish_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     }
   },
-  "type": [
-    "null",
-    "object"
-  ]
+  "type": ["null", "object"]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_country.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_country.json
@@ -1,22 +1,13 @@
 {
   "properties": {
     "account_currency": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "account_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "account_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "action_values": {
       "$ref": "ads_action_stats.json"
@@ -28,91 +19,49 @@
       "$ref": "ads_action_stats.json"
     },
     "ad_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "ad_impression_actions": {
       "$ref": "ads_action_stats.json"
     },
     "ad_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "adset_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "adset_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "age_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "attribution_setting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "auction_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "auction_competitiveness": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "auction_max_competitor_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "buying_type": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaign_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaign_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "canvas_avg_view_percent": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "canvas_avg_view_time": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "catalog_segment_actions": {
       "$ref": "ads_action_stats.json"
@@ -130,16 +79,10 @@
       "$ref": "ads_action_stats.json"
     },
     "clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "conversion_rate_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "conversion_values": {
       "$ref": "ads_action_stats.json"
@@ -169,22 +112,13 @@
       "$ref": "ads_action_stats.json"
     },
     "cost_per_estimated_ad_recallers": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_inline_link_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_inline_post_engagement": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_outbound_click": {
       "$ref": "ads_action_stats.json"
@@ -199,205 +133,109 @@
       "$ref": "ads_action_stats.json"
     },
     "cost_per_unique_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_unique_inline_link_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_unique_outbound_click": {
       "$ref": "ads_action_stats.json"
     },
     "country": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "cpc": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cpm": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cpp": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "created_time": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "date_start": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "date_stop": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "engagement_rate_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "estimated_ad_recall_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recall_rate_lower_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recall_rate_upper_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers_lower_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers_upper_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "frequency": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "full_view_impressions": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "full_view_reach": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "gender_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "impressions": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "inline_link_click_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "inline_link_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "inline_post_engagement": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "instant_experience_clicks_to_open": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "instant_experience_clicks_to_start": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "instant_experience_outbound_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "labels": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "location": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "mobile_app_purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "objective": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "optimization_goal": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "outbound_clicks": {
       "$ref": "ads_action_stats.json"
@@ -409,34 +247,19 @@
       "$ref": "ads_action_stats.json"
     },
     "qualifying_question_qualify_answer_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "quality_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "reach": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "social_spend": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "spend": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "store_visit_actions": {
       "$ref": "ads_action_stats.json"
@@ -445,34 +268,19 @@
       "$ref": "ads_action_stats.json"
     },
     "unique_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "unique_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_inline_link_click_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_inline_link_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "unique_link_clicks_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_outbound_clicks": {
       "$ref": "ads_action_stats.json"
@@ -482,10 +290,7 @@
     },
     "updated_time": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "video_15_sec_watched_actions": {
       "$ref": "ads_action_stats.json"
@@ -539,14 +344,8 @@
       "$ref": "ads_action_stats.json"
     },
     "wish_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     }
   },
-  "type": [
-    "null",
-    "object"
-  ]
+  "type": ["null", "object"]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_country.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_country.json
@@ -1,185 +1,552 @@
 {
-  "type": ["null", "object"],
   "properties": {
-    "unique_actions": { "$ref": "ads_action_stats.json" },
-    "actions": { "$ref": "ads_action_stats.json" },
-    "action_values": { "$ref": "ads_action_stats.json" },
-    "outbound_clicks": { "$ref": "ads_action_stats.json" },
-    "video_30_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p25_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p50_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p75_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p100_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_play_curve_actions": { "$ref": "ads_histogram_stats.json" },
-    "clicks": {
-      "type": ["null", "integer"]
-    },
-    "date_stop": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "ad_id": {
-      "type": ["null", "string"]
-    },
-    "website_ctr": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "number"]
-          },
-          "action_destination": {
-            "type": ["null", "string"]
-          },
-          "action_target_id": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "adset_id": {
-      "type": ["null", "string"]
-    },
-    "frequency": {
-      "type": ["null", "number"]
-    },
-    "account_name": {
-      "type": ["null", "string"]
-    },
-    "canvas_avg_view_time": {
-      "type": ["null", "number"]
-    },
-    "unique_inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "cost_per_unique_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "inline_post_engagement": {
-      "type": ["null", "integer"]
-    },
-    "campaign_name": {
-      "type": ["null", "string"]
-    },
-    "inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "campaign_id": {
-      "type": ["null", "string"]
-    },
-    "cpc": {
-      "type": ["null", "number"]
-    },
-    "ad_name": {
-      "type": ["null", "string"]
-    },
-    "cost_per_unique_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "cpm": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_post_engagement": {
-      "type": ["null", "number"]
-    },
-    "inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "cpp": {
-      "type": ["null", "number"]
-    },
-    "cost_per_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_link_clicks_ctr": {
-      "type": ["null", "number"]
-    },
-    "spend": {
-      "type": ["null", "number"]
-    },
-    "cost_per_unique_click": {
-      "type": ["null", "number"]
-    },
-    "adset_name": {
-      "type": ["null", "string"]
-    },
-    "unique_clicks": {
-      "type": ["null", "integer"]
-    },
-    "social_spend": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "canvas_avg_view_percent": {
-      "type": ["null", "number"]
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "account_id": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "date_start": {
-      "type": ["null", "string"],
-      "format": "date-time"
+    "account_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "objective": {
-      "type": ["null", "string"]
+    "action_values": {
+      "$ref": "ads_action_stats.json"
     },
-    "impressions": {
-      "type": ["null", "integer"]
+    "actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "unique_ctr": {
-      "type": ["null", "number"]
+    "ad_click_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "cost_per_inline_link_click": {
-      "type": ["null", "number"]
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "ctr": {
-      "type": ["null", "number"]
+    "ad_impression_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "reach": {
-      "type": ["null", "integer"]
+    "ad_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "country": {
-      "type": ["null", "string"]
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "quality_ranking": {
-      "type": ["null", "string"]
+    "adset_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "engagement_rate_ranking": {
-      "type": ["null", "string"]
+    "age_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "auction_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_competitiveness": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_max_competitor_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "buying_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_percent": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "canvas_avg_view_time": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "conversion_rate_ranking": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "conversion_values": {
+      "$ref": "ads_action_stats.json"
+    },
+    "conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_15_sec_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_2_sec_continuous_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_ad_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_post_engagement": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_store_visit_action": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_thruplay": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "country": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "cpc": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpm": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpp": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "created_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "date_start": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_stop": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "engagement_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recall_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_impressions": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_reach": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "gender_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_post_engagement": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "labels": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "location": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "quality_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reach": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "social_spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_link_clicks_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "updated_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "video_15_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_30_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_avg_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_continuous_2_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p100_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p25_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p50_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p75_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p95_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_play_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_curve_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_0_to_15s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_20_to_60s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "wish_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
     }
-  }
+  },
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_dma.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_dma.json
@@ -1,22 +1,13 @@
 {
   "properties": {
     "account_currency": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "account_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "account_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "action_values": {
       "$ref": "ads_action_stats.json"
@@ -28,91 +19,49 @@
       "$ref": "ads_action_stats.json"
     },
     "ad_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "ad_impression_actions": {
       "$ref": "ads_action_stats.json"
     },
     "ad_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "adset_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "adset_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "age_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "attribution_setting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "auction_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "auction_competitiveness": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "auction_max_competitor_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "buying_type": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaign_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaign_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "canvas_avg_view_percent": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "canvas_avg_view_time": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "catalog_segment_actions": {
       "$ref": "ads_action_stats.json"
@@ -130,16 +79,10 @@
       "$ref": "ads_action_stats.json"
     },
     "clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "conversion_rate_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "conversion_values": {
       "$ref": "ads_action_stats.json"
@@ -169,22 +112,13 @@
       "$ref": "ads_action_stats.json"
     },
     "cost_per_estimated_ad_recallers": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_inline_link_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_inline_post_engagement": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_outbound_click": {
       "$ref": "ads_action_stats.json"
@@ -199,205 +133,109 @@
       "$ref": "ads_action_stats.json"
     },
     "cost_per_unique_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_unique_inline_link_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_unique_outbound_click": {
       "$ref": "ads_action_stats.json"
     },
     "cpc": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cpm": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cpp": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "created_time": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "date_start": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "date_stop": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "dma": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "engagement_rate_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "estimated_ad_recall_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recall_rate_lower_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recall_rate_upper_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers_lower_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers_upper_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "frequency": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "full_view_impressions": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "full_view_reach": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "gender_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "impressions": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "inline_link_click_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "inline_link_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "inline_post_engagement": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "instant_experience_clicks_to_open": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "instant_experience_clicks_to_start": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "instant_experience_outbound_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "labels": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "location": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "mobile_app_purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "objective": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "optimization_goal": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "outbound_clicks": {
       "$ref": "ads_action_stats.json"
@@ -409,34 +247,19 @@
       "$ref": "ads_action_stats.json"
     },
     "qualifying_question_qualify_answer_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "quality_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "reach": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "social_spend": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "spend": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "store_visit_actions": {
       "$ref": "ads_action_stats.json"
@@ -445,34 +268,19 @@
       "$ref": "ads_action_stats.json"
     },
     "unique_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "unique_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_inline_link_click_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_inline_link_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "unique_link_clicks_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_outbound_clicks": {
       "$ref": "ads_action_stats.json"
@@ -482,10 +290,7 @@
     },
     "updated_time": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "video_15_sec_watched_actions": {
       "$ref": "ads_action_stats.json"
@@ -539,14 +344,8 @@
       "$ref": "ads_action_stats.json"
     },
     "wish_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     }
   },
-  "type": [
-    "null",
-    "object"
-  ]
+  "type": ["null", "object"]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_dma.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_dma.json
@@ -1,185 +1,552 @@
 {
-  "type": ["null", "object"],
   "properties": {
-    "unique_actions": { "$ref": "ads_action_stats.json" },
-    "actions": { "$ref": "ads_action_stats.json" },
-    "action_values": { "$ref": "ads_action_stats.json" },
-    "outbound_clicks": { "$ref": "ads_action_stats.json" },
-    "video_30_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p25_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p50_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p75_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p100_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_play_curve_actions": { "$ref": "ads_histogram_stats.json" },
-    "clicks": {
-      "type": ["null", "integer"]
-    },
-    "date_stop": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "ad_id": {
-      "type": ["null", "string"]
-    },
-    "website_ctr": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "number"]
-          },
-          "action_destination": {
-            "type": ["null", "string"]
-          },
-          "action_target_id": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "adset_id": {
-      "type": ["null", "string"]
-    },
-    "frequency": {
-      "type": ["null", "number"]
-    },
-    "account_name": {
-      "type": ["null", "string"]
-    },
-    "canvas_avg_view_time": {
-      "type": ["null", "number"]
-    },
-    "unique_inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "cost_per_unique_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "inline_post_engagement": {
-      "type": ["null", "integer"]
-    },
-    "campaign_name": {
-      "type": ["null", "string"]
-    },
-    "inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "campaign_id": {
-      "type": ["null", "string"]
-    },
-    "cpc": {
-      "type": ["null", "number"]
-    },
-    "ad_name": {
-      "type": ["null", "string"]
-    },
-    "cost_per_unique_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "cpm": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_post_engagement": {
-      "type": ["null", "number"]
-    },
-    "inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "cpp": {
-      "type": ["null", "number"]
-    },
-    "cost_per_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_link_clicks_ctr": {
-      "type": ["null", "number"]
-    },
-    "spend": {
-      "type": ["null", "number"]
-    },
-    "cost_per_unique_click": {
-      "type": ["null", "number"]
-    },
-    "adset_name": {
-      "type": ["null", "string"]
-    },
-    "unique_clicks": {
-      "type": ["null", "integer"]
-    },
-    "social_spend": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "canvas_avg_view_percent": {
-      "type": ["null", "number"]
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "account_id": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "date_start": {
-      "type": ["null", "string"],
-      "format": "date-time"
+    "account_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "objective": {
-      "type": ["null", "string"]
+    "action_values": {
+      "$ref": "ads_action_stats.json"
     },
-    "impressions": {
-      "type": ["null", "integer"]
+    "actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "unique_ctr": {
-      "type": ["null", "number"]
+    "ad_click_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "cost_per_inline_link_click": {
-      "type": ["null", "number"]
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "ctr": {
-      "type": ["null", "number"]
+    "ad_impression_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "reach": {
-      "type": ["null", "integer"]
+    "ad_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "dma": {
-      "type": ["null", "string"]
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "quality_ranking": {
-      "type": ["null", "string"]
+    "adset_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "engagement_rate_ranking": {
-      "type": ["null", "string"]
+    "age_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "auction_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_competitiveness": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_max_competitor_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "buying_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_percent": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "canvas_avg_view_time": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "conversion_rate_ranking": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "conversion_values": {
+      "$ref": "ads_action_stats.json"
+    },
+    "conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_15_sec_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_2_sec_continuous_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_ad_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_post_engagement": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_store_visit_action": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_thruplay": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cpc": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpm": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpp": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "created_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "date_start": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_stop": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "dma": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "engagement_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recall_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_impressions": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_reach": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "gender_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_post_engagement": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "labels": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "location": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "quality_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reach": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "social_spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_link_clicks_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "updated_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "video_15_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_30_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_avg_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_continuous_2_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p100_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p25_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p50_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p75_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p95_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_play_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_curve_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_0_to_15s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_20_to_60s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "wish_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
     }
-  }
+  },
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_platform_and_device.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_platform_and_device.json
@@ -1,19 +1,523 @@
 {
-  "type": ["null", "object"],
   "properties": {
-    "unique_actions": {
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "account_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "account_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "action_values": {
       "$ref": "ads_action_stats.json"
     },
     "actions": {
       "$ref": "ads_action_stats.json"
     },
-    "action_values": {
+    "ad_click_actions": {
       "$ref": "ads_action_stats.json"
+    },
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_impression_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "ad_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "age_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "auction_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_competitiveness": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_max_competitor_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "buying_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_percent": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "canvas_avg_view_time": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "conversion_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "conversion_values": {
+      "$ref": "ads_action_stats.json"
+    },
+    "conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_15_sec_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_2_sec_continuous_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_ad_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_post_engagement": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_store_visit_action": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_thruplay": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cpc": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpm": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpp": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "created_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "date_start": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_stop": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "engagement_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recall_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_impressions": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_reach": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "gender_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impression_device": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_post_engagement": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "labels": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "location": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "outbound_clicks": {
       "$ref": "ads_action_stats.json"
     },
+    "outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "placement": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "platform_position": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "publisher_platform": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "quality_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reach": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "social_spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_link_clicks_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "updated_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "video_15_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
     "video_30_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_avg_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_continuous_2_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p100_watched_actions": {
       "$ref": "ads_action_stats.json"
     },
     "video_p25_watched_actions": {
@@ -25,190 +529,42 @@
     "video_p75_watched_actions": {
       "$ref": "ads_action_stats.json"
     },
-    "video_p100_watched_actions": {
+    "video_p95_watched_actions": {
       "$ref": "ads_action_stats.json"
+    },
+    "video_play_actions": {
+      "$ref": "ads_histogram_stats.json"
     },
     "video_play_curve_actions": {
       "$ref": "ads_histogram_stats.json"
     },
-    "impression_device": {
-      "type": ["null", "string"]
+    "video_play_retention_0_to_15s_actions": {
+      "$ref": "ads_histogram_stats.json"
     },
-    "platform_position": {
-      "type": ["null", "string"]
+    "video_play_retention_20_to_60s_actions": {
+      "$ref": "ads_histogram_stats.json"
     },
-    "publisher_platform": {
-      "type": ["null", "string"]
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
     },
-    "clicks": {
-      "type": ["null", "integer"]
-    },
-    "date_stop": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "ad_id": {
-      "type": ["null", "string"]
+    "video_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
     },
     "website_ctr": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "number"]
-          },
-          "action_destination": {
-            "type": ["null", "string"]
-          },
-          "action_target_id": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
+      "$ref": "ads_action_stats.json"
     },
-    "unique_inline_link_click_ctr": {
-      "type": ["null", "number"]
+    "website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
     },
-    "adset_id": {
-      "type": ["null", "string"]
-    },
-    "frequency": {
-      "type": ["null", "number"]
-    },
-    "account_name": {
-      "type": ["null", "string"]
-    },
-    "canvas_avg_view_time": {
-      "type": ["null", "number"]
-    },
-    "unique_inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "cost_per_unique_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "inline_post_engagement": {
-      "type": ["null", "integer"]
-    },
-    "campaign_name": {
-      "type": ["null", "string"]
-    },
-    "inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "campaign_id": {
-      "type": ["null", "string"]
-    },
-    "cpc": {
-      "type": ["null", "number"]
-    },
-    "ad_name": {
-      "type": ["null", "string"]
-    },
-    "cost_per_unique_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "cpm": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_post_engagement": {
-      "type": ["null", "number"]
-    },
-    "inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "cpp": {
-      "type": ["null", "number"]
-    },
-    "cost_per_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_link_clicks_ctr": {
-      "type": ["null", "number"]
-    },
-    "spend": {
-      "type": ["null", "number"]
-    },
-    "cost_per_unique_click": {
-      "type": ["null", "number"]
-    },
-    "adset_name": {
-      "type": ["null", "string"]
-    },
-    "unique_clicks": {
-      "type": ["null", "integer"]
-    },
-    "social_spend": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "canvas_avg_view_percent": {
-      "type": ["null", "number"]
-    },
-    "account_id": {
-      "type": ["null", "string"]
-    },
-    "date_start": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "objective": {
-      "type": ["null", "string"]
-    },
-    "impressions": {
-      "type": ["null", "integer"]
-    },
-    "unique_ctr": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "ctr": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "placement": {
-      "type": ["null", "string"]
-    },
-    "quality_ranking": {
-      "type": ["null", "string"]
-    },
-    "engagement_rate_ranking": {
-      "type": ["null", "string"]
-    },
-    "conversion_rate_ranking": {
-      "type": ["null", "string"]
+    "wish_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
     }
-  }
+  },
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_platform_and_device.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_platform_and_device.json
@@ -1,22 +1,13 @@
 {
   "properties": {
     "account_currency": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "account_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "account_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "action_values": {
       "$ref": "ads_action_stats.json"
@@ -28,91 +19,49 @@
       "$ref": "ads_action_stats.json"
     },
     "ad_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "ad_impression_actions": {
       "$ref": "ads_action_stats.json"
     },
     "ad_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "adset_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "adset_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "age_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "attribution_setting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "auction_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "auction_competitiveness": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "auction_max_competitor_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "buying_type": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaign_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaign_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "canvas_avg_view_percent": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "canvas_avg_view_time": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "catalog_segment_actions": {
       "$ref": "ads_action_stats.json"
@@ -130,16 +79,10 @@
       "$ref": "ads_action_stats.json"
     },
     "clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "conversion_rate_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "conversion_values": {
       "$ref": "ads_action_stats.json"
@@ -169,22 +112,13 @@
       "$ref": "ads_action_stats.json"
     },
     "cost_per_estimated_ad_recallers": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_inline_link_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_inline_post_engagement": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_outbound_click": {
       "$ref": "ads_action_stats.json"
@@ -199,205 +133,109 @@
       "$ref": "ads_action_stats.json"
     },
     "cost_per_unique_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_unique_inline_link_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_unique_outbound_click": {
       "$ref": "ads_action_stats.json"
     },
     "cpc": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cpm": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cpp": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "created_time": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "date_start": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "date_stop": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "engagement_rate_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "estimated_ad_recall_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recall_rate_lower_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recall_rate_upper_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers_lower_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers_upper_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "frequency": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "full_view_impressions": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "full_view_reach": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "gender_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "impression_device": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "impressions": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "inline_link_click_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "inline_link_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "inline_post_engagement": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "instant_experience_clicks_to_open": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "instant_experience_clicks_to_start": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "instant_experience_outbound_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "labels": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "location": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "mobile_app_purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "objective": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "optimization_goal": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "outbound_clicks": {
       "$ref": "ads_action_stats.json"
@@ -406,55 +244,31 @@
       "$ref": "ads_action_stats.json"
     },
     "placement": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "platform_position": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "publisher_platform": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "qualifying_question_qualify_answer_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "quality_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "reach": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "social_spend": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "spend": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "store_visit_actions": {
       "$ref": "ads_action_stats.json"
@@ -463,34 +277,19 @@
       "$ref": "ads_action_stats.json"
     },
     "unique_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "unique_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_inline_link_click_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_inline_link_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "unique_link_clicks_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_outbound_clicks": {
       "$ref": "ads_action_stats.json"
@@ -500,10 +299,7 @@
     },
     "updated_time": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "video_15_sec_watched_actions": {
       "$ref": "ads_action_stats.json"
@@ -557,14 +353,8 @@
       "$ref": "ads_action_stats.json"
     },
     "wish_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     }
   },
-  "type": [
-    "null",
-    "object"
-  ]
+  "type": ["null", "object"]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_region.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_region.json
@@ -1,22 +1,13 @@
 {
   "properties": {
     "account_currency": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "account_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "account_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "action_values": {
       "$ref": "ads_action_stats.json"
@@ -28,91 +19,49 @@
       "$ref": "ads_action_stats.json"
     },
     "ad_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "ad_impression_actions": {
       "$ref": "ads_action_stats.json"
     },
     "ad_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "adset_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "adset_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "age_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "attribution_setting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "auction_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "auction_competitiveness": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "auction_max_competitor_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "buying_type": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaign_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaign_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "canvas_avg_view_percent": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "canvas_avg_view_time": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "catalog_segment_actions": {
       "$ref": "ads_action_stats.json"
@@ -130,16 +79,10 @@
       "$ref": "ads_action_stats.json"
     },
     "clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "conversion_rate_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "conversion_values": {
       "$ref": "ads_action_stats.json"
@@ -169,22 +112,13 @@
       "$ref": "ads_action_stats.json"
     },
     "cost_per_estimated_ad_recallers": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_inline_link_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_inline_post_engagement": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_outbound_click": {
       "$ref": "ads_action_stats.json"
@@ -199,199 +133,106 @@
       "$ref": "ads_action_stats.json"
     },
     "cost_per_unique_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_unique_inline_link_click": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cost_per_unique_outbound_click": {
       "$ref": "ads_action_stats.json"
     },
     "cpc": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cpm": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "cpp": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "created_time": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "date_start": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "date_stop": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "engagement_rate_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "estimated_ad_recall_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recall_rate_lower_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recall_rate_upper_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers_lower_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "estimated_ad_recallers_upper_bound": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "frequency": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "full_view_impressions": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "full_view_reach": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "gender_targeting": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "impressions": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "inline_link_click_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "inline_link_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "inline_post_engagement": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "instant_experience_clicks_to_open": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "instant_experience_clicks_to_start": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "instant_experience_outbound_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "labels": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "location": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "mobile_app_purchase_roas": {
       "$ref": "ads_action_stats.json"
     },
     "objective": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "optimization_goal": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "outbound_clicks": {
       "$ref": "ads_action_stats.json"
@@ -403,40 +244,22 @@
       "$ref": "ads_action_stats.json"
     },
     "qualifying_question_qualify_answer_rate": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "quality_ranking": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "reach": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "region": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "social_spend": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "spend": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "store_visit_actions": {
       "$ref": "ads_action_stats.json"
@@ -445,34 +268,19 @@
       "$ref": "ads_action_stats.json"
     },
     "unique_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "unique_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_inline_link_click_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_inline_link_clicks": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "unique_link_clicks_ctr": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "unique_outbound_clicks": {
       "$ref": "ads_action_stats.json"
@@ -482,10 +290,7 @@
     },
     "updated_time": {
       "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "video_15_sec_watched_actions": {
       "$ref": "ads_action_stats.json"
@@ -539,14 +344,8 @@
       "$ref": "ads_action_stats.json"
     },
     "wish_bid": {
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     }
   },
-  "type": [
-    "null",
-    "object"
-  ]
+  "type": ["null", "object"]
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_region.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ads_insights_region.json
@@ -1,185 +1,552 @@
 {
-  "type": ["null", "object"],
   "properties": {
-    "unique_actions": { "$ref": "ads_action_stats.json" },
-    "actions": { "$ref": "ads_action_stats.json" },
-    "action_values": { "$ref": "ads_action_stats.json" },
-    "outbound_clicks": { "$ref": "ads_action_stats.json" },
-    "video_30_sec_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p25_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p50_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p75_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_p100_watched_actions": { "$ref": "ads_action_stats.json" },
-    "video_play_curve_actions": { "$ref": "ads_histogram_stats.json" },
-    "clicks": {
-      "type": ["null", "integer"]
-    },
-    "date_stop": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "ad_id": {
-      "type": ["null", "string"]
-    },
-    "website_ctr": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "number"]
-          },
-          "action_destination": {
-            "type": ["null", "string"]
-          },
-          "action_target_id": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "adset_id": {
-      "type": ["null", "string"]
-    },
-    "frequency": {
-      "type": ["null", "number"]
-    },
-    "account_name": {
-      "type": ["null", "string"]
-    },
-    "canvas_avg_view_time": {
-      "type": ["null", "number"]
-    },
-    "unique_inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "cost_per_unique_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "inline_post_engagement": {
-      "type": ["null", "integer"]
-    },
-    "campaign_name": {
-      "type": ["null", "string"]
-    },
-    "inline_link_clicks": {
-      "type": ["null", "integer"]
-    },
-    "campaign_id": {
-      "type": ["null", "string"]
-    },
-    "cpc": {
-      "type": ["null", "number"]
-    },
-    "ad_name": {
-      "type": ["null", "string"]
-    },
-    "cost_per_unique_inline_link_click": {
-      "type": ["null", "number"]
-    },
-    "cpm": {
-      "type": ["null", "number"]
-    },
-    "cost_per_inline_post_engagement": {
-      "type": ["null", "number"]
-    },
-    "inline_link_click_ctr": {
-      "type": ["null", "number"]
-    },
-    "cpp": {
-      "type": ["null", "number"]
-    },
-    "cost_per_action_type": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["null", "object"],
-        "properties": {
-          "value": {
-            "type": ["null", "string"]
-          },
-          "action_type": {
-            "type": ["null", "string"]
-          }
-        }
-      }
-    },
-    "unique_link_clicks_ctr": {
-      "type": ["null", "number"]
-    },
-    "spend": {
-      "type": ["null", "number"]
-    },
-    "cost_per_unique_click": {
-      "type": ["null", "number"]
-    },
-    "adset_name": {
-      "type": ["null", "string"]
-    },
-    "unique_clicks": {
-      "type": ["null", "integer"]
-    },
-    "social_spend": {
-      "type": ["null", "number"]
-    },
-    "reach": {
-      "type": ["null", "integer"]
-    },
-    "canvas_avg_view_percent": {
-      "type": ["null", "number"]
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "account_id": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "date_start": {
-      "type": ["null", "string"],
-      "format": "date-time"
+    "account_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "objective": {
-      "type": ["null", "string"]
+    "action_values": {
+      "$ref": "ads_action_stats.json"
     },
-    "impressions": {
-      "type": ["null", "integer"]
+    "actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "unique_ctr": {
-      "type": ["null", "number"]
+    "ad_click_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "cost_per_inline_link_click": {
-      "type": ["null", "number"]
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "ctr": {
-      "type": ["null", "number"]
+    "ad_impression_actions": {
+      "$ref": "ads_action_stats.json"
     },
-    "reach": {
-      "type": ["null", "integer"]
+    "ad_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "region": {
-      "type": ["null", "string"]
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "quality_ranking": {
-      "type": ["null", "string"]
+    "adset_name": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
-    "engagement_rate_ranking": {
-      "type": ["null", "string"]
+    "age_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "auction_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_competitiveness": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "auction_max_competitor_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "buying_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_percent": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "canvas_avg_view_time": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "catalog_segment_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_mobile_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_omni_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "catalog_segment_value_website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "conversion_rate_ranking": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "conversion_values": {
+      "$ref": "ads_action_stats.json"
+    },
+    "conversions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_quantity": {
+      "$ref": "ads_action_stats.json"
+    },
+    "converted_product_value": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_15_sec_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_2_sec_continuous_video_view": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_ad_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_conversion": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_inline_post_engagement": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_store_visit_action": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_thruplay": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_action_type": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cost_per_unique_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_inline_link_click": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cost_per_unique_outbound_click": {
+      "$ref": "ads_action_stats.json"
+    },
+    "cpc": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpm": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "cpp": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "created_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "date_start": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_stop": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "engagement_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recall_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recall_rate_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_lower_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "estimated_ad_recallers_upper_bound": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "frequency": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_impressions": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "full_view_reach": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "gender_targeting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "inline_post_engagement": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "labels": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "location": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "mobile_app_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "quality_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reach": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "region": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "social_spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "spend": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "store_visit_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_click_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_inline_link_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "unique_link_clicks_ctr": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "unique_outbound_clicks": {
+      "$ref": "ads_action_stats.json"
+    },
+    "unique_outbound_clicks_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "updated_time": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "video_15_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_30_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_avg_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_continuous_2_sec_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p100_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p25_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p50_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p75_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_p95_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "video_play_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_curve_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_0_to_15s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_20_to_60s_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_play_retention_graph_actions": {
+      "$ref": "ads_histogram_stats.json"
+    },
+    "video_time_watched_actions": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_ctr": {
+      "$ref": "ads_action_stats.json"
+    },
+    "website_purchase_roas": {
+      "$ref": "ads_action_stats.json"
+    },
+    "wish_bid": {
+      "type": [
+        "null",
+        "number"
+      ]
     }
-  }
+  },
+  "type": [
+    "null",
+    "object"
+  ]
 }


### PR DESCRIPTION
## What
original PR https://github.com/airbytehq/airbyte/pull/3646
closes #3645 
all credits to @zestyping

## How
*Describe the solution*

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `test.java`
1. `component.ts`
1. the rest
