### PR TITLE
📚 Replace npm install + generate -> ./generate.sh in docs

### DIFF
--- a/airbyte-cdk/python/docs/tutorials/cdk-tutorial-any-percent/cdk-speedrun.md
+++ b/airbyte-cdk/python/docs/tutorials/cdk-tutorial-any-percent/cdk-speedrun.md
@@ -12,8 +12,7 @@ This is a blazing fast guide to building an HTTP source connector. Think of it a
 
 ```bash
 $ cd airbyte-integrations/connector-templates/generator # start from repo root
-$ npm install
-$ npm run generate
+$ ./generate.sh
 ```
 
 Select the `Python HTTP API Source` and name it `python-http-example`.

--- a/airbyte-cdk/python/docs/tutorials/cdk-tutorial-python-http/1-creating-the-source.md
+++ b/airbyte-cdk/python/docs/tutorials/cdk-tutorial-python-http/1-creating-the-source.md
@@ -4,9 +4,7 @@ Airbyte provides a code generator which bootstraps the scaffolding for our conne
 
 ```bash
 $ cd airbyte-integrations/connector-templates/generator # assumes you are starting from the root of the Airbyte project.
-# Install NPM from https://www.npmjs.com/get-npm if you don't have it
-$ npm install
-$ npm run generate
+$ ./generate.sh 
 ```
 
 Select the `Python HTTP API Source` template and then input the name of your connector. For this walk-through we will refer to our source as `python-http-example`. The finalized source code for this tutorial can be found [here](https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors/source-python-http-tutorial).

--- a/airbyte-cdk/python/docs/tutorials/http_api_source.md
+++ b/airbyte-cdk/python/docs/tutorials/http_api_source.md
@@ -33,9 +33,7 @@ Airbyte provides a code generator which bootstraps the scaffolding for our conne
 
 ```bash
 $ cd airbyte-integrations/connector-templates/generator # assumes you are starting from the root of the Airbyte project.
-# Install NPM from https://www.npmjs.com/get-npm if you don't have it
-$ npm install
-$ npm run generate
+$ ./generate.sh
 ```
 
 Select the `Python HTTP CDK Source` template and then input the name of your connector. For this walk-through we will refer to our source as `python-http-example`. The finalized source code for this tutorial can be found [here](https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors/source-python-http-tutorial).

--- a/airbyte-integrations/bases/base-python/docs/tutorials/http_api_source.md
+++ b/airbyte-integrations/bases/base-python/docs/tutorials/http_api_source.md
@@ -33,9 +33,7 @@ Airbyte provides a code generator which bootstraps the scaffolding for our conne
 
 ```bash
 $ cd airbyte-integrations/connector-templates/generator # assumes you are starting from the root of the Airbyte project.
-# Install NPM from https://www.npmjs.com/get-npm if you don't have it
-$ npm install
-$ npm run generate
+$ ./generate.sh
 ```
 
 Select the `Python HTTP CDK Source` template and then input the name of your connector. For this walk-through we will refer to our source as `python-http-example`. The finalized source code for this tutorial can be found [here](https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors/source-python-http-tutorial).

--- a/docs/contributing-to-airbyte/building-new-connector/java-connectors.md
+++ b/docs/contributing-to-airbyte/building-new-connector/java-connectors.md
@@ -10,7 +10,7 @@ For the JDBC based sources the Code Generator maybe used to create a module's sk
 
 ```bash
 $ cd airbyte-integrations/connector-templates/generator # start from repo root
-$ npm install
-$ npm run generate
-In menu choose the "Java JDBC Source"
+$ ./generate.sh
 ```
+
+In menu choose the `"Java JDBC Source"`

--- a/docs/contributing-to-airbyte/python/tutorials/cdk-speedrun.md
+++ b/docs/contributing-to-airbyte/python/tutorials/cdk-speedrun.md
@@ -14,8 +14,7 @@ This is a blazing fast guide to building an HTTP source connector. Think of it a
 
 ```bash
 $ cd airbyte-integrations/connector-templates/generator # start from repo root
-$ npm install
-$ npm run generate
+$ ./generate.sh
 ```
 
 Select the `Python HTTP API Source` and name it `python-http-example`.

--- a/docs/contributing-to-airbyte/python/tutorials/cdk-tutorial-python-http/1-creating-the-source.md
+++ b/docs/contributing-to-airbyte/python/tutorials/cdk-tutorial-python-http/1-creating-the-source.md
@@ -5,8 +5,7 @@ Airbyte provides a code generator which bootstraps the scaffolding for our conne
 ```bash
 $ cd airbyte-integrations/connector-templates/generator # assumes you are starting from the root of the Airbyte project.
 # Install NPM from https://www.npmjs.com/get-npm if you don't have it
-$ npm install
-$ npm run generate
+$ ./generate.sh
 ```
 
 Select the `Python HTTP API Source` template and then input the name of your connector. For this walk-through we will refer to our source as `python-http-example`. The finalized source code for this tutorial can be found [here](https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors/source-python-http-tutorial).

--- a/docs/tutorials/tutorials/build-a-connector-the-hard-way.md
+++ b/docs/tutorials/tutorials/build-a-connector-the-hard-way.md
@@ -74,9 +74,7 @@ Airbyte provides a code generator which bootstraps the scaffolding for our conne
 
 ```bash
 $ cd airbyte-integrations/connector-templates/generator
-# Install NPM from https://www.npmjs.com/get-npm if you don't have it
-$ npm install
-$ npm run generate
+$ ./generate.sh 
 ```
 
 We'll select the `generic` template and call the connector `stock-ticker-api`:

--- a/docs/tutorials/tutorials/building-a-python-source.md
+++ b/docs/tutorials/tutorials/building-a-python-source.md
@@ -57,9 +57,7 @@ Airbyte provides a code generator which bootstraps the scaffolding for our conne
 
 ```bash
 $ cd airbyte-integrations/connector-templates/generator # assumes you are starting from the root of the Airbyte project.
-# Install NPM from https://www.npmjs.com/get-npm if you don't have it
-$ npm install
-$ npm run generate
+$ ./generate.sh
 ```
 
 Select the `python` template and then input the name of your connector. For this walk through we will refer to our source as `example-python`


### PR DESCRIPTION
## What
Replace all mentions of `npm install` and `npm run generate` to `./generate.sh` 
сonsidering the usage of a new docker based generator script

## How
By replacing old text with the new one

## Recommended reading order
No matter

## Pre-merge Checklist
- [ ] Documentation which references the generator is updated as needed.
- [ ] Build successful
