### PR TITLE
Use 0.17.0-alpha-db-patch for auto migration test

### DIFF
--- a/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
+++ b/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
@@ -107,6 +107,7 @@ public class MigrationAcceptanceTest {
   private void firstRun() throws Exception {
     // 0.17.0-alpha-db-patch is specifically built for this test;
     // it connects to the database with retries to fix flaky connection issue
+    // https://github.com/airbytehq/airbyte/issues/4955
     final Map<String, String> environmentVariables = getEnvironmentVariables("0.17.0-alpha-db-patch");
 
     final Set<String> logsToExpect = new HashSet<>();

--- a/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
+++ b/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
@@ -105,10 +105,12 @@ public class MigrationAcceptanceTest {
 
   @SuppressWarnings("UnstableApiUsage")
   private void firstRun() throws Exception {
-    final Map<String, String> environmentVariables = getEnvironmentVariables("0.17.0-alpha");
+    // 0.17.0-alpha-db-patch is specifically built for this test;
+    // it connects to the database with retries to fix flaky connection issue
+    final Map<String, String> environmentVariables = getEnvironmentVariables("0.17.0-alpha-db-patch");
 
     final Set<String> logsToExpect = new HashSet<>();
-    logsToExpect.add("Version: 0.17.0-alpha");
+    logsToExpect.add("Version: 0.17.0-alpha-db-patch");
 
     final AirbyteTestContainer airbyteTestContainer =
         new AirbyteTestContainer.Builder(new File(Resources.getResource("docker-compose-migration-test-0-17-0-alpha.yaml").toURI()))

--- a/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
+++ b/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
@@ -135,7 +135,7 @@ public class MigrationAcceptanceTest {
   private void secondRun(String targetVersion) throws Exception {
     final Set<String> logsToExpect = new HashSet<>();
     logsToExpect.add("Version: " + targetVersion);
-    logsToExpect.add("Starting migrations. Current version: 0.17.0-alpha, Target version: " + targetVersionWithoutPatch(targetVersion));
+    logsToExpect.add("Starting migrations. Current version: 0.17.0-alpha-db-patch, Target version: " + targetVersionWithoutPatch(targetVersion));
     logsToExpect.add("Migrating from version: 0.17.0-alpha to version 0.18.0-alpha.");
     logsToExpect.add("Migrating from version: 0.18.0-alpha to version 0.19.0-alpha.");
     logsToExpect.add("Migrating from version: 0.19.0-alpha to version 0.20.0-alpha.");


### PR DESCRIPTION
## What
- This resolves #4955.

## TODO
- Test the build five times to verify that there is no more failed build:
  - [x] 1
  - [x] 2
  - [x] 3
  - [x] 4
  - [x] 5

## How
- Use a specifical build, [`0.17.0-alpha-db-patch`](https://github.com/airbytehq/airbyte/releases/tag/v0.17.0-alpha-db-patch), for the auto migration test.
- This patch connects to the database with retries ([diff](https://github.com/airbytehq/airbyte/compare/v0.17.0-alpha...branch-v0.17.0-alpha-db-patch)) to fix the flaky connection issue.
