### PR TITLE
add fullstory

### DIFF
--- a/airbyte-webapp/nginx/default.conf.template
+++ b/airbyte-webapp/nginx/default.conf.template
@@ -18,6 +18,7 @@ server {
                 '</head><script language="javascript"\>
                 window.TRACKING_STRATEGY = "$TRACKING_STRATEGY";
                 window.PAPERCUPS_STORYTIME = "$PAPERCUPS_STORYTIME";
+                window.FULLSTORY = "$FULLSTORY";
                 window.AIRBYTE_VERSION = "$AIRBYTE_VERSION";
                 window.API_URL = "$API_URL";
                 window.IS_DEMO = "$IS_DEMO";

--- a/airbyte-webapp/src/components/hooks/useFullStory.tsx
+++ b/airbyte-webapp/src/components/hooks/useFullStory.tsx
@@ -6,7 +6,6 @@ const useFullStory = (org?: string): void => {
     if (org) {
       const script = document.createElement("script");
       script.innerText = `
-          <script>
           window['_fs_debug'] = false;
           window['_fs_host'] = 'fullstory.com';
           window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
@@ -29,7 +28,6 @@ const useFullStory = (org?: string): void => {
               if(m[y])m[y]=function(){return g._w[y].apply(this,arguments)};
               g._v="1.3.0";
           })(window,document,window['_fs_namespace'],'script','user');
-          </script>
       `;
       script.async = true;
 

--- a/airbyte-webapp/src/components/hooks/useFullStory.tsx
+++ b/airbyte-webapp/src/components/hooks/useFullStory.tsx
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+
+// if org is undefined calls to segment will be a no-op.
+const useFullStory = (org?: string): void => {
+  useEffect(() => {
+    if (org) {
+      const script = document.createElement("script");
+      script.innerText = `
+          <script>
+          window['_fs_debug'] = false;
+          window['_fs_host'] = 'fullstory.com';
+          window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
+          window['_fs_org'] = '${org}';
+          window['_fs_namespace'] = 'FS';
+          (function(m,n,e,t,l,o,g,y){
+              if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
+              g=m[e]=function(a,b,s){g.q?g.q.push([a,b,s]):g._api(a,b,s);};g.q=[];
+              o=n.createElement(t);o.async=1;o.crossOrigin='anonymous';o.src='https://'+_fs_script;
+              y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
+              g.identify=function(i,v,s){g(l,{uid:i},s);if(v)g(l,v,s)};g.setUserVars=function(v,s){g(l,v,s)};g.event=function(i,v,s){g('event',{n:i,p:v},s)};
+              g.anonymize=function(){g.identify(!!0)};
+              g.shutdown=function(){g("rec",!1)};g.restart=function(){g("rec",!0)};
+              g.log = function(a,b){g("log",[a,b])};
+              g.consent=function(a){g("consent",!arguments.length||a)};
+              g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
+              g.clearUserCookie=function(){};
+              g.setVars=function(n, p){g('setVars',[n,p]);};
+              g._w={};y='XMLHttpRequest';g._w[y]=m[y];y='fetch';g._w[y]=m[y];
+              if(m[y])m[y]=function(){return g._w[y].apply(this,arguments)};
+              g._v="1.3.0";
+          })(window,document,window['_fs_namespace'],'script','user');
+          </script>
+      `;
+      script.async = true;
+
+      if (typeof window !== "undefined" && !window._fs_namespace) {
+        document.body.appendChild(script);
+      }
+    }
+  }, [token]);
+};
+
+export default useFullStory;

--- a/airbyte-webapp/src/components/hooks/useFullStory.tsx
+++ b/airbyte-webapp/src/components/hooks/useFullStory.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-// if org is undefined calls to segment will be a no-op.
+// if org is undefined calls to fullstory will be a no-op.
 const useFullStory = (org?: string): void => {
   useEffect(() => {
     if (org) {
@@ -33,11 +33,11 @@ const useFullStory = (org?: string): void => {
       `;
       script.async = true;
 
-      if (typeof window !== "undefined" && !window._fs_namespace) {
+      if (typeof window !== "undefined" && !("_fs_namespace" in window)) {
         document.body.appendChild(script);
       }
     }
-  }, [token]);
+  }, [org]);
 };
 
 export default useFullStory;

--- a/airbyte-webapp/src/config/index.ts
+++ b/airbyte-webapp/src/config/index.ts
@@ -57,6 +57,9 @@ const config: Config = {
     baseUrl: "https://app.papercups.io",
     enableStorytime: window.PAPERCUPS_STORYTIME !== "disabled",
   },
+  fullstory: {
+    org: window.FULLSTORY === "disabled" ? "" : "13AXQ4",
+  },
   version: window.AIRBYTE_VERSION,
   apiUrl:
     window.API_URL ||

--- a/airbyte-webapp/src/config/index.ts
+++ b/airbyte-webapp/src/config/index.ts
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     TRACKING_STRATEGY?: string;
     PAPERCUPS_STORYTIME?: string;
+    FULLSTORY?: string;
     AIRBYTE_VERSION?: string;
     API_URL?: string;
     IS_DEMO?: string;
@@ -26,6 +27,9 @@ type Config = {
     accountId: string;
     baseUrl: string;
     enableStorytime: boolean;
+  };
+  fullstory: {
+    org: string;
   };
   apiUrl: string;
   healthCheckInterval: number;

--- a/airbyte-webapp/src/pages/routes.tsx
+++ b/airbyte-webapp/src/pages/routes.tsx
@@ -21,6 +21,7 @@ import MainView from "components/MainView";
 import SupportChat from "components/SupportChat";
 
 import useSegment from "components/hooks/useSegment";
+import useFullStory from "components/hooks/useFullStory";
 import useRouter from "components/hooks/useRouterHook";
 import useWorkspace from "components/hooks/services/useWorkspaceHook";
 import { AnalyticsService } from "core/analytics/AnalyticsService";
@@ -152,6 +153,7 @@ const OnboardingsRoutes = () => {
 
 export const Routing: React.FC = () => {
   useSegment(config.segment.token);
+  useFullStory(config.fullstory.org);
   useApiHealthPoll(config.healthCheckInterval);
 
   const { workspace } = useWorkspace();

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -99,6 +99,7 @@ services:
       - API_URL=${API_URL:-}
       - IS_DEMO=${IS_DEMO:-}
       - PAPERCUPS_STORYTIME=${PAPERCUPS_STORYTIME:-}
+      - FULLSTORY=${FULLSTORY:-}
       - TRACKING_STRATEGY=${TRACKING_STRATEGY}
       - INTERNAL_API_HOST=${INTERNAL_API_HOST}
   airbyte-temporal:

--- a/kube/overlays/dev/.env
+++ b/kube/overlays/dev/.env
@@ -14,6 +14,7 @@ TRACKING_STRATEGY=logging
 WORKER_ENVIRONMENT=kubernetes
 LOCAL_ROOT=/tmp/airbyte_local
 PAPERCUPS_STORYTIME=disabled
+FULLSTORY=disabled
 IS_DEMO=false
 TEMPORAL_HOST=airbyte-temporal-svc:7233
 INTERNAL_API_HOST=airbyte-server-svc:8001

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -14,6 +14,7 @@ TRACKING_STRATEGY=segment
 WORKER_ENVIRONMENT=kubernetes
 LOCAL_ROOT=/tmp/airbyte_local
 PAPERCUPS_STORYTIME=enabled
+FULLSTORY=enabled
 IS_DEMO=false
 TEMPORAL_HOST=airbyte-temporal-svc:7233
 INTERNAL_API_HOST=airbyte-server-svc:8001

--- a/kube/resources/webapp.yaml
+++ b/kube/resources/webapp.yaml
@@ -48,6 +48,11 @@ spec:
                 configMapKeyRef:
                   name: airbyte-env
                   key: PAPERCUPS_STORYTIME
+            - name: FULLSTORY
+              valueFrom:
+                configMapKeyRef:
+                  name: airbyte-env
+                  key: FULLSTORY
             - name: IS_DEMO
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
see https://github.com/airbytehq/airbyte/issues/4065

Adds FullStory support. Can be disabled if the `FULLSTORY` env variable is set to `disabled`.

I can see a replay on the FullStory app. It's likely we'll want to add `customerId`-level [identification](https://help.fullstory.com/hc/en-us/articles/360020828113-FS-identify-Identifying-users). I'm not positive where this should go (part of `AnalyticsService`? part of a different service?) so I'm going to punt that to @Jamakase to do later.