### PR TITLE
RFC: allow unknown fields in the API 

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -27,6 +27,7 @@ package io.airbyte.server;
 import io.airbyte.analytics.Deployment;
 import io.airbyte.analytics.Deployment.DeploymentMode;
 import io.airbyte.analytics.TrackingClientSingleton;
+import io.airbyte.commons.jackson.MoreMappers;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.Configs;
@@ -108,6 +109,10 @@ public class ServerApp implements ServerRunnable {
 
     final Map<String, String> mdc = MDC.getCopyOfContextMap();
 
+    // user custom provider so that we do not fail request if there are unknown properties
+    final JacksonJaxbJsonProvider jacksonJaxbJsonProvider = new JacksonJaxbJsonProvider();
+    jacksonJaxbJsonProvider.setMapper(MoreMappers.initMapper());
+
     final ResourceConfig rc =
         new ResourceConfig()
             .register(new RequestLogger(mdc))
@@ -119,7 +124,7 @@ public class ServerApp implements ServerRunnable {
             .register(NotFoundExceptionMapper.class)
             // needed so that the custom json exception mappers don't get overridden
             // https://stackoverflow.com/questions/35669774/jersey-custom-exception-mapper-for-invalid-json-string
-            .register(JacksonJaxbJsonProvider.class);
+            .register(jacksonJaxbJsonProvider);
 
     // inject custom server functionality
     customComponentClasses.forEach(rc::register);


### PR DESCRIPTION
## What
Currently we do not ever allow additional properties in the API. This doesn't follow [Postel's law](https://en.wikipedia.org/wiki/Robustness_principle) in being liberal in what an API accepts, which is generally considered a good practice. The change in this PR would make it so that we would not fail if we receive unknown properties. 

This came up recently in this [bug](https://airbytehq.slack.com/archives/C01MFR03D5W/p1627411815421000). That being said, generally when have this sort of validation error, where unknown values are being sent, it is unintentional and a bug on the client or a problem with open api spec. I'm fine with leaving things as the are since it does allow  us to catch bugs faster, but figured I'd throw it out there so that we at least make a principled choice one way or another.

