### PR TITLE
fix kube overlay version

### DIFF
--- a/kube/overlays/stable-with-resource-limits/.env
+++ b/kube/overlays/stable-with-resource-limits/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.27.2-alpha
+AIRBYTE_VERSION=0.27.3-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_USER=docker

--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/seed
-    newTag: 0.27.2-alpha
+    newTag: 0.27.3-alpha
   - name: airbyte/db
-    newTag: 0.27.2-alpha
+    newTag: 0.27.3-alpha
   - name: airbyte/scheduler
-    newTag: 0.27.2-alpha
+    newTag: 0.27.3-alpha
   - name: airbyte/server
-    newTag: 0.27.2-alpha
+    newTag: 0.27.3-alpha
   - name: airbyte/webapp
-    newTag: 0.27.2-alpha
+    newTag: 0.27.3-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 


### PR DESCRIPTION
between creation of https://github.com/airbytehq/airbyte/pull/4749 and the merge, version 0.27.3 was released, which meant that the release didn't bump the version in the new overlay.