### PR TITLE
🐛  Fix Stripe Schema.

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e094cb9a-26de-4645-8761-65c0c425d1de.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e094cb9a-26de-4645-8761-65c0c425d1de.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "e094cb9a-26de-4645-8761-65c0c425d1de",
   "name": "Stripe",
   "dockerRepository": "airbyte/source-stripe",
-  "dockerImageTag": "0.1.10",
+  "dockerImageTag": "0.1.11",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-stripe",
   "icon": "stripe.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -78,7 +78,7 @@
 - sourceDefinitionId: e094cb9a-26de-4645-8761-65c0c425d1de
   name: Stripe
   dockerRepository: airbyte/source-stripe
-  dockerImageTag: 0.1.10
+  dockerImageTag: 0.1.11
   documentationUrl: https://hub.docker.com/r/airbyte/source-stripe
   icon: stripe.svg
 - sourceDefinitionId: b03a9f3e-22a5-11eb-adc1-0242ac120002

--- a/airbyte-integrations/connectors/source-stripe/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe/Dockerfile
@@ -11,5 +11,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.10
+LABEL io.airbyte.version=0.1.11
 LABEL io.airbyte.name=airbyte/source-stripe

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/bank_accounts.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/bank_accounts.json
@@ -26,7 +26,7 @@
       "type": ["null", "string"]
     },
     "fingerprint": {
-      "type": ["null", "integer"]
+      "type": ["null", "string"]
     },
     "last4": {
       "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoices.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoices.json
@@ -4,6 +4,9 @@
     "date": {
       "type": ["null", "integer"]
     },
+    "created": {
+      "type": ["null", "integer"]
+    },
     "next_payment_attempt": {
       "type": ["null", "string"],
       "format": "date-time"
@@ -69,7 +72,7 @@
     "paid": {
       "type": ["null", "boolean"]
     },
-    "discount": {
+    "discounts": {
       "type": ["null", "object"],
       "properties": {
         "end": {
@@ -127,7 +130,7 @@
               "type": ["null", "number"]
             },
             "created": {
-              "type": ["null", "number"]
+              "type": ["null", "integer"]
             }
           }
         },


### PR DESCRIPTION
## What
One of the schema's has a wrong type and should be string instead of integer. I discovered this while trying to debug a user's error.

This was erroring out E2E locally for me, and works after this change (for the entire catalog).

<img width="903" alt="Screen Shot 2021-05-30 at 2 53 13 PM" src="https://user-images.githubusercontent.com/9772859/120095138-d46a0c00-c156-11eb-87d9-4dc3daf1abea.png">

Second change is a cursor field that is missing from the schema. This took me a while to debug. Since the resource contains an object that has a field of the same name.

<img width="943" alt="Screen Shot 2021-05-30 at 4 16 13 PM" src="https://user-images.githubusercontent.com/9772859/120097329-6fb4ae80-c162-11eb-9694-6edd955e01f4.png">

The two most recent syncs are after I corrected this error.

## How
Change the type.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. The one schema file.
