### PR TITLE
Recurly catalog update

### DIFF
--- a/airbyte-integrations/connectors/source-recurly/Dockerfile
+++ b/airbyte-integrations/connectors/source-recurly/Dockerfile
@@ -12,5 +12,5 @@ COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.3
+LABEL io.airbyte.version=0.2.4
 LABEL io.airbyte.name=airbyte/source-recurly

--- a/airbyte-integrations/connectors/source-recurly/source_recurly/schemas/plans.json
+++ b/airbyte-integrations/connectors/source-recurly/source_recurly/schemas/plans.json
@@ -27,7 +27,7 @@
       "type": "number"
     },
     "trial_unit": {
-      "type": "number"
+      "type": "string"
     },
     "trial_length": {
       "type": "number"

--- a/airbyte-integrations/connectors/source-recurly/source_recurly/schemas/subscriptions.json
+++ b/airbyte-integrations/connectors/source-recurly/source_recurly/schemas/subscriptions.json
@@ -167,13 +167,13 @@
       "type": "number"
     },
     "terms_and_conditions": {
-      "type": "number"
+      "type": "string"
     },
     "customer_notes": {
-      "type": "number"
+      "type": "string"
     },
     "expiration_reason": {
-      "type": "number"
+      "type": "string"
     },
     "custom_fields": {
       "type": "array"


### PR DESCRIPTION
## What
update schema from Recurly source as informed [here](https://developers.recurly.com/api/v2019-10-10/index.html#operation/list_account_subscriptions)

```
“2021-06-02 16:02:13 INFO (/tmp/workspace/51/0) LineGobbler(voidCall):69 - invalid input syntax for type double precision: “canceled”"
```
[logs-recurly-postgres-1.txt](https://github.com/airbytehq/airbyte/files/6586187/logs-recurly-postgres-1.txt)
## How
User having a problem with data types when applying normalization.
We tested sync using a local image and it's worked.

## Pre-merge Checklist
- [ ] *Run integration tests*
- [ ] *Publish Docker images*

## Recommended reading order
1. `plans.json`
2. `subscriptions.json`
