### PR TITLE
🐛 Fix: change all integers to number on Source Recurly catalog

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/cd42861b-01fc-4658-a8ab-5d11d0510f01.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/cd42861b-01fc-4658-a8ab-5d11d0510f01.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "cd42861b-01fc-4658-a8ab-5d11d0510f01",
   "name": "Recurly",
   "dockerRepository": "airbyte/source-recurly",
-  "dockerImageTag": "0.2.2",
+  "dockerImageTag": "0.2.3",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-recurly",
   "icon": "recurly.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -42,7 +42,7 @@
 - sourceDefinitionId: cd42861b-01fc-4658-a8ab-5d11d0510f01
   name: Recurly
   dockerRepository: airbyte/source-recurly
-  dockerImageTag: 0.2.2
+  dockerImageTag: 0.2.3
   documentationUrl: https://hub.docker.com/r/airbyte/source-recurly
   icon: recurly.svg
 - sourceDefinitionId: fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87

--- a/airbyte-integrations/connectors/source-recurly/Dockerfile
+++ b/airbyte-integrations/connectors/source-recurly/Dockerfile
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.2
+LABEL io.airbyte.version=0.2.3
 LABEL io.airbyte.name=airbyte/source-recurly

--- a/airbyte-integrations/connectors/source-recurly/source_recurly/schemas/coupons.json
+++ b/airbyte-integrations/connectors/source-recurly/source_recurly/schemas/coupons.json
@@ -18,13 +18,13 @@
       "type": "string"
     },
     "max_redemptions": {
-      "type": "integer"
+      "type": "number"
     },
     "max_redemptions_per_account": {
-      "type": "integer"
+      "type": "number"
     },
     "unique_coupon_codes_count": {
-      "type": "integer"
+      "type": "number"
     },
     "unique_code_template": {
       "type": "string"
@@ -33,7 +33,7 @@
       "type": "string"
     },
     "temporal_amount": {
-      "type": "integer"
+      "type": "number"
     },
     "temporal_unit": {
       "type": "string"
@@ -42,7 +42,7 @@
       "type": "string"
     },
     "free_trial_amount": {
-      "type": "integer"
+      "type": "number"
     },
     "applies_to_all_plans": {
       "type": "boolean"
@@ -72,7 +72,7 @@
           "type": "string"
         },
         "percent": {
-          "type": "integer"
+          "type": "number"
         },
         "currencies": {
           "type": "array"
@@ -84,7 +84,7 @@
               "type": "string"
             },
             "length": {
-              "type": "integer"
+              "type": "number"
             }
           }
         }

--- a/airbyte-integrations/connectors/source-recurly/source_recurly/schemas/plans.json
+++ b/airbyte-integrations/connectors/source-recurly/source_recurly/schemas/plans.json
@@ -24,19 +24,19 @@
       "type": "string"
     },
     "interval_length": {
-      "type": "integer"
+      "type": "number"
     },
     "trial_unit": {
-      "type": "integer"
+      "type": "number"
     },
     "trial_length": {
-      "type": "integer"
+      "type": "number"
     },
     "trial_requires_billing_info": {
       "type": "boolean"
     },
     "total_billing_cycles": {
-      "type": "integer"
+      "type": "number"
     },
     "auto_renew": {
       "type": "boolean"
@@ -54,10 +54,10 @@
       "type": "string"
     },
     "avalara_transaction_type": {
-      "type": "integer"
+      "type": "number"
     },
     "avalara_service_type": {
-      "type": "integer"
+      "type": "number"
     },
     "tax_code": {
       "type": "string"

--- a/airbyte-integrations/connectors/source-recurly/source_recurly/schemas/subscriptions.json
+++ b/airbyte-integrations/connectors/source-recurly/source_recurly/schemas/subscriptions.json
@@ -90,7 +90,7 @@
           }
         },
         "amount": {
-          "type": "integer"
+          "type": "number"
         }
       }
     },
@@ -119,13 +119,13 @@
       "type": "string"
     },
     "remaining_billing_cycles": {
-      "type": "integer"
+      "type": "number"
     },
     "total_billing_cycles": {
-      "type": "integer"
+      "type": "number"
     },
     "renewal_billing_cycles": {
-      "type": "integer"
+      "type": "number"
     },
     "auto_renew": {
       "type": "boolean"
@@ -134,7 +134,7 @@
       "type": "string"
     },
     "remaining_pause_cycles": {
-      "type": "integer"
+      "type": "number"
     },
     "currency": {
       "type": "string"
@@ -143,19 +143,19 @@
       "type": "string"
     },
     "unit_amount": {
-      "type": "integer"
+      "type": "number"
     },
     "quantity": {
-      "type": "integer"
+      "type": "number"
     },
     "add_ons": {
       "type": "array"
     },
     "add_ons_total": {
-      "type": "integer"
+      "type": "number"
     },
     "subtotal": {
-      "type": "integer"
+      "type": "number"
     },
     "collection_method": {
       "type": "string"
@@ -164,16 +164,16 @@
       "type": "string"
     },
     "net_terms": {
-      "type": "integer"
+      "type": "number"
     },
     "terms_and_conditions": {
-      "type": "integer"
+      "type": "number"
     },
     "customer_notes": {
-      "type": "integer"
+      "type": "number"
     },
     "expiration_reason": {
-      "type": "integer"
+      "type": "number"
     },
     "custom_fields": {
       "type": "array"

--- a/airbyte-integrations/connectors/source-recurly/source_recurly/schemas/transactions.json
+++ b/airbyte-integrations/connectors/source-recurly/source_recurly/schemas/transactions.json
@@ -99,7 +99,7 @@
       "type": "string"
     },
     "amount": {
-      "type": "integer"
+      "type": "number"
     },
     "status": {
       "type": "string"
@@ -164,10 +164,10 @@
           "type": "string"
         },
         "exp_month": {
-          "type": "integer"
+          "type": "number"
         },
         "exp_year": {
-          "type": "integer"
+          "type": "number"
         },
         "gateway_token": {
           "type": "string"
@@ -240,7 +240,7 @@
       "type": "string"
     },
     "gateway_response_time": {
-      "type": "integer"
+      "type": "number"
     },
     "gateway_response_values": {
       "type": "object"


### PR DESCRIPTION
## What
From user:
> I've notice that there is a new version of the Recurly Source connector (0.2.2) I've tried with that version and It seems that the invoice table worked correctly but as I've mentioned before that wasn't the only table throwing error, plans , subscriptions and transactions are the tables, I attach the full log from the server

## How
Change all integers to numbers on catalog.json.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1 `.json` files
2. the rest
