### PR TITLE
fix excessive logging from mysql debezium connector

### DIFF
--- a/airbyte-commons/src/main/resources/log4j2.xml
+++ b/airbyte-commons/src/main/resources/log4j2.xml
@@ -70,7 +70,13 @@
         <Logger name="org.apache" level="WARN" />
         <Logger name="httpclient" level="WARN" />
         <Logger name="com.amazonaws" level="WARN" />
+        <!--MySQL Debezium connector generates a log whenever it converts an invalid value to empty value.
+        Ex: Invalid value '0000-00-00 00:00:00' stored in column 'column_name' of table 'table_name' converted to empty value
+        If a user a lots of such values in their table, the logs would be filled with such messages-->
         <Logger name="io.debezium.connector.mysql.MySqlValueConverters" level="OFF" />
+        <!--MySQL Debezium connector generates a log whenever it comes across a DDL query to mention that it skipped it.
+        If a database has tons of DDL queries, the logs would be filled with such messages-->
+        <Logger name="io.debezium.relational.history" level="OFF" />
 
     </Loggers>
 

--- a/airbyte-commons/src/main/resources/log4j2.xml
+++ b/airbyte-commons/src/main/resources/log4j2.xml
@@ -70,6 +70,7 @@
         <Logger name="org.apache" level="WARN" />
         <Logger name="httpclient" level="WARN" />
         <Logger name="com.amazonaws" level="WARN" />
+        <Logger name="io.debezium.connector.mysql.MySqlValueConverters" level="OFF" />
 
     </Loggers>
 

--- a/airbyte-commons/src/main/resources/log4j2.xml
+++ b/airbyte-commons/src/main/resources/log4j2.xml
@@ -72,7 +72,7 @@
         <Logger name="com.amazonaws" level="WARN" />
         <!--MySQL Debezium connector generates a log whenever it converts an invalid value to empty value.
         Ex: Invalid value '0000-00-00 00:00:00' stored in column 'column_name' of table 'table_name' converted to empty value
-        If a user a lots of such values in their table, the logs would be filled with such messages-->
+        If a database has tons of such values, the logs would be filled with such messages-->
         <Logger name="io.debezium.connector.mysql.MySqlValueConverters" level="OFF" />
         <!--MySQL Debezium connector generates a log whenever it comes across a DDL query to mention that it skipped it.
         If a database has tons of DDL queries, the logs would be filled with such messages-->

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/435bb9a5-7887-4809-aa58-28c27df0d7ad.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/435bb9a5-7887-4809-aa58-28c27df0d7ad.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "435bb9a5-7887-4809-aa58-28c27df0d7ad",
   "name": "MySQL",
   "dockerRepository": "airbyte/source-mysql",
-  "dockerImageTag": "0.3.5",
+  "dockerImageTag": "0.3.6",
   "documentationUrl": "https://docs.airbyte.io/integrations/sources/mysql",
   "icon": "mysql.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -71,7 +71,7 @@
 - sourceDefinitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
   name: MySQL
   dockerRepository: airbyte/source-mysql
-  dockerImageTag: 0.3.5
+  dockerImageTag: 0.3.6
   documentationUrl: https://docs.airbyte.io/integrations/sources/mysql
   icon: mysql.svg
 - sourceDefinitionId: 2470e835-feaf-4db6-96f3-70fd645acc77

--- a/airbyte-integrations/connectors/source-mysql/Dockerfile
+++ b/airbyte-integrations/connectors/source-mysql/Dockerfile
@@ -8,6 +8,6 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.3.5
+LABEL io.airbyte.version=0.3.6
 
 LABEL io.airbyte.name=airbyte/source-mysql


