### PR TITLE
generate legacy source test referecne docs in the right location

### DIFF
--- a/airbyte-integrations/bases/standard-source-test/build.gradle
+++ b/airbyte-integrations/bases/standard-source-test/build.gradle
@@ -63,7 +63,7 @@ task generateSourceTestDocs(type: Javadoc) {
             md += "## ${methodName}\n\n"
             md += "${methodDocstring != null ? methodDocstring.text().replaceAll(/([()])/, '\\\\$1') : 'No method description was provided'}\n\n"
         }
-        def outputDoc = new File("${rootDir}/docs/contributing-to-airbyte/building-new-connector/standard-source-tests.md")
+        def outputDoc = new File("${rootDir}/docs/connector-development/testing-connectors/standard-source-tests.md")
         outputDoc.write "# Standard Source Test Suite\n\n"
         outputDoc.append "Test methods start with `test`. Other methods are internal helpers in the java class implementing the test suite.\n\n"
         outputDoc.append md


### PR DESCRIPTION
Fix the broken master build by outputting these autogenerated docs to the right location. The previous location was deleted in a doc reorganization PR. 
