### PR TITLE
improve api server boundary

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigurationApiBinder.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigurationApiBinder.java
@@ -1,0 +1,40 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.server;
+
+import io.airbyte.server.apis.ConfigurationApi;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+
+public class ConfigurationApiBinder extends AbstractBinder {
+
+  @Override
+  protected void configure() {
+    bindFactory(ConfigurationApiFactory.class)
+        .to(ConfigurationApi.class)
+        .in(RequestScoped.class);
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -161,7 +161,7 @@ public class ServerApp implements ServerRunnable {
     }
   }
 
-  public static ServerRunnable getServer(ServerFactory.Api apiFactory) throws Exception {
+  public static ServerRunnable getServer(ServerFactory apiFactory) throws Exception {
     final Configs configs = new EnvConfigs();
 
     MDC.put(LogClientSingleton.WORKSPACE_MDC_KEY, LogClientSingleton.getServerLogsRoot(configs).toString());

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -25,7 +25,6 @@
 package io.airbyte.server;
 
 import io.airbyte.analytics.TrackingClientSingleton;
-import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.Configs;
@@ -42,12 +41,12 @@ import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
 import io.airbyte.scheduler.client.DefaultSchedulerJobClient;
 import io.airbyte.scheduler.client.DefaultSynchronousSchedulerClient;
+import io.airbyte.scheduler.client.SchedulerJobClient;
 import io.airbyte.scheduler.client.SpecCachingSynchronousSchedulerClient;
 import io.airbyte.scheduler.persistence.DefaultJobCreator;
 import io.airbyte.scheduler.persistence.DefaultJobPersistence;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.scheduler.persistence.job_tracker.JobTracker;
-import io.airbyte.server.apis.ConfigurationApi;
 import io.airbyte.server.errors.InvalidInputExceptionMapper;
 import io.airbyte.server.errors.InvalidJsonExceptionMapper;
 import io.airbyte.server.errors.InvalidJsonInputExceptionMapper;
@@ -61,27 +60,21 @@ import io.airbyte.workers.temporal.TemporalUtils;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.container.ContainerResponseFilter;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJaxbJsonProvider;
-import org.glassfish.jersey.process.internal.RequestScoped;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-public class ServerApp {
+public class ServerApp implements ServerRunnable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerApp.class);
   private static final int PORT = 8001;
@@ -91,24 +84,19 @@ public class ServerApp {
    * wouldn't run
    */
   private static final AirbyteVersion KUBE_SUPPORT_FOR_AUTOMATIC_MIGRATION = new AirbyteVersion("0.26.5-alpha");
-  private final ConfigRepository configRepository;
-  private final JobPersistence jobPersistence;
-  private final Configs configs;
-  private final Set<ContainerRequestFilter> requestFilters;
-  private final Set<ContainerResponseFilter> responseFilters;
+  private final String airbyteVersion;
+  private final Set<Class<?>> customComponentClasses;
+  private final Set<Object> customComponents;
 
-  public ServerApp(final ConfigRepository configRepository,
-                   final JobPersistence jobPersistence,
-                   final Configs configs,
-                   final Set<ContainerRequestFilter> requestFilters,
-                   final Set<ContainerResponseFilter> responseFilters) {
-    this.configRepository = configRepository;
-    this.jobPersistence = jobPersistence;
-    this.configs = configs;
-    this.requestFilters = requestFilters;
-    this.responseFilters = responseFilters;
+  public ServerApp(final String airbyteVersion,
+                   final Set<Class<?>> customComponentClasses,
+                   final Set<Object> customComponents) {
+    this.airbyteVersion = airbyteVersion;
+    this.customComponentClasses = customComponentClasses;
+    this.customComponents = customComponents;
   }
 
+  @Override
   public void start() throws Exception {
     TrackingClientSingleton.get().identify();
 
@@ -118,38 +106,9 @@ public class ServerApp {
 
     Map<String, String> mdc = MDC.getCopyOfContextMap();
 
-    ConfigurationApiFactory.setSchedulerJobClient(new DefaultSchedulerJobClient(jobPersistence, new DefaultJobCreator(jobPersistence)));
-    final JobTracker jobTracker = new JobTracker(configRepository, jobPersistence);
-    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService(configs.getTemporalHost());
-    final TemporalClient temporalClient = TemporalClient.production(configs.getTemporalHost(), configs.getWorkspaceRoot());
-
-    ConfigurationApiFactory
-        .setSynchronousSchedulerClient(new SpecCachingSynchronousSchedulerClient(new DefaultSynchronousSchedulerClient(temporalClient, jobTracker)));
-    ConfigurationApiFactory.setTemporalService(temporalService);
-    ConfigurationApiFactory.setConfigRepository(configRepository);
-    ConfigurationApiFactory.setJobPersistence(jobPersistence);
-    ConfigurationApiFactory.setConfigs(configs);
-    ConfigurationApiFactory.setArchiveTtlManager(new FileTtlManager(10, TimeUnit.MINUTES, 10));
-    ConfigurationApiFactory.setMdc(mdc);
-
     ResourceConfig rc =
         new ResourceConfig()
-            // request logging
             .register(new RequestLogger(mdc))
-            // api
-            .register(ConfigurationApi.class)
-            .register(
-                new AbstractBinder() {
-
-                  @Override
-                  public void configure() {
-                    bindFactory(ConfigurationApiFactory.class)
-                        .to(ConfigurationApi.class)
-                        .in(RequestScoped.class);
-                  }
-
-                })
-            // exception handling
             .register(InvalidInputExceptionMapper.class)
             .register(InvalidJsonExceptionMapper.class)
             .register(InvalidJsonInputExceptionMapper.class)
@@ -160,9 +119,9 @@ public class ServerApp {
             // https://stackoverflow.com/questions/35669774/jersey-custom-exception-mapper-for-invalid-json-string
             .register(JacksonJaxbJsonProvider.class);
 
-    // add filters
-    requestFilters.forEach(rc::register);
-    responseFilters.forEach(rc::register);
+    // inject custom server functionality
+    customComponentClasses.forEach(rc::register);
+    customComponents.forEach(rc::register);
 
     ServletHolder configServlet = new ServletHolder(new ServletContainer(rc));
 
@@ -172,7 +131,7 @@ public class ServerApp {
 
     server.start();
     final String banner = MoreResources.readResource("banner/banner.txt");
-    LOGGER.info(banner + String.format("Version: %s\n", configs.getAirbyteVersion()));
+    LOGGER.info(banner + String.format("Version: %s\n", airbyteVersion));
     server.join();
   }
 
@@ -202,9 +161,7 @@ public class ServerApp {
     }
   }
 
-  public static void runServer(final Set<ContainerRequestFilter> requestFilters,
-                               final Set<ContainerResponseFilter> responseFilters)
-      throws Exception {
+  public static ServerRunnable getServer(ServerFactory.Api apiFactory) throws Exception {
     final Configs configs = new EnvConfigs();
 
     MDC.put(LogClientSingleton.WORKSPACE_MDC_KEY, LogClientSingleton.getServerLogsRoot(configs).toString());
@@ -254,15 +211,29 @@ public class ServerApp {
 
     if (airbyteDatabaseVersion.isPresent() && AirbyteVersion.isCompatible(airbyteVersion, airbyteDatabaseVersion.get())) {
       LOGGER.info("Starting server...");
-      new ServerApp(configRepository, jobPersistence, configs, requestFilters, responseFilters).start();
+
+      final JobTracker jobTracker = new JobTracker(configRepository, jobPersistence);
+      final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService(configs.getTemporalHost());
+      final TemporalClient temporalClient = TemporalClient.production(configs.getTemporalHost(), configs.getWorkspaceRoot());
+      final SchedulerJobClient schedulerJobClient = new DefaultSchedulerJobClient(jobPersistence, new DefaultJobCreator(jobPersistence));
+      final DefaultSynchronousSchedulerClient syncSchedulerClient = new DefaultSynchronousSchedulerClient(temporalClient, jobTracker);
+      final SpecCachingSynchronousSchedulerClient cachingSchedulerClient = new SpecCachingSynchronousSchedulerClient(syncSchedulerClient);
+
+      return apiFactory.create(
+          schedulerJobClient,
+          cachingSchedulerClient,
+          temporalService,
+          configRepository,
+          jobPersistence,
+          configs);
     } else {
       LOGGER.info("Start serving version mismatch errors. Automatic migration either failed or didn't run");
-      new VersionMismatchServer(airbyteVersion, airbyteDatabaseVersion.get(), PORT).start();
+      return new VersionMismatchServer(airbyteVersion, airbyteDatabaseVersion.get(), PORT);
     }
   }
 
   public static void main(String[] args) throws Exception {
-    runServer(Collections.emptySet(), Set.of(new CorsFilter()));
+    getServer(new ServerFactory.Api()).start();
   }
 
   /**

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerFactory.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerFactory.java
@@ -1,0 +1,77 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.server;
+
+import io.airbyte.commons.io.FileTtlManager;
+import io.airbyte.config.Configs;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.scheduler.client.SchedulerJobClient;
+import io.airbyte.scheduler.client.SpecCachingSynchronousSchedulerClient;
+import io.airbyte.scheduler.persistence.JobPersistence;
+import io.airbyte.server.apis.ConfigurationApi;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.MDC;
+
+public interface ServerFactory {
+
+  ServerRunnable create(SchedulerJobClient schedulerJobClient,
+                        SpecCachingSynchronousSchedulerClient cachingSchedulerClient,
+                        WorkflowServiceStubs temporalService,
+                        ConfigRepository configRepository,
+                        JobPersistence jobPersistence,
+                        Configs configs);
+
+  class Api implements ServerFactory {
+
+    @Override
+    public ServerRunnable create(SchedulerJobClient schedulerJobClient,
+                                 SpecCachingSynchronousSchedulerClient cachingSchedulerClient,
+                                 WorkflowServiceStubs temporalService,
+                                 ConfigRepository configRepository,
+                                 JobPersistence jobPersistence,
+                                 Configs configs) {
+      // set static values for factory
+      ConfigurationApiFactory.setSchedulerJobClient(schedulerJobClient);
+      ConfigurationApiFactory.setSynchronousSchedulerClient(cachingSchedulerClient);
+      ConfigurationApiFactory.setTemporalService(temporalService);
+      ConfigurationApiFactory.setConfigRepository(configRepository);
+      ConfigurationApiFactory.setJobPersistence(jobPersistence);
+      ConfigurationApiFactory.setConfigs(configs);
+      ConfigurationApiFactory.setArchiveTtlManager(new FileTtlManager(10, TimeUnit.MINUTES, 10));
+      ConfigurationApiFactory.setMdc(MDC.getCopyOfContextMap());
+
+      // server configurations
+      final Set<Class<?>> componentClasses = Set.of(ConfigurationApi.class);
+      final Set<Object> components = Set.of(new CorsFilter(), new ConfigurationApiBinder());
+
+      // construct server
+      return new ServerApp(configs.getAirbyteVersion(), componentClasses, components);
+    }
+
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerRunnable.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerRunnable.java
@@ -1,0 +1,31 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.airbyte.server;
+
+public interface ServerRunnable {
+
+  void start() throws Exception;
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/version_mismatch/VersionMismatchServer.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/version_mismatch/VersionMismatchServer.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.server.CorsFilter;
+import io.airbyte.server.ServerRunnable;
 import java.io.IOException;
 import java.util.Map;
 import javax.servlet.http.HttpServlet;
@@ -44,7 +45,7 @@ import org.slf4j.LoggerFactory;
  * mismatch occurs, a migration is required to upgrade the database. Until then, we show errors
  * using this server in order to prevent getting into a bad state.
  */
-public class VersionMismatchServer {
+public class VersionMismatchServer implements ServerRunnable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(VersionMismatchServer.class);
   private final String version1;
@@ -57,6 +58,7 @@ public class VersionMismatchServer {
     this.port = port;
   }
 
+  @Override
   public void start() throws Exception {
     final Server server = getServer();
     server.start();


### PR DESCRIPTION
Improves the abstraction around the server creation so it's easier to mock various parts while building. It also separates shared OSS + Cloud configurations and OSS-specific configurations.

For Cloud, this will allows to implement a `ServerFactory` that configures the server that we will run with just `getServer(new CouldServerFactory()).start();` in a separate PR. We will also be able to run it in tests with mocked data on just a server running in a thread (which will allow us to do things like CORS header testing for the OSS project) by just running `new ServerFactory.Api().create(...).start()`.