### PR TITLE
🐛  Handle workspace id for operations in web backend

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2266,9 +2266,12 @@ components:
       required:
         - name
         - operatorConfiguration
+        - workspaceId
       properties:
         operationId:
           $ref: "#/components/schemas/OperationId"
+        workspaceId:
+          $ref: "#/components/schemas/WorkspaceId"
         name:
           type: string
         operatorConfiguration:

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -27,7 +27,6 @@ package io.airbyte.server;
 import io.airbyte.analytics.Deployment;
 import io.airbyte.analytics.Deployment.DeploymentMode;
 import io.airbyte.analytics.TrackingClientSingleton;
-import io.airbyte.commons.jackson.MoreMappers;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.Configs;
@@ -109,10 +108,6 @@ public class ServerApp implements ServerRunnable {
 
     final Map<String, String> mdc = MDC.getCopyOfContextMap();
 
-    final JacksonJaxbJsonProvider jacksonJaxbJsonProvider = new JacksonJaxbJsonProvider();
-    // do not fail request if there are unknown properties
-    jacksonJaxbJsonProvider.setMapper(MoreMappers.initMapper());
-
     final ResourceConfig rc =
         new ResourceConfig()
             .register(new RequestLogger(mdc))
@@ -125,7 +120,6 @@ public class ServerApp implements ServerRunnable {
             // needed so that the custom json exception mappers don't get overridden
             // https://stackoverflow.com/questions/35669774/jersey-custom-exception-mapper-for-invalid-json-string
             .register(JacksonJaxbJsonProvider.class);
-    // .register(jacksonJaxbJsonProvider);
 
     // inject custom server functionality
     customComponentClasses.forEach(rc::register);

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -27,6 +27,7 @@ package io.airbyte.server;
 import io.airbyte.analytics.Deployment;
 import io.airbyte.analytics.Deployment.DeploymentMode;
 import io.airbyte.analytics.TrackingClientSingleton;
+import io.airbyte.commons.jackson.MoreMappers;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.Configs;
@@ -108,6 +109,10 @@ public class ServerApp implements ServerRunnable {
 
     final Map<String, String> mdc = MDC.getCopyOfContextMap();
 
+    final JacksonJaxbJsonProvider jacksonJaxbJsonProvider = new JacksonJaxbJsonProvider();
+    // do not fail request if there are unknown properties
+    jacksonJaxbJsonProvider.setMapper(MoreMappers.initMapper());
+
     final ResourceConfig rc =
         new ResourceConfig()
             .register(new RequestLogger(mdc))
@@ -120,6 +125,7 @@ public class ServerApp implements ServerRunnable {
             // needed so that the custom json exception mappers don't get overridden
             // https://stackoverflow.com/questions/35669774/jersey-custom-exception-mapper-for-invalid-json-string
             .register(JacksonJaxbJsonProvider.class);
+    // .register(jacksonJaxbJsonProvider);
 
     // inject custom server functionality
     customComponentClasses.forEach(rc::register);

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -177,8 +177,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
         destinationHandler,
         jobHistoryHandler,
         schedulerHandler,
-        operationsHandler,
-        workspaceHelper);
+        operationsHandler);
     webBackendSourceHandler = new WebBackendSourceHandler(sourceHandler, schedulerHandler, workspaceHelper);
     webBackendDestinationHandler = new WebBackendDestinationHandler(destinationHandler, schedulerHandler, workspaceHelper);
     healthCheckHandler = new HealthCheckHandler(configRepository);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -244,6 +244,7 @@ public class WebBackendConnectionsHandler {
 
   public WebBackendConnectionRead webBackendCreateConnection(WebBackendConnectionCreate webBackendConnectionCreate)
       throws ConfigNotFoundException, IOException, JsonValidationException {
+    // hack - UI doesn't supply the workspace id yet, so for now, we sneak it in the backend.
     final UUID workspaceId = getWorkspaceIdForSource(webBackendConnectionCreate.getSourceId());
     final List<UUID> operationIds = createOperations(webBackendConnectionCreate, workspaceId);
     final ConnectionCreate connectionCreate = toConnectionCreate(webBackendConnectionCreate, operationIds);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -117,20 +117,20 @@ class WebBackendConnectionsHandlerTest {
   public void setup() throws IOException, JsonValidationException, ConfigNotFoundException {
     connectionsHandler = mock(ConnectionsHandler.class);
     operationsHandler = mock(OperationsHandler.class);
-    SourceHandler sourceHandler = mock(SourceHandler.class);
-    DestinationHandler destinationHandler = mock(DestinationHandler.class);
-    JobHistoryHandler jobHistoryHandler = mock(JobHistoryHandler.class);
+    final SourceHandler sourceHandler = mock(SourceHandler.class);
+    final DestinationHandler destinationHandler = mock(DestinationHandler.class);
+    final JobHistoryHandler jobHistoryHandler = mock(JobHistoryHandler.class);
     schedulerHandler = mock(SchedulerHandler.class);
     wbHandler = new WebBackendConnectionsHandler(connectionsHandler, sourceHandler, destinationHandler, jobHistoryHandler, schedulerHandler,
         operationsHandler);
 
     final StandardSourceDefinition standardSourceDefinition = SourceDefinitionHelpers.generateSource();
-    SourceConnection source = SourceHelpers.generateSource(UUID.randomUUID());
+    final SourceConnection source = SourceHelpers.generateSource(UUID.randomUUID());
     sourceRead = SourceHelpers.getSourceRead(source, standardSourceDefinition);
 
     final StandardDestinationDefinition destinationDefinition = DestinationDefinitionHelpers.generateDestination();
     final DestinationConnection destination = DestinationHelpers.generateDestination(UUID.randomUUID());
-    DestinationRead destinationRead = DestinationHelpers.getDestinationRead(destination, destinationDefinition);
+    final DestinationRead destinationRead = DestinationHelpers.getDestinationRead(destination, destinationDefinition);
 
     final StandardSync standardSync = ConnectionHelpers.generateSyncWithSourceId(source.getSourceId());
     connectionRead = ConnectionHelpers.generateExpectedConnectionRead(standardSync);
@@ -403,7 +403,7 @@ class WebBackendConnectionsHandlerTest {
 
   @Test
   void testUpdateConnection() throws JsonValidationException, ConfigNotFoundException, IOException {
-    WebBackendConnectionUpdate updateBody = new WebBackendConnectionUpdate()
+    final WebBackendConnectionUpdate updateBody = new WebBackendConnectionUpdate()
         .namespaceDefinition(expected.getNamespaceDefinition())
         .namespaceFormat(expected.getNamespaceFormat())
         .prefix(expected.getPrefix())
@@ -432,7 +432,7 @@ class WebBackendConnectionsHandlerTest {
 
     assertEquals(expected.getSyncCatalog(), connectionRead.getSyncCatalog());
 
-    ConnectionIdRequestBody connectionId = new ConnectionIdRequestBody().connectionId(connectionRead.getConnectionId());
+    final ConnectionIdRequestBody connectionId = new ConnectionIdRequestBody().connectionId(connectionRead.getConnectionId());
     verify(schedulerHandler, times(0)).resetConnection(connectionId);
     verify(schedulerHandler, times(0)).syncConnection(connectionId);
   }
@@ -443,7 +443,7 @@ class WebBackendConnectionsHandlerTest {
         .name("Test Operation")
         .operationId(connectionRead.getOperationIds().get(0));
     final OperationUpdate operationUpdate = WebBackendConnectionsHandler.toOperationUpdate(operationCreateOrUpdate);
-    WebBackendConnectionUpdate updateBody = new WebBackendConnectionUpdate()
+    final WebBackendConnectionUpdate updateBody = new WebBackendConnectionUpdate()
         .namespaceDefinition(expected.getNamespaceDefinition())
         .namespaceFormat(expected.getNamespaceFormat())
         .prefix(expected.getPrefix())
@@ -480,7 +480,7 @@ class WebBackendConnectionsHandlerTest {
 
   @Test
   void testUpdateConnectionWithUpdatedSchema() throws JsonValidationException, ConfigNotFoundException, IOException {
-    WebBackendConnectionUpdate updateBody = new WebBackendConnectionUpdate()
+    final WebBackendConnectionUpdate updateBody = new WebBackendConnectionUpdate()
         .namespaceDefinition(expected.getNamespaceDefinition())
         .namespaceFormat(expected.getNamespaceFormat())
         .prefix(expected.getPrefix())
@@ -506,7 +506,7 @@ class WebBackendConnectionsHandlerTest {
             .status(expected.getStatus())
             .schedule(expected.getSchedule()));
 
-    WebBackendConnectionRead connectionRead = wbHandler.webBackendUpdateConnection(updateBody);
+    final WebBackendConnectionRead connectionRead = wbHandler.webBackendUpdateConnection(updateBody);
 
     assertEquals(expectedWithNewSchema.getSyncCatalog(), connectionRead.getSyncCatalog());
 

--- a/airbyte-webapp/src/core/domain/connection/OperationService.ts
+++ b/airbyte-webapp/src/core/domain/connection/OperationService.ts
@@ -8,9 +8,12 @@ class OperationService extends AirbyteRequestService {
   }
 
   public async check(
-    body: Operation
+    operation: Operation
   ): Promise<{ status: "succeeded" | "failed"; message: string }> {
-    const rs = ((await this.fetch(`${this.url}/check`, body)) as any) as {
+    const rs = ((await this.fetch(
+      `${this.url}/check`,
+      operation.operatorConfiguration
+    )) as any) as {
       status: "succeeded" | "failed";
       message: string;
     };

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -6244,6 +6244,7 @@ font-style: italic;
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">operationId (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">workspaceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">operatorConfiguration </div><div class="param-desc"><span class="param-type"><a href="#OperatorConfiguration">OperatorConfiguration</a></span>  </div>
     </div>  <!-- field-items -->


### PR DESCRIPTION
## What
* slack [convo](https://airbytehq.slack.com/archives/C01MFR03D5W/p1627411815421000)
* operations in web back failed validation now that they have workspace id.

## How
* update backend to accept workspace id
* the `operations/check` was broken too. it should have been accepting a configuration not the operation wrapper object. i think this is a mistake when i released operations but forgot to fix it in the ui. fixed that.