### PR TITLE
save docker log space by setting log driver to none

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
@@ -108,7 +108,6 @@ public class DockerProcessFactory implements ProcessFactory {
               "run",
               "--rm",
               "--init",
-              "--log-driver none",
               "-i",
               "-v",
               String.format("%s:%s", workspaceMountSource, DATA_MOUNT_DESTINATION),
@@ -117,7 +116,9 @@ public class DockerProcessFactory implements ProcessFactory {
               "-w",
               rebasePath(jobRoot).toString(),
               "--network",
-              networkName);
+              networkName,
+              "--log-driver",
+              "none");
       if (!Strings.isNullOrEmpty(entrypoint)) {
         cmd.add("--entrypoint");
         cmd.add(entrypoint);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
@@ -108,6 +108,7 @@ public class DockerProcessFactory implements ProcessFactory {
               "run",
               "--rm",
               "--init",
+              "--log-driver none",
               "-i",
               "-v",
               String.format("%s:%s", workspaceMountSource, DATA_MOUNT_DESTINATION),


### PR DESCRIPTION
Trying to solve part of https://github.com/airbytehq/airbyte/issues/4366

Here's an example of how Docker persists logs for lines emitted.
```
# jrhizor in ~ [22:04:33]
→ docker ps --filter status=exited -q > one

# jrhizor in ~ [22:04:50]
→ docker run --entrypoint echo airbyte/source-googleanalytics-singer:0.2.6 aaajdfaj83uhajhjkfdhs38adkjfhkjdhkj83sdfasdf83hkakfjhkjdhajhjhkjsdj3jhj3hkj3h4k3jh4k3jh4jk3h4jk3hj4k3h4jk3hjkh4kj3hkjh34jhkj3
aaajdfaj83uhajhjkfdhs38adkjfhkjdhkj83sdfasdf83hkakfjhkjdhajhjhkjsdj3jhj3hkj3h4k3jh4k3jh4jk3h4jk3hj4k3h4jk3hjkh4kj3hkjh34jhkj3

# jrhizor in ~ [22:04:53]
→ docker ps --filter status=exited -q > two

# jrhizor in ~ [22:04:57]
→ diff one two
0a1
> 35a8c47d3d9f

# jrhizor in ~ [22:05:00]
→ docker logs 35a8c47d3d9f
aaajdfaj83uhajhjkfdhs38adkjfhkjdhkj83sdfasdf83hkakfjhkjdhajhjhkjsdj3jhj3hkj3h4k3jh4k3jh4jk3h4jk3hj4k3h4jk3hjkh4kj3hkjh34jhkj3

# jrhizor in ~ [22:05:05]
→ docker run --entrypoint echo --log-driver none airbyte/source-googleanalytics-singer:0.2.6 aaajdfaj83uhajhjkfdhs38adkjfhkjdhkj83sdfasdf83hkakfjhkjdhajhjhkjsdj3jhj3hkj3h4k3jh4k3jh4jk3h4jk3hj4k3h4jk3hjkh4kj3hkjh34jhkj3
aaajdfaj83uhajhjkfdhs38adkjfhkjdhkj83sdfasdf83hkakfjhkjdhajhjhkjsdj3jhj3hkj3h4k3jh4k3jh4jk3h4jk3hj4k3h4jk3hjkh4kj3hkjh34jhkj3

# jrhizor in ~ [22:06:26]
→ docker ps --filter status=exited -q > three

# jrhizor in ~ [22:06:34]
→ diff two three
0a1
> fed5a2dd4a07

# jrhizor in ~ [22:06:38]
→ docker logs fed5a2dd4a07
Error response from daemon: configured logging driver does not support reading
```