### PR TITLE
upgrade fabric8 client

### DIFF
--- a/airbyte-scheduler/app/build.gradle
+++ b/airbyte-scheduler/app/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'io.fabric8:kubernetes-client:5.3.1'
+    implementation 'io.fabric8:kubernetes-client:5.5.0'
     implementation 'io.kubernetes:client-java-api:10.0.0'
     implementation 'io.kubernetes:client-java:10.0.0'
     implementation 'io.kubernetes:client-java-extended:10.0.0'


### PR DESCRIPTION
I think we can close https://github.com/airbytehq/airbyte/issues/3611 as a won't fix since our exit conditions were mostly hit when we were closing an application (our testing `main` function) without at SIGINT. It seems like it's working properly without it.

However, the https://github.com/fabric8io/kubernetes-client/releases/tag/v5.5.0 release still has relevant minor improvements around watches that we should pick up.