### PR TITLE
make kube overwritten entrypoints posix-compatible

### DIFF
--- a/airbyte-workers/src/main/resources/entrypoints/check.sh
+++ b/airbyte-workers/src/main/resources/entrypoints/check.sh
@@ -1,11 +1,11 @@
 trap "touch TERMINATION_FILE_CHECK" EXIT
 (set -e; while true; do curl -s HEARTBEAT_URL &> /dev/null; sleep 1; done) &
 CHILD_PID=$!
-(while true; do if [[ -f TERMINATION_FILE_MAIN ]]; then kill $CHILD_PID; exit 0; fi; sleep 1; done) &
+(while true; do if [ -f TERMINATION_FILE_MAIN ]; then kill $CHILD_PID; exit 0; fi; sleep 1; done) &
 wait $CHILD_PID
 EXIT_CODE=$?
 
-if [[ -f TERMINATION_FILE_MAIN ]]
+if [ -f TERMINATION_FILE_MAIN ]
 then
   exit 0
 else

--- a/airbyte-workers/src/main/resources/entrypoints/main.sh
+++ b/airbyte-workers/src/main/resources/entrypoints/main.sh
@@ -1,6 +1,6 @@
 trap "touch TERMINATION_FILE_MAIN" EXIT
 (OPTIONAL_STDIN (ENTRYPOINT) 2> STDERR_PIPE_FILE > STDOUT_PIPE_FILE) &
 CHILD_PID=$!
-(while true; do if [[ -f TERMINATION_FILE_CHECK ]]; then echo "Heartbeat to worker failed, exiting..."; exit 1; fi; sleep 1; done) &
+(while true; do if [ -f TERMINATION_FILE_CHECK ]; then echo "Heartbeat to worker failed, exiting..."; exit 1; fi; sleep 1; done) &
 wait $CHILD_PID
 exit $?


### PR DESCRIPTION
If a container internally is using something that isn't bash for `sh -c` we run into compatibility issues since double brackets `[[`/`]]` aren't POSIX-compatible.