### PR TITLE
Stablise Python Builds.

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{github.event.pull_request.head.repo.full_name}} # always use the branch's repository
-      # This does not set anything else up is because it is using an AMI image that has everything pre-installed.
+      # Beside PyEnv, this does not set any runtimes up because it uses an AMI image that has everything pre-installed.
       - name: Install Pyenv
         run: python3 -m pip install virtualenv==16.7.9 --user
       - name: Write Integration Test Credentials # TODO DRY this with test-command.yml

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
-          ec2-image-id: ami-04bd6e81239f4f3fb
+          ec2-image-id: ami-0a5f6900e1cc7e07e
           ec2-instance-type: c5.2xlarge
           subnet-id: subnet-0469a9e68a379c1d3
           security-group-id: sg-0793f3c9413f21970
@@ -64,26 +64,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{github.event.pull_request.head.repo.full_name}} # always use the branch's repository
-
-      # this intentionally does not use restore-keys so we don't mess with gradle caching
-      - name: Gradle and Python Caching
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            **/.venv
-          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/requirements.txt') }}
-
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '14'
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '14.7'
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
+      # This does not set anything else up is because it is using an AMI image that has everything pre-installed.
+      - name: Install Pyenv
+        run: python3 -m pip install virtualenv==16.7.9 --user
       - name: Write Integration Test Credentials # TODO DRY this with test-command.yml
         run: ./tools/bin/ci_credentials.sh
         env:

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{github.event.pull_request.head.repo.full_name}} # always use the branch's repository
-      # Beside PyEnv, this does not set any runtimes up because it uses an AMI image that has everything pre-installed.
+      # Beside PyEnv, this does not set any runtimes up because it uses an AMI image that has everything pre-installed. See https://github.com/airbytehq/airbyte/issues/4559.
       - name: Install Pyenv
         run: python3 -m pip install virtualenv==16.7.9 --user
       - name: Write Integration Test Credentials # TODO DRY this with test-command.yml

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
-          ec2-image-id: ami-04bd6e81239f4f3fb
+          ec2-image-id: ami-0a5f6900e1cc7e07e
           ec2-instance-type: c5.2xlarge
           subnet-id: subnet-0469a9e68a379c1d3
           security-group-id: sg-0793f3c9413f21970
@@ -62,15 +62,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ github.event.inputs.repo }}
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '14'
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '14.7'
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
+      # This does not set anything else up is because it is using an AMI image that has everything pre-installed.
+      - name: Install Pyenv
+        run: python3 -m pip install virtualenv==16.7.9 --user
       - name: Write Integration Test Credentials
         run: ./tools/bin/ci_credentials.sh
         env:

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ github.event.inputs.repo }}
-      # Beside PyEnv, this does not set any runtimes up because it uses an AMI image that has everything pre-installed.
+      # Beside PyEnv, this does not set any runtimes up because it uses an AMI image that has everything pre-installed. See https://github.com/airbytehq/airbyte/issues/4559/
       - name: Install Pyenv
         run: python3 -m pip install virtualenv==16.7.9 --user
       - name: Write Integration Test Credentials

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ github.event.inputs.repo }}
-      # This does not set anything else up is because it is using an AMI image that has everything pre-installed.
+      # Beside PyEnv, this does not set any runtimes up because it uses an AMI image that has everything pre-installed.
       - name: Install Pyenv
         run: python3 -m pip install virtualenv==16.7.9 --user
       - name: Write Integration Test Credentials

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -30,16 +30,15 @@ cmd_build() {
   [ -d "$path" ] || error "Path must be the root path of the integration"
 
   local run_tests=$1; shift || run_tests=true
-  # TODO re-enable build cache if needed (https://github.com/airbytehq/airbyte/issues/4508)
   echo "Building $path"
-  ./gradlew --no-daemon -no-build-cache "$(_to_gradle_path "$path" clean)"
-  ./gradlew --no-daemon -no-build-cache "$(_to_gradle_path "$path" build)"
+  ./gradlew --no-daemon "$(_to_gradle_path "$path" clean)"
+  ./gradlew --no-daemon "$(_to_gradle_path "$path" build)"
 
   if [ "$run_tests" = false ] ; then
     echo "Skipping integration tests..."
   else
     echo "Running integration tests..."
-    ./gradlew --no-daemon --no-build-cache "$(_to_gradle_path "$path" integrationTest)"
+    ./gradlew --no-daemon "$(_to_gradle_path "$path" integrationTest)"
   fi
 }
 


### PR DESCRIPTION
## What
Attempt to stablise the python test/publish builds. This is a subset of the changes from #4539 that have been pulled out to keep that PR clean.

