### PR TITLE
📚 Add a tutorial for how to build a java destination 

### DIFF
--- a/airbyte-integrations/connector-templates/destination-java/DestinationAcceptanceTest.java.hbs
+++ b/airbyte-integrations/connector-templates/destination-java/DestinationAcceptanceTest.java.hbs
@@ -44,14 +44,16 @@ public class {{properCase name}}DestinationAcceptanceTest extends DestinationAcc
 
   @Override
   protected JsonNode getConfig() {
-    // TODO: configJson can either be static and read from secrets/config.json
-    // directly, or created in the setup method
+    // TODO: Generate the configuration JSON file to be used for running the destination during the test
+    // configJson can either be static and read from secrets/config.json directly
+    // or created in the setup method
     return configJson;
   }
 
   @Override
   protected JsonNode getFailCheckConfig() {
-    // TODO
+    // TODO return an invalid config which, when used to run the connector's check connection operation,
+    // should result in a failed connection check
     return null;
   }
 
@@ -61,18 +63,20 @@ public class {{properCase name}}DestinationAcceptanceTest extends DestinationAcc
                                            String namespace,
                                            JsonNode streamSchema)
       throws IOException {
-    // TODO
+    // TODO Implement this method to retrieve records which written to the destination by the connector.
+    // Records returned from this method will be compared against records provided to the connector
+    // to verify they were written correctly
     return null;
   }
 
   @Override
   protected void setup(TestDestinationEnv testEnv) {
-    // TODO
+    // TODO Implement this method to run any setup actions needed before every test case
   }
 
   @Override
   protected void tearDown(TestDestinationEnv testEnv) {
-    // TODO
+    // TODO Implement this method to run any cleanup actions needed after every test case
   }
 
 }

--- a/airbyte-integrations/connector-templates/destination-java/README.md.hbs
+++ b/airbyte-integrations/connector-templates/destination-java/README.md.hbs
@@ -12,21 +12,15 @@ From the Airbyte repository root, run:
 ```
 
 #### Create credentials
-**If you are a community contributor**, generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `destination{{snakeCase name}}/spec.json` file.
+**If you are a community contributor**, generate the necessary credentials and place them in `secrets/config.json` conforming to the spec file in `src/main/resources/spec.json`.
 Note that the `secrets` directory is git-ignored by default, so there is no danger of accidentally checking in sensitive information.
-See `integration_tests/sample_config.json` for a sample config file.
 
-**If you are an Airbyte core member**, follow the [instruction](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#using-credentials-in-ci) to set up the credentials.
+**If you are an Airbyte core member**, follow the [instructions](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#using-credentials-in-ci) to set up the credentials.
 
 ### Locally running the connector docker image
 
 #### Build
-First, make sure you build the latest Docker image:
-```
-docker build . -t airbyte/destination-{{dashCase name}}:dev
-```
-
-You can also build the connector image via Gradle:
+Build the connector image via Gradle:
 ```
 ./gradlew :airbyte-integrations:connectors:destination-{{dashCase name}}:airbyteDocker
 ```
@@ -49,7 +43,8 @@ We use `JUnit` for Java tests.
 Place unit and integration test files under `src/test/io/airbyte/integrations/destinations/{{snakeCase name}}`.
 
 #### Acceptance Tests
-Airbyte has a test suite for all connectors. Place acceptance test under `src/test-integration/java/io/airbyte/integrations/destinations/{{snakeCase name}}`.
+Airbyte has a standard test suite that all destination connectors must pass. Implement the `TODO`s in
+`src/test-integration/java/io/airbyte/integrations/destinations/{{snakeCase name}}DestinationAcceptanceTest.java`.
 
 ### Using gradle to run tests
 All commands should be run from airbyte project root.

--- a/airbyte-integrations/connector-templates/generator/generate.sh
+++ b/airbyte-integrations/connector-templates/generator/generate.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env sh
 
 # Remove container if already exist
+echo "Removing previous generator if it exists..."
 docker container rm -f airbyte-connector-bootstrap >/dev/null 2>&1
 
 # Build image for container from Dockerfile
 # Specify the host system user UID and GID to chown the generated files to host system user.
 # This is done because all generated files in container with mounted folders has root owner
+echo "Building generator docker image..."
 docker build --build-arg UID="$(id -u)" --build-arg GID="$(id -g)" . -t airbyte/connector-bootstrap
 
 # Run the container and mount the airbyte folder
@@ -13,10 +15,10 @@ if [ $# -eq 2 ]; then
   echo "2 arguments supplied: 1=$1 2=$2"
   docker run --name airbyte-connector-bootstrap -e package_desc="$1" -e package_name="$2" -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
 else
-  docker run -it --name airbyte-connector-bootstrap -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
+  echo "Running generator..."
+  docker run --rm -it --name airbyte-connector-bootstrap -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
 fi
 
-# Remove container after coping files
-docker container rm -f airbyte-connector-bootstrap >/dev/null 2>&1
+echo "Finished running generator"
 
 exit 0

--- a/airbyte-integrations/connector-templates/generator/plopfile.js
+++ b/airbyte-integrations/connector-templates/generator/plopfile.js
@@ -162,7 +162,7 @@ module.exports = function (plop) {
     });
 
   plop.setGenerator('Java Destination', {
-    description: 'Generate a minimal Java Airbyte Destination Connector that works with any kind of data source. Use this if none of the other templates serve your use case.',
+    description: 'Generate a Java Destination Connector.',
     prompts: [
       {
         type: 'input',

--- a/airbyte-integrations/connector-templates/generator/plopfile.js
+++ b/airbyte-integrations/connector-templates/generator/plopfile.js
@@ -167,7 +167,7 @@ module.exports = function (plop) {
       {
         type: 'input',
         name: 'name',
-        message: 'Destination name, without the "destination-" prefix e.g: "google-analytics"',
+        message: 'Destination name, without the "destination-" prefix e.g: "google-pubsub"',
       },
       {
         type: 'input',

--- a/airbyte-integrations/connector-templates/source-java-jdbc/README.md
+++ b/airbyte-integrations/connector-templates/source-java-jdbc/README.md
@@ -1,14 +1,14 @@
-# Destination {{titleCase name}}
+# Source {{titleCase name}}
 
-This is the repository for the {{titleCase name}} destination connector in Java.
-For information about how to use this connector within Airbyte, see [the User Documentation](https://docs.airbyte.io/integrations/destinations/{{dashCase name}}).
+This is the repository for the {{titleCase name}} source connector in Java.
+For information about how to use this connector within Airbyte, see [the User Documentation](https://docs.airbyte.io/integrations/sources/{{dashCase name}}).
 
 ## Local development
 
 #### Building via Gradle
 From the Airbyte repository root, run:
 ```
