### PR TITLE
Try to enable Test commands to run from forked branches.

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -32,6 +32,8 @@ jobs:
             > :clock2: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
       - name: Checkout Airbyte
         uses: actions/checkout@v2
+        with:
+          repository: ${{github.event.pull_request.head.repo.full_name}} # always use the branch's repository
       - uses: actions/setup-java@v1
         with:
           java-version: '14'

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -32,6 +32,7 @@ jobs:
             > :clock2: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
       - name: Checkout Airbyte
         uses: actions/checkout@v2
+        with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -32,6 +32,9 @@ jobs:
             > :clock2: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
       - name: Checkout Airbyte
         uses: actions/checkout@v2
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - uses: actions/setup-java@v1
         with:
           java-version: '14'

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -33,9 +33,7 @@ jobs:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          repository: ${{github.event.pull_request.head.repo.full_name}} # always use the branch's repository
       - uses: actions/setup-java@v1
         with:
           java-version: '14'


### PR DESCRIPTION
## What
Today the test/publish commands always pull from the airbyte repo regardless of where the PR branch lives in. This means we cannot run the test/publish command on forked PRs.

Configure the checkout action to pull from the PR branch's repository instead of always defaulting to the repository the PR lives in.

Ran one integration test to show this change is no-op if the PR branch is from the Airbyte repo. The real test is running this command on #3660 .

## Pre-merge Checklist
- [x] *Run integration tests*

## Recommended reading order
1. Both files.
