### PR TITLE
🎉 New Destination: Google PubSub

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/356668e2-7e34-47f3-a3b0-67a8a481b692.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/356668e2-7e34-47f3-a3b0-67a8a481b692.json
@@ -1,0 +1,7 @@
+{
+  "destinationDefinitionId": "356668e2-7e34-47f3-a3b0-67a8a481b692",
+  "name": "PubSub",
+  "dockerRepository": "airbyte/destination-pubsub",
+  "dockerImageTag": "0.1.0",
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/pubsub"
+}

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/356668e2-7e34-47f3-a3b0-67a8a481b692.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/356668e2-7e34-47f3-a3b0-67a8a481b692.json
@@ -1,6 +1,6 @@
 {
   "destinationDefinitionId": "356668e2-7e34-47f3-a3b0-67a8a481b692",
-  "name": "PubSub",
+  "name": "Google PubSub",
   "dockerRepository": "airbyte/destination-pubsub",
   "dockerImageTag": "0.1.0",
   "documentationUrl": "https://docs.airbyte.io/integrations/destinations/pubsub"

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -24,6 +24,11 @@
   dockerRepository: airbyte/destination-bigquery-denormalized
   dockerImageTag: 0.1.0
   documentationUrl: https://docs.airbyte.io/integrations/destinations/bigquery
+- destinationDefinitionId: 356668e2-7e34-47f3-a3b0-67a8a481b692
+  name: PubSub
+  dockerRepository: airbyte/destination-pubsub
+  dockerImageTag: 0.1.0
+  documentationUrl: https://docs.airbyte.io/integrations/destinations/pubsub
 - destinationDefinitionId: 424892c4-daac-4491-b35d-c6688ba547ba
   name: Snowflake
   dockerRepository: airbyte/destination-snowflake

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -25,7 +25,7 @@
   dockerImageTag: 0.1.0
   documentationUrl: https://docs.airbyte.io/integrations/destinations/bigquery
 - destinationDefinitionId: 356668e2-7e34-47f3-a3b0-67a8a481b692
-  name: PubSub
+  name: Google PubSub
   dockerRepository: airbyte/destination-pubsub
   dockerImageTag: 0.1.0
   documentationUrl: https://docs.airbyte.io/integrations/destinations/pubsub

--- a/airbyte-integrations/builds.md
+++ b/airbyte-integrations/builds.md
@@ -123,6 +123,8 @@
 
  Postgres   [![destination-postgres](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-postgres%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-postgres) 
 
+ PubSub   [![destination-pubsub](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-pubsub%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-pubsub)
+
  Redshift   [![destination-redshift](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-redshift%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-redshift) 
 
  S3         [![destination-s3](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-s3%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-s3)

--- a/airbyte-integrations/builds.md
+++ b/airbyte-integrations/builds.md
@@ -123,7 +123,7 @@
 
  Postgres   [![destination-postgres](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-postgres%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-postgres) 
 
- PubSub   [![destination-pubsub](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-pubsub%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-pubsub)
+ Google PubSub   [![destination-pubsub](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-pubsub%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-pubsub)
 
  Redshift   [![destination-redshift](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-redshift%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-redshift) 
 

--- a/airbyte-integrations/connectors/destination-pubsub/.dockerignore
+++ b/airbyte-integrations/connectors/destination-pubsub/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!build

--- a/airbyte-integrations/connectors/destination-pubsub/Dockerfile
+++ b/airbyte-integrations/connectors/destination-pubsub/Dockerfile
@@ -1,0 +1,11 @@
+FROM airbyte/integration-base-java:dev
+
+WORKDIR /airbyte
+ENV APPLICATION destination-pubsub
+
+COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
+
+RUN tar xf ${APPLICATION}.tar --strip-components=1
+
+LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.name=airbyte/destination-pubsub

--- a/airbyte-integrations/connectors/destination-pubsub/README.md
+++ b/airbyte-integrations/connectors/destination-pubsub/README.md
@@ -1,0 +1,21 @@
+# PubSub Test Configuration
+
+In order to test the PubSub destination, you need a service account key file.
+
+## Community Contributor
+
+As a community contributor, you will need access to a GCP project and BigQuery to run tests.
+
+1. Go to the `Service Accounts` page on the GCP console
+1. Click on `+ Create Service Account" button
+1. Fill out a descriptive name/id/description
+1. Click the edit icon next to the service account you created on the `IAM` page
+1. Add the `Pub/Sub Editor` role
+1. Go back to the `Service Accounts` page and use the actions modal to `Create Key`
+1. Download this key as a JSON file
+1. Move and rename this file to `secrets/credentials.json`
+
+## Airbyte Employee
+
+1. Access the `PubSub Integration Test User` secret on Rippling under the `Engineering` folder
+1. Create a file with the contents at `secrets/credentials.json`

--- a/airbyte-integrations/connectors/destination-pubsub/README.md
+++ b/airbyte-integrations/connectors/destination-pubsub/README.md
@@ -17,5 +17,5 @@ As a community contributor, you will need access to a GCP project and BigQuery t
 
 ## Airbyte Employee
 
-1. Access the `PubSub Integration Test User` secret on Rippling under the `Engineering` folder
+1. Access the `google pubsub test credentials.json` secret on Lastpass under the `shared-integration-test` folder
 1. Create a file with the contents at `secrets/credentials.json`

--- a/airbyte-integrations/connectors/destination-pubsub/README.md
+++ b/airbyte-integrations/connectors/destination-pubsub/README.md
@@ -1,10 +1,10 @@
-# PubSub Test Configuration
+# Google PubSub Test Configuration
 
 In order to test the PubSub destination, you need a service account key file.
 
 ## Community Contributor
 
-As a community contributor, you will need access to a GCP project and BigQuery to run tests.
+As a community contributor, you will need access to a GCP project and PubSub to run tests.
 
 1. Go to the `Service Accounts` page on the GCP console
 1. Click on `+ Create Service Account" button

--- a/airbyte-integrations/connectors/destination-pubsub/build.gradle
+++ b/airbyte-integrations/connectors/destination-pubsub/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'application'
+    id 'airbyte-docker'
+    id 'airbyte-integration-test-java'
+}
+
+application {
+    mainClass = 'io.airbyte.integrations.destination.pubsub.PubsubDestination'
+}
+
+dependencies {
+    implementation group: 'com.google.cloud', name: 'google-cloud-pubsub', version: '1.113.3'
+
+    implementation project(':airbyte-config:models')
+    implementation project(':airbyte-protocol:models')
+    implementation project(':airbyte-integrations:bases:base-java')
+    implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
+
+    integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
+    integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-pubsub')
+}

--- a/airbyte-integrations/connectors/destination-pubsub/src/main/java/io/airbyte/integrations/destination/pubsub/PubsubConsumer.java
+++ b/airbyte-integrations/connectors/destination-pubsub/src/main/java/io/airbyte/integrations/destination/pubsub/PubsubConsumer.java
@@ -102,6 +102,7 @@ public class PubsubConsumer extends FailureTrackingAirbyteMessageConsumer {
   protected void acceptTracked(AirbyteMessage msg) throws Exception {
     if (msg.getType() == Type.STATE) {
       lastStateMessage = msg;
+      outputRecordCollector.accept(lastStateMessage);
       return;
     } else if (msg.getType() != Type.RECORD) {
       return;

--- a/airbyte-integrations/connectors/destination-pubsub/src/main/java/io/airbyte/integrations/destination/pubsub/PubsubConsumer.java
+++ b/airbyte-integrations/connectors/destination-pubsub/src/main/java/io/airbyte/integrations/destination/pubsub/PubsubConsumer.java
@@ -1,0 +1,138 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.airbyte.integrations.destination.pubsub;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.TopicName;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.base.AirbyteStreamNameNamespacePair;
+import io.airbyte.integrations.base.FailureTrackingAirbyteMessageConsumer;
+import io.airbyte.integrations.base.JavaBaseConstants;
+import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteMessage.Type;
+import io.airbyte.protocol.models.AirbyteRecordMessage;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.ConfiguredAirbyteStream;
+import java.io.ByteArrayInputStream;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PubsubConsumer extends FailureTrackingAirbyteMessageConsumer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PubsubConsumer.class);
+  private final JsonNode config;
+  private final ConfiguredAirbyteCatalog catalog;
+  private final Consumer<AirbyteMessage> outputRecordCollector;
+  private final Map<AirbyteStreamNameNamespacePair, Map<String, String>> attributes;
+  private Publisher publisher;
+  private AirbyteMessage lastStateMessage;
+
+  public PubsubConsumer(JsonNode config,
+      ConfiguredAirbyteCatalog catalog,
+      Consumer<AirbyteMessage> outputRecordCollector) {
+    this.outputRecordCollector = outputRecordCollector;
+    this.config = config;
+    this.catalog = catalog;
+    this.lastStateMessage = null;
+    this.attributes = Maps.newHashMap();
+    this.publisher = null;
+    LOGGER.info("initializing consumer.");
+  }
+
+  @Override
+  protected void startTracked() throws Exception {
+    // get publisher
+    final String projectId = config.get(PubsubDestination.CONFIG_PROJECT_ID).asText();
+    final String topicName = config.get(PubsubDestination.CONFIG_TOPIC_ID).asText();
+    TopicName topic = TopicName.of(projectId, topicName);
+    final String credentialsString =
+        config.get(PubsubDestination.CONFIG_CREDS).isObject() ? Jsons.serialize(config.get(
+            PubsubDestination.CONFIG_CREDS))
+            : config.get(PubsubDestination.CONFIG_CREDS).asText();
+    final ServiceAccountCredentials credentials = ServiceAccountCredentials
+        .fromStream(new ByteArrayInputStream(credentialsString.getBytes(Charsets.UTF_8)));
+    publisher = Publisher.newBuilder(topic)
+        .setEnableMessageOrdering(true)
+        .setCredentialsProvider(FixedCredentialsProvider.create(credentials)).build();
+    for (final ConfiguredAirbyteStream configStream : catalog.getStreams()) {
+      final Map<String, String> attrs = Maps.newHashMap();
+      var key = AirbyteStreamNameNamespacePair.fromAirbyteSteam(configStream.getStream());
+      attrs.put(PubsubDestination.STREAM, key.getName());
+      if (!Strings.isNullOrEmpty(key.getNamespace())) {
+        attrs.put(PubsubDestination.NAMESPACE, key.getNamespace());
+      }
+      attributes.put(key, attrs);
+    }
+  }
+
+  @Override
+  protected void acceptTracked(AirbyteMessage msg) throws Exception {
+    if (msg.getType() == Type.STATE) {
+      lastStateMessage = msg;
+      return;
+    } else if (msg.getType() != Type.RECORD) {
+      return;
+    }
+    final AirbyteRecordMessage recordMessage = msg.getRecord();
+    final AirbyteStreamNameNamespacePair streamKey = AirbyteStreamNameNamespacePair
+        .fromRecordMessage(recordMessage);
+
+    if (!attributes.containsKey(streamKey)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Message contained record from a stream that was not in the catalog. \ncatalog: %s , \nmessage: %s",
+              Jsons.serialize(catalog), Jsons.serialize(recordMessage)));
+    }
+    final JsonNode data = Jsons.jsonNode(ImmutableMap.of(
+        JavaBaseConstants.COLUMN_NAME_AB_ID, UUID.randomUUID().toString(),
+        JavaBaseConstants.COLUMN_NAME_DATA, recordMessage.getData(),
+        JavaBaseConstants.COLUMN_NAME_EMITTED_AT, recordMessage.getEmittedAt()));
+
+    publisher.publish(
+        PubsubMessage.newBuilder().putAllAttributes(attributes.get(streamKey))
+            .setOrderingKey(streamKey.toString())
+            .setData(ByteString.copyFromUtf8(Jsons.serialize(data))).build());
+  }
+
+  @Override
+  protected void close(boolean hasFailed) throws Exception {
+    if (!hasFailed) {
+      publisher.shutdown();
+      LOGGER.info("shutting down consumer.");
+      outputRecordCollector.accept(lastStateMessage);
+    }
+  }
+}

--- a/airbyte-integrations/connectors/destination-pubsub/src/main/java/io/airbyte/integrations/destination/pubsub/PubsubDestination.java
+++ b/airbyte-integrations/connectors/destination-pubsub/src/main/java/io/airbyte/integrations/destination/pubsub/PubsubDestination.java
@@ -1,0 +1,91 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.integrations.destination.pubsub;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminSettings;
+import com.google.common.base.Charsets;
+import com.google.pubsub.v1.TopicName;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.BaseConnector;
+import io.airbyte.integrations.base.AirbyteMessageConsumer;
+import io.airbyte.integrations.base.Destination;
+import io.airbyte.integrations.base.IntegrationRunner;
+import io.airbyte.protocol.models.AirbyteConnectionStatus;
+import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
+import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import java.io.ByteArrayInputStream;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PubsubDestination extends BaseConnector implements Destination {
+
+  static final String CONFIG_TOPIC_ID = "topic_id";
+  static final String CONFIG_PROJECT_ID = "project_id";
+  static final String CONFIG_CREDS = "credentials_json";
+  static final String STREAM = "_stream";
+  static final String NAMESPACE = "_namespace";
+  private static final Logger LOGGER = LoggerFactory.getLogger(PubsubDestination.class);
+
+  public static void main(String[] args) throws Exception {
+    new IntegrationRunner(new PubsubDestination()).run(args);
+  }
+
+  @Override
+  public AirbyteConnectionStatus check(JsonNode config) {
+    try {
+      final String projectId = config.get(CONFIG_PROJECT_ID).asText();
+      final String topicId = config.get(CONFIG_TOPIC_ID).asText();
+      final String credentialsString =
+          config.get(CONFIG_CREDS).isObject() ? Jsons.serialize(config.get(CONFIG_CREDS))
+              : config.get(CONFIG_CREDS).asText();
+      final ServiceAccountCredentials credentials = ServiceAccountCredentials
+          .fromStream(new ByteArrayInputStream(credentialsString.getBytes(Charsets.UTF_8)));
+
+      TopicAdminClient adminClient = TopicAdminClient
+          .create(TopicAdminSettings.newBuilder().setCredentialsProvider(
+              FixedCredentialsProvider.create(credentials)).build());
+      TopicName topicName = TopicName.of(projectId, topicId);
+      adminClient.getTopic(topicName);
+      return new AirbyteConnectionStatus().withStatus(Status.SUCCEEDED);
+    } catch (Exception e) {
+      LOGGER.info("Check failed.", e);
+      return new AirbyteConnectionStatus().withStatus(Status.FAILED)
+          .withMessage(e.getMessage() != null ? e.getMessage() : e.toString());
+    }
+  }
+
+  @Override
+  public AirbyteMessageConsumer getConsumer(JsonNode config,
+      ConfiguredAirbyteCatalog configuredCatalog,
+      Consumer<AirbyteMessage> outputRecordCollector) {
+    return new PubsubConsumer(config, configuredCatalog, outputRecordCollector);
+  }
+}

--- a/airbyte-integrations/connectors/destination-pubsub/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-pubsub/src/main/resources/spec.json
@@ -1,0 +1,32 @@
+{
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/pubsub",
+  "supportsIncremental": true,
+  "supportsNormalization": false,
+  "supportsDBT": false,
+  "supported_destination_sync_modes": ["append"],
+  "connectionSpecification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PubSub Destination Spec",
+    "type": "object",
+    "required": ["project_id", "topic_name", "credentials_json"],
+    "additionalProperties": true,
+    "properties": {
+      "project_id": {
+        "type": "string",
+        "description": "The GCP project ID for the project containing the target PubSub",
+        "title": "Project ID"
+      },
+      "topic_id": {
+        "type": "string",
+        "description": "PubSub topic ID in the given GCP project ID",
+        "title": "PubSub Topic ID"
+      },
+      "credentials_json": {
+        "type": "string",
+        "description": "The contents of the JSON service account key. Check out the <a href=\"https://docs.airbyte.io/integrations/destinations/pubsub\">docs</a> if you need help generating this key.",
+        "title": "Credentials JSON",
+        "airbyte_secret": true
+      }
+    }
+  }
+}

--- a/airbyte-integrations/connectors/destination-pubsub/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-pubsub/src/main/resources/spec.json
@@ -6,7 +6,7 @@
   "supported_destination_sync_modes": ["append"],
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "PubSub Destination Spec",
+    "title": "Google PubSub Destination Spec",
     "type": "object",
     "required": ["project_id", "topic_name", "credentials_json"],
     "additionalProperties": true,

--- a/airbyte-integrations/connectors/destination-pubsub/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-pubsub/src/main/resources/spec.json
@@ -8,7 +8,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Google PubSub Destination Spec",
     "type": "object",
-    "required": ["project_id", "topic_name", "credentials_json"],
+    "required": ["project_id", "topic_id", "credentials_json"],
     "additionalProperties": true,
     "properties": {
       "project_id": {

--- a/airbyte-integrations/connectors/destination-pubsub/src/test-integration/java/io/airbyte/integrations/destination/pubsub/PubsubDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-pubsub/src/test-integration/java/io/airbyte/integrations/destination/pubsub/PubsubDestinationAcceptanceTest.java
@@ -1,0 +1,250 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.integrations.destination.pubsub;
+
+import static com.google.common.base.Strings.nullToEmpty;
+import static io.airbyte.integrations.destination.pubsub.PubsubDestination.CONFIG_CREDS;
+import static io.airbyte.integrations.destination.pubsub.PubsubDestination.CONFIG_PROJECT_ID;
+import static io.airbyte.integrations.destination.pubsub.PubsubDestination.CONFIG_TOPIC_ID;
+import static io.airbyte.integrations.destination.pubsub.PubsubDestination.NAMESPACE;
+import static io.airbyte.integrations.destination.pubsub.PubsubDestination.STREAM;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.api.client.util.Lists;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminSettings;
+import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
+import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
+import com.google.common.collect.ImmutableMap;
+import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PullRequest;
+import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.ReceivedMessage;
+import com.google.pubsub.v1.Subscription;
+import com.google.pubsub.v1.Topic;
+import com.google.pubsub.v1.TopicName;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.string.Strings;
+import io.airbyte.integrations.base.AirbyteStreamNameNamespacePair;
+import io.airbyte.integrations.base.JavaBaseConstants;
+import io.airbyte.integrations.standardtest.destination.DestinationAcceptanceTest;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PubsubDestinationAcceptanceTest extends DestinationAcceptanceTest {
+
+  private static final Logger LOGGER = LoggerFactory
+      .getLogger(PubsubDestinationAcceptanceTest.class);
+  private static final Path CREDENTIALS_PATH = Path.of("secrets/credentials.json");
+  private TopicAdminClient topicAdminClient;
+  private SubscriptionAdminClient subscriptionAdminClient;
+  private TopicName topicName;
+  private ProjectSubscriptionName subscriptionName;
+  private Credentials credentials;
+  private JsonNode configJson;
+  // TODO: is this ok for a streaming destination test?
+  private List<JsonNode> records;
+
+  @Override
+  protected String getImageName() {
+    return "airbyte/destination-pubsub:dev";
+  }
+
+  @Override
+  protected JsonNode getConfig() {
+    return configJson;
+  }
+
+  @Override
+  protected JsonNode getFailCheckConfig() {
+    ((ObjectNode) configJson).put(CONFIG_PROJECT_ID, "fake");
+    return configJson;
+  }
+
+  @Override
+  protected boolean implementsNamespaces() {
+    return true;
+  }
+
+  private AirbyteStreamNameNamespacePair fromJsonNode(JsonNode j) {
+    var stream = j.get(STREAM).asText("");
+    var namespace = j.get(NAMESPACE).asText("");
+    return new AirbyteStreamNameNamespacePair(stream, namespace);
+  }
+
+  @Override
+  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
+                                           String streamName,
+                                           String namespace,
+                                           JsonNode streamSchema)
+      throws IOException {
+    if (records.isEmpty()) {
+      // first time retrieving records, retrieve all and keep locally for easier
+      // verification
+      SubscriberStubSettings subscriberStubSettings =
+          SubscriberStubSettings.newBuilder()
+              .setTransportChannelProvider(
+                  SubscriberStubSettings.defaultGrpcTransportProviderBuilder()
+                      .setCredentials(credentials)
+                      .build())
+              .build();
+      try (SubscriberStub subscriber = GrpcSubscriberStub.create(subscriberStubSettings)) {
+        PullRequest pullRequest =
+            PullRequest.newBuilder()
+                .setMaxMessages(1000)
+                .setSubscription(subscriptionName.toString())
+                .build();
+
+        PullResponse pullResponse = subscriber.pullCallable()
+            .call(pullRequest);
+        var list = pullResponse.getReceivedMessagesList();
+        do {
+          List<String> ackIds = Lists.newArrayList();
+          for (ReceivedMessage message : list) {
+            var m = message.getMessage();
+            var s = m.getAttributesMap().get(STREAM);
+            var n = m.getAttributesMap().get(NAMESPACE);
+            records.add(Jsons.jsonNode(ImmutableMap.of(
+                STREAM, nullToEmpty(s),
+                NAMESPACE, nullToEmpty(n),
+                "data", Jsons.deserialize(m.getData().toStringUtf8())
+                    .get(JavaBaseConstants.COLUMN_NAME_DATA))));
+            ackIds.add(message.getAckId());
+          }
+          if (!ackIds.isEmpty()) {
+            // Acknowledge received messages.
+            AcknowledgeRequest acknowledgeRequest =
+                AcknowledgeRequest.newBuilder()
+                    .setSubscription(subscriptionName.toString())
+                    .addAllAckIds(ackIds)
+                    .build();
+            // Use acknowledgeCallable().futureCall to asynchronously perform this operation.
+            subscriber.acknowledgeCallable().call(acknowledgeRequest);
+          }
+          pullResponse = subscriber.pullCallable()
+              .call(pullRequest);
+          list = pullResponse.getReceivedMessagesList();
+        } while (list.size() > 0);
+      }
+    }
+
+    // at this point we have fetched all records first time, or it was already there
+    // just filter based on stream/ns and send results back
+    return records
+        .stream()
+        .filter(Objects::nonNull)
+        .filter(
+            e -> fromJsonNode(e).equals(new AirbyteStreamNameNamespacePair(nullToEmpty(streamName),
+                nullToEmpty(namespace))))
+        .map(e -> e.get("data"))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  protected void setup(TestDestinationEnv testEnv) throws Exception {
+    if (!Files.exists(CREDENTIALS_PATH)) {
+      throw new IllegalStateException(
+          "Must provide path to a gcp service account credentials file. By default {module-root}/"
+              + CREDENTIALS_PATH
+              + ". Override by setting setting path with the CREDENTIALS_PATH constant.");
+    }
+
+    final String credentialsJsonString = new String(Files.readAllBytes(CREDENTIALS_PATH));
+
+    final JsonNode credentialsJson = Jsons.deserialize(credentialsJsonString);
+    final String projectId = credentialsJson.get(CONFIG_PROJECT_ID).asText();
+    final String topicId = Strings.addRandomSuffix("airbyte_tests", "_", 8);
+    final String subscriptionId = Strings.addRandomSuffix("airbyte_tests", "_", 8);
+
+    configJson = Jsons.jsonNode(ImmutableMap.builder()
+        .put(CONFIG_PROJECT_ID, projectId)
+        .put(CONFIG_CREDS, credentialsJsonString)
+        .put(CONFIG_TOPIC_ID, topicId)
+        .build());
+
+    credentials =
+        ServiceAccountCredentials
+            .fromStream(new ByteArrayInputStream(configJson.get(CONFIG_CREDS).asText().getBytes()));
+    // create topic
+    topicName = TopicName.of(projectId, topicId);
+    topicAdminClient = TopicAdminClient
+        .create(TopicAdminSettings.newBuilder().setCredentialsProvider(
+            FixedCredentialsProvider.create(credentials)).build());
+    Topic topic = topicAdminClient.createTopic(topicName);
+    LOGGER.info("Created topic: " + topic.getName());
+
+    // create subscription - with ordering, cause tests expect it
+    subscriptionName = ProjectSubscriptionName.of(projectId, subscriptionId);
+    subscriptionAdminClient = SubscriptionAdminClient.create(
+        SubscriptionAdminSettings.newBuilder()
+            .setCredentialsProvider(FixedCredentialsProvider.create(credentials))
+            .build());
+    Subscription subscription =
+        subscriptionAdminClient.createSubscription(
+            Subscription.newBuilder().setName(subscriptionName.toString())
+                .setTopic(topicName.toString()).setEnableMessageOrdering(true)
+                .setAckDeadlineSeconds(10).build());
+    LOGGER.info("Created pull subscription: " + subscription.getName());
+
+    // init local records container
+    records = Lists.newArrayList();
+  }
+
+  @Override
+  public void testSecondSync() throws Exception {
+    // PubSub cannot overwrite messages, its always append only
+  }
+
+  @Override
+  protected void tearDown(TestDestinationEnv testEnv) {
+    // delete subscription
+    if (subscriptionAdminClient != null && subscriptionName != null) {
+      subscriptionAdminClient.deleteSubscription(subscriptionName);
+      subscriptionAdminClient.close();
+    }
+    // delete topic
+    if (topicAdminClient != null && topicName != null) {
+      topicAdminClient.deleteTopic(topicName);
+      topicAdminClient.close();
+    }
+    records.clear();
+  }
+
+}

--- a/airbyte-integrations/connectors/destination-pubsub/src/test-integration/java/io/airbyte/integrations/destination/pubsub/PubsubDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-pubsub/src/test-integration/java/io/airbyte/integrations/destination/pubsub/PubsubDestinationAcceptanceTest.java
@@ -79,7 +79,7 @@ public class PubsubDestinationAcceptanceTest extends DestinationAcceptanceTest {
   private ProjectSubscriptionName subscriptionName;
   private Credentials credentials;
   private JsonNode configJson;
-  // TODO: is this ok for a streaming destination test?
+  // Store retrieved data during the test run since we can't re-read it multiple times (ACKing messages causes them to be removed from pubsub)
   private List<JsonNode> records;
 
   @Override
@@ -120,6 +120,7 @@ public class PubsubDestinationAcceptanceTest extends DestinationAcceptanceTest {
       // verification
       SubscriberStubSettings subscriberStubSettings =
           SubscriberStubSettings.newBuilder()
+          .setCredentialsProvider(FixedCredentialsProvider.create(credentials))
               .setTransportChannelProvider(
                   SubscriberStubSettings.defaultGrpcTransportProviderBuilder()
                       .setCredentials(credentials)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -99,7 +99,7 @@
     * [MySQL](integrations/destinations/mysql.md)
     * [Oracle DB](integrations/destinations/oracle.md)
     * [Postgres](integrations/destinations/postgres.md)
-    * [PubSub](integrations/destinations/pubsub.md)
+    * [Google PubSub](integrations/destinations/pubsub.md)
     * [Redshift](integrations/destinations/redshift.md)
     * [S3](integrations/destinations/s3.md)
     * [Snowflake](integrations/destinations/snowflake.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -99,6 +99,7 @@
     * [MySQL](integrations/destinations/mysql.md)
     * [Oracle DB](integrations/destinations/oracle.md)
     * [Postgres](integrations/destinations/postgres.md)
+    * [PubSub](integrations/destinations/pubsub.md)
     * [Redshift](integrations/destinations/redshift.md)
     * [S3](integrations/destinations/s3.md)
     * [Snowflake](integrations/destinations/snowflake.md)

--- a/docs/integrations/destinations/pubsub.md
+++ b/docs/integrations/destinations/pubsub.md
@@ -87,3 +87,4 @@ Once you've configured PubSub as a destination, delete the Service Account Key f
 
 | Version | Date | Pull Request | Subject |
 | :--- | :---  | :--- | :--- |
+| 0.1.0 | June 24, 2021 | [#4339](https://github.com/airbytehq/airbyte/pull/4339)| Initial release | 

--- a/docs/integrations/destinations/pubsub.md
+++ b/docs/integrations/destinations/pubsub.md
@@ -1,0 +1,89 @@
+---
+description: >-
+Pub/Sub is an asynchronous messaging service provided by Google Cloud Provider.
+---
+
+# PubSub
+
+## Overview
+
+The Airbyte PubSub destination allows you to send/stream data into PubSub. Pub/Sub is an asynchronous messaging service provided by Google Cloud Provider.
+
+### Sync overview
+
+#### Output schema
+
+Each stream will be output a PubSubMessage with attributes. The message attributes will be
+
+* `_stream`: the name of stream where the data is coming from
+* `_namespace`: namespace if available from the stream
+
+The data will be a serialized JSON, containing the following fields  
+* `_airbyte_ab_id`: a uuid string assigned by Airbyte to each event that is processed.
+* `_airbyte_emitted_at`: a long timestamp(ms) representing when the event was pulled from the data source.
+* `_airbyte_data`: a json string representing with the event data.
+
+#### Features
+
+| Feature | Supported?\(Yes/No\) | Notes |
+| :--- | :--- | :--- |
+| Full Refresh Sync | Yes |  |
+| Incremental - Append Sync | Yes |  |
+| Namespaces | Yes |  |
+
+## Getting started
+
+### Requirements
+
+To use the PubSub destination, you'll need:
+
+* A Google Cloud Project with PubSub enabled
+* A PubSub Topic to which Airbyte can stream/sync your data
+* A Google Cloud Service Account with the `Pub/Sub Editor` role in your GCP project
+* A Service Account Key to authenticate into your Service Account
+
+See the setup guide for more information about how to create the required resources.
+
+### Setup guide
+
+#### Google cloud project
+
+If you have a Google Cloud Project with PubSub enabled, skip to the "Create a Topic" section.
+
+First, follow along the Google Cloud instructions to [Create a Project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#before_you_begin).
+PubSub is enabled automatically in new projects. If this is not the case for your project, find it in [Marketplace](https://console.cloud.google.com/marketplace/product/google/pubsub.googleapis.com) and enable.
+
+#### PubSub topic for Airbyte syncs
+
+Airbyte needs a topic in PubSub to write the data being streamed/synced from your data sources. If you already have a Topic into which Airbyte should stream/sync data, skip this section. Otherwise, follow the Google Cloud guide for [Creating a PubSub Topic](https://cloud.google.com/pubsub/docs/admin#creating_a_topic) to achieve this.
+
+#### Service account
+
+In order for Airbyte to stream/sync data into PubSub, it needs credentials for a [Service Account](https://cloud.google.com/iam/docs/service-accounts) with the `Pub/Sub Editor` role, which grants permissions to publish messages into PubSub topics. We highly recommend that this Service Account is exclusive to Airbyte for ease of permissioning and auditing. However, you can use a pre-existing Service Account if you already have one with the correct permissions.
+
+The easiest way to create a Service Account is to follow GCP's guide for [Creating a Service Account](https://cloud.google.com/iam/docs/creating-managing-service-accounts). Once you've created the Service Account, make sure to keep its ID handy as you will need to reference it when granting roles. Service Account IDs typically take the form `<account-name>@<project-name>.iam.gserviceaccount.com`
+
+Then, add the service account as a Member in your Google Cloud Project with the `Pub/Sub Editor` role. To do this, follow the instructions for [Granting Access](https://cloud.google.com/iam/docs/granting-changing-revoking-access#granting-console) in the Google documentation. The email address of the member you are adding is the same as the Service Account ID you just created.
+
+At this point you should have a service account with the `Pub/Sub Editor` project-level permission.
+
+#### Service account key
+
+Service Account Keys are used to authenticate as Google Service Accounts. For Airbyte to leverage the permissions you granted to the Service Account in the previous step, you'll need to provide its Service Account Keys. See the [Google documentation](https://cloud.google.com/iam/docs/service-accounts#service_account_keys) for more information about Keys.
+
+Follow the [Creating and Managing Service Account Keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) guide to create a key. Airbyte currently supports JSON Keys only, so make sure you create your key in that format. As soon as you created the key, make sure to download it, as that is the only time Google will allow you to see its contents. Once you've successfully configured BigQuery as a destination in Airbyte, delete this key from your computer.
+
+### Setup the PubSub destination in Airbyte
+
+You should now have all the requirements needed to configure BigQuery as a destination in the UI. You'll need the following information to configure the BigQuery destination:
+
+* **Project ID**: GCP project id
+* **Topic ID**: name of pubsub topic under the project
+* **Service Account Key**: the contents of your Service Account Key JSON file
+
+Once you've configured PubSub as a destination, delete the Service Account Key from your computer.
+
+## CHANGELOG
+
+| Version | Date | Pull Request | Subject |
+| :--- | :---  | :--- | :--- |

--- a/docs/integrations/destinations/pubsub.md
+++ b/docs/integrations/destinations/pubsub.md
@@ -3,14 +3,14 @@ description: >-
 Pub/Sub is an asynchronous messaging service provided by Google Cloud Provider.
 ---
 
-# PubSub
+# Google PubSub
 
 ## Overview
 
-The Airbyte PubSub destination allows you to send/stream data into PubSub. Pub/Sub is an asynchronous messaging service provided by Google Cloud Provider.
+The Airbyte Google PubSub destination allows you to send/stream data into PubSub. Pub/Sub is an asynchronous messaging service provided by Google Cloud Provider.
 
 ### Sync overview
-
+    
 #### Output schema
 
 Each stream will be output a PubSubMessage with attributes. The message attributes will be
@@ -21,7 +21,7 @@ Each stream will be output a PubSubMessage with attributes. The message attribut
 The data will be a serialized JSON, containing the following fields  
 * `_airbyte_ab_id`: a uuid string assigned by Airbyte to each event that is processed.
 * `_airbyte_emitted_at`: a long timestamp(ms) representing when the event was pulled from the data source.
-* `_airbyte_data`: a json string representing with the event data.
+* `_airbyte_data`: a json string representing source data.
 
 #### Features
 


### PR DESCRIPTION
## What
* New Destination: Pubsub

## How
* Uses one topic for sending all data. It expects topic to be present
 * `check` tests for availability of topic and will fail otherwise
* Adds `stream` name and `namespace` as attributes to the `PubSubMessage`. Enables filtering by them on subscribers if necessary. 
* Data is serialized as string (_contains `id`, `emitted_at` and actual source `data`_)
* Had to enable ordering for making acceptance tests pass, validations expects messages in same order.
* Had to skip `testSecondSync()` for this streaming destination, which is append only. Let me know if that is not the case and we need to make sure it passes.
* Regarding service account permissions, acceptance tests needed to be Editor to create random topics/subscriptions, so I kept the same. But we only need Publisher role + topics.get permission. Let me know if trimming it down makes sense

## Recommended reading order
1. `spec.json`
2. `PubsubDestination.java`
3. `PubsubConsumer.java`
4. `PubsubDestinationAcceptanceTest.java`

### Local Acceptance Test
![image](https://user-images.githubusercontent.com/47996246/123364975-3afe0200-d52a-11eb-8538-d16f3856879e.png)

## Pre-merge Checklist
Expand the checklist which is relevant for this PR. 

<details><summary> <strong> Connector checklist </strong> </summary>
<p>

- [ ] Issue acceptance criteria met
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Secrets are annotated with `airbyte_secret` in output spec
- [x] Unit & integration tests added as appropriate (and are passing)
    * Community members: please provide proof of this succeeding locally e.g: screenshot or copy-paste acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] `/test connector=connectors/<name>` command as documented [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-an-existing-connector) is passing. 
    * Community members can skip this, Airbyters will run this for you. 
- [x] Code reviews completed
- [x] Credentials added to Github CI if needed and not already present. [instructions for injecting secrets into CI](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#using-credentials-in-ci). 
- [ ] Documentation updated 
    - [x] `README.md`
    - [x] `docs/SUMMARY.md` if it's a new connector
    - [x] Reference docs in the `docs/integrations/` directory.
    - [x] Changelog in the appropriate page in `docs/integrations/...`. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [x] Build status added to [build page](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/builds.md)
- [ ] Build is successful
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] No major blockers
- [ ] PR merged into master branch
- [ ] Follow up tickets have been created
- [ ] Associated tickets have been closed & stakeholders notified
</p>
</details>

<details><summary> <strong> Connector Generator checklist </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
