### PR TITLE
fix broken assertions for automatic migration tests

### DIFF
--- a/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
@@ -159,7 +159,11 @@ public class RunMigrationTest {
     assertEquals("MySQL", mysqlDefinition.getName());
 
     final StandardSourceDefinition postgresDefinition = sourceDefinitions.get("decd338e-5647-4c0b-adf4-da0e75f5a750");
-    assertTrue(postgresDefinition.getDockerImageTag().compareTo("0.3.4") >= 0);
+    String[] tagBrokenAsArray = postgresDefinition.getDockerImageTag().replace(".", ",").split(",");
+    assertEquals(3, tagBrokenAsArray.length);
+    assertTrue(Integer.parseInt(tagBrokenAsArray[0]) >= 0);
+    assertTrue(Integer.parseInt(tagBrokenAsArray[1]) >= 3);
+    assertTrue(Integer.parseInt(tagBrokenAsArray[2]) >= 4);
     assertTrue(postgresDefinition.getName().contains("Postgres"));
   }
 
@@ -178,7 +182,11 @@ public class RunMigrationTest {
     assertEquals("0.2.0", localCsvDefinition.getDockerImageTag());
 
     final StandardDestinationDefinition snowflakeDefinition = sourceDefinitions.get("424892c4-daac-4491-b35d-c6688ba547ba");
-    assertTrue(snowflakeDefinition.getDockerImageTag().compareTo("0.3.9") >= 0);
+    String[] tagBrokenAsArray = snowflakeDefinition.getDockerImageTag().replace(".", ",").split(",");
+    assertEquals(3, tagBrokenAsArray.length);
+    assertTrue(Integer.parseInt(tagBrokenAsArray[0]) >= 0);
+    assertTrue(Integer.parseInt(tagBrokenAsArray[1]) >= 3);
+    assertTrue(Integer.parseInt(tagBrokenAsArray[2]) >= 9);
     assertTrue(snowflakeDefinition.getName().contains("Snowflake"));
   }
 

--- a/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
+++ b/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
@@ -204,7 +204,11 @@ public class MigrationAcceptanceTest {
         foundMysqlSourceDefinition = true;
       } else if (sourceDefinitionRead.getSourceDefinitionId().toString()
           .equals("decd338e-5647-4c0b-adf4-da0e75f5a750")) {
-        assertTrue(sourceDefinitionRead.getDockerImageTag().compareTo("0.3.4") >= 0);
+        String[] tagBrokenAsArray = sourceDefinitionRead.getDockerImageTag().replace(".", ",").split(",");
+        assertEquals(3, tagBrokenAsArray.length);
+        assertTrue(Integer.parseInt(tagBrokenAsArray[0]) >= 0);
+        assertTrue(Integer.parseInt(tagBrokenAsArray[1]) >= 3);
+        assertTrue(Integer.parseInt(tagBrokenAsArray[2]) >= 4);
         assertTrue(sourceDefinitionRead.getName().contains("Postgres"));
         foundPostgresSourceDefinition = true;
       }
@@ -235,7 +239,11 @@ public class MigrationAcceptanceTest {
           foundLocalCSVDestinationDefinition = true;
         }
         case "424892c4-daac-4491-b35d-c6688ba547ba" -> {
-          assertTrue(destinationDefinitionRead.getDockerImageTag().compareTo("0.3.9") >= 0);
+          String[] tagBrokenAsArray = destinationDefinitionRead.getDockerImageTag().replace(".", ",").split(",");
+          assertEquals(3, tagBrokenAsArray.length);
+          assertTrue(Integer.parseInt(tagBrokenAsArray[0]) >= 0);
+          assertTrue(Integer.parseInt(tagBrokenAsArray[1]) >= 3);
+          assertTrue(Integer.parseInt(tagBrokenAsArray[2]) >= 9);
           assertTrue(destinationDefinitionRead.getName().contains("Snowflake"));
           foundSnowflakeDestinationDefintion = true;
         }


### PR DESCRIPTION
The tests were comparing docker versions using `compareTo` but when Sherif released snowflake in this PR https://github.com/airbytehq/airbyte/pull/4713, the version became `0.3.10` and a compareTo call against `0.3.9` makes `0.3.10` smaller, thats why master build broke


## Pre-merge Checklist
Expand the checklist which is relevant for this PR. 

<details><summary> <strong> Connector checklist </strong> </summary>
<p>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Secrets are annotated with `airbyte_secret` in the connector's spec
- [ ] Credentials added to Github CI if needed and not already present. [instructions for injecting secrets into CI](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#using-credentials-in-ci). 
- [ ] Unit & integration tests added as appropriate (and are passing)
    * Community members: please provide proof of this succeeding locally e.g: screenshot or copy-paste acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] `/test connector=connectors/<name>` command as documented [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-an-existing-connector) is passing. 
    * Community members can skip this, Airbyters will run this for you. 
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] `README.md`
    - [ ] `docs/SUMMARY.md` if it's a new connector
    - [ ] Created or updated reference docs in `docs/integrations/<source or destination>/<name>`.
    - [ ] Changelog in the appropriate page in `docs/integrations/...`. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md` contains a reference to the new connector
    - [ ] Build status added to [build page](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/builds.md)
- [ ] Build is successful
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [ ] No major blockers
- [ ] PR merged into master branch
- [ ] Follow up tickets have been created
- [ ] Associated tickets have been closed & stakeholders notified
</p>
</details>

<details><summary> <strong> Connector Generator checklist </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
