### PR TITLE
allow FileSystemConfigPersistence to fail on missing root dir

### DIFF
--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/FileSystemConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/FileSystemConfigPersistence.java
@@ -76,7 +76,7 @@ public class FileSystemConfigPersistence implements ConfigPersistence {
 
   public FileSystemConfigPersistence(final Path storageRoot) {
     this.storageRoot = storageRoot;
-    this.configRoot = Exceptions.toRuntime(() -> Files.createDirectories(storageRoot.resolve(CONFIG_DIR)));
+    this.configRoot = storageRoot.resolve(CONFIG_DIR);
   }
 
   @Override


### PR DESCRIPTION
## What
* if the root dir is missing the `FileSystemConfigPersistence` should fail as we expect that dir to be created elsewhere. If it hasn't been created that means something has gone wrong and we want to fail loudly instead of papering over it. Thanks to @tuliren for pointing out the mistake [here](https://github.com/airbytehq/airbyte/pull/4976#discussion_r676274187).