-./gradlew :airbyte-integrations:connectors:destination-{{dashCase name}}:build
+./gradlew :airbyte-integrations:connectors:source-{{dashCase name}}:build
 ```
 
 #### Create credentials
@@ -22,7 +22,7 @@ Note that the `secrets` directory is git-ignored by default, so there is no dang
 #### Build
 Build the connector image via Gradle:
 ```
-./gradlew :airbyte-integrations:connectors:destination-{{dashCase name}}:airbyteDocker
+./gradlew :airbyte-integrations:connectors:source-{{dashCase name}}:airbyteDocker
 ```
 When building via Gradle, the docker image name and tag, respectively, are the values of the `io.airbyte.name` and `io.airbyte.version` `LABEL`s in
 the Dockerfile.
@@ -30,31 +30,31 @@ the Dockerfile.
 #### Run
 Then run any of the connector commands as follows:
 ```
-docker run --rm airbyte/destination-{{dashCase name}}:dev spec
-docker run --rm -v $(pwd)/secrets:/secrets airbyte/destination-{{dashCase name}}:dev check --config /secrets/config.json
-docker run --rm -v $(pwd)/secrets:/secrets airbyte/destination-{{dashCase name}}:dev discover --config /secrets/config.json
-docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests airbyte/destination-{{dashCase name}}:dev read --config /secrets/config.json --catalog /integration_tests/configured_catalog.json
+docker run --rm airbyte/source-{{dashCase name}}:dev spec
+docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-{{dashCase name}}:dev check --config /secrets/config.json
+docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-{{dashCase name}}:dev discover --config /secrets/config.json
+docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests airbyte/source-{{dashCase name}}:dev read --config /secrets/config.json --catalog /integration_tests/configured_catalog.json
 ```
 
 ## Testing
 We use `JUnit` for Java tests.
 
 ### Unit and Integration Tests
-Place unit tests under `src/test/io/airbyte/integrations/destinations/{{snakeCase name}}`.
+Place unit tests under `src/test/io/airbyte/integrations/sources/{{snakeCase name}}`.
 
 #### Acceptance Tests
-Airbyte has a standard test suite that all destination connectors must pass. Implement the `TODO`s in
-`src/test-integration/java/io/airbyte/integrations/destinations/{{snakeCase name}}DestinationAcceptanceTest.java`.
+Airbyte has a standard test suite that all source connectors must pass. Implement the `TODO`s in
+`src/test-integration/java/io/airbyte/integrations/sources/{{snakeCase name}}SourceAcceptanceTest.java`.
 
 ### Using gradle to run tests
 All commands should be run from airbyte project root.
 To run unit tests:
 ```
