### PR TITLE
Add hint to Airflow guide about local example

### DIFF
--- a/docs/operator-guides/using-the-airflow-airbyte-operator.md
+++ b/docs/operator-guides/using-the-airflow-airbyte-operator.md
@@ -8,6 +8,10 @@ Airbyte is an official community provider for the Apache Airflow project.
 The Airbyte operator allows you to trigger synchronization jobs in Apache Airflow,
 and this tutorial will walk through configuring your Airflow DAG to do so.
 
+{% hint style="warning" %}
+Due to some difficulties in setting up Airflow, we recommend first trying out the deployment using the local example [here](https://github.com/airbytehq/airbyte/tree/master/resources/examples/airflow), as it contains accurate configuration required to get the Airbyte operator up and running.
+{% endhint %}
+
 The Airbyte Provider documentation on Airflow project can be found [here](https://airflow.apache.org/docs/apache-airflow-providers-airbyte/stable/index.html).
 
 ## 1. Set up the tools


### PR DESCRIPTION
## Main Changes
- Mention Airflow local example in Airflow guide as an alternative.