### PR TITLE
Point to new location for connector build status history

### DIFF
--- a/airbyte-integrations/builds.md
+++ b/airbyte-integrations/builds.md
@@ -1,148 +1,148 @@
 # Build statuses
 
 # Sources 
- Amazon Seller Partner   [![source-amazon-seller-partner](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-amazon-seller-partner%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-amazon-seller-partner)
+ Amazon Seller Partner   [![source-amazon-seller-partner](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-amazon-seller-partner%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-amazon-seller-partner)
 
- Amplitude   [![source-amplitude](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-amplitude%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-amplitude)
+ Amplitude   [![source-amplitude](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-amplitude%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-amplitude)
 
- AppsFlyer   [![source-braintree-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-appsflyer-singer%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-appsflyer-singer) 
+ AppsFlyer   [![source-braintree-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-appsflyer-singer%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-appsflyer-singer) 
 
- App Store   [![source-appstore-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-appstore-singer%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-appstore-singer)
+ App Store   [![source-appstore-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-appstore-singer%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-appstore-singer)
 
- Asana   [![source-asana](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-asana%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-asana)
+ Asana   [![source-asana](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-asana%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-asana)
 
- AWS CloudTrail   [![source-aws-cloudtrail](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-aws-cloudtrail%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-aws-cloudtrail)
+ AWS CloudTrail   [![source-aws-cloudtrail](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-aws-cloudtrail%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-aws-cloudtrail)
 
- Braintree   [![source-braintree-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-braintree-singer%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-braintree-singer)
+ Braintree   [![source-braintree-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-braintree-singer%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-braintree-singer)
 
- Dixa   [![source-dixa](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-dixa%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-dixa)
+ Dixa   [![source-dixa](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-dixa%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-dixa)
 
- Drift   [![source-drift](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-drift%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-drift) 
+ Drift   [![source-drift](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-drift%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-drift) 
 
- Exchange Rates API   [![source-exchangeratesapi-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-exchangeratesapi-singer%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-exchangeratesapi-singer) 
+ Exchange Rates API   [![source-exchangeratesapi-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-exchangeratesapi-singer%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-exchangeratesapi-singer) 
 
- Facebook Marketing   [![source-facebook-marketing](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-facebook-marketing%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-facebook-marketing) 
+ Facebook Marketing   [![source-facebook-marketing](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-facebook-marketing%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-facebook-marketing) 
 
- Files   [![source-file](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-file%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-file) 
+ Files   [![source-file](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-file%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-file) 
 
- Freshdesk   [![source-freshdesk](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-freshdesk%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-freshdesk) 
+ Freshdesk   [![source-freshdesk](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-freshdesk%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-freshdesk) 
 
- GitHub   [![source-github](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-github%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-github) 
+ GitHub   [![source-github](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-github%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-github) 
 
- GitLab   [![source-gitlab](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-gitlab%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-gitlab) 
+ GitLab   [![source-gitlab](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-gitlab%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-gitlab) 
 
- Google Ads   [![source-google-ads](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-google-ads%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-google-ads) 
+ Google Ads   [![source-google-ads](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-google-ads%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-google-ads) 
  
- Google Adwords   [![source-google-adwords-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-google-adwords-singer%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-google-adwords-singer) 
+ Google Adwords   [![source-google-adwords-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-google-adwords-singer%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-google-adwords-singer) 
 
- Google Analytics   [![source-googleanalytics-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-googleanalytics-singer%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-googleanalytics-singer) 
+ Google Analytics   [![source-googleanalytics-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-googleanalytics-singer%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-googleanalytics-singer) 
 
- Google Sheets   [![source-google-sheets](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-google-sheets%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-google-sheets) 
+ Google Sheets   [![source-google-sheets](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-google-sheets%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-google-sheets) 
 
- Google Directory API   [![source-google-directory](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-google-directory%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-google-directory) 
+ Google Directory API   [![source-google-directory](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-google-directory%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-google-directory) 
 
- Google Workspace Admin   [![source-google-workspace-admin-reports](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-google-workspace-admin-reports%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-google-workspace-admin-reports) 
+ Google Workspace Admin   [![source-google-workspace-admin-reports](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-google-workspace-admin-reports%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-google-workspace-admin-reports) 
 
- Greenhouse   [![source-greenhouse](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-greenhouse%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-greenhouse) 
+ Greenhouse   [![source-greenhouse](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-greenhouse%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-greenhouse) 
 
- HTTP Request   [![source-http-request](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-http-request%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-http-request) 
+ HTTP Request   [![source-http-request](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-http-request%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-http-request) 
 
- Hubspot   [![source-hubspot-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-hubspot%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-hubspot) 
+ Hubspot   [![source-hubspot-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-hubspot%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-hubspot) 
 
- Klaviyo   [![source-klaviyo](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-klaviyo%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-klaviyo) 
+ Klaviyo   [![source-klaviyo](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-klaviyo%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-klaviyo) 
 
- IBM Db2   [![source-db2](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-db2%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-db2)
+ IBM Db2   [![source-db2](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-db2%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-db2)
 
- Instagram   [![source-instagram](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-instagram%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-instagram) 
+ Instagram   [![source-instagram](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-instagram%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-instagram) 
 
- Intercom   [![source-intercom](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-intercom-singer%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-intercom) 
+ Intercom   [![source-intercom](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-intercom-singer%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-intercom) 
 
- Iterable   [![source-iterable](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-iterable%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-iterable) 
+ Iterable   [![source-iterable](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-iterable%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-iterable) 
 
- Jira   [![source-jira](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-jira%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-jira) 
+ Jira   [![source-jira](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-jira%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-jira) 
 
- Looker   [![source-looker](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-looker%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-looker) 
+ Looker   [![source-looker](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-looker%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-looker) 
 
- Mailchimp   [![source-mailchimp](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-mailchimp%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-mailchimp) 
+ Mailchimp   [![source-mailchimp](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-mailchimp%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-mailchimp) 
 
- Marketo   [![source-marketo-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-marketo-singer%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-marketo-singer) 
+ Marketo   [![source-marketo-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-marketo-singer%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-marketo-singer) 
 
- Microsoft SQL Server \(MSSQL\)   [![source-mssql](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-mssql%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-mssql) 
+ Microsoft SQL Server \(MSSQL\)   [![source-mssql](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-mssql%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-mssql) 
 
- Microsoft Teams   [![source-microsoft-teams](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-microsoft-teams%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-microsoft-teams) 
+ Microsoft Teams   [![source-microsoft-teams](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-microsoft-teams%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-microsoft-teams) 
 
- Mixpanel   [![source-mixpanel-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-mixpanel-singer%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-mixpanel-singer) 
+ Mixpanel   [![source-mixpanel-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-mixpanel-singer%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-mixpanel-singer) 
 
- Mongo DB   [![source-mongodb](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-mongodb%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-mongodb) 
+ Mongo DB   [![source-mongodb](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-mongodb%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-mongodb) 
 
- MySQL   [![source-mysql](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-mysql%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-mysql) 
+ MySQL   [![source-mysql](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-mysql%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-mysql) 
 
- Oracle DB   [![source-oracle](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-oracle%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-oracle) 
+ Oracle DB   [![source-oracle](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-oracle%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-oracle) 
 
- Paypal Transaction   [![paypal-transaction](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-paypal-transaction%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-paypal-transaction)
+ Paypal Transaction   [![paypal-transaction](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-paypal-transaction%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-paypal-transaction)
 
- Pipedrive   [![source-pipedrive](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-plaid%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-pipedrive) 
+ Pipedrive   [![source-pipedrive](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-plaid%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-pipedrive) 
  
- Plaid   [![source-plaid](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-plaid%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-plaid) 
+ Plaid   [![source-plaid](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-plaid%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-plaid) 
 
- Postgres   [![source-postgres](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-postgres%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-postgres) 
+ Postgres   [![source-postgres](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-postgres%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-postgres) 
  
- CockroachDb   [![source-cockroachdb](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-cockroachdb%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-cockroachdb)
+ CockroachDb   [![source-cockroachdb](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-cockroachdb%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-cockroachdb)
 
- Quickbooks   [![source-quickbooks-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-quickbooks-singer%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-quickbooks-singer) 
+ Quickbooks   [![source-quickbooks-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-quickbooks-singer%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-quickbooks-singer) 
 
- Recharge   [![source-recharge](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-recharge%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-recharge) 
+ Recharge   [![source-recharge](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-recharge%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-recharge) 
 
- Recurly   [![source-recurly](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-recurly%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-recurly) 
+ Recurly   [![source-recurly](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-recurly%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-recurly) 
 
- Redshift   [![source-redshift](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-redshift%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-redshift) 
+ Redshift   [![source-redshift](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-redshift%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-redshift) 
 
- Salesforce   [![source-salesforce-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-salesforce-singer%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-salesforce-singer) 
+ Salesforce   [![source-salesforce-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-salesforce-singer%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-salesforce-singer) 
 
- Sendgrid   [![source-sendgrid](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-sendgrid%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-sendgrid) 
+ Sendgrid   [![source-sendgrid](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-sendgrid%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-sendgrid) 
 
- Shopify   [![source-shopify](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-shopify%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-shopify) 
+ Shopify   [![source-shopify](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-shopify%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-shopify) 
 
- Slack   [![source-slack-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-slack-singer%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-slack-singer) 
+ Slack   [![source-slack-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-slack-singer%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-slack-singer) 
 
- Smartsheets   [![source-smartsheets](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-smartsheets%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-smartsheets) 
+ Smartsheets   [![source-smartsheets](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-smartsheets%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-smartsheets) 
 
- Snowflake   [![source-snowflake](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-snowflake%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-snowflake)
+ Snowflake   [![source-snowflake](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-snowflake%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-snowflake)
 
- Square   [![source-square](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-square%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-square)
+ Square   [![source-square](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-square%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-square)
 
- Stripe   [![source-stripe](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-stripe%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-stripe) 
+ Stripe   [![source-stripe](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-stripe%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-stripe) 
 
- Tempo   [![source-tempo](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-tempo%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-tempo) 
+ Tempo   [![source-tempo](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-tempo%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-tempo) 
 
- Twilio   [![source-twilio](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-twilio%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-twilio) 
+ Twilio   [![source-twilio](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-twilio%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-twilio) 
 
- Typeform   [![source-typeform](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-typeform%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-typeform)
+ Typeform   [![source-typeform](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-typeform%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-typeform)
 
- Zendesk Chat   [![source-zendesk-chat](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-zendesk-chat%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-zendesk-chat) 
+ Zendesk Chat   [![source-zendesk-chat](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-zendesk-chat%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-zendesk-chat) 
 
- Zendesk Support   [![source-zendesk-support-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-zendesk-support-singer%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-zendesk-support-singer) 
+ Zendesk Support   [![source-zendesk-support-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-zendesk-support-singer%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-zendesk-support-singer) 
 
- Zendesk Talk   [![source-zendesk-talk](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-zendesk-talk%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-zendesk-talk) 
+ Zendesk Talk   [![source-zendesk-talk](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-zendesk-talk%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-zendesk-talk) 
 
- Zoom   [![source-zoom-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fsource-zoom-singer%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/source-zoom-singer) 
+ Zoom   [![source-zoom-singer](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fsource-zoom-singer%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/source-zoom-singer) 
 
  
 # Destinations
- BigQuery   [![destination-bigquery](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-bigquery%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-bigquery) 
+ BigQuery   [![destination-bigquery](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fdestination-bigquery%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/destination-bigquery) 
 
- Google Cloud Storage (GCS) [![destination-gcs](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-s3%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-gcs)
+ Google Cloud Storage (GCS) [![destination-gcs](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fdestination-s3%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/destination-gcs)
 
- Google PubSub   [![destination-pubsub](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-pubsub%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-pubsub)
+ Google PubSub   [![destination-pubsub](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fdestination-pubsub%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/destination-pubsub)
 
- Local CSV   [![destination-csv](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-csv%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-csv) 
+ Local CSV   [![destination-csv](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fdestination-csv%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/destination-csv) 
 
- Local JSON   [![destination-local-json](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-local-json%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-local-json) 
+ Local JSON   [![destination-local-json](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fdestination-local-json%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/destination-local-json) 
 
- Postgres   [![destination-postgres](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-postgres%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-postgres) 
+ Postgres   [![destination-postgres](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fdestination-postgres%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/destination-postgres) 
 
- Redshift   [![destination-redshift](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-redshift%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-redshift) 
+ Redshift   [![destination-redshift](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fdestination-redshift%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/destination-redshift) 
 
- S3         [![destination-s3](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-s3%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-s3)
+ S3         [![destination-s3](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fdestination-s3%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/destination-s3)
 
- Snowflake   [![destination-snowflake](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2Fdestination-snowflake%2Fbadge.json)](https://status-api.airbyte.io/tests/summary/destination-snowflake) 
+ Snowflake   [![destination-snowflake](https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2Fdestination-snowflake%2Fbadge.json)](https://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/tests/summary/destination-snowflake) 

--- a/tools/status/init.sh
+++ b/tools/status/init.sh
@@ -5,14 +5,14 @@ set -e
 # This script should only be used to set up the status site for the first time or to make your own version for testing.
 # Prod refers to the prod environment used for prior Airbyte projects.
 
-BUCKET=airbyte-status
-PROFILE=prod
+BUCKET=airbyte-connector-build-status
+PROFILE=dev
 REGION=us-east-2
 S3_DOMAIN="$BUCKET.s3-website.$REGION.amazonaws.com"
 
 export AWS_PAGER=""
 
-echo "This has already been created. Comment out this line if you really want to run this again." && exit 1
+#echo "This has already been created. Comment out this line if you really want to run this again." && exit 1
 
 echo "Creating bucket..."
 aws s3api create-bucket --bucket "$BUCKET" --region "$REGION"  --create-bucket-configuration LocationConstraint="$REGION" --profile "$PROFILE"

--- a/tools/status/init.sh
+++ b/tools/status/init.sh
@@ -34,5 +34,5 @@ aws cloudfront create-distribution \
 
 echo "Site should be ready at http://$S3_DOMAIN"
 echo "1. Add a certificate and cname to the distribution: https://advancedweb.hu/how-to-use-a-custom-domain-on-cloudfront-with-cloudflare-managed-dns/"
-echo "2. Configure a CNAME on Cloudflare for airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com to point to the bucket!"
+echo "2. Configure a CNAME on Cloudflare for status-api.airbyte.io to point to the bucket!"
 echo "3. Create STATUS_API_AWS_ACCESS_KEY_ID and STATUS_API_AWS_SECRET_ACCESS_KEY Github secrets with access to the bucket."

--- a/tools/status/init.sh
+++ b/tools/status/init.sh
@@ -3,16 +3,16 @@
 set -e
 
 # This script should only be used to set up the status site for the first time or to make your own version for testing.
-# Prod refers to the prod environment used for prior Airbyte projects.
+# TODO move this setup to terraform
 
 BUCKET=airbyte-connector-build-status
-PROFILE=dev
+PROFILE=dev # AWS dev environment
 REGION=us-east-2
 S3_DOMAIN="$BUCKET.s3-website.$REGION.amazonaws.com"
 
 export AWS_PAGER=""
 
-#echo "This has already been created. Comment out this line if you really want to run this again." && exit 1
+echo "This has already been created. Comment out this line if you really want to run this again." && exit 1
 
 echo "Creating bucket..."
 aws s3api create-bucket --bucket "$BUCKET" --region "$REGION"  --create-bucket-configuration LocationConstraint="$REGION" --profile "$PROFILE"
@@ -34,5 +34,5 @@ aws cloudfront create-distribution \
 
 echo "Site should be ready at http://$S3_DOMAIN"
 echo "1. Add a certificate and cname to the distribution: https://advancedweb.hu/how-to-use-a-custom-domain-on-cloudfront-with-cloudflare-managed-dns/"
-echo "2. Configure a CNAME on Cloudflare for status-api.airbyte.io to point to the bucket!"
+echo "2. Configure a CNAME on Cloudflare for airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com to point to the bucket!"
 echo "3. Create STATUS_API_AWS_ACCESS_KEY_ID and STATUS_API_AWS_SECRET_ACCESS_KEY Github secrets with access to the bucket."

--- a/tools/status/policy.json
+++ b/tools/status/policy.json
@@ -6,7 +6,7 @@
       "Effect": "Allow",
       "Principal": "*",
       "Action": "s3:GetObject",
-      "Resource": "arn:aws:s3:::airbyte-status/*"
+      "Resource": "arn:aws:s3:::airbyte-connector-build-status/*"
     }
   ]
 }

--- a/tools/status/report.sh
+++ b/tools/status/report.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-BUCKET=airbyte-status
+BUCKET=airbyte-connector-build-status
 
 CONNECTOR=$1
 REPOSITORY=$2

--- a/tools/status/report.sh
+++ b/tools/status/report.sh
@@ -89,7 +89,7 @@ function write_badge_and_summary() {
 
   echo "message: $message"
 
-  HTML_TOP="<html><head><title>$CONNECTOR</title><style>body {padding:20px; font-family:monospace;} table {border-collapse: collapse;} th, td {padding:20px; text-align:left;} th, td { border:1px solid #c5c4ff;} </style></head><body><p><img src=\"https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus-api.airbyte.io%2Ftests%2Fsummary%2F$CONNECTOR%2Fbadge.json\"></p><h1>$CONNECTOR</h1>"
+  HTML_TOP="<html><head><title>$CONNECTOR</title><style>body {padding:20px; font-family:monospace;} table {border-collapse: collapse;} th, td {padding:20px; text-align:left;} th, td { border:1px solid #c5c4ff;} </style></head><body><p><img src=\"https://img.shields.io/endpoint?url=https%3A%2F%2Fairbyte-connector-build-status.s3-website.us-east-2.amazonaws.com%2Ftests%2Fsummary%2F$CONNECTOR%2Fbadge.json\"></p><h1>$CONNECTOR</h1>"
   HTML_BOTTOM="</body></html>"
   HTML_TABLE="<table><tr><th>datetime</th><th>status</th><th>workflow</th></tr>$HTML_TABLE_ROWS</table>"
 


### PR DESCRIPTION
## What
Connector builds were previously hosted at status-api.airbyte.io. This was backed by an S3 bucket on the Dataline AWS prod environment. The environment was destroyed since it was no longer being used post-pivot, and it was presumed no useful resources occupied it anymore. Connector build statuses were collateral damage. 

I created a new bucket using the `init.sh` script. While this does not work with status-api.airbyte.io it does leverage the S3 bucket's public domain name, http://airbyte-connector-build-status.s3-website.us-east-2.amazonaws.com/. We can redirect status-api.airbyte.io to the bucket at some point but for now we just need to unblock the ability to see build statuses. 