-./gradlew :airbyte-integrations:connectors:destination-{{dashCase name}}:unitTest
+./gradlew :airbyte-integrations:connectors:source-{{dashCase name}}:unitTest
 ```
 To run acceptance and custom integration tests:
 ```
-./gradlew :airbyte-integrations:connectors:destination-{{dashCase name}}:integrationTest
+./gradlew :airbyte-integrations:connectors:source-{{dashCase name}}:integrationTest
 ```
 
 ## Dependency Management

--- a/airbyte-integrations/connectors/source-scaffold-java-jdbc/README.md
+++ b/airbyte-integrations/connectors/source-scaffold-java-jdbc/README.md
@@ -1,0 +1,68 @@
+# Source Scaffold Java Jdbc
+
+This is the repository for the Scaffold Java Jdbc source connector in Java.
+For information about how to use this connector within Airbyte, see [the User Documentation](https://docs.airbyte.io/integrations/sources/scaffold-java-jdbc).
+
+## Local development
+
+#### Building via Gradle
+From the Airbyte repository root, run:
+```
+./gradlew :airbyte-integrations:connectors:source-scaffold-java-jdbc:build
+```
+
+#### Create credentials
+**If you are a community contributor**, generate the necessary credentials and place them in `secrets/config.json` conforming to the spec file in `src/main/resources/spec.json`.
+Note that the `secrets` directory is git-ignored by default, so there is no danger of accidentally checking in sensitive information.
+
+**If you are an Airbyte core member**, follow the [instructions](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#using-credentials-in-ci) to set up the credentials.
+
+### Locally running the connector docker image
+
+#### Build
+Build the connector image via Gradle:
+```
+./gradlew :airbyte-integrations:connectors:source-scaffold-java-jdbc:airbyteDocker
+```
+When building via Gradle, the docker image name and tag, respectively, are the values of the `io.airbyte.name` and `io.airbyte.version` `LABEL`s in
+the Dockerfile.
+
+#### Run
+Then run any of the connector commands as follows:
+```
+docker run --rm airbyte/source-scaffold-java-jdbc:dev spec
+docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-scaffold-java-jdbc:dev check --config /secrets/config.json
+docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-scaffold-java-jdbc:dev discover --config /secrets/config.json
+docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests airbyte/source-scaffold-java-jdbc:dev read --config /secrets/config.json --catalog /integration_tests/configured_catalog.json
+```
+
+## Testing
+We use `JUnit` for Java tests.
+
+### Unit and Integration Tests
+Place unit tests under `src/test/io/airbyte/integrations/sources/scaffold_java_jdbc`.
+
+#### Acceptance Tests
+Airbyte has a standard test suite that all source connectors must pass. Implement the `TODO`s in
+`src/test-integration/java/io/airbyte/integrations/sources/scaffold_java_jdbcSourceAcceptanceTest.java`.
+
+### Using gradle to run tests
+All commands should be run from airbyte project root.
+To run unit tests:
+```
+./gradlew :airbyte-integrations:connectors:source-scaffold-java-jdbc:unitTest
+```
+To run acceptance and custom integration tests:
+```
+./gradlew :airbyte-integrations:connectors:source-scaffold-java-jdbc:integrationTest
+```
+
+## Dependency Management
+
+### Publishing a new version of the connector
+You've checked out the repo, implemented a million dollar feature, and you're ready to share your changes with the world. Now what?
+1. Make sure your changes are passing unit and integration tests.
+1. Bump the connector version in `Dockerfile` -- just increment the value of the `LABEL io.airbyte.version` appropriately (we use [SemVer](https://semver.org/)).
+1. Create a Pull Request.
+1. Pat yourself on the back for being an awesome contributor.
+1. Someone from Airbyte will take a look at your PR and iterate with you to merge it into master.

--- a/docs/contributing-to-airbyte/building-new-connector/README.md
+++ b/docs/contributing-to-airbyte/building-new-connector/README.md
@@ -8,7 +8,7 @@ To build a new connector in Java or Python, we provide templates so you don't ne
 
 ## Connector-Development Kit (CDK)
 
-You can build a source connector very quickly with the [Airbyte CDK](../python/README.md), which generates 75% of the code required for you. Currently, creating destinations isn't supported, but it will be soon.
+You can build a source connector very quickly with the [Airbyte CDK](../python/README.md), which generates 75% of the code required for you. The CDK does not currently support creating destinations, but it will soon.
 
 
 ## The Airbyte specification
@@ -34,6 +34,7 @@ If you are building a connector in any of the following languages/frameworks, th
 
 * **Python Source Connector**
 * [**Singer**](https://singer.io)**-based Python Source Connector**. [Singer.io](https://singer.io/) is an open source framework with a large community and many available connectors \(known as taps & targets\). To build an Airbyte connector from a Singer tap, wrap the tap in a thin Python package to make it Airbyte Protocol-compatible. See the [Github Connector](https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors/source-github-singer) for an example of an Airbyte Connector implemented on top of a Singer tap.
+
 * **Java Destination Connector**
 * **Generic Connector**: This template provides a basic starting point for any language.
 
@@ -48,9 +49,12 @@ cd airbyte-integrations/connector-templates/generator
 
 and choose the relevant template. This will generate a new connector in the `airbyte-integrations/connectors/<your-connector>` directory.
 
-Search the generated directory for "TODO"s and follow them to implement your connector.
+Search the generated directory for "TODO"s and follow them to implement your connector. For more detailed walkthroughs and instructions, follow the relevant tutorial:
 
-If you are developing a Python connector, you may find the [building a Python connector tutorial](../tutorials/building-a-python-source.md) helpful.
+* [Building a Python source connector tutorial](../tutorials/building-a-python-source.md) 
+* [Building a Java destination connector tutorial](../tutorials/building-a-java-destination.md) 
+
+As you implement your connector, make sure to review the [Best Practices for Connector Development](best-practices.md) guide. Following best practices is not a requirement for merging your contribution to Airbyte, but it certainly doesn't hurt ;\)
 
 ### 2. Integration tests
 
@@ -73,11 +77,7 @@ When you submit a PR to Airbyte with your connector, the reviewer will use the c
 2. `:airbyte-integrations:connectors:source-<name>:integrationTest` should run integration tests including Airbyte's Standard test suite.
 
 ### 4. Publish the connector
-Typically this will be handled as part of code review by an Airbyter. There is a section below on what steps are needed for publishing a connector. 
-
-### Best practices
-
-Make sure to review the [Best Practices for Connector Development](best-practices.md) guide. Following best practices is **not** a requirement for merging your contribution to Airbyte, but it certainly doesn't hurt ;\)
+Typically this will be handled as part of code review by an Airbyter. There is a section below on what steps are needed for publishing a connector and will mostly be used by Airbyte employees publishing the connector. 
 
 ## Updating an existing connector
 The steps for updating an existing connector are the same as for building a new connector minus the need to use the autogenerator to create a new connector. Therefore the steps are: 
@@ -102,12 +102,12 @@ Once you've finished iterating on the changes to a connector as specified in its
 
    ```text
    # to run integration tests for the connector
