### PR TITLE
Fix broken links in docs.

### DIFF
--- a/docs/contributing-to-airbyte/python/tutorials/cdk-tutorial-python-http/1-creating-the-source.md
+++ b/docs/contributing-to-airbyte/python/tutorials/cdk-tutorial-python-http/1-creating-the-source.md
@@ -10,5 +10,5 @@ $ ./generate.sh
 
 Select the `Python HTTP API Source` template and then input the name of your connector. For this walk-through we will refer to our source as `python-http-example`. The finalized source code for this tutorial can be found [here](https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors/source-python-http-tutorial).
 
-The source we will build in this tutorial will pull data from the [Rates API](https://ratesapi.io/), a free and open API which documents historical exchange rates for fiat currencies.
+The source we will build in this tutorial will pull data from the [Rates API](https://exchangeratesapi.io/), a free and open API which documents historical exchange rates for fiat currencies.
 

--- a/docs/contributing-to-airbyte/python/tutorials/cdk-tutorial-python-http/8-test-your-connector.md
+++ b/docs/contributing-to-airbyte/python/tutorials/cdk-tutorial-python-http/8-test-your-connector.md
@@ -8,7 +8,7 @@ You can run the tests using `python -m pytest -s unit_tests`
 
 ## Integration Tests
 
-Place any integration tests in the `integration_tests` directory such that they can be [discovered by pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html).
+Place any integration tests in the `integration_tests` directory such that they can be [discovered by pytest](https://docs.pytest.org/en/6.2.x/goodpractices.html#conventions-for-python-test-discovery).
 
 ## Standard Tests
 

--- a/docs/contributing-to-airbyte/tutorials/building-a-python-source.md
+++ b/docs/contributing-to-airbyte/tutorials/building-a-python-source.md
@@ -191,7 +191,7 @@ You can run the tests using `python -m pytest -s unit_tests`
 
 #### Integration Tests
 
-Place any integration tests in the `integration_tests` directory such that they can be [discovered by pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html).
+Place any integration tests in the `integration_tests` directory such that they can be [discovered by pytest](https://docs.pytest.org/en/6.2.x/goodpractices.html#conventions-for-python-test-discovery).
 
 Run integration tests using `python -m pytest -s integration_tests`.
 

--- a/docs/deploying-airbyte/local-deployment.md
+++ b/docs/deploying-airbyte/local-deployment.md
@@ -45,4 +45,4 @@ If you can successfully run Airbyte using a MacBook with the M1 chip, let us kno
 
 **Other issues**
 
-If you encounter any issues, just connect to our [Slack](https://slack.airbyte.io). Our community will help! We also have a [FAQ](../troubleshooting/on-deploy.md) section in our docs for common problems.
+If you encounter any issues, just connect to our [Slack](https://slack.airbyte.io). Our community will help! We also have a [troubleshooting](../troubleshooting/on-deploying.md) section in our docs for common problems.

--- a/docs/deploying-airbyte/on-aws-ec2.md
+++ b/docs/deploying-airbyte/on-aws-ec2.md
@@ -125,5 +125,5 @@ ssh -i $SSH_KEY -L 8000:localhost:8000 -N -f ec2-user@$INSTANCE_IP
 
 ## Troubleshooting
 
-If you encounter any issues, just connect to our [Slack](https://slack.airbyte.io). Our community will help! We also have a [FAQ](../troubleshooting/on-deploy.md) section in our docs for common problems.
+If you encounter any issues, just connect to our [Slack](https://slack.airbyte.io). Our community will help! We also have a [FAQ](../troubleshooting/on-deploying.md) section in our docs for common problems.
 

--- a/docs/deploying-airbyte/on-azure-vm-cloud-shell.md
+++ b/docs/deploying-airbyte/on-azure-vm-cloud-shell.md
@@ -134,5 +134,5 @@ This part assumes that you have access to a terminal on your workstation
 
 ## Troubleshooting
 
-If you encounter any issues, just connect to our [Slack](https://slack.airbyte.io). Our community will help! We also have a [FAQ](../troubleshooting/on-deploy.md) section in our docs for common problems.
+If you encounter any issues, just connect to our [Slack](https://slack.airbyte.io). Our community will help! We also have a [FAQ](../troubleshooting/on-deploying.md) section in our docs for common problems.
 

--- a/docs/deploying-airbyte/on-gcp-compute-engine.md
+++ b/docs/deploying-airbyte/on-gcp-compute-engine.md
@@ -131,5 +131,5 @@ gcloud --project=$PROJECT_ID beta compute ssh airbyte -- -L 8000:localhost:8000 
 
 ## Troubleshooting
 
-If you encounter any issues, just connect to our [Slack](https://slack.airbyte.io). Our community will help! We also have a [FAQ](../troubleshooting/on-deploy.md) section in our docs for common problems.
+If you encounter any issues, just connect to our [Slack](https://slack.airbyte.io). Our community will help! We also have a [FAQ](../troubleshooting/on-deploying.md) section in our docs for common problems.
 

--- a/docs/project-overview/roadmap.md
+++ b/docs/project-overview/roadmap.md
@@ -26,6 +26,7 @@ We understand that we're not "production-ready" for a lot of companies yet. In t
 * OAuth support for connector configuration \([\#768](https://github.com/airbytehq/airbyte/issues/768)\).
 * Adapt automatically to sources' schema changes.
 * Webhook connector.
+* Airbyte Cloud Beta.
 
 Our goal is to become "production-ready" for any company whatever their data stack, infrastructure, architecture, data volume, and connector needs. **If you see anything missing in this list that you would need before deploying us in prod, please talk to us via** [**Slack**](https://slack.airbyte.io) **or** [**email**](mailto:contact@airbyte.io)**!**
 

--- a/docs/understanding-airbyte/basic-normalization.md
+++ b/docs/understanding-airbyte/basic-normalization.md
@@ -275,5 +275,6 @@ To enable basic normalization (which is optional), you can toggle it on or disab
 
 Note that all the choices made by Normalization as described in this documentation page in terms of naming could be overridden by your own custom choices. To do so, you can follow the following tutorials:
 
-* to build a [custom SQL view](../tutorials/transformation-and-normalization/transformations-with-sql.md) with your own naming conventions
-* to export, edit and run [custom dbt normalization](../tutorials/transformation-and-normalization/transformations-with-dbt.md) yourself
+* to build a [custom SQL view](../operator-guides/transformation-and-normalization/transformations-with-sql.md) with your own naming conventions
+* to export, edit and run [custom dbt normalization](../operator-guides/transformation-and-normalization/transformations-with-dbt.md) yourself
+* or further, you can configure the use of a custom dbt project within Airbyte by following [this guide](../operator-guides/transformation-and-normalization/transformations-with-airbyte.md).


### PR DESCRIPTION
## Main Changes
Fixes a bunch of broken links, including the following:
1. Exchange Rates API
2. Pytest naming conventions
3. Normalization docs
4. Troubleshooting

## Misc Changes
- Adds note about custom dbt transformations in basic normalization doc
- Add note about Airbyte Cloud in roadmap