### PR TITLE
Kube Improvements.

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/errors/UncaughtExceptionMapper.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/errors/UncaughtExceptionMapper.java
@@ -39,8 +39,8 @@ public class UncaughtExceptionMapper implements ExceptionMapper<Throwable> {
 
   @Override
   public Response toResponse(Throwable e) {
+    LOGGER.error("Uncaught exception", e);
     KnownExceptionInfo exceptionInfo = KnownException.infoFromThrowableWithMessage(e, "Internal Server Error: " + e.getMessage());
-    LOGGER.error("Uncaught exception", exceptionInfo);
     return Response.status(500)
         .entity(Jsons.serialize(exceptionInfo))
         .type("application/json")

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -475,7 +475,7 @@ public class AcceptanceTests {
     // todo: wait for two attempts in the UI
     // if the wait isn't long enough, failures say "Connection refused" because the assert kills the
     // syncs in progress
-    sleep(Duration.ofMinutes(2).toMillis());
+    sleep(Duration.ofMinutes(4).toMillis());
     assertSourceAndDestinationDbInSync(sourcePsql, false);
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -216,7 +216,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
             destination.accept(message);
             recordsRead += 1;
 
-            if (recordsRead % 100 == 0) {
+            if (recordsRead % 1000 == 0) {
               LOGGER.info("Records read: {}", recordsRead);
             }
           }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -205,6 +205,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
     return () -> {
       MDC.setContextMap(mdc);
       LOGGER.info("Replication thread started.");
+      var recordsRead = 0;
       try {
         while (!cancelled.get() && !source.isFinished()) {
           final Optional<AirbyteMessage> messageOptional = source.attemptRead();
@@ -213,6 +214,11 @@ public class DefaultReplicationWorker implements ReplicationWorker {
 
             sourceMessageTracker.accept(message);
             destination.accept(message);
+            recordsRead += 1;
+
+            if (recordsRead % 100 == 0) {
+              LOGGER.info("Records read: {}", recordsRead);
+            }
           }
         }
         destination.notifyEndOfStream();

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -99,6 +99,7 @@ public class KubePodProcess extends Process {
   private static final Logger LOGGER = LoggerFactory.getLogger(KubePodProcess.class);
 
   private static final String INIT_CONTAINER_NAME = "init";
+  private static final Long STATUS_CHECK_INTERVAL_MS = 30 * 1000L;
 
   private static final String PIPES_DIR = "/pipes";
   private static final String STDIN_PIPE_FILE = PIPES_DIR + "/stdin";
@@ -127,6 +128,7 @@ public class KubePodProcess extends Process {
   private InputStream stdout;
   private InputStream stderr;
   private Integer returnCode = null;
+  private Long lastStatusCheck = null;
 
   private final Consumer<Integer> portReleaser;
   private final ServerSocket stdoutServerSocket;
@@ -528,9 +530,17 @@ public class KubePodProcess extends Process {
     }
   }
 
+  /**
+   * This method hits the Kube Api server to retrieve statuses. Most of the complexity here is minimising the api calls for performance.
+   */
   private int getReturnCode(Pod pod) {
     if (returnCode != null) {
       return returnCode;
+    }
+
+    // Reuse the last status check result to prevent overloading the Kube Api server.
+    if (lastStatusCheck != null && System.currentTimeMillis() - lastStatusCheck < STATUS_CHECK_INTERVAL_MS) {
+      throw new IllegalThreadStateException("Kube pod process has not exited yet.");
     }
 
     var name = pod.getMetadata().getName();
@@ -547,6 +557,7 @@ public class KubePodProcess extends Process {
     }
 
     if (!isTerminal(refreshedPod)) {
+      lastStatusCheck = System.currentTimeMillis();
       throw new IllegalThreadStateException("Kube pod process has not exited yet.");
     }
 
@@ -554,13 +565,12 @@ public class KubePodProcess extends Process {
         .stream()
         .filter(containerStatus -> containerStatus.getState() != null && containerStatus.getState().getTerminated() != null)
         .map(containerStatus -> {
-          int statusCode = containerStatus.getState().getTerminated().getExitCode();
-          LOGGER.info("Exit code for pod {}, container {} is {}", name, containerStatus.getName(), statusCode);
-          return statusCode;
+          return containerStatus.getState().getTerminated().getExitCode();
         })
         .reduce(Integer::sum)
         .orElseThrow();
 
+    LOGGER.info("Exit code for pod {} is {}", name, returnCode);
     return returnCode;
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -531,7 +531,8 @@ public class KubePodProcess extends Process {
   }
 
   /**
-   * This method hits the Kube Api server to retrieve statuses. Most of the complexity here is minimising the api calls for performance.
+   * This method hits the Kube Api server to retrieve statuses. Most of the complexity here is
+   * minimising the api calls for performance.
    */
   private int getReturnCode(Pod pod) {
     if (returnCode != null) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -144,8 +144,14 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
   @Override
   public boolean isFinished() {
     Preconditions.checkState(destinationProcess != null);
+    // As this check is done on every message read, it is important for this operation to be efficient.
+    // Short circuit early to avoid checking the underlying process.
+    var isEmpty = !messageIterator.hasNext();
+    if (!isEmpty) {
+      return false;
+    }
 
-    return !destinationProcess.isAlive() && !messageIterator.hasNext();
+    return !destinationProcess.isAlive();
   }
 
   @Override

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSource.java
@@ -97,6 +97,12 @@ public class DefaultAirbyteSource implements AirbyteSource {
   @Override
   public boolean isFinished() {
     Preconditions.checkState(sourceProcess != null);
+    // As this check is done on every message read, it is important for this operation to be efficient.
+    // Short circuit early to avoid checking the underlying process.
+    var isEmpty = !messageIterator.hasNext();
+    if (!isEmpty) {
+      return false;
+    }
 
     return !sourceProcess.isAlive() && !messageIterator.hasNext();
   }


### PR DESCRIPTION
## What
Make sync loop more efficient with pinging the Kube server when checking pod statuses.

 Also add a counter for records read to make it clearer to users.

## How
* In the replication worker, only check if the source and destination is empty if the message iterator is empty.
* In the KubePodProcess, cache and use the last status check for 30 seconds. This means we might spend up to 30 seconds waiting for a pod to be reported as completed, but the alternative, repeatedly hitting the Kube API server is worse since it affects ALL pods in the cluster.

## Pre-merge Checklist
Expand the checklist which is relevant for this PR. 

<details><summary> <strong> Connector checklist </strong> </summary>
<p>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Secrets are annotated with `airbyte_secret` in output spec
- [ ] Unit & integration tests added as appropriate (and are passing)
    * Community members: please provide proof of this succeeding locally e.g: screenshot or copy-paste acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] `/test connector=connectors/<name>` command as documented [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-an-existing-connector) is passing. 
    * Community members can skip this, Airbyters will run this for you. 
- [ ] Code reviews completed
- [ ] Credentials added to Github CI if needed and not already present. [instructions for injecting secrets into CI](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#using-credentials-in-ci). 
- [ ] Documentation updated 
    - [ ] `README.md`
    - [ ] `docs/SUMMARY.md` if it's a new connector
    - [ ] Reference docs in the `docs/integrations/` directory.
    - [ ] Changelog in the appropriate page in `docs/integrations/...`. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] Build status added to [build page](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/builds.md)
- [ ] Build is successful
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] No major blockers
- [ ] PR merged into master branch
- [ ] Follow up tickets have been created
- [ ] Associated tickets have been closed & stakeholders notified
</p>
</details>

<details><summary> <strong> Connector Generator checklist </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
