### PR TITLE
Fix invalid JSON syntax

### DIFF
--- a/docs/contributing-to-airbyte/python/tutorials/cdk-tutorial-python-http/3-define-inputs.md
+++ b/docs/contributing-to-airbyte/python/tutorials/cdk-tutorial-python-http/3-define-inputs.md
@@ -28,7 +28,7 @@ Given that we'll pulling currency data for our example source, we'll define the 
       },
       "base": {
         "type": "string",
-        "examples": ["USD", "EUR"]
+        "examples": ["USD", "EUR"],
         "description": "ISO reference currency. See <a href=\"https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html\">here</a>."
       }
     }


### PR DESCRIPTION
## What
Documentation example contains invalid JSON syntax.  Missing a comma at the end of a list element.  Copy and paste, which most people will do going through the tutorial, will result in an error running the spec command on the integration.  This just adds a comma.

## How
Add a comma to the example JSON for the spec so that it complies with JSON standard/syntax.

## Recommended reading order
I have no idea what this section is for.

## Pre-merge Checklist
I don't think either is applicable for this checklist, this is just a documentation fix.  One character...
