### PR TITLE
Remove merge step in publish workflow

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -117,12 +117,6 @@ jobs:
           comment-id: ${{ github.event.inputs.comment-id }}
           body: |
             > :white_check_mark: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-      - name: Merge Pull Request
-        if: success()
-        uses: ridedott/merge-me-action@v1
-        with:
-          GITHUB_TOKEN: ${{ secrets.SLASH_COMMAND_PAT }}
-          MERGE_METHOD: SQUASH
       - name: Add Failure Comment
         if: github.event.inputs.comment-id && !success()
         uses: peter-evans/create-or-update-comment@v1


### PR DESCRIPTION
## Why
1. it wasn't working before
2. it assumes too much about what the PR is trying to accomplish e.g: some PRs publish multiple connectors. 

de-facto this changes nothing since we already manually merged due to point no. 1

