### PR TITLE
🐛  bug fix: make sure logs from threads in replication workers are added…

### DIFF
--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.string.Strings;
 import io.airbyte.config.ConfigSchema;
@@ -55,6 +56,7 @@ import io.airbyte.workers.protocols.airbyte.AirbyteMessageTracker;
 import io.airbyte.workers.protocols.airbyte.AirbyteMessageUtils;
 import io.airbyte.workers.protocols.airbyte.AirbyteSource;
 import io.airbyte.workers.protocols.airbyte.NamespacingMapper;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -62,6 +64,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,6 +72,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 class DefaultReplicationWorkerTest {
 
@@ -96,6 +100,8 @@ class DefaultReplicationWorkerTest {
   @SuppressWarnings("unchecked")
   @BeforeEach
   void setup() throws Exception {
+    MDC.clear();
+
     jobRoot = Files.createDirectories(Files.createTempDirectory("test").resolve(WORKSPACE_ROOT));
 
     final ImmutablePair<StandardSync, StandardSyncInput> syncPair = TestConfigHelpers.createSyncConfig();
@@ -118,6 +124,11 @@ class DefaultReplicationWorkerTest {
     when(mapper.mapMessage(RECORD_MESSAGE2)).thenReturn(RECORD_MESSAGE2);
   }
 
+  @AfterEach
+  void tearDown() {
+    MDC.clear();
+  }
+
   @Test
   void test() throws Exception {
     final ReplicationWorker worker = new DefaultReplicationWorker(
@@ -137,6 +148,32 @@ class DefaultReplicationWorkerTest {
     verify(destination).accept(RECORD_MESSAGE2);
     verify(source).close();
     verify(destination).close();
+  }
+
+  @Test
+  void testLoggingInThreads() throws IOException, WorkerException {
+    // set up the mdc so that actually log to a file, so that we can verify that file logging captures
+    // threads.
+    final Path jobRoot = Files.createTempDirectory(Path.of("/tmp"), "mdc_test");
+    WorkerUtils.setJobMdc(jobRoot, "1");
+
+    final ReplicationWorker worker = new DefaultReplicationWorker(
+        JOB_ID,
+        JOB_ATTEMPT,
+        source,
+        mapper,
+        destination,
+        sourceMessageTracker,
+        destinationMessageTracker);
+
+    worker.run(syncInput, jobRoot);
+
+    final Path logPath = jobRoot.resolve(WorkerConstants.LOG_FILENAME);
+    final String logs = IOs.readFile(logPath);
+
+    // make sure we get logs from the threads.
+    assertTrue(logs.contains("Replication thread started."));
+    assertTrue(logs.contains("Destination output thread started."));
   }
 
   @SuppressWarnings({"BusyWait"})


### PR DESCRIPTION
… to log file

closes https://github.com/airbytehq/airbyte/issues/3824

## What
* Checkpointing introduced 2 threads to the `ReplicationWorker` that are executed via an `ExecutorService`. We rely on metadata in the `MDC` to make sure that log lines are appended to our log file. Because in java the MDC of the parent thread is not by default passed to threads executed in an `ExecutorService`, STDOUT of the newly introduced threads was not making it into the log file. 
* To be clear we were logging to STDOUT, we just were not getting these logs into the log file. This was particularly bad because when helping users debug issues, we generally ask them to download the scheduler logs from the UI. These logs come directly from the log file. So these important logs were not included in the debugging information, making it very hard to debug issues (and was also a red herring making it look like certain parts of the code path were not running when really they were).

## How
* Explicitly copy the MDC of the parent thread into the children threads.
* Add test to verify that the logging works as expected.
