### PR TITLE
allow publishing airbyte-server to local maven repo

### DIFF
--- a/airbyte-server/Dockerfile
+++ b/airbyte-server/Dockerfile
@@ -6,7 +6,7 @@ ENV APPLICATION airbyte-server
 
 WORKDIR /app
 
-COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
+COPY build/distributions/${APPLICATION}-0*.tar ${APPLICATION}.tar
 
 RUN mkdir latest_seeds
 COPY build/config_init/resources/main/config latest_seeds

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -1,5 +1,26 @@
 plugins {
     id 'application'
+    id 'maven-publish'
+    id 'com.github.johnrengelman.shadow' version '6.1.0'
+}
+
+shadowJar {
+    zip64 true
+    mergeServiceFiles()
+    exclude 'META-INF/*.RSA'
+    exclude 'META-INF/*.SF'
+    exclude 'META-INF/*.DSA'
+}
+
+publishing {
+    publications {
+        shadow(MavenPublication) { publication ->
+            project.shadow.component(publication)
+        }
+    }
+    repositories {
+        mavenLocal()
+    }
 }
 
 dependencies {
@@ -52,8 +73,10 @@ task copySeed(type: Copy, dependsOn: [project(':airbyte-config:init').processRes
 //project.tasks.copySeed.mustRunAfter(project(':airbyte-config:init').tasks.processResources)
 assemble.dependsOn(project.tasks.copySeed)
 
+mainClassName = 'io.airbyte.server.ServerApp'
+
 application {
-    mainClass = 'io.airbyte.server.ServerApp'
+    mainClass = mainClassName
 }
 
 Properties env = new Properties()

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -10,6 +10,7 @@ shadowJar {
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/*.SF'
     exclude 'META-INF/*.DSA'
+    classifier = ''
 }
 
 publishing {

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -10,6 +10,7 @@ shadowJar {
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/*.SF'
     exclude 'META-INF/*.DSA'
+    // Not stubbing this out adds 'all' to the end of the jar's name.
     classifier = ''
 }
 


### PR DESCRIPTION
This builds a jar that includes all dependencies.

If we need something the server doesn't include we can move this to a new project that depends on all of the relevant projects and call it `airbyte-cloud-export` or something.

If this is the direction we're going, I'll also add publication to a separate Maven repo as well.

I'm using a fat jar here to dodge the complications of publishing Maven dependencies for every subproject and making sure the dependency declarations for Maven match for each of them.