### PR TITLE
Do not run Connector Integration Test on merge to master.

### DIFF
--- a/.github/workflows/connector_integration_tests.yml
+++ b/.github/workflows/connector_integration_tests.yml
@@ -1,0 +1,18 @@
+name: Connector Integration Tests
+
+on:
+  schedule:
+    # 5pm UTC is 10am PDT.
+    - cron: '0 17 * * *'
+
+jobs:
+  launch_integration_tests:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v2
+      - name: Launch Integration Tests
+        run: ./tools/bin/ci_integration_workflow_launcher.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.SLASH_COMMAND_PAT }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,21 +2,10 @@ name: Airbyte CI
 
 on:
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: '0 */1 * * *'
   push:
 
 jobs:
-  launch_integration_tests:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Checkout Airbyte
-        uses: actions/checkout@v2
-      - name: Launch Integration Tests
-        run: ./tools/bin/ci_integration_workflow_launcher.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets.SLASH_COMMAND_PAT }}
-
   ## Gradle Build
   # In case of self-hosted EC2 errors, remove the `start-build-runner` block.
   start-build-runner:


### PR DESCRIPTION
## What
Closes #3958 

## How
* Split integration test into their own workflow run once a day at 5pm UTC (10 AM PST).
* Master build runs hourly.
