### PR TITLE
Tweak notification tracking behavior

### DIFF
--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/JobNotifierTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/JobNotifierTest.java
@@ -146,7 +146,7 @@ class JobNotifierTest {
     return new Notification()
         .withNotificationType(NotificationType.SLACK)
         .withSlackConfiguration(new SlackNotificationConfiguration()
-            .withWebhook("http://random.webhook.url"));
+            .withWebhook("http://random.webhook.url/hooks.slack.com/"));
   }
 
 }


### PR DESCRIPTION
## What
Following discussions and questions from @nataliekwong , we should track "slack" notification types and mark them as slack only if they are really slack notifications that uses slack webhooks (`hooks.slack.com`)

