### PR TITLE
retry db connection pool creation in the server and scheduler

### DIFF
--- a/airbyte-db/src/main/java/io/airbyte/db/Databases.java
+++ b/airbyte-db/src/main/java/io/airbyte/db/Databases.java
@@ -24,6 +24,7 @@
 
 package io.airbyte.db;
 
+import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.db.jdbc.DefaultJdbcDatabase;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.db.jdbc.JdbcStreamingQueryConfiguration;
@@ -31,11 +32,35 @@ import io.airbyte.db.jdbc.StreamingJdbcDatabase;
 import java.util.Optional;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.jooq.SQLDialect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Databases {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(Databases.class);
+
   public static Database createPostgresDatabase(String username, String password, String jdbcConnectionString) {
     return createDatabase(username, password, jdbcConnectionString, "org.postgresql.Driver", SQLDialect.POSTGRES);
+  }
+
+  public static Database createPostgresDatabaseWithRetry(String username, String password, String jdbcConnectionString) {
+    Database database = null;
+
+    while (database == null) {
+      LOGGER.warn("Waiting for database to become available...");
+
+      try {
+        database = createPostgresDatabase(username, password, jdbcConnectionString);
+      } catch (Exception e) {
+        // Ignore the exception because this likely means that the database server is still initializing.
+        LOGGER.warn("Ignoring exception while trying to request database:", e);
+        database = null;
+        Exceptions.toRuntime(() -> Thread.sleep(5000));
+      }
+    }
+
+    LOGGER.info("Database available!");
+    return database;
   }
 
   public static JdbcDatabase createRedshiftDatabase(String username, String password, String jdbcConnectionString) {

--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
@@ -193,7 +193,7 @@ public class SchedulerApp {
     LOGGER.info("temporalHost = " + temporalHost);
 
     LOGGER.info("Creating DB connection pool...");
-    final Database database = Databases.createPostgresDatabase(
+    final Database database = Databases.createPostgresDatabaseWithRetry(
         configs.getDatabaseUser(),
         configs.getDatabasePassword(),
         configs.getDatabaseUrl());

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -199,7 +199,7 @@ public class ServerApp {
         configRepository);
 
     LOGGER.info("Creating Scheduler persistence...");
-    final Database database = Databases.createPostgresDatabase(
+    final Database database = Databases.createPostgresDatabaseWithRetry(
         configs.getDatabaseUser(),
         configs.getDatabasePassword(),
         configs.getDatabaseUrl());

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalPool.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalPool.java
@@ -26,6 +26,7 @@ package io.airbyte.workers.temporal;
 
 import static java.util.stream.Collectors.toSet;
 
+import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.workers.process.ProcessFactory;
 import io.airbyte.workers.temporal.SyncWorkflow.DbtTransformationActivityImpl;
 import io.airbyte.workers.temporal.SyncWorkflow.NormalizationActivityImpl;
@@ -91,7 +92,7 @@ public class TemporalPool implements Runnable {
 
     while (!temporalStatus) {
       LOGGER.warn("Waiting for default namespace to be initialized in temporal...");
-      wait(2);
+      Exceptions.toRuntime(() -> Thread.sleep(2000));
 
       try {
         temporalStatus = getNamespaces(temporalService).contains("default");
@@ -102,17 +103,9 @@ public class TemporalPool implements Runnable {
     }
 
     // sometimes it takes a few additional seconds for workflow queue listening to be available
-    wait(5);
+    Exceptions.toRuntime(() -> Thread.sleep(5000));
 
     LOGGER.info("Found temporal default namespace!");
-  }
-
-  private static void wait(int seconds) {
-    try {
-      Thread.sleep(seconds * 1000);
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   protected static Set<String> getNamespaces(WorkflowServiceStubs temporalService) {


### PR DESCRIPTION
The db takes longer to initialize on Kubernetes and does an internal restart after applying the initial sql files. This should allow us to have a less error prone startup than before.