### PR TITLE
Tweak ConfigNotFoundException class

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
@@ -31,9 +31,11 @@ public interface Configs {
 
   String getAirbyteRole();
 
-  String getAirbyteServerHost();
-
   String getAirbyteVersion();
+
+  String getAirbyteApiUrl();
+
+  int getAirbyteApiPort();
 
   String getAirbyteVersionOrWarning();
 

--- a/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
@@ -31,6 +31,8 @@ public interface Configs {
 
   String getAirbyteRole();
 
+  String getAirbyteServerHost();
+
   String getAirbyteVersion();
 
   String getAirbyteVersionOrWarning();

--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -40,6 +40,7 @@ public class EnvConfigs implements Configs {
   private static final Logger LOGGER = LoggerFactory.getLogger(EnvConfigs.class);
 
   public static final String AIRBYTE_ROLE = "AIRBYTE_ROLE";
+  public static final String AIRBYTE_SERVER_HOST = "AIRBYTE_SERVER_HOST";
   public static final String AIRBYTE_VERSION = "AIRBYTE_VERSION";
   public static final String WORKER_ENVIRONMENT = "WORKER_ENVIRONMENT";
   public static final String WORKSPACE_ROOT = "WORKSPACE_ROOT";
@@ -89,6 +90,11 @@ public class EnvConfigs implements Configs {
   @Override
   public String getAirbyteRole() {
     return getEnv(AIRBYTE_ROLE);
+  }
+
+  @Override
+  public String getAirbyteServerHost() {
+    return getEnsureEnv(AIRBYTE_SERVER_HOST);
   }
 
   @Override

--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -40,8 +40,8 @@ public class EnvConfigs implements Configs {
   private static final Logger LOGGER = LoggerFactory.getLogger(EnvConfigs.class);
 
   public static final String AIRBYTE_ROLE = "AIRBYTE_ROLE";
-  public static final String AIRBYTE_SERVER_HOST = "AIRBYTE_SERVER_HOST";
   public static final String AIRBYTE_VERSION = "AIRBYTE_VERSION";
+  public static final String INTERNAL_API_HOST = "INTERNAL_API_HOST";
   public static final String WORKER_ENVIRONMENT = "WORKER_ENVIRONMENT";
   public static final String WORKSPACE_ROOT = "WORKSPACE_ROOT";
   public static final String WORKSPACE_DOCKER_MOUNT = "WORKSPACE_DOCKER_MOUNT";
@@ -93,8 +93,13 @@ public class EnvConfigs implements Configs {
   }
 
   @Override
-  public String getAirbyteServerHost() {
-    return getEnsureEnv(AIRBYTE_SERVER_HOST);
+  public String getAirbyteApiUrl() {
+    return getEnsureEnv(INTERNAL_API_HOST).split(":")[0];
+  }
+
+  @Override
+  public int getAirbyteApiPort() {
+    return Integer.parseInt(getEnsureEnv(INTERNAL_API_HOST).split(":")[1]);
   }
 
   @Override

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigNotFoundException.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigNotFoundException.java
@@ -29,20 +29,24 @@ import java.util.UUID;
 
 public class ConfigNotFoundException extends Exception {
 
-  private ConfigSchema type;
+  private final String type;
   private final String configId;
 
-  public ConfigNotFoundException(ConfigSchema type, String configId) {
+  public ConfigNotFoundException(String type, String configId) {
     super(String.format("config type: %s id: %s", type, configId));
     this.type = type;
     this.configId = configId;
   }
 
-  public ConfigNotFoundException(ConfigSchema type, UUID uuid) {
-    this(type, uuid.toString());
+  public ConfigNotFoundException(ConfigSchema type, String configId) {
+    this(type.toString(), configId);
   }
 
-  public ConfigSchema getType() {
+  public ConfigNotFoundException(ConfigSchema type, UUID uuid) {
+    this(type.toString(), uuid.toString());
+  }
+
+  public String getType() {
     return type;
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/errors/InvalidInputExceptionMapper.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/errors/InvalidInputExceptionMapper.java
@@ -52,7 +52,7 @@ public class InvalidInputExceptionMapper implements ExceptionMapper<ConstraintVi
       props.add(new InvalidInputProperty()
           .propertyPath(cv.getPropertyPath().toString())
           .message(cv.getMessage())
-          .invalidValue(cv.getInvalidValue().toString()));
+          .invalidValue(cv.getInvalidValue() != null ? cv.getInvalidValue().toString() : "null"));
     }
     exceptionInfo.validationErrors(props);
     return exceptionInfo;


### PR DESCRIPTION
## What
The exception has constructors that require a first argument of `ConfigSchema`:
`ConfigNotFoundException(ConfigSchema type, UUID uuid)` 

## How
Make it accept more than just `ConfigSchema` in case we are loading other configuration objects.