A week or so ago we started running into the following errors while trying to test or publish python connectors:
```
* Where:
Build file '/home/runner/work/airbyte/airbyte/airbyte-integrations/connectors/source-zendesk-talk/build.gradle' line: 2
* What went wrong:
An exception occurred applying plugin request [id: 'airbyte-python']
> Failed to apply plugin 'airbyte-python'.
   > A problem occurred configuring project ':airbyte-integrations:connectors:source-zoom-singer'.
      > Could not open cp_proj generic class cache for build file '/home/runner/work/airbyte/airbyte/airbyte-integrations/connectors/source-zoom-singer/build.gradle' (/home/runner/.gradle/caches/6.7.1/scripts/4ffd4lk4g399iqzx3xoc30xgr).
         > java.lang.StackOverflowError (no error message)
```

This error is happening when Gradle first configures itself, as it is reading all the various build files and trying to build an internal dependency graph. No real building has happened yet.

At that time, our python builds were running on the `ubuntu-latest` github runners. Switching to other types of ubuntu runners did not fix the problem.

The best clue I could find was this [stackoverflow](https://stackoverflow.com/questions/32513740/gradle-build-failure-could-not-open-proj-class-cache-for-build-file). The most promising answer here is to increase the heap, which doesn't seem realistic since the Github runners are memory constrained. I was also unable to reproduce this locally or on any ubuntu ec2 machines I spun up.

Since I know gradle configures itself fine on our ec2 runners, I moved the build to run on an ec2 instance instead of the github instances. This solved our Gradle configure issue but presents another problem with the install of `ciso8601` (see [this](https://github.com/airbytehq/airbyte/runs/2990110571?check_suite_focus=true#step:12:47)), which is a package some of the singer sources use to parse date time. This is because `ciso8601` doesn't provide wheels and thus requires very specific C libs to [be installed on the instance](https://github.com/closeio/ciso8601/issues/98#issuecomment-720875244). The github runners have an extensive list of [pre-installed software](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md) that fulfills these requirements that our minimal ec2 AMIs do not.

Things I tried and failed:
* Installing the [required binaries ](https://github.com/closeio/ciso8601/issues/88#issuecomment-590902052)on top of our minimal AMI.
* Installing 'clang' instead of 'gcc', since I noticed the Github instances bundle 'clang'.
* Trying to generate an identical AMI to the Github instances - sadly they use a custom DSL on top of packer. The current build scripts using Azure and aren't compatible with AWS.

At every point in this process, I validated my hypothesis on a parallel ec2 Ubuntu instance (funny enough, this always worked) built on top of our initial minimal AMI. So I inadvertently created an AMI that contains all the build dependencies Airbyte requires. This is the final AMI we use here. I think this is an okay medium-term solution. The main risk I see from using our own AMI is 1) updates 2) making sure the AMI image can always be built. This ticket contains all this context + is a follow up to address this when we have more time.

This exercise has made me realise we have 3 distinct build runtimes:
1) Java code - natively handled by Gradle so 'just works'.
2) Python CDK connectors - all dependencies are explicitly stated so easy to manage. 
3) Python Singer connectors - dependencies are pulled in during compile time so tough to manage.

I've ran a test from each connector 'type' to prove this set up works. Note: the shopify test is failing from actual failures and not compile/build failures.

Added follows up in #4559 .

## Pre-merge Checklist
Expand the checklist which is relevant for this PR. 

<details><summary> <strong> Connector checklist </strong> </summary>
<p>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Secrets are annotated with `airbyte_secret` in the connector's spec
- [ ] Credentials added to Github CI if needed and not already present. [instructions for injecting secrets into CI](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#using-credentials-in-ci). 
- [ ] Unit & integration tests added as appropriate (and are passing)
    * Community members: please provide proof of this succeeding locally e.g: screenshot or copy-paste acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] `/test connector=connectors/<name>` command as documented [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-an-existing-connector) is passing. 
    * Community members can skip this, Airbyters will run this for you. 
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] `README.md`
    - [ ] `docs/SUMMARY.md` if it's a new connector
    - [ ] Created or updated reference docs in `docs/integrations/<source or destination>/<name>`.
    - [ ] Changelog in the appropriate page in `docs/integrations/...`. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md` contains a reference to the new connector
    - [ ] Build status added to [build page](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/builds.md)
- [ ] Build is successful
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] No major blockers
- [ ] PR merged into master branch
- [ ] Follow up tickets have been created
- [ ] Associated tickets have been closed & stakeholders notified
</p>
</details>

<details><summary> <strong> Connector Generator checklist </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
