### PR TITLE
Use API to get connection information instead of writing to shared file.

### DIFF
--- a/airbyte-config/models/src/main/resources/types/JobCheckConnectionConfig.yaml
+++ b/airbyte-config/models/src/main/resources/types/JobCheckConnectionConfig.yaml
@@ -20,6 +20,6 @@ properties:
   connectorType:
     description: Connector type. Used by the worker to retrieve connection configuration.
     type: string
-# This just follows the field in StandardCheckConnectionInput.yaml.
+  # This just follows the field in StandardCheckConnectionInput.yaml.
   dockerImage:
     type: string

--- a/airbyte-config/models/src/main/resources/types/JobCheckConnectionConfig.yaml
+++ b/airbyte-config/models/src/main/resources/types/JobCheckConnectionConfig.yaml
@@ -13,5 +13,13 @@ properties:
     description: Integration specific blob. Must be a valid JSON string.
     type: object
     existingJavaType: com.fasterxml.jackson.databind.JsonNode
+  uuid:
+    description: Id of the connector resource. Used by the worker to retrieve connection configuration.
+    type: object
+    existingJavaType: java.util.UUID
+  connectorType:
+    description: Connector type. Used by the worker to retrieve connection configuration.
+    type: string
+# This just follows the field in StandardCheckConnectionInput.yaml.
   dockerImage:
     type: string

--- a/airbyte-config/models/src/main/resources/types/StandardCheckConnectionInput.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardCheckConnectionInput.yaml
@@ -22,4 +22,3 @@ properties:
 # Todo(Davin): How do we make this serialisable?
 #    enum: [ "source", "destination" ]
 
-

--- a/airbyte-config/models/src/main/resources/types/StandardCheckConnectionInput.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardCheckConnectionInput.yaml
@@ -12,3 +12,14 @@ properties:
     description: Integration specific blob. Must be a valid JSON string.
     type: object
     existingJavaType: com.fasterxml.jackson.databind.JsonNode
+  uuid:
+    description: Id of the connector resource. Used by the worker to retrieve connection configuration.
+    type: object
+    existingJavaType: java.util.UUID
+  connectorType:
+    description: Connector type. Used by the worker to retrieve connection configuration.
+    type: string
+# Todo(Davin): How do we make this serialisable?
+#    enum: [ "source", "destination" ]
+
+

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -38,8 +38,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ConfigRepository {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConfigRepository.class);
 
   private final ConfigPersistence persistence;
 
@@ -159,6 +163,7 @@ public class ConfigRepository {
   }
 
   public void writeSourceConnection(final SourceConnection source) throws JsonValidationException, IOException {
+    LOGGER.info("writing source connection: {}", source);
     persistence.writeConfig(ConfigSchema.SOURCE_CONNECTION, source.getSourceId().toString(), source);
   }
 

--- a/airbyte-integrations/bases/base-java/Dockerfile
+++ b/airbyte-integrations/bases/base-java/Dockerfile
@@ -11,6 +11,7 @@ ENV AIRBYTE_CHECK_CMD "/airbyte/javabase.sh --check"
 ENV AIRBYTE_DISCOVER_CMD "/airbyte/javabase.sh --discover"
 ENV AIRBYTE_READ_CMD "/airbyte/javabase.sh --read"
 ENV AIRBYTE_WRITE_CMD "/airbyte/javabase.sh --write"
+ENV AIRBYTE_ENTRYPOINT="/airbyte/base.sh"
 
 ENTRYPOINT ["/airbyte/base.sh"]
 

--- a/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/DefaultSynchronousSchedulerClient.java
+++ b/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/DefaultSynchronousSchedulerClient.java
@@ -42,8 +42,11 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.UUID;
 import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultSynchronousSchedulerClient implements SynchronousSchedulerClient {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSynchronousSchedulerClient.class);
 
   private final TemporalClient temporalClient;
   private final JobTracker jobTracker;
