### PR TITLE
wait until uuid is available to start server and scheduler

### DIFF
--- a/airbyte-db/src/main/java/io/airbyte/db/Databases.java
+++ b/airbyte-db/src/main/java/io/airbyte/db/Databases.java
@@ -51,6 +51,10 @@ public class Databases {
 
       try {
         database = createPostgresDatabase(username, password, jdbcConnectionString);
+        Optional<String> uuid = ServerUuid.get(database);
+        if (uuid.isEmpty()) {
+          throw new Exception("Server UUID not available yet!");
+        }
       } catch (Exception e) {
         // Ignore the exception because this likely means that the database server is still initializing.
         LOGGER.warn("Ignoring exception while trying to request database:", e);


### PR DESCRIPTION
We're still seeing occasional problems where startup results in a bad state since the db connection hasn't been established after the db server restart.