### PR TITLE
📚 📝 Build a connector-The hard way: added missed import

### DIFF
--- a/docs/tutorials/tutorials/build-a-connector-the-hard-way.md
+++ b/docs/tutorials/tutorials/build-a-connector-the-hard-way.md
@@ -262,6 +262,8 @@ Make sure to add your actual API key \(the private key\) instead of the placehol
 Then we'll add the `check_method`:
 
 ```python
+import requests
+
 def _call_api(endpoint, token):
     return requests.get("https://cloud.iexapis.com/v1/" + endpoint + "?token=" + token)
 


### PR DESCRIPTION
## What
The guide Build a connector - The hard way (build-a-connector-the-hard-way.md) had a missed step to add an import. For non Python devs it may be not obvious that it's missed. 

## How
Added a missed steps step to guide 

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

