### PR TITLE
use new AMI ID for connector builds

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
-          ec2-image-id: ami-0a5f6900e1cc7e07e
+          ec2-image-id: ami-0d648081937c75a73
           ec2-instance-type: c5.2xlarge
           subnet-id: subnet-0469a9e68a379c1d3
           security-group-id: sg-0793f3c9413f21970

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
-          ec2-image-id: ami-0a5f6900e1cc7e07e
+          ec2-image-id: ami-0d648081937c75a73
           ec2-instance-type: c5.2xlarge
           subnet-id: subnet-0469a9e68a379c1d3
           security-group-id: sg-0793f3c9413f21970

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -161,7 +161,6 @@ jobs:
             **/normalization_test_output/**/build/run/airbyte_utils/**
             **/normalization_test_output/**/models/generated/**
       - name: Report Status
-        if: github.ref == 'refs/heads/master' && always()
         run: ./tools/status/report.sh ${{ github.event.inputs.connector }} ${{github.repository}} ${{github.run_id}} ${{steps.test.outcome}}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.STATUS_API_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -161,6 +161,7 @@ jobs:
             **/normalization_test_output/**/build/run/airbyte_utils/**
             **/normalization_test_output/**/models/generated/**
       - name: Report Status
+        if: github.ref == 'refs/heads/master' && always()
         run: ./tools/status/report.sh ${{ github.event.inputs.connector }} ${{github.repository}} ${{github.run_id}} ${{steps.test.outcome}}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.STATUS_API_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## What
Use a new AMI ID which has the `aws` CLI installed (needed to publish connector build statuses to S3)
