### PR TITLE
Temporarily disable google analytics build in CI 

### DIFF
--- a/airbyte-integrations/connectors/source-googleanalytics-singer/build.gradle
+++ b/airbyte-integrations/connectors/source-googleanalytics-singer/build.gradle
@@ -14,8 +14,9 @@ dependencies {
     implementation files(project(':airbyte-integrations:bases:base-singer').airbyteDocker.outputs)
 }
 
-airbyteStandardSourceTestFile {
-    specPath = "source_googleanalytics_singer/spec.json"
-    configPath = "secrets/config.json"
-    configuredCatalogPath = "sample_files/test_catalog.json"
-}
+// TODO(sherifnada) re-enable tests. Currently they're disabled because they hog up so much bandwidth that they prevent local iteration at times. 
+// airbyteStandardSourceTestFile {
+//    specPath = "source_googleanalytics_singer/spec.json"
+//    configPath = "secrets/config.json"
+//    configuredCatalogPath = "sample_files/test_catalog.json"
+// }


### PR DESCRIPTION
locally iterating on GA is not currently feasible due to rampant 429s . Disabling CI to preserve bandwidth. Will be improved with https://github.com/airbytehq/airbyte/issues/3958 

@po3na4skld we'll need to re-enable this once you merge your change.