### PR TITLE
Working Kube Cancel.

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -113,7 +113,7 @@ public class WorkerUtils {
       try {
         process.waitFor(gracefulShutdownDuration.toMillis(), TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
-        LOGGER.error("Exception during grace period for process to finish", e);
+        LOGGER.error("Exception during grace period for process to finish. This can happen when cancelling jobs.");
       }
     }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -51,6 +51,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import org.apache.commons.io.output.NullOutputStream;
 import org.slf4j.Logger;
@@ -96,10 +97,18 @@ public class KubePodProcess extends Process {
   private static final String CONFIG_DIR = "/config";
   private static final String SUCCESS_FILE_NAME = "FINISHED_UPLOADING";
 
+  // 143 is the typical SIGTERM exit code.
+  private static final int KILLED_EXIT_CODE = 143;
   private static final int STDIN_REMOTE_PORT = 9001;
 
   private final KubernetesClient client;
   private final Pod podDefinition;
+  // Necessary since it is not possible to retrieve the pod's actual exit code upon termination. This
+  // is because the Kube API server does not keep
+  // terminated pod history like it does for successful pods.
+  // This variable should be set in functions where the pod is forcefully terminated. See
+  // getReturnCode() for more info.
+  private final AtomicBoolean wasKilled = new AtomicBoolean(false);
 
   private final OutputStream stdin;
   private InputStream stdout;
@@ -332,7 +341,8 @@ public class KubePodProcess extends Process {
     LOGGER.info("Copying files...");
     Map<String, String> filesWithSuccess = new HashMap<>(files);
 
-    // we always copy the empty success file to ensure our waiting step can detect init container in RUNNING
+    // We always copy the empty success file to ensure our waiting step can detect the init container in
+    // RUNNING. Otherwise, the container can complete and exit before we are able to detect it.
     filesWithSuccess.put(SUCCESS_FILE_NAME, "");
     copyFilesToKubeConfigVolume(client, podName, namespace, filesWithSuccess);
 
@@ -392,17 +402,25 @@ public class KubePodProcess extends Process {
     return this.stderr;
   }
 
+  /**
+   * Immediately terminates the Kube Pod backing this process and cleans up IO resources.
+   */
   @Override
   public int waitFor() throws InterruptedException {
     try {
       Pod refreshedPod = client.pods().inNamespace(podDefinition.getMetadata().getNamespace()).withName(podDefinition.getMetadata().getName()).get();
       client.resource(refreshedPod).waitUntilCondition(this::isTerminal, 10, TimeUnit.DAYS);
+      wasKilled.set(true);
       return exitValue();
     } finally {
       close();
     }
   }
 
+  /**
+   * Intended to gracefully clean up after a completed Kube Pod. This should only be called if the
+   * process is successful.
+   */
   @Override
   public boolean waitFor(long timeout, TimeUnit unit) throws InterruptedException {
     try {
@@ -412,17 +430,24 @@ public class KubePodProcess extends Process {
     }
   }
 
+  /**
+   * Immediately terminates the Kube Pod backing this process and cleans up IO resources.
+   */
   @Override
   public void destroy() {
     LOGGER.info("Destroying Kube process: {}", podDefinition.getMetadata().getName());
     try {
       client.resource(podDefinition).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+      wasKilled.set(true);
     } finally {
       close();
       LOGGER.info("Destroyed Kube process: {}", podDefinition.getMetadata().getName());
     }
   }
 
+  /**
+   * Close all open resource in the opposite order of resource creation.
+   */
   private void close() {
     Exceptions.swallow(this.stdin::close);
     Exceptions.swallow(this.stdout::close);
@@ -446,8 +471,18 @@ public class KubePodProcess extends Process {
   }
 
   private int getReturnCode(Pod pod) {
-    Pod refreshedPod = client.pods().inNamespace(pod.getMetadata().getNamespace()).withName(pod.getMetadata().getName()).get();
-    // If the pod cannot be found, it either means the pod was alrady termianted, or wasn't started up in the first place.
+    var name = pod.getMetadata().getName();
+    Pod refreshedPod = client.pods().inNamespace(pod.getMetadata().getNamespace()).withName(name).get();
+    if (refreshedPod == null) {
+      if (wasKilled.get()) {
+        LOGGER.info("Unable to find pod {} to retrieve exit value. Defaulting to  value {}. This is expected if the job was cancelled.", name,
+            KILLED_EXIT_CODE);
+        return KILLED_EXIT_CODE;
+      }
+      // If the pod cannot be found and was not killed, it either means 1) the pod was not created
+      // properly 2) this method is incorrectly called.
+      throw new RuntimeException("Cannot find pod while trying to retrieve exit code. This probably means the Pod was not correctly created.");
+    }
     if (!isTerminal(refreshedPod)) {
       throw new IllegalThreadStateException("Kube pod process has not exited yet.");
     }
@@ -457,7 +492,7 @@ public class KubePodProcess extends Process {
         .filter(containerStatus -> containerStatus.getState() != null && containerStatus.getState().getTerminated() != null)
         .map(containerStatus -> {
           int statusCode = containerStatus.getState().getTerminated().getExitCode();
-          LOGGER.info("Termination status for container " + containerStatus.getName() + " is " + statusCode);
+          LOGGER.info("Exit code for pod {}, container {} is {}", name, containerStatus.getName(), statusCode);
           return statusCode;
         })
         .reduce(Integer::sum)

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -414,10 +414,12 @@ public class KubePodProcess extends Process {
 
   @Override
   public void destroy() {
+    LOGGER.info("Destroying Kube process: {}", podDefinition.getMetadata().getName());
     try {
       client.resource(podDefinition).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     } finally {
       close();
+      LOGGER.info("Destroyed Kube process: {}", podDefinition.getMetadata().getName());
     }
   }
 
@@ -445,6 +447,7 @@ public class KubePodProcess extends Process {
 
   private int getReturnCode(Pod pod) {
     Pod refreshedPod = client.pods().inNamespace(pod.getMetadata().getNamespace()).withName(pod.getMetadata().getName()).get();
+    // If the pod cannot be found, it either means the pod was alrady termianted, or wasn't started up in the first place.
     if (!isTerminal(refreshedPod)) {
       throw new IllegalThreadStateException("Kube pod process has not exited yet.");
     }


### PR DESCRIPTION
## What
Continuation of #3922 - get Kube cancel working.

After these changes, we still have one noisy exception remaining, but this is from temporal and not easily muted. 
```
complete.
2021-06-09 08:55:39 INFO (/workspace/22/0) KubePodProcess(getReturnCode):475 - Unable to find pod airbyte-worker-22-0-epznb to retrieve exit value. Defaulting to 143. This is expected if the job was cancelled.
2021-06-09 08:55:39 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):82 - Port consumer skipping releasing: 9024
2021-06-09 08:55:39 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):82 - Port consumer skipping releasing: 9025
2021-06-09 08:55:39 INFO (/workspace/22/0) KubePodProcess(getReturnCode):475 - Unable to find pod airbyte-worker-22-0-epznb to retrieve exit value. Defaulting to 143. This is expected if the job was cancelled.
2021-06-09 08:55:39 INFO (/workspace/22/0) DefaultAirbyteDestination(cancel):140 - Cancelled destination process!
2021-06-09 08:55:39 INFO (/workspace/22/0) DefaultReplicationWorker(cancel):276 - Cancelling source...
2021-06-09 08:55:39 INFO (/workspace/22/0) DefaultAirbyteSource(cancel):134 - Attempting to cancel source process...
2021-06-09 08:55:39 INFO (/workspace/22/0) DefaultAirbyteSource(cancel):139 - Source process exists, cancelling...
2021-06-09 08:55:39 INFO (/workspace/22/0) KubePodProcess(destroy):435 - Destroying Kube process: airbyte-worker-22-0-rbysz
2021-06-09 08:55:39 WARN (/workspace/22/0) LineGobbler(voidCall):88 - airbyte-source gobbler IOException: Socket closed. Typically happens when cancelling a job.
2021-06-09 08:55:39 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):80 - Port consumer releasing: 9026
2021-06-09 08:55:39 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):80 - Port consumer releasing: 9027
2021-06-09 08:55:39 INFO (/workspace/22/0) KubePodProcess(destroy):441 - Destroyed Kube process: airbyte-worker-22-0-rbysz
2021-06-09 08:55:49 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):82 - Port consumer skipping releasing: 9026
2021-06-09 08:55:49 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):82 - Port consumer skipping releasing: 9027
2021-06-09 08:55:49 INFO (/workspace/22/0) KubePodProcess(destroy):435 - Destroying Kube process: airbyte-worker-22-0-rbysz
2021-06-09 08:55:49 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):82 - Port consumer skipping releasing: 9026
2021-06-09 08:55:49 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):82 - Port consumer skipping releasing: 9027
2021-06-09 08:55:49 INFO (/workspace/22/0) KubePodProcess(destroy):441 - Destroyed Kube process: airbyte-worker-22-0-rbysz
2021-06-09 08:55:49 INFO (/workspace/22/0) DefaultAirbyteSource(cancel):141 - Cancelled source process!
2021-06-09 08:55:49 INFO (/workspace/22/0) TemporalAttemptExecution(lambda$getCancellationChecker$3):185 - Interrupting worker thread...
2021-06-09 08:55:49 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):82 - Port consumer skipping releasing: 9026
2021-06-09 08:55:49 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):82 - Port consumer skipping releasing: 9027
2021-06-09 08:55:49 INFO (/workspace/22/0) TemporalAttemptExecution(lambda$getCancellationChecker$3):188 - Cancelling completable future...
2021-06-09 08:55:49 INFO (/workspace/22/0) TemporalAttemptExecution(get):134 - Stopping cancellation check scheduling...
2021-06-09 08:55:49 ERROR (/workspace/22/0) WorkerUtils(gentleCloseWithHeartbeat):116 - Exception during grace period for process to finish. This can happen when cancelling jobs.
2021-06-09 08:55:49 WARN (/workspace/22/0) CancellationHandler$TemporalCancellationHandler(checkAndHandleCancellation):71 - Job either timeout-ed or was cancelled.
2021-06-09 08:55:49 WARN (/workspace/22/0) POJOActivityTaskHandler$POJOActivityImplementation(execute):243 - Activity failure. ActivityId=5df00f51-d9db-3660-928e-3a4a69f8f406, activityType=Replicate, attempt=1
java.util.concurrent.CancellationException: null
at java.util.concurrent.CompletableFuture.cancel(CompletableFuture.java:2468) ~[?:?]
at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getCancellationChecker$3(TemporalAttemptExecution.java:191) ~[io.airbyte-airbyte-workers-0.24.7-alpha.jar:?]
at io.airbyte.workers.temporal.CancellationHandler$TemporalCancellationHandler.checkAndHandleCancellation(CancellationHandler.java:70) ~[io.airbyte-airbyte-workers-0.24.7-alpha.jar:?]
at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getCancellationChecker$4(TemporalAttemptExecution.java:194) ~[io.airbyte-airbyte-workers-0.24.7-alpha.jar:?]
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) [?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) [?:?]
at java.lang.Thread.run(Thread.java:832) [?:?]
2021-06-09 08:55:49 WARN (/workspace/22/0) WorkerUtils(forceShutdown):128 - Process is taking too long to finish. Killing it
2021-06-09 08:55:49 INFO (/workspace/22/0) KubePodProcess(destroy):435 - Destroying Kube process: airbyte-worker-22-0-rbysz
2021-06-09 08:55:49 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):82 - Port consumer skipping releasing: 9026
2021-06-09 08:55:49 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):82 - Port consumer skipping releasing: 9027
2021-06-09 08:55:49 INFO (/workspace/22/0) KubePodProcess(destroy):441 - Destroyed Kube process: airbyte-worker-22-0-rbysz
2021-06-09 08:55:49 INFO (/workspace/22/0) LoggingTrackingClient(track):60 - track. version: dev, userId: d6452139-98e9-4958-b170-5c5a51aa85c5, action: Connector Jobs, metadata: {job_type=sync, connector_source=Postgres, config.source.host=set, config.source.port=set, config.source.username=set, frequency=manual, connector_source_definition_id=decd338e-5647-4c0b-adf4-da0e75f5a750, config.source.ssl=false, config.source.database=set, config.source.password=set, attempt_stage=ENDED, attempt_completion_status=FAILED, catalog.sync_mode.full_refresh=set, connection_id=85aa5cff-24e7-4127-8e65-1468cd1f692a, job_id=22, connector_source_version=0.3.2, config.destination.destination_path=set, catalog.destination_sync_mode.append=set, connector_destination_version=0.2.6, attempt_id=0, connector_destination=Local CSV, connector_destination_definition_id=8be1cf83-fde1-477f-a4ad-318d23c9f3c6}
2021-06-09 08:56:19 INFO (/workspace/22/0) KubePodProcess(getReturnCode):475 - Unable to find pod airbyte-worker-22-0-rbysz to retrieve exit value. Defaulting to 143. This is expected if the job was cancelled.
2021-06-09 08:56:19 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):82 - Port consumer skipping releasing: 9026
2021-06-09 08:56:19 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):82 - Port consumer skipping releasing: 9027
2021-06-09 08:56:19 INFO (/workspace/22/0) KubePodProcess(getReturnCode):475 - Unable to find pod airbyte-worker-22-0-rbysz to retrieve exit value. Defaulting to 143. This is expected if the job was cancelled.
2021-06-09 08:56:19 INFO (/workspace/22/0) KubePodProcess(getReturnCode):475 - Unable to find pod airbyte-worker-22-0-rbysz to retrieve exit value. Defaulting to 143. This is expected if the job was cancelled.
2021-06-09 08:56:19 INFO (/workspace/22/0) KubePodProcess(getReturnCode):475 - Unable to find pod airbyte-worker-22-0-rbysz to retrieve exit value. Defaulting to 143. This is expected if the job was cancelled.
2021-06-09 08:56:19 INFO (/workspace/22/0) KubePodProcess(getReturnCode):475 - Unable to find pod airbyte-worker-22-0-rbysz to retrieve exit value. Defaulting to 143. This is expected if the job was cancelled.
2021-06-09 08:56:19 INFO (/workspace/22/0) KubePodProcess(getReturnCode):475 - Unable to find pod airbyte-worker-22-0-rbysz to retrieve exit value. Defaulting to 143. This is expected if the job was cancelled.
2021-06-09 08:56:19 WARN (/workspace/22/0) DefaultAirbyteSource(close):126 - Source process might not have shut down correctly. source process alive: false, source process exit value: 143. This warning is normal if the job was cancelled.
2021-06-09 08:56:19 INFO (/workspace/22/0) KubePodProcess(getReturnCode):475 - Unable to find pod airbyte-worker-22-0-epznb to retrieve exit value. Defaulting to 143. This is expected if the job was cancelled.
2021-06-09 08:56:19 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):82 - Port consumer skipping releasing: 9024
2021-06-09 08:56:19 INFO (/workspace/22/0) KubeProcessFactory(lambda$create$0):82 - Port consumer skipping releasing: 9025
2021-06-09 08:56:19 INFO (/workspace/22/0) KubePodProcess(getReturnCode):475 - Unable to find pod airbyte-worker-22-0-epznb to retrieve exit value. Defaulting to 143. This is expected if the job was cancelled.
2021-06-09 08:56:19 INFO (/workspace/22/0) KubePodProcess(getReturnCode):475 - Unable to find pod airbyte-worker-22-0-epznb to retrieve exit value. Defaulting to 143. This is expected if the job was cancelled.
2021-06-09 08:56:19 INFO (/workspace/22/0) KubePodProcess(getReturnCode):475 - Unable to find pod airbyte-worker-22-0-epznb to retrieve exit value. Defaulting to 143. This is expected if the job was cancelled.
2021-06-09 08:56:19 INFO (/workspace/22/0) KubePodProcess(getReturnCode):475 - Unable to find pod airbyte-worker-22-0-epznb to retrieve exit value. Defaulting to 143. This is expected if the job was cancelled.
2021-06-09 08:56:19 INFO (/workspace/22/0) KubePodProcess(getReturnCode):475 - Unable to find pod airbyte-worker-22-0-epznb to retrieve exit value. Defaulting to 143. This is expected if the job was cancelled.
2021-06-09 08:56:19 WARN (/workspace/22/0) DefaultAirbyteDestination(close):125 - Destination process might not have shut down correctly. destination process alive: false, destination process exit value: 143. This warning is normal if the job was cancelled.
2021-06-09 08:56:19 INFO (/workspace/22/0) DefaultReplicationWorker(run):169 - sync summary: io.airbyte.config.ReplicationAttemptSummary@1eae3eef[status=cancelled,recordsSynced=0,bytesSynced=0,startTime=1623228910570,endTime=1623228979233]
2021-06-09 08:56:19 INFO (/workspace/22/0) DefaultReplicationWorker(run):178 - Source did not output any state messages
2021-06-09 08:56:19 WARN (/workspace/22/0) DefaultReplicationWorker(run):189 - State capture: No state retained.
```


## How
As we discussed, the only remaining gotcha is we cannot retrieve exit value when the pod is terminated (since Kube doesn't save this). Instead, we set a boolean and return a 143, which is the default SIGTERM exit code.

Also added some comments to explain functions.

## Recommended reading order
- `KubePodProcess`
