### PR TITLE
Update and rename code-of-conduct.md to slack-code-of-conduct.md

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -169,7 +169,7 @@
   * [Changelog](project-overview/changelog/README.md)
     * [Platform](project-overview/changelog/platform.md)
     * [Connectors](project-overview/changelog/connectors.md)
-  * [Code of Conduct](project-overview/code-of-conduct.md)
+  * [Slack Code of Conduct](project-overview/slack-code-of-conduct.md)
   * [License](project-overview/license.md)
 * [Careers & Open Positions](career-and-open-positions/README.md)
   * [Senior Software Engineer](career-and-open-positions/senior-software-engineer.md)

--- a/docs/project-overview/slack-code-of-conduct.md
+++ b/docs/project-overview/slack-code-of-conduct.md
@@ -2,7 +2,7 @@
 description: 'Be nice to one another.'
 ---
 
-# Code of Conduct
+# Slack Code of Conduct
 
 Airbyte's Slack community is growing incredibly fast. We're home to over 1500 data professionals and are growing at an awesome pace. We are proud of our community, and have provided these guidelines to support new members in maintaining the wholesome spirit we have developed here. We appreciate your continued commitment to making this a community we are all excited to be a part of.
 


### PR DESCRIPTION
It's not explicit enough that the code of conduct applies to our Slack community