### PR TITLE
🐛 Source Zendesk support : add missing env var to image

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d29764f8-80d7-4dd7-acbe-1a42005ee5aa.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d29764f8-80d7-4dd7-acbe-1a42005ee5aa.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "d29764f8-80d7-4dd7-acbe-1a42005ee5aa",
   "name": "Zendesk Support",
   "dockerRepository": "airbyte/source-zendesk-support-singer",
-  "dockerImageTag": "0.2.2",
+  "dockerImageTag": "0.2.3",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-zendesk-support-singer",
   "icon": "zendesk.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -180,7 +180,7 @@
 - sourceDefinitionId: d29764f8-80d7-4dd7-acbe-1a42005ee5aa
   name: Zendesk Support
   dockerRepository: airbyte/source-zendesk-support-singer
-  dockerImageTag: 0.2.2
+  dockerImageTag: 0.2.3
   documentationUrl: https://hub.docker.com/r/airbyte/source-zendesk-support-singer
   icon: zendesk.svg
 - sourceDefinitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a

--- a/airbyte-integrations/connectors/source-zendesk-support-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-zendesk-support-singer/Dockerfile
@@ -5,11 +5,12 @@ RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
 ENV CODE_PATH="source_zendesk_support_singer"
 ENV AIRBYTE_IMPL_MODULE="source_zendesk_support_singer"
 ENV AIRBYTE_IMPL_PATH="SourceZendeskSupportSinger"
+ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/source.py"
 
 WORKDIR /airbyte/integration_code
 COPY $CODE_PATH ./$CODE_PATH
 COPY setup.py ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.2
+LABEL io.airbyte.version=0.2.3
 LABEL io.airbyte.name=airbyte/source-zendesk-support-singer


### PR DESCRIPTION
## What
This PR  https://github.com/airbytehq/airbyte/pull/3973 added a required environment variable on some connectors images so that they can run on kubernetes. But I looks like the `source-zendesk-support-singer` does not have this env var set up.

## How
* Set `ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/source.py"` in `source-zendesk-support-singer` Dockerfile
* Bump image version / tag in sources definitions
