### PR TITLE
Add standalone getting started guides structure.

### DIFF
--- a/docs/integrations/getting-started/destination-redshift.md
+++ b/docs/integrations/getting-started/destination-redshift.md
@@ -1,0 +1,66 @@
+# Getting started
+
+## Requirements
+
+1. Active Redshift cluster
+2. Allow connections from Airbyte to your Redshift cluster \(if they exist in separate VPCs\)
+3. A staging S3 bucket with credentials \(for the COPY strategy\).
+
+## Setup guide
+
+### 1. Make sure your cluster is active and accessible from the machine running Airbyte
+
+This is dependent on your networking setup. The easiest way to verify if Airbyte is able to connect to your Redshift cluster is via the check connection tool in the UI. You can check AWS Redshift documentation with a tutorial on how to properly configure your cluster's access [here](https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-authorize-cluster-access.html)
+
+### 2. Fill up connection info
+
+Next is to provide the necessary information on how to connect to your cluster such as the `host` whcih is part of the connection string or Endpoint accessible [here](https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-connect-to-cluster.html#rs-gsg-how-to-get-connection-string) without the `port` and `database` name \(it typically includes the cluster-id, region and end with `.redshift.amazonaws.com`\).
+
+You should have all the requirements needed to configure Redshift as a destination in the UI. You'll need the following information to configure the destination:
+
+* **Host**
+* **Port**
+* **Username**
+* **Password**
+* **Schema**
+* **Database**
+    * This database needs to exist within the cluster provided.
+
+### 2a. Fill up S3 info \(for COPY strategy\)
+
+Provide the required S3 info.
+
+* **S3 Bucket Name**
+    * See [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) to create an S3 bucket.
+* **S3 Bucket Region**
+    * Place the S3 bucket and the Redshift cluster in the same region to save on networking costs.
+* **Access Key Id**
+    * See [this](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) on how to generate an access key.
+    * We recommend creating an Airbyte-specific user. This user will require [read and write permissions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_rw-bucket.html) to objects in the staging bucket.
+* **Secret Access Key**
+    * Corresponding key to the above key id.
+* **Part Size**
+    * Affects the size limit of an individual Redshift table. Optional. Increase this if syncing tables larger than 100GB. Files are streamed to S3 in parts. This determines the size of each part, in MBs. As S3 has a limit of 10,000 parts per file, part size affects the table size. This is 10MB by default, resulting in a default table limit of 100GB. Note, a larger part size will result in larger memory requirements. A rule of thumb is to multiply the part size by 10 to get the memory requirement. Modify this with care.
+
+## Notes about Redshift Naming Conventions
+
+From [Redshift Names & Identifiers](https://docs.aws.amazon.com/redshift/latest/dg/r_names.html):
+
+### Standard Identifiers
+
+* Begin with an ASCII single-byte alphabetic character or underscore character, or a UTF-8 multibyte character two to four bytes long.
+* Subsequent characters can be ASCII single-byte alphanumeric characters, underscores, or dollar signs, or UTF-8 multibyte characters two to four bytes long.
+* Be between 1 and 127 bytes in length, not including quotation marks for delimited identifiers.
+* Contain no quotation marks and no spaces.
+
+### Delimited Identifiers
+
+Delimited identifiers \(also known as quoted identifiers\) begin and end with double quotation marks \("\). If you use a delimited identifier, you must use the double quotation marks for every reference to that object. The identifier can contain any standard UTF-8 printable characters other than the double quotation mark itself. Therefore, you can create column or table names that include otherwise illegal characters, such as spaces or the percent symbol. ASCII letters in delimited identifiers are case-insensitive and are folded to lowercase. To use a double quotation mark in a string, you must precede it with another double quotation mark character.
+
+Therefore, Airbyte Redshift destination will create tables and schemas using the Unquoted identifiers when possible or fallback to Quoted Identifiers if the names are containing special characters.
+
+## Data Size Limitations
+
+Redshift specifies a maximum limit of 65535 bytes to store the raw JSON record data. Thus, when a row is too big to fit, the Redshift destination fails to load such data and currently ignores that record.
+
+For more information, see the [docs here.](https://docs.aws.amazon.com/redshift/latest/dg/r_Character_types.html)

--- a/docs/integrations/getting-started/destination-redshift.md
+++ b/docs/integrations/getting-started/destination-redshift.md
@@ -1,4 +1,4 @@
-# Getting started
+# Getting Started: Destination Redshift 
 
 ## Requirements
 

--- a/docs/integrations/getting-started/source-facebook-marketing.md
+++ b/docs/integrations/getting-started/source-facebook-marketing.md
@@ -1,0 +1,42 @@
+# Getting started with Facebook Marketing
+
+## Requirements
+
+Google Ads Account with an approved Developer Token \(note: In order to get API access to Google Ads, you must have a "manager" account. This must be created separately from your standard account. You can find more information about this distinction in the [google ads docs](https://ads.google.com/home/tools/manager-accounts/).\)
+
+* developer_token
+* client_id
+* client_secret
+* refresh_token
+* start_date
+* customer_id
+
+## Setup guide
+
+This guide will provide information as if starting from scratch. Please skip over any steps you have already completed.
+
+* Create an Google Ads Account. Here are [Google's instruction](https://support.google.com/google-ads/answer/6366720) on how to create one.
+* Create an Google Ads MANAGER Account. Here are [Google's instruction](https://ads.google.com/home/tools/manager-accounts/) on how to create one.
+* You should now have two Google Ads accounts: a normal account and a manager account. Link the Manager account to the normal account following [Google's documentation](https://support.google.com/google-ads/answer/7459601).
+* Apply for a developer token \(**make sure you follow our** [**instructions**](google-ads.md#how-to-apply-for-the-developer-token)\) on your Manager account.  This token allows you to access your data from the Google Ads API. Here are [Google's instructions](https://developers.google.com/google-ads/api/docs/first-call/dev-token). The docs are a little unclear on this point, but you will _not_ be able to access your data via the Google Ads API until this token is approved. You cannot use a test developer token, it has to be at least a basic developer token. It usually takes Google 24 hours to respond to these applications. This developer token is the value you will use in the `developer_token` field.
+* Fetch your `client_id`, `client_secret`, and `refresh_token`. Google provides [instructions](https://developers.google.com/google-ads/api/docs/first-call/overview) on how to do this.
+* Select your `customer_id`. The `customer_is` refer to the id of each of your Google Ads accounts. This is the 10 digit number in the top corner of the page when you are in google ads ui. The source will only pull data from the accounts for which you provide an id. If you are having trouble finding it, check out [Google's instructions](https://support.google.com/google-ads/answer/1704344).
+
+Wow! That was a lot of steps. We are working on making the OAuth flow for all of our connectors simpler \(allowing you to skip needing to get a `developer_token` and a `refresh_token` which are the most painful / time-consuming steps in this walkthrough\).
+
+## How to apply for the developer token
+
+Google is very picky about which software and which use case can get access to a developer token. The Airbyte team has worked with the Google Ads team to whitelist Airbyte and make sure you can get one \(see [issue 1981](https://github.com/airbytehq/airbyte/issues/1981) for more information\).
+
+When you apply for a token, you need to mention:
+
+* Why you need the token \(eg: want to run some internal analytics...\)
+* That you will be using the Airbyte Open Source project
+* That you have full access to the code base \(because we're open source\)
+* That you have full access to the server running the code \(because you're self-hosting Airbyte\)
+
+If for any reason the request gets denied, let us know and we will be able to unblock you.
+
+## Understanding Google Ads Query Language
+
+The Google Ads Query Language can query the Google Ads API. Check out [Google Ads Query Language](https://developers.google.com/google-ads/api/docs/query/overview)

--- a/docs/integrations/getting-started/source-facebook-marketing.md
+++ b/docs/integrations/getting-started/source-facebook-marketing.md
@@ -1,4 +1,4 @@
-# Getting started with Facebook Marketing
+# Getting Started: Source Facebook Marketing
 
 ## Requirements
 

--- a/docs/integrations/getting-started/source-github.md
+++ b/docs/integrations/getting-started/source-github.md
@@ -1,0 +1,12 @@
+## Getting Started: Source GitHub
+
+### Requirements
+
+* Github Account
+* Github Personal Access Token wih the necessary permissions \(described below\)
+
+### Setup guide
+
+Log into Github and then generate a [personal access token](https://github.com/settings/tokens).
+
+Your token should have at least the `repo` scope. Depending on which streams you want to sync, the user generating the token needs more permissions:


### PR DESCRIPTION
## Thoughts
We have been designing the new format for the docs being displayed in the webapp for source and destination setup as per this issue: #3879 and its children. We thought we could just create a directory for each source and destination right where they lived, but this would massively change the directory structure, causing us to need to change things in a lot of different places. I propose a less invasive solution:

- Create another directory called `getting-started` and place all getting-started guides here initially. Have the naming convention be `type-name` e.g. `source-facebook-marketing` to be identified and loaded by the backend onto the image.

## Main Changes
- Implements this directory structure and adds two guides (one for a source and one for a destination) for testing.