### PR TITLE
🐛 Increase max file size in import config upgrade process (error 413) 

### DIFF
--- a/airbyte-webapp/nginx/default.conf.template
+++ b/airbyte-webapp/nginx/default.conf.template
@@ -35,6 +35,7 @@ server {
     }
 
     location /api/ {
+        client_max_body_size 200M;
         proxy_pass http://api-server/api/;
     }
 }


### PR DESCRIPTION
## What
This solves (partially) #4086 

I had downloaded the configuration from demo.airbyte. It's 12Mb compressed.
Try to import without modification and got error 413.
After change the nginx I built the webapp using dev tag and try again running `v1/deployment/import`

## How
Increase the file size limit in the nginx config file.

## Recommended reading order
1. `airbyte-webapp/nginx/default.conf.template`
