### PR TITLE
set db version after full import is complete

### DIFF
--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobPersistence.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobPersistence.java
@@ -38,6 +38,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+/**
+ * TODO Introduce a locking mechanism so that no DB operation is allowed when automatic migration is
+ * running
+ */
 public interface JobPersistence {
 
   Job getJob(long jobId) throws IOException;

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImport.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImport.java
@@ -117,11 +117,7 @@ public class ConfigDumpImport {
         // 1. Unzip source
         Archives.extractArchive(archive.toPath(), sourceRoot);
 
-        // 2. Set DB version
-        LOGGER.info("Setting the DB Airbyte version to : " + targetVersion);
-        postgresPersistence.setVersion(targetVersion);
-
-        // 3. dry run
+        // 2. dry run
         try {
           checkImport(sourceRoot);
         } catch (Exception e) {
@@ -130,11 +126,15 @@ public class ConfigDumpImport {
           throw e;
         }
 
-        // 4. Import Postgres content
+        // 3. Import Postgres content
         importDatabaseFromArchive(sourceRoot, targetVersion);
 
-        // 5. Import Configs
+        // 4. Import Configs
         importConfigsFromArchive(sourceRoot, false);
+
+        // 5. Set DB version
+        LOGGER.info("Setting the DB Airbyte version to : " + targetVersion);
+        postgresPersistence.setVersion(targetVersion);
         result = new ImportRead().status(StatusEnum.SUCCEEDED);
       } finally {
         FileUtils.deleteDirectory(sourceRoot.toFile());
@@ -164,7 +164,6 @@ public class ConfigDumpImport {
               "Please upgrade your Airbyte Archive, see more at https://docs.airbyte.io/tutorials/upgrading-airbyte\n",
               importVersion, targetVersion));
     }
-    checkDBVersion(targetVersion);
     importConfigsFromArchive(tempFolder, true);
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImport.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImport.java
@@ -135,6 +135,9 @@ public class ConfigDumpImport {
         // 5. Set DB version
         LOGGER.info("Setting the DB Airbyte version to : " + targetVersion);
         postgresPersistence.setVersion(targetVersion);
+
+        // 6. check db version
+        checkDBVersion(targetVersion);
         result = new ImportRead().status(StatusEnum.SUCCEEDED);
       } finally {
         FileUtils.deleteDirectory(sourceRoot.toFile());

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -240,6 +240,10 @@ public class ServerApp {
     }
   }
 
+  /**
+   * Ideally when automatic migration runs, we should make sure that we acquire a lock on database and
+   * no other operation is allowed
+   */
   private static void runAutomaticMigration(ConfigRepository configRepository,
                                             JobPersistence jobPersistence,
                                             String airbyteVersion,


### PR DESCRIPTION
A user reported issues with automatic migration [here](https://airbytehq.slack.com/archives/C01MFR03D5W/p1625665832088700). After going through the logs shared by the user, the findings are :
When we trigger automatic migration, we take a full dump of the database and then pass it through our migration logic and then load it back in the db.
Before loading it back, we truncate the existing tables.All this is done by airbyte-server.
Meanwhile, airbyte-scheduler waits for server to complete automatic migration. The scheduler relies on the check (found [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java#L242)) which states that the airbyte version stored in the database and the new version coming in from environment variable should be compatible, if it's not compatible then scheduler waits and doesn't start.
The problem is that when we load data back into the database, before importing, we set the database version to the latest version ([here](https://github.com/airbytehq/airbyte/blob/master/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImport.java#L122)).
As a result the check which was keeping the scheduler on hold becomes false and then scheduler starts.
The moment scheduler starts, it starts interacting with the database, reading and writing records into the DB. Meanwhile, the import has not yet completed, and as mentioned before, when it tries to truncate the tables, it hits a deadlock situation cause the scheduler is reading from the tables.
Take a look at the following logs
```
airbyte-db          | 2021-07-07 13:26:44.086 UTC [76] ERROR:  deadlock detected
airbyte-db          | 2021-07-07 13:26:44.086 UTC [76] DETAIL:  Process 76 waits for AccessExclusiveLock on relation 16443 of database 16385; blocked by process 74.
airbyte-db          | 	Process 74 waits for AccessShareLock on relation 16453 of database 16385; blocked by process 76.
airbyte-db          | 	Process 76: truncate table public.JOBS restart identity
airbyte-db          | 	Process 74: SELECT
airbyte-db          | 	jobs.id AS job_id,
airbyte-db          | 	jobs.config_type AS config_type,
airbyte-db          | 	jobs.scope AS scope,
airbyte-db          | 	jobs.config AS config,
airbyte-db          | 	jobs.status AS job_status,
airbyte-db          | 	jobs.started_at AS job_started_at,
airbyte-db          | 	jobs.created_at AS job_created_at,
airbyte-db          | 	jobs.updated_at AS job_updated_at,
airbyte-db          | 	attempts.attempt_number AS attempt_number,
airbyte-db          | 	attempts.log_path AS log_path,
airbyte-db          | 	attempts.output AS attempt_output,
airbyte-db          | 	attempts.status AS attempt_status,
airbyte-db          | 	attempts.created_at AS attempt_created_at,
airbyte-db          | 	attempts.updated_at AS attempt_updated_at,
airbyte-db          | 	attempts.ended_at AS attempt_ended_at
airbyte-db          | 	FROM jobs LEFT OUTER JOIN attempts ON jobs.id = attempts.job_id WHERE CAST(config_type AS VARCHAR) IN ('get_spec','sync','check_connection_destination','check_connection_source','discover_schema','reset_connection') AND CAST(jobs.status AS VARCHAR) = $1 ORDER BY jobs.created_at DESC, jobs.id DESC, attempts.created_at ASC, attempts.id ASC 
airbyte-db          | 2021-07-07 13:26:44.086 UTC [76] HINT:  See server log for query details.
airbyte-db          | 2021-07-07 13:26:44.086 UTC [76] STATEMENT:  truncate table public.JOBS restart identity
```
As you can see it states that process 76 is the `truncate table public.JOBS` from the import and process 74 is the `SELECT` query from the scheduler
[docker-compose.txt](https://github.com/airbytehq/airbyte/files/6783845/docker-compose.txt)

We can move the setting of db version at last after the import is complete

## Pre-merge Checklist
Expand the checklist which is relevant for this PR. 

<details><summary> <strong> Connector checklist </strong> </summary>
<p>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Secrets are annotated with `airbyte_secret` in the connector's spec
- [ ] Credentials added to Github CI if needed and not already present. [instructions for injecting secrets into CI](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#using-credentials-in-ci). 
- [ ] Unit & integration tests added as appropriate (and are passing)
    * Community members: please provide proof of this succeeding locally e.g: screenshot or copy-paste acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] `/test connector=connectors/<name>` command as documented [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-an-existing-connector) is passing. 
    * Community members can skip this, Airbyters will run this for you. 
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] `README.md`
    - [ ] `docs/SUMMARY.md` if it's a new connector
    - [ ] Created or updated reference docs in `docs/integrations/<source or destination>/<name>`.
    - [ ] Changelog in the appropriate page in `docs/integrations/...`. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md` contains a reference to the new connector
    - [ ] Build status added to [build page](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/builds.md)
- [ ] Build is successful
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] No major blockers
- [ ] PR merged into master branch
- [ ] Follow up tickets have been created
- [ ] Associated tickets have been closed & stakeholders notified
</p>
</details>

<details><summary> <strong> Connector Generator checklist </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
