### PR TITLE
copy docs to webapp docker image

### DIFF
--- a/airbyte-webapp/Dockerfile
+++ b/airbyte-webapp/Dockerfile
@@ -2,5 +2,8 @@ FROM nginx:1.19-alpine as webapp
 
 EXPOSE 80
 
+COPY build/docs docs/
+# docs get copied twice because npm gradle plugin ignores output dir.
 COPY build /usr/share/nginx/html
+RUN rm -rf /usr/share/nginx/html/docs
 COPY nginx/default.conf.template /etc/nginx/templates/default.conf.template

--- a/airbyte-webapp/build.gradle
+++ b/airbyte-webapp/build.gradle
@@ -14,6 +14,7 @@ npm_run_build {
     inputs.file 'package.json'
     inputs.file 'package-lock.json'
 
+    // todo (cgardens) - the plugin seems to ignore this value when the copy command is run. ideally the output would be place in build/app.
     outputs.dir project.buildDir
 }
 
@@ -29,3 +30,10 @@ task test(type: NpmTask) {
 assemble.dependsOn npm_run_build
 build.finalizedBy test
 
+task copyDocs(type: Copy) {
+    from "${System.getProperty("user.dir")}/docs/integrations/getting-started"
+    into "${buildDir}/docs/getting-started/"
+}
+
+copyDocs.dependsOn npm_run_build
+assemble.dependsOn copyDocs


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/4281

## What
* make the getting started docs for connectors available to the webapp

## How
* copy them onto the docker image.
* one silly compromise here is that the npm plugin seems to ignore the output directory when a copy command is run. so we have to do a little skullduggery when we build the docker container.