### PR TITLE
explicitly check for jq in unit test

### DIFF
--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
@@ -24,15 +24,20 @@
 
 package io.airbyte.workers.process;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.io.IOs;
+import io.airbyte.commons.io.LineGobbler;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.workers.WorkerException;
+import io.airbyte.workers.WorkerUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 // todo (cgardens) - these are not truly "unit" tests as they are check resources on the internet.
@@ -41,6 +46,29 @@ class DockerProcessFactoryTest {
 
   private static final Path TEST_ROOT = Path.of("/tmp/airbyte_tests");
 
+  /**
+   * {@link DockerProcessFactoryTest#testImageExists()} will fail if JQ is not installed. The logs get
+   * swallowed when run from gradle. This test exists to explicitly fail with a clear error message
+   * when JQ is not installed.
+   */
+  @Test
+  public void testJqExists() throws IOException {
+    final Process process = new ProcessBuilder("jq", "--version").start();
+    final StringBuilder out = new StringBuilder();
+    final StringBuilder err = new StringBuilder();
+    LineGobbler.gobble(process.getInputStream(), out::append);
+    LineGobbler.gobble(process.getErrorStream(), err::append);
+
+    WorkerUtils.gentleClose(process, 1, TimeUnit.MINUTES);
+
+    assertEquals(0, process.exitValue(), String.format("Error while checking for JQ. STDOUT: %s STDERR: %s", out, err));
+  }
+
+  /**
+   * This test will fail if JQ is not installed. If run from gradle the log line that mentions the JQ
+   * issue will be swallowed. The exception is visible if run from intellij or with STDERR logging
+   * turned on in gradle.
+   */
   @Test
   public void testImageExists() throws IOException, WorkerException {
     Path workspaceRoot = Files.createTempDirectory(Files.createDirectories(TEST_ROOT), "process_factory");

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
@@ -47,9 +47,9 @@ class DockerProcessFactoryTest {
   private static final Path TEST_ROOT = Path.of("/tmp/airbyte_tests");
 
   /**
-   * {@link DockerProcessFactoryTest#testImageExists()} will fail if JQ is not installed. The logs get
+   * {@link DockerProcessFactoryTest#testImageExists()} will fail if jq is not installed. The logs get
    * swallowed when run from gradle. This test exists to explicitly fail with a clear error message
-   * when JQ is not installed.
+   * when jq is not installed.
    */
   @Test
   public void testJqExists() throws IOException {
@@ -61,11 +61,12 @@ class DockerProcessFactoryTest {
 
     WorkerUtils.gentleClose(process, 1, TimeUnit.MINUTES);
 
-    assertEquals(0, process.exitValue(), String.format("Error while checking for JQ. STDOUT: %s STDERR: %s", out, err));
+    assertEquals(0, process.exitValue(),
+        String.format("Error while checking for jq. STDOUT: %s STDERR: %s Please make sure jq is installed (used by testImageExists)", out, err));
   }
 
   /**
-   * This test will fail if JQ is not installed. If run from gradle the log line that mentions the JQ
+   * This test will fail if jq is not installed. If run from gradle the log line that mentions the jq
    * issue will be swallowed. The exception is visible if run from intellij or with STDERR logging
    * turned on in gradle.
    */


### PR DESCRIPTION
## What
* We have a uniq test that fails if `jq` is not installed. The error message is pretty hard to find (and is swallowed entirely when just run with `./gradlew :airbyte-workers:build` because the STDERR from the tests don't get logged.
* I've seen a couple people who are new to the code base get hung up on this. It's really not obvious.

## How
* Add an additional test to the affected test suite that explicitly checks for the presence of `jq`. If `jq` is not present it fails loudly with an explicit error message _and_ relevant logs.