### PR TITLE
🐛 Correct bad Kube deploy url.

### DIFF
--- a/kube/overlays/dev/.env
+++ b/kube/overlays/dev/.env
@@ -16,4 +16,4 @@ LOCAL_ROOT=/tmp/airbyte_local
 PAPERCUPS_STORYTIME=disabled
 IS_DEMO=false
 TEMPORAL_HOST=airbyte-temporal-svc:7233
-INTERNAL_API_HOST=http://airbyte-server-svc:8001/api/
+INTERNAL_API_HOST=airbyte-server-svc:8001

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -16,4 +16,4 @@ LOCAL_ROOT=/tmp/airbyte_local
 PAPERCUPS_STORYTIME=enabled
 IS_DEMO=false
 TEMPORAL_HOST=airbyte-temporal-svc:7233
-INTERNAL_API_HOST=http://airbyte-server-svc:8001/api/
+INTERNAL_API_HOST=airbyte-server-svc:8001


### PR DESCRIPTION
## What
This url is wrong. Kubernetes deploys will error out.

## How
The url should not have the scheme or the path. Edit this to match https://github.com/airbytehq/airbyte/blob/master/.env#L24.

I tested this by hand-editing the Kubernetes deploy that was erroring out.

Screen shot showing this works after I edited the env var.

<img width="1060" alt="Screen Shot 2021-05-31 at 2 36 26 PM" src="https://user-images.githubusercontent.com/9772859/120150394-9683eb00-c21d-11eb-9d25-b503be4678d8.png">
