### PR TITLE
Separate config validation from FileSystemConfigPersistence

### DIFF
--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/FileSystemConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/FileSystemConfigPersistence.java
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -219,7 +218,6 @@ public class FileSystemConfigPersistence implements ConfigPersistence {
   private <T> void writeConfigInternal(ConfigSchema configType, String configId, T config) throws IOException {
     writeConfigInternal(configType, configId, config, storageRoot);
   }
-
 
   private <T> void writeConfigInternal(ConfigSchema configType, String configId, T config, Path storageRoot) throws IOException {
 

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ValidatingConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ValidatingConfigPersistence.java
@@ -31,6 +31,8 @@ import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 // we force all interaction with disk storage to be effectively single threaded.
 public class ValidatingConfigPersistence implements ConfigPersistence {
@@ -68,6 +70,17 @@ public class ValidatingConfigPersistence implements ConfigPersistence {
   public <T> void writeConfig(ConfigSchema configType, String configId, T config) throws JsonValidationException, IOException {
     validateJson(Jsons.jsonNode(config), configType);
     decoratedPersistence.writeConfig(configType, configId, config);
+  }
+
+  @Override
+  public <T> void replaceAllConfigs(final Map<ConfigSchema, Stream<T>> configs, final boolean dryRun) throws IOException {
+    // todo (cgardens) need to do validation here.
+    decoratedPersistence.replaceAllConfigs(configs, dryRun);
+  }
+
+  @Override
+  public Map<String, Stream<JsonNode>> dumpConfigs() throws IOException {
+    return decoratedPersistence.dumpConfigs();
   }
 
   private <T> void validateJson(T config, ConfigSchema configType) throws JsonValidationException {

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ValidatingConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ValidatingConfigPersistence.java
@@ -1,0 +1,78 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.config.persistence;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ConfigSchema;
+import io.airbyte.validation.json.JsonSchemaValidator;
+import io.airbyte.validation.json.JsonValidationException;
+import java.io.IOException;
+import java.util.List;
+
+// we force all interaction with disk storage to be effectively single threaded.
+public class ValidatingConfigPersistence implements ConfigPersistence {
+
+  private final JsonSchemaValidator schemaValidator;
+  private final ConfigPersistence decoratedPersistence;
+
+  public ValidatingConfigPersistence(final ConfigPersistence decoratedPersistence) {
+    this(decoratedPersistence, new JsonSchemaValidator());
+  }
+
+  public ValidatingConfigPersistence(final ConfigPersistence decoratedPersistence, final JsonSchemaValidator schemaValidator) {
+    this.decoratedPersistence = decoratedPersistence;
+    this.schemaValidator = schemaValidator;
+  }
+
+  @Override
+  public <T> T getConfig(final ConfigSchema configType, final String configId, final Class<T> clazz)
+      throws ConfigNotFoundException, JsonValidationException, IOException {
+    final T config = decoratedPersistence.getConfig(configType, configId, clazz);
+    validateJson(config, configType);
+    return config;
+  }
+
+  @Override
+  public <T> List<T> listConfigs(ConfigSchema configType, Class<T> clazz) throws JsonValidationException, IOException {
+    final List<T> configs = decoratedPersistence.listConfigs(configType, clazz);
+    for (T config : configs) {
+      validateJson(config, configType);
+    }
+    return configs;
+  }
+
+  @Override
+  public <T> void writeConfig(ConfigSchema configType, String configId, T config) throws JsonValidationException, IOException {
+    validateJson(Jsons.jsonNode(config), configType);
+    decoratedPersistence.writeConfig(configType, configId, config);
+  }
+
+  private <T> void validateJson(T config, ConfigSchema configType) throws JsonValidationException {
+    JsonNode schema = JsonSchemaValidator.getSchema(configType.getFile());
+    schemaValidator.ensure(schema, Jsons.jsonNode(config));
+  }
+
+}

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/FileSystemConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/FileSystemConfigPersistenceTest.java
@@ -25,16 +25,12 @@
 package io.airbyte.config.persistence;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 import com.google.common.collect.Sets;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
-import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -44,14 +40,13 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class DefaultConfigPersistenceTest {
+class FileSystemConfigPersistenceTest {
 
   public static final UUID UUID_1 = new UUID(0, 1);
   public static final StandardSourceDefinition SOURCE_1 = new StandardSourceDefinition();
 
   static {
-    SOURCE_1.withSourceDefinitionId(UUID_1)
-        .withName("apache storm");
+    SOURCE_1.withSourceDefinitionId(UUID_1).withName("apache storm");
   }
 
   public static final UUID UUID_2 = new UUID(0, 2);
@@ -59,21 +54,16 @@ class DefaultConfigPersistenceTest {
   private static final Path TEST_ROOT = Path.of("/tmp/airbyte_tests");
 
   static {
-    SOURCE_2.withSourceDefinitionId(UUID_2)
-        .withName("apache storm");
+    SOURCE_2.withSourceDefinitionId(UUID_2).withName("apache storm");
   }
 
-  private Path rootPath;
-  private JsonSchemaValidator schemaValidator;
-
-  private DefaultConfigPersistence configPersistence;
+  private FileSystemConfigPersistence configPersistence;
 
   @BeforeEach
   void setUp() throws IOException {
-    schemaValidator = mock(JsonSchemaValidator.class);
-    rootPath = Files.createTempDirectory(Files.createDirectories(TEST_ROOT), DefaultConfigPersistenceTest.class.getName());
+    final Path rootPath = Files.createTempDirectory(Files.createDirectories(TEST_ROOT), FileSystemConfigPersistenceTest.class.getName());
 
-    configPersistence = new DefaultConfigPersistence(rootPath, schemaValidator);
+    configPersistence = new FileSystemConfigPersistence(rootPath);
   }
 
   @Test
@@ -115,18 +105,6 @@ class DefaultConfigPersistenceTest {
     assertEquals(
         standardSync,
         configPersistence.getConfig(ConfigSchema.STANDARD_SYNC, UUID_1.toString(), StandardSync.class));
-  }
-
-  @Test
-  void writeConfigInvalidConfig() throws JsonValidationException {
-    StandardSourceDefinition standardSourceDefinition = SOURCE_1.withName(null);
-
-    doThrow(new JsonValidationException("error")).when(schemaValidator).ensure(any(), any());
-
-    assertThrows(JsonValidationException.class, () -> configPersistence.writeConfig(
-        ConfigSchema.STANDARD_SOURCE_DEFINITION,
-        UUID_1.toString(),
-        standardSourceDefinition));
   }
 
 }

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ValidatingConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ValidatingConfigPersistenceTest.java
@@ -1,0 +1,137 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.config.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Sets;
+import io.airbyte.config.ConfigSchema;
+import io.airbyte.config.StandardSourceDefinition;
+import io.airbyte.validation.json.JsonSchemaValidator;
+import io.airbyte.validation.json.JsonValidationException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ValidatingConfigPersistenceTest {
+
+  public static final UUID UUID_1 = new UUID(0, 1);
+  public static final StandardSourceDefinition SOURCE_1 = new StandardSourceDefinition();
+
+  static {
+    SOURCE_1.withSourceDefinitionId(UUID_1).withName("apache storm");
+  }
+
+  public static final UUID UUID_2 = new UUID(0, 2);
+  public static final StandardSourceDefinition SOURCE_2 = new StandardSourceDefinition();
+  private static final Path TEST_ROOT = Path.of("/tmp/airbyte_tests");
+
+  static {
+    SOURCE_2.withSourceDefinitionId(UUID_2).withName("apache storm");
+  }
+
+  private JsonSchemaValidator schemaValidator;
+
+  private ValidatingConfigPersistence configPersistence;
+  private ConfigPersistence decoratedConfigPersistence;
+
+  @BeforeEach
+  void setUp() {
+    schemaValidator = mock(JsonSchemaValidator.class);
+
+    decoratedConfigPersistence = mock(ConfigPersistence.class);
+    configPersistence = new ValidatingConfigPersistence(decoratedConfigPersistence, schemaValidator);
+  }
+
+  @Test
+  void testWriteConfigSuccess() throws IOException, JsonValidationException {
+    configPersistence.writeConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, UUID_1.toString(), SOURCE_1);
+    verify(decoratedConfigPersistence).writeConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, UUID_1.toString(), SOURCE_1);
+  }
+
+  @Test
+  void testWriteConfigFailure() throws JsonValidationException {
+    doThrow(new JsonValidationException("error")).when(schemaValidator).ensure(any(), any());
+    assertThrows(JsonValidationException.class,
+        () -> configPersistence.writeConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, UUID_1.toString(), SOURCE_1));
+
+    verifyNoInteractions(decoratedConfigPersistence);
+  }
+
+  @Test
+  void testGetConfigSuccess() throws IOException, JsonValidationException, ConfigNotFoundException {
+    when(decoratedConfigPersistence.getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, UUID_1.toString(), StandardSourceDefinition.class))
+        .thenReturn(SOURCE_1);
+    final StandardSourceDefinition actualConfig = configPersistence
+        .getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, UUID_1.toString(), StandardSourceDefinition.class);
+
+    assertEquals(SOURCE_1, actualConfig);
+  }
+
+  @Test
+  void testGetConfigFailure() throws IOException, JsonValidationException, ConfigNotFoundException {
+    doThrow(new JsonValidationException("error")).when(schemaValidator).ensure(any(), any());
+    when(decoratedConfigPersistence.getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, UUID_1.toString(), StandardSourceDefinition.class))
+        .thenReturn(SOURCE_1);
+
+    assertThrows(
+        JsonValidationException.class,
+        () -> configPersistence.getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, UUID_1.toString(), StandardSourceDefinition.class));
+  }
+
+  @Test
+  void testListConfigsSuccess() throws JsonValidationException, IOException {
+    when(decoratedConfigPersistence.listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class))
+        .thenReturn(List.of(SOURCE_1, SOURCE_2));
+
+    final List<StandardSourceDefinition> actualConfigs = configPersistence
+        .listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class);
+
+    assertEquals(
+        Sets.newHashSet(SOURCE_1, SOURCE_2),
+        Sets.newHashSet(actualConfigs));
+  }
+
+  @Test
+  void testListConfigsFailure() throws JsonValidationException, IOException {
+    doThrow(new JsonValidationException("error")).when(schemaValidator).ensure(any(), any());
+    when(decoratedConfigPersistence.listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class))
+        .thenReturn(List.of(SOURCE_1, SOURCE_2));
+
+    assertThrows(JsonValidationException.class, () -> configPersistence
+        .listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class));
+  }
+
+}

