### PR TITLE
Add note about placing your Redshift cluster and server in the same SG

### DIFF
--- a/docs/integrations/destinations/redshift.md
+++ b/docs/integrations/destinations/redshift.md
@@ -40,6 +40,10 @@ You will need to choose an existing database or create a new database that will 
 2. Allow connections from Airbyte to your Redshift cluster \(if they exist in separate VPCs\)
 3. A staging S3 bucket with credentials \(for the COPY strategy\).
 
+{% hint style="info" %}
+Even if your Airbyte instance is running on a server in the same VPC as your Redshift cluster, you may need to place them in the **same security group** to allow connections between the two. 
+{% endhint %}
+
 ### Setup guide
 
 #### 1. Make sure your cluster is active and accessible from the machine running Airbyte


### PR DESCRIPTION
## Main Inspiration
- This Slack conversation: https://airbytehq.slack.com/archives/C01MFR03D5W/p1624559711443900

## Main Changes
- Sometimes, even if your Redshift cluster is in the same VPC as the server that is running your Airbyte instance, they will still need to be in the same security group in order to communicate with each other. 