### PR TITLE
Rewrite scaffoldTemplateTask test to work with new docker generator

### DIFF
--- a/airbyte-integrations/connector-templates/generator/Dockerfile
+++ b/airbyte-integrations/connector-templates/generator/Dockerfile
@@ -8,4 +8,6 @@ ENV ENV_GID $GID
 RUN mkdir -p /airbyte
 WORKDIR /airbyte/airbyte-integrations/connector-templates/generator
 
-CMD npm install --silent --no-update-notifier && npm run generate && chown -R $ENV_UID:$ENV_GID /airbyte/*
+CMD npm install --silent --no-update-notifier && \
+    npm run generate "$package_desc" "$package_name" && \
+    chown -R $ENV_UID:$ENV_GID /airbyte/*

--- a/airbyte-integrations/connector-templates/generator/generate.sh
+++ b/airbyte-integrations/connector-templates/generator/generate.sh
@@ -9,7 +9,12 @@ docker container rm -f airbyte-connector-bootstrap >/dev/null 2>&1
 docker build --build-arg UID="$(id -u)" --build-arg GID="$(id -g)" . -t airbyte/connector-bootstrap
 
 # Run the container and mount the airbyte folder
-docker run -it --name airbyte-connector-bootstrap -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
+if [ $# -eq 2 ]; then
+  echo "2 arguments supplied: 1=$1 2=$2"
+  docker run --name airbyte-connector-bootstrap -e package_desc="$1" -e package_name="$2" -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
+else
+  docker run -it --name airbyte-connector-bootstrap -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
+fi
 
 # Remove container after coping files
 docker container rm -f airbyte-connector-bootstrap >/dev/null 2>&1

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -20,8 +20,7 @@ cmd_scaffold() {
   echo "Scaffolding connector"
   (
     cd airbyte-integrations/connector-templates/generator &&
-    npm install &&
-    npm run generate "$@"
+    ./generate.sh "$@"
   )
 }
 


### PR DESCRIPTION
## What
A [scaffoldTemplateTask](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle) used the old way `npm run generate` for testing generation of scaffold connectors.
Update it to use new docker wrapped generator

## How
By changing the manage.sh in tools->integration to use new ./generate.sh script and also
allow passing the parameters into generate.sh and then use them as env variable running docker container

## Recommended reading order
tools/integrations/manage.sh
airbyte-integrations/connector-templates/generator/generate.sh
airbyte-integrations/connector-templates/generator/Dockerfile 

## Pre-merge Checklist
Expand the checklist which is relevant for this PR. 
- [x] Build is successful ([here is the test success in CI](https://github.com/airbytehq/airbyte/runs/2796288970?check_suite_focus=true#step:11:341))