### PR TITLE
Code generator: scope chowned directories to reduce runtime

### DIFF
--- a/airbyte-integrations/connector-templates/generator/Dockerfile
+++ b/airbyte-integrations/connector-templates/generator/Dockerfile
@@ -8,6 +8,8 @@ ENV ENV_GID $GID
 RUN mkdir -p /airbyte
 WORKDIR /airbyte/airbyte-integrations/connector-templates/generator
 
-CMD npm install --silent --no-update-notifier && \
+CMD npm install --silent --no-update-notifier && echo "INSTALL DONE" && \
     npm run generate "$package_desc" "$package_name" && \
-    chown -R $ENV_UID:$ENV_GID /airbyte/*
+    LAST_CREATED_CONNECTOR=$(ls -td /airbyte/airbyte-integrations/connectors/* | head -n 1) && \
+    echo "chowning generated directory: $LAST_CREATED_CONNECTOR" && \
+    chown -R $ENV_UID:$ENV_GID $LAST_CREATED_CONNECTOR/*


### PR DESCRIPTION
## What
This was hanging forever because it was trying to chown the whole world. Changed it to chown only the latest generated connector directory. 
