### PR TITLE
updating integrations destinations local files doccs

### DIFF
--- a/docs/integrations/destinations/local-csv.md
+++ b/docs/integrations/destinations/local-csv.md
@@ -48,8 +48,8 @@ The local mount is mounted by Docker onto `LOCAL_ROOT`. This means the `/local` 
 
 If your Airbyte instance is running on the same computer that you are navigating with, you can open your browser and enter [file:///tmp/airbyte\_local](file:///tmp/airbyte_local) to look at the replicated data locally.
 If the first approach fails or if your Airbyte instance is running on a remote server, follow the following steps to access the replicated files:
-    * Access the scheduler container using `docker exec -it airbyte-scheduler bash`
-    * Navigate to the default local mount using `cd /tmp/airbyte_local`
-    * Navigate to the replicated file directory you specified when you created the destination, using `cd /{Directory_Specified}`
-    * List files containing the replicated data using `ls`
-    * After that you can execute `cat {filename}` to display the data in a particular file
+1. Access the scheduler container using `docker exec -it airbyte-scheduler bash`
+2. Navigate to the default local mount using `cd /tmp/airbyte_local`
+3. Navigate to the replicated file directory you specified when you created the destination, using `cd /{Directory_Specified}`
+4. List files containing the replicated data using `ls`
+5. Execute `cat {filename}` to display the data in a particular file

--- a/docs/integrations/destinations/local-csv.md
+++ b/docs/integrations/destinations/local-csv.md
@@ -44,5 +44,12 @@ The local mount is mounted by Docker onto `LOCAL_ROOT`. This means the `/local` 
 * the local mount is using the `/tmp/airbyte_local` default
 * then all data will be written to `/tmp/airbyte_local/cars/models` directory.
 
-\(If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to [file:///tmp/airbyte\_local](file:///tmp/airbyte_local) and look at the replicated data locally\)
+### Access Replicated Data Files
 
+* If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to [file:///tmp/airbyte\_local](file:///tmp/airbyte_local) and look at the replicated data locally
+* If Airbyte instance is running on a remote server or for some reasons you can't use the first approach ([file:///tmp/airbyte\_local]) to access the replicated files, follow the following steps to access the replicated files:
+    * Access the scheduler container using `docker exec -it airbyte-scheduler bash`
+    * Make sure you are at the root folder of the container using `cd ..`
+    * Navigate to the default local mount using `cd /tmp/airbyte_local`
+    * Navigate to the replicated file directory you specified when you created the destination, using `cd /{Directory_Specified}`
+    * Now you can see all the files containing the replicated data using `ls`

--- a/docs/integrations/destinations/local-csv.md
+++ b/docs/integrations/destinations/local-csv.md
@@ -46,7 +46,7 @@ The local mount is mounted by Docker onto `LOCAL_ROOT`. This means the `/local` 
 
 ## Access Replicated Data Files
 
-* If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to [file:///tmp/airbyte\_local](file:///tmp/airbyte_local) and look at the replicated data locally
+If your Airbyte instance is running on the same computer that you are navigating with, you can open your browser and enter [file:///tmp/airbyte\_local](file:///tmp/airbyte_local) to look at the replicated data locally.
 If the first approach fails or if your Airbyte instance is running on a remote server, follow the following steps to access the replicated files:
     * Access the scheduler container using `docker exec -it airbyte-scheduler bash`
     * Navigate to the default local mount using `cd /tmp/airbyte_local`

--- a/docs/integrations/destinations/local-csv.md
+++ b/docs/integrations/destinations/local-csv.md
@@ -47,7 +47,7 @@ The local mount is mounted by Docker onto `LOCAL_ROOT`. This means the `/local` 
 ## Access Replicated Data Files
 
 * If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to [file:///tmp/airbyte\_local](file:///tmp/airbyte_local) and look at the replicated data locally
-* If Airbyte instance is running on a remote server or for some reasons you can't use the first approach ([file:///tmp/airbyte\_local]) to access the replicated files, follow the following steps to access the replicated files:
+If the first approach fails or if your Airbyte instance is running on a remote server, follow the following steps to access the replicated files:
     * Access the scheduler container using `docker exec -it airbyte-scheduler bash`
     * Navigate to the default local mount using `cd /tmp/airbyte_local`
     * Navigate to the replicated file directory you specified when you created the destination, using `cd /{Directory_Specified}`

--- a/docs/integrations/destinations/local-csv.md
+++ b/docs/integrations/destinations/local-csv.md
@@ -51,6 +51,6 @@ The local mount is mounted by Docker onto `LOCAL_ROOT`. This means the `/local` 
     * Access the scheduler container using `docker exec -it airbyte-scheduler bash`
     * Navigate to the default local mount using `cd /tmp/airbyte_local`
     * Navigate to the replicated file directory you specified when you created the destination, using `cd /{Directory_Specified}`
-    * Now you can see all the files containing the replicated data using `ls`
+    * List files containing the replicated data using `ls`
     * After that you can execute `cat {filename}` to display the data in a particular file
 

--- a/docs/integrations/destinations/local-csv.md
+++ b/docs/integrations/destinations/local-csv.md
@@ -49,7 +49,8 @@ The local mount is mounted by Docker onto `LOCAL_ROOT`. This means the `/local` 
 * If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to [file:///tmp/airbyte\_local](file:///tmp/airbyte_local) and look at the replicated data locally
 * If Airbyte instance is running on a remote server or for some reasons you can't use the first approach ([file:///tmp/airbyte\_local]) to access the replicated files, follow the following steps to access the replicated files:
     * Access the scheduler container using `docker exec -it airbyte-scheduler bash`
-    * Make sure you are at the root folder of the container using `cd ..`
     * Navigate to the default local mount using `cd /tmp/airbyte_local`
     * Navigate to the replicated file directory you specified when you created the destination, using `cd /{Directory_Specified}`
     * Now you can see all the files containing the replicated data using `ls`
+    * After that you can execute `cat {filename}` to display the data in a particular file
+

--- a/docs/integrations/destinations/local-csv.md
+++ b/docs/integrations/destinations/local-csv.md
@@ -44,7 +44,7 @@ The local mount is mounted by Docker onto `LOCAL_ROOT`. This means the `/local` 
 * the local mount is using the `/tmp/airbyte_local` default
 * then all data will be written to `/tmp/airbyte_local/cars/models` directory.
 
-### Access Replicated Data Files
+## Access Replicated Data Files
 
 * If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to [file:///tmp/airbyte\_local](file:///tmp/airbyte_local) and look at the replicated data locally
 * If Airbyte instance is running on a remote server or for some reasons you can't use the first approach ([file:///tmp/airbyte\_local]) to access the replicated files, follow the following steps to access the replicated files:
@@ -53,4 +53,3 @@ The local mount is mounted by Docker onto `LOCAL_ROOT`. This means the `/local` 
     * Navigate to the replicated file directory you specified when you created the destination, using `cd /{Directory_Specified}`
     * List files containing the replicated data using `ls`
     * After that you can execute `cat {filename}` to display the data in a particular file
-

--- a/docs/integrations/destinations/local-json.md
+++ b/docs/integrations/destinations/local-json.md
@@ -49,8 +49,6 @@ The local mount is mounted by Docker onto `LOCAL_ROOT`. This means the `/local` 
 * If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to [file:///tmp/airbyte\_local](file:///tmp/airbyte_local) and look at the replicated data locally
 * If Airbyte instance is running on a remote server or for some reasons you can't use the first approach ([file:///tmp/airbyte\_local]) to access the replicated files, follow the following steps to access the replicated files:
     * Access the scheduler container using `docker exec -it airbyte-scheduler bash`
-    * Make sure you are at the root folder of the container using `cd ..`
     * Navigate to the default local mount using `cd /tmp/airbyte_local`
     * Navigate to the replicated file directory you specified when you created the destination, using `cd /{Directory_Specified}`
     * Now you can see all the files containing the replicated data using `ls`
-

--- a/docs/integrations/destinations/local-json.md
+++ b/docs/integrations/destinations/local-json.md
@@ -51,4 +51,5 @@ The local mount is mounted by Docker onto `LOCAL_ROOT`. This means the `/local` 
     * Access the scheduler container using `docker exec -it airbyte-scheduler bash`
     * Navigate to the default local mount using `cd /tmp/airbyte_local`
     * Navigate to the replicated file directory you specified when you created the destination, using `cd /{Directory_Specified}`
-    * Now you can see all the files containing the replicated data using `ls`
+    * List files containing the replicated data using `ls`
+    * After that you can execute `cat {filename}` to display the data in a particular file

--- a/docs/integrations/destinations/local-json.md
+++ b/docs/integrations/destinations/local-json.md
@@ -44,12 +44,12 @@ The local mount is mounted by Docker onto `LOCAL_ROOT`. This means the `/local` 
 * the local mount is using the `/tmp/airbyte_local` default
 * then all data will be written to `/tmp/airbyte_local/cars/models` directory.
 
-### Access Replicated Data Files
+## Access Replicated Data Files
 
-* If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to [file:///tmp/airbyte\_local](file:///tmp/airbyte_local) and look at the replicated data locally
-* If Airbyte instance is running on a remote server or for some reasons you can't use the first approach ([file:///tmp/airbyte\_local]) to access the replicated files, follow the following steps to access the replicated files:
-    * Access the scheduler container using `docker exec -it airbyte-scheduler bash`
-    * Navigate to the default local mount using `cd /tmp/airbyte_local`
-    * Navigate to the replicated file directory you specified when you created the destination, using `cd /{Directory_Specified}`
-    * List files containing the replicated data using `ls`
-    * After that you can execute `cat {filename}` to display the data in a particular file
+If your Airbyte instance is running on the same computer that you are navigating with, you can open your browser and enter [file:///tmp/airbyte\_local](file:///tmp/airbyte_local) to look at the replicated data locally.
+If the first approach fails or if your Airbyte instance is running on a remote server, follow the following steps to access the replicated files:
+1. Access the scheduler container using `docker exec -it airbyte-scheduler bash`
+2. Navigate to the default local mount using `cd /tmp/airbyte_local`
+3. Navigate to the replicated file directory you specified when you created the destination, using `cd /{Directory_Specified}`
+4. List files containing the replicated data using `ls`
+5. Execute `cat {filename}` to display the data in a particular file

--- a/docs/integrations/destinations/local-json.md
+++ b/docs/integrations/destinations/local-json.md
@@ -44,5 +44,13 @@ The local mount is mounted by Docker onto `LOCAL_ROOT`. This means the `/local` 
 * the local mount is using the `/tmp/airbyte_local` default
 * then all data will be written to `/tmp/airbyte_local/cars/models` directory.
 
-\(If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to [file:///tmp/airbyte\_local](file:///tmp/airbyte_local) and look at the replicated data locally\)
+### Access Replicated Data Files
+
+* If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to [file:///tmp/airbyte\_local](file:///tmp/airbyte_local) and look at the replicated data locally
+* If Airbyte instance is running on a remote server or for some reasons you can't use the first approach ([file:///tmp/airbyte\_local]) to access the replicated files, follow the following steps to access the replicated files:
+    * Access the scheduler container using `docker exec -it airbyte-scheduler bash`
+    * Make sure you are at the root folder of the container using `cd ..`
+    * Navigate to the default local mount using `cd /tmp/airbyte_local`
+    * Navigate to the replicated file directory you specified when you created the destination, using `cd /{Directory_Specified}`
+    * Now you can see all the files containing the replicated data using `ls`
 


### PR DESCRIPTION
## What
This change will help users to easily locate local JSON and local CSV files. The previous Docs at the following link :
https://docs.airbyte.io/integrations/destinations/local-json and 
https://docs.airbyte.io/integrations/destinations/local-csv,
     Explain how to customize the local directory that stores the replicated files and also states at the end that - " If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to file:///tmp/airbyte_local and look at the replicated data locally "

  However it does not state how to access the replicated files if you are running airbyte on a remote server or for some reason cant access the file by using the specified approach above (file:///tmp/airbyte_local)

 So it's important to show the user how to get to those file though the shell command by accessing the not-so-obvious container which hosts them. In fact the container which hosts these files is the airbyte-scheduler which is not obvious at all. I'am an airbyte user and I thought those files were stored in the airbyte-server. Thus it's even important to let the user know how and where to get those local files at. Following is the change I made to the local JSON and local CSV docs:
 
 I changed this 

 With this in both files
(If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to file:///tmp/airbyte_local and look at the replicated data locally)
 ### Access Replicated Data Files

* If Airbyte instance is running on the same computer that you are navigating with, you can open your browser to go to [file:///tmp/airbyte\_local](file:///tmp/airbyte_local) and look at the replicated data locally
* If Airbyte instance is running on a remote server or for some reasons you can't use the first approach ([file:///tmp/airbyte\_local]) to access the replicated files, follow the following steps to access the replicated files:
    * Access the scheduler container using `docker exec -it airbyte-scheduler bash`
    * Make sure you are at the root folder of the container using `cd ..`
    * Navigate to the default local mount using `cd /tmp/airbyte_local`
    * Navigate to the replicated file directory you specified when you created the destination, using `cd /{Directory_Specified}`
    * Now you can see all the files containing the replicated data using `ls`


