### PR TITLE
kill pod process on IO server failures

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -427,7 +427,8 @@ public class KubePodProcess extends Process {
         LOGGER.info("Setting stdout...");
         this.stdout = socket.getInputStream();
       } catch (IOException e) {
-        e.printStackTrace(); // todo: propagate exception / join at the end of constructor
+        LOGGER.error("Server 'stdout' failed, killing pod.", e);
+        System.exit(1);
       }
     });
     executorService.submit(() -> {
@@ -438,7 +439,8 @@ public class KubePodProcess extends Process {
         LOGGER.info("Setting stderr...");
         this.stderr = socket.getInputStream();
       } catch (IOException e) {
-        e.printStackTrace(); // todo: propagate exception / join at the end of constructor
+        LOGGER.error("Server 'stderr' failed, killing pod.", e);
+        System.exit(1);
       }
     });
   }


### PR DESCRIPTION
we need to signal actual shutdown so these handle an interrupt properly without exiting with an error code.

addresses https://github.com/airbytehq/airbyte-internal-issues/issues/117

This might just mean catching an interrupted exception and not calling the exit and catching all other exceptions?