### PR TITLE
check connector images exist in platform build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,6 +36,9 @@ jobs:
     name: "Ensure all required Docker images exist on Dockerhub"
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v2
+
       - name: Check images exist
         run: ./tools/bin/check_images_exist.sh all
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -175,7 +175,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check images exist
-        run: ./tools/bin/check_images_exist.sh platform
+        run: ./tools/bin/check_images_exist.sh all
 
       - name: Pip Caching
         uses: actions/cache@v2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,6 +31,14 @@ jobs:
           ec2-instance-type: c5.2xlarge
           subnet-id: subnet-0469a9e68a379c1d3
           security-group-id: sg-0793f3c9413f21970
+
+  ensure-images-exist:
+    name: "Ensure all required Docker images exist on Dockerhub"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check images exist
+        run: ./tools/bin/check_images_exist.sh all
+
   build-connectors-base:
     # In case of self-hosted EC2 errors, removed the `needs` line and switch back to running on ubuntu-latest.
     needs: start-connectors-base-build-runner # required to start the main job when the runner is ready
@@ -39,9 +47,6 @@ jobs:
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
-
-      - name: Check images exist
-        run: ./tools/bin/check_images_exist.sh connectors
 
       - name: Pip Caching
         uses: actions/cache@v2
@@ -173,9 +178,6 @@ jobs:
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
-
-      - name: Check images exist
-        run: ./tools/bin/check_images_exist.sh all
 
       - name: Pip Caching
         uses: actions/cache@v2


### PR DESCRIPTION
## What
This was removed in a previous PR but is a necessary check because the absence of connectors in the connector index will cause platform bugs. 