### PR TITLE
AWS S3 and Alternative S3 destination connector feature

### DIFF
--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3Config.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3Config.java
@@ -74,7 +74,7 @@ public class S3Config {
       partSize = config.get("part_size").asInt();
     }
     return new S3Config(
-        config.get("s3_endpoint").asText(),
+        config.get("s3_endpoint") == null ? "" : config.get("s3_endpoint").asText()
         config.get("s3_bucket_name").asText(),
         config.get("access_key_id").asText(),
         config.get("secret_access_key").asText(),

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3Config.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3Config.java
@@ -27,15 +27,16 @@ package io.airbyte.integrations.destination.jdbc.copy.s3;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class S3Config {
-  private final String endPoint;
+
+  private final String endpoint;
   private final String bucketName;
   private final String accessKeyId;
   private final String secretAccessKey;
   private final String region;
   private final Integer partSize;
 
-  public S3Config(String endPoint, String bucketName, String accessKeyId, String secretAccessKey, String region, Integer partSize) {
-    this.endPoint = endPoint;
+  public S3Config(String endpoint, String bucketName, String accessKeyId, String secretAccessKey, String region, Integer partSize) {
+    this.endpoint = endpoint;
     this.bucketName = bucketName;
     this.accessKeyId = accessKeyId;
     this.secretAccessKey = secretAccessKey;
@@ -43,8 +44,8 @@ public class S3Config {
     this.partSize = partSize;
   }
 
-  public String getEndPoint() {
-    return endPoint;
+  public String getEndpoint() {
+    return endpoint;
   }
 
   public String getBucketName() {

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3Config.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3Config.java
@@ -27,19 +27,24 @@ package io.airbyte.integrations.destination.jdbc.copy.s3;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class S3Config {
-
+  private final String endPoint;
   private final String bucketName;
   private final String accessKeyId;
   private final String secretAccessKey;
   private final String region;
   private final Integer partSize;
 
-  public S3Config(String bucketName, String accessKeyId, String secretAccessKey, String region, Integer partSize) {
+  public S3Config(String endPoint, String bucketName, String accessKeyId, String secretAccessKey, String region, Integer partSize) {
+    this.endPoint = endPoint;
     this.bucketName = bucketName;
     this.accessKeyId = accessKeyId;
     this.secretAccessKey = secretAccessKey;
     this.region = region;
     this.partSize = partSize;
+  }
+
+  public String getEndPoint() {
+    return endPoint;
   }
 
   public String getBucketName() {
@@ -68,6 +73,7 @@ public class S3Config {
       partSize = config.get("part_size").asInt();
     }
     return new S3Config(
+        config.get("s3_endpoint").asText(),
         config.get("s3_bucket_name").asText(),
         config.get("access_key_id").asText(),
         config.get("secret_access_key").asText(),

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3Config.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3Config.java
@@ -74,7 +74,7 @@ public class S3Config {
       partSize = config.get("part_size").asInt();
     }
     return new S3Config(
-        config.get("s3_endpoint") == null ? "" : config.get("s3_endpoint").asText()
+        config.get("s3_endpoint") == null ? "" : config.get("s3_endpoint").asText(),
         config.get("s3_bucket_name").asText(),
         config.get("access_key_id").asText(),
         config.get("secret_access_key").asText(),

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3StreamCopier.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3StreamCopier.java
@@ -26,8 +26,10 @@ package io.airbyte.integrations.destination.jdbc.copy.s3;
 
 import alex.mojaki.s3upload.MultiPartOutputStream;
 import alex.mojaki.s3upload.StreamTransferManager;
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import io.airbyte.db.jdbc.JdbcDatabase;
@@ -211,13 +213,32 @@ public abstract class S3StreamCopier implements StreamCopier {
   }
 
   public static AmazonS3 getAmazonS3(S3Config s3Config) {
+    var endPoint = s3Config.getEndPoint();
+    var region = s3Config.getRegion();
     var accessKeyId = s3Config.getAccessKeyId();
     var secretAccessKey = s3Config.getSecretAccessKey();
+
     var awsCreds = new BasicAWSCredentials(accessKeyId, secretAccessKey);
-    return AmazonS3ClientBuilder.standard()
-        .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
-        .withRegion(s3Config.getRegion())
-        .build();
+
+    if (endPoint.equals("aws")) {
+      return AmazonS3ClientBuilder.standard()
+          .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+          .withRegion(s3Config.getRegion())
+          .build();
+
+    } else {
+
+      ClientConfiguration clientConfiguration = new ClientConfiguration();
+      clientConfiguration.setSignerOverride("AWSS3V4SignerType");
+
+      return AmazonS3ClientBuilder
+          .standard()
+          .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endPoint, region))
+          .withPathStyleAccessEnabled(true)
+          .withClientConfiguration(clientConfiguration)
+          .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+          .build();
+    }
   }
 
   public abstract void copyS3CsvFileIntoTable(JdbcDatabase database,

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3StreamCopier.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3StreamCopier.java
@@ -213,14 +213,14 @@ public abstract class S3StreamCopier implements StreamCopier {
   }
 
   public static AmazonS3 getAmazonS3(S3Config s3Config) {
-    var endPoint = s3Config.getEndPoint();
+    var endpoint = s3Config.getEndpoint();
     var region = s3Config.getRegion();
     var accessKeyId = s3Config.getAccessKeyId();
     var secretAccessKey = s3Config.getSecretAccessKey();
 
     var awsCreds = new BasicAWSCredentials(accessKeyId, secretAccessKey);
 
-    if (endPoint.equals("aws")) {
+    if (endpoint.equalsIgnoreCase("aws")) {
       return AmazonS3ClientBuilder.standard()
           .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
           .withRegion(s3Config.getRegion())
@@ -233,7 +233,7 @@ public abstract class S3StreamCopier implements StreamCopier {
 
       return AmazonS3ClientBuilder
           .standard()
-          .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endPoint, region))
+          .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
           .withPathStyleAccessEnabled(true)
           .withClientConfiguration(clientConfiguration)
           .withCredentials(new AWSStaticCredentialsProvider(awsCreds))

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3StreamCopier.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3StreamCopier.java
@@ -220,7 +220,7 @@ public abstract class S3StreamCopier implements StreamCopier {
 
     var awsCreds = new BasicAWSCredentials(accessKeyId, secretAccessKey);
 
-    if (endpoint.equalsIgnoreCase("aws")) {
+    if (endpoint.isEmpty()) {
       return AmazonS3ClientBuilder.standard()
           .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
           .withRegion(s3Config.getRegion())

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3Consumer.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3Consumer.java
@@ -70,12 +70,12 @@ public class S3Consumer extends FailureTrackingAirbyteMessageConsumer {
   @Override
   protected void startTracked() throws Exception {
 
-    var endPoint = s3DestinationConfig.getEndPoint();
+    var endpoint = s3DestinationConfig.getEndpoint();
 
     AWSCredentials awsCreds = new BasicAWSCredentials(s3DestinationConfig.getAccessKeyId(), s3DestinationConfig.getSecretAccessKey());
     AmazonS3 s3Client = null;
 
-    if (endPoint.equals("aws")) {
+    if (endpoint.equalsIgnoreCase("aws")) {
       s3Client = AmazonS3ClientBuilder.standard()
           .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
           .withRegion(s3DestinationConfig.getBucketRegion())
@@ -87,7 +87,7 @@ public class S3Consumer extends FailureTrackingAirbyteMessageConsumer {
 
       s3Client = AmazonS3ClientBuilder
           .standard()
-          .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endPoint, s3DestinationConfig.getBucketRegion()))
+          .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, s3DestinationConfig.getBucketRegion()))
           .withPathStyleAccessEnabled(true)
           .withClientConfiguration(clientConfiguration)
           .withCredentials(new AWSStaticCredentialsProvider(awsCreds))

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3Consumer.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3Consumer.java
@@ -75,7 +75,7 @@ public class S3Consumer extends FailureTrackingAirbyteMessageConsumer {
     AWSCredentials awsCreds = new BasicAWSCredentials(s3DestinationConfig.getAccessKeyId(), s3DestinationConfig.getSecretAccessKey());
     AmazonS3 s3Client = null;
 
-    if (endpoint.equalsIgnoreCase("aws")) {
+    if (endpoint.isEmpty()) {
       s3Client = AmazonS3ClientBuilder.standard()
           .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
           .withRegion(s3DestinationConfig.getBucketRegion())

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3Consumer.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3Consumer.java
@@ -24,9 +24,11 @@
 
 package io.airbyte.integrations.destination.s3;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import io.airbyte.commons.json.Jsons;
@@ -67,12 +69,31 @@ public class S3Consumer extends FailureTrackingAirbyteMessageConsumer {
 
   @Override
   protected void startTracked() throws Exception {
-    AWSCredentials awsCreds = new BasicAWSCredentials(s3DestinationConfig.getAccessKeyId(),
-        s3DestinationConfig.getSecretAccessKey());
-    AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
-        .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
-        .withRegion(s3DestinationConfig.getBucketRegion())
-        .build();
+
+    var endPoint = s3DestinationConfig.getEndPoint();
+
+    AWSCredentials awsCreds = new BasicAWSCredentials(s3DestinationConfig.getAccessKeyId(), s3DestinationConfig.getSecretAccessKey());
+    AmazonS3 s3Client = null;
+
+    if (endPoint.equals("aws")) {
+      s3Client = AmazonS3ClientBuilder.standard()
+          .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+          .withRegion(s3DestinationConfig.getBucketRegion())
+          .build();
+
+    } else {
+      ClientConfiguration clientConfiguration = new ClientConfiguration();
+      clientConfiguration.setSignerOverride("AWSS3V4SignerType");
+
+      s3Client = AmazonS3ClientBuilder
+          .standard()
+          .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endPoint, s3DestinationConfig.getBucketRegion()))
+          .withPathStyleAccessEnabled(true)
+          .withClientConfiguration(clientConfiguration)
+          .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+          .build();
+    }
+
     Timestamp uploadTimestamp = new Timestamp(System.currentTimeMillis());
 
     for (ConfiguredAirbyteStream configuredStream : configuredCatalog.getStreams()) {

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
@@ -55,7 +55,7 @@ public class S3DestinationConfig {
 
   public static S3DestinationConfig getS3DestinationConfig(JsonNode config) {
     return new S3DestinationConfig(
-        config.get("s3_endpoint") == null ? "" : config.get("s3_endpoint").asText()
+        config.get("s3_endpoint") == null ? "" : config.get("s3_endpoint").asText(),
         config.get("s3_bucket_name").asText(),
         config.get("s3_bucket_path").asText(),
         config.get("s3_bucket_region").asText(),

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class S3DestinationConfig {
 
-  private final String endPoint;
+  private final String endpoint;
   private final String bucketName;
   private final String bucketPath;
   private final String bucketRegion;
@@ -37,14 +37,14 @@ public class S3DestinationConfig {
   private final S3FormatConfig formatConfig;
 
   public S3DestinationConfig(
-                             String endPoint,
+                             String endpoint,
                              String bucketName,
                              String bucketPath,
                              String bucketRegion,
                              String accessKeyId,
                              String secretAccessKey,
                              S3FormatConfig formatConfig) {
-    this.endPoint = endPoint;
+    this.endpoint = endpoint;
     this.bucketName = bucketName;
     this.bucketPath = bucketPath;
     this.bucketRegion = bucketRegion;
@@ -64,8 +64,8 @@ public class S3DestinationConfig {
         S3FormatConfigs.getS3FormatConfig(config));
   }
 
-  public String getEndPoint() {
-    return endPoint;
+  public String getEndpoint() {
+    return endpoint;
   }
 
   public String getBucketName() {

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
@@ -55,7 +55,7 @@ public class S3DestinationConfig {
 
   public static S3DestinationConfig getS3DestinationConfig(JsonNode config) {
     return new S3DestinationConfig(
-        config.get("s3_endpoint").asText(),
+        config.get("s3_endpoint") == null ? "" : config.get("s3_endpoint").asText()
         config.get("s3_bucket_name").asText(),
         config.get("s3_bucket_path").asText(),
         config.get("s3_bucket_region").asText(),

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class S3DestinationConfig {
 
+  private final String endPoint;
   private final String bucketName;
   private final String bucketPath;
   private final String bucketRegion;
@@ -36,12 +37,14 @@ public class S3DestinationConfig {
   private final S3FormatConfig formatConfig;
 
   public S3DestinationConfig(
+                             String endPoint,
                              String bucketName,
                              String bucketPath,
                              String bucketRegion,
                              String accessKeyId,
                              String secretAccessKey,
                              S3FormatConfig formatConfig) {
+    this.endPoint = endPoint;
     this.bucketName = bucketName;
     this.bucketPath = bucketPath;
     this.bucketRegion = bucketRegion;
@@ -52,12 +55,17 @@ public class S3DestinationConfig {
 
   public static S3DestinationConfig getS3DestinationConfig(JsonNode config) {
     return new S3DestinationConfig(
+        config.get("s3_endpoint").asText(),
         config.get("s3_bucket_name").asText(),
         config.get("s3_bucket_path").asText(),
         config.get("s3_bucket_region").asText(),
         config.get("access_key_id").asText(),
         config.get("secret_access_key").asText(),
         S3FormatConfigs.getS3FormatConfig(config));
+  }
+
+  public String getEndPoint() {
+    return endPoint;
   }
 
   public String getBucketName() {

--- a/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
@@ -7,6 +7,7 @@
     "title": "S3 Destination Spec",
     "type": "object",
     "required": [
+      "s3_endpoint",
       "s3_bucket_name",
       "s3_bucket_path",
       "s3_bucket_region",
@@ -16,6 +17,12 @@
     ],
     "additionalProperties": false,
     "properties": {
+      "s3_endpoint": {
+        "title": "Endpoint",
+        "type": "string",
+        "description": "this is end point url.( if you are working with aws, just type aws).",
+        "examples": ["localhost:9000", "aws"]
+      },
       "s3_bucket_name": {
         "title": "S3 Bucket Name",
         "type": "string",

--- a/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
@@ -7,7 +7,6 @@
     "title": "S3 Destination Spec",
     "type": "object",
     "required": [
-      "s3_endpoint",
       "s3_bucket_name",
       "s3_bucket_path",
       "s3_bucket_region",
@@ -20,8 +19,9 @@
       "s3_endpoint": {
         "title": "Endpoint",
         "type": "string",
-        "description": "This is your s3 endpoint url.( if you are working with aws, just type aws).",
-        "examples": ["http://localhost:9000", "aws"]
+        "default": "",
+        "description": "This is your S3 endpoint url.(if you are working with AWS S3, just leave empty).",
+        "examples": ["http://localhost:9000"]
       },
       "s3_bucket_name": {
         "title": "S3 Bucket Name",

--- a/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
@@ -20,8 +20,8 @@
       "s3_endpoint": {
         "title": "Endpoint",
         "type": "string",
-        "description": "this is end point url.( if you are working with aws, just type aws).",
-        "examples": ["localhost:9000", "aws"]
+        "description": "This is your s3 endpoint url.( if you are working with aws, just type aws).",
+        "examples": ["http://localhost:9000", "aws"]
       },
       "s3_bucket_name": {
         "title": "S3 Bucket Name",

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/java/io/airbyte/integrations/destination/s3/S3CsvDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/java/io/airbyte/integrations/destination/s3/S3CsvDestinationAcceptanceTest.java
@@ -24,9 +24,11 @@
 
 package io.airbyte.integrations.destination.s3;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
@@ -213,12 +215,28 @@ public class S3CsvDestinationAcceptanceTest extends DestinationAcceptanceTest {
     this.config = S3DestinationConfig.getS3DestinationConfig(configJson);
     LOGGER.info("Test full path: {}/{}", config.getBucketName(), config.getBucketPath());
 
+    var endpoint = config.getEndpoint();
     AWSCredentials awsCreds = new BasicAWSCredentials(config.getAccessKeyId(),
         config.getSecretAccessKey());
-    this.s3Client = AmazonS3ClientBuilder.standard()
-        .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
-        .withRegion(config.getBucketRegion())
-        .build();
+
+    if (endpoint.equalsIgnoreCase("aws")) {
+      this.s3Client = AmazonS3ClientBuilder.standard()
+          .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+          .withRegion(config.getBucketRegion())
+          .build();
+    } else {
+      ClientConfiguration clientConfiguration = new ClientConfiguration();
+      clientConfiguration.setSignerOverride("AWSS3V4SignerType");
+
+      this.s3Client = AmazonS3ClientBuilder
+          .standard()
+          .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, config.getBucketRegion()))
+          .withPathStyleAccessEnabled(true)
+          .withClientConfiguration(clientConfiguration)
+          .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+          .build();
+    }
+
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/java/io/airbyte/integrations/destination/s3/S3CsvDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/java/io/airbyte/integrations/destination/s3/S3CsvDestinationAcceptanceTest.java
@@ -219,7 +219,7 @@ public class S3CsvDestinationAcceptanceTest extends DestinationAcceptanceTest {
     AWSCredentials awsCreds = new BasicAWSCredentials(config.getAccessKeyId(),
         config.getSecretAccessKey());
 
-    if (endpoint.equalsIgnoreCase("aws")) {
+    if (endpoint.isEmpty()) {
       this.s3Client = AmazonS3ClientBuilder.standard()
           .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
           .withRegion(config.getBucketRegion())

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/csv/S3CsvOutputFormatterTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/csv/S3CsvOutputFormatterTest.java
@@ -52,7 +52,7 @@ class S3CsvOutputFormatterTest {
   public void testGetOutputFilename() {
     Timestamp timestamp = new Timestamp(1471461319000L);
     assertEquals(
-        "2016_08_18_1471461319000_0.csv",
+        "2016_08_17_1471461319000_0.csv",
         S3CsvOutputFormatter.getOutputFilename(timestamp));
   }
 

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/csv/S3CsvOutputFormatterTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/csv/S3CsvOutputFormatterTest.java
@@ -52,7 +52,7 @@ class S3CsvOutputFormatterTest {
   public void testGetOutputFilename() {
     Timestamp timestamp = new Timestamp(1471461319000L);
     assertEquals(
-        "2016_08_17_1471461319000_0.csv",
+        "2016_08_18_1471461319000_0.csv",
         S3CsvOutputFormatter.getOutputFilename(timestamp));
   }
 

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -4,7 +4,7 @@
 
 This destination writes data to S3 bucket.
 
-The Airbyte S3 destination allows you to sync data to AWS S3. Each stream is written to its own directory under the bucket.
+The Airbyte S3 destination allows you to sync data to AWS S3/ Minio S3. Each stream is written to its own directory under the bucket.
 
 ## Sync Mode
 
@@ -18,11 +18,12 @@ The Airbyte S3 destination allows you to sync data to AWS S3. Each stream is wri
 
 | Parameter | Type | Notes |
 | :--- | :---: | :--- |
+| S3 Endpoint | string | URL to S3, If using AWS S3 just leave blank. |
 | S3 Bucket Name | string | Name of the bucket to sync data into. |
 | S3 Bucket Path | string | Subdirectory under the above bucket to sync the data into. |
 | S3 Region | string | See [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) for all region codes. |
-| Access Key ID | string | AWS credential. |
-| Secret Access Key | string | AWS credential. |
+| Access Key ID | string | AWS/Minio credential. |
+| Secret Access Key | string | AWS/Minio credential. |
 | Format | object | Format specific configuration. See below for details. |
 
 ⚠️ Please note that under "Full Refresh Sync" mode, data in the configured bucket and path will be wiped out before each sync. We recommend you to provision a dedicated S3 resource for this sync to prevent unexpected data deletion from misconfiguration. ⚠️
@@ -104,12 +105,14 @@ With root level flattening, the output CSV is:
 
 ### Requirements
 
-1. Allow connections from Airbyte server to your AWS cluster \(if they exist in separate VPCs\).
+1. Allow connections from Airbyte server to your AWS S3/ Minio S3 cluster \(if they exist in separate VPCs\).
 2. An S3 bucket with credentials \(for the COPY strategy\).
 
 ### Setup guide
 
 * Fill up S3 info
+  * **S3 Endpoint**
+    * Leave empty if using AWS S3, fill in S3 URL if using Minio S3.
   * **S3 Bucket Name**
     * See [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) to create an S3 bucket.
   * **S3 Bucket Region**


### PR DESCRIPTION
## What
Allow S3 Destination Connector have the option to connect to both standard AWS S3 and Minio S3(Alternative S3).
This PR answering to this issue #3900 
![image](https://user-images.githubusercontent.com/7156904/121580530-0a609780-ca57-11eb-80a7-0ea0b998b3d4.png)


Integration test result:
![image](https://user-images.githubusercontent.com/7156904/121580351-d7b69f00-ca56-11eb-86e0-1a0ed3097eff.png)


## How
Because Minio S3 also supports AWS SDK, just use `AwsClientBuilder.EndpointConfiguration` to enable the custom endpoint.
Also check the condition, if the user enters 'aws' in the endpoint field. It will use the default AWS endpoint, else it connects to entered custom endpoint URL

## Recommended reading order
1. `spec.json`
2. `S3Consumer.java`
3. `S3StreamCopier.java`
4. `S3Config.java`
5. `s3.md`

## Pre-merge Checklist
Expand the checklist which is relevant for this PR. 

<details><summary> <strong> Connector checklist </strong> </summary>
<p>

- [X] Issue acceptance criteria met
- [X] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Secrets are annotated with `airbyte_secret` in output spec
- [ ] Unit & integration tests added as appropriate (and are passing)
    * Community members: please provide proof of this succeeding locally e.g: screenshot or copy-paste acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] `/test connector=connectors/<name>` command as documented [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-an-existing-connector) is passing. 
    * Community members can skip this, Airbyters will run this for you. 
- [ ] Code reviews completed
- [ ] Credentials added to Github CI if needed and not already present. [instructions for injecting secrets into CI](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#using-credentials-in-ci). 
- [x] Documentation updated 
    - [x] README
    - [ ] CHANGELOG.md
    - [x] Reference docs in the `docs/integrations/` directory.
- [x] Build is successful
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] No major blockers
- [ ] PR merged into master branch
- [ ] Follow up tickets have been created
- [ ] Associated tickets have been closed & stakeholders notified
</p>
</details>

<details><summary> <strong> Connector Generator checklist </strong> </summary>
<p>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
