### PR TITLE
🐛Source Stripe bugfix: Update stripe data types to output number instead of int

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e094cb9a-26de-4645-8761-65c0c425d1de.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e094cb9a-26de-4645-8761-65c0c425d1de.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "e094cb9a-26de-4645-8761-65c0c425d1de",
   "name": "Stripe",
   "dockerRepository": "airbyte/source-stripe",
-  "dockerImageTag": "0.1.9",
+  "dockerImageTag": "0.1.10",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-stripe",
   "icon": "stripe.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -78,7 +78,7 @@
 - sourceDefinitionId: e094cb9a-26de-4645-8761-65c0c425d1de
   name: Stripe
   dockerRepository: airbyte/source-stripe
-  dockerImageTag: 0.1.9
+  dockerImageTag: 0.1.10
   documentationUrl: https://hub.docker.com/r/airbyte/source-stripe
   icon: stripe.svg
 - sourceDefinitionId: b03a9f3e-22a5-11eb-adc1-0242ac120002

--- a/airbyte-integrations/connectors/source-stripe/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe/Dockerfile
@@ -11,5 +11,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.9
+LABEL io.airbyte.version=0.1.10
 LABEL io.airbyte.name=airbyte/source-stripe

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoices.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoices.json
@@ -90,20 +90,20 @@
               "type": ["null", "boolean"]
             },
             "amount_off": {
-              "type": ["null", "integer"]
+              "type": ["null", "number"]
             },
             "redeem_by": {
               "type": ["null", "string"],
               "format": "date-time"
             },
             "duration_in_months": {
-              "type": ["null", "integer"]
+              "type": ["null", "number"]
             },
             "percent_off_precise": {
               "type": ["null", "number"]
             },
             "max_redemptions": {
-              "type": ["null", "integer"]
+              "type": ["null", "number"]
             },
             "currency": {
               "type": ["null", "string"]
@@ -112,7 +112,7 @@
               "type": ["null", "string"]
             },
             "times_redeemed": {
-              "type": ["null", "integer"]
+              "type": ["null", "number"]
             },
             "id": {
               "type": ["null", "string"]
@@ -124,10 +124,10 @@
               "type": ["null", "string"]
             },
             "percent_off": {
-              "type": ["null", "integer"]
+              "type": ["null", "number"]
             },
             "created": {
-              "type": ["null", "integer"]
+              "type": ["null", "number"]
             }
           }
         },

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/subscriptions.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/subscriptions.json
@@ -63,20 +63,20 @@
               "type": ["null", "boolean"]
             },
             "amount_off": {
-              "type": ["null", "integer"]
+              "type": ["null", "number"]
             },
             "redeem_by": {
               "type": ["null", "string"],
               "format": "date-time"
             },
             "duration_in_months": {
-              "type": ["null", "integer"]
+              "type": ["null", "number"]
             },
             "percent_off_precise": {
               "type": ["null", "number"]
             },
             "max_redemptions": {
-              "type": ["null", "integer"]
+              "type": ["null", "number"]
             },
             "currency": {
               "type": ["null", "string"]
@@ -85,7 +85,7 @@
               "type": ["null", "string"]
             },
             "times_redeemed": {
-              "type": ["null", "integer"]
+              "type": ["null", "number"]
             },
             "id": {
               "type": ["null", "string"]
@@ -97,10 +97,10 @@
               "type": ["null", "string"]
             },
             "percent_off": {
-              "type": ["null", "integer"]
+              "type": ["null", "number"]
             },
             "created": {
-              "type": ["null", "integer"]
+              "type": ["null", "number"]
             }
           }
         },


### PR DESCRIPTION
For some reason a lot of integer fields are being output as `<value>.0` which breaks normalization. This is also happening in other sources, Shopify and Recurly. We need to root cause this issue or roll out a wider fix, perhaps using the CDK. For now, we're just trying to unblock the user.