-   /test connector=(connectors|bases)/<connector_name> 
    # Example: /test connector=connectors/source-hubspot
+   /test connector=(connectors|bases)/<connector_name> 
 
    # to run integration tests and publish the connector
-   /publish connector=(connectors|bases)/<connector_name>
    # Example: /publish connector=connectors/source-hubspot
+   /publish connector=(connectors|bases)/<connector_name>
    ```
 
 6. The new version of the connector is now available for everyone who uses it. Thank you!

--- a/docs/contributing-to-airbyte/tutorials/building-a-java-destination.md
+++ b/docs/contributing-to-airbyte/tutorials/building-a-java-destination.md
@@ -76,7 +76,7 @@ This will build the code and run any unit tests. This approach is great when you
 
 **TDD using acceptance tests & integration tests**
 
-Airbyte provides a standard test suite (dubbed "Acceptance Tests") that is run against every destination. The objective of these tests is to provide some "free" baseline tests that ensure that the basic functionality of the destination works. One approach to developing your connector is to simply run the tests between each change and use the feedback from them to guide your development.
+Airbyte provides a standard test suite (dubbed "Acceptance Tests") that runs against every destination. They are "free" baseline tests to ensure the basic functionality of the destination. When developing a connector, you can simply run the tests between each change and use the feedback to guide your development.
 
 If you want to try out this approach, check out Step 6 which describes what you need to do to set up the acceptance Tests for your destination.
 
@@ -109,7 +109,7 @@ The nice thing about this approach is that you are running your destination exac
 
 Each destination contains a specification written in JsonSchema that describes its inputs. Defining the specification is a good place to start when developing your destination. Check out the documentation [here](https://json-schema.org/) to learn the syntax. Here's [an example](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-postgres/src/main/resources/spec.json) of what the `spec.json` looks like for the postgres destination.
 
-Your generated template should have the spec file in `airbyte-integrations/connectors/destination-<name>/src/main/resources/spec.json`. Edit it and you should be done with this step. 
+Your generated template should have the spec file in `airbyte-integrations/connectors/destination-<name>/src/main/resources/spec.json`. The generated connector will take care of reading this file and converting it to the correct output. Edit it and you should be done with this step. 
 
 For more details on what the spec is, you can read about the Airbyte Protocol [here](../../understanding-airbyte/airbyte-specification.md).
 

--- a/docs/contributing-to-airbyte/tutorials/building-a-java-destination.md
+++ b/docs/contributing-to-airbyte/tutorials/building-a-java-destination.md
@@ -61,9 +61,9 @@ this compiles the java code for your destination and builds a Docker image with 
 
 We recommend the following ways of iterating on your connector as you're making changes:
 
-1. Test-driven development in Java 
-2. Test-driven development using Airbyte's Acceptance Tests
-3. Directly running the docker image 
+* Test-driven development (TDD) in Java 
+* Test-driven development (TDD) using Airbyte's Acceptance Tests
+* Directly running the docker image 
 
 **Test-driven development in Java**
 This should feel like a standard flow for a Java developer: you make some code changes then run java tests against them. You can do this directly in your IDE, but you can also run all unit tests via Gradle by running the command to build the connector: 
@@ -76,11 +76,11 @@ This will build the code and run any unit tests. This approach is great when you
 
 **TDD using acceptance tests & integration tests**
 
-Airbyte provides a standard test suite (dubbed "Acceptance Tests") that is run against every destination. The objective of these tests is to provide some "free" baseline tests that ensure that the basic functionality of the destination works. One approach to developing your connector is to simply run the tests between each change and use the feedback from them to guide your development.
+Airbyte provides a standard test suite (dubbed "Destination Acceptance Tests") that is run against every Airbyte destination connector. The objective of these tests is to provide some "free" baseline tests that ensure that the basic functionality of the destination works. One approach to developing your connector is to simply run the tests between each change and use the feedback from them to guide your development.
 
 If you want to try out this approach, check out Step 6 which describes what you need to do to set up the acceptance Tests for your destination.
 
-The nice thing about this approach is that you are running your destination exactly as Airbyte will run it in the CI. The downside is that the tests do not run very quickly. As such, we recommend this iteration approach only once you've implemented most of your connector and are in the finishing stages of implementation. 
+The nice thing about this approach is that you are running your destination exactly as Airbyte will run it in the CI. The downside is that the tests do not run very quickly. As such, we recommend this iteration approach only once you've implemented most of your connector and are in the finishing stages of implementation. Note that Acceptance Tests are required for every connector supported by Airbyte, so you should make sure to run them a couple of times while iterating to make sure your connector is compatible with Airbyte. 
 
 **Directly running the destination using Docker**
 
@@ -112,10 +112,6 @@ Each destination contains a specification that describes what inputs it needs in
 Your generated template should have the spec file in `airbyte-integrations/connectors/destination-<name>/src/main/resources/spec.json`. Edit it and you should be done with this step. 
 
 For more details on what the spec is, you can read about the Airbyte Protocol [here](../../understanding-airbyte/airbyte-specification.md).
-
-{% hint style="info" %}
-The generated code implements the `spec` method for you. As long as there's a file called `spec.json` in the directory mentioned above, the generated connector will take care of reading it and converting 
-{% endhint %}
 
 See the `spec` operation in action:  
 ```bash
