### PR TITLE
Fix broken link in Local CSV doc

### DIFF
--- a/docs/integrations/destinations/local-csv.md
+++ b/docs/integrations/destinations/local-csv.md
@@ -62,4 +62,4 @@ docker cp airbyte-scheduler:/tmp/airbyte_local/{destination_path}/{filename}.csv
 ```
 
 
-Note: If you are running Airbyte on Windows with Docker backed by WSL2, you have to use similar step as above or refer to this [link](../tutorials/locating-files-local-destination.md) for an alternative approach.
+Note: If you are running Airbyte on Windows with Docker backed by WSL2, you have to use similar step as above or refer to this [link](../../operator-guides/locating-files-local-destination.md) for an alternative approach.


### PR DESCRIPTION
## Main Changes
There was a broken link here: https://docs.airbyte.io/integrations/destinations/local-csv that is now fixed!