### PR TITLE
🐛 Fix Oracle spec to declare `sid` instead of `database` param, Redshift to allow `additionalProperties`, MSSQL test and spec to declare spec type correctly

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/3986776d-2319-4de9-8af8-db14c0996e72.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/3986776d-2319-4de9-8af8-db14c0996e72.json
@@ -2,6 +2,6 @@
   "destinationDefinitionId": "3986776d-2319-4de9-8af8-db14c0996e72",
   "name": "Oracle (Alpha)",
   "dockerRepository": "airbyte/destination-oracle",
-  "dockerImageTag": "0.1.1",
+  "dockerImageTag": "0.1.2",
   "documentationUrl": "https://docs.airbyte.io/integrations/destinations/oracle"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/d4353156-9217-4cad-8dd7-c108fd4f74cf.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/d4353156-9217-4cad-8dd7-c108fd4f74cf.json
@@ -2,6 +2,6 @@
   "destinationDefinitionId": "d4353156-9217-4cad-8dd7-c108fd4f74cf",
   "name": "MS SQL Server",
   "dockerRepository": "airbyte/destination-mssql",
-  "dockerImageTag": "0.1.4",
+  "dockerImageTag": "0.1.5",
   "documentationUrl": "https://docs.airbyte.io/integrations/destinations/mssql"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/f7a7d195-377f-cf5b-70a5-be6b819019dc.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/f7a7d195-377f-cf5b-70a5-be6b819019dc.json
@@ -2,7 +2,7 @@
   "destinationDefinitionId": "f7a7d195-377f-cf5b-70a5-be6b819019dc",
   "name": "Redshift",
   "dockerRepository": "airbyte/destination-redshift",
-  "dockerImageTag": "0.3.10",
+  "dockerImageTag": "0.3.11",
   "documentationUrl": "https://docs.airbyte.io/integrations/destinations/redshift",
   "icon": "redshift.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -47,7 +47,7 @@
 - destinationDefinitionId: f7a7d195-377f-cf5b-70a5-be6b819019dc
   name: Redshift
   dockerRepository: airbyte/destination-redshift
-  dockerImageTag: 0.3.10
+  dockerImageTag: 0.3.11
   documentationUrl: https://docs.airbyte.io/integrations/destinations/redshift
   icon: redshift.svg
 - destinationDefinitionId: af7c921e-5892-4ff2-b6c1-4a5ab258fb7e
@@ -68,5 +68,5 @@
 - destinationDefinitionId: 3986776d-2319-4de9-8af8-db14c0996e72
   name: Oracle (Alpha)
   dockerRepository: airbyte/destination-oracle
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   documentationUrl: https://docs.airbyte.io/integrations/destinations/oracle

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -63,7 +63,7 @@
 - destinationDefinitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
   name: MS SQL Server
   dockerRepository: airbyte/destination-mssql
-  dockerImageTag: 0.1.4
+  dockerImageTag: 0.1.5
   documentationUrl: https://docs.airbyte.io/integrations/destinations/mssql
 - destinationDefinitionId: 3986776d-2319-4de9-8af8-db14c0996e72
   name: Oracle (Alpha)

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
@@ -30,15 +30,18 @@ import com.google.common.base.Preconditions;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.util.AutoCloseableIterator;
+import io.airbyte.protocol.models.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.validation.json.JsonSchemaValidator;
+
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.function.Consumer;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,11 +69,10 @@ public class IntegrationRunner {
     this(new IntegrationCliParser(), Destination::defaultOutputRecordCollector, null, source);
   }
 
