### PR TITLE
FIx schema for required properties

### DIFF
--- a/docs/contributing-to-airbyte/python/tutorials/cdk-tutorial-python-http/3-define-inputs.md
+++ b/docs/contributing-to-airbyte/python/tutorials/cdk-tutorial-python-http/3-define-inputs.md
@@ -17,7 +17,7 @@ Given that we'll pulling currency data for our example source, we'll define the 
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Python Http Tutorial Spec",
     "type": "object",
-    "required": ["start_date", "currency_base"],
+    "required": ["start_date", "base"],
     "additionalProperties": false,
     "properties": {
       "start_date": {


### PR DESCRIPTION
## What
Example schema in CDK tutorial is incorrect.  It lists "currency_base" as a required property, but the property is called "base" later in the schema.

## How
Fix schema

## Recommended reading order
? - there's one line in one file.

## Pre-merge Checklist
N/A - web site documentation update
