### PR TITLE
Add note about orphaned Airbyte configs preventing automatic upgrades

### DIFF
--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -30,6 +30,12 @@ If you are running [Airbyte on Kubernetes](../deploying-airbyte/on-kubernetes.md
    docker-compose up
    ```
 
+{% hint style="info" %}
+If you did not start Airbyte from the root of the Airbyte monorepo, you will need to still need to manually remove these now orphaned Airbyte configurations. You can do this with `docker volume rm $(docker volume ls -q | grep airbyte)`.
+{% endhint %}
+
+docker volume rm $(docker volume ls -q | grep airbyte)
+
 ## Upgrading on K8s (0.27.0-alpha and above)
 
 If you are upgrading from (i.e. your current version of Airbyte is) Airbyte version **0.27.0-alpha or above** on Kubernetes :

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -34,8 +34,6 @@ If you are running [Airbyte on Kubernetes](../deploying-airbyte/on-kubernetes.md
 If you did not start Airbyte from the root of the Airbyte monorepo, you will need to still need to manually remove these now orphaned Airbyte configurations. You can do this with `docker volume rm $(docker volume ls -q | grep airbyte)`.
 {% endhint %}
 
-docker volume rm $(docker volume ls -q | grep airbyte)
-
 ## Upgrading on K8s (0.27.0-alpha and above)
 
 If you are upgrading from (i.e. your current version of Airbyte is) Airbyte version **0.27.0-alpha or above** on Kubernetes :

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -30,8 +30,12 @@ If you are running [Airbyte on Kubernetes](../deploying-airbyte/on-kubernetes.md
    docker-compose up
    ```
 
-{% hint style="info" %}
-If you did not start Airbyte from the root of the Airbyte monorepo, you will need to still need to manually remove these now orphaned Airbyte configurations. You can do this with `docker volume rm $(docker volume ls -q | grep airbyte)`.
+### Resetting your Configuration
+
+If you did not start Airbyte from the root of the Airbyte monorepo, you may run into issues where existing orphaned Airbyte configurations will prevent you from upgrading with the automatic process. To fix this, we will need to globally remove these lost Airbyte configurations. You can do this with `docker volume rm $(docker volume ls -q | grep airbyte)`.
+
+{% hint style="danger" %}
+This will completely reset your Airbyte instance back to scratch and you will lose all data.
 {% endhint %}
 
 ## Upgrading on K8s (0.27.0-alpha and above)


### PR DESCRIPTION
## Main Inspiration
This Slack thread: https://airbytehq.slack.com/archives/C021JANJ6TY/p1626084844151700

## Main Changes
We need to include a note in the upgrading doc that tells users how to upgrade when you didn't start Airbyte from the root of the monorepo.