### PR TITLE
Bump version: 0.24.8-alpha → 0.25.0-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.24.8-alpha
+current_version = 0.25.0-alpha
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.24.8-alpha
+VERSION=0.25.0-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_DB=airbyte

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.24.8-alpha",
+  "version": "0.25.0-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.24.8-alpha",
+  "version": "0.25.0-alpha",
   "private": true,
   "scripts": {
     "start": "react-scripts start",

--- a/docs/tutorials/upgrading-airbyte.md
+++ b/docs/tutorials/upgrading-airbyte.md
@@ -44,7 +44,7 @@ If you inadvertently upgrade to a version of Airbyte that is not compatible with
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.24.8-alpha --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.25.0-alpha --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.24.8-alpha
+AIRBYTE_VERSION=0.25.0-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_URL=jdbc:postgresql://airbyte-db-svc:5432/airbyte

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -6,15 +6,15 @@ bases:
 
 images:
   - name: airbyte/seed
-    newTag: 0.24.8-alpha
+    newTag: 0.25.0-alpha
   - name: airbyte/db
-    newTag: 0.24.8-alpha
+    newTag: 0.25.0-alpha
   - name: airbyte/scheduler
-    newTag: 0.24.8-alpha
+    newTag: 0.25.0-alpha
   - name: airbyte/server
-    newTag: 0.24.8-alpha
+    newTag: 0.25.0-alpha
   - name: airbyte/webapp
-    newTag: 0.24.8-alpha
+    newTag: 0.25.0-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 


### PR DESCRIPTION
## What
Release 0.25.0 to avoid migration problems during upgrade process

Release checklist
- [x] ./tools/bin/release_version.sh minor
- [x] push your PR
- [x] Merge your PR
- [x] Switch to master
- [x] Run ./tools/bin/tag_version.sh