### PR TITLE
Clean up Cancel Exception Handling.

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/io/LineGobbler.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/io/LineGobbler.java
@@ -42,16 +42,15 @@ public class LineGobbler implements VoidCallable {
 
   private final static Logger LOGGER = LoggerFactory.getLogger(LineGobbler.class);
 
-  public static LineGobbler gobble(final InputStream is, final Consumer<String> consumer) {
-    return gobble(is, consumer, "generic");
+  public static void gobble(final InputStream is, final Consumer<String> consumer) {
+    gobble(is, consumer, "generic");
   }
 
-  public static LineGobbler gobble(final InputStream is, final Consumer<String> consumer, String caller) {
+  public static void gobble(final InputStream is, final Consumer<String> consumer, String caller) {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     final Map<String, String> mdc = MDC.getCopyOfContextMap();
     var gobbler = new LineGobbler(is, consumer, executor, mdc, caller);
     executor.submit(gobbler);
-    return gobbler;
   }
 
   private final BufferedReader is;

--- a/airbyte-commons/src/main/java/io/airbyte/commons/io/LineGobbler.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/io/LineGobbler.java
@@ -31,9 +31,7 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import javax.sound.sampled.Line;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -60,9 +58,9 @@ public class LineGobbler implements VoidCallable {
   private final String caller;
 
   LineGobbler(final InputStream is,
-      final Consumer<String> consumer,
-      final ExecutorService executor,
-      final Map<String, String> mdc) {
+              final Consumer<String> consumer,
+              final ExecutorService executor,
+              final Map<String, String> mdc) {
     this(is, consumer, executor, mdc, "generic");
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -207,7 +207,6 @@ public class DefaultReplicationWorker implements ReplicationWorker {
       LOGGER.info("Replication thread started.");
       try {
         while (!cancelled.get() && !source.isFinished()) {
-          LOGGER.info("====== replication thread trying to read");
           final Optional<AirbyteMessage> messageOptional = source.attemptRead();
           if (messageOptional.isPresent()) {
             final AirbyteMessage message = mapper.mapMessage(messageOptional.get());
@@ -215,7 +214,6 @@ public class DefaultReplicationWorker implements ReplicationWorker {
             sourceMessageTracker.accept(message);
             destination.accept(message);
           }
-          LOGGER.info("====== replication thread read; next loop");
         }
         destination.notifyEndOfStream();
       } catch (Exception e) {
@@ -235,13 +233,11 @@ public class DefaultReplicationWorker implements ReplicationWorker {
       LOGGER.info("Destination output thread started.");
       try {
         while (!cancelled.get() && !destination.isFinished()) {
-          LOGGER.info("====== destination output trying to read");
           final Optional<AirbyteMessage> messageOptional = destination.attemptRead();
           if (messageOptional.isPresent()) {
             LOGGER.info("state in DefaultReplicationWorker from Destination: {}", messageOptional.get());
             destinationMessageTracker.accept(messageOptional.get());
           }
-          LOGGER.info("====== destination output read; next loop");
         }
       } catch (Exception e) {
         if (!cancelled.get()) {
@@ -260,7 +256,6 @@ public class DefaultReplicationWorker implements ReplicationWorker {
       e.printStackTrace();
     }
     cancelled.set(true);
-    LOGGER.info("====== cancelled set to True");
 
     LOGGER.info("Cancelling destination...");
     try {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -207,6 +207,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
       LOGGER.info("Replication thread started.");
       try {
         while (!cancelled.get() && !source.isFinished()) {
+          LOGGER.info("====== replication thread trying to read");
           final Optional<AirbyteMessage> messageOptional = source.attemptRead();
           if (messageOptional.isPresent()) {
             final AirbyteMessage message = mapper.mapMessage(messageOptional.get());

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -249,6 +249,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
 
   @Override
   public void cancel() {
+    // Resources are closed in the opposite order they are declared.
     LOGGER.info("Cancelling replication worker...");
     try {
       executors.awaitTermination(10, TimeUnit.SECONDS);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -60,6 +61,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
   private final MessageTracker<AirbyteMessage> sourceMessageTracker;
   private final MessageTracker<AirbyteMessage> destinationMessageTracker;
 
+  private final ExecutorService executors;
   private final AtomicBoolean cancelled;
   private final AtomicBoolean hasFailed;
 
@@ -77,6 +79,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
     this.destination = destination;
     this.sourceMessageTracker = sourceMessageTracker;
     this.destinationMessageTracker = destinationMessageTracker;
+    this.executors = Executors.newFixedThreadPool(2);
 
     this.cancelled = new AtomicBoolean(false);
     this.hasFailed = new AtomicBoolean(false);
@@ -111,7 +114,6 @@ public class DefaultReplicationWorker implements ReplicationWorker {
               s -> String.format("%s - %s", s.getSyncMode(), s.getDestinationSyncMode()))));
       final StandardTapConfig sourceConfig = WorkerUtils.syncToTapConfig(syncInput);
 
-      final ExecutorService executorService = Executors.newFixedThreadPool(2);
       final Map<String, String> mdc = MDC.getCopyOfContextMap();
 
       // note: resources are closed in the opposite order in which they are declared. thus source will be
@@ -120,13 +122,13 @@ public class DefaultReplicationWorker implements ReplicationWorker {
         destination.start(destinationConfig, jobRoot);
         source.start(sourceConfig, jobRoot);
 
-        final Future<?> destinationOutputThreadFuture = executorService.submit(getDestinationOutputRunnable(
+        final Future<?> destinationOutputThreadFuture = executors.submit(getDestinationOutputRunnable(
             destination,
             cancelled,
             destinationMessageTracker,
             mdc));
 
-        final Future<?> replicationThreadFuture = executorService.submit(getReplicationRunnable(
+        final Future<?> replicationThreadFuture = executors.submit(getReplicationRunnable(
             source,
             destination,
             cancelled,
@@ -145,7 +147,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
         hasFailed.set(true);
         LOGGER.error("Sync worker failed.", e);
       } finally {
-        executorService.shutdownNow();
+        executors.shutdownNow();
       }
 
       final ReplicationStatus outputStatus;
@@ -212,10 +214,13 @@ public class DefaultReplicationWorker implements ReplicationWorker {
             sourceMessageTracker.accept(message);
             destination.accept(message);
           }
+          LOGGER.info("====== replication thread read; next loop");
         }
         destination.notifyEndOfStream();
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        if (!cancelled.get()) {
+          throw new RuntimeException(e);
+        }
       }
     };
   }
@@ -229,14 +234,18 @@ public class DefaultReplicationWorker implements ReplicationWorker {
       LOGGER.info("Destination output thread started.");
       try {
         while (!cancelled.get() && !destination.isFinished()) {
+          LOGGER.info("====== destination output trying to read");
           final Optional<AirbyteMessage> messageOptional = destination.attemptRead();
           if (messageOptional.isPresent()) {
             LOGGER.info("state in DefaultReplicationWorker from Destination: {}", messageOptional.get());
             destinationMessageTracker.accept(messageOptional.get());
           }
+          LOGGER.info("====== destination output read; next loop");
         }
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        if (!cancelled.get()) {
+          throw new RuntimeException(e);
+        }
       }
     };
   }
@@ -244,20 +253,26 @@ public class DefaultReplicationWorker implements ReplicationWorker {
   @Override
   public void cancel() {
     LOGGER.info("Cancelling replication worker...");
+    try {
+      executors.awaitTermination(10, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
     cancelled.set(true);
+    LOGGER.info("====== cancelled set to True");
 
     LOGGER.info("Cancelling source...");
     try {
       source.cancel();
     } catch (Exception e) {
-      e.printStackTrace();
+      LOGGER.info("Error cancelling source: ", e);
     }
 
     LOGGER.info("Cancelling destination...");
     try {
       destination.cancel();
     } catch (Exception e) {
-      e.printStackTrace();
+      LOGGER.info("Error cancelling destination: ", e);
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -261,6 +261,13 @@ public class DefaultReplicationWorker implements ReplicationWorker {
     cancelled.set(true);
     LOGGER.info("====== cancelled set to True");
 
+    LOGGER.info("Cancelling destination...");
+    try {
+      destination.cancel();
+    } catch (Exception e) {
+      LOGGER.info("Error cancelling destination: ", e);
+    }
+
     LOGGER.info("Cancelling source...");
     try {
       source.cancel();
@@ -268,12 +275,6 @@ public class DefaultReplicationWorker implements ReplicationWorker {
       LOGGER.info("Error cancelling source: ", e);
     }
 
-    LOGGER.info("Cancelling destination...");
-    try {
-      destination.cancel();
-    } catch (Exception e) {
-      LOGGER.info("Error cancelling destination: ", e);
-    }
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -218,6 +218,8 @@ public class DefaultReplicationWorker implements ReplicationWorker {
         destination.notifyEndOfStream();
       } catch (Exception e) {
         if (!cancelled.get()) {
+          // Although this thread is closed first, it races with the source's closure and can attempt one final read after the source is closed before it's terminated.
+          // This read will fail and throw an exception. Because of this, throw exceptions only if the worker was not cancelled.
           throw new RuntimeException(e);
         }
       }
@@ -241,6 +243,8 @@ public class DefaultReplicationWorker implements ReplicationWorker {
         }
       } catch (Exception e) {
         if (!cancelled.get()) {
+          // Although this thread is closed first, it races with the destination's closure and can attempt one final read after the destination is closed before it's terminated.
+          // This read will fail and throw an exception. Because of this, throw exceptions only if the worker was not cancelled.
           throw new RuntimeException(e);
         }
       }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -218,8 +218,10 @@ public class DefaultReplicationWorker implements ReplicationWorker {
         destination.notifyEndOfStream();
       } catch (Exception e) {
         if (!cancelled.get()) {
-          // Although this thread is closed first, it races with the source's closure and can attempt one final read after the source is closed before it's terminated.
-          // This read will fail and throw an exception. Because of this, throw exceptions only if the worker was not cancelled.
+          // Although this thread is closed first, it races with the source's closure and can attempt one
+          // final read after the source is closed before it's terminated.
+          // This read will fail and throw an exception. Because of this, throw exceptions only if the worker
+          // was not cancelled.
           throw new RuntimeException(e);
         }
       }
@@ -243,8 +245,10 @@ public class DefaultReplicationWorker implements ReplicationWorker {
         }
       } catch (Exception e) {
         if (!cancelled.get()) {
-          // Although this thread is closed first, it races with the destination's closure and can attempt one final read after the destination is closed before it's terminated.
-          // This read will fail and throw an exception. Because of this, throw exceptions only if the worker was not cancelled.
+          // Although this thread is closed first, it races with the destination's closure and can attempt one
+          // final read after the destination is closed before it's terminated.
+          // This read will fail and throw an exception. Because of this, throw exceptions only if the worker
+          // was not cancelled.
           throw new RuntimeException(e);
         }
       }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/Worker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/Worker.java
@@ -34,9 +34,9 @@ public interface Worker<InputType, OutputType> {
    */
   OutputType run(InputType inputType, Path jobRoot) throws WorkerException;
 
-
   /**
-   * Cancels in-progress workers. Although all workers support cancel, in reality only the asynchronous {@link DefaultReplicationWorker}'s cancel is used.
+   * Cancels in-progress workers. Although all workers support cancel, in reality only the
+   * asynchronous {@link DefaultReplicationWorker}'s cancel is used.
    */
   void cancel();
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/Worker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/Worker.java
@@ -34,6 +34,10 @@ public interface Worker<InputType, OutputType> {
    */
   OutputType run(InputType inputType, Path jobRoot) throws WorkerException;
 
+
+  /**
+   * Cancels in-progress workers. Although all workers support cancel, in reality only the asynchronous {@link DefaultReplicationWorker}'s cancel is used.
+   */
   void cancel();
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -53,6 +53,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
 
   private final IntegrationLauncher integrationLauncher;
   private final AirbyteStreamFactory streamFactory;
+  private LineGobbler gobbler;
 
   private final AtomicBoolean endOfStream = new AtomicBoolean(false);
 
@@ -84,7 +85,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
         WorkerConstants.DESTINATION_CONFIG_JSON_FILENAME,
         WorkerConstants.DESTINATION_CATALOG_JSON_FILENAME);
     // stdout logs are logged elsewhere since stdout also contains data
-    LineGobbler.gobble(destinationProcess.getErrorStream(), LOGGER::error);
+    gobbler = LineGobbler.gobble(destinationProcess.getErrorStream(), LOGGER::error);
 
     writer = new BufferedWriter(new OutputStreamWriter(destinationProcess.getOutputStream(), Charsets.UTF_8));
 
@@ -120,6 +121,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
       notifyEndOfStream();
     }
 
+    gobbler.close();
     LOGGER.debug("Closing destination process");
     WorkerUtils.gentleClose(destinationProcess, 10, TimeUnit.HOURS);
     if (destinationProcess.isAlive() || destinationProcess.exitValue() != 0) {
@@ -135,6 +137,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
       LOGGER.info("Destination process no longer exists, cancellation is a no-op.");
     } else {
       LOGGER.info("Destination process exists, cancelling...");
+      gobbler.close();
       WorkerUtils.cancelProcess(destinationProcess);
       LOGGER.info("Cancelled destination process!");
     }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -111,7 +111,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
   }
 
   @Override
-  public void close() throws WorkerException, IOException {
+  public void close() throws IOException {
     if (destinationProcess == null) {
       return;
     }
@@ -123,7 +123,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
     LOGGER.debug("Closing destination process");
     WorkerUtils.gentleClose(destinationProcess, 10, TimeUnit.HOURS);
     if (destinationProcess.isAlive() || destinationProcess.exitValue() != 0) {
-      throw new WorkerException("destination process wasn't successful");
+      LOGGER.warn("destination process might not have shut down correctly. destination process alive: {}, destination process exit value: {}", destinationProcess.isAlive(), destinationProcess.exitValue());
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -53,7 +53,6 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
 
   private final IntegrationLauncher integrationLauncher;
   private final AirbyteStreamFactory streamFactory;
-  private LineGobbler gobbler;
 
   private final AtomicBoolean endOfStream = new AtomicBoolean(false);
 
@@ -85,7 +84,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
         WorkerConstants.DESTINATION_CONFIG_JSON_FILENAME,
         WorkerConstants.DESTINATION_CATALOG_JSON_FILENAME);
     // stdout logs are logged elsewhere since stdout also contains data
-    gobbler = LineGobbler.gobble(destinationProcess.getErrorStream(), LOGGER::error, "airbyte-destination");
+    LineGobbler.gobble(destinationProcess.getErrorStream(), LOGGER::error, "airbyte-destination");
 
     writer = new BufferedWriter(new OutputStreamWriter(destinationProcess.getOutputStream(), Charsets.UTF_8));
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -123,7 +123,9 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
     LOGGER.debug("Closing destination process");
     WorkerUtils.gentleClose(destinationProcess, 10, TimeUnit.HOURS);
     if (destinationProcess.isAlive() || destinationProcess.exitValue() != 0) {
-      LOGGER.warn("Destination process might not have shut down correctly. destination process alive: {}, destination process exit value: {}. This warning is normal if the job was cancelled.", destinationProcess.isAlive(), destinationProcess.exitValue());
+      LOGGER.warn(
+          "Destination process might not have shut down correctly. destination process alive: {}, destination process exit value: {}. This warning is normal if the job was cancelled.",
+          destinationProcess.isAlive(), destinationProcess.exitValue());
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -123,7 +123,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
     LOGGER.debug("Closing destination process");
     WorkerUtils.gentleClose(destinationProcess, 10, TimeUnit.HOURS);
     if (destinationProcess.isAlive() || destinationProcess.exitValue() != 0) {
-      LOGGER.warn("destination process might not have shut down correctly. destination process alive: {}, destination process exit value: {}", destinationProcess.isAlive(), destinationProcess.exitValue());
+      LOGGER.warn("Destination process might not have shut down correctly. destination process alive: {}, destination process exit value: {}", destinationProcess.isAlive(), destinationProcess.exitValue());
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
@@ -127,7 +127,7 @@ public class DefaultAirbyteSource implements AirbyteSource {
         FORCED_SHUTDOWN_DURATION);
 
     if (sourceProcess.isAlive() || sourceProcess.exitValue() != 0) {
-      throw new WorkerException("Source process wasn't successful");
+      LOGGER.warn("Source process might not have shut down correctly. source process alive: {}, source process exit value: {}", sourceProcess.isAlive(), sourceProcess.exitValue());
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
@@ -58,7 +58,6 @@ public class DefaultAirbyteSource implements AirbyteSource {
   private final IntegrationLauncher integrationLauncher;
   private final AirbyteStreamFactory streamFactory;
   private final HeartbeatMonitor heartbeatMonitor;
-  private LineGobbler gobbler;
 
   private Process sourceProcess = null;
   private Iterator<AirbyteMessage> messageIterator = null;
@@ -91,7 +90,7 @@ public class DefaultAirbyteSource implements AirbyteSource {
         WorkerConstants.SOURCE_CATALOG_JSON_FILENAME,
         input.getState() == null ? null : WorkerConstants.INPUT_STATE_JSON_FILENAME);
     // stdout logs are logged elsewhere since stdout also contains data
-    gobbler = LineGobbler.gobble(sourceProcess.getErrorStream(), LOGGER::error, "airbyte-source");
+    LineGobbler.gobble(sourceProcess.getErrorStream(), LOGGER::error, "airbyte-source");
 
     messageIterator = streamFactory.create(IOs.newBufferedReader(sourceProcess.getInputStream()))
         .peek(message -> heartbeatMonitor.beat())

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
@@ -33,7 +33,6 @@ import io.airbyte.config.StandardTapConfig;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.workers.WorkerConstants;
-import io.airbyte.workers.WorkerException;
 import io.airbyte.workers.WorkerUtils;
 import io.airbyte.workers.process.IntegrationLauncher;
 import java.nio.file.Path;
@@ -127,7 +126,9 @@ public class DefaultAirbyteSource implements AirbyteSource {
         FORCED_SHUTDOWN_DURATION);
 
     if (sourceProcess.isAlive() || sourceProcess.exitValue() != 0) {
-      LOGGER.warn("Source process might not have shut down correctly. source process alive: {}, source process exit value: {}. This warning is normal if the job was cancelled.", sourceProcess.isAlive(), sourceProcess.exitValue());
+      LOGGER.warn(
+          "Source process might not have shut down correctly. source process alive: {}, source process exit value: {}. This warning is normal if the job was cancelled.",
+          sourceProcess.isAlive(), sourceProcess.exitValue());
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CancellationHandler.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CancellationHandler.java
@@ -24,7 +24,6 @@
 
 package io.airbyte.workers.temporal;
 
-import io.airbyte.workers.DefaultReplicationWorker;
 import io.airbyte.workers.WorkerException;
 import io.temporal.activity.Activity;
 import io.temporal.activity.ActivityExecutionContext;
@@ -34,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 public interface CancellationHandler {
 
-  void checkAndHandleCancellation(Runnable onCancellationCallback) ;
+  void checkAndHandleCancellation(Runnable onCancellationCallback);
 
   class TemporalCancellationHandler implements CancellationHandler {
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CancellationHandler.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CancellationHandler.java
@@ -24,16 +24,21 @@
 
 package io.airbyte.workers.temporal;
 
+import io.airbyte.workers.DefaultReplicationWorker;
 import io.airbyte.workers.WorkerException;
 import io.temporal.activity.Activity;
 import io.temporal.activity.ActivityExecutionContext;
 import io.temporal.client.ActivityCompletionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public interface CancellationHandler {
 
   void checkAndHandleCancellation(Runnable onCancellationCallback) throws WorkerException;
 
   class TemporalCancellationHandler implements CancellationHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TemporalCancellationHandler.class);
 
     final ActivityExecutionContext context;
 
@@ -54,7 +59,7 @@ public interface CancellationHandler {
      * @throws WorkerException
      */
     @Override
-    public void checkAndHandleCancellation(Runnable onCancellationCallback) throws WorkerException {
+    public void checkAndHandleCancellation(Runnable onCancellationCallback) {
       try {
         // Heartbeat is somewhat misleading here. What it does is check the current Temporal activity's
         // context and
@@ -64,7 +69,7 @@ public interface CancellationHandler {
         context.heartbeat(null);
       } catch (ActivityCompletionException e) {
         onCancellationCallback.run();
-        throw new WorkerException("Worker cleaned up after exception", e);
+        LOGGER.warn("Job either timeout-ed or was cancelled.");
       }
     }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CancellationHandler.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CancellationHandler.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 
 public interface CancellationHandler {
 
-  void checkAndHandleCancellation(Runnable onCancellationCallback) throws WorkerException;
+  void checkAndHandleCancellation(Runnable onCancellationCallback) ;
 
   class TemporalCancellationHandler implements CancellationHandler {
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
@@ -31,14 +31,12 @@ import io.airbyte.commons.io.IOs;
 import io.airbyte.config.EnvConfigs;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.Worker;
-import io.airbyte.workers.WorkerException;
 import io.airbyte.workers.WorkerUtils;
 import io.temporal.activity.Activity;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -155,13 +153,14 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
     });
   }
 
-
   /**
-   * Cancel is implementation in a slightly convoluted manner due to Temporal's semantics. Cancel requests are routed to the Temporal Scheduler via
-   * the cancelJob function in SchedulerHandler.java. This manifests as a {@link io.temporal.client.ActivityCompletionException} when the {@link CancellationHandler}
-   * heartbeats to the Temporal Scheduler.
+   * Cancel is implementation in a slightly convoluted manner due to Temporal's semantics. Cancel
+   * requests are routed to the Temporal Scheduler via the cancelJob function in
+   * SchedulerHandler.java. This manifests as a {@link io.temporal.client.ActivityCompletionException}
+   * when the {@link CancellationHandler} heartbeats to the Temporal Scheduler.
    *
-   * The callback defined in this function is executed after the above exception is caught, and defines the clean up operations executed as part of cancel.
+   * The callback defined in this function is executed after the above exception is caught, and
+   * defines the clean up operations executed as part of cancel.
    *
    * See {@link CancellationHandler} for more info.
    */
@@ -173,7 +172,8 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
 
         final Runnable onCancellationCallback = () -> {
           if (cancelled.get()) {
-            // Since this is a separate thread, race condition between the executor service shutting down and this thread's next invocation can happen. This
+            // Since this is a separate thread, race condition between the executor service shutting down and
+            // this thread's next invocation can happen. This
             // check guarantees cancel operations are only executed once.
             return;
           }
@@ -186,7 +186,8 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
           workerThread.interrupt();
 
           LOGGER.info("Cancelling completable future...");
-          // This throws a CancellationException as part of the cancelling and is the exception seen in logs when cancelling the job.
+          // This throws a CancellationException as part of the cancelling and is the exception seen in logs
+          // when cancelling the job.
           outputFuture.cancel(false);
         };
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
@@ -155,9 +155,7 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
     });
   }
 
-  /**
-   *
-   */
+
   private Runnable getCancellationChecker(Worker<INPUT, OUTPUT> worker, Thread workerThread, CompletableFuture<OUTPUT> outputFuture) {
     var cancelled = new AtomicBoolean(false);
     return () -> {
@@ -180,11 +178,8 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
 
           LOGGER.info("Cancelling completable future...");
           LOGGER.info("===== future: {}", outputFuture);
-          try {
-            outputFuture.cancel(false);
-          } catch (Throwable e) {
-            // This exception is how the CompletableFuture is cancelled, and can be ignored.
-          }
+          // This throws a CancellationException as part of the cancelling and is the exception seen when cancelling the job.
+          outputFuture.cancel(false);
         };
 
         cancellationHandler.checkAndHandleCancellation(onCancellationCallback);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
@@ -186,7 +186,7 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
           workerThread.interrupt();
 
           LOGGER.info("Cancelling completable future...");
-          // This throws a CancellationException as part of the cancelling and is the exception seen when cancelling the job.
+          // This throws a CancellationException as part of the cancelling and is the exception seen in logs when cancelling the job.
           outputFuture.cancel(false);
         };
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
@@ -147,14 +147,4 @@ class DefaultAirbyteDestinationTest {
     verify(outputStream).close();
   }
 
-  @Test
-  public void testProcessFailLifecycle() throws Exception {
-    final AirbyteDestination destination = new DefaultAirbyteDestination(integrationLauncher);
-    destination.start(DESTINATION_CONFIG, jobRoot);
-
-    when(process.isAlive()).thenReturn(false);
-    when(process.exitValue()).thenReturn(1);
-    Assertions.assertThrows(WorkerException.class, destination::close);
-  }
-
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
@@ -152,14 +152,4 @@ class DefaultAirbyteSourceTest {
     verify(process).exitValue();
   }
 
-  @Test
-  public void testProcessFail() throws Exception {
-    final AirbyteSource tap = new DefaultAirbyteSource(integrationLauncher, streamFactory, heartbeatMonitor);
-    tap.start(SOURCE_CONFIG, jobRoot);
-
-    when(process.exitValue()).thenReturn(1);
-
-    Assertions.assertThrows(WorkerException.class, tap::close);
-  }
-
 }


### PR DESCRIPTION
## What
As part of working on the Kube cancelling, I realised our exception handling for the cancel operation is noisy and confusing. It was quite scary to me as I tried to debug why Kube was not happening. Decided to clean this up as is before nailing down Kube cancel behaviour.

This PR tries to clean this up. Unnecessary exceptions have been removed. Exceptions that happen on cancel have been converted into log lines that state this exception is typically thrown on cancel.

Overall this felt much cleaner after I was done with this. However, this isn't a 'standard' PR since the bulk of the changes are judgement based, so feel free to push back on this.

**Logs Before Changes**
```
[32mINFO[m i.a.i.b.IntegrationRunner(run):82 - {} - Command: READ
2021-06-04 12:53:36 INFO (/tmp/workspace/39/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:53:36 [32mINFO[m i.a.i.b.IntegrationRunner(run):83 - {} - Integration config: IntegrationConfig{command=READ, configPath='source_config.json', catalogPath='source_catalog.json', statePath='input_state.json'}
2021-06-04 12:53:37 INFO (/tmp/workspace/39/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:53:36 [32mINFO[m i.a.i.s.p.PostgresSource(isCdc):277 - {} - using CDC: false
2021-06-04 12:53:37 INFO (/tmp/workspace/39/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:53:37 [32mINFO[m i.a.i.s.j.AbstractJdbcSource(lambda$getCheckOperations$1):150 - {} - Attempting to get metadata from the database to see if we can connect.
2021-06-04 12:53:38 INFO (/tmp/workspace/39/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:53:38 [32mINFO[m i.a.i.d.l.LocalJsonDestination$JsonConsumer(<init>):158 - {} - initializing consumer.
2021-06-04 12:53:41 INFO (/tmp/workspace/39/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:53:41 [32mINFO[m i.a.i.s.j.JdbcCdcStateManager(<init>):46 - {} - Initialized CDC state with: null
2021-06-04 12:53:41 INFO (/tmp/workspace/39/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:53:41 [32mINFO[m i.a.i.s.j.JdbcStateManager(createCursorInfoForStream):138 - {} - No cursor field set in catalog but not present in state. Stream: AirbyteStreamNameNamespacePair{name='med_table', namespace='public'}, New Cursor Field: null. Resetting cursor value
2021-06-04 12:53:57 INFO (/tmp/workspace/39/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:53:57 [32mINFO[m i.a.i.s.p.PostgresSource(isCdc):277 - {} - using CDC: false
2021-06-04 12:53:57 INFO (/tmp/workspace/39/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:53:57 [32mINFO[m i.a.i.s.j.AbstractJdbcSource(queryTableFullRefresh):518 - {} - Queueing query for table: med_table
2021-06-04 12:54:01 INFO (/tmp/workspace/39/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:54:01 [32mINFO[m i.a.i.s.j.AbstractJdbcSource(lambda$queryTableFullRefresh$29):523 - {} - Preparing query for table: med_table
2021-06-04 12:54:01 INFO (/tmp/workspace/39/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:54:01 [32mINFO[m i.a.i.s.j.AbstractJdbcSource(lambda$queryTableFullRefresh$29):528 - {} - Executing query for table: med_table
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) TemporalAttemptExecution(lambda$getCancellationChecker$3):162 - Running sync worker cancellation...
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) DefaultReplicationWorker(cancel):246 - Cancelling replication worker...
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) DefaultReplicationWorker(cancel):249 - Cancelling source...
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) DefaultAirbyteSource(cancel):136 - Attempting to cancel source process...
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) DefaultAirbyteSource(cancel):141 - Source process exists, cancelling...
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) DefaultAirbyteSource(cancel):143 - Cancelled source process!
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) DefaultReplicationWorker(cancel):256 - Cancelling destination...
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) DefaultAirbyteDestination(cancel):132 - Attempting to cancel destination process...
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) DefaultAirbyteDestination(cancel):137 - Destination process exists, cancelling...
2021-06-04 12:54:25 ERROR (/tmp/workspace/39/0) LineGobbler(voidCall):72 - Error when reading stream
java.io.IOException: Stream closed
at java.io.BufferedInputStream.getBufIfOpen(BufferedInputStream.java:168) ~[?:?]
at java.io.BufferedInputStream.read1(BufferedInputStream.java:281) ~[?:?]
at java.io.BufferedInputStream.read(BufferedInputStream.java:343) ~[?:?]
at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:297) ~[?:?]
at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:339) ~[?:?]
at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:188) ~[?:?]
at java.io.InputStreamReader.read(InputStreamReader.java:181) ~[?:?]
at java.io.BufferedReader.fill(BufferedReader.java:161) ~[?:?]
at java.io.BufferedReader.readLine(BufferedReader.java:326) ~[?:?]
at java.io.BufferedReader.readLine(BufferedReader.java:392) ~[?:?]
at io.airbyte.commons.io.LineGobbler.voidCall(LineGobbler.java:68) [io.airbyte-airbyte-commons-0.24.6-alpha.jar:?]
at io.airbyte.commons.concurrency.VoidCallable.call(VoidCallable.java:35) [io.airbyte-airbyte-commons-0.24.6-alpha.jar:?]
at io.airbyte.commons.concurrency.VoidCallable.call(VoidCallable.java:29) [io.airbyte-airbyte-commons-0.24.6-alpha.jar:?]
at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) [?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) [?:?]
at java.lang.Thread.run(Thread.java:832) [?:?]
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) DefaultAirbyteDestination(cancel):139 - Cancelled destination process!
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) TemporalAttemptExecution(lambda$getCancellationChecker$3):165 - Interrupting worker thread...
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) TemporalAttemptExecution(lambda$getCancellationChecker$3):168 - Cancelling completable future...
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) TemporalAttemptExecution(get):134 - Stopping cancellation check scheduling...
2021-06-04 12:54:25 ERROR (/tmp/workspace/39/0) TemporalAttemptExecution(lambda$getCancellationChecker$4):174 - Cancellation checker exception
io.airbyte.workers.WorkerException: Worker cleaned up after exception
at io.airbyte.workers.temporal.CancellationHandler$TemporalCancellationHandler.checkAndHandleCancellation(CancellationHandler.java:67) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getCancellationChecker$4(TemporalAttemptExecution.java:172) [io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) [?:?]
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) [?:?]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) [?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) [?:?]
at java.lang.Thread.run(Thread.java:832) [?:?]
Caused by: io.temporal.client.ActivityCanceledException: WorkflowId=401948d0-6c04-49ad-aa2a-3633821583de, RunId=8650a318-e211-46dc-a7be-cfef4273ae38, ActivityType=Replicate, ActivityId=f0e2ed74-5abf-35b7-bfbf-fc6a615152b4
at io.temporal.internal.sync.ActivityExecutionContextImpl.sendHeartbeatRequest(ActivityExecutionContextImpl.java:205) ~[temporal-sdk-1.0.4.jar:?]
at io.temporal.internal.sync.ActivityExecutionContextImpl.doHeartBeat(ActivityExecutionContextImpl.java:147) ~[temporal-sdk-1.0.4.jar:?]
at io.temporal.internal.sync.ActivityExecutionContextImpl.heartbeat(ActivityExecutionContextImpl.java:108) ~[temporal-sdk-1.0.4.jar:?]
at io.airbyte.workers.temporal.CancellationHandler$TemporalCancellationHandler.checkAndHandleCancellation(CancellationHandler.java:64) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
... 7 more
2021-06-04 12:54:25 WARN (/tmp/workspace/39/0) POJOActivityTaskHandler$POJOActivityImplementation(execute):243 - Activity failure. ActivityId=f0e2ed74-5abf-35b7-bfbf-fc6a615152b4, activityType=Replicate, attempt=1
java.util.concurrent.CancellationException: null
at java.util.concurrent.CompletableFuture.cancel(CompletableFuture.java:2468) ~[?:?]
at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getCancellationChecker$3(TemporalAttemptExecution.java:169) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.temporal.CancellationHandler$TemporalCancellationHandler.checkAndHandleCancellation(CancellationHandler.java:66) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getCancellationChecker$4(TemporalAttemptExecution.java:172) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) [?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) [?:?]
at java.lang.Thread.run(Thread.java:832) [?:?]
2021-06-04 12:54:25 ERROR (/tmp/workspace/39/0) DefaultReplicationWorker(run):146 - Sync worker failed.
java.util.concurrent.ExecutionException: java.lang.RuntimeException: java.io.UncheckedIOException: java.io.IOException: Stream closed
at java.util.concurrent.FutureTask.report(FutureTask.java:122) ~[?:?]
at java.util.concurrent.FutureTask.get(FutureTask.java:191) ~[?:?]
at io.airbyte.workers.DefaultReplicationWorker.run(DefaultReplicationWorker.java:138) [io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.DefaultReplicationWorker.run(DefaultReplicationWorker.java:51) [io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getWorkerThread$2(TemporalAttemptExecution.java:147) [io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at java.lang.Thread.run(Thread.java:832) [?:?]
Suppressed: io.airbyte.workers.WorkerException: Source process wasn't successful
at io.airbyte.workers.protocols.airbyte.DefaultAirbyteSource.close(DefaultAirbyteSource.java:130) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.DefaultReplicationWorker.run(DefaultReplicationWorker.java:119) [io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.DefaultReplicationWorker.run(DefaultReplicationWorker.java:51) [io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getWorkerThread$2(TemporalAttemptExecution.java:147) [io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at java.lang.Thread.run(Thread.java:832) [?:?]
Suppressed: io.airbyte.workers.WorkerException: destination process wasn't successful
at io.airbyte.workers.protocols.airbyte.DefaultAirbyteDestination.close(DefaultAirbyteDestination.java:126) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.DefaultReplicationWorker.run(DefaultReplicationWorker.java:119) [io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.DefaultReplicationWorker.run(DefaultReplicationWorker.java:51) [io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getWorkerThread$2(TemporalAttemptExecution.java:147) [io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at java.lang.Thread.run(Thread.java:832) [?:?]
Caused by: java.lang.RuntimeException: java.io.UncheckedIOException: java.io.IOException: Stream closed
at io.airbyte.workers.DefaultReplicationWorker.lambda$getReplicationRunnable$2(DefaultReplicationWorker.java:218) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) ~[?:?]
... 1 more
Caused by: java.io.UncheckedIOException: java.io.IOException: Stream closed
at java.io.BufferedReader$1.hasNext(BufferedReader.java:577) ~[?:?]
at java.util.Spliterators$IteratorSpliterator.tryAdvance(Spliterators.java:1811) ~[?:?]
at java.util.stream.StreamSpliterators$WrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:294) ~[?:?]
at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:206) ~[?:?]
at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:169) ~[?:?]
at java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:300) ~[?:?]
at java.util.Spliterators$1Adapter.hasNext(Spliterators.java:681) ~[?:?]
at io.airbyte.workers.protocols.airbyte.DefaultAirbyteSource.attemptRead(DefaultAirbyteSource.java:112) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.DefaultReplicationWorker.lambda$getReplicationRunnable$2(DefaultReplicationWorker.java:208) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) ~[?:?]
... 1 more
Caused by: java.io.IOException: Stream closed
at java.io.BufferedInputStream.getBufIfOpen(BufferedInputStream.java:168) ~[?:?]
at java.io.BufferedInputStream.read(BufferedInputStream.java:334) ~[?:?]
at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:297) ~[?:?]
at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:339) ~[?:?]
at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:188) ~[?:?]
at java.io.InputStreamReader.read(InputStreamReader.java:181) ~[?:?]
at java.io.BufferedReader.fill(BufferedReader.java:161) ~[?:?]
at java.io.BufferedReader.readLine(BufferedReader.java:326) ~[?:?]
at java.io.BufferedReader.readLine(BufferedReader.java:392) ~[?:?]
at java.io.BufferedReader$1.hasNext(BufferedReader.java:574) ~[?:?]
at java.util.Spliterators$IteratorSpliterator.tryAdvance(Spliterators.java:1811) ~[?:?]
at java.util.stream.StreamSpliterators$WrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:294) ~[?:?]
at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:206) ~[?:?]
at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:169) ~[?:?]
at java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:300) ~[?:?]
at java.util.Spliterators$1Adapter.hasNext(Spliterators.java:681) ~[?:?]
at io.airbyte.workers.protocols.airbyte.DefaultAirbyteSource.attemptRead(DefaultAirbyteSource.java:112) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.DefaultReplicationWorker.lambda$getReplicationRunnable$2(DefaultReplicationWorker.java:208) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) ~[?:?]
... 1 more
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) DefaultReplicationWorker(run):167 - sync summary: io.airbyte.config.ReplicationAttemptSummary@3b8cff96[status=cancelled,recordsSynced=6000,bytesSynced=30606000,startTime=1622811215221,endTime=1622811265379]
2021-06-04 12:54:25 INFO (/tmp/workspace/39/0) DefaultReplicationWorker(run):176 - Source did not output any state messages
2021-06-04 12:54:25 WARN (/tmp/workspace/39/0) DefaultReplicationWorker(run):184 - State capture: No new state, falling back on input state: io.airbyte.config.State@118f4432[state={}]
```

**Logs After Changes** (truncated from READ onwards, the lines with ===== are debug lines and have been removed)
The last exception is printed by Temporal and outside our control.
```
2021-06-04 12:33:26 INFO (/tmp/workspace/35/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:33:26 [32mINFO[m i.a.i.b.IntegrationRunner(run):82 - {} - Command: READ
2021-06-04 12:33:26 INFO (/tmp/workspace/35/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:33:26 [32mINFO[m i.a.i.b.IntegrationRunner(run):83 - {} - Integration config: IntegrationConfig{command=READ, configPath='source_config.json', catalogPath='source_catalog.json', statePath='null'}
2021-06-04 12:33:26 INFO (/tmp/workspace/35/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:33:26 [32mINFO[m i.a.i.d.l.LocalJsonDestination$JsonConsumer(<init>):158 - {} - initializing consumer.
2021-06-04 12:33:26 INFO (/tmp/workspace/35/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:33:26 [32mINFO[m i.a.i.s.p.PostgresSource(isCdc):277 - {} - using CDC: false
2021-06-04 12:33:26 INFO (/tmp/workspace/35/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:33:26 [32mINFO[m i.a.i.s.j.AbstractJdbcSource(lambda$getCheckOperations$1):150 - {} - Attempting to get metadata from the database to see if we can connect.
2021-06-04 12:33:32 INFO (/tmp/workspace/35/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:33:32 [32mINFO[m i.a.i.s.j.JdbcCdcStateManager(<init>):46 - {} - Initialized CDC state with: null
2021-06-04 12:33:32 INFO (/tmp/workspace/35/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-04 12:33:32 [32mINFO[m i.a.i.s.j.JdbcStateManager(createCursorInfoForStream):138 - {} - No cursor field set in catalog but not present in state. Stream: AirbyteStreamNameNamespacePair{name='tiny_table', namespace='public'}, New Cursor Field: null. Resetting cursor value
2021-06-04 12:33:34 INFO (/tmp/workspace/35/0) TemporalAttemptExecution(lambda$getCancellationChecker$3):172 - Running sync worker cancellation...
2021-06-04 12:33:34 INFO (/tmp/workspace/35/0) DefaultReplicationWorker(cancel):256 - Cancelling replication worker...
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) DefaultReplicationWorker(cancel):263 - ====== cancelled set to True
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) DefaultReplicationWorker(cancel):265 - Cancelling destination...
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) DefaultAirbyteDestination(cancel):134 - Attempting to cancel destination process...
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) DefaultAirbyteDestination(cancel):139 - Destination process exists, cancelling...
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) LineGobbler(close):102 - closing line gobbler
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) LineGobbler(close):104 - closed line gobbler
2021-06-04 12:33:44 WARN (/tmp/workspace/35/0) LineGobbler(voidCall):92 - airbyte-destination gobbler IOException: Stream closed. Typically happens when cancelling a job.
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) DefaultAirbyteDestination(cancel):142 - Cancelled destination process!
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) DefaultReplicationWorker(cancel):272 - Cancelling source...
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) DefaultAirbyteSource(cancel):138 - Attempting to cancel source process...
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) DefaultAirbyteSource(cancel):143 - Source process exists, cancelling...
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) LineGobbler(close):102 - closing line gobbler
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) LineGobbler(close):104 - closed line gobbler
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) DefaultAirbyteSource(cancel):146 - Cancelled source process!
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) TemporalAttemptExecution(lambda$getCancellationChecker$3):176 - Interrupting worker thread...
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) DefaultReplicationWorker(run):141 - Source thread complete.
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) DefaultReplicationWorker(run):142 - Waiting for destination thread to join.
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) DefaultReplicationWorker(run):144 - Destination thread complete.
2021-06-04 12:33:44 WARN (/tmp/workspace/35/0) DefaultAirbyteSource(close):132 - Source process might not have shut down correctly. source process alive: false, source process exit value: 143
2021-06-04 12:33:44 WARN (/tmp/workspace/35/0) DefaultAirbyteDestination(close):128 - Destination process might not have shut down correctly. destination process alive: false, destination process exit value: 1
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) TemporalAttemptExecution(lambda$getCancellationChecker$3):179 - Cancelling completable future...
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) TemporalAttemptExecution(lambda$getCancellationChecker$3):180 - ===== future: java.util.concurrent.CompletableFuture@4f27ecde[Not completed, 1 dependents]
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) DefaultReplicationWorker(run):169 - sync summary: io.airbyte.config.ReplicationAttemptSummary@1153ace0[status=cancelled,recordsSynced=0,bytesSynced=0,startTime=1622810004409,endTime=1622810024573]
2021-06-04 12:33:44 WARN (/tmp/workspace/35/0) CancellationHandler$TemporalCancellationHandler(checkAndHandleCancellation):72 - Job either timeout-ed or was cancelled.
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) TemporalAttemptExecution(get):136 - Stopping cancellation check scheduling...
2021-06-04 12:33:44 INFO (/tmp/workspace/35/0) DefaultReplicationWorker(run):178 - Source did not output any state messages
2021-06-04 12:33:44 WARN (/tmp/workspace/35/0) DefaultReplicationWorker(run):189 - State capture: No state retained.
2021-06-04 12:33:44 WARN (/tmp/workspace/35/0) POJOActivityTaskHandler$POJOActivityImplementation(execute):243 - Activity failure. ActivityId=6e970354-969b-35b5-9ced-54772bf598a5, activityType=Replicate, attempt=1
java.util.concurrent.CancellationException: null
at java.util.concurrent.CompletableFuture.cancel(CompletableFuture.java:2468) ~[?:?]
at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getCancellationChecker$3(TemporalAttemptExecution.java:182) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.temporal.CancellationHandler$TemporalCancellationHandler.checkAndHandleCancellation(CancellationHandler.java:71) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getCancellationChecker$4(TemporalAttemptExecution.java:185) ~[io.airbyte-airbyte-workers-0.24.6-alpha.jar:?]
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) [?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) [?:?]
at java.lang.Thread.run(Thread.java:832) [?:?]
2021-06-04 12:33:44 WARN (/tmp/workspace/35/0) CancellationHandler$TemporalCancellationHandler(checkAndHandleCancellation):72 - Job either timeout-ed or was cancelled.
```

## How
Rationale have either been left as source comments or PR comments.


## Recommended reading order
1. `DefaultReplicationWorker`
2. `CancellationHandler` and `TemporalAttemptExecution`
3. `LineGobbler`, `DefaultAirbyteSource` and `DefaultAirbyteDestination`

