### PR TITLE
S3 Destination Timestamp Formatter should use UTC.

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/4816b78f-1489-44c1-9060-4b19d5fa9362.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/4816b78f-1489-44c1-9060-4b19d5fa9362.json
@@ -2,6 +2,6 @@
   "destinationDefinitionId": "4816b78f-1489-44c1-9060-4b19d5fa9362",
   "name": "S3",
   "dockerRepository": "airbyte/destination-s3",
-  "dockerImageTag": "0.1.1",
+  "dockerImageTag": "0.1.2",
   "documentationUrl": "https://docs.airbyte.io/integrations/destinations/s3"
 }

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -27,7 +27,7 @@
 - destinationDefinitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
   name: S3
   dockerRepository: airbyte/destination-s3
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   documentationUrl: https://docs.airbyte.io/integrations/destinations/s3
 - destinationDefinitionId: f7a7d195-377f-cf5b-70a5-be6b819019dc
   name: Redshift

--- a/airbyte-integrations/connectors/destination-s3/Dockerfile
+++ b/airbyte-integrations/connectors/destination-s3/Dockerfile
@@ -7,5 +7,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/destination-s3

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConstants.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConstants.java
@@ -24,9 +24,6 @@
 
 package io.airbyte.integrations.destination.s3;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-
 public final class S3DestinationConstants {
 
   // These parameters are used by {@link StreamTransferManager}.
@@ -38,7 +35,7 @@ public final class S3DestinationConstants {
   public static final int DEFAULT_QUEUE_CAPACITY = 2;
   public static final int DEFAULT_PART_SIZE_MD = 5;
   public static final int DEFAULT_NUM_STREAMS = 1;
-  public static final DateFormat YYYY_MM_DD_FORMAT = new SimpleDateFormat("yyyy_MM_dd");
+  public static final String YYYY_MM_DD_FORMAT_STRING = "yyyy_MM_dd";
 
   private S3DestinationConstants() {}
 

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/S3CsvOutputFormatter.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/S3CsvOutputFormatter.java
@@ -24,8 +24,6 @@
 
 package io.airbyte.integrations.destination.s3.csv;
 
-import static io.airbyte.integrations.destination.s3.S3DestinationConstants.YYYY_MM_DD_FORMAT;
-
 import alex.mojaki.s3upload.MultiPartOutputStream;
 import alex.mojaki.s3upload.StreamTransferManager;
 import com.amazonaws.services.s3.AmazonS3;
@@ -46,8 +44,10 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.UUID;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
@@ -131,7 +131,9 @@ public class S3CsvOutputFormatter implements S3OutputFormatter {
   }
 
   static String getOutputFilename(Timestamp timestamp) {
-    return String.format("%s_%d_0.csv", YYYY_MM_DD_FORMAT.format(timestamp), timestamp.getTime());
+    var formatter = new SimpleDateFormat(S3DestinationConstants.YYYY_MM_DD_FORMAT_STRING);
+    formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+    return String.format("%s_%d_0.csv", formatter.format(timestamp), timestamp.getTime());
   }
 
   /**


### PR DESCRIPTION
## What
This test was failing on my machine and on a user's machine that I was pairing with today. Turns out this is because we aren't explicitly setting the calendar.

Explicitly set UTC to make sure this we always produce the same timestamp format. This will otherwise use the machine's locale.

