### PR TITLE
fix acceptance tests deps

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -247,18 +247,8 @@ jobs:
       #      - name: Get Docker Space
       #        run: docker run --rm busybox df -h
 
-      - name: Image Cleanup
-        run: ./tools/bin/clean_images.sh
-
-      - name: Build Platform Docker Images
-        if: success() && github.ref == 'refs/heads/master'
-        run: GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcs.json" ./gradlew composeBuild --scan
-        env:
-          GIT_REVISION: ${{ github.sha }}
-
       # make sure these always run before pushing platform docker images
       - name: Run End-to-End Acceptance Tests
-        if: success() && github.ref == 'refs/heads/master'
         run: ./tools/bin/acceptance_test.sh
 
       - name: Automatic Migration Acceptance Test

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -254,14 +254,6 @@ jobs:
       - name: Automatic Migration Acceptance Test
         run: MIGRATION_TEST_VERSION=$(grep VERSION .env | tr  -d "VERSION=") SUB_BUILD=PLATFORM ./gradlew :airbyte-tests:automaticMigrationAcceptanceTest --scan -i
 
-      - name: Push Platform Docker Images
-        if: success() && github.ref == 'refs/heads/master'
-        run: |
-          docker login -u airbytebot -p ${DOCKER_PASSWORD}
-          VERSION=dev docker-compose -f docker-compose.build.yaml push
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Slack Notification - Failure
         if: failure() && github.ref == 'refs/heads/master'
         uses: rtCamp/action-slack-notify@master

--- a/airbyte-integrations/connectors/destination-e2e-test/Dockerfile
+++ b/airbyte-integrations/connectors/destination-e2e-test/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=dev
+LABEL io.airbyte.version=0.1.0
 LABEL io.airbyte.name=airbyte/destination-e2e-test

--- a/airbyte-integrations/connectors/source-e2e-test/Dockerfile
+++ b/airbyte-integrations/connectors/source-e2e-test/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=dev
+LABEL io.airbyte.version=0.1.0
 LABEL io.airbyte.name=airbyte/source-e2e-test

--- a/airbyte-tests/build.gradle
+++ b/airbyte-tests/build.gradle
@@ -42,13 +42,13 @@ dependencies {
     acceptanceTestsImplementation project(':airbyte-test-utils')
 
     acceptanceTestsImplementation 'org.apache.commons:commons-csv:1.4'
-    acceptanceTestsImplementation "org.testcontainers:postgresql:1.15.1"
-    acceptanceTestsImplementation "org.postgresql:postgresql:42.2.18"
-    acceptanceTestsImplementation "com.fasterxml.jackson.core:jackson-databind"
+    acceptanceTestsImplementation 'org.testcontainers:postgresql:1.15.1'
+    acceptanceTestsImplementation 'org.postgresql:postgresql:42.2.18'
+    acceptanceTestsImplementation 'com.fasterxml.jackson.core:jackson-databind'
 
     automaticMigrationAcceptanceTestImplementation project(':airbyte-api')
     automaticMigrationAcceptanceTestImplementation project(':airbyte-commons')
-    automaticMigrationAcceptanceTestImplementation "org.testcontainers:testcontainers:1.15.3"
+    automaticMigrationAcceptanceTestImplementation 'org.testcontainers:testcontainers:1.15.3'
 }
 
 task acceptanceTests(type: Test) {
@@ -61,12 +61,6 @@ task acceptanceTests(type: Test) {
         exceptionFormat "full"
     }
     mustRunAfter test
-
-    dependsOn ':airbyte-integrations:connectors:source-postgres:airbyteDocker'
-    dependsOn ':airbyte-integrations:connectors:destination-postgres:airbyteDocker'
-    // for checkpointing tests
-    dependsOn ':airbyte-integrations:connectors:source-e2e-test:airbyteDocker'
-    dependsOn ':airbyte-integrations:connectors:destination-e2e-test:airbyteDocker'
 }
 
 task automaticMigrationAcceptanceTest(type: Test) {

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -137,6 +137,9 @@ public class AcceptanceTests {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AcceptanceTests.class);
 
+  private static final String SOURCE_E2E_TEST_CONNECTOR_VERSION = "0.1.0";
+  private static final String DESTINATION_E2E_TEST_CONNECTOR_VERSION = "0.1.0";
+
   private static final boolean IS_KUBE = System.getenv().containsKey("KUBE");
   private static final boolean IS_MINIKUBE = System.getenv().containsKey("IS_MINIKUBE");
 
@@ -605,14 +608,14 @@ public class AcceptanceTests {
     final SourceDefinitionRead sourceDefinition = apiClient.getSourceDefinitionApi().createSourceDefinition(new SourceDefinitionCreate()
         .name("E2E Test Source")
         .dockerRepository("airbyte/source-e2e-test")
-        .dockerImageTag("dev")
+        .dockerImageTag(SOURCE_E2E_TEST_CONNECTOR_VERSION)
         .documentationUrl(URI.create("https://example.com")));
 
     final DestinationDefinitionRead destinationDefinition = apiClient.getDestinationDefinitionApi()
         .createDestinationDefinition(new DestinationDefinitionCreate()
             .name("E2E Test Destination")
             .dockerRepository("airbyte/destination-e2e-test")
-            .dockerImageTag("dev")
+            .dockerImageTag(DESTINATION_E2E_TEST_CONNECTOR_VERSION)
             .documentationUrl(URI.create("https://example.com")));
 
     final SourceRead source = createSource(
@@ -705,14 +708,14 @@ public class AcceptanceTests {
     final SourceDefinitionRead sourceDefinition = apiClient.getSourceDefinitionApi().createSourceDefinition(new SourceDefinitionCreate()
         .name("E2E Test Source")
         .dockerRepository("airbyte/source-e2e-test")
-        .dockerImageTag("dev")
+        .dockerImageTag(SOURCE_E2E_TEST_CONNECTOR_VERSION)
         .documentationUrl(URI.create("https://example.com")));
 
     final DestinationDefinitionRead destinationDefinition = apiClient.getDestinationDefinitionApi()
         .createDestinationDefinition(new DestinationDefinitionCreate()
             .name("E2E Test Destination")
             .dockerRepository("airbyte/destination-e2e-test")
-            .dockerImageTag("dev")
+            .dockerImageTag(DESTINATION_E2E_TEST_CONNECTOR_VERSION)
             .documentationUrl(URI.create("https://example.com")));
 
     final SourceRead source = createSource(

--- a/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
+++ b/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
@@ -97,7 +97,7 @@ public class MigrationAcceptanceTest {
           logs.remove(keyToRemove);
         }
 
-        LOGGER.info(log.trim());
+        LOGGER.info(log);
       }
     };
   }

--- a/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
+++ b/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
@@ -97,7 +97,7 @@ public class MigrationAcceptanceTest {
           logs.remove(keyToRemove);
         }
 
-        LOGGER.info(log);
+        LOGGER.info(log.trim());
       }
     };
   }
