### PR TITLE
JDBC sources: Fix unexcepcted long Integer value failure

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/435bb9a5-7887-4809-aa58-28c27df0d7ad.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/435bb9a5-7887-4809-aa58-28c27df0d7ad.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "435bb9a5-7887-4809-aa58-28c27df0d7ad",
   "name": "MySQL",
   "dockerRepository": "airbyte/source-mysql",
-  "dockerImageTag": "0.3.3",
+  "dockerImageTag": "0.3.4",
   "documentationUrl": "https://docs.airbyte.io/integrations/sources/mysql",
   "icon": "mysql.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -71,7 +71,7 @@
 - sourceDefinitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
   name: MySQL
   dockerRepository: airbyte/source-mysql
-  dockerImageTag: 0.3.3
+  dockerImageTag: 0.3.4
   documentationUrl: https://docs.airbyte.io/integrations/sources/mysql
   icon: mysql.svg
 - sourceDefinitionId: 2470e835-feaf-4db6-96f3-70fd645acc77

--- a/airbyte-db/src/main/java/io/airbyte/db/jdbc/JdbcUtils.java
+++ b/airbyte-db/src/main/java/io/airbyte/db/jdbc/JdbcUtils.java
@@ -152,9 +152,9 @@ public class JdbcUtils {
   }
 
   /**
-   * In some sources Integer might have value larger than {@link Integer#MAX_VALUE}. E.q. MySQL has unsigned Integer type,
-   * which can contain value 3428724653.
-   * If we fail to cast Integer value, we will try to cast Long.
+   * In some sources Integer might have value larger than {@link Integer#MAX_VALUE}. E.q. MySQL has
+   * unsigned Integer type, which can contain value 3428724653. If we fail to cast Integer value, we
+   * will try to cast Long.
    */
   private static void putInteger(ObjectNode node, String columnName, ResultSet r, int i) {
     try {

--- a/airbyte-db/src/main/java/io/airbyte/db/jdbc/JdbcUtils.java
+++ b/airbyte-db/src/main/java/io/airbyte/db/jdbc/JdbcUtils.java
@@ -156,11 +156,11 @@ public class JdbcUtils {
    * unsigned Integer type, which can contain value 3428724653. If we fail to cast Integer value, we
    * will try to cast Long.
    */
-  private static void putInteger(ObjectNode node, String columnName, ResultSet r, int i) {
+  private static void putInteger(ObjectNode node, String columnName, ResultSet resultSet, int index) {
     try {
-      node.put(columnName, r.getInt(i));
+      node.put(columnName, resultSet.getInt(index));
     } catch (SQLException e) {
-      node.put(columnName, nullIfInvalid(() -> r.getLong(i)));
+      node.put(columnName, nullIfInvalid(() -> resultSet.getLong(index)));
     }
   }
 

--- a/airbyte-db/src/main/java/io/airbyte/db/jdbc/JdbcUtils.java
+++ b/airbyte-db/src/main/java/io/airbyte/db/jdbc/JdbcUtils.java
@@ -132,7 +132,7 @@ public class JdbcUtils {
     switch (columnType) {
       case BIT, BOOLEAN -> o.put(columnName, r.getBoolean(i));
       case TINYINT, SMALLINT -> o.put(columnName, r.getShort(i));
-      case INTEGER -> o.put(columnName, r.getInt(i));
+      case INTEGER -> putInteger(o, columnName, r, i);
       case BIGINT -> o.put(columnName, nullIfInvalid(() -> r.getLong(i)));
       case FLOAT, DOUBLE -> o.put(columnName, nullIfInvalid(() -> r.getDouble(i), Double::isFinite));
       case REAL -> o.put(columnName, nullIfInvalid(() -> r.getFloat(i), Float::isFinite));
@@ -148,6 +148,19 @@ public class JdbcUtils {
       }
       case BLOB, BINARY, VARBINARY, LONGVARBINARY -> o.put(columnName, r.getBytes(i));
       default -> o.put(columnName, r.getString(i));
+    }
+  }
+
+  /**
+   * In some sources Integer might have value larger than {@link Integer#MAX_VALUE}. E.q. MySQL has unsigned Integer type,
+   * which can contain value 3428724653.
+   * If we fail to cast Integer value, we will try to cast Long.
+   */
+  private static void putInteger(ObjectNode node, String columnName, ResultSet r, int i) {
+    try {
+      node.put(columnName, r.getInt(i));
+    } catch (SQLException e) {
+      node.put(columnName, nullIfInvalid(() -> r.getLong(i)));
     }
   }
 

--- a/airbyte-integrations/connectors/source-mysql/Dockerfile
+++ b/airbyte-integrations/connectors/source-mysql/Dockerfile
@@ -8,6 +8,6 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.3.3
+LABEL io.airbyte.version=0.3.4
 
 LABEL io.airbyte.name=airbyte/source-mysql


### PR DESCRIPTION
Issue: #3840

## What
Fix an error when JDBC source produces Integer value bigger than max Java Integer value. 

## How
Implement handler which tries to convert into Integer first. My assumption is that at most cases the value will be in the range. 
If it fails, the handler tries to convert into the Long type. In all other negative cases it will replace value by `null`.

## Pre-merge Checklist
- [x] *Run integration tests*
- [x] *Publish Docker images*

## Recommended reading order
1. `JdbcUtils.java`
