### PR TITLE
Github Runner more disk space.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -115,13 +115,14 @@ jobs:
         run: ./tools/site/link_checker.sh check_docs
 
       - name: Free up space
+        # Get rid of dot net libraries we don't need to get us more space. See https://github.com/actions/virtual-environments/issues/2606#issuecomment-772683150.
         run: sudo rm -rf /usr/share/dotnet
 
       - name: Get Docker Space
         run: docker run --rm busybox df -h
 
       - name: Build Core Docker Images
-        if: success()
+        if: success() && github.ref == 'refs/heads/master'
         run: ./gradlew --no-daemon composeBuild --scan
         env:
           GIT_REVISION: ${{ github.sha }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -114,11 +114,14 @@ jobs:
         if: success() && github.ref == 'refs/heads/master'
         run: ./tools/site/link_checker.sh check_docs
 
+      - name: Free up space
+        run: sudo rm -rf /usr/share/dotnet
+
       - name: Get Docker Space
         run: docker run --rm busybox df -h
 
       - name: Build Core Docker Images
-        if: success() && github.ref == 'refs/heads/master'
+        if: success()
         run: ./gradlew --no-daemon composeBuild --scan
         env:
           GIT_REVISION: ${{ github.sha }}


### PR DESCRIPTION
## What
The usual Github runner is failing because we don't have enough disk space. Remove unused dotnet library to get us another 20GB of disk space.

