### PR TITLE
Add LOG_LEVEL for temporal

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -135,6 +135,7 @@ services:
       - POSTGRES_PWD=${DATABASE_PASSWORD}
       - POSTGRES_SEEDS=${DATABASE_HOST}
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
+      - LOG_LEVEL=${LOG_LEVEL}
     volumes:
       - ./temporal/dynamicconfig:/etc/temporal/config/dynamicconfig
 volumes:


### PR DESCRIPTION
## What
Just add `LOG_LEVEL=${LOG_LEVEL}` for airbyte-temporal.

## How
This will allow the control on the log of airbyte-temporal too.
Tested with: "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"

None of them cause to crash the application. 
- FATAL and ERROR: give a great result in Terminal, so silence
- INFO and DEBUG: show a ton of info.

## Recommended reading order
1. docker_compose.
