### PR TITLE
fix db configuration for build

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@ DATABASE_PASSWORD=docker
 DATABASE_HOST=db
 DATABASE_PORT=5432
 DATABASE_DB=airbyte
-DATABASE_URL=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DB}
+DATABASE_URL=jdbc:postgresql://db:5432/airbyte
 
 # When using the airbyte-db via default docker image:
 CONFIG_ROOT=/data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -120,10 +120,10 @@ services:
       - 7233:7233
     environment:
       - DB=postgresql
-      - DB_PORT=5432
+      - DB_PORT=${DATABASE_PORT}
       - POSTGRES_USER=${DATABASE_USER}
       - POSTGRES_PWD=${DATABASE_PASSWORD}
-      - POSTGRES_SEEDS=db
+      - POSTGRES_SEEDS=${DATABASE_HOST}
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
     volumes:
       - ./temporal/dynamicconfig:/etc/temporal/config/dynamicconfig

--- a/docs/operator-guides/configuring-airbyte-db.md
+++ b/docs/operator-guides/configuring-airbyte-db.md
@@ -31,10 +31,10 @@ DATABASE_PORT=3000
 DATABASE_DB=postgres
 ```
 
-Additionally, you are free to redefine the JDBC URL constructed in the environment variable `DATABASE_URL` if you need to provide extra arguments to the JDBC driver (for example, to handle SSL):
+Additionally, you must redefine the JDBC URL constructed in the environment variable `DATABASE_URL` to include the correct host, port, and database. If you need to provide extra arguments to the JDBC driver (for example, to handle SSL) you should add it here as well:
 
 ```bash
-DATABASE_URL=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DB}?ssl=true&sslmode=require
+DATABASE_URL=jdbc:postgresql://host.docker.internal:3000/postgres?ssl=true&sslmode=require
 ```
 
 ## Initializing the database


### PR DESCRIPTION
Variable interpolation in ENV files doesn't work reliably cross-platform. It works locally on my Mac but doesn't work on the EC2 build runners for example.

They're currently failing with errors like:
```
airbyte-server      | 2021-06-21T16:47:14.085255691Z Caused by: java.sql.SQLException: Cannot create JDBC driver of class 'org.postgresql.Driver' for connect URL 'jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DB}'
airbyte-server      | 2021-06-21T16:47:14.085258364Z 	at org.apache.commons.dbcp2.DriverFactory.createDriver(DriverFactory.java:75) ~[commons-dbcp2-2.7.0.jar:2.7.0]
airbyte-server      | 2021-06-21T16:47:14.085260976Z 	at org.apache.commons.dbcp2.BasicDataSource.createConnectionFactory(BasicDataSource.java:472) ~[commons-dbcp2-2.7.0.jar:2.7.0]
airbyte-server      | 2021-06-21T16:47:14.085263500Z 	at org.apache.commons.dbcp2.BasicDataSource.createDataSource(BasicDataSource.java:538) ~[commons-dbcp2-2.7.0.jar:2.7.0]
airbyte-server      | 2021-06-21T16:47:14.085266039Z 	at org.apache.commons.dbcp2.BasicDataSource.getConnection(BasicDataSource.java:753) ~[commons-dbcp2-2.7.0.jar:2.7.0]
airbyte-server      | 2021-06-21T16:47:14.085269102Z 	at org.jooq.impl.DataSourceConnectionProvider.acquire(DataSourceConnectionProvider.java:83) ~[jooq-3.13.4.jar:?]
airbyte-server      | 2021-06-21T16:47:14.085271657Z 	... 9 more
airbyte-server      | 2021-06-21T16:47:14.085274032Z Caused by: java.sql.SQLException: No suitable driver
```
because interpolation isn't working.
