### PR TITLE
Slightly improve sed-based yaml parsing

### DIFF
--- a/airbyte-workers/src/main/resources/dbt_transformation_entrypoint.sh
+++ b/airbyte-workers/src/main/resources/dbt_transformation_entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 CWD=$(pwd)
 if [[ -f "${CWD}/git_repo/dbt_project.yml" ]]; then
   # Find profile name used in the custom dbt project:
-  PROFILE_NAME=$(grep -e "profile:" < "${CWD}/git_repo/dbt_project.yml" | sed -E "s/profile: *['\"](.*)['\"]/\1/")
+  PROFILE_NAME=$(grep -e "profile:" < "${CWD}/git_repo/dbt_project.yml" | sed -E "s/profile: *['\"]?([^'\"]*)['\"]?/\1/")
   if [[ -n "${PROFILE_NAME}" ]]; then
     mv "${CWD}/profiles.yml" "${CWD}/profiles.txt"
     # Refer to the appropriate profile name in the profiles.yml file


### PR DESCRIPTION
Previous sed did not handle the valid `profile: foo`

## What
I was getting DBT error, traced it to this file: when you have a profile yaml line without quotes, ala `profile: foo`, this would fail to extract `foo`, instead returning `profile: foo`, causing the resulting yaml file to be invalid.

## How
This makes non-quoted profiles work at the cost of failing on combined-quoted, e.g. `profile: "foo's"`. The former intuitively seems much more common than the latter.

Of course, proper yaml parsing would be ideal, but that's more complicated. Will leave to future us :).

CC @ChristopheDuong