### PR TITLE
Add missing Sources and Destinations to Catalog Table.

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -13,17 +13,21 @@ Airbyte uses a grading system for connectors to help users understand what to ex
 | Connector | Grade |
 |----|----|
 |[Amazon Seller Partner](./sources/amazon-seller-partner.md)| Alpha |
+|[Amplitude](./sources/amplitude.md)| Beta |
 |[Appstore](./sources/appstore.md)| Alpha |
 |[Asana](./sources/asana.md) | Beta |
+|[AWS CloudTrail](./sources/aws-cloudtrail.md)| Beta |
 |[Braintree](./sources/braintree.md)| Alpha |
 |[ClickHouse](./sources/clickhouse.md)| Beta |
+|[Db2](./sources/db2.md)| Beta |
 |[Drift](./sources/drift.md)| Beta |
 |[Exchange Rates API](./sources/exchangeratesapi.md)| Certified |
-|[Facebook Marketing](./sources/facebook-marketing.md)| Beta |
+|[Facebook Marketing](./sources/facebook-marketing.md)| Certified |
 |[Files](./sources/file.md)| Certified |
 |[Freshdesk](./sources/freshdesk.md)| Certified |
 |[GitHub](./sources/github.md)| Beta |
 |[GitLab](./sources/gitlab.md)| Beta |
+|[Google Ads](./sources/google-ads.md)| Beta |
 |[Google Adwords](./sources/google-adwords.md)| Beta |
 |[Google Analytics](./sources/googleanalytics.md)| Beta |
 |[Google Directory](./sources/google-directory.md)| Certified |
@@ -33,13 +37,12 @@ Airbyte uses a grading system for connectors to help users understand what to ex
 |[Greenhouse](./sources/greenhouse.md)| Beta |
 |[HTTP Request](./sources/http-request.md)| Alpha |
 |[Hubspot](./sources/hubspot.md)| Certified |
-|[IBM Db2](./sources/db2.md)| Beta |
 |[Instagram](./sources/instagram.md)| Certified |
 |[Intercom](./sources/intercom.md)| Beta |
 |[Iterable](./sources/iterable.md)| Beta |
 |[Jira](./sources/jira.md)| Certified |
-|[Klaviyo](./sources/klaviyo.md)| Beta |
 |[Looker](./sources/looker.md)| Beta |
+|[Klaviyo](./sources/klaviyo.md)| Beta |
 |[Mailchimp](./sources/mailchimp.md)| Certified |
 |[Marketo](./sources/marketo.md)| Certified |
 |[Microsoft SQL Server \(MSSQL\)](./sources/mssql.md)| Certified |
@@ -52,6 +55,7 @@ Airbyte uses a grading system for connectors to help users understand what to ex
 |[Plaid](./sources/plaid.md)| Alpha |
 |[PokéAPI](./sources/pokeapi.md)| Beta |
 |[Postgres](./sources/postgres.md)| Certified |
+|[PostHog](./sources/posthog.md)| Certified |
 |[Quickbooks](./sources/quickbooks.md)| Beta |
 |[Recharge](./sources/recharge.md)| Beta |
 |[Recurly](./sources/recurly.md)| Beta |
@@ -62,6 +66,7 @@ Airbyte uses a grading system for connectors to help users understand what to ex
 |[Slack](./sources/slack.md)| Beta |
 |[Smartsheets](./sources/smartsheets.md)| Beta |
 |[Stripe](./sources/stripe.md)| Certified |
+|[Tempo](./sources/tempo.md)| Beta |
 |[Twilio](./sources/twilio.md)| Beta |
 |[Zendesk Chat](./sources/zendesk-chat.md)| Certified |
 |[Zendesk Support](./sources/zendesk-support.md)| Certified |
@@ -80,5 +85,6 @@ Airbyte uses a grading system for connectors to help users understand what to ex
 |[Oracle](./destinations/oracle.md)| Alpha |
 |[Postgres](./destinations/postgres.md)| Certified |
 |[Redshift](./destinations/redshift.md)| Certified |
+|[S3](./destinations/s3.md)| Certified |
 |[SQL Server (MSSQL)](./destinations/mssql.md)| Alpha |
 |[Snowflake](./destinations/snowflake.md)| Certified |

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -22,7 +22,7 @@ Airbyte uses a grading system for connectors to help users understand what to ex
 |[Db2](./sources/db2.md)| Beta |
 |[Drift](./sources/drift.md)| Beta |
 |[Exchange Rates API](./sources/exchangeratesapi.md)| Certified |
-|[Facebook Marketing](./sources/facebook-marketing.md)| Certified |
+|[Facebook Marketing](./sources/facebook-marketing.md)| Beta |
 |[Files](./sources/file.md)| Certified |
 |[Freshdesk](./sources/freshdesk.md)| Certified |
 |[GitHub](./sources/github.md)| Beta |
@@ -55,7 +55,7 @@ Airbyte uses a grading system for connectors to help users understand what to ex
 |[Plaid](./sources/plaid.md)| Alpha |
 |[PokéAPI](./sources/pokeapi.md)| Beta |
 |[Postgres](./sources/postgres.md)| Certified |
-|[PostHog](./sources/posthog.md)| Certified |
+|[PostHog](./sources/posthog.md)| Beta |
 |[Quickbooks](./sources/quickbooks.md)| Beta |
 |[Recharge](./sources/recharge.md)| Beta |
 |[Recurly](./sources/recurly.md)| Beta |

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -65,6 +65,7 @@ Airbyte uses a grading system for connectors to help users understand what to ex
 |[Shopify](./sources/shopify.md)| Certified |
 |[Slack](./sources/slack.md)| Beta |
 |[Smartsheets](./sources/smartsheets.md)| Beta |
+|[Snowflake](./sources/snowflake.md)| Beta |
 |[Stripe](./sources/stripe.md)| Certified |
 |[Tempo](./sources/tempo.md)| Beta |
 |[Twilio](./sources/twilio.md)| Beta |


### PR DESCRIPTION
## Main Changes
We are missing a few sources and destinations from the catalog table, so I updated it to include them.
Some examples:
- S3
- Amplitude
- Google Ads

## Misc Changes
- I upgraded Facebook Marketing to Certified, as I think we did recently upgrade and certify it, @sherifnada can you confirm?