### PR TITLE
preserve kube db after deleting db pod

### DIFF
--- a/kube/resources/db.yaml
+++ b/kube/resources/db.yaml
@@ -34,11 +34,13 @@ spec:
               value: docker
             - name: POSTGRES_USER
               value: docker
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           ports:
             - containerPort: 5432
           volumeMounts:
             - name: airbyte-volume-db
-              mountPath: /var/lib/postgresql
+              mountPath: /var/lib/postgresql/data
       volumes:
         - name: airbyte-volume-db
           persistentVolumeClaim:


### PR DESCRIPTION
Issue https://github.com/airbytehq/airbyte/issues/4399

After trying to debug this myself for a while (unsuccessfully) I found a StackOverflow page that pointed to the `PGDATA` section on https://hub.docker.com/_/postgres

The important part is here:
> The default is /var/lib/postgresql/data. If the data volume you're using is a filesystem mountpoint (like with GCE persistent disks) or remote folder that cannot be chowned to the postgres user (like some NFS mounts), Postgres initdb recommends a subdirectory be created to contain the data.

Setting the var and using a subdirectory appeared to work.