### PR TITLE
Source Facebook Marketing: Add 80000 as a rate-limiting error code.

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e7778cfc-e97c-4458-9ecb-b4f2bba8946c.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e7778cfc-e97c-4458-9ecb-b4f2bba8946c.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "e7778cfc-e97c-4458-9ecb-b4f2bba8946c",
   "name": "Facebook Marketing",
   "dockerRepository": "airbyte/source-facebook-marketing",
-  "dockerImageTag": "0.2.7",
+  "dockerImageTag": "0.2.8",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-facebook-marketing",
   "icon": "facebook.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -106,7 +106,7 @@
 - sourceDefinitionId: e7778cfc-e97c-4458-9ecb-b4f2bba8946c
   name: Facebook Marketing
   dockerRepository: airbyte/source-facebook-marketing
-  dockerImageTag: 0.2.7
+  dockerImageTag: 0.2.8
   documentationUrl: https://hub.docker.com/r/airbyte/source-facebook-marketing
   icon: facebook.svg
 - sourceDefinitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c

--- a/airbyte-integrations/connectors/source-facebook-marketing/CHANGELOG.md
+++ b/airbyte-integrations/connectors/source-facebook-marketing/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.8
+Add 80000 as a rate-limiting error code (#3996) 
+
 ## 0.2.7
 Add missing fields to AdInsights streams (#3693) 
 

--- a/airbyte-integrations/connectors/source-facebook-marketing/Dockerfile
+++ b/airbyte-integrations/connectors/source-facebook-marketing/Dockerfile
@@ -11,5 +11,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.7
+LABEL io.airbyte.version=0.2.8
 LABEL io.airbyte.name=airbyte/source-facebook-marketing

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/client/common.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/client/common.py
@@ -34,7 +34,7 @@ from facebook_business.exceptions import FacebookRequestError
 
 # The Facebook API error codes indicating rate-limiting are listed at
 # https://developers.facebook.com/docs/graph-api/overview/rate-limiting/
-FACEBOOK_RATE_LIMIT_ERROR_CODES = (4, 17, 32, 613, 8000, 80000, 80001, 80002, 80003, 80004, 80005, 80006, 80008)
+FACEBOOK_RATE_LIMIT_ERROR_CODES = (4, 17, 32, 613, 80000, 80001, 80002, 80003, 80004, 80005, 80006, 80008)
 FACEBOOK_UNKNOWN_ERROR_CODE = 99
 DEFAULT_SLEEP_INTERVAL = pendulum.Interval(minutes=1)
 

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/client/common.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/client/common.py
@@ -59,13 +59,13 @@ def handle_call_rate_response(exc: FacebookRequestError) -> bool:
     if platform_header:
         platform_header = json.loads(platform_header)
         call_count = platform_header.get("call_count") or platform_header.get("acc_id_util_pct")
-        if call_count > 99:
+        if call_count and call_count > 99:
             logger.info(f"Reached platform call limit: {exc}")
 
     buc_header = exc.http_headers().get("x-business-use-case-usage")
     buc_header = json.loads(buc_header) if buc_header else {}
     for business_object_id, stats in buc_header.items():
-        if stats["call_count"] > 99:
+        if stats.get("call_count", 0) > 99:
             logger.info(f"Reached call limit on {stats['type']}: {exc}")
             pause_time = max(pause_time, stats["estimated_time_to_regain_access"])
     logger.info(f"Sleeping for {pause_time.total_seconds()} seconds")

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/client/common.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/client/common.py
@@ -32,8 +32,10 @@ import pendulum
 from airbyte_cdk.entrypoint import logger  # FIXME (Eugene K): register logger as standard python logger
 from facebook_business.exceptions import FacebookRequestError
 
+# The Facebook API error codes indicating rate-limiting are listed at
+# https://developers.facebook.com/docs/graph-api/overview/rate-limiting/
+FACEBOOK_RATE_LIMIT_ERROR_CODES = (4, 17, 32, 613, 8000, 80000, 80001, 80002, 80003, 80004, 80005, 80006, 80008)
 FACEBOOK_UNKNOWN_ERROR_CODE = 99
-FACEBOOK_API_CALL_LIMIT_ERROR_CODES = (4, 17, 32, 613, 8000, 80001, 80002, 80003, 80004, 80005, 80006, 80008)
 DEFAULT_SLEEP_INTERVAL = pendulum.Interval(minutes=1)
 
 
@@ -80,7 +82,7 @@ def retry_pattern(backoff_type, exception, **wait_gen_kwargs):
 
     def should_retry_api_error(exc):
         if isinstance(exc, FacebookRequestError):
-            if exc.api_error_code() in FACEBOOK_API_CALL_LIMIT_ERROR_CODES:
+            if exc.api_error_code() in FACEBOOK_RATE_LIMIT_ERROR_CODES:
                 return handle_call_rate_response(exc)
             return exc.api_transient_error() or exc.api_error_subcode() == FACEBOOK_UNKNOWN_ERROR_CODE
         return True

--- a/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_client.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_client.py
@@ -56,7 +56,7 @@ def client_fixture(some_config, requests_mock, fb_account_response):
 
 @pytest.fixture(name="fb_call_rate_response")
 def fb_call_rate_response_fixture():
-    error = {"message": "(#32) Page request limit reached", "type": "OAuthException", "code": 32, "fbtrace_id": "Fz54k3GZrio"}
+    error = {"message": "(#80000) Page request limit reached", "type": "OAuthException", "code": 80000, "fbtrace_id": "Fz54k3GZrio"}
 
     headers = {"x-app-usage": json.dumps({"call_count": 28, "total_time": 25, "total_cputime": 25})}
 

--- a/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_client.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_client.py
@@ -56,7 +56,13 @@ def client_fixture(some_config, requests_mock, fb_account_response):
 
 @pytest.fixture(name="fb_call_rate_response")
 def fb_call_rate_response_fixture():
-    error = {"message": "(#80000) Page request limit reached", "type": "OAuthException", "code": 80000, "fbtrace_id": "Fz54k3GZrio"}
+    error = {
+        "message": "(#80000) There have been too many calls from this ad-account. Wait a bit and try again. For more info, please refer to https://developers.facebook.com/docs/graph-api/overview/rate-limiting.",
+        "type": "OAuthException",
+        "code": 80000,
+        "error_subcode": 2446079,
+        "fbtrace_id": "Fz54k3GZrio"
+    }
 
     headers = {"x-app-usage": json.dumps({"call_count": 28, "total_time": 25, "total_cputime": 25})}
 


### PR DESCRIPTION
## What
The Facebook Marketing source failed with the error code #80000 from Facebook:

```
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 - facebook_business.exceptions.FacebookRequestError: 
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 - 
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -   Message: Call was not successful
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -   Method:  GET
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -   Path:    https://graph.facebook.com/v10.0/789823021731939/
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -   Params:  {}
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 - 
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -   Status:  400
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -   Response:
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -     {
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -       "error": {
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -         "message": "(#80000) There have been too many calls from this ad-account. Wait a bit and try again. For more info, please refer to https://developers.facebook.com/docs/graph-api/overview/rate-limiting.",
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -         "type": "OAuthException",
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -         "code": 80000,
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -         "error_subcode": 2446079,
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -         "fbtrace_id": "AWj71vGYQ4p8abkAFKdWAXm"
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -       }
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 -     }
2021-06-09 08:05:48 ERROR (/tmp/workspace/805/2) LineGobbler(voidCall):69 - 
```

## How
It looks like there was a typo in `source_facebook_marketing/client/common.py`, and the error code #80000 was omitted.  This PR adds `80000` to the list of error codes recognized as rate-limiting errors, and also adds a comment with a link to the Facebook API documentation where the error codes are listed.

## Test output
```
python -m pytest unit_tests
============================= test session starts ==============================
platform darwin -- Python 3.7.9, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/ping/dev/airbyte/airbyte-integrations/connectors/source-facebook-marketing
plugins: requests-mock-1.9.2, mock-3.6.1
collected 3 items

unit_tests/test_client.py ...                                            [100%]

=============================== warnings summary ===============================
.venv/lib/python3.7/site-packages/jsonschema/compat.py:6
.venv/lib/python3.7/site-packages/jsonschema/compat.py:6
  /Users/ping/dev/airbyte/airbyte-integrations/connectors/source-facebook-marketing/.venv/lib/python3.7/site-packages/jsonschema/compat.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import MutableMapping, Sequence  # noqa

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================== 3 passed, 2 warnings in 21.01s ========================
```

## Pre-merge Checklist
<details><summary> <strong> Connector checklist </strong> </summary>
<p>

- [x] Issue acceptance criteria met
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [x] Secrets are annotated with `airbyte_secret` in output spec
- [x] Unit & integration tests added as appropriate (and are passing)
    * Community members: please provide proof of this succeeding locally e.g: screenshot or copy-paste acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] `/test connector=connectors/<name>` command as documented [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-an-existing-connector) is passing. 
    * Community members can skip this, Airbyters will run this for you. 
- [x] Code reviews completed
- [x] Credentials added to Github CI if needed and not already present. [instructions for injecting secrets into CI](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#using-credentials-in-ci). 
- [x] Documentation updated 
    - [x] README
    - [x] CHANGELOG.md
    - [ ] Reference docs in the `docs/integrations/` directory.
- [ ] Build is successful
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [x] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] No major blockers
- [ ] PR merged into master branch
- [ ] Follow up tickets have been created
- [ ] Associated tickets have been closed & stakeholders notified
</p>
</details>

