### PR TITLE
fix gke file copy errors

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -24,7 +24,6 @@
 
 package io.airbyte.workers.process;
 
-import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.string.Strings;
@@ -38,16 +37,21 @@ import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
+import io.kubernetes.client.Copy;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -110,7 +114,7 @@ public class KubePodProcess extends Process {
   private static final int KILLED_EXIT_CODE = 143;
   private static final int STDIN_REMOTE_PORT = 9001;
 
-  private final KubernetesClient client;
+  private final KubernetesClient fabricClient;
   private final Pod podDefinition;
   // Necessary since it is not possible to retrieve the pod's actual exit code upon termination. This
   // is because the Kube API server does not keep
@@ -222,24 +226,25 @@ public class KubePodProcess extends Process {
         .build();
   }
 
-  private static void copyFilesToKubeConfigVolume(KubernetesClient client, String podName, String namespace, Map<String, String> files) {
+  private static void copyFilesToKubeConfigVolume(ApiClient officialClient, String podName, String namespace, Map<String, String> files) {
     List<Map.Entry<String, String>> fileEntries = new ArrayList<>(files.entrySet());
 
+    // copy this file last to indicate that the copy has completed
+    fileEntries.add(new AbstractMap.SimpleEntry<>(SUCCESS_FILE_NAME, ""));
+
     for (Map.Entry<String, String> file : fileEntries) {
-      Path tmpFile = null;
       try {
-        tmpFile = Path.of(IOs.writeFileToRandomTmpDir(file.getKey(), file.getValue()));
-
         LOGGER.info("Uploading file: " + file.getKey());
+        var contents = file.getValue().getBytes(StandardCharsets.UTF_8);
+        var containerPath = Path.of(CONFIG_DIR + "/" + file.getKey());
 
-        client.pods().inNamespace(namespace).withName(podName).inContainer(INIT_CONTAINER_NAME)
-            .file(CONFIG_DIR + "/" + file.getKey())
-            .upload(tmpFile);
+        // fabric8 kube client upload doesn't work on gke:
+        // https://github.com/fabric8io/kubernetes-client/issues/2217
+        Copy copy = new Copy(officialClient);
+        copy.copyFileToPod(namespace, podName, INIT_CONTAINER_NAME, contents, containerPath);
 
-      } finally {
-        if (tmpFile != null) {
-          tmpFile.toFile().delete();
-        }
+      } catch (KubernetesClientException | IOException | ApiException e) {
+        throw new RuntimeException(e);
       }
     }
   }
@@ -260,7 +265,8 @@ public class KubePodProcess extends Process {
     LOGGER.info("Init container ready..");
   }
 
-  public KubePodProcess(KubernetesClient client,
+  public KubePodProcess(ApiClient officialClient,
+                        KubernetesClient fabricClient,
                         Consumer<Integer> portReleaser,
                         String podName,
                         String namespace,
@@ -273,7 +279,7 @@ public class KubePodProcess extends Process {
                         final String entrypointOverride,
                         final String... args)
       throws IOException, InterruptedException {
-    this.client = client;
+    this.fabricClient = fabricClient;
     this.portReleaser = portReleaser;
     this.stdoutLocalPort = stdoutLocalPort;
     this.stderrLocalPort = stderrLocalPort;
@@ -283,7 +289,7 @@ public class KubePodProcess extends Process {
     executorService = Executors.newFixedThreadPool(2);
     setupStdOutAndStdErrListeners();
 
-    String entrypoint = entrypointOverride == null ? getCommandFromImage(client, image, namespace) : entrypointOverride;
+    String entrypoint = entrypointOverride == null ? getCommandFromImage(fabricClient, image, namespace) : entrypointOverride;
     LOGGER.info("Found entrypoint: {}", entrypoint);
 
     Volume pipeVolume = new VolumeBuilder()
@@ -376,17 +382,12 @@ public class KubePodProcess extends Process {
         .build();
 
     LOGGER.info("Creating pod...");
-    this.podDefinition = client.pods().inNamespace(namespace).createOrReplace(pod);
+    this.podDefinition = fabricClient.pods().inNamespace(namespace).createOrReplace(pod);
 
-    waitForInitPodToRun(client, podDefinition);
+    waitForInitPodToRun(fabricClient, podDefinition);
 
     LOGGER.info("Copying files...");
-    Map<String, String> filesWithSuccess = new HashMap<>(files);
-
-    // We always copy the empty success file to ensure our waiting step can detect the init container in
-    // RUNNING. Otherwise, the container can complete and exit before we are able to detect it.
-    filesWithSuccess.put(SUCCESS_FILE_NAME, "");
-    copyFilesToKubeConfigVolume(client, podName, namespace, filesWithSuccess);
+    copyFilesToKubeConfigVolume(officialClient, podName, namespace, files);
 
     LOGGER.info("Waiting until pod is ready...");
     // If a pod gets into a non-terminal error state it should be automatically killed by our
@@ -396,14 +397,14 @@ public class KubePodProcess extends Process {
     // This doesn't manage things like pods that are blocked from running for some cluster reason or if
     // the init
     // container got stuck somehow.
-    client.resource(podDefinition).waitUntilCondition(p -> {
+    fabricClient.resource(podDefinition).waitUntilCondition(p -> {
       boolean isReady = Objects.nonNull(p) && Readiness.getInstance().isReady(p);
       return isReady || isTerminal(p);
     }, 10, TimeUnit.DAYS);
 
     // allow writing stdin to pod
     LOGGER.info("Reading pod IP...");
-    var podIp = getPodIP(client, podName, namespace);
+    var podIp = getPodIP(fabricClient, podName, namespace);
     LOGGER.info("Pod IP: {}", podIp);
 
     if (usesStdin) {
@@ -460,8 +461,9 @@ public class KubePodProcess extends Process {
   @Override
   public int waitFor() throws InterruptedException {
     try {
-      Pod refreshedPod = client.pods().inNamespace(podDefinition.getMetadata().getNamespace()).withName(podDefinition.getMetadata().getName()).get();
-      client.resource(refreshedPod).waitUntilCondition(this::isTerminal, 10, TimeUnit.DAYS);
+      Pod refreshedPod =
+          fabricClient.pods().inNamespace(podDefinition.getMetadata().getNamespace()).withName(podDefinition.getMetadata().getName()).get();
+      fabricClient.resource(refreshedPod).waitUntilCondition(this::isTerminal, 10, TimeUnit.DAYS);
       wasKilled.set(true);
       return exitValue();
     } finally {
@@ -489,7 +491,7 @@ public class KubePodProcess extends Process {
   public void destroy() {
     LOGGER.info("Destroying Kube process: {}", podDefinition.getMetadata().getName());
     try {
-      client.resource(podDefinition).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+      fabricClient.resource(podDefinition).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
       wasKilled.set(true);
     } finally {
       close();
@@ -524,7 +526,7 @@ public class KubePodProcess extends Process {
 
   private int getReturnCode(Pod pod) {
     var name = pod.getMetadata().getName();
-    Pod refreshedPod = client.pods().inNamespace(pod.getMetadata().getNamespace()).withName(name).get();
+    Pod refreshedPod = fabricClient.pods().inNamespace(pod.getMetadata().getNamespace()).withName(name).get();
     if (refreshedPod == null) {
       if (wasKilled.get()) {
         LOGGER.info("Unable to find pod {} to retrieve exit value. Defaulting to  value {}. This is expected if the job was cancelled.", name,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -37,7 +37,6 @@ import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.kubernetes.client.Copy;
 import io.kubernetes.client.openapi.ApiClient;
@@ -243,7 +242,7 @@ public class KubePodProcess extends Process {
         Copy copy = new Copy(officialClient);
         copy.copyFileToPod(namespace, podName, INIT_CONTAINER_NAME, contents, containerPath);
 
-      } catch (KubernetesClientException | IOException | ApiException e) {
+      } catch (IOException | ApiException e) {
         throw new RuntimeException(e);
       }
     }

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
@@ -33,6 +33,8 @@ import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.workers.WorkerException;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.util.Config;
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.ServerSocket;
@@ -45,6 +47,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
+import org.apache.commons.lang.RandomStringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,7 +60,8 @@ public class KubePodProcessIntegrationTest {
   private List<Integer> openWorkerPorts;
   private int heartbeatPort;
   private String heartbeatUrl;
-  private KubernetesClient kubeClient;
+  private ApiClient officialClient;
+  private KubernetesClient fabricClient;
   private BlockingQueue<Integer> workerPorts;
   private KubeProcessFactory processFactory;
 
@@ -70,9 +74,10 @@ public class KubePodProcessIntegrationTest {
     heartbeatPort = openPorts.get(0);
     heartbeatUrl = getHost() + ":" + heartbeatPort;
 
-    kubeClient = new DefaultKubernetesClient();
+    officialClient = Config.defaultClient();
+    fabricClient = new DefaultKubernetesClient();
     workerPorts = new LinkedBlockingDeque<>(openWorkerPorts);
-    processFactory = new KubeProcessFactory("default", kubeClient, heartbeatUrl, workerPorts);
+    processFactory = new KubeProcessFactory("default", officialClient, fabricClient, heartbeatUrl, workerPorts);
 
     server = new WorkerHeartbeatServer(heartbeatPort);
     server.startBackground();
@@ -143,14 +148,31 @@ public class KubePodProcessIntegrationTest {
     assertNotEquals(0, process.exitValue());
   }
 
+  private static String getRandomFile(int lines) {
+    var sb = new StringBuilder();
+    for (int i = 0; i < lines; i++) {
+      sb.append(RandomStringUtils.randomAlphabetic(100));
+      sb.append("\n");
+    }
+    return sb.toString();
+  }
+
   private Process getProcess(String entrypoint) throws WorkerException {
+    // these files aren't used for anything, it's just to check for exceptions when uploading
+    var files = ImmutableMap.of(
+        "file0", "fixed str",
+        "file1", getRandomFile(1),
+        "file2", getRandomFile(100),
+        "file3", getRandomFile(1000),
+        "file3", getRandomFile(10000));
+
     return processFactory.create(
         "some-id",
         0,
         Path.of("/tmp/job-root"),
         "busybox:latest",
         false,
-        ImmutableMap.of(),
+        files,
         entrypoint);
   }
 

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
@@ -163,8 +163,7 @@ public class KubePodProcessIntegrationTest {
         "file0", "fixed str",
         "file1", getRandomFile(1),
         "file2", getRandomFile(100),
-        "file3", getRandomFile(1000),
-        "file3", getRandomFile(10000));
+        "file3", getRandomFile(1000));
 
     return processFactory.create(
         "some-id",


### PR DESCRIPTION
For some reason, gke file upload isn't working reliably on the fabric8 client (see https://github.com/fabric8io/kubernetes-client/issues/2217). We tried to work around it in https://github.com/airbytehq/airbyte/pull/4195. Even when the message says it succeeded its behavior varied. I've seen cases where it successfully copied the contents, cases where it partially copied, and cases where it copied no contents at all (and this was  after fixing the other bugfix in this pr, which is to make sure the success file flag is copied last).

I haven't been able to reproduce this a single time after switching to the official client for this operation. The only reason I'm not tearing out all of the fabric8 client usage and only using the official client is because the api is so much more ergonomic in fabric8. Both libraries are about equally popular and have comparable development activity. This is the first serious issue we've seen with fabric8's client. If we see any other serious issues we should revisit our client decision.

This bug would have been detected with acceptance tests that run on GKE: https://github.com/airbytehq/airbyte/issues/4212