### PR TITLE
Test publishing to GCS.

### DIFF
--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -1,5 +1,26 @@
 plugins {
     id 'application'
+    id 'maven-publish'
+    id 'com.github.johnrengelman.shadow' version '6.1.0'
+}
+
+shadowJar {
+    zip64 true
+    mergeServiceFiles()
+    exclude 'META-INF/*.RSA'
+    exclude 'META-INF/*.SF'
+    exclude 'META-INF/*.DSA'
+}
+
+publishing {
+    publications {
+        shadow(MavenPublication) { publication ->
+            project.shadow.component(publication)
+        }
+    }
+    repositories {
+        mavenLocal()
+    }
 }
 
 dependencies {
@@ -52,8 +73,10 @@ task copySeed(type: Copy, dependsOn: [project(':airbyte-config:init').processRes
 //project.tasks.copySeed.mustRunAfter(project(':airbyte-config:init').tasks.processResources)
 assemble.dependsOn(project.tasks.copySeed)
 
+mainClassName = 'io.airbyte.server.ServerApp'
+
 application {
-    mainClass = 'io.airbyte.server.ServerApp'
+    mainClass = mainClassName
 }
 
 Properties env = new Properties()

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -21,7 +21,10 @@ publishing {
         }
     }
     repositories {
-        mavenLocal()
+        maven {
+            name 'GcsRepository'
+            url 'gcs://airbyte-test-public-bucket/'
+        }
     }
 }
 

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -10,6 +10,7 @@ shadowJar {
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/*.SF'
     exclude 'META-INF/*.DSA'
+    classifier = ''
 }
 
 publishing {

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -10,6 +10,7 @@ shadowJar {
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/*.SF'
     exclude 'META-INF/*.DSA'
+    // Not stubbing this out adds 'all' to the end of the jar's name.
     classifier = ''
 }
 


### PR DESCRIPTION
## What
POC on how publishing to GCS. I was running into the exact same issue and stumbled on [this](https://linuxtut.com/build-maven-in-house-repository-on-google-cloud-storage-847ff/).

This POC sets this up for local publishing.

Steps:
```
// Set up GCP cli.
$ gcloud init
// Hydrate local credentials.
$ gcloud auth application-default login
// Run the publish command. Disable daemon so the Java process always uses the latest creds in the env.
$CORE_ONLY=true ./gradlew :airbyte-server:publish --no-daemon
```

Result: 

<img width="1788" alt="Screen Shot 2021-07-13 at 8 36 42 PM" src="https://user-images.githubusercontent.com/9772859/125452653-cafec5f2-bc2c-468f-96dc-1a8ccd039415.png">

Browse [here](https://console.cloud.google.com/storage/browser/airbyte-test-public-bucket/io/airbyte/airbyte-server/0.27.1-alpha?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&authuser=1&project=dataline-integration-testing&prefix=&forceOnObjectsSortingFiltering=false).

Lost some time because the bucket name cannot contain special characters except for `-` due to this [bug](https://github.com/gradle/gradle/issues/16513) in Gradle.

PR to read from GCS here: https://github.com/airbytehq/airbyte-cloud/pull/47. Configuration is exactly the same.

## How
Point Maven to a GCS bucket.

## Pre-merge Checklist
Expand the checklist which is relevant for this PR. 

<details><summary> <strong> Connector checklist </strong> </summary>
<p>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Secrets are annotated with `airbyte_secret` in the connector's spec
- [ ] Credentials added to Github CI if needed and not already present. [instructions for injecting secrets into CI](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#using-credentials-in-ci). 
- [ ] Unit & integration tests added as appropriate (and are passing)
    * Community members: please provide proof of this succeeding locally e.g: screenshot or copy-paste acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] `/test connector=connectors/<name>` command as documented [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-an-existing-connector) is passing. 
    * Community members can skip this, Airbyters will run this for you. 
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] `README.md`
    - [ ] `docs/SUMMARY.md` if it's a new connector
    - [ ] Created or updated reference docs in `docs/integrations/<source or destination>/<name>`.
    - [ ] Changelog in the appropriate page in `docs/integrations/...`. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md` contains a reference to the new connector
    - [ ] Build status added to [build page](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/builds.md)
- [ ] Build is successful
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] No major blockers
- [ ] PR merged into master branch
- [ ] Follow up tickets have been created
- [ ] Associated tickets have been closed & stakeholders notified
</p>
</details>

<details><summary> <strong> Connector Generator checklist </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