--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
@@ -33,7 +33,7 @@ import io.airbyte.config.EnvConfigs;
 import io.airbyte.config.helpers.LogHelpers;
 import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.config.persistence.DefaultConfigPersistence;
+import io.airbyte.config.persistence.FileSystemConfigPersistence;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
 import io.airbyte.scheduler.app.worker_run.TemporalWorkerRunFactory;
@@ -210,7 +210,7 @@ public class SchedulerApp {
     final ProcessFactory processFactory = getProcessBuilderFactory(configs);
 
     final JobPersistence jobPersistence = new DefaultJobPersistence(database);
-    final ConfigPersistence configPersistence = new DefaultConfigPersistence(configRoot);
+    final ConfigPersistence configPersistence = FileSystemConfigPersistence.createWithValidation(configRoot);
     final ConfigRepository configRepository = new ConfigRepository(configPersistence);
     final JobCleaner jobCleaner = new JobCleaner(
         configs.getWorkspaceRetentionConfig(),

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImport.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImport.java
@@ -144,8 +144,7 @@ public class ConfigDumpImport {
       // identify this instance as the new customer id.
       TrackingClientSingleton.get().identify();
       // report that the previous customer id is now superseded by the imported one.
-      previousCustomerIdOptional.ifPresent(
-          previousCustomerId -> TrackingClientSingleton.get().alias(previousCustomerId.toString()));
+      previousCustomerIdOptional.ifPresent(previousCustomerId -> TrackingClientSingleton.get().alias(previousCustomerId.toString()));
     } catch (IOException | JsonValidationException | RuntimeException e) {
       LOGGER.error("Import failed", e);
       result = new ImportRead().status(StatusEnum.FAILED).reason(e.getMessage());

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -35,7 +35,7 @@ import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.helpers.LogHelpers;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.config.persistence.DefaultConfigPersistence;
+import io.airbyte.config.persistence.FileSystemConfigPersistence;
 import io.airbyte.config.persistence.PersistenceConstants;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
@@ -187,7 +187,7 @@ public class ServerApp {
     LOGGER.info("configRoot = " + configRoot);
 
     LOGGER.info("Creating config repository...");
-    final ConfigRepository configRepository = new ConfigRepository(new DefaultConfigPersistence(configRoot));
+    final ConfigRepository configRepository = new ConfigRepository(FileSystemConfigPersistence.createWithValidation(configRoot));
 
     // hack: upon installation we need to assign a random customerId so that when
     // tracking we can associate all action with the correct anonymous id.

--- a/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
@@ -43,7 +43,7 @@ import io.airbyte.config.StandardSyncOperation.OperatorType;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.config.persistence.DefaultConfigPersistence;
+import io.airbyte.config.persistence.FileSystemConfigPersistence;
 import io.airbyte.db.Database;
 import io.airbyte.migrate.Migrations;
 import io.airbyte.scheduler.persistence.DefaultJobPersistence;
@@ -121,8 +121,7 @@ public class RunMigrationTest {
 
   private void assertPostMigrationConfigs(Path importRoot)
       throws IOException, JsonValidationException, ConfigNotFoundException {
-    ConfigRepository configRepository = new ConfigRepository(
-        new DefaultConfigPersistence(importRoot));
+    final ConfigRepository configRepository = new ConfigRepository(FileSystemConfigPersistence.createWithValidation(importRoot));
     StandardSyncOperation standardSyncOperation = assertSyncOperations(configRepository);
     assertStandardSyncs(configRepository, standardSyncOperation);
     assertWorkspace(configRepository);
@@ -287,7 +286,7 @@ public class RunMigrationTest {
     try (RunMigration runMigration = new RunMigration(
         INITIAL_VERSION,
         jobPersistence,
-        new ConfigRepository(new DefaultConfigPersistence(exportConfigRoot)),
+        new ConfigRepository(FileSystemConfigPersistence.createWithValidation(exportConfigRoot)),
         TARGET_VERSION,
         Path.of(System.getProperty("user.dir")).resolve("build/config_init/resources/main/config"))) {
       runMigration.run();

--- a/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
@@ -53,7 +53,6 @@ import io.airbyte.server.converters.DatabaseArchiver;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -63,17 +62,22 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class RunMigrationTest {
 
   private static final String INITIAL_VERSION = "0.17.0-alpha";
-  private static final String TARGET_VERSION = Migrations.MIGRATIONS
-      .get(Migrations.MIGRATIONS.size() - 1).getVersion();
-  private final List<File> resourceToBeCleanedUp = new ArrayList<>();
+  private static final String TARGET_VERSION = Migrations.MIGRATIONS.get(Migrations.MIGRATIONS.size() - 1).getVersion();
+  private List<File> resourceToBeCleanedUp;
 
-  @After
+  @BeforeEach
+  public void setup() {
+    resourceToBeCleanedUp = new ArrayList<>();
+  }
+
+  @AfterEach
   public void cleanup() throws IOException {
     for (File file : resourceToBeCleanedUp) {
       if (file.exists()) {
@@ -93,13 +97,12 @@ public class RunMigrationTest {
           .of(Resources.getResource("migration/03a4c904-c91d-447f-ab59-27a43b52c2fd.gz").toURI())
           .toFile();
 
-      Path dummyDataSource = Path.of(Resources.getResource("migration/dummy_data").toURI());
+      final Path dummyDataSource = Path.of(Resources.getResource("migration/dummy_data").toURI());
 
-      Path configRoot = Files.createTempDirectory("dummy_data");
+      final Path configRoot = Files.createTempDirectory(Path.of("/tmp"), "dummy_data");
       FileUtils.copyDirectory(dummyDataSource.toFile(), configRoot.toFile());
       resourceToBeCleanedUp.add(configRoot.toFile());
-      JobPersistence jobPersistence = getJobPersistence(stubAirbyteDB.getDatabase(), file,
-          INITIAL_VERSION);
+      final JobPersistence jobPersistence = getJobPersistence(stubAirbyteDB.getDatabase(), file, INITIAL_VERSION);
       assertDatabaseVersion(jobPersistence, INITIAL_VERSION);
 
       runMigration(jobPersistence, configRoot);
@@ -112,17 +115,15 @@ public class RunMigrationTest {
     }
   }
 
-  private void assertDatabaseVersion(JobPersistence jobPersistence, String version)
-      throws IOException {
-    Optional<String> versionFromDb = jobPersistence.getVersion();
+  private void assertDatabaseVersion(JobPersistence jobPersistence, String version) throws IOException {
+    final Optional<String> versionFromDb = jobPersistence.getVersion();
     assertTrue(versionFromDb.isPresent());
     assertEquals(versionFromDb.get(), version);
   }
 
-  private void assertPostMigrationConfigs(Path importRoot)
-      throws IOException, JsonValidationException, ConfigNotFoundException {
+  private void assertPostMigrationConfigs(Path importRoot) throws IOException, JsonValidationException, ConfigNotFoundException {
     final ConfigRepository configRepository = new ConfigRepository(FileSystemConfigPersistence.createWithValidation(importRoot));
-    StandardSyncOperation standardSyncOperation = assertSyncOperations(configRepository);
+    final StandardSyncOperation standardSyncOperation = assertSyncOperations(configRepository);
     assertStandardSyncs(configRepository, standardSyncOperation);
     assertWorkspace(configRepository);
     assertSources(configRepository);
@@ -132,31 +133,34 @@ public class RunMigrationTest {
   }
 
   private void assertSourceDefinitions(ConfigRepository configRepository) throws JsonValidationException, IOException {
-    Map<String, StandardSourceDefinition> sourceDefinitions =
-        configRepository.listStandardSources().stream().collect(Collectors.toMap(c -> c.getSourceDefinitionId().toString(), c -> c));
+    final Map<String, StandardSourceDefinition> sourceDefinitions = configRepository.listStandardSources()
+        .stream()
+        .collect(Collectors.toMap(c -> c.getSourceDefinitionId().toString(), c -> c));
     assertTrue(sourceDefinitions.size() >= 59);
-    StandardSourceDefinition mysqlDefinition = sourceDefinitions.get("435bb9a5-7887-4809-aa58-28c27df0d7ad");
+    final StandardSourceDefinition mysqlDefinition = sourceDefinitions.get("435bb9a5-7887-4809-aa58-28c27df0d7ad");
     assertEquals("0.2.0", mysqlDefinition.getDockerImageTag());
     assertEquals("MySQL", mysqlDefinition.getName());
 
-    StandardSourceDefinition postgresDefinition = sourceDefinitions.get("decd338e-5647-4c0b-adf4-da0e75f5a750");
+    final StandardSourceDefinition postgresDefinition = sourceDefinitions.get("decd338e-5647-4c0b-adf4-da0e75f5a750");
     assertTrue(postgresDefinition.getDockerImageTag().compareTo("0.3.4") >= 0);
     assertTrue(postgresDefinition.getName().contains("Postgres"));
   }
 
   private void assertDestinationDefinitions(ConfigRepository configRepository) throws JsonValidationException, IOException {
-    Map<String, StandardDestinationDefinition> sourceDefinitions = configRepository.listStandardDestinationDefinitions().stream()
+    final Map<String, StandardDestinationDefinition> sourceDefinitions = configRepository.listStandardDestinationDefinitions()
+        .stream()
         .collect(Collectors.toMap(c -> c.getDestinationDefinitionId().toString(), c -> c));
     assertTrue(sourceDefinitions.size() >= 11);
-    StandardDestinationDefinition postgresDefinition = sourceDefinitions.get("25c5221d-dce2-4163-ade9-739ef790f503");
+
+    final StandardDestinationDefinition postgresDefinition = sourceDefinitions.get("25c5221d-dce2-4163-ade9-739ef790f503");
     assertEquals("0.2.0", postgresDefinition.getDockerImageTag());
     assertEquals(postgresDefinition.getName(), "Postgres");
 
-    StandardDestinationDefinition localCsvDefinition = sourceDefinitions.get("8be1cf83-fde1-477f-a4ad-318d23c9f3c6");
+    final StandardDestinationDefinition localCsvDefinition = sourceDefinitions.get("8be1cf83-fde1-477f-a4ad-318d23c9f3c6");
     assertTrue(localCsvDefinition.getName().contains("Local CSV"));
     assertEquals("0.2.0", localCsvDefinition.getDockerImageTag());
 
-    StandardDestinationDefinition snowflakeDefinition = sourceDefinitions.get("424892c4-daac-4491-b35d-c6688ba547ba");
+    final StandardDestinationDefinition snowflakeDefinition = sourceDefinitions.get("424892c4-daac-4491-b35d-c6688ba547ba");
     assertTrue(snowflakeDefinition.getDockerImageTag().compareTo("0.3.9") >= 0);
     assertTrue(snowflakeDefinition.getName().contains("Snowflake"));
   }
@@ -164,28 +168,23 @@ public class RunMigrationTest {
   private void assertStandardSyncs(ConfigRepository configRepository,
                                    StandardSyncOperation standardSyncOperation)
       throws ConfigNotFoundException, IOException, JsonValidationException {
-    List<StandardSync> standardSyncs = configRepository.listStandardSyncs();
+    final List<StandardSync> standardSyncs = configRepository.listStandardSyncs();
     assertEquals(standardSyncs.size(), 2);
     for (StandardSync standardSync : standardSyncs) {
-      if (standardSync.getConnectionId().toString()
-          .equals("a294256f-1abe-4837-925f-91602c7207b4")) {
+      if (standardSync.getConnectionId().toString().equals("a294256f-1abe-4837-925f-91602c7207b4")) {
         assertEquals(standardSync.getPrefix(), "");
         assertEquals(standardSync.getSourceId().toString(), "28ffee2b-372a-4f72-9b95-8ed56a8b99c5");
-        assertEquals(standardSync.getDestinationId().toString(),
-            "4e00862d-5484-4f50-9860-f3bbb4317397");
+        assertEquals(standardSync.getDestinationId().toString(), "4e00862d-5484-4f50-9860-f3bbb4317397");
         assertEquals(standardSync.getOperationIds().size(), 1);
-        assertEquals(standardSync.getOperationIds().get(0).toString(),
-            standardSyncOperation.getOperationId().toString());
+        assertEquals(standardSync.getOperationIds().get(0).toString(), standardSyncOperation.getOperationId().toString());
         assertEquals(standardSync.getName(), "default");
         assertEquals(standardSync.getStatus().value(), "active");
         assertNull(standardSync.getSchedule());
         assertTrue(standardSync.getManual());
-      } else if (standardSync.getConnectionId().toString()
-          .equals("49dae3f0-158b-4737-b6e4-0eed77d4b74e")) {
+      } else if (standardSync.getConnectionId().toString().equals("49dae3f0-158b-4737-b6e4-0eed77d4b74e")) {
         assertEquals(standardSync.getPrefix(), "");
         assertEquals(standardSync.getSourceId().toString(), "28ffee2b-372a-4f72-9b95-8ed56a8b99c5");
-        assertEquals(standardSync.getDestinationId().toString(),
-            "5434615d-a3b7-4351-bc6b-a9a695555a30");
+        assertEquals(standardSync.getDestinationId().toString(), "5434615d-a3b7-4351-bc6b-a9a695555a30");
         assertEquals(standardSync.getOperationIds().size(), 0);
         assertEquals(standardSync.getName(), "default");
         assertEquals(standardSync.getStatus().value(), "active");
@@ -198,10 +197,8 @@ public class RunMigrationTest {
   }
 
   @NotNull
-  private StandardSyncOperation assertSyncOperations(ConfigRepository configRepository)
-      throws IOException, JsonValidationException {
-    List<StandardSyncOperation> standardSyncOperations = configRepository
-        .listStandardSyncOperations();
+  private StandardSyncOperation assertSyncOperations(ConfigRepository configRepository) throws IOException, JsonValidationException {
+    final List<StandardSyncOperation> standardSyncOperations = configRepository.listStandardSyncOperations();
     assertEquals(standardSyncOperations.size(), 1);
     StandardSyncOperation standardSyncOperation = standardSyncOperations.get(0);
     assertEquals(standardSyncOperation.getName(), "default-normalization");
@@ -212,16 +209,13 @@ public class RunMigrationTest {
     return standardSyncOperation;
   }
 
-  private void assertSources(ConfigRepository configRepository)
-      throws JsonValidationException, IOException {
-    List<SourceConnection> sourceConnections = configRepository.listSourceConnection();
+  private void assertSources(ConfigRepository configRepository) throws JsonValidationException, IOException {
+    final List<SourceConnection> sourceConnections = configRepository.listSourceConnection();
     assertEquals(sourceConnections.size(), 1);
-    SourceConnection sourceConnection = sourceConnections.get(0);
+    final SourceConnection sourceConnection = sourceConnections.get(0);
     assertEquals(sourceConnection.getName(), "MySQL localhost");
-    assertEquals(sourceConnection.getSourceDefinitionId().toString(),
-        "435bb9a5-7887-4809-aa58-28c27df0d7ad");
-    assertEquals(sourceConnection.getWorkspaceId().toString(),
-        "5ae6b09b-fdec-41af-aaf7-7d94cfc33ef6");
+    assertEquals(sourceConnection.getSourceDefinitionId().toString(), "435bb9a5-7887-4809-aa58-28c27df0d7ad");
+    assertEquals(sourceConnection.getWorkspaceId().toString(), "5ae6b09b-fdec-41af-aaf7-7d94cfc33ef6");
     assertEquals(sourceConnection.getSourceId().toString(), "28ffee2b-372a-4f72-9b95-8ed56a8b99c5");
     assertEquals(sourceConnection.getConfiguration().get("username").asText(), "root");
     assertEquals(sourceConnection.getConfiguration().get("password").asText(), "password");
@@ -230,9 +224,8 @@ public class RunMigrationTest {
     assertEquals(sourceConnection.getConfiguration().get("host").asText(), "host.docker.internal");
   }
 
-  private void assertWorkspace(ConfigRepository configRepository)
-      throws JsonValidationException, IOException {
-    List<StandardWorkspace> standardWorkspaces = configRepository.listStandardWorkspaces(true);
+  private void assertWorkspace(ConfigRepository configRepository) throws JsonValidationException, IOException {
+    final List<StandardWorkspace> standardWorkspaces = configRepository.listStandardWorkspaces(true);
     assertEquals(standardWorkspaces.size(), 1);
     StandardWorkspace workspace = standardWorkspaces.get(0);
     assertEquals(workspace.getWorkspaceId().toString(), "5ae6b09b-fdec-41af-aaf7-7d94cfc33ef6");
@@ -246,19 +239,14 @@ public class RunMigrationTest {
     assertEquals(workspace.getDisplaySetupWizard(), false);
   }
 
-  private void assertDestinations(ConfigRepository configRepository)
-      throws JsonValidationException, IOException {
-    List<DestinationConnection> destinationConnections = configRepository
-        .listDestinationConnection();
+  private void assertDestinations(ConfigRepository configRepository) throws JsonValidationException, IOException {
+    final List<DestinationConnection> destinationConnections = configRepository.listDestinationConnection();
     assertEquals(destinationConnections.size(), 2);
     for (DestinationConnection destination : destinationConnections) {
-      if (destination.getDestinationId().toString()
-          .equals("4e00862d-5484-4f50-9860-f3bbb4317397")) {
+      if (destination.getDestinationId().toString().equals("4e00862d-5484-4f50-9860-f3bbb4317397")) {
         assertEquals(destination.getName(), "Postgres Docker");
-        assertEquals(destination.getDestinationDefinitionId().toString(),
-            "25c5221d-dce2-4163-ade9-739ef790f503");
-        assertEquals(destination.getWorkspaceId().toString(),
-            "5ae6b09b-fdec-41af-aaf7-7d94cfc33ef6");
+        assertEquals(destination.getDestinationDefinitionId().toString(), "25c5221d-dce2-4163-ade9-739ef790f503");
+        assertEquals(destination.getWorkspaceId().toString(), "5ae6b09b-fdec-41af-aaf7-7d94cfc33ef6");
         assertEquals(destination.getConfiguration().get("username").asText(), "postgres");
         assertEquals(destination.getConfiguration().get("password").asText(), "password");
         assertEquals(destination.getConfiguration().get("database").asText(), "postgres");
@@ -266,43 +254,35 @@ public class RunMigrationTest {
         assertEquals(destination.getConfiguration().get("port").asInt(), 3000);
         assertEquals(destination.getConfiguration().get("host").asText(), "localhost");
         assertNull(destination.getConfiguration().get("basic_normalization"));
-      } else if (destination.getDestinationId().toString()
-          .equals("5434615d-a3b7-4351-bc6b-a9a695555a30")) {
+      } else if (destination.getDestinationId().toString().equals("5434615d-a3b7-4351-bc6b-a9a695555a30")) {
         assertEquals(destination.getName(), "CSV");
-        assertEquals(destination.getDestinationDefinitionId().toString(),
-            "8be1cf83-fde1-477f-a4ad-318d23c9f3c6");
-        assertEquals(destination.getWorkspaceId().toString(),
-            "5ae6b09b-fdec-41af-aaf7-7d94cfc33ef6");
+        assertEquals(destination.getDestinationDefinitionId().toString(), "8be1cf83-fde1-477f-a4ad-318d23c9f3c6");
+        assertEquals(destination.getWorkspaceId().toString(), "5ae6b09b-fdec-41af-aaf7-7d94cfc33ef6");
         assertEquals(destination.getConfiguration().get("destination_path").asText(), "csv_data");
       } else {
-        fail("Unknown destination found with destination id : " + destination.getDestinationId()
-            .toString());
+        fail("Unknown destination found with destination id : " + destination.getDestinationId().toString());
       }
     }
   }
 
-  private void runMigration(JobPersistence jobPersistence, Path exportConfigRoot)
-      throws IOException, URISyntaxException {
+  private void runMigration(JobPersistence jobPersistence, Path configRoot) throws IOException {
     try (RunMigration runMigration = new RunMigration(
         INITIAL_VERSION,
         jobPersistence,
-        new ConfigRepository(FileSystemConfigPersistence.createWithValidation(exportConfigRoot)),
+        new ConfigRepository(FileSystemConfigPersistence.createWithValidation(configRoot)),
         TARGET_VERSION,
         Path.of(System.getProperty("user.dir")).resolve("build/config_init/resources/main/config"))) {
       runMigration.run();
     }
   }
 
-  private JobPersistence getJobPersistence(Database database,
-                                           File file,
-                                           String version)
-      throws IOException {
-    DefaultJobPersistence jobPersistence = new DefaultJobPersistence(database);
+  private JobPersistence getJobPersistence(Database database, File file, String version) throws IOException {
+    final DefaultJobPersistence jobPersistence = new DefaultJobPersistence(database);
     final Path tempFolder = Files.createTempDirectory(Path.of("/tmp"), "db_init");
     resourceToBeCleanedUp.add(tempFolder.toFile());
 
     Archives.extractArchive(file.toPath(), tempFolder);
-    DatabaseArchiver databaseArchiver = new DatabaseArchiver(jobPersistence);
+    final DatabaseArchiver databaseArchiver = new DatabaseArchiver(jobPersistence);
     databaseArchiver.importDatabaseFromArchive(tempFolder, version);
     return jobPersistence;
   }


### PR DESCRIPTION
## What
* When we started working on a `PostgresConfigPersistence` we noticed that were were duplicate the code for validating the schema of configs.

## How
* Instead of doing that duplication, this PR creates a new class `ValidatingConfigPersistence` that will decorate any `ConfigPersistence` with the validation logic.
* Rename `DefaultConfigPersistence` => `FileSystemConfigPersistence` (in preparation of us having a `PostgresConfigPersistence`
* Change usages in `ServerApp` and `SchedulerApp` to use the decorated-with-validation version of `FileSystemConfigPersistence`.
* Hopefully this makes the next step of adding `PostgresConfigPersistence` a bit easier.

## Other...
Instead of going with the decorator pattern here we could have these class extend a `ValidatingConfigPersistence` base instead. I'm open to that as well. In watching @subodh1810 deal with some of the validation stuff getting in the way that being able to interact with these persistences without opinionated validation might be helpful. I might be misguided on this though.

## Recommended reading order
1. `FileSystemConfigPersistence.java`
2. `ValidatingConfigPersistence.java`
3. the rest...

@tuliren tagged you since this will interact with the [issue](https://github.com/airbytehq/airbyte/issues/3605) you are going to work in.