### PR TITLE
🐛  Bug Fix: Handle missing data types in migrations.

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/set/MoreSets.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/set/MoreSets.java
@@ -35,7 +35,7 @@ public class MoreSets {
     Preconditions.checkNotNull(set2);
 
     Preconditions.checkArgument(set1.equals(set2), String.format(
-        "Sets are not the same. Elements in set 1 and not in set 2: %s.  Elements in set 2 and not in set 1 %s",
+        "Sets are not the same. Elements in set 1 and not in set 2: %s.  Elements in set 2 and not in set 1: %s",
         Sets.difference(set1, set2), Sets.difference(set2, set1)));
   }
 

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/Migrate.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/Migrate.java
@@ -161,10 +161,15 @@ public class Migrate {
         createInputStreamsForResourceType(migrationInputRoot, ResourceType.CONFIG),
         createInputStreamsForResourceType(migrationInputRoot, ResourceType.JOB));
 
-    try {
-      MoreSets.assertEqualsVerbose(migration.getInputSchema().keySet(), resourceIdToInputStreams.keySet());
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("Input record resources do not match declared schema resources", e);
+    System.out.println("\n\nschema = \n" + migration.getInputSchema().keySet().stream().map(ResourceId::getName).collect(Collectors.joining("\n")));
+    System.out.println("\n\nrecords = \n" + resourceIdToInputStreams.keySet().stream().map(ResourceId::getName).collect(Collectors.joining("\n")));
+    if (!migration.getInputSchema().keySet().containsAll(resourceIdToInputStreams.keySet())) {
+      try {
+        // we know something is wrong. check equality to get a full log message of the total difference.
+        MoreSets.assertEqualsVerbose(migration.getInputSchema().keySet(), resourceIdToInputStreams.keySet());
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Input records contain resource not declared in schema resources", e);
+      }
     }
     return resourceIdToInputStreams;
   }


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/5082

Previously, when Airbyte exported configurations, even if there were not configurations of a type (e.g. operations) it would create a placeholder file for it in the export archive. The implementation has changed such that we cannot make that guarantee anymore. Specifically the postgres database only exports data that it actually has.

The migration assumed that every archive it processed would contain data from all types. This commit makes the change to make sure that the types represented in the archive just need to be a subset of the types declared in the schema.

In the future we can decide if we have an opinion on whether we should always export placeholder files. Since we have versions of Airbyte that don't do it though, we need to make this change in the migration code.
