### PR TITLE
docker-container: limit the log size to 500MB

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,16 @@
 version: "3.7"
-
+#https://github.com/compose-spec/compose-spec/blob/master/spec.md#using-extensions-as-fragments
+x-logging: &default-logging
+  options:
+    max-size: "100m"
+    max-file: "5"
+  driver: json-file
 services:
   # hook in case we need to add init behavior
   # every root service (no depends_on) should depend on init
   init:
     image: airbyte/init:${VERSION}
+    logging: *default-logging
     container_name: init
     command: /bin/sh -c "./scripts/create_mount_directories.sh /local_parent ${HACK_LOCAL_ROOT_PARENT} ${LOCAL_ROOT}"
     environment:
@@ -14,6 +20,7 @@ services:
       - ${HACK_LOCAL_ROOT_PARENT}:/local_parent
   db:
     image: airbyte/db:${VERSION}
+    logging: *default-logging
     container_name: airbyte-db
     restart: unless-stopped
     environment:
@@ -30,6 +37,7 @@ services:
       - data:/app/seed
   scheduler:
     image: airbyte/scheduler:${VERSION}
+    logging: *default-logging
     container_name: airbyte-scheduler
     restart: unless-stopped
     environment:
@@ -56,6 +64,7 @@ services:
       - data:${CONFIG_ROOT}
   server:
     image: airbyte/server:${VERSION}
+    logging: *default-logging
     container_name: airbyte-server
     restart: unless-stopped
     environment:
@@ -79,6 +88,7 @@ services:
       - data:${CONFIG_ROOT}
   webapp:
     image: airbyte/webapp:${VERSION}
+    logging: *default-logging
     container_name: airbyte-webapp
     restart: unless-stopped
     ports:
@@ -93,6 +103,7 @@ services:
       - INTERNAL_API_HOST=${INTERNAL_API_HOST}
   airbyte-temporal:
     image: temporalio/auto-setup:1.7.0
+    logging: *default-logging
     container_name: airbyte-temporal
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## What
Issue : https://github.com/airbytehq/airbyte/issues/3665
Testing info (@davinchia suggested this approach so credit to him):
1. I added a loop in `JobScheduler` class to generate millions of logs. 
2. I did docker compose up and observed the size of the log file without this change. The file size quickly started growing and within few minutes it became more than 200MB.
3. I killed the process and made this change and then again did docker compose up and then again started observing the file size. This time 5 files were created. Naming convention was 
```
-rw-r-----    1 root     root        8.6M May 28 09:11 ddeb0a66f2eba90ed7324f1d6dfd48865df9ae594a35319f7668c0b563d347bf-json.log
-rw-r-----    1 root     root       11.4M May 28 09:11 ddeb0a66f2eba90ed7324f1d6dfd48865df9ae594a35319f7668c0b563d347bf-json.log.1
-rw-r-----    1 root     root       11.4M May 28 09:10 ddeb0a66f2eba90ed7324f1d6dfd48865df9ae594a35319f7668c0b563d347bf-json.log.2
-rw-r-----    1 root     root       11.4M May 28 09:10 ddeb0a66f2eba90ed7324f1d6dfd48865df9ae594a35319f7668c0b563d347bf-json.log.3
-rw-r-----    1 root     root       11.4M May 28 09:10 ddeb0a66f2eba90ed7324f1d6dfd48865df9ae594a35319f7668c0b563d347bf-json.log.4

```
As you can see from above, each file's size was capped to the `max-size` value (for the purpose of my test I used 12m as the limit). The files were being rolled over. 

With the specification of 
```
max-size: "100m"
max-file: "5"
```
The maximum disk occupied by logs for each container can be 500MB

Ref : https://github.com/compose-spec/compose-spec/blob/master/spec.md

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

