### PR TITLE
Github Store should not error if the file cannot be found.

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -47,8 +47,12 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DestinationDefinitionsHandler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DestinationDefinitionsHandler.class);
 
   private final DockerImageValidator imageValidator;
   private final ConfigRepository configRepository;
@@ -108,8 +112,6 @@ public class DestinationDefinitionsHandler {
   private List<StandardDestinationDefinition> getLatestDestinations() {
     try {
       return githubStore.getLatestDestinations();
-    } catch (IOException e) {
-      return Collections.emptyList();
     } catch (InterruptedException e) {
       throw new InternalServerKnownException("Request to retrieve latest destination definitions failed", e);
     }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -42,7 +42,6 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -103,14 +103,12 @@ public class SourceDefinitionsHandler {
   }
 
   public SourceDefinitionReadList listLatestSourceDefinitions() {
-    return toSourceDefinitionReadList(getLatestDestinations());
+    return toSourceDefinitionReadList(getLatestSources());
   }
 
-  private List<StandardSourceDefinition> getLatestDestinations() {
+  private List<StandardSourceDefinition> getLatestSources() {
     try {
       return githubStore.getLatestSources();
-    } catch (IOException e) {
-      return Collections.emptyList();
     } catch (InterruptedException e) {
       throw new InternalServerKnownException("Request to retrieve latest destination definitions failed", e);
     }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -42,7 +42,6 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;

--- a/airbyte-server/src/main/java/io/airbyte/server/services/AirbyteGithubStore.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/services/AirbyteGithubStore.java
@@ -100,9 +100,8 @@ public class AirbyteGithubStore {
         .header("accept", "*/*") // accept any file type
         .build();
     final var resp = httpClient.send(request, BodyHandlers.ofString());
-    if (resp.statusCode() == 404) {
-      // If the file does not exist.
-      throw new IOException("Missing file!");
+    if (resp.statusCode() >= 400) {
+      throw new IOException("getFile request ran into status code error: " + resp.statusCode() + "with message: " + resp.getClass());
     }
     return resp.body();
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/services/AirbyteGithubStore.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/services/AirbyteGithubStore.java
@@ -74,7 +74,8 @@ public class AirbyteGithubStore {
     try {
       return YamlListToStandardDefinitions.toStandardDestinationDefinitions(getFile(DESTINATION_DEFINITION_LIST_LOCATION_PATH));
     } catch (IOException e) {
-      LOGGER.warn("Unable to retrieve latest Destination list from Github. Using the list bundled with Airbyte. This warning is expected if this Airbyte cluster does not have internet access.");
+      LOGGER.warn(
+          "Unable to retrieve latest Destination list from Github. Using the list bundled with Airbyte. This warning is expected if this Airbyte cluster does not have internet access.");
       return Collections.emptyList();
     }
   }
@@ -83,7 +84,8 @@ public class AirbyteGithubStore {
     try {
       return YamlListToStandardDefinitions.toStandardSourceDefinitions(getFile(SOURCE_DEFINITION_LIST_LOCATION_PATH));
     } catch (IOException e) {
-      LOGGER.warn("Unable to retrieve latest Source list from Github. Using the list bundled with Airbyte. This warning is expected if this Airbyte cluster does not have internet access.");
+      LOGGER.warn(
+          "Unable to retrieve latest Source list from Github. Using the list bundled with Airbyte. This warning is expected if this Airbyte cluster does not have internet access.");
       return Collections.emptyList();
     }
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/services/AirbyteGithubStore.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/services/AirbyteGithubStore.java
@@ -34,12 +34,17 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Convenience class for retrieving files checked into the Airbyte Github repo.
  */
 public class AirbyteGithubStore {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AirbyteGithubStore.class);
 
   private static final String GITHUB_BASE_URL = "https://raw.githubusercontent.com";
   private static final String SOURCE_DEFINITION_LIST_LOCATION_PATH =
@@ -65,12 +70,22 @@ public class AirbyteGithubStore {
     this.timeout = timeout;
   }
 
-  public List<StandardDestinationDefinition> getLatestDestinations() throws IOException, InterruptedException {
-    return YamlListToStandardDefinitions.toStandardDestinationDefinitions(getFile(DESTINATION_DEFINITION_LIST_LOCATION_PATH));
+  public List<StandardDestinationDefinition> getLatestDestinations() throws InterruptedException {
+    try {
+      return YamlListToStandardDefinitions.toStandardDestinationDefinitions(getFile(DESTINATION_DEFINITION_LIST_LOCATION_PATH));
+    } catch (IOException e) {
+      LOGGER.warn("Unable to retrieve latest Destination list from Github. Using the list bundled with Airbyte. This warning is expected if this Airbyte cluster does not have internet access.");
+      return Collections.emptyList();
+    }
   }
 
-  public List<StandardSourceDefinition> getLatestSources() throws IOException, InterruptedException {
-    return YamlListToStandardDefinitions.toStandardSourceDefinitions(getFile(SOURCE_DEFINITION_LIST_LOCATION_PATH));
+  public List<StandardSourceDefinition> getLatestSources() throws InterruptedException {
+    try {
+      return YamlListToStandardDefinitions.toStandardSourceDefinitions(getFile(SOURCE_DEFINITION_LIST_LOCATION_PATH));
+    } catch (IOException e) {
+      LOGGER.warn("Unable to retrieve latest Source list from Github. Using the list bundled with Airbyte. This warning is expected if this Airbyte cluster does not have internet access.");
+      return Collections.emptyList();
+    }
   }
 
   @VisibleForTesting

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
@@ -192,7 +192,7 @@ class DestinationDefinitionsHandlerTest {
 
     @Test
     @DisplayName("should return the latest list")
-    void testCorrect() throws IOException, InterruptedException {
+    void testCorrect() throws InterruptedException {
       final StandardDestinationDefinition destinationDefinition = generateDestination();
       when(githubStore.getLatestDestinations()).thenReturn(Collections.singletonList(destinationDefinition));
 
@@ -205,8 +205,7 @@ class DestinationDefinitionsHandlerTest {
 
     @Test
     @DisplayName("returns empty collection if cannot find latest definitions")
-    void testHttpTimeout() throws IOException, InterruptedException {
-      when(githubStore.getLatestDestinations()).thenThrow(new IOException());
+    void testHttpTimeout() {
       assertEquals(0, destinationHandler.listLatestDestinationDefinitions().getDestinationDefinitions().size());
     }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -207,8 +207,7 @@ class SourceDefinitionsHandlerTest {
 
     @Test
     @DisplayName("returns empty collection if cannot find latest definitions")
-    void testHttpTimeout() throws IOException, InterruptedException {
-      when(githubStore.getLatestSources()).thenThrow(new IOException());
+    void testHttpTimeout() {
       assertEquals(0, sourceHandler.listLatestSourceDefinitions().getSourceDefinitions().size());
     }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/services/AirbyteGithubStoreTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/services/AirbyteGithubStoreTest.java
@@ -55,6 +55,7 @@ public class AirbyteGithubStoreTest {
   @Nested
   @DisplayName("when no internet")
   class noInternet {
+
     @Test
     void testGetLatestDestinations() throws InterruptedException, IOException {
       webServer.shutdown();
@@ -66,6 +67,7 @@ public class AirbyteGithubStoreTest {
       webServer.shutdown();
       assertEquals(Collections.emptyList(), githubStore.getLatestSources());
     }
+
   }
 
   @Nested

--- a/airbyte-server/src/test/java/io/airbyte/server/services/AirbyteGithubStoreTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/services/AirbyteGithubStoreTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.IOException;
 import java.net.http.HttpTimeoutException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -49,6 +50,22 @@ public class AirbyteGithubStoreTest {
   public static void setUp() {
     webServer = new MockWebServer();
     githubStore = AirbyteGithubStore.test(webServer.url("/").toString(), TIMEOUT);
+  }
+
+  @Nested
+  @DisplayName("when no internet")
+  class noInternet {
+    @Test
+    void testGetLatestDestinations() throws InterruptedException, IOException {
+      webServer.shutdown();
+      assertEquals(Collections.emptyList(), githubStore.getLatestDestinations());
+    }
+
+    @Test
+    void testGetLatestSources() throws InterruptedException, IOException {
+      webServer.shutdown();
+      assertEquals(Collections.emptyList(), githubStore.getLatestSources());
+    }
   }
 
   @Nested
@@ -79,6 +96,12 @@ public class AirbyteGithubStoreTest {
       webServer.enqueue(timeoutResp);
 
       assertThrows(HttpTimeoutException.class, () -> githubStore.getFile("test-file"));
+    }
+
+    @Test
+    void testNoInternet() throws IOException, InterruptedException {
+      webServer.shutdown();
+      githubStore.getFile("test-file");
     }
 
   }


### PR DESCRIPTION
## What
Fixes #4411.

There are two cases here:
1) No internet access
2) The file cannot be found.

In both cases, we return an empty list instead. This turns this operation into a noop and Airbyte then uses the list bundled with the current version.

## How
Explicitly check and catch for these conditions, turning them into IOExceptions. These exceptions are caught at the Github store level. We always return an empty list.

## Pre-merge Checklist
Expand the checklist which is relevant for this PR. 

<details><summary> <strong> Connector checklist </strong> </summary>
<p>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Secrets are annotated with `airbyte_secret` in the connector's spec
- [ ] Credentials added to Github CI if needed and not already present. [instructions for injecting secrets into CI](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#using-credentials-in-ci). 
- [ ] Unit & integration tests added as appropriate (and are passing)
    * Community members: please provide proof of this succeeding locally e.g: screenshot or copy-paste acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] `/test connector=connectors/<name>` command as documented [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-an-existing-connector) is passing. 
    * Community members can skip this, Airbyters will run this for you. 
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] `README.md`
    - [ ] `docs/SUMMARY.md` if it's a new connector
    - [ ] Created or updated reference docs in `docs/integrations/<source or destination>/<name>`.
    - [ ] Changelog in the appropriate page in `docs/integrations/...`. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md` contains a reference to the new connector
    - [ ] Build status added to [build page](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/builds.md)
- [ ] Build is successful
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] No major blockers
- [ ] PR merged into master branch
- [ ] Follow up tickets have been created
- [ ] Associated tickets have been closed & stakeholders notified
</p>
</details>

<details><summary> <strong> Connector Generator checklist </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
