### PR TITLE
fail if entrypoint not found on connector image

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -156,8 +156,7 @@ public class KubePodProcess extends Process {
 
     var envVal = logs.split("=")[1].strip();
     if (envVal.isEmpty()) {
-      // default to returning default entrypoint in bases
-      return "/airbyte/base.sh";
+      throw new RuntimeException("No AIRBYTE_ENTRYPOINT environment variable found. Connectors must have this set in order to run on Kubernetes.");
     }
 
     return envVal;


### PR DESCRIPTION
partially addresses https://github.com/airbytehq/airbyte/issues/3903

Since all officially supported images now have `AIRBYTE_ENTRYPOINT` added, we can remove this default for the next release.