### PR TITLE
use kind instead of minikube for kube integration tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -337,6 +337,7 @@ jobs:
         with:
           minikube version: 'v1.21.0-beta.0'
           kubernetes version: 'v1.20.7'
+          driver: 'docker'
         # In case of self-hosted EC2 errors, remove this env block.
         env:
           USER: root

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -332,12 +332,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install socat
 
-      - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.4.1
-        with:
-          minikube version: 'v1.21.0-beta.0'
-          kubernetes version: 'v1.20.7'
-          driver: 'docker'
+      - name: KIND Kubernetes Cluster Setup
+        uses: helm/kind-action@v1.1.0
         # In case of self-hosted EC2 errors, remove this env block.
         env:
           USER: root

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -340,15 +340,6 @@ jobs:
           HOME: /home/runner
           CHANGE_MINIKUBE_NONE_USER: true
 
-      - name: Manual Minikube Linking and Starting for EC2
-        env:
-          USER: root
-          HOME: /home/runner
-        run: |
-          ln -s $(which minikube) /usr/local/bin/kubectl
-          minikube start --memory=6000
-          kubectl get pods
-
       - name: Build Core Docker Images and Run Tests
         run: CORE_ONLY=true ./gradlew --no-daemon build --scan --rerun-tasks
 


### PR DESCRIPTION
It's easier to set up and guarantees we're using the correct Docker images for our testing. This latest run almost completed but @davinchia was fixing the logs issue which ended up killing it.