### PR TITLE
add deployments to tracking model

### DIFF
--- a/airbyte-analytics/src/main/java/io/airbyte/analytics/Deployment.java
+++ b/airbyte-analytics/src/main/java/io/airbyte/analytics/Deployment.java
@@ -1,0 +1,78 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.analytics;
+
+import com.google.common.base.Preconditions;
+import io.airbyte.config.Configs;
+import io.airbyte.config.Configs.WorkerEnvironment;
+import java.util.UUID;
+
+public class Deployment {
+
+  public enum DeploymentMode {
+    OSS,
+    CLOUD
+  }
+
+  /**
+   * deployment - deployment tracking info.
+   */
+  private final DeploymentMode deploymentMode;
+  /**
+   * deploymentId - Identifier for the deployment.
+   *
+   * This identifier tracks an install of Airbyte. Any time Airbyte is started up with new volumes or
+   * persistence, it will be assigned a new deployment id. This is different from the lifecycle of the
+   * rest of the data layer which may be persisted across deployments.
+   */
+  private final UUID deploymentId;
+  /**
+   * deploymentEnvironment - the environment that airbyte is running in.
+   */
+  private final Configs.WorkerEnvironment deploymentEnv;
+
+  public Deployment(final DeploymentMode deploymentMode, final UUID deploymentId, final WorkerEnvironment deploymentEnv) {
+    Preconditions.checkNotNull(deploymentMode);
+    Preconditions.checkNotNull(deploymentId);
+    Preconditions.checkNotNull(deploymentEnv);
+
+    this.deploymentMode = deploymentMode;
+    this.deploymentId = deploymentId;
+    this.deploymentEnv = deploymentEnv;
+  }
+
+  public DeploymentMode getDeploymentMode() {
+    return deploymentMode;
+  }
+
+  public UUID getDeploymentId() {
+    return deploymentId;
+  }
+
+  public WorkerEnvironment getDeploymentEnv() {
+    return deploymentEnv;
+  }
+
+}

--- a/airbyte-analytics/src/main/java/io/airbyte/analytics/SegmentTrackingClient.java
+++ b/airbyte-analytics/src/main/java/io/airbyte/analytics/SegmentTrackingClient.java
@@ -30,8 +30,6 @@ import com.segment.analytics.Analytics;
 import com.segment.analytics.messages.AliasMessage;
 import com.segment.analytics.messages.IdentifyMessage;
 import com.segment.analytics.messages.TrackMessage;