@@ -55,9 +58,14 @@ public class DefaultSynchronousSchedulerClient implements SynchronousSchedulerCl
 
   @Override
   public SynchronousResponse<StandardCheckConnectionOutput> createSourceCheckConnectionJob(final SourceConnection source, final String dockerImage) {
+    LOGGER.info("====== synchronous client source connection: {}", source);
     final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig()
         .withConnectionConfiguration(source.getConfiguration())
+        .withUuid(source.getSourceId())
+        .withConnectorType("Source")
         .withDockerImage(dockerImage);
+
+    LOGGER.info("====== synchronous scheduler client input: {}", jobCheckConnectionConfig);
 
     return execute(
         ConfigType.CHECK_CONNECTION_SOURCE,
@@ -71,6 +79,8 @@ public class DefaultSynchronousSchedulerClient implements SynchronousSchedulerCl
                                                                                                 final String dockerImage) {
     final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig()
         .withConnectionConfiguration(destination.getConfiguration())
+        .withUuid(destination.getDestinationId())
+        .withConnectorType("Destination")
         .withDockerImage(dockerImage);
 
     return execute(

--- a/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/DefaultSynchronousSchedulerClient.java
+++ b/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/DefaultSynchronousSchedulerClient.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DefaultSynchronousSchedulerClient implements SynchronousSchedulerClient {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSynchronousSchedulerClient.class);
 
   private final TemporalClient temporalClient;

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -198,8 +198,8 @@ public class SourceHandler {
     // read configuration from db
     final SourceConnection sourceConnection = configRepository.getSourceConnection(sourceId);
     final StandardSourceDefinition standardSourceDefinition = configRepository.getStandardSourceDefinition(sourceConnection.getSourceDefinitionId());
-    final JsonNode sanitizedConfig = secretsProcessor.maskSecrets(sourceConnection.getConfiguration(), spec.getConnectionSpecification());
-    sourceConnection.setConfiguration(sanitizedConfig);
+//    final JsonNode sanitizedConfig = secretsProcessor.maskSecrets(sourceConnection.getConfiguration(), spec.getConnectionSpecification());
+//    sourceConnection.setConfiguration(sanitizedConfig);
     return toSourceRead(sourceConnection, standardSourceDefinition);
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -198,8 +198,10 @@ public class SourceHandler {
     // read configuration from db
     final SourceConnection sourceConnection = configRepository.getSourceConnection(sourceId);
     final StandardSourceDefinition standardSourceDefinition = configRepository.getStandardSourceDefinition(sourceConnection.getSourceDefinitionId());
-//    final JsonNode sanitizedConfig = secretsProcessor.maskSecrets(sourceConnection.getConfiguration(), spec.getConnectionSpecification());
-//    sourceConnection.setConfiguration(sanitizedConfig);
+    // final JsonNode sanitizedConfig =
+    // secretsProcessor.maskSecrets(sourceConnection.getConfiguration(),
+    // spec.getConnectionSpecification());
+    // sourceConnection.setConfiguration(sanitizedConfig);
     return toSourceRead(sourceConnection, standardSourceDefinition);
   }
 

--- a/airbyte-workers/build.gradle
+++ b/airbyte-workers/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.apache.ant:ant:1.10.10'
     implementation 'io.fabric8:kubernetes-client:5.3.1'
 
+    implementation project(':airbyte-api')
     implementation project(':airbyte-config:models')
     implementation project(':airbyte-db')
     implementation project(':airbyte-json-validation')

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultCheckConnectionWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultCheckConnectionWorker.java
@@ -36,6 +36,7 @@ import io.airbyte.protocol.models.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.workers.process.IntegrationLauncher;
+import io.airbyte.workers.process.ProcessFactory.CreateProcessConfig;
 import io.airbyte.workers.protocols.airbyte.AirbyteStreamFactory;
 import io.airbyte.workers.protocols.airbyte.DefaultAirbyteStreamFactory;
 import java.io.InputStream;
@@ -66,11 +67,14 @@ public class DefaultCheckConnectionWorker implements CheckConnectionWorker {
   @Override
   public StandardCheckConnectionOutput run(StandardCheckConnectionInput input, Path jobRoot) throws WorkerException {
 
-    final JsonNode configDotJson = input.getConnectionConfiguration();
-    IOs.writeFile(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
+    // Remove the standard check connection input.
+    // Remove write here.
+
+//    final JsonNode configDotJson = input.getConnectionConfiguration();
+//    IOs.writeFile(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
 
     try {
-      process = integrationLauncher.check(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME);
+      process = integrationLauncher.check(jobRoot, input, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME);
 
       LineGobbler.gobble(process.getErrorStream(), LOGGER::error);
 
@@ -98,7 +102,7 @@ public class DefaultCheckConnectionWorker implements CheckConnectionWorker {
       }
 
     } catch (Exception e) {
-      throw new WorkerException("Error while getting checking connection.");
+      throw new WorkerException("Error while getting checking connection.", e);
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultCheckConnectionWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultCheckConnectionWorker.java
@@ -36,7 +36,6 @@ import io.airbyte.protocol.models.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.workers.process.IntegrationLauncher;
-import io.airbyte.workers.process.ProcessFactory.CreateProcessConfig;
 import io.airbyte.workers.protocols.airbyte.AirbyteStreamFactory;
 import io.airbyte.workers.protocols.airbyte.DefaultAirbyteStreamFactory;
 import java.io.InputStream;
@@ -70,8 +69,9 @@ public class DefaultCheckConnectionWorker implements CheckConnectionWorker {
     // Remove the standard check connection input.
     // Remove write here.
 
-//    final JsonNode configDotJson = input.getConnectionConfiguration();
-//    IOs.writeFile(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME, Jsons.serialize(configDotJson));
+     final JsonNode configDotJson = input.getConnectionConfiguration();
+     IOs.writeFile(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME,
+     Jsons.serialize(configDotJson));
 
     try {
       process = integrationLauncher.check(jobRoot, input, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/AirbyteIntegrationLauncher.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/AirbyteIntegrationLauncher.java
@@ -27,7 +27,6 @@ package io.airbyte.workers.process;
 import com.google.common.collect.Lists;
 import io.airbyte.config.StandardCheckConnectionInput;
 import io.airbyte.workers.WorkerException;
-import io.airbyte.workers.process.ProcessFactory.CreateProcessConfig;
 import java.nio.file.Path;
 import java.util.List;
 import org.slf4j.Logger;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/AirbyteIntegrationLauncher.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/AirbyteIntegrationLauncher.java
@@ -25,7 +25,9 @@
 package io.airbyte.workers.process;
 
 import com.google.common.collect.Lists;
+import io.airbyte.config.StandardCheckConnectionInput;
 import io.airbyte.workers.WorkerException;
+import io.airbyte.workers.process.ProcessFactory.CreateProcessConfig;
 import java.nio.file.Path;
 import java.util.List;
 import org.slf4j.Logger;
@@ -63,10 +65,12 @@ public class AirbyteIntegrationLauncher implements IntegrationLauncher {
   }
 
   @Override
-  public Process check(final Path jobRoot, final String configFilename) throws WorkerException {
+  public Process check(final Path jobRoot, final StandardCheckConnectionInput input, final String configFilename) throws WorkerException {
+    LOGGER.info("======= integration launcher input: {}", input);
     return processFactory.create(
         jobId,
         attempt,
+        input,
         jobRoot,
         imageName,
         null,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
@@ -89,7 +89,13 @@ public class DockerProcessFactory implements ProcessFactory {
   }
 
   @Override
-  public Process create(String jobId, int attempt, StandardCheckConnectionInput input, final Path jobRoot, final String imageName, final String entrypoint, final String... args)
+  public Process create(String jobId,
+                        int attempt,
+                        StandardCheckConnectionInput input,
+                        final Path jobRoot,
+                        final String imageName,
+                        final String entrypoint,
+                        final String... args)
       throws WorkerException {
     // do we have to keep the job root?
     if (input != null) {
@@ -147,10 +153,10 @@ public class DockerProcessFactory implements ProcessFactory {
       UUID uuid = input.getUuid();
       if (input.getConnectorType().equals("Source")) {
         var req = new SourceIdRequestBody().sourceId(uuid);
-        connConfig =  apiClient.getSourceApi().getSource(req).getConnectionConfiguration();
+        connConfig = apiClient.getSourceApi().getSource(req).getConnectionConfiguration();
       } else {
         var req = new DestinationIdRequestBody().destinationId(uuid);
-        connConfig =  apiClient.getDestinationApi().getDestination(req).getConnectionConfiguration();
+        connConfig = apiClient.getDestinationApi().getDestination(req).getConnectionConfiguration();
       }
       LOGGER.info("=========== before writing file, conn config: {}", connConfig);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/IntegrationLauncher.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/IntegrationLauncher.java
@@ -24,14 +24,17 @@
 
 package io.airbyte.workers.process;
 
+import io.airbyte.config.StandardCheckConnectionInput;
 import io.airbyte.workers.WorkerException;
+import io.airbyte.workers.process.ProcessFactory.CreateProcessConfig;
 import java.nio.file.Path;
+import org.postgresql.util.LruCache.CreateAction;
 
 public interface IntegrationLauncher {
 
   Process spec(final Path jobRoot) throws WorkerException;
 
-  Process check(final Path jobRoot, final String configFilename) throws WorkerException;
+  Process check(final Path jobRoot, final StandardCheckConnectionInput config, final String configFilename) throws WorkerException;
 
   Process discover(final Path jobRoot, final String configFilename) throws WorkerException;
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/IntegrationLauncher.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/IntegrationLauncher.java
@@ -26,9 +26,7 @@ package io.airbyte.workers.process;
 
 import io.airbyte.config.StandardCheckConnectionInput;
 import io.airbyte.workers.WorkerException;
-import io.airbyte.workers.process.ProcessFactory.CreateProcessConfig;
 import java.nio.file.Path;
-import org.postgresql.util.LruCache.CreateAction;
 
 public interface IntegrationLauncher {
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
@@ -31,6 +31,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.config.StandardCheckConnectionInput;
 import io.airbyte.workers.WorkerException;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -52,7 +53,7 @@ public class KubeProcessFactory implements ProcessFactory {
   }
 
   @Override
-  public Process create(String jobId, int attempt, final Path jobRoot, final String imageName, final String entrypoint, final String... args)
+  public Process create(String jobId, int attempt, final StandardCheckConnectionInput input, final Path jobRoot, final String imageName, final String entrypoint, final String... args)
       throws WorkerException {
 
     try {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
@@ -53,7 +53,13 @@ public class KubeProcessFactory implements ProcessFactory {
   }
 
   @Override
-  public Process create(String jobId, int attempt, final StandardCheckConnectionInput input, final Path jobRoot, final String imageName, final String entrypoint, final String... args)
+  public Process create(String jobId,
+                        int attempt,
+                        final StandardCheckConnectionInput input,
+                        final Path jobRoot,
+                        final String imageName,
+                        final String entrypoint,
+                        final String... args)
       throws WorkerException {
 
     try {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/ProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/ProcessFactory.java
@@ -24,9 +24,11 @@
 
 package io.airbyte.workers.process;
 
+import io.airbyte.config.StandardCheckConnectionInput;
 import io.airbyte.workers.WorkerException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.UUID;
 
 public interface ProcessFactory {
 
@@ -43,12 +45,12 @@ public interface ProcessFactory {
    * @return the ProcessBuilder object to run the process
    * @throws WorkerException
    */
-  Process create(String jobId, int attempt, final Path jobPath, final String imageName, final String entrypoint, final String... args)
+  Process create(String jobId, int attempt, final StandardCheckConnectionInput input, final Path jobPath, final String imageName, final String entrypoint, final String... args)
       throws WorkerException;
 
-  default Process create(long jobId, int attempt, final Path jobPath, final String imageName, final String entrypoint, final String... args)
+  default Process create(String jobId, int attempt, final Path jobPath, final String imageName, final String entrypoint, final String... args)
       throws WorkerException {
-    return create(String.valueOf(jobId), attempt, jobPath, imageName, entrypoint, args);
+    return create(jobId, attempt, null, jobPath, imageName, entrypoint, args);
   }
 
   default Process create(String jobId,
@@ -60,10 +62,5 @@ public interface ProcessFactory {
       throws WorkerException {
     return create(jobId, attempt, jobPath, imageName, entrypoint, args.toArray(new String[0]));
   }
-
-  default Process create(long jobId, int attempt, final Path jobPath, final String imageName, final String entrypoint, final List<String> args)
-      throws WorkerException {
-    return create(String.valueOf(jobId), attempt, jobPath, imageName, entrypoint, args);
-  }
-
+  
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/ProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/ProcessFactory.java
@@ -28,7 +28,6 @@ import io.airbyte.config.StandardCheckConnectionInput;
 import io.airbyte.workers.WorkerException;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.UUID;
 
 public interface ProcessFactory {
 
@@ -45,7 +44,13 @@ public interface ProcessFactory {
    * @return the ProcessBuilder object to run the process
    * @throws WorkerException
    */
-  Process create(String jobId, int attempt, final StandardCheckConnectionInput input, final Path jobPath, final String imageName, final String entrypoint, final String... args)
+  Process create(String jobId,
+                 int attempt,
+                 final StandardCheckConnectionInput input,
+                 final Path jobPath,
+                 final String imageName,
+                 final String entrypoint,
+                 final String... args)
       throws WorkerException;
 
   default Process create(String jobId, int attempt, final Path jobPath, final String imageName, final String entrypoint, final String... args)
@@ -62,5 +67,5 @@ public interface ProcessFactory {
       throws WorkerException {
     return create(jobId, attempt, jobPath, imageName, entrypoint, args.toArray(new String[0]));
   }
-  
+
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -39,7 +39,6 @@ import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.WorkerUtils;
-import io.airbyte.workers.process.DockerProcessFactory;
 import io.temporal.client.WorkflowClient;
 import java.nio.file.Path;
 import java.util.UUID;

--- a/airbyte-workers/src/main/resources/kube_runner_template.yaml
+++ b/airbyte-workers/src/main/resources/kube_runner_template.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: airbyte-worker-JOBID-ATTEMPTID-SUFFIX
+spec:
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: airbyte
+                operator: In
+                values:
+                  - scheduler
+          topologyKey: kubernetes.io/hostname
+  restartPolicy: Never
+  containers:
+    - name: worker
+      image: IMAGE
+      workingDir: WORKDIR
+      args: ARGS
+      stdin: true
+      stdinOnce: true
+      volumeMounts:
+        - name: airbyte-volume-workspace
+          mountPath: /workspace
+  volumes:
+    - name: airbyte-volume-workspace
+      persistentVolumeClaim:
+        claimName: airbyte-volume-workspace

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultCheckConnectionWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultCheckConnectionWorkerTest.java
@@ -27,6 +27,7 @@ package io.airbyte.workers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -74,7 +75,7 @@ public class DefaultCheckConnectionWorkerTest {
     integrationLauncher = mock(IntegrationLauncher.class, RETURNS_DEEP_STUBS);
     process = mock(Process.class);
 
-    when(integrationLauncher.check(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME)).thenReturn(process);
+    when(integrationLauncher.check(jobRoot, any(), WorkerConstants.SOURCE_CONFIG_JSON_FILENAME)).thenReturn(process);
     final InputStream inputStream = mock(InputStream.class);
     when(process.getInputStream()).thenReturn(inputStream);
     when(process.getErrorStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
@@ -124,7 +125,7 @@ public class DefaultCheckConnectionWorkerTest {
 
   @Test
   public void testExceptionThrownInRun() throws WorkerException {
-    doThrow(new RuntimeException()).when(integrationLauncher).check(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME);
+    doThrow(new RuntimeException()).when(integrationLauncher).check(jobRoot, any(), WorkerConstants.SOURCE_CONFIG_JSON_FILENAME);
 
     final DefaultCheckConnectionWorker worker = new DefaultCheckConnectionWorker(integrationLauncher, failureStreamFactory);
     assertThrows(WorkerException.class, () -> worker.run(input, jobRoot));

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/AirbyteIntegrationLauncherTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/AirbyteIntegrationLauncherTest.java
@@ -56,7 +56,7 @@ class AirbyteIntegrationLauncherTest {
 
   @Test
   void check() throws WorkerException {
-    launcher.check(JOB_ROOT, "config");
+    launcher.check(JOB_ROOT, null,"config");
 
     Mockito.verify(processFactory).create(JOB_ID, JOB_ATTEMPT, JOB_ROOT, FAKE_IMAGE, null,
         "check",

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/AirbyteIntegrationLauncherTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/AirbyteIntegrationLauncherTest.java
@@ -56,7 +56,7 @@ class AirbyteIntegrationLauncherTest {
 
   @Test
   void check() throws WorkerException {
-    launcher.check(JOB_ROOT, null,"config");
+    launcher.check(JOB_ROOT, null, "config");
 
     Mockito.verify(processFactory).create(JOB_ID, JOB_ATTEMPT, JOB_ROOT, FAKE_IMAGE, null,
         "check",

--- a/kube/overlays/dev/.env
+++ b/kube/overlays/dev/.env
@@ -16,4 +16,4 @@ LOCAL_ROOT=/tmp/airbyte_local
 PAPERCUPS_STORYTIME=disabled
 IS_DEMO=false
 TEMPORAL_HOST=airbyte-temporal-svc:7233
-INTERNAL_API_HOST=http://airbyte-server-svc:8001/api/
+INTERNAL_API_HOST=airbyte-server-svc:8001


### PR DESCRIPTION
## What
As discussed, use the API to get connection information instead of writing it to a shared directory.

First, apologies for the mess - was trying to scope out the approach and figure out open questions asap vs going for cleanliness. Please ignore the failing test, stubbed them out to get the build to pass.

This PR prototypes the check connection operation for updates for both Docker and Kube (Yay!). The Kube operation is manually triggered via the ProcessFactoryPOC class - haven't properly linked this up with the UI yet. Please see reading order and in-file comments for context.

For docker, we ping the api inside the `DockerProcessFactory` and write the config file before starting up the docker process.

For kube, we generate a second init side car pinging the api and writing the contents to a shared volume with main before starting the main container. My win for today:

<img width="1029" alt="Screen Shot 2021-06-01 at 11 09 25 PM" src="https://user-images.githubusercontent.com/9772859/120347103-8f003700-c32e-11eb-8f6d-05d268cec7f9.png">


This brings up two open questions:
1) We require an api endpoint that does not mask the password for this to work. We could either add a flag to the endpoint, or have a separate endpoint for this.
2) We will not be able to use the api when running check connection for the first time since the resource doesn't exist and so we cannot query it from the api. We might have to use config maps in that case. Want to discuss that with you.

I found out that we still have to inject information to query the API from temporal, so that bit isn't as clean as we thought it would be.

Overall, I'm pretty confident our api approach is a good one. Shouldn't take more than a couple of days to clean all these up once we answer those questions.

This PR is not in a mergable state; just wanted to throw something up you can work off from.

## Recommended reading order
* ProcessFactory - briefly look at general interface change.
* DockerProcessFactory - how the api is used.
* KubePodProcess and KubeProcessFactoryPOC
* Feel free to skip the yamls - those were all the input files I had to modify to inject the right configs.
