### PR TITLE
Bump version: 0.26.2-alpha → 0.26.3-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.26.2-alpha
+current_version = 0.26.3-alpha
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.26.2-alpha
+VERSION=0.26.3-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_USER=docker

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.26.2-alpha",
+  "version": "0.26.3-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.26.2-alpha",
+  "version": "0.26.3-alpha",
   "private": true,
   "scripts": {
     "start": "react-scripts start",

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -44,7 +44,7 @@ If you inadvertently upgrade to a version of Airbyte that is not compatible with
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.26.2-alpha --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.26.3-alpha --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.26.2-alpha
+AIRBYTE_VERSION=0.26.3-alpha
 DATABASE_USER=docker
 DATABASE_PASSWORD=docker
 DATABASE_URL=jdbc:postgresql://airbyte-db-svc:5432/airbyte

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -6,15 +6,15 @@ bases:
 
 images:
   - name: airbyte/seed
-    newTag: 0.26.2-alpha
+    newTag: 0.26.3-alpha
   - name: airbyte/db
-    newTag: 0.26.2-alpha
+    newTag: 0.26.3-alpha
   - name: airbyte/scheduler
-    newTag: 0.26.2-alpha
+    newTag: 0.26.3-alpha
   - name: airbyte/server
-    newTag: 0.26.2-alpha
+    newTag: 0.26.3-alpha
   - name: airbyte/webapp
-    newTag: 0.26.2-alpha
+    newTag: 0.26.3-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 


### PR DESCRIPTION
Releases version to pick up recent changes.
