### PR TITLE
removing <details> block from exchange api doc gitbook doenst support it

### DIFF
--- a/docs/integrations/sources/exchangeratesapi.md
+++ b/docs/integrations/sources/exchangeratesapi.md
@@ -46,10 +46,7 @@ If you have `free` subscription plan (you may check it [here](https://manage.exc
 
 ## Changelog
 
-<details>
-
 | Version | Date       | Pull Request | Subject |
 | :------ | :--------  | :-----       | :------ |
 | 0.2.0   | 2021-05-26 | [3566](https://github.com/airbytehq/airbyte/pull/3566) | Move from `api.ratesapi.io/` to `api.exchangeratesapi.io/`.  <br>Add required field `access_key` to `config.json`. |
 | 0.1.0   | 2021-04-19 | [2942](https://github.com/airbytehq/airbyte/pull/2942) | Implement Exchange API using the CDK |
-</details>


### PR DESCRIPTION
## What
Remove `<details>` block from Exchange API documentation.
I'll work during the week to resolve this or suggest other way to show changelog.


<details>
<summary>Connector changelog</summary>

| Version | Date       | Pull Request | Subject |
| :------ | :--------  | :-----       | :------ |
| 0.2.0   | 2021-05-26 | [3566](https://github.com/airbytehq/airbyte/pull/3566) | Move from `api.ratesapi.io/` to `api.exchangeratesapi.io/`.  &lt;br&gt;Add required field `access_key` to `config.json`. |
| 0.1.0   | 2021-04-19 | [2942](https://github.com/airbytehq/airbyte/pull/2942) | Implement Exchange API using the CDK |
</details>

## How
*Describe the solution*

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `test.java`
1. `component.ts`
1. the rest
