### PR TITLE
Also stop gradle watch as part of moving back to Github instances.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,9 @@
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx2g
 org.gradle.caching=true
-org.gradle.vfs.watch=true
+
+# Remove this until we are back on AWS.
+# org.gradle.vfs.watch=true
 
 # Tune # of cores Gradle uses.
 # org.gradle.workers.max=3


### PR DESCRIPTION
## What
As title suggest. The default github instance doesn't have a high enough file limit for us to use watch.