### PR TITLE
Add skip keyword for gl which allows to skip default assingments prio…

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -18,6 +18,7 @@ reviewers:
 skipKeywords:
   - dnm
   - zazmic
+  - globallogic
 
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)


### PR DESCRIPTION
Add 'globallogic' skip .github keyword.
## What
Disables adding default airbyte reviewers for GL consultants pull requests, in order to fulfill the process of internal/airbyte code reviews.

## How
By adding skip keyword to .github keyword.