### PR TITLE
Airflow Demo: Remove superset in down.sh

### DIFF
--- a/resources/examples/airflow/down.sh
+++ b/resources/examples/airflow/down.sh
@@ -2,4 +2,5 @@
 cd ../../..
 docker-compose down -v
 cd resources/examples/airflow || exit
-docker-compose down -v
+docker-compose -f docker-compose-superset.yaml down -v
+docker-compose -f docker-compose.yaml down -v

--- a/resources/examples/airflow/up.sh
+++ b/resources/examples/airflow/up.sh
@@ -15,4 +15,5 @@ docker exec -ti airflow_webserver airflow variables set 'AIRBYTE_CONNECTION_ID' 
 docker exec -ti airflow_webserver airflow connections add 'airbyte_example' --conn-uri 'airbyte://host.docker.internal:8000'
 echo "Access Airflow at http://localhost:8085 to kick off your Airbyte sync DAG."
 # Create Superset containers.
+docker-compose -f docker-compose-superset.yaml down -v
 docker-compose -f docker-compose-superset.yaml up -d


### PR DESCRIPTION
## Main Changes
- `down.sh` now removes the superset containers as expected.
- We now remove orphaned superset containers before creating them in `up.sh`