### PR TITLE
add kube entrypoint env variable for google analytics

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/39f092a6-8c87-4f6f-a8d9-5cef45b7dbe1.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/39f092a6-8c87-4f6f-a8d9-5cef45b7dbe1.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "39f092a6-8c87-4f6f-a8d9-5cef45b7dbe1",
   "name": "Google Analytics",
   "dockerRepository": "airbyte/source-googleanalytics-singer",
-  "dockerImageTag": "0.2.5",
+  "dockerImageTag": "0.2.6",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-googleanalytics-singer",
   "icon": "google-analytics.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -105,7 +105,7 @@
 - sourceDefinitionId: 39f092a6-8c87-4f6f-a8d9-5cef45b7dbe1
   name: Google Analytics
   dockerRepository: airbyte/source-googleanalytics-singer
-  dockerImageTag: 0.2.5
+  dockerImageTag: 0.2.6
   documentationUrl: https://hub.docker.com/r/airbyte/source-googleanalytics-singer
   icon: google-analytics.svg
 - sourceDefinitionId: e7778cfc-e97c-4458-9ecb-b4f2bba8946c

--- a/airbyte-integrations/connectors/source-googleanalytics-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-googleanalytics-singer/Dockerfile
@@ -7,8 +7,9 @@ RUN apt-get update && apt-get install -y \
 ENV CODE_PATH="source_googleanalytics_singer"
 ENV AIRBYTE_IMPL_MODULE="source_googleanalytics_singer"
 ENV AIRBYTE_IMPL_PATH="GoogleAnalyticsSingerSource"
+ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/source.py"
 
-LABEL io.airbyte.version=0.2.5
+LABEL io.airbyte.version=0.2.6
 LABEL io.airbyte.name=airbyte/source-googleanalytics-singer
 
 WORKDIR /airbyte/integration_code


### PR DESCRIPTION
I missed this in the original PR.