### PR TITLE
Validate source/destination definition ids before create connection - issue 144

### DIFF
--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigNotFoundException.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigNotFoundException.java
@@ -25,7 +25,6 @@
 package io.airbyte.config.persistence;
 
 import io.airbyte.config.ConfigSchema;
-
 import java.util.UUID;
 
 public class ConfigNotFoundException extends Exception {
@@ -38,6 +37,7 @@ public class ConfigNotFoundException extends Exception {
     this.type = type;
     this.configId = configId;
   }
+
   public ConfigNotFoundException(ConfigSchema type, UUID uuid) {
     this(type, uuid.toString());
   }

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigNotFoundException.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigNotFoundException.java
@@ -26,6 +26,8 @@ package io.airbyte.config.persistence;
 
 import io.airbyte.config.ConfigSchema;
 
+import java.util.UUID;
+
 public class ConfigNotFoundException extends Exception {
 
   private ConfigSchema type;
@@ -35,6 +37,9 @@ public class ConfigNotFoundException extends Exception {
     super(String.format("config type: %s id: %s", type, configId));
     this.type = type;
     this.configId = configId;
+  }
+  public ConfigNotFoundException(ConfigSchema type, UUID uuid) {
+    this(type, uuid.toString());
   }
 
   public ConfigSchema getType() {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -109,6 +109,10 @@ public class ConnectionsHandler {
       standardSync.withManual(true);
     }
 
+    // Validate source and destination
+    configRepository.getSourceConnection(connectionCreate.getSourceId());
+    configRepository.getDestinationConnection(connectionCreate.getDestinationId());
+
     configRepository.writeStandardSync(standardSync);
 
     trackNewConnection(standardSync);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -114,7 +114,6 @@ class ConnectionsHandlerTest {
     verify(configRepository).writeStandardSync(standardSync);
   }
 
-
   @Test
   void testCreateConnectionWithBadDefinitionIds() throws JsonValidationException, ConfigNotFoundException, IOException {
     when(uuidGenerator.get()).thenReturn(standardSync.getConnectionId());
@@ -122,45 +121,47 @@ class ConnectionsHandlerTest {
     UUID destinationDefinitionIdBad = UUID.randomUUID();
 
     final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
-            .withName("source-test")
-            .withSourceDefinitionId(UUID.randomUUID());
+        .withName("source-test")
+        .withSourceDefinitionId(UUID.randomUUID());
     final StandardDestinationDefinition destinationDefinition = new StandardDestinationDefinition()
-            .withName("destination-test")
-            .withDestinationDefinitionId(UUID.randomUUID());
+        .withName("destination-test")
+        .withDestinationDefinitionId(UUID.randomUUID());
     when(configRepository.getStandardSync(standardSync.getConnectionId())).thenReturn(standardSync);
     when(configRepository.getSourceDefinitionFromConnection(standardSync.getConnectionId())).thenReturn(sourceDefinition);
     when(configRepository.getDestinationDefinitionFromConnection(standardSync.getConnectionId())).thenReturn(destinationDefinition);
 
-    when(configRepository.getSourceConnection(sourceDefinitionIdBad)).thenThrow(new ConfigNotFoundException(ConfigSchema.SOURCE_CONNECTION, sourceDefinitionIdBad));
-    when(configRepository.getDestinationConnection(destinationDefinitionIdBad)).thenThrow(new ConfigNotFoundException(ConfigSchema.DESTINATION_CONNECTION, destinationDefinitionIdBad));
+    when(configRepository.getSourceConnection(sourceDefinitionIdBad))
+        .thenThrow(new ConfigNotFoundException(ConfigSchema.SOURCE_CONNECTION, sourceDefinitionIdBad));
+    when(configRepository.getDestinationConnection(destinationDefinitionIdBad))
+        .thenThrow(new ConfigNotFoundException(ConfigSchema.DESTINATION_CONNECTION, destinationDefinitionIdBad));
 
     final AirbyteCatalog catalog = ConnectionHelpers.generateBasicApiCatalog();
 
     final ConnectionCreate connectionCreateBadSource = new ConnectionCreate()
-            .sourceId(sourceDefinitionIdBad)
-            .destinationId(standardSync.getDestinationId())
-            .operationIds(standardSync.getOperationIds())
-            .name("presto to hudi")
-            .namespaceDefinition(NamespaceDefinitionType.SOURCE)
-            .namespaceFormat(null)
-            .prefix("presto_to_hudi")
-            .status(ConnectionStatus.ACTIVE)
-            .schedule(ConnectionHelpers.generateBasicConnectionSchedule())
-            .syncCatalog(catalog);
+        .sourceId(sourceDefinitionIdBad)
+        .destinationId(standardSync.getDestinationId())
+        .operationIds(standardSync.getOperationIds())
+        .name("presto to hudi")
+        .namespaceDefinition(NamespaceDefinitionType.SOURCE)
+        .namespaceFormat(null)
+        .prefix("presto_to_hudi")
+        .status(ConnectionStatus.ACTIVE)
+        .schedule(ConnectionHelpers.generateBasicConnectionSchedule())
+        .syncCatalog(catalog);
 
     assertThrows(ConfigNotFoundException.class, () -> connectionsHandler.createConnection(connectionCreateBadSource));
 
     final ConnectionCreate connectionCreateBadDestination = new ConnectionCreate()
-            .sourceId(standardSync.getSourceId())
-            .destinationId(destinationDefinitionIdBad)
-            .operationIds(standardSync.getOperationIds())
-            .name("presto to hudi")
-            .namespaceDefinition(NamespaceDefinitionType.SOURCE)
-            .namespaceFormat(null)
-            .prefix("presto_to_hudi")
-            .status(ConnectionStatus.ACTIVE)
-            .schedule(ConnectionHelpers.generateBasicConnectionSchedule())
-            .syncCatalog(catalog);
+        .sourceId(standardSync.getSourceId())
+        .destinationId(destinationDefinitionIdBad)
+        .operationIds(standardSync.getOperationIds())
+        .name("presto to hudi")
+        .namespaceDefinition(NamespaceDefinitionType.SOURCE)
+        .namespaceFormat(null)
+        .prefix("presto_to_hudi")
+        .status(ConnectionStatus.ACTIVE)
+        .schedule(ConnectionHelpers.generateBasicConnectionSchedule())
+        .syncCatalog(catalog);
 
     assertThrows(ConfigNotFoundException.class, () -> connectionsHandler.createConnection(connectionCreateBadDestination));
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -24,8 +24,7 @@
 
 package io.airbyte.server.handlers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -45,12 +44,7 @@ import io.airbyte.api.model.NamespaceDefinitionType;
 import io.airbyte.api.model.SyncMode;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.enums.Enums;
-import io.airbyte.config.DataType;
-import io.airbyte.config.Schedule;
-import io.airbyte.config.SourceConnection;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
-import io.airbyte.config.StandardSync;
+import io.airbyte.config.*;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
@@ -118,6 +112,58 @@ class ConnectionsHandlerTest {
     assertEquals(expectedConnectionRead, actualConnectionRead);
 
     verify(configRepository).writeStandardSync(standardSync);
+  }
+
+
+  @Test
+  void testCreateConnectionWithBadDefinitionIds() throws JsonValidationException, ConfigNotFoundException, IOException {
+    when(uuidGenerator.get()).thenReturn(standardSync.getConnectionId());
+    UUID sourceDefinitionIdBad = UUID.randomUUID();
+    UUID destinationDefinitionIdBad = UUID.randomUUID();
+
+    final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
+            .withName("source-test")
+            .withSourceDefinitionId(UUID.randomUUID());
+    final StandardDestinationDefinition destinationDefinition = new StandardDestinationDefinition()
+            .withName("destination-test")
+            .withDestinationDefinitionId(UUID.randomUUID());
+    when(configRepository.getStandardSync(standardSync.getConnectionId())).thenReturn(standardSync);
+    when(configRepository.getSourceDefinitionFromConnection(standardSync.getConnectionId())).thenReturn(sourceDefinition);
+    when(configRepository.getDestinationDefinitionFromConnection(standardSync.getConnectionId())).thenReturn(destinationDefinition);
+
+    when(configRepository.getSourceConnection(sourceDefinitionIdBad)).thenThrow(new ConfigNotFoundException(ConfigSchema.SOURCE_CONNECTION, sourceDefinitionIdBad));
+    when(configRepository.getDestinationConnection(destinationDefinitionIdBad)).thenThrow(new ConfigNotFoundException(ConfigSchema.DESTINATION_CONNECTION, destinationDefinitionIdBad));
+
+    final AirbyteCatalog catalog = ConnectionHelpers.generateBasicApiCatalog();
+
+    final ConnectionCreate connectionCreateBadSource = new ConnectionCreate()
+            .sourceId(sourceDefinitionIdBad)
+            .destinationId(standardSync.getDestinationId())
+            .operationIds(standardSync.getOperationIds())
+            .name("presto to hudi")
+            .namespaceDefinition(NamespaceDefinitionType.SOURCE)
+            .namespaceFormat(null)
+            .prefix("presto_to_hudi")
+            .status(ConnectionStatus.ACTIVE)
+            .schedule(ConnectionHelpers.generateBasicConnectionSchedule())
+            .syncCatalog(catalog);
+
+    assertThrows(ConfigNotFoundException.class, () -> connectionsHandler.createConnection(connectionCreateBadSource));
+
+    final ConnectionCreate connectionCreateBadDestination = new ConnectionCreate()
+            .sourceId(standardSync.getSourceId())
+            .destinationId(destinationDefinitionIdBad)
+            .operationIds(standardSync.getOperationIds())
+            .name("presto to hudi")
+            .namespaceDefinition(NamespaceDefinitionType.SOURCE)
+            .namespaceFormat(null)
+            .prefix("presto_to_hudi")
+            .status(ConnectionStatus.ACTIVE)
+            .schedule(ConnectionHelpers.generateBasicConnectionSchedule())
+            .syncCatalog(catalog);
+
+    assertThrows(ConfigNotFoundException.class, () -> connectionsHandler.createConnection(connectionCreateBadDestination));
+
   }
 
   @Test


### PR DESCRIPTION
ConnectionsHandler checks that sourceDefinitionId and destinationDefinitionId are valid before creating a connector.

## What
ConnectionsHandler checks that sourceDefinitionId and destinationDefinitionId are valid before creating a connector. If they are not, ConfigNotFoundException is thrown.

## How
Looks up the definitions by id before allowing create to continue.  If they are not found, exception is raised.

## Recommended reading order
1. `airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java`
2. `airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest`

Closes https://github.com/airbytehq/airbyte/issues/144