@@ -113,7 +113,7 @@ public class MigrationAcceptanceTest {
     Set<String> logsToExpect = new HashSet<>();
     logsToExpect.add("Version: 0.17.0-alpha");
 
-    DockerComposeContainer dockerComposeContainer = new DockerComposeContainer(firstRun)
+    final DockerComposeContainer dockerComposeContainer = new DockerComposeContainer(firstRun)
         .withLogConsumer("server", logConsumerForServer(logsToExpect))
         .withEnv(environmentVariables);
     try {
@@ -122,8 +122,7 @@ public class MigrationAcceptanceTest {
        * {@link org.testcontainers.containers.DockerComposeContainer#stop()} method also deletes the
        * volume but we dont want to delete the volume to test the automatic migration
        */
-      CustomDockerComposeContainer customDockerComposeContainer = new CustomDockerComposeContainer(
-          dockerComposeContainer);
+      final CustomDockerComposeContainer customDockerComposeContainer = new CustomDockerComposeContainer(dockerComposeContainer);
 
       customDockerComposeContainer.start();
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -52,23 +52,6 @@ if(!System.getenv().containsKey("SUB_BUILD") || System.getenv().get("SUB_BUILD")
     include ':airbyte-server'
     include ':airbyte-webapp'
     include ':airbyte-tests'
-
-    // acceptance tests
-    include ':airbyte-integrations:bases:airbyte-protocol'
-    include ':airbyte-integrations:bases:base'
-    include ':airbyte-integrations:bases:base-java'
-    include ':airbyte-integrations:bases:base-normalization'
-    include ':airbyte-integrations:bases:standard-destination-test'
-    include ':airbyte-integrations:bases:standard-source-test'
-    include ':airbyte-integrations:bases:debezium'
-    include ':airbyte-integrations:connectors:source-jdbc'
-    include ':airbyte-integrations:connectors:source-postgres'
-    include ':airbyte-integrations:connectors:destination-postgres'
-    include ':airbyte-integrations:connectors:source-relational-db'
-    include ':airbyte-integrations:connectors:destination-e2e-test'
-    include ':airbyte-integrations:connectors:destination-jdbc'
-    include ':airbyte-integrations:connectors:source-e2e-test'
-    include ':tools:code-generator'
 }
 
 // connectors base


### PR DESCRIPTION
## What
* @davinchia in this PR: https://github.com/airbytehq/airbyte/pull/4808 had to add a bunch of deps to the platform build because I missed deps that were needed for acceptance tests. Adding these deps is increasing the build time from ~5 min to ~18min.

## How
* remove the deps that were added. this requires...
* removing an unused dep declared in gradle on postgres source and destination
* having acceptance tests rely on a pinned version of source-e2e-test or destination-e2e-test

## Recommended reading order
1. `x.java`
2. `y.python`
