### PR TITLE
🐛 Fix issue with 'connector code generator is breaking'

### DIFF
--- a/airbyte-integrations/connector-templates/generator/Dockerfile
+++ b/airbyte-integrations/connector-templates/generator/Dockerfile
@@ -8,5 +8,4 @@ ENV ENV_GID $GID
 RUN mkdir -p /airbyte
 WORKDIR /airbyte/airbyte-integrations/connector-templates/generator
 
-RUN npm install npm@7 --silent --no-update-notifier
-CMD npm run generate && chown -R $ENV_UID:$ENV_GID /airbyte/*
+CMD npm install --silent --no-update-notifier && npm run generate && chown -R $ENV_UID:$ENV_GID /airbyte/*


### PR DESCRIPTION
## What
#4017 Connector Code generator is breaking 

## How
Put the `npm install ` section in the CMD command in Dockerfile

## Recommended reading order
airbyte-integrations/connector-templates/generator/Dockerfile

## Pre-merge Checklist
No significant changes in core
