### PR TITLE
Code generator: Update generator to chown docs and config definition directories

### DIFF
--- a/airbyte-integrations/connector-templates/generator/Dockerfile
+++ b/airbyte-integrations/connector-templates/generator/Dockerfile
@@ -4,6 +4,8 @@ ARG UID
 ARG GID
 ENV ENV_UID $UID
 ENV ENV_GID $GID
+ENV DOCS_DIR "/airbyte/docs/integrations"
+ENV CONFIG_DIR "/airbyte/airbyte-config/init/src/main/resources/config"
 
 RUN mkdir -p /airbyte
 WORKDIR /airbyte/airbyte-integrations/connector-templates/generator
@@ -12,4 +14,8 @@ CMD npm install --silent --no-update-notifier && echo "INSTALL DONE" && \
     npm run generate "$package_desc" "$package_name" && \
     LAST_CREATED_CONNECTOR=$(ls -td /airbyte/airbyte-integrations/connectors/* | head -n 1) && \
     echo "chowning generated directory: $LAST_CREATED_CONNECTOR" && \
-    chown -R $ENV_UID:$ENV_GID $LAST_CREATED_CONNECTOR/*
+    chown -R $ENV_UID:$ENV_GID $LAST_CREATED_CONNECTOR/* && \
+    echo "chowning docs directory: $DOCS_DIR" && \
+    chown -R $ENV_UID:$ENV_GID $DOCS_DIR/* && \
+    echo "chowning docs directory: $CONFIG_DIR" && \
+    chown -R $ENV_UID:$ENV_GID $CONFIG_DIR/*

--- a/airbyte-integrations/connector-templates/generator/Dockerfile
+++ b/airbyte-integrations/connector-templates/generator/Dockerfile
@@ -17,5 +17,5 @@ CMD npm install --silent --no-update-notifier && echo "INSTALL DONE" && \
     chown -R $ENV_UID:$ENV_GID $LAST_CREATED_CONNECTOR/* && \
     echo "chowning docs directory: $DOCS_DIR" && \
     chown -R $ENV_UID:$ENV_GID $DOCS_DIR/* && \
-    echo "chowning docs directory: $CONFIG_DIR" && \
+    echo "chowning config directory: $CONFIG_DIR" && \
     chown -R $ENV_UID:$ENV_GID $CONFIG_DIR/*


### PR DESCRIPTION
## What
Creating the Java-Destination connector via generator creates the files in next folders: 
```
docs/integrations
airbyte-config/init/src/main/resources/config
```
Update for PR [#4774](https://github.com/airbytehq/airbyte/pull/4774)

## How
I add them to Dockerfile to chown those folders after generating

## Recommended reading order
`airbyte-integrations/connector-templates/generator/Dockerfile`
