### PR TITLE
run docker acceptance tests once

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -120,7 +120,6 @@ jobs:
 
       # make sure these always run before pushing core docker images
       - name: Run End-to-End Acceptance Tests
-        if: success() && github.ref == 'refs/heads/master'
         run: ./tools/bin/acceptance_test.sh
 
       - name: Push Core Docker Images

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -231,7 +231,6 @@ jobs:
     # In case of self-hosted EC2 errors, remove the next two lines and uncomment the currently commented out `runs-on` line.
     needs: start-kube-acceptance-test-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-kube-acceptance-test-runner.outputs.label }} # run the job on the newly created runner
-#    runs-on: ubuntu-latest
     name: Acceptance Tests (Kube)
     steps:
       - name: Checkout Airbyte

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,7 +35,6 @@ jobs:
     # In case of self-hosted EC2 errors, remove the next two lines and uncomment the currently commented out `runs-on` line.
     needs: start-build-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-build-runner.outputs.label }} # run the job on the newly created runner
-#    runs-on: ubuntu-latest
     name: Build Airbyte
     steps:
       - name: Checkout Airbyte
@@ -203,87 +202,9 @@ jobs:
       - name: Run End-to-End Frontend Tests
         run: ./tools/bin/e2e_test.sh
 
-  ## Acceptance Test
-  # In case of self-hosted EC2 errors, remove the next two lines and uncomment the currently commented out `runs-on` line.
-  start-acceptance-test-runner:
-    name: Start Acceptance Test EC2 Runner
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
-      - name: Start EC2 runner
-        id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.1.0
-        with:
-          mode: start
-          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
-          ec2-image-id: ami-04bd6e81239f4f3fb
-          ec2-instance-type: c5.2xlarge
-          subnet-id: subnet-0469a9e68a379c1d3
-          security-group-id: sg-0793f3c9413f21970
-  acceptance-test:
-    # In case of self-hosted EC2 errors, remove the next two lines and uncomment the currently commented out `runs-on` line.
-    needs: start-acceptance-test-runner # required to start the main job when the runner is ready
-    runs-on: ${{ needs.start-acceptance-test-runner.outputs.label }} # run the job on the newly created runner
-#    runs-on: ubuntu-latest
-    name: Acceptance Tests (Docker Compose)
-    steps:
-      - name: Checkout Airbyte
-        uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '14'
-
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '14.7'
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
-
-      - name: Install Pyenv
-        run: python3 -m pip install virtualenv==16.7.9 --user
-
-      - name: Build Core Docker Images and Run Tests
-        run: CORE_ONLY=true ./gradlew --no-daemon composeBuild --scan
-
-      - name: Run Docker End-to-End Acceptance Tests
-        run: |
-          ./tools/bin/acceptance_test.sh
-  # In case of self-hosted EC2 errors, remove this block.
-  stop-acceptance-test-runner:
-    name: Stop Acceptance Test EC2 Runner
-    needs:
-      - start-acceptance-test-runner # required to get output from the start-runner job
-      - acceptance-test # required to wait when the main job is done
-    runs-on: ubuntu-latest
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
-      - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.1.0
-        with:
-          mode: stop
-          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
-          label: ${{ needs.start-acceptance-test-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-acceptance-test-runner.outputs.ec2-instance-id }}
-
   ## Kube Acceptance Tests
   # In case of self-hosted EC2 errors, remove the next two lines and uncomment the currently commented out `runs-on` line.
+  # Docker acceptance tests run as part of the build job.
   start-kube-acceptance-test-runner:
     name: Start Kube Acceptance Test EC2 Runner
     runs-on: ubuntu-latest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -198,7 +198,7 @@ jobs:
         run: python3 -m pip install virtualenv==16.7.9 --user
 
       - name: Build Core Docker Images and Run Tests
-        run: CORE_ONLY=true ./gradlew --no-daemon build --scan
+        run: CORE_ONLY=true ./gradlew --no-daemon composebuild --scan
 
       - name: Run End-to-End Frontend Tests
         run: ./tools/bin/e2e_test.sh
@@ -254,10 +254,7 @@ jobs:
         run: python3 -m pip install virtualenv==16.7.9 --user
 
       - name: Build Core Docker Images and Run Tests
-        run: CORE_ONLY=true ./gradlew --no-daemon composeBuild test -x :airbyte-webapp:test --scan
-        env:
-          GIT_REVISION: ${{ github.sha }}
-          CORE_ONLY: true
+        run: CORE_ONLY=true ./gradlew --no-daemon composeBuild --scan
 
       - name: Run Docker End-to-End Acceptance Tests
         run: |
@@ -353,7 +350,7 @@ jobs:
           CHANGE_MINIKUBE_NONE_USER: true
 
       - name: Build Core Docker Images and Run Tests
-        run: CORE_ONLY=true ./gradlew --no-daemon build --scan --rerun-tasks
+        run: CORE_ONLY=true ./gradlew --no-daemon composeBuild --scan
 
       - name: Run Logging Tests
         run: ./tools/bin/cloud_storage_logging_test.sh


### PR DESCRIPTION
## What
* The current github action configurations runs the _docker_ acceptance tests twice. They are run in the `build` job and also in the `run acceptance test` job. This appears to be purely duplicative. I don't really care where we run them. Happy to keep the extra job and just remove it from the build, but doing it twice doesn't make sense to me.