-import io.airbyte.config.Configs;
-import io.airbyte.config.Configs.WorkerEnvironment;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,24 +44,26 @@ public class SegmentTrackingClient implements TrackingClient {
   // Analytics is threadsafe.
   private final Analytics analytics;
   private final Supplier<TrackingIdentity> identitySupplier;
+  private final Deployment deployment;
   private final String airbyteRole;
-  private final WorkerEnvironment deploymentEnvironment;
 
   @VisibleForTesting
   SegmentTrackingClient(final Supplier<TrackingIdentity> identitySupplier,
-                        final Configs.WorkerEnvironment deploymentEnvironment,
+                        final Deployment deployment,
+
                         final String airbyteRole,
                         final Analytics analytics) {
     this.identitySupplier = identitySupplier;
-    this.deploymentEnvironment = deploymentEnvironment;
+    this.deployment = deployment;
     this.analytics = analytics;
     this.airbyteRole = airbyteRole;
   }
 
   public SegmentTrackingClient(final Supplier<TrackingIdentity> identitySupplier,
-                               final Configs.WorkerEnvironment deploymentEnvironment,
+                               final Deployment deployment,
+
                                final String airbyteRole) {
-    this(identitySupplier, deploymentEnvironment, airbyteRole, Analytics.builder(SEGMENT_WRITE_KEY).build());
+    this(identitySupplier, deployment, airbyteRole, Analytics.builder(SEGMENT_WRITE_KEY).build());
   }
 
   @Override
@@ -73,7 +73,9 @@ public class SegmentTrackingClient implements TrackingClient {
 
     // deployment
     identityMetadata.put(AIRBYTE_VERSION_KEY, trackingIdentity.getAirbyteVersion());
-    identityMetadata.put("deployment_env", deploymentEnvironment);
+    identityMetadata.put("deployment_mode", deployment.getDeploymentMode());
+    identityMetadata.put("deployment_env", deployment.getDeploymentEnv());
+    identityMetadata.put("deployment_id", deployment.getDeploymentId());
 
     // workspace (includes info that in the future we would store in an organization)
     identityMetadata.put("anonymized", trackingIdentity.isAnonymousDataCollection());

--- a/airbyte-analytics/src/main/java/io/airbyte/analytics/TrackingClientSingleton.java
+++ b/airbyte-analytics/src/main/java/io/airbyte/analytics/TrackingClientSingleton.java
@@ -56,13 +56,13 @@ public class TrackingClientSingleton {
   }
 
   public static void initialize(final Configs.TrackingStrategy trackingStrategy,
-                                final Configs.WorkerEnvironment deploymentEnvironment,
+                                final Deployment deployment,
                                 final String airbyteRole,
                                 final String airbyteVersion,
                                 final ConfigRepository configRepository) {
     initialize(createTrackingClient(
         trackingStrategy,
-        deploymentEnvironment,
+        deployment,
         airbyteRole,
         () -> getTrackingIdentity(configRepository, airbyteVersion)));
   }
@@ -98,7 +98,8 @@ public class TrackingClientSingleton {
    * Creates a tracking client that uses the appropriate strategy from an identity supplier.
    *
    * @param trackingStrategy - what type of tracker we want to use.
-   * @param deploymentEnvironment - the environment that airbyte is running in.
+   * @param deployment - deployment tracking info. static because it should not change once the
+   *        instance is running.
    * @param airbyteRole
    * @param trackingIdentitySupplier - how we get the identity of the user. we have a supplier,
    *        because we if the identity updates over time (which happens during initial setup), we
@@ -107,11 +108,11 @@ public class TrackingClientSingleton {
    */
   @VisibleForTesting
   static TrackingClient createTrackingClient(final Configs.TrackingStrategy trackingStrategy,
-                                             final Configs.WorkerEnvironment deploymentEnvironment,
+                                             final Deployment deployment,
                                              final String airbyteRole,
                                              final Supplier<TrackingIdentity> trackingIdentitySupplier) {
     return switch (trackingStrategy) {
-      case SEGMENT -> new SegmentTrackingClient(trackingIdentitySupplier, deploymentEnvironment, airbyteRole);
+      case SEGMENT -> new SegmentTrackingClient(trackingIdentitySupplier, deployment, airbyteRole);
       case LOGGING -> new LoggingTrackingClient(trackingIdentitySupplier);
       default -> throw new IllegalStateException("unrecognized tracking strategy");
     };

--- a/airbyte-analytics/src/test/java/io/airbyte/analytics/SegmentTrackingClientTest.java
+++ b/airbyte-analytics/src/test/java/io/airbyte/analytics/SegmentTrackingClientTest.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableMap;
 import com.segment.analytics.Analytics;
 import com.segment.analytics.messages.IdentifyMessage;
 import com.segment.analytics.messages.TrackMessage;
+import io.airbyte.analytics.Deployment.DeploymentMode;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import java.util.Map;
 import java.util.UUID;
@@ -44,6 +45,7 @@ import org.mockito.ArgumentCaptor;
 class SegmentTrackingClientTest {
 
   private static final String AIRBYTE_VERSION = "dev";
+  private static final Deployment DEPLOYMENT = new Deployment(DeploymentMode.OSS, UUID.randomUUID(), WorkerEnvironment.DOCKER);
   private static final String EMAIL = "a@airbyte.io";
   private static final TrackingIdentity identity = new TrackingIdentity(AIRBYTE_VERSION, UUID.randomUUID(), EMAIL, false, false, true);
 
@@ -56,7 +58,7 @@ class SegmentTrackingClientTest {
   void setup() {
     analytics = mock(Analytics.class);
     roleSupplier = mock(Supplier.class);
-    segmentTrackingClient = new SegmentTrackingClient(() -> identity, WorkerEnvironment.DOCKER, null, analytics);
+    segmentTrackingClient = new SegmentTrackingClient(() -> identity, DEPLOYMENT, null, analytics);
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")
@@ -71,7 +73,9 @@ class SegmentTrackingClientTest {
     verify(analytics).enqueue(mockBuilder.capture());
     final IdentifyMessage actual = mockBuilder.getValue().build();
     final Map<String, Object> expectedTraits = ImmutableMap.<String, Object>builder()
-        .put("deployment_env", WorkerEnvironment.DOCKER)
+        .put("deployment_env", DEPLOYMENT.getDeploymentEnv())
+        .put("deployment_mode", DEPLOYMENT.getDeploymentMode())
+        .put("deployment_id", DEPLOYMENT.getDeploymentId())
         .put("airbyte_version", AIRBYTE_VERSION)
         .put("email", identity.getEmail().get())
         .put("anonymized", identity.isAnonymousDataCollection())
@@ -84,7 +88,7 @@ class SegmentTrackingClientTest {
 
   @Test
   void testIdentifyWithRole() {
-    segmentTrackingClient = new SegmentTrackingClient(() -> identity, WorkerEnvironment.DOCKER, "role", analytics);
+    segmentTrackingClient = new SegmentTrackingClient(() -> identity, DEPLOYMENT, "role", analytics);
     // equals is not defined on MessageBuilder, so we need to use ArgumentCaptor to inspect each field
     // manually.
     ArgumentCaptor<IdentifyMessage.Builder> mockBuilder = ArgumentCaptor.forClass(IdentifyMessage.Builder.class);
@@ -95,7 +99,9 @@ class SegmentTrackingClientTest {
     verify(analytics).enqueue(mockBuilder.capture());
     final IdentifyMessage actual = mockBuilder.getValue().build();
     final Map<String, Object> expectedTraits = ImmutableMap.<String, Object>builder()
-        .put("deployment_env", WorkerEnvironment.DOCKER)
+        .put("deployment_env", DEPLOYMENT.getDeploymentEnv())
+        .put("deployment_mode", DEPLOYMENT.getDeploymentMode())
+        .put("deployment_id", DEPLOYMENT.getDeploymentId())
         .put("airbyte_version", AIRBYTE_VERSION)
         .put("email", identity.getEmail().get())
         .put("anonymized", identity.isAnonymousDataCollection())

--- a/airbyte-analytics/src/test/java/io/airbyte/analytics/TrackingClientSingletonTest.java
+++ b/airbyte-analytics/src/test/java/io/airbyte/analytics/TrackingClientSingletonTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.airbyte.analytics.Deployment.DeploymentMode;
 import io.airbyte.config.Configs;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.StandardWorkspace;
@@ -44,7 +45,7 @@ import org.junit.jupiter.api.Test;
 class TrackingClientSingletonTest {
 
   private static final String AIRBYTE_VERSION = "dev";
-
+  private static final Deployment DEPLOYMENT = new Deployment(DeploymentMode.OSS, UUID.randomUUID(), WorkerEnvironment.DOCKER);
   private ConfigRepository configRepository;
 
   @BeforeEach
@@ -59,7 +60,7 @@ class TrackingClientSingletonTest {
     assertTrue(
         TrackingClientSingleton.createTrackingClient(
             Configs.TrackingStrategy.LOGGING,
-            WorkerEnvironment.DOCKER,
+            DEPLOYMENT,
             "role",
             TrackingIdentity::empty) instanceof LoggingTrackingClient);
   }
@@ -69,7 +70,7 @@ class TrackingClientSingletonTest {
     assertTrue(
         TrackingClientSingleton.createTrackingClient(
             Configs.TrackingStrategy.SEGMENT,
-            WorkerEnvironment.DOCKER,
+            DEPLOYMENT,
             "role",
             TrackingIdentity::empty) instanceof SegmentTrackingClient);
   }

--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
@@ -25,6 +25,8 @@
 package io.airbyte.scheduler.app;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.airbyte.analytics.Deployment;
+import io.airbyte.analytics.Deployment.DeploymentMode;
 import io.airbyte.analytics.TrackingClientSingleton;
 import io.airbyte.commons.concurrency.GracefulShutdownHandler;
 import io.airbyte.commons.version.AirbyteVersion;
@@ -239,13 +241,6 @@ public class SchedulerApp {
           });
     }
 
-    TrackingClientSingleton.initialize(
-        configs.getTrackingStrategy(),
-        configs.getWorkerEnvironment(),
-        configs.getAirbyteRole(),
-        configs.getAirbyteVersion(),
-        configRepository);
-
     Optional<String> airbyteDatabaseVersion = jobPersistence.getVersion();
     int loopCount = 0;
     while ((airbyteDatabaseVersion.isEmpty() || !AirbyteVersion.isCompatible(configs.getAirbyteVersion(), airbyteDatabaseVersion.get()))
@@ -260,6 +255,15 @@ public class SchedulerApp {
     } else {
       throw new IllegalStateException("Unable to retrieve Airbyte Version, aborting...");
     }
+
+    TrackingClientSingleton.initialize(
+        configs.getTrackingStrategy(),
+        // todo (cgardens) - we need to do the `#runServer` pattern here that we do in `ServerApp` so that
+        // the deployment mode can be set by the cloud version.
+        new Deployment(DeploymentMode.OSS, jobPersistence.getDeployment().orElseThrow(), configs.getWorkerEnvironment()),
+        configs.getAirbyteRole(),
+        configs.getAirbyteVersion(),
+        configRepository);
 
     final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService(temporalHost);
     final TemporalClient temporalClient = TemporalClient.production(temporalHost, workspaceRoot);

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobPersistence.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobPersistence.java
@@ -162,14 +162,26 @@ public interface JobPersistence {
   /// ARCHIVE
 
   /**
-   * Returns the AirbyteVersion stored in the database
+   * Returns the AirbyteVersion.
    */
   Optional<String> getVersion() throws IOException;
 
   /**
-   * Set the database to @param AirbyteVersion
+   * Set the airbyte version
    */
   void setVersion(String airbyteVersion) throws IOException;
+
+  /**
+   * Returns a deployment UUID.
+   */
+  Optional<UUID> getDeployment() throws IOException;
+  // a deployment references a setup of airbyte. it is created the first time the docker compose or
+  // K8s is ready.
+
+  /**
+   * Set deployment id. If one is already set, the new value is ignored.
+   */
+  void setDeployment(UUID uuid) throws IOException;
 
   /**
    * Export all SQL tables from @param schema into streams of JsonNode objects. This returns a Map of

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpExport.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpExport.java
@@ -103,15 +103,11 @@ public class ConfigDumpExport {
     }
   }
 
-  private void writeTableToArchive(final Path tablePath, final Stream<JsonNode> tableStream)
-      throws Exception {
+  private void writeTableToArchive(final Path tablePath, final Stream<JsonNode> tableStream) throws Exception {
     Files.createDirectories(tablePath.getParent());
-    final BufferedWriter recordOutputWriter = new BufferedWriter(
-        new FileWriter(tablePath.toFile()));
+    final BufferedWriter recordOutputWriter = new BufferedWriter(new FileWriter(tablePath.toFile()));
     final CloseableConsumer<JsonNode> recordConsumer = Yamls.listWriter(recordOutputWriter);
-    tableStream.forEach(row -> Exceptions.toRuntime(() -> {
-      recordConsumer.accept(row);
-    }));
+    tableStream.forEach(row -> Exceptions.toRuntime(() -> recordConsumer.accept(row)));
     recordConsumer.close();
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -24,6 +24,8 @@
 
 package io.airbyte.server;
 
+import io.airbyte.analytics.Deployment;
+import io.airbyte.analytics.Deployment.DeploymentMode;
 import io.airbyte.analytics.TrackingClientSingleton;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.version.AirbyteVersion;
@@ -100,13 +102,13 @@ public class ServerApp implements ServerRunnable {
   public void start() throws Exception {
     TrackingClientSingleton.get().identify();
 
-    Server server = new Server(PORT);
+    final Server server = new Server(PORT);
 
-    ServletContextHandler handler = new ServletContextHandler();
+    final ServletContextHandler handler = new ServletContextHandler();
 
-    Map<String, String> mdc = MDC.getCopyOfContextMap();
+    final Map<String, String> mdc = MDC.getCopyOfContextMap();
 
-    ResourceConfig rc =
+    final ResourceConfig rc =
         new ResourceConfig()
             .register(new RequestLogger(mdc))
             .register(InvalidInputExceptionMapper.class)
@@ -133,6 +135,17 @@ public class ServerApp implements ServerRunnable {
     final String banner = MoreResources.readResource("banner/banner.txt");
     LOGGER.info(banner + String.format("Version: %s\n", airbyteVersion));
     server.join();
+  }
+
+  private static void createDeploymentIfNoneExists(final JobPersistence jobPersistence) throws IOException {
+    final Optional<UUID> deploymentOptional = jobPersistence.getDeployment();
+      if (deploymentOptional.isPresent()) {
+      LOGGER.info("running deployment: {}", deploymentOptional.get());
+    } else {
+      final UUID deploymentId = UUID.randomUUID();
+      jobPersistence.setDeployment(deploymentId);
+      LOGGER.info("created deployment: {}", deploymentId);
+    }
   }
 
   private static void setCustomerIdIfNotSet(final ConfigRepository configRepository) throws InterruptedException {
@@ -174,13 +187,6 @@ public class ServerApp implements ServerRunnable {
     // tracking we can associate all action with the correct anonymous id.
     setCustomerIdIfNotSet(configRepository);
 
-    TrackingClientSingleton.initialize(
-        configs.getTrackingStrategy(),
-        WorkerEnvironment.DOCKER,
-        configs.getAirbyteRole(),
-        configs.getAirbyteVersion(),
-        configRepository);
-
     LOGGER.info("Creating Scheduler persistence...");
     final Database jobDatabase = Databases.createPostgresDatabaseWithRetry(
         configs.getDatabaseUser(),
@@ -188,6 +194,15 @@ public class ServerApp implements ServerRunnable {
         configs.getDatabaseUrl(),
         Databases.IS_JOB_DATABASE_READY);
     final JobPersistence jobPersistence = new DefaultJobPersistence(jobDatabase);
+
+    createDeploymentIfNoneExists(jobPersistence);
+
+    TrackingClientSingleton.initialize(
+        configs.getTrackingStrategy(),
+        new Deployment(DeploymentMode.OSS, jobPersistence.getDeployment().orElseThrow(), configs.getWorkerEnvironment()),
+        configs.getAirbyteRole(),
+        configs.getAirbyteVersion(),
+        configRepository);
 
     final String airbyteVersion = configs.getAirbyteVersion();
     if (jobPersistence.getVersion().isEmpty()) {
@@ -228,7 +243,7 @@ public class ServerApp implements ServerRunnable {
           configs);
     } else {
       LOGGER.info("Start serving version mismatch errors. Automatic migration either failed or didn't run");
-      return new VersionMismatchServer(airbyteVersion, airbyteDatabaseVersion.get(), PORT);
+      return new VersionMismatchServer(airbyteVersion, airbyteDatabaseVersion.orElseThrow(), PORT);
     }
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -139,7 +139,7 @@ public class ServerApp implements ServerRunnable {
 
   private static void createDeploymentIfNoneExists(final JobPersistence jobPersistence) throws IOException {
     final Optional<UUID> deploymentOptional = jobPersistence.getDeployment();
-      if (deploymentOptional.isPresent()) {
+    if (deploymentOptional.isPresent()) {
       LOGGER.info("running deployment: {}", deploymentOptional.get());
     } else {
       final UUID deploymentId = UUID.randomUUID();

--- a/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
@@ -93,7 +93,7 @@ public class RunMigrationTest {
   }
 
   @Test
-  public void testRunMigration() {
+  public void testRunMigration() throws Exception {
     try (StubAirbyteDB stubAirbyteDB = new StubAirbyteDB()) {
       final File file = Path
           .of(Resources.getResource("migration/03a4c904-c91d-447f-ab59-27a43b52c2fd.gz").toURI())
@@ -112,8 +112,6 @@ public class RunMigrationTest {
       assertDatabaseVersion(jobPersistence, TARGET_VERSION);
       assertPostMigrationConfigs(configRoot);
       FileUtils.deleteDirectory(configRoot.toFile());
-    } catch (Exception e) {
-      throw new RuntimeException(e);
     }
   }
 

--- a/docs/contributing-to-airbyte/gradle-cheatsheet.md
+++ b/docs/contributing-to-airbyte/gradle-cheatsheet.md
@@ -79,7 +79,7 @@ Unit Tests can be run using the `:test` task on any submodule. These test class-
 ##### Acceptance Tests
 We split Acceptance Tests into 2 different test suites:
 * Platform Acceptance Tests: These tests are a coarse test to sanity check that each major feature in the platform. They are run with the following command: `SUB_BUILD=PLATFORM ./gradlew :airbyte-tests:acceptanceTests`. These tests expect to find a local version of Airbyte running. For testing the docker version start Airbyte locally. For an example, see the [script](https://github.com/airbytehq/airbyte/blob/master/tools/bin/acceptance_test.sh) that is used by the CI. For Kubernetes, see the [script](https://github.com/airbytehq/airbyte/blob/master/tools/bin/acceptance_test_kube.sh) that is used by the CI.
-* Migration Acceptance Tests: These tests make sure the end-to-end process of migrating from one version of Airbyte to the next works. These tests are run with the following command: `SUB_BUILD=PLATFORM ./gradlew :airbyte-tests:automaticMigrationAcceptanceTest --scan`. These tests do not expect there to be a separate instance of Airbyte running.
+* Migration Acceptance Tests: These tests make sure the end-to-end process of migrating from one version of Airbyte to the next works. These tests are run with the following command: `SUB_BUILD=PLATFORM ./gradlew :airbyte-tests:automaticMigrationAcceptanceTest --scan`. These tests do not expect there to be a separate deployment of Airbyte running.
 
 These tests currently all live in `airbyte-tests`
 

--- a/docs/deploying-airbyte/on-kubernetes.md
+++ b/docs/deploying-airbyte/on-kubernetes.md
@@ -220,7 +220,7 @@ See [Upgrading K8s](../operator-guides/upgrading-airbyte.md).
 
 ### Resizing Volumes
 To resize a volume, change the `.spec.resources.requests.storage` value. After re-applying, the mount should be extended if that operation is supported
-for your type of mount. For a production instance, it's useful to track the usage of volumes to ensure they don't run out of space.
+for your type of mount. For a production deployment, it's useful to track the usage of volumes to ensure they don't run out of space.
 
 ### Copy Files To/From Volumes
 See the documentation for [`kubectl cp`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#cp).

--- a/docs/operator-guides/browsing-output-logs.md
+++ b/docs/operator-guides/browsing-output-logs.md
@@ -95,7 +95,7 @@ cat catalog.json
 
 ## CSV or JSON local Destinations: Check local data folder
 
-If you setup a pipeline using one of the local File based destinations \(CSV or JSON\), Airbyte is writing the resulting files containing the data in the special `/local/` directory in the container. By default, this volume is mounted from `/tmp/airbyte_local` on the host machine. So you need to navigate to this [local folder](file:///tmp/airbyte_local/) on the filesystem of the machine running the Airbyte instance to retrieve the local data files.
+If you setup a pipeline using one of the local File based destinations \(CSV or JSON\), Airbyte is writing the resulting files containing the data in the special `/local/` directory in the container. By default, this volume is mounted from `/tmp/airbyte_local` on the host machine. So you need to navigate to this [local folder](file:///tmp/airbyte_local/) on the filesystem of the machine running the Airbyte deployment to retrieve the local data files.
 
 Or, you can also run through docker commands as proxy:
 

--- a/docs/operator-guides/transformation-and-normalization/transformations-with-sql.md
+++ b/docs/operator-guides/transformation-and-normalization/transformations-with-sql.md
@@ -36,7 +36,7 @@ Note: We will rely on docker commands that we've gone over as part of another [T
 
 ## \(Optional\) Configure some Covid \(data\) source and Postgres destinations
 
-If you have sources and destinations already setup on your instance, you can skip to the next section.
+If you have sources and destinations already setup on your deployment, you can skip to the next section.
 
 For the sake of this tutorial, let's create some source and destination as an example that we can refer to afterward. We'll be using a file accessible from a public API, so you can easily reproduce this setup:
 

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -35,7 +35,7 @@ If you are running [Airbyte on Kubernetes](../deploying-airbyte/on-kubernetes.md
 If you did not start Airbyte from the root of the Airbyte monorepo, you may run into issues where existing orphaned Airbyte configurations will prevent you from upgrading with the automatic process. To fix this, we will need to globally remove these lost Airbyte configurations. You can do this with `docker volume rm $(docker volume ls -q | grep airbyte)`.
 
 {% hint style="danger" %}
-This will completely reset your Airbyte instance back to scratch and you will lose all data.
+This will completely reset your Airbyte deployment back to scratch and you will lose all data.
 {% endhint %}
 
 ## Upgrading on K8s (0.27.0-alpha and above)
@@ -48,7 +48,7 @@ If you are upgrading from (i.e. your current version of Airbyte is) Airbyte vers
    kubectl delete deployments airbyte-db airbyte-scheduler airbyte-server airbyte-temporal airbyte-webapp --namespace=<yournamespace or default>
    ```
 
-2. Upgrade the kube instance to new version.
+2. Upgrade the kube deployment to new version.
 
    i. If you are running Airbyte from a cloned version of the Airbyte GitHub repo and want to use the current most recent stable version, just `git pull`.
 

--- a/docs/project-overview/changelog/platform.md
+++ b/docs/project-overview/changelog/platform.md
@@ -197,7 +197,7 @@ This is the changelog for Airbyte Platform. For our connector changelog, please 
 * Support Import / Export of Airbyte Data in the Admin section of the UI
 * Bug fixes:
   * If Airbyte is closed during a sync the running job is not marked as failed
-  * Airbyte should fail when instance version doesn't match data version
+  * Airbyte should fail when deployment version doesn't match data version
   * Upgrade Airbyte Version without losing existing configuration / data
 
 ## [0.12-alpha](https://github.com/airbytehq/airbyte/milestone/14?closed=1) - Released 01/20/2021


### PR DESCRIPTION
depends on https://github.com/airbytehq/airbyte/pull/4797
(arguably) blocks https://github.com/airbytehq/airbyte/issues/4716

## What
* For a workspace, we want to know "where" it is deployed (e.g. on cloud, OSS)
* For a workspace, we want to identify if it is colocated with other workspaces. Our tracking model is about to become workspace-centric. Which means that if a user has multiple workspaces on their self-hosted install, we would not be able to track that they are the same user. Thus we want some identifier that can give us some notion of this. The more rigorous way of doing this would be to add an organization concept, but that is a more invasive change. For now, we can make the assumption that workspaces (that are not on cloud) that are colocated on the same install (deployment).

## How
* Add a deployment id that tracks an install of Airbyte. Its lifecycle with be the same as a volume. 
    * if an Airbyte instance is turned off and on, the deployment id remains the same
    * if an Airbyte instance is spun down and its volumes destroyed, when it is spun back up, the deployment id will change (call it deployment id prime). even when data is then imported into this instance the deployment id will not be overwritten by the import, the deployment id will remain deployment id prime.
* When Airbyte first starts up with fresh volumes / persistence, it generated a deployment id (see `ServerApp.java`)
* When Airbyte imports data it needs to make sure that it keeps its original deployment id (`ConfigDumpImporter.java`)
 
## to do
- [x] - unit tests (going to wait until i get a sanity check on the approach before i write tests)
- [x] - track OSS versus cloud