### PR TITLE
Build Core Docker Images and Run Tests should only do composeBuild

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -198,7 +198,7 @@ jobs:
         run: python3 -m pip install virtualenv==16.7.9 --user
 
       - name: Build Core Docker Images and Run Tests
-        run: CORE_ONLY=true ./gradlew --no-daemon composebuild --scan
+        run: CORE_ONLY=true ./gradlew --no-daemon composeBuild --scan
 
       - name: Run End-to-End Frontend Tests
         run: ./tools/bin/e2e_test.sh

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -198,7 +198,7 @@ jobs:
         run: python3 -m pip install virtualenv==16.7.9 --user
 
       - name: Build Core Docker Images and Run Tests
-        run: CORE_ONLY=true ./gradlew --no-daemon build --scan
+        run: CORE_ONLY=true ./gradlew --no-daemon composebuild --scan
 
       - name: Run End-to-End Frontend Tests
         run: ./tools/bin/e2e_test.sh
@@ -254,10 +254,7 @@ jobs:
         run: python3 -m pip install virtualenv==16.7.9 --user
 
       - name: Build Core Docker Images and Run Tests
-        run: CORE_ONLY=true ./gradlew --no-daemon composeBuild test -x :airbyte-webapp:test --scan
-        env:
-          GIT_REVISION: ${{ github.sha }}
-          CORE_ONLY: true
+        run: CORE_ONLY=true ./gradlew --no-daemon composeBuild --scan
 
       - name: Run Docker End-to-End Acceptance Tests
         run: |
@@ -353,7 +350,7 @@ jobs:
           CHANGE_MINIKUBE_NONE_USER: true
 
       - name: Build Core Docker Images and Run Tests
-        run: CORE_ONLY=true ./gradlew --no-daemon build --scan --rerun-tasks
+        run: CORE_ONLY=true ./gradlew --no-daemon composeBuild --scan
 
       - name: Run Logging Tests
         run: ./tools/bin/cloud_storage_logging_test.sh


### PR DESCRIPTION
## What
The step mentioned in the title is running unit tests. This is superfluous as these steps are meant to run _acceptance tests_. Running the unit tests is always duplicative with the build step. replace `build` => `composeBuild` and remove the test directive.

## Why
Our python infra is still flakey so PRs like this [one](https://github.com/airbytehq/airbyte/runs/2918150544) get all fouled up due to unrelated problems.