### PR TITLE
refactor import / export endpoints to use the same code path as auto migration

### DIFF
--- a/airbyte-analytics/src/main/java/io/airbyte/analytics/TrackingClientSingleton.java
+++ b/airbyte-analytics/src/main/java/io/airbyte/analytics/TrackingClientSingleton.java
@@ -56,10 +56,15 @@ public class TrackingClientSingleton {
   }
 
   public static void initialize(final Configs.TrackingStrategy trackingStrategy,
+                                final Configs.WorkerEnvironment deploymentEnvironment,
                                 final String airbyteRole,
                                 final String airbyteVersion,
                                 final ConfigRepository configRepository) {
-    initialize(createTrackingClient(trackingStrategy, airbyteRole, () -> getTrackingIdentity(configRepository, airbyteVersion)));
+    initialize(createTrackingClient(
+        trackingStrategy,
+        deploymentEnvironment,
+        airbyteRole,
+        () -> getTrackingIdentity(configRepository, airbyteVersion)));
   }
 
   // fallback on a logging client with an empty identity.
@@ -93,6 +98,7 @@ public class TrackingClientSingleton {
    * Creates a tracking client that uses the appropriate strategy from an identity supplier.
    *
    * @param trackingStrategy - what type of tracker we want to use.
+   * @param deploymentEnvironment - the environment that airbyte is running in.
    * @param airbyteRole
    * @param trackingIdentitySupplier - how we get the identity of the user. we have a supplier,
    *        because we if the identity updates over time (which happens during initial setup), we
@@ -101,10 +107,11 @@ public class TrackingClientSingleton {
    */
   @VisibleForTesting
   static TrackingClient createTrackingClient(final Configs.TrackingStrategy trackingStrategy,
+                                             final Configs.WorkerEnvironment deploymentEnvironment,
                                              final String airbyteRole,
                                              final Supplier<TrackingIdentity> trackingIdentitySupplier) {
     return switch (trackingStrategy) {
-      case SEGMENT -> new SegmentTrackingClient(trackingIdentitySupplier, airbyteRole);
+      case SEGMENT -> new SegmentTrackingClient(trackingIdentitySupplier, deploymentEnvironment, airbyteRole);
       case LOGGING -> new LoggingTrackingClient(trackingIdentitySupplier);
       default -> throw new IllegalStateException("unrecognized tracking strategy");
     };

--- a/airbyte-analytics/src/test/java/io/airbyte/analytics/TrackingClientSingletonTest.java
+++ b/airbyte-analytics/src/test/java/io/airbyte/analytics/TrackingClientSingletonTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.airbyte.config.Configs;
+import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
@@ -58,6 +59,7 @@ class TrackingClientSingletonTest {
     assertTrue(
         TrackingClientSingleton.createTrackingClient(
             Configs.TrackingStrategy.LOGGING,
+            WorkerEnvironment.DOCKER,
             "role",
             TrackingIdentity::empty) instanceof LoggingTrackingClient);
   }
@@ -67,6 +69,7 @@ class TrackingClientSingletonTest {
     assertTrue(
         TrackingClientSingleton.createTrackingClient(
             Configs.TrackingStrategy.SEGMENT,
+            WorkerEnvironment.DOCKER,
             "role",
             TrackingIdentity::empty) instanceof SegmentTrackingClient);
   }

--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
@@ -236,6 +236,7 @@ public class SchedulerApp {
 
     TrackingClientSingleton.initialize(
         configs.getTrackingStrategy(),
+        configs.getWorkerEnvironment(),
         configs.getAirbyteRole(),
         configs.getAirbyteVersion(),
         configRepository);


### PR DESCRIPTION
## What
I was trying to figure out how to deprecate the default workspace. One thing that makes that a bit easier is scoping the import / export endpoints by workspace id. As I started on that, I realized they were using a different code path that the auto migration code. This made me nervous that we had two code paths and made it non obvious how to approach the scoping work I wanted to do in such a way that it might not be throwaway. 

Therefore this PR refactors the migration code so that both auto migration and import / export endpoints use the same code paths.

## How
*Describe the solution*

## Recommended reading order
1. `ConfigDumpImporter.java`
2. `ConfigDumpExporter.java`
3. `ArchiveHandler.java`

## Future Work
I could not get rid of the `DatabaseArchiver.java` which is one of the old code paths entirely because it used as part of the testing for auto migration. I spent a long time trying to pull it out and wasn't getting anywhere. I will need to spend more time with `RunMigrationTest` before I can figure that out. So for now, I just moved it into a test package so that no one uses it for prod use cases.