@@ -149,9 +145,14 @@ The `write` operation is the main workhorse of a destination connector: it reads
 
 To implement the `write` Airbyte operation, implement the `getConsumer` method in your generated `<Name>Destination.java` file. Here are some example implementations from different destination conectors:
  
-* [BigQuery](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java#L188) 
+* [BigQuery](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java#L188)
+* [Google Pubsub](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-pubsub/src/main/java/io/airbyte/integrations/destination/pubsub/PubsubDestination.java#L98) 
 * [Local CSV](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java#L90)
-* [Google Pubsub](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-pubsub/src/main/java/io/airbyte/integrations/destination/pubsub/PubsubDestination.java#L98)
+* [Postgres](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-postgres/src/main/java/io/airbyte/integrations/destination/postgres/PostgresDestination.java)
+
+{% hint style="info" %}
+The Postgres destination leverages the `AbstractJdbcDestination` superclass which makes it extremely easy to create a destination for a database or data warehouse if it has a compatible JDBC driver. If the destination you are implementing has a JDBC driver, be sure to check out `AbstractJdbcDestination`. 
+{% endhint %}
 
 For a brief overview on the Airbyte catalog check out [the Beginner's Guide to the Airbyte Catalog](beginners-guide-to-catalog.md).
 
@@ -168,8 +169,6 @@ The Acceptance Tests are meant to cover the basic functionality of a destination
 #### Step 8: Update the docs
 
 Each connector has its own documentation page. By convention, that page should have the following path: in `docs/integrations/destinations/<destination-name>.md`. For the documentation to get packaged with the docs, make sure to add a link to it in `docs/SUMMARY.md`. You can pattern match doing that from existing connectors.
-
-
 
 ## Wrapping up
 Well done on making it this far! If you'd like your connector to ship with Airbyte by default, create a PR against the Airbyte repo and we'll work with you to get it across the finish line.  

--- a/docs/contributing-to-airbyte/tutorials/building-a-java-destination.md
+++ b/docs/contributing-to-airbyte/tutorials/building-a-java-destination.md
@@ -107,7 +107,7 @@ The nice thing about this approach is that you are running your destination exac
 
 ### Step 3: Implement `spec`
 
-Each destination contains a specification that describes what inputs it needs in order to run. Defining the specification is a good place to start when developing your destination. The easiest way is to use [JsonSchema](https://json-schema.org/) to define what the inputs are \(e.g. username and password\). Here's [an example](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-postgres/src/main/resources/spec.json) of what the `spec.json` looks like for the postgres destination.
+Each destination contains a specification written in JsonSchema that describes its inputs. Defining the specification is a good place to start when developing your destination. Check out the documentation [here](https://json-schema.org/) to learn the syntax. Here's [an example](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-postgres/src/main/resources/spec.json) of what the `spec.json` looks like for the postgres destination.
 
 Your generated template should have the spec file in `airbyte-integrations/connectors/destination-<name>/src/main/resources/spec.json`. Edit it and you should be done with this step. 
 

--- a/docs/contributing-to-airbyte/tutorials/building-a-java-destination.md
+++ b/docs/contributing-to-airbyte/tutorials/building-a-java-destination.md
@@ -1,0 +1,160 @@
+# Building a Java Destination
+
+## Summary
+
+This article provides a checklist for how to create a Java destination. Each step in the checklist has a link to a more detailed explanation below.
+
+## Requirements
+
+Docker and Java with the versions listed in the [tech stack section](../../understanding-airbyte/tech-stack.md).
+
+## Checklist
+
+### Creating a destination
+
+* Step 1: Create the destination using the template generator
+* Step 2: Build the newly generated destination 
+* Step 3: Implement `spec` to define the configuration required to run the connector
+* Step 4: Implement `check` to provide a way to validate configurations provided to the connector
+* Step 5: Implement `write` to write data to the destination
+* Step 6: Set up Acceptance Tests
+* Step 7: Write unit tests or integration tests
+* Step 8: Update the docs \(in `docs/integrations/destinations/<destination-name>.md`\)
+
+{% hint style="info" %}
+All `./gradlew` commands must be run from the root of the airbyte project.
+{% endhint %}
+
+{% hint style="info" %}
+If you need help with any step of the process, feel free to submit a PR with your progress and any questions you have, or ask us on [slack](https://slack.airbyte.io).
+{% endhint %}
+
+## Explaining Each Step
+
+### Step 1: Create the destination using the template
+
+Airbyte provides a code generator which bootstraps the scaffolding for our connector.
+
+```bash
+$ cd airbyte-integrations/connector-templates/generator # assumes you are starting from the root of the Airbyte project.
+$ ./generate.sh
+```
+
+Select the `Java Destination` template and then input the name of your connector. We'll refer to the destination as `<name>-destination` in this tutorial, but you should replace `<name>` with the actual name you used for your connector e.g: `BigQueryDestination` or `bigquery-destination`. 
+
+### Step 2: Build the newly generated destination
+
+You can build the destination by running:
+
+```bash
+# Must be run from the Airbyte project root
+./gradlew :airbyte-integrations:connectors:destination-<name>:build
+```
+
+this compiles the java code for your destination and builds a Docker image with the connector. At this point, we haven't implemented anything of value yet, but once we do, you'll use this command to compile your code and Docker image. 
+
+{% hint style="info" %}
+    Airbyte uses Gradle to manage Java dependencies. To add dependencies for your connector, manage them in the `build.gradle` file inside your connector's directory.   
+{% endhint %}
+
+#### Iterating on your implementation
+
+We recommend the following ways of iterating on your connector as you're making changes:
+
+1. Test-driven development in Java 
+2. Test-driven development using Airbyte's Acceptance Tests
+3. Directly running the docker image 
+
+**Test-driven development in Java**
+This should feel like a standard flow for a Java developer: you make some code changes then run java tests against them. You can do this directly in your IDE, but you can also run all unit tests via Gradle by running the command to build the connector: 
+
+```
+./gradlew :airbyte-integrations:connectors:destination-<name>:build
+```
+
+This will build the code and run any unit tests. This approach is great when you are testing local behaviors and writing unit tests. 
+
+**TDD using acceptance tests & integration tests**
+
+Airbyte provides a standard test suite (dubbed "Acceptance Tests") that is run against every destination. The objective of these tests is to provide some "free" baseline tests that ensure that the basic functionality of the destination works. One approach to developing your connector is to simply run the tests between each change and use the feedback from them to guide your development.
+
+If you want to try out this approach, check out Step 6 which describes what you need to do to set up the acceptance Tests for your destination.
+
+The nice thing about this approach is that you are running your destination exactly as Airbyte will run it in the CI. The downside is that the tests do not run very quickly. As such, we recommend this iteration approach only once you've implemented most of your connector and are in the finishing stages of implementation. 
+
+**Directly running the destination using Docker**
+
+If you want to run your destination exactly as it will be run by Airbyte \(i.e. within a docker container\), you can use the following commands from the connector module directory \(`airbyte-integrations/connectors/destination-<name>`\):
+
+```text
+# First build the container
+docker build . -t airbyte/destination-<name>:dev
+
+# Then use the following commands to run it
+# Runs the "spec" command, used to find out what configurations are needed to run a connector 
+docker run --rm airbyte/destination-<name>:dev spec
+
+# Runs the "check" command, used to validate if the input configurations are valid
+docker run --rm -v $(pwd)/secrets:/secrets airbyte/destination-<name>:dev check --config /secrets/config.json
+
+# Runs the "write" command which reads records from stdin and writes them to the underlying destination
+docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/sample_files:/sample_files airbyte/destination-<name>:dev write --config /secrets/config.json --catalog /sample_files/configured_catalog.json
+```
+
+Note: Each time you make a change to your implementation you need to re-build the connector image via `docker build . -t airbyte/destination-<name>:dev`.
+
+The nice thing about this approach is that you are running your destination exactly as it will be run by Airbyte. The tradeoff is that iteration is slightly slower, because you need to re-build the connector between each change.
+
+### Step 3: Implement `spec`
+
+Each destination contains a specification that describes what inputs it needs in order to run. Defining the specification is a good place to start when developing your destination. The easiest way is to use [JsonSchema](https://json-schema.org/) to define what the inputs are \(e.g. username and password\). Here's [an example](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-postgres/src/main/resources/spec.json) of what the `spec.json` looks like for the postgres destination.
+
+Your generated template should have the spec file in `airbyte-integrations/connectors/destination-<name>/src/main/resources/spec.json`. Edit it and you should be done with this step. 
+
+For more details on what the spec is, you can read about the Airbyte Protocol [here](../../understanding-airbyte/airbyte-specification.md).
+
+{% hint style="info" %}
+The generated code implements the `spec` method for you. As long as there's a file called `spec.json` in the directory mentioned above, the generated connector will take care of reading it and converting 
+{% endhint %}
+
+See the `spec` operation in action:  
+```bash
+# First build the connector 
+docker build . -t airbyte/destination-<name>:dev
+
+# Run the spec operation
+docker run --rm airbyte/destination-<name>:dev spec
+```
+
+### Step 4: Implement `check`
+
+The check operation accepts a JSON object conforming to the `spec.json`. In other words if the `spec.json` said that the destination requires a `username` and `password` the config object might be `{ "username": "airbyte", "password": "password123" }`. It returns a json object that reports, given the credentials in the config, whether we were able to connect to the destination. 
+
+While developing, we recommend storing any credentials in `secrets/config.json`. Any `secrets` directory in the Airbyte repo is gitignored by default.
+
+Implement the `check` method in the generated file `<Name>Destination.java`. Here's an [example implementation](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java#L94) from the BigQuery destination.  
+
+### Step 5: Implement `write`
+The `write` operation is the main workhorse of a destination connector: it reads input data from the source and writes it to the underlying destination. It takes as input the config file used to run the connector as well as the configured catalog: the file used to describe the schema of the incoming data and how it should be written to the destination. 
+
+To implement the `write` Airbyte operation, implement the `getConsumer` method in your generated `<Name>Destination.java` file. Here are some example implementations from different destination conectors:
+ 
+* [BigQuery](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java#L188) 
+* [Local CSV](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-csv/src/main/java/io/airbyte/integrations/destination/csv/CsvDestination.java#L90)
+* [Google Pubsub](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-pubsub/src/main/java/io/airbyte/integrations/destination/pubsub/PubsubDestination.java#L98)
+
+For a brief overview on the Airbyte catalog check out [the Beginner's Guide to the Airbyte Catalog](beginners-guide-to-catalog.md).
+
+### Step 6: Set up Acceptance Tests
+
+The Acceptance Tests are a set of tests that run against all destinations. These tests are run in the Airbyte CI to prevent regressions and verify a baseline of functionality. The test cases are contained and documented in the [following file](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java).
+
+To setup acceptance Tests for your connector, follow the `TODO`s in the generated file `<name>DestinationAcceptanceTest.java`. Once setup, you can run the tests using `./gradlew :airbyte-integrations:connectors:destination-<name>:integrationTest`. Make sure to run this command from the Airbyte repository root.
+
+### Step 7: Write unit tests and/or integration tests
+The Acceptance Tests are meant to cover the basic functionality of a destination. Think of it as the bare minimum required for us to add a destination to Airbyte. You should probably add some unit testing or custom integration testing in case you need to test additional functionality of your destination.
+
+#### Step 8: Update the docs
+
+Each connector has its own documentation page. By convention, that page should have the following path: in `docs/integrations/destinations/<destination-name>.md`. For the documentation to get packaged with the docs, make sure to add a link to it in `docs/SUMMARY.md`. You can pattern match doing that from existing connectors.
+

--- a/docs/contributing-to-airbyte/tutorials/building-a-java-destination.md
+++ b/docs/contributing-to-airbyte/tutorials/building-a-java-destination.md
@@ -169,3 +169,7 @@ The Acceptance Tests are meant to cover the basic functionality of a destination
 
 Each connector has its own documentation page. By convention, that page should have the following path: in `docs/integrations/destinations/<destination-name>.md`. For the documentation to get packaged with the docs, make sure to add a link to it in `docs/SUMMARY.md`. You can pattern match doing that from existing connectors.
 
+
+
+## Wrapping up
+Well done on making it this far! If you'd like your connector to ship with Airbyte by default, create a PR against the Airbyte repo and we'll work with you to get it across the finish line.  

--- a/docs/contributing-to-airbyte/tutorials/building-a-java-destination.md
+++ b/docs/contributing-to-airbyte/tutorials/building-a-java-destination.md
@@ -88,7 +88,7 @@ If you want to run your destination exactly as it will be run by Airbyte \(i.e. 
 
 ```text
 # First build the container
-docker build . -t airbyte/destination-<name>:dev
+./gradlew :airbyte-integrations:connectors:destination-<name>:build
 
 # Then use the following commands to run it
 # Runs the "spec" command, used to find out what configurations are needed to run a connector 
@@ -101,7 +101,7 @@ docker run --rm -v $(pwd)/secrets:/secrets airbyte/destination-<name>:dev check 
 docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/sample_files:/sample_files airbyte/destination-<name>:dev write --config /secrets/config.json --catalog /sample_files/configured_catalog.json
 ```
 
-Note: Each time you make a change to your implementation you need to re-build the connector image via `docker build . -t airbyte/destination-<name>:dev`.
+Note: Each time you make a change to your implementation you need to re-build the connector image via `./gradlew :airbyte-integrations:connectors:destination-<name>:build`.
 
 The nice thing about this approach is that you are running your destination exactly as it will be run by Airbyte. The tradeoff is that iteration is slightly slower, because you need to re-build the connector between each change.
 
@@ -120,7 +120,7 @@ The generated code implements the `spec` method for you. As long as there's a fi
 See the `spec` operation in action:  
 ```bash
 # First build the connector 
-docker build . -t airbyte/destination-<name>:dev
+./gradlew :airbyte-integrations:connectors:destination-<name>:build
 
 # Run the spec operation
 docker run --rm airbyte/destination-<name>:dev spec
@@ -134,6 +134,16 @@ While developing, we recommend storing any credentials in `secrets/config.json`.
 
 Implement the `check` method in the generated file `<Name>Destination.java`. Here's an [example implementation](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java#L94) from the BigQuery destination.  
 
+Verify that the method is working by placing your config in `secrets/config.json` then running: 
+
+```
+# First build the connector
+./gradlew :airbyte-integrations:connectors:destination-<name>:build
+
+# Run the check method
+docker run -v $(pwd)/secrets:/secrets --rm airbyte/destination-<name>:dev check --config /secrets/config.json
+```
+
 ### Step 5: Implement `write`
 The `write` operation is the main workhorse of a destination connector: it reads input data from the source and writes it to the underlying destination. It takes as input the config file used to run the connector as well as the configured catalog: the file used to describe the schema of the incoming data and how it should be written to the destination. 
 
@@ -144,6 +154,7 @@ To implement the `write` Airbyte operation, implement the `getConsumer` method i
 * [Google Pubsub](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-pubsub/src/main/java/io/airbyte/integrations/destination/pubsub/PubsubDestination.java#L98)
 
 For a brief overview on the Airbyte catalog check out [the Beginner's Guide to the Airbyte Catalog](beginners-guide-to-catalog.md).
+
 
 ### Step 6: Set up Acceptance Tests
 


### PR DESCRIPTION
## What
1. Adds a tutorial for how to create a new java destination connector
3. Various other drive-by improvements for documentation & templates


## Recommended reading order
1. `building-a-java-destination.md`
2. `building-new-connector/README.md`
3. the rest 

