### PR TITLE
Remove Tap / Target Nomenclature from Workers

### DIFF
--- a/airbyte-config/models/src/main/resources/types/StandardSync.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSync.yaml
@@ -2,7 +2,7 @@
 "$schema": http://json-schema.org/draft-07/schema#
 "$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSync.yaml
 title: StandardSync
-description: configuration required for sync for ALL taps
+description: configuration required for sync for ALL sources
 type: object
 required:
   - sourceId

--- a/airbyte-config/models/src/main/resources/types/StandardSyncSummary.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSyncSummary.yaml
@@ -3,7 +3,7 @@
 "$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSyncSummary.yaml
 title: StandardSyncSummary
 description:
-  standard information output by ALL taps for a sync step (our version
+  standard information output by ALL sources for a sync step (our version
   of state.json)
 type: object
 required:

--- a/airbyte-config/models/src/main/resources/types/WorkerDestinationConfig.yaml
+++ b/airbyte-config/models/src/main/resources/types/WorkerDestinationConfig.yaml
@@ -1,20 +1,24 @@
 ---
 "$schema": http://json-schema.org/draft-07/schema#
-"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardTapConfig.yaml
-title: StandardTapConfig
-description: StandardTapConfig
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/WorkerDestinationConfig.yaml
+title: WorkerDestinationConfig
+description: WorkerDestinationConfig
 type: object
 additionalProperties: false
 required:
-  - sourceConnectionConfiguration
+  - destinationConnectionConfiguration
   - catalog
+  - connectionId
 properties:
-  sourceConnectionConfiguration:
+  destinationConnectionConfiguration:
     description: Integration specific blob. Must be a valid JSON string.
     type: object
     existingJavaType: com.fasterxml.jackson.databind.JsonNode
   catalog:
     type: object
     existingJavaType: io.airbyte.protocol.models.ConfiguredAirbyteCatalog
+  connectionId:
+    type: string
+    format: uuid
   state:
     "$ref": State.yaml

--- a/airbyte-config/models/src/main/resources/types/WorkerSourceConfig.yaml
+++ b/airbyte-config/models/src/main/resources/types/WorkerSourceConfig.yaml
@@ -1,24 +1,20 @@
 ---
 "$schema": http://json-schema.org/draft-07/schema#
-"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardTargetConfig.yaml
-title: StandardTargetConfig
-description: StandardTargetConfig
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/WorkerSourceConfig.yaml
+title: WorkerSourceConfig
+description: WorkerSourceConfig
 type: object
 additionalProperties: false
 required:
-  - destinationConnectionConfiguration
+  - sourceConnectionConfiguration
   - catalog
-  - connectionId
 properties:
-  destinationConnectionConfiguration:
+  sourceConnectionConfiguration:
     description: Integration specific blob. Must be a valid JSON string.
     type: object
     existingJavaType: com.fasterxml.jackson.databind.JsonNode
   catalog:
     type: object
     existingJavaType: io.airbyte.protocol.models.ConfiguredAirbyteCatalog
-  connectionId:
-    type: string
-    format: uuid
   state:
     "$ref": State.yaml

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -45,7 +45,7 @@ import io.airbyte.config.OperatorDbt;
 import io.airbyte.config.StandardCheckConnectionInput;
 import io.airbyte.config.StandardCheckConnectionOutput;
 import io.airbyte.config.StandardCheckConnectionOutput.Status;
-import io.airbyte.config.StandardTargetConfig;
+import io.airbyte.config.WorkerDestinationConfig;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
@@ -883,7 +883,7 @@ public abstract class DestinationAcceptanceTest {
   private List<AirbyteMessage> runSync(JsonNode config, List<AirbyteMessage> messages, ConfiguredAirbyteCatalog catalog, boolean runNormalization)
       throws Exception {
 
-    final StandardTargetConfig targetConfig = new StandardTargetConfig()
+    final WorkerDestinationConfig targetConfig = new WorkerDestinationConfig()
         .withConnectionId(UUID.randomUUID())
         .withCatalog(catalog)
         .withDestinationConnectionConfiguration(config);

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -883,14 +883,14 @@ public abstract class DestinationAcceptanceTest {
   private List<AirbyteMessage> runSync(JsonNode config, List<AirbyteMessage> messages, ConfiguredAirbyteCatalog catalog, boolean runNormalization)
       throws Exception {
 
-    final WorkerDestinationConfig targetConfig = new WorkerDestinationConfig()
+    final WorkerDestinationConfig destinationConfig = new WorkerDestinationConfig()
         .withConnectionId(UUID.randomUUID())
         .withCatalog(catalog)
         .withDestinationConnectionConfiguration(config);
 
     final AirbyteDestination destination = getDestination();
 
-    destination.start(targetConfig, jobRoot);
+    destination.start(destinationConfig, jobRoot);
     messages.forEach(message -> Exceptions.toRuntime(() -> destination.accept(message)));
     destination.notifyEndOfStream();
 
@@ -910,7 +910,8 @@ public abstract class DestinationAcceptanceTest {
         processFactory);
     runner.start();
     final Path normalizationRoot = Files.createDirectories(jobRoot.resolve("normalize"));
-    if (!runner.normalize(JOB_ID, JOB_ATTEMPT, normalizationRoot, targetConfig.getDestinationConnectionConfiguration(), targetConfig.getCatalog())) {
+    if (!runner.normalize(JOB_ID, JOB_ATTEMPT, normalizationRoot, destinationConfig.getDestinationConnectionConfiguration(),
+        destinationConfig.getCatalog())) {
       throw new WorkerException("Normalization Failed.");
     }
     runner.close();

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/LocalAirbyteDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/LocalAirbyteDestination.java
@@ -24,7 +24,7 @@
 
 package io.airbyte.integrations.standardtest.destination;
 
-import io.airbyte.config.StandardTargetConfig;
+import io.airbyte.config.WorkerDestinationConfig;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
 import io.airbyte.integrations.base.Destination;
 import io.airbyte.protocol.models.AirbyteMessage;
@@ -45,7 +45,7 @@ public class LocalAirbyteDestination implements AirbyteDestination {
   }
 
   @Override
-  public void start(StandardTargetConfig targetConfig, Path jobRoot) throws Exception {
+  public void start(WorkerDestinationConfig targetConfig, Path jobRoot) throws Exception {
     consumer =
         dest.getConsumer(targetConfig.getDestinationConnectionConfiguration(), targetConfig.getCatalog(), Destination::defaultOutputRecordCollector);
     consumer.start();

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/LocalAirbyteDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/LocalAirbyteDestination.java
@@ -45,9 +45,10 @@ public class LocalAirbyteDestination implements AirbyteDestination {
   }
 
   @Override
-  public void start(WorkerDestinationConfig targetConfig, Path jobRoot) throws Exception {
+  public void start(WorkerDestinationConfig destinationConfig, Path jobRoot) throws Exception {
     consumer =
-        dest.getConsumer(targetConfig.getDestinationConnectionConfiguration(), targetConfig.getCatalog(), Destination::defaultOutputRecordCollector);
+        dest.getConsumer(destinationConfig.getDestinationConnectionConfiguration(), destinationConfig.getCatalog(),
+            Destination::defaultOutputRecordCollector);
     consumer.start();
   }
 

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAbstractTest.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAbstractTest.java
@@ -29,8 +29,8 @@ import io.airbyte.config.JobGetSpecConfig;
 import io.airbyte.config.StandardCheckConnectionInput;
 import io.airbyte.config.StandardCheckConnectionOutput;
 import io.airbyte.config.StandardDiscoverCatalogInput;
-import io.airbyte.config.StandardTapConfig;
 import io.airbyte.config.State;
+import io.airbyte.config.WorkerSourceConfig;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
@@ -139,7 +139,7 @@ public abstract class SourceAbstractTest {
 
   // todo (cgardens) - assume no state since we are all full refresh right now.
   protected List<AirbyteMessage> runRead(ConfiguredAirbyteCatalog catalog, JsonNode state) throws Exception {
-    final StandardTapConfig sourceConfig = new StandardTapConfig()
+    final WorkerSourceConfig sourceConfig = new WorkerSourceConfig()
         .withSourceConnectionConfiguration(getConfig())
         .withState(state == null ? null : new State().withState(state))
         .withCatalog(catalog);

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
@@ -173,7 +173,7 @@ class PostgresSourceTest {
 
   @Test
   public void testCanReadUtf8() throws Exception {
-    // force the db server to start with sql_ascii encoding to verify the tap can read UTF8 even when
+    // force the db server to start with sql_ascii encoding to verify the source can read UTF8 even when
     // default settings are in another encoding
     try (PostgreSQLContainer<?> db = new PostgreSQLContainer<>("postgres:13-alpine").withCommand("postgres -c client_encoding=sql_ascii")) {
       db.start();

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_14_0/airbyte_config/StandardSync.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_14_0/airbyte_config/StandardSync.yaml
@@ -2,7 +2,7 @@
 "$schema": http://json-schema.org/draft-07/schema#
 "$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSync.yaml
 title: StandardSync
-description: configuration required for sync for ALL taps
+description: configuration required for sync for ALL sources
 type: object
 required:
   - sourceId

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_14_3/airbyte_config/StandardSync.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_14_3/airbyte_config/StandardSync.yaml
@@ -2,7 +2,7 @@
 "$schema": http://json-schema.org/draft-07/schema#
 "$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSync.yaml
 title: StandardSync
-description: configuration required for sync for ALL taps
+description: configuration required for sync for ALL sources
 type: object
 required:
   - sourceId

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_20_0/StandardSync.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_20_0/StandardSync.yaml
@@ -2,7 +2,7 @@
 "$schema": http://json-schema.org/draft-07/schema#
 "$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSync.yaml
 title: StandardSync
-description: configuration required for sync for ALL taps
+description: configuration required for sync for ALL sources
 type: object
 required:
   - sourceId

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_23_0/StandardSync.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_23_0/StandardSync.yaml
@@ -2,7 +2,7 @@
 "$schema": http://json-schema.org/draft-07/schema#
 "$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSync.yaml
 title: StandardSync
-description: configuration required for sync for ALL taps
+description: configuration required for sync for ALL sources
 type: object
 required:
   - sourceId

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_24_0/StandardSync.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_24_0/StandardSync.yaml
@@ -2,7 +2,7 @@
 "$schema": http://json-schema.org/draft-07/schema#
 "$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSync.yaml
 title: StandardSync
-description: configuration required for sync for ALL taps
+description: configuration required for sync for ALL sources
 type: object
 required:
   - sourceId

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_25_0/StandardSync.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_25_0/StandardSync.yaml
@@ -2,7 +2,7 @@
 "$schema": http://json-schema.org/draft-07/schema#
 "$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSync.yaml
 title: StandardSync
-description: configuration required for sync for ALL taps
+description: configuration required for sync for ALL sources
 type: object
 required:
   - sourceId

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -382,7 +382,7 @@ public class AcceptanceTests {
 
     final JobInfoRead connectionSyncRead = apiClient.getConnectionApi().syncConnection(new ConnectionIdRequestBody().connectionId(connectionId));
     waitForSuccessfulJob(apiClient.getJobsApi(), connectionSyncRead.getJob());
-    assertSourceAndTargetDbInSync(sourcePsql, false);
+    assertSourceAndDestinationDbInSync(sourcePsql, false);
   }
 
   @Test
@@ -415,7 +415,7 @@ public class AcceptanceTests {
     waitForSuccessfulJob(apiClient.getJobsApi(), connectionSyncRead1.getJob());
     LOGGER.info("state after sync 1: {}", apiClient.getConnectionApi().getState(new ConnectionIdRequestBody().connectionId(connectionId)));
 
-    assertSourceAndTargetDbInSync(sourcePsql, false);
+    assertSourceAndDestinationDbInSync(sourcePsql, false);
 
     // add new records and run again.
     final Database source = getDatabase(sourcePsql);
@@ -450,7 +450,7 @@ public class AcceptanceTests {
     waitForSuccessfulJob(apiClient.getJobsApi(), connectionSyncRead3.getJob());
     LOGGER.info("state after sync 3: {}", apiClient.getConnectionApi().getState(new ConnectionIdRequestBody().connectionId(connectionId)));
 
-    assertSourceAndTargetDbInSync(sourcePsql, false);
+    assertSourceAndDestinationDbInSync(sourcePsql, false);
   }
 
   @Test
@@ -475,7 +475,7 @@ public class AcceptanceTests {
     // if the wait isn't long enough, failures say "Connection refused" because the assert kills the
     // syncs in progress
     sleep(Duration.ofMinutes(2).toMillis());
-    assertSourceAndTargetDbInSync(sourcePsql, false);
+    assertSourceAndDestinationDbInSync(sourcePsql, false);
   }
 
   @Test
@@ -498,7 +498,7 @@ public class AcceptanceTests {
 
     final JobInfoRead connectionSyncRead = apiClient.getConnectionApi().syncConnection(new ConnectionIdRequestBody().connectionId(connectionId));
     waitForSuccessfulJob(apiClient.getJobsApi(), connectionSyncRead.getJob());
-    assertSourceAndTargetDbInSync(sourcePsql, false);
+    assertSourceAndDestinationDbInSync(sourcePsql, false);
   }
 
   @Test
@@ -521,7 +521,7 @@ public class AcceptanceTests {
 
     final JobInfoRead connectionSyncRead = apiClient.getConnectionApi().syncConnection(new ConnectionIdRequestBody().connectionId(connectionId));
     waitForSuccessfulJob(apiClient.getJobsApi(), connectionSyncRead.getJob());
-    assertSourceAndTargetDbInSync(sourcePsql, false);
+    assertSourceAndDestinationDbInSync(sourcePsql, false);
   }
 
   @Test
@@ -547,7 +547,7 @@ public class AcceptanceTests {
         .syncConnection(new ConnectionIdRequestBody().connectionId(connectionId));
     waitForSuccessfulJob(apiClient.getJobsApi(), connectionSyncRead1.getJob());
 
-    assertSourceAndTargetDbInSync(sourcePsql, true);
+    assertSourceAndDestinationDbInSync(sourcePsql, true);
 
     // add new records and run again.
     final Database source = getDatabase(sourcePsql);
@@ -668,7 +668,7 @@ public class AcceptanceTests {
     return apiClient.getSourceApi().discoverSchemaForSource(new SourceIdRequestBody().sourceId(sourceId)).getCatalog();
   }
 
-  private void assertSourceAndTargetDbInSync(PostgreSQLContainer sourceDb, boolean withScdTable) throws Exception {
+  private void assertSourceAndDestinationDbInSync(PostgreSQLContainer sourceDb, boolean withScdTable) throws Exception {
     final Database source = getDatabase(sourceDb);
 
     final Set<SchemaTableNamePair> sourceTables = listAllTables(source);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -28,9 +28,9 @@ import io.airbyte.config.ReplicationAttemptSummary;
 import io.airbyte.config.ReplicationOutput;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardSyncSummary.ReplicationStatus;
-import io.airbyte.config.StandardTapConfig;
-import io.airbyte.config.StandardTargetConfig;
 import io.airbyte.config.State;
+import io.airbyte.config.WorkerDestinationConfig;
+import io.airbyte.config.WorkerSourceConfig;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.workers.protocols.Destination;
 import io.airbyte.workers.protocols.Mapper;
@@ -103,7 +103,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
 
     // todo (cgardens) - this should not be happening in the worker. this is configuration information
     // that is independent of workflow executions.
-    final StandardTargetConfig destinationConfig = WorkerUtils.syncToTargetConfig(syncInput);
+    final WorkerDestinationConfig destinationConfig = WorkerUtils.syncToTargetConfig(syncInput);
     destinationConfig.setCatalog(mapper.mapCatalog(destinationConfig.getCatalog()));
 
     long startTime = System.currentTimeMillis();
@@ -112,7 +112,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
           .stream()
           .collect(Collectors.toMap(s -> s.getStream().getNamespace() + "." + s.getStream().getName(),
               s -> String.format("%s - %s", s.getSyncMode(), s.getDestinationSyncMode()))));
-      final StandardTapConfig sourceConfig = WorkerUtils.syncToTapConfig(syncInput);
+      final WorkerSourceConfig sourceConfig = WorkerUtils.syncToTapConfig(syncInput);
 
       final Map<String, String> mdc = MDC.getCopyOfContextMap();
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -103,7 +103,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
 
     // todo (cgardens) - this should not be happening in the worker. this is configuration information
     // that is independent of workflow executions.
-    final WorkerDestinationConfig destinationConfig = WorkerUtils.syncToTargetConfig(syncInput);
+    final WorkerDestinationConfig destinationConfig = WorkerUtils.syncToWorkerDestinationConfig(syncInput);
     destinationConfig.setCatalog(mapper.mapCatalog(destinationConfig.getCatalog()));
 
     long startTime = System.currentTimeMillis();
@@ -112,7 +112,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
           .stream()
           .collect(Collectors.toMap(s -> s.getStream().getNamespace() + "." + s.getStream().getName(),
               s -> String.format("%s - %s", s.getSyncMode(), s.getDestinationSyncMode()))));
-      final WorkerSourceConfig sourceConfig = WorkerUtils.syncToTapConfig(syncInput);
+      final WorkerSourceConfig sourceConfig = WorkerUtils.syncToWorkerSourceConfig(syncInput);
 
       final Map<String, String> mdc = MDC.getCopyOfContextMap();
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -172,7 +172,7 @@ public class WorkerUtils {
    * Translates a StandardSyncInput into a WorkerSourceConfig. WorkerSourceConfig is a subset of
    * StandardSyncInput.
    */
-  public static WorkerSourceConfig syncToTapConfig(StandardSyncInput sync) {
+  public static WorkerSourceConfig syncToWorkerSourceConfig(StandardSyncInput sync) {
     return new WorkerSourceConfig()
         .withSourceConnectionConfiguration(sync.getSourceConfiguration())
         .withCatalog(sync.getCatalog())
@@ -183,7 +183,7 @@ public class WorkerUtils {
    * Translates a StandardSyncInput into a WorkerDestinationConfig. WorkerDestinationConfig is a
    * subset of StandardSyncInput.
    */
-  public static WorkerDestinationConfig syncToTargetConfig(StandardSyncInput sync) {
+  public static WorkerDestinationConfig syncToWorkerDestinationConfig(StandardSyncInput sync) {
     return new WorkerDestinationConfig()
         .withDestinationConnectionConfiguration(sync.getDestinationConfiguration())
         .withCatalog(sync.getCatalog())

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -26,8 +26,8 @@ package io.airbyte.workers;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.config.StandardSyncInput;
-import io.airbyte.config.StandardTapConfig;
-import io.airbyte.config.StandardTargetConfig;
+import io.airbyte.config.WorkerDestinationConfig;
+import io.airbyte.config.WorkerSourceConfig;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.process.AirbyteIntegrationLauncher;
@@ -169,22 +169,22 @@ public class WorkerUtils {
   }
 
   /**
-   * Translates a StandardSyncInput into a StandardTapConfig. StandardTapConfig is a subset of
+   * Translates a StandardSyncInput into a WorkerSourceConfig. WorkerSourceConfig is a subset of
    * StandardSyncInput.
    */
-  public static StandardTapConfig syncToTapConfig(StandardSyncInput sync) {
-    return new StandardTapConfig()
+  public static WorkerSourceConfig syncToTapConfig(StandardSyncInput sync) {
+    return new WorkerSourceConfig()
         .withSourceConnectionConfiguration(sync.getSourceConfiguration())
         .withCatalog(sync.getCatalog())
         .withState(sync.getState());
   }
 
   /**
-   * Translates a StandardSyncInput into a StandardTargetConfig. StandardTargetConfig is a subset of
-   * StandardSyncInput.
+   * Translates a StandardSyncInput into a WorkerDestinationConfig. WorkerDestinationConfig is a
+   * subset of StandardSyncInput.
    */
-  public static StandardTargetConfig syncToTargetConfig(StandardSyncInput sync) {
-    return new StandardTargetConfig()
+  public static WorkerDestinationConfig syncToTargetConfig(StandardSyncInput sync) {
+    return new WorkerDestinationConfig()
         .withDestinationConnectionConfiguration(sync.getDestinationConfiguration())
         .withCatalog(sync.getCatalog())
         .withState(sync.getState());

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/Destination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/Destination.java
@@ -25,13 +25,13 @@
 package io.airbyte.workers.protocols;
 
 import io.airbyte.commons.functional.CheckedConsumer;
-import io.airbyte.config.StandardTargetConfig;
+import io.airbyte.config.WorkerDestinationConfig;
 import java.nio.file.Path;
 import java.util.Optional;
 
 public interface Destination<T> extends CheckedConsumer<T, Exception>, AutoCloseable {
 
-  void start(StandardTargetConfig targetConfig, Path jobRoot) throws Exception;
+  void start(WorkerDestinationConfig targetConfig, Path jobRoot) throws Exception;
 
   @Override
   void accept(T message) throws Exception;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/Destination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/Destination.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 
 public interface Destination<T> extends CheckedConsumer<T, Exception>, AutoCloseable {
 
-  void start(WorkerDestinationConfig targetConfig, Path jobRoot) throws Exception;
+  void start(WorkerDestinationConfig destinationConfig, Path jobRoot) throws Exception;
 
   @Override
   void accept(T message) throws Exception;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/MessageTracker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/MessageTracker.java
@@ -31,7 +31,7 @@ import java.util.function.Consumer;
 public interface MessageTracker<T> extends Consumer<T> {
 
   @Override
-  public void accept(T message);
+  void accept(T message);
 
   long getRecordCount();
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/Source.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/Source.java
@@ -24,13 +24,13 @@
 
 package io.airbyte.workers.protocols;
 
-import io.airbyte.config.StandardTapConfig;
+import io.airbyte.config.WorkerSourceConfig;
 import java.nio.file.Path;
 import java.util.Optional;
 
 public interface Source<T> extends AutoCloseable {
 
-  void start(StandardTapConfig input, Path jobRoot) throws Exception;
+  void start(WorkerSourceConfig input, Path jobRoot) throws Exception;
 
   boolean isFinished();
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/Source.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/Source.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 
 public interface Source<T> extends AutoCloseable {
 
-  void start(WorkerSourceConfig input, Path jobRoot) throws Exception;
+  void start(WorkerSourceConfig sourceConfig, Path jobRoot) throws Exception;
 
   boolean isFinished();
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -29,7 +29,7 @@ import com.google.common.base.Preconditions;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.io.LineGobbler;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.config.StandardTargetConfig;
+import io.airbyte.config.WorkerDestinationConfig;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.workers.WorkerConstants;
@@ -72,7 +72,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
   }
 
   @Override
-  public void start(StandardTargetConfig destinationConfig, Path jobRoot) throws IOException, WorkerException {
+  public void start(WorkerDestinationConfig destinationConfig, Path jobRoot) throws IOException, WorkerException {
     Preconditions.checkState(destinationProcess == null);
 
     LOGGER.info("Running destination...");

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
@@ -75,16 +75,16 @@ public class DefaultAirbyteSource implements AirbyteSource {
   }
 
   @Override
-  public void start(WorkerSourceConfig input, Path jobRoot) throws Exception {
+  public void start(WorkerSourceConfig sourceConfig, Path jobRoot) throws Exception {
     Preconditions.checkState(sourceProcess == null);
 
     sourceProcess = integrationLauncher.read(jobRoot,
         WorkerConstants.SOURCE_CONFIG_JSON_FILENAME,
-        Jsons.serialize(input.getSourceConnectionConfiguration()),
+        Jsons.serialize(sourceConfig.getSourceConnectionConfiguration()),
         WorkerConstants.SOURCE_CATALOG_JSON_FILENAME,
-        Jsons.serialize(input.getCatalog()),
-        input.getState() == null ? null : WorkerConstants.INPUT_STATE_JSON_FILENAME,
-        input.getState() == null ? null : Jsons.serialize(input.getState().getState()));
+        Jsons.serialize(sourceConfig.getCatalog()),
+        sourceConfig.getState() == null ? null : WorkerConstants.INPUT_STATE_JSON_FILENAME,
+        sourceConfig.getState() == null ? null : Jsons.serialize(sourceConfig.getState().getState()));
     // stdout logs are logged elsewhere since stdout also contains data
     LineGobbler.gobble(sourceProcess.getErrorStream(), LOGGER::error, "airbyte-source");
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
@@ -29,7 +29,7 @@ import com.google.common.base.Preconditions;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.io.LineGobbler;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.config.StandardTapConfig;
+import io.airbyte.config.WorkerSourceConfig;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.workers.WorkerConstants;
@@ -75,7 +75,7 @@ public class DefaultAirbyteSource implements AirbyteSource {
   }
 
   @Override
-  public void start(StandardTapConfig input, Path jobRoot) throws Exception {
+  public void start(WorkerSourceConfig input, Path jobRoot) throws Exception {
     Preconditions.checkState(sourceProcess == null);
 
     sourceProcess = integrationLauncher.read(jobRoot,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/EmptyAirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/EmptyAirbyteSource.java
@@ -25,7 +25,7 @@
 package io.airbyte.workers.protocols.airbyte;
 
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.config.StandardTapConfig;
+import io.airbyte.config.WorkerSourceConfig;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.protocol.models.AirbyteStateMessage;
@@ -46,7 +46,7 @@ public class EmptyAirbyteSource implements AirbyteSource {
   }
 
   @Override
-  public void start(StandardTapConfig input, Path jobRoot) throws Exception {
+  public void start(WorkerSourceConfig input, Path jobRoot) throws Exception {
     // no op.
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/EmptyAirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/EmptyAirbyteSource.java
@@ -46,7 +46,7 @@ public class EmptyAirbyteSource implements AirbyteSource {
   }
 
   @Override
-  public void start(WorkerSourceConfig input, Path jobRoot) throws Exception {
+  public void start(WorkerSourceConfig sourceConfig, Path jobRoot) throws Exception {
     // no op.
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
@@ -46,9 +46,9 @@ import io.airbyte.config.ReplicationOutput;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardSyncSummary.ReplicationStatus;
-import io.airbyte.config.StandardTapConfig;
-import io.airbyte.config.StandardTargetConfig;
 import io.airbyte.config.State;
+import io.airbyte.config.WorkerDestinationConfig;
+import io.airbyte.config.WorkerSourceConfig;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.workers.protocols.airbyte.AirbyteDestination;
@@ -92,8 +92,8 @@ class DefaultReplicationWorkerTest {
   private NamespacingMapper mapper;
   private AirbyteDestination destination;
   private StandardSyncInput syncInput;
-  private StandardTapConfig sourceConfig;
-  private StandardTargetConfig destinationConfig;
+  private WorkerSourceConfig sourceConfig;
+  private WorkerDestinationConfig destinationConfig;
   private AirbyteMessageTracker sourceMessageTracker;
   private AirbyteMessageTracker destinationMessageTracker;
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
@@ -107,8 +107,8 @@ class DefaultReplicationWorkerTest {
     final ImmutablePair<StandardSync, StandardSyncInput> syncPair = TestConfigHelpers.createSyncConfig();
     syncInput = syncPair.getValue();
 
-    sourceConfig = WorkerUtils.syncToTapConfig(syncInput);
-    destinationConfig = WorkerUtils.syncToTargetConfig(syncInput);
+    sourceConfig = WorkerUtils.syncToWorkerSourceConfig(syncInput);
+    destinationConfig = WorkerUtils.syncToWorkerDestinationConfig(syncInput);
 
     source = mock(AirbyteSource.class);
     mapper = mock(NamespacingMapper.class);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
@@ -64,7 +64,8 @@ class DefaultAirbyteDestinationTest {
   private static final String STREAM_NAME = "user_preferences";
   private static final String FIELD_NAME = "favorite_color";
 
-  private static final WorkerDestinationConfig DESTINATION_CONFIG = WorkerUtils.syncToTargetConfig(TestConfigHelpers.createSyncConfig().getValue());
+  private static final WorkerDestinationConfig DESTINATION_CONFIG =
+      WorkerUtils.syncToWorkerDestinationConfig(TestConfigHelpers.createSyncConfig().getValue());
 
   private static final List<AirbyteMessage> MESSAGES = Lists.newArrayList(
       AirbyteMessageUtils.createStateMessage("checkpoint", "1"),

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.config.StandardTargetConfig;
+import io.airbyte.config.WorkerDestinationConfig;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.workers.TestConfigHelpers;
 import io.airbyte.workers.WorkerConstants;
@@ -64,7 +64,7 @@ class DefaultAirbyteDestinationTest {
   private static final String STREAM_NAME = "user_preferences";
   private static final String FIELD_NAME = "favorite_color";
 
-  private static final StandardTargetConfig DESTINATION_CONFIG = WorkerUtils.syncToTargetConfig(TestConfigHelpers.createSyncConfig().getValue());
+  private static final WorkerDestinationConfig DESTINATION_CONFIG = WorkerUtils.syncToTargetConfig(TestConfigHelpers.createSyncConfig().getValue());
 
   private static final List<AirbyteMessage> MESSAGES = Lists.newArrayList(
       AirbyteMessageUtils.createStateMessage("checkpoint", "1"),

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
@@ -37,8 +37,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.config.StandardTapConfig;
 import io.airbyte.config.State;
+import io.airbyte.config.WorkerSourceConfig;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
@@ -76,7 +76,7 @@ class DefaultAirbyteSourceTest {
       NAMESPACE,
       Field.of(FIELD_NAME, JsonSchemaPrimitive.STRING));
 
-  private static final StandardTapConfig SOURCE_CONFIG = new StandardTapConfig()
+  private static final WorkerSourceConfig SOURCE_CONFIG = new WorkerSourceConfig()
       .withState(new State().withState(STATE))
       .withSourceConnectionConfiguration(CONFIG)
       .withCatalog(CATALOG);


### PR DESCRIPTION
StandardTapConfig => WorkerSourceConfig; StandardTargetConfig => WorkerDestinationConfig


closes https://github.com/airbytehq/airbyte/issues/2842