-  @VisibleForTesting
-  IntegrationRunner(IntegrationCliParser cliParser,
-                    Consumer<AirbyteMessage> outputRecordCollector,
-                    Destination destination,
-                    Source source) {
+  @VisibleForTesting IntegrationRunner(IntegrationCliParser cliParser,
+                                       Consumer<AirbyteMessage> outputRecordCollector,
+                                       Destination destination,
+                                       Source source) {
     Preconditions.checkState(destination != null ^ source != null, "can only pass in a destination or a source");
     this.cliParser = cliParser;
     this.outputRecordCollector = outputRecordCollector;
@@ -81,12 +83,11 @@ public class IntegrationRunner {
     validator = new JsonSchemaValidator();
   }
 
-  @VisibleForTesting
-  IntegrationRunner(IntegrationCliParser cliParser,
-                    Consumer<AirbyteMessage> outputRecordCollector,
-                    Destination destination,
-                    Source source,
-                    JsonSchemaValidator jsonSchemaValidator) {
+  @VisibleForTesting IntegrationRunner(IntegrationCliParser cliParser,
+                                       Consumer<AirbyteMessage> outputRecordCollector,
+                                       Destination destination,
+                                       Source source,
+                                       JsonSchemaValidator jsonSchemaValidator) {
     this(cliParser, outputRecordCollector, destination, source);
     this.validator = jsonSchemaValidator;
   }
@@ -104,7 +105,23 @@ public class IntegrationRunner {
       case SPEC -> outputRecordCollector.accept(new AirbyteMessage().withType(Type.SPEC).withSpec(integration.spec()));
       case CHECK -> {
         final JsonNode config = parseConfig(parsed.getConfigPath());
-        validateConfig(integration.spec().getConnectionSpecification(), config, "CHECK");
+        try {
+          validateConfig(integration.spec().getConnectionSpecification(), config, "CHECK");
+        } catch (Exception e) {
+          // if validation fails don't throw an exception, return a failed connection check message
+          outputRecordCollector
+              .accept(
+                  new AirbyteMessage()
+                      .withType(Type.CONNECTION_STATUS)
+                      .withConnectionStatus(
+                          new AirbyteConnectionStatus()
+                              .withStatus(AirbyteConnectionStatus.Status.FAILED)
+                              .withMessage(e.getMessage()
+                              )
+                      )
+              );
+        }
+
         outputRecordCollector.accept(new AirbyteMessage().withType(Type.CONNECTION_STATUS).withConnectionStatus(integration.check(config)));
       }
       // source only

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
@@ -35,13 +35,11 @@ import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.validation.json.JsonSchemaValidator;
-
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.function.Consumer;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,10 +67,11 @@ public class IntegrationRunner {
     this(new IntegrationCliParser(), Destination::defaultOutputRecordCollector, null, source);
   }
 
-  @VisibleForTesting IntegrationRunner(IntegrationCliParser cliParser,
-                                       Consumer<AirbyteMessage> outputRecordCollector,
-                                       Destination destination,
-                                       Source source) {
+  @VisibleForTesting
+  IntegrationRunner(IntegrationCliParser cliParser,
+                    Consumer<AirbyteMessage> outputRecordCollector,
+                    Destination destination,
+                    Source source) {
     Preconditions.checkState(destination != null ^ source != null, "can only pass in a destination or a source");
     this.cliParser = cliParser;
     this.outputRecordCollector = outputRecordCollector;
@@ -83,11 +82,12 @@ public class IntegrationRunner {
     validator = new JsonSchemaValidator();
   }
 
-  @VisibleForTesting IntegrationRunner(IntegrationCliParser cliParser,
-                                       Consumer<AirbyteMessage> outputRecordCollector,
-                                       Destination destination,
-                                       Source source,
-                                       JsonSchemaValidator jsonSchemaValidator) {
+  @VisibleForTesting
+  IntegrationRunner(IntegrationCliParser cliParser,
+                    Consumer<AirbyteMessage> outputRecordCollector,
+                    Destination destination,
+                    Source source,
+                    JsonSchemaValidator jsonSchemaValidator) {
     this(cliParser, outputRecordCollector, destination, source);
     this.validator = jsonSchemaValidator;
   }
@@ -116,10 +116,7 @@ public class IntegrationRunner {
                       .withConnectionStatus(
                           new AirbyteConnectionStatus()
                               .withStatus(AirbyteConnectionStatus.Status.FAILED)
-                              .withMessage(e.getMessage()
-                              )
-                      )
-              );
+                              .withMessage(e.getMessage())));
         }
 
         outputRecordCollector.accept(new AirbyteMessage().withType(Type.CONNECTION_STATUS).withConnectionStatus(integration.check(config)));

--- a/airbyte-integrations/connectors/destination-mssql/Dockerfile
+++ b/airbyte-integrations/connectors/destination-mssql/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.1.4
+LABEL io.airbyte.version=0.1.5
 LABEL io.airbyte.name=airbyte/destination-mssql

--- a/airbyte-integrations/connectors/destination-mssql/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/resources/spec.json
@@ -65,6 +65,7 @@
             "additionalProperties": false,
             "description": "Data transfer will not be encrypted.",
             "required": ["ssl_method"],
+            "type": "object",
             "properties": {
               "ssl_method": {
                 "type": "string",
@@ -78,6 +79,7 @@
             "additionalProperties": false,
             "description": "Use the cert provided by the server without verification.  (For testing purposes only!)",
             "required": ["ssl_method"],
+            "type": "object",
             "properties": {
               "ssl_method": {
                 "type": "string",
@@ -91,6 +93,7 @@
             "additionalProperties": false,
             "description": "Verify and use the cert provided by the server.",
             "required": ["ssl_method", "trustStoreName", "trustStorePassword"],
+            "type": "object",
             "properties": {
               "ssl_method": {
                 "type": "string",

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/java/io/airbyte/integrations/destination/mssql/MSSQLDestinationAcceptanceTestSSL.java
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/java/io/airbyte/integrations/destination/mssql/MSSQLDestinationAcceptanceTestSSL.java
@@ -27,6 +27,7 @@ package io.airbyte.integrations.destination.mssql;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Database;
@@ -65,13 +66,14 @@ public class MSSQLDestinationAcceptanceTestSSL extends DestinationAcceptanceTest
   }
 
   private JsonNode getConfig(MSSQLServerContainer<?> db) {
+
     return Jsons.jsonNode(ImmutableMap.builder()
         .put("host", db.getHost())
         .put("port", db.getFirstMappedPort())
         .put("username", db.getUsername())
         .put("password", db.getPassword())
         .put("schema", "testSchema")
-        .put("ssl_method", "encrypted_trust_server_certificate")
+        .put("ssl_method", Jsons.jsonNode(ImmutableMap.of("method", "encrypted_trust_server_certificate")))
         .build());
   }
 

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/java/io/airbyte/integrations/destination/mssql/MSSQLDestinationAcceptanceTestSSL.java
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/java/io/airbyte/integrations/destination/mssql/MSSQLDestinationAcceptanceTestSSL.java
@@ -27,7 +27,6 @@ package io.airbyte.integrations.destination.mssql;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Database;
@@ -73,7 +72,7 @@ public class MSSQLDestinationAcceptanceTestSSL extends DestinationAcceptanceTest
         .put("username", db.getUsername())
         .put("password", db.getPassword())
         .put("schema", "testSchema")
-        .put("ssl_method", Jsons.jsonNode(ImmutableMap.of("method", "encrypted_trust_server_certificate")))
+        .put("ssl_method", Jsons.jsonNode(ImmutableMap.of("ssl_method", "encrypted_trust_server_certificate")))
         .build());
   }
 

--- a/airbyte-integrations/connectors/destination-oracle/Dockerfile
+++ b/airbyte-integrations/connectors/destination-oracle/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/destination-oracle

--- a/airbyte-integrations/connectors/destination-oracle/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-oracle/src/main/resources/spec.json
@@ -8,7 +8,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Oracle Destination Spec",
     "type": "object",
-    "required": ["host", "port", "username", "database"],
+    "required": ["host", "port", "username", "sid"],
     "additionalProperties": false,
     "properties": {
       "host": {
@@ -27,9 +27,9 @@
         "examples": ["1521"],
         "order": 1
       },
-      "database": {
-        "title": "DB Name",
-        "description": "Name of the database.",
+      "sid": {
+        "title": "SID",
+        "description": "SID",
         "type": "string",
         "order": 2
       },

--- a/airbyte-integrations/connectors/destination-redshift/Dockerfile
+++ b/airbyte-integrations/connectors/destination-redshift/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.3.10
+LABEL io.airbyte.version=0.3.11
 LABEL io.airbyte.name=airbyte/destination-redshift

--- a/airbyte-integrations/connectors/destination-redshift/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/resources/spec.json
@@ -9,7 +9,7 @@
     "title": "Redshift Destination Spec",
     "type": "object",
     "required": ["host", "port", "database", "username", "password", "schema"],
-    "additionalProperties": false,
+    "additionalProperties": true,
     "properties": {
       "host": {
         "description": "Host Endpoint of the Redshift Cluster (must include the cluster-id, region and end with .redshift.amazonaws.com)",

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/resources/spec.json
@@ -17,7 +17,6 @@
       "username",
       "password"
     ],
-
     "additionalProperties": false,
     "properties": {
       "host": {

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -75,6 +75,7 @@ You should now have all the requirements needed to configure SQL Server as a des
 
 | Version | Date       | Pull Request | Subject |
 | :------ | :--------  | :-----       | :------ |
+| 0.1.5   | 2021-07-20 | [4874](https://github.com/airbytehq/airbyte/pull/4874) | declare object types correctly in spec |
 | 0.1.4   | 2021-06-17 | [3744](https://github.com/airbytehq/airbyte/pull/3744) | Fix doc/params in specification file |
 | 0.1.3   | 2021-05-28 | [3728](https://github.com/airbytehq/airbyte/pull/3973) | Change dockerfile entrypoint |
 | 0.1.2   | 2021-05-13 | [3367](https://github.com/airbytehq/airbyte/pull/3671) | Fix handle symbols unicode |

--- a/docs/integrations/destinations/oracle.md
+++ b/docs/integrations/destinations/oracle.md
@@ -49,3 +49,8 @@ You should now have all the requirements needed to configure Oracle as a destina
 * **Username**
 * **Password**
 * **Database**
+
+## Changelog
+| Version | Date | Pull Request | Subject |
+| :--- | :---  | :--- | :--- |
+| 0.1.2 | 2021-07-20 | [4874](https://github.com/airbytehq/airbyte/pull/4874) | Require `sid` instead of `database` in connector specification |

--- a/docs/integrations/destinations/redshift.md
+++ b/docs/integrations/destinations/redshift.md
@@ -103,3 +103,8 @@ Redshift specifies a maximum limit of 65535 bytes to store the raw JSON record d
 
 See [docs](https://docs.aws.amazon.com/redshift/latest/dg/r_Character_types.html)
 
+## Changelog
+
+| Version | Date       | Pull Request | Subject |
+| :------ | :--------  | :-----       | :------ |
+| 0.3.11   | 2021-07-20 | [4874](https://github.com/airbytehq/airbyte/pull/4874) | allow `additionalProperties` in connector spec |


### PR DESCRIPTION
## What
Redshift, Snowflake, MSSQL, and Oracle destinations were failing due to mis-specificed specs/secrets. 

## How
**Oracle**: use `sid` instead of `database` param
**Redshift**: allow additionalProperties (the config we use in CI has a `$comment` field which explains context behind where we got this secret)
**Snowflake**: CI secrets did not match the spec, fixing now
**MSSQL**: secrets used in test were incorrect, spec didn't specify object types