### PR DESCRIPTION
Debezium pushes logs like these whenever it converts an invalid value. Unfortunately a user has tons of such values and for each value a log is being pushed thus making the logs huge. We need to switch off these logs to make sure the logs are not being spammed
```
2021-06-08 16:04:00 INFO (/tmp/workspace/3/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-08 16:04:00 [33mWARN[m i.d.c.m.MySqlValueConverters(containsZeroValuesInDatePart):859 - {dbz.connectorContext=snapshot, dbz.connectorName=optimus, dbz.connectorType=MySQL} - Invalid value '0000-00-00 00:00:00' stored in column 'lastInteracted' of table 'optimus.borrowers' converted to empty value
2021-06-08 16:04:00 INFO (/tmp/workspace/3/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-08 16:04:00 [33mWARN[m i.d.c.m.MySqlValueConverters(containsZeroValuesInDatePart):859 - {dbz.connectorContext=snapshot, dbz.connectorName=optimus, dbz.connectorType=MySQL} - Invalid value '0000-00-00 00:00:00' stored in column 'lastInteracted' of table 'optimus.borrowers' converted to empty value
2021-06-08 16:04:00 INFO (/tmp/workspace/3/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-08 16:04:00 [33mWARN[m i.d.c.m.MySqlValueConverters(containsZeroValuesInDatePart):859 - {dbz.connectorContext=snapshot, dbz.connectorName=optimus, dbz.connectorType=MySQL} - Invalid value '0000-00-00 00:00:00' stored in column 'lastInteracted' of table 'optimus.borrowers' converted to empty value
2021-06-08 16:04:00 INFO (/tmp/workspace/3/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-08 16:04:00 [33mWARN[m i.d.c.m.MySqlValueConverters(containsZeroValuesInDatePart):859 - {dbz.connectorContext=snapshot, dbz.connectorName=optimus, dbz.connectorType=MySQL} - Invalid value '0000-00-00 00:00:00' stored in column 'lastInteracted' of table 'optimus.borrowers' converted to empty value
2021-06-08 16:04:00 INFO (/tmp/workspace/3/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-08 16:04:00 [33mWARN[m i.d.c.m.MySqlValueConverters(containsZeroValuesInDatePart):859 - {dbz.connectorContext=snapshot, dbz.connectorName=optimus, dbz.connectorType=MySQL} - Invalid value '0000-00-00 00:00:00' stored in column 'lastInteracted' of table 'optimus.borrowers' converted to empty value
2021-06-08 16:04:00 INFO (/tmp/workspace/3/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-08 16:04:00 [33mWARN[m i.d.c.m.MySqlValueConverters(containsZeroValuesInDatePart):859 - {dbz.connectorContext=snapshot, dbz.connectorName=optimus, dbz.connectorType=MySQL} - Invalid value '0000-00-00 00:00:00' stored in column 'lastInteracted' of table 'optimus.borrowers' converted to empty value
2021-06-08 16:04:00 INFO (/tmp/workspace/3/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-08 16:04:00 [33mWARN[m i.d.c.m.MySqlValueConverters(containsZeroValuesInDatePart):859 - {dbz.connectorContext=snapshot, dbz.connectorName=optimus, dbz.connectorType=MySQL} - Invalid value '0000-00-00 00:00:00' stored in column 'lastInteracted' of table 'optimus.borrowers' converted to empty value
2021-06-08 16:04:00 INFO (/tmp/workspace/3/0) DefaultAirbyteStreamFactory(lambda$create$0):73 - 2021-06-08 16:04:00 [33mWARN[m i.d.c.m.MySqlValueConverters(containsZeroValuesInDatePart):859 - {dbz.connectorContext=snapshot, dbz.connectorName=optimus, dbz.connectorType=MySQL} - Invalid value '0000-00-00 00:00:00' stored in column 'lastInteracted' of table 'optimus.borrowers' converted to empty value
```

## Pre-merge Checklist
Expand the checklist which is relevant for this PR. 

<details><summary> <strong> Connector checklist </strong> </summary>
<p>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Secrets are annotated with `airbyte_secret` in output spec
- [ ] Unit & integration tests added as appropriate (and are passing)
    * Community members: please provide proof of this succeeding locally e.g: screenshot or copy-paste acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] `/test connector=connectors/<name>` command as documented [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-an-existing-connector) is passing. 
    * Community members can skip this, Airbyters will run this for you. 
- [ ] Code reviews completed
- [ ] Credentials added to Github CI if needed and not already present. [instructions for injecting secrets into CI](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#using-credentials-in-ci). 
- [ ] Documentation updated 
    - [ ] README
    - [ ] CHANGELOG.md
    - [ ] Reference docs in the `docs/integrations/` directory.
- [ ] Build is successful
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] No major blockers
- [ ] PR merged into master branch
- [ ] Follow up tickets have been created
- [ ] Associated tickets have been closed & stakeholders notified
</p>
</details>

<details><summary> <strong> Connector Generator checklist </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
