### PR TITLE
Allow spec.jsons with no properties

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1663,7 +1663,9 @@ components:
         sourceDefinitionId:
           $ref: "#/components/schemas/SourceDefinitionId"
         connectionConfiguration:
-          $ref: "#/components/schemas/SourceConfiguration"
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/SourceConfiguration"
     SourceCreate:
       allOf:
         - $ref: "#/components/schemas/SourceCoreConfig"


### PR DESCRIPTION
## What
Copied from https://github.com/airbytehq/airbyte/issues/3029:

"A user reported wanting to create a source that doesn't have any configuration properties. However, his connector didn't function in the UI because the UI expected some properties in spec.json

He got the error

{"message":"The received object did not pass validation","details":"property: webBackendCreateSource.arg0.connectionConfiguration message: must not be null invalid value: null"}
We should make it not required to have params in the spec.json"



## How
SourceCreate points to a SourceCoreConfig. The [SourceCoreConfig](https://github.com/airbytehq/airbyte/blob/07a45df4547fa5f12a170dff0bfc56c39c3d2e9f/airbyte-api/src/main/openapi/config.yaml#L1484) schema expects a $ref, but the error above states the [connectionConfiguration](https://github.com/airbytehq/airbyte/blob/07a45df4547fa5f12a170dff0bfc56c39c3d2e9f/airbyte-api/src/main/openapi/config.yaml#L1492) was null. Note that although [SourceConfiguration](https://github.com/airbytehq/airbyte/blob/07a45df4547fa5f12a170dff0bfc56c39c3d2e9f/airbyte-api/src/main/openapi/config.yaml#L1481) has no `type` specified and therefore [allows for any type (including null)](http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1), Open API nullable $ref handling requires special care (as described [here](https://stackoverflow.com/a/48114924)). This tweak makes [SourceCoreConfig's](https://github.com/airbytehq/airbyte/blob/07a45df4547fa5f12a170dff0bfc56c39c3d2e9f/airbyte-api/src/main/openapi/config.yaml#L1484) $ref nullable.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*
