### PR TITLE
Run test command on forked repos.

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -5,6 +5,10 @@ on:
       connector:
         description: 'Airbyte Connector'
         required: true
+      repo:
+        description: 'Repo to check out code from. Defaults to the main airbyte repo. Set this when building connectors from forked repos.'
+        required: false
+        default: 'airbytehq/airbyte'
       comment-id:
         description: 'The comment-id of the slash command. Used to update the comment with the status.'
         required: false
@@ -33,7 +37,7 @@ jobs:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
         with:
-          repository: ${{github.event.pull_request.head.repo.full_name}} # always use the branch's repository
+          repository: ${{ github.event.inputs.repo }}
       - uses: actions/setup-java@v1
         with:
           java-version: '14'


### PR DESCRIPTION
## What
Today the test command always runs on the Airbyte repo. An Airbyte dev has to jump through hoops to build a contributor's code.

## How
Test command accepts the repo parameter. This defaults to the main airbyte repo. This repo command is passed into the checkout action.

I tested this here https://github.com/airbytehq/github-workflow-test-repo-base/pull/8.

But the real test is in #3660. Unfortunately I have to merge this in to test it.
