### PR TITLE
test for AIRBYTE_ENTRYPOINT env variable in connectors

### DIFF
--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -68,6 +68,7 @@ import io.airbyte.workers.process.DockerProcessFactory;
 import io.airbyte.workers.process.ProcessFactory;
 import io.airbyte.workers.protocols.airbyte.AirbyteDestination;
 import io.airbyte.workers.protocols.airbyte.DefaultAirbyteDestination;
+import io.airbyte.workers.test_helpers.EntrypointEnvChecker;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -843,6 +844,24 @@ public abstract class DestinationAcceptanceTest {
     final String defaultSchema = getDefaultSchema(config);
     runSyncAndVerifyStateOutput(config, allMessages, configuredCatalog, false);
     retrieveRawRecordsAndAssertSameMessages(catalog, allMessages, defaultSchema);
+  }
+
+  /**
+   * In order to launch a source on Kubernetes in a pod, we need to be able to wrap the entrypoint.
+   * The source connector must specify its entrypoint in the AIRBYTE_ENTRYPOINT variable. This test
+   * ensures that the entrypoint environment variable is set.
+   */
+  @Test
+  public void testEntrypointEnvVar() throws Exception {
+    final String entrypoint = EntrypointEnvChecker.getEntrypointEnvVariable(
+        processFactory,
+        JOB_ID,
+        JOB_ATTEMPT,
+        jobRoot,
+        getImageName());
+
+    assertNotNull(entrypoint);
+    assertFalse(entrypoint.isBlank());
   }
 
   private ConnectorSpecification runSpec() throws WorkerException {

--- a/airbyte-integrations/bases/standard-source-test/readme.md
+++ b/airbyte-integrations/bases/standard-source-test/readme.md
@@ -17,14 +17,14 @@
 We will _not_ merge sources that cannot pass these tests unless the author can provide a very good reason™.
 
 ## What tests do the standard tests include?
-Check out each function in [TestSource](src/main/java/io/airbyte/integrations/standardtest/source/TestSource.java). Each function annotated with `@Test` is a single test. Each of these functions is proceeded by comments that document what they are testing.
+Check out each function in [SourceAcceptanceTest](src/main/java/io/airbyte/integrations/standardtest/source/SourceAcceptanceTest.java). Each function annotated with `@Test` is a single test. Each of these functions is proceeded by comments that document what they are testing.
 
 ## How to run them from your integration?
 * If writing a source in Python, check out this [readme](../base-python-test/readme.md)
 
 ## What do I need to provide as input to these tests?
 * The name of the image of your integration (with the `:dev` tag at the end).
-* A handful of json inputs, e.g. a valid configuration file and a catalog that will be used to try to run the `read` operation on your integration. These are fully documented in [TestSource](src/main/java/io/airbyte/integrations/standardtest/source/TestSource.java). Each method that is marked as `abstract` are methods that the user needs to implement to provide the necessary information. Each of these methods are preceded by comments explaining what they need to return.
+* A handful of json inputs, e.g. a valid configuration file and a catalog that will be used to try to run the `read` operation on your integration. These are fully documented in [SourceAcceptanceTest](src/main/java/io/airbyte/integrations/standardtest/source/SourceAcceptanceTest.java). Each method that is marked as `abstract` are methods that the user needs to implement to provide the necessary information. Each of these methods are preceded by comments explaining what they need to return.
 * Optionally you can run before and after methods before each test.
 
 ## Do I have to write java to use these tests?

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAbstractTest.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAbstractTest.java
@@ -24,6 +24,9 @@
 
 package io.airbyte.integrations.standardtest.source;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.config.JobGetSpecConfig;
 import io.airbyte.config.StandardCheckConnectionInput;
@@ -44,6 +47,7 @@ import io.airbyte.workers.process.DockerProcessFactory;
 import io.airbyte.workers.process.ProcessFactory;
 import io.airbyte.workers.protocols.airbyte.AirbyteSource;
 import io.airbyte.workers.protocols.airbyte.DefaultAirbyteSource;
+import io.airbyte.workers.test_helpers.EntrypointEnvChecker;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -131,6 +135,18 @@ public abstract class SourceAbstractTest {
   protected AirbyteCatalog runDiscover() throws Exception {
     return new DefaultDiscoverCatalogWorker(new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory))
         .run(new StandardDiscoverCatalogInput().withConnectionConfiguration(getConfig()), jobRoot);
+  }
+
+  protected void checkEntrypointEnvVariable() throws Exception {
+    final String entrypoint = EntrypointEnvChecker.getEntrypointEnvVariable(
+        processFactory,
+        String.valueOf(JOB_ID),
+        JOB_ATTEMPT,
+        jobRoot,
+        getImageName());
+
+    assertNotNull(entrypoint);
+    assertFalse(entrypoint.isBlank());
   }
 
   protected List<AirbyteMessage> runRead(ConfiguredAirbyteCatalog configuredCatalog) throws Exception {

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAcceptanceTest.java
@@ -292,6 +292,16 @@ public abstract class SourceAcceptanceTest extends SourceAbstractTest {
     assertSameRecords(fullRefreshRecords, emptyStateRecords, assertionMessage);
   }
 
+  /**
+   * In order to launch a source on Kubernetes in a pod, we need to be able to wrap the entrypoint.
+   * The source connector must specify its entrypoint in the AIRBYTE_ENTRYPOINT variable. This test
+   * ensures that the entrypoint environment variable is set.
+   */
+  @Test
+  public void testEntrypointEnvVar() throws Exception {
+    checkEntrypointEnvVariable();
+  }
+
   private List<AirbyteRecordMessage> filterRecords(Collection<AirbyteMessage> messages) {
     return messages.stream()
         .filter(m -> m.getType() == Type.RECORD)

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -167,7 +167,7 @@ public class KubePodProcess extends Process {
           "Missing AIRBYTE_ENTRYPOINT from command fetcher logs. This should not happen. Check the echo command has not been changed.");
     }
 
-    var envVal = logs.split("=", 1)[1].strip();
+    var envVal = logs.split("=", 2)[1].strip();
     if (envVal.isEmpty()) {
       throw new RuntimeException("No AIRBYTE_ENTRYPOINT environment variable found. Connectors must have this set in order to run on Kubernetes.");
     }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -167,7 +167,7 @@ public class KubePodProcess extends Process {
           "Missing AIRBYTE_ENTRYPOINT from command fetcher logs. This should not happen. Check the echo command has not been changed.");
     }
 
-    var envVal = logs.split("=")[1].strip();
+    var envVal = logs.split("=", 1)[1].strip();
     if (envVal.isEmpty()) {
       throw new RuntimeException("No AIRBYTE_ENTRYPOINT environment variable found. Connectors must have this set in order to run on Kubernetes.");
     }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/test_helpers/EntrypointEnvChecker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/test_helpers/EntrypointEnvChecker.java
@@ -1,0 +1,82 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.workers.test_helpers;
+
+import io.airbyte.workers.WorkerException;
+import io.airbyte.workers.process.ProcessFactory;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.Collections;
+
+public class EntrypointEnvChecker {
+
+  /**
+   * @param processFactory any process factory
+   * @param jobId used as input to processFactory.create
+   * @param jobAttempt used as input to processFactory.create
+   * @param jobRoot used as input to processFactory.create
+   * @param imageName used as input to processFactory.create
+   * @return the entrypoint in the env variable AIRBYTE_ENTRYPOINT
+   * @throws RuntimeException if there is ambiguous output from the container
+   */
+  public static String getEntrypointEnvVariable(ProcessFactory processFactory, String jobId, int jobAttempt, Path jobRoot, String imageName)
+      throws IOException, InterruptedException, WorkerException {
+    Process process = processFactory.create(
+        jobId,
+        jobAttempt,
+        jobRoot,
+        imageName,
+        false,
+        Collections.emptyMap(),
+        "echo \"AIRBYTE_ENTRYPOINT=$AIRBYTE_ENTRYPOINT\"");
+
+    BufferedReader stdInput = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+    String outputLine = null;
+
+    String line = null;
+    while (((line = stdInput.readLine()) != null) && outputLine == null) {
+      if (line.contains("AIRBYTE_ENTRYPOINT")) {
+        outputLine = line;
+      }
+    }
+
+    process.waitFor();
+
+    if (outputLine != null) {
+      String[] splits = outputLine.split("=", 1);
+      if (splits.length != 2) {
+        throw new RuntimeException("String could not be split into multiple segments: " + outputLine);
+      } else {
+        return splits[1].strip();
+      }
+    } else {
+      return null;
+    }
+  }
+
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/test_helpers/EntrypointEnvChecker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/test_helpers/EntrypointEnvChecker.java
@@ -68,7 +68,7 @@ public class EntrypointEnvChecker {
     process.waitFor();
 
     if (outputLine != null) {
-      String[] splits = outputLine.split("=", 1);
+      String[] splits = outputLine.split("=", 2);
       if (splits.length != 2) {
         throw new RuntimeException("String could not be split into multiple segments: " + outputLine);
       } else {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/test_helpers/EntrypointEnvChecker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/test_helpers/EntrypointEnvChecker.java
@@ -52,14 +52,14 @@ public class EntrypointEnvChecker {
         imageName,
         false,
         Collections.emptyMap(),
-        "echo \"AIRBYTE_ENTRYPOINT=$AIRBYTE_ENTRYPOINT\"");
+        "printenv");
 
-    BufferedReader stdInput = new BufferedReader(new InputStreamReader(process.getInputStream()));
+    BufferedReader stdout = new BufferedReader(new InputStreamReader(process.getInputStream()));
 
     String outputLine = null;
 
     String line = null;
-    while (((line = stdInput.readLine()) != null) && outputLine == null) {
+    while (((line = stdout.readLine()) != null) && outputLine == null) {
       if (line.contains("AIRBYTE_ENTRYPOINT")) {
         outputLine = line;
       }

--- a/docs/contributing-to-airbyte/building-new-connector/standard-source-tests.md
+++ b/docs/contributing-to-airbyte/building-new-connector/standard-source-tests.md
@@ -30,3 +30,6 @@ This test verifies that all streams in the input catalog which support increment
 
 If the source does not support incremental sync, this test is skipped. Otherwise, this test runs two syncs: one where all streams provided in the input catalog sync in full refresh mode, and another where all the streams which in the input catalog which support incremental, sync in incremental mode \(streams which don't support incremental sync in full refresh mode\). Then, the test asserts that the two syncs produced the same RECORD messages. Any other type of message is disregarded.
 
+## testEntrypointEnvVar
+
+In order to launch a source on Kubernetes in a pod, we need to be able to wrap the entrypoint at runtime. The environment variable `AIRBYTE_ENTRYPOINT` must be set to the entrypoint of the `Dockerfile` so we can access the entrypoint at runtime. This test asserts that the environment variable is set.


### PR DESCRIPTION
Final item required for closing https://github.com/airbytehq/airbyte/issues/3903

Tests for setting the entrypoint env variable in the source and destination standard tests.

I thought about trying to match this to the actual entrypoint for the image, but that seemed difficult since you'd need to combine parts of an array of strings, handle spacing correctly, etc (and even then the var doesn't technically _have_ to match the main entrypoint anyways).