### PR TITLE
🐛  fix npe in migration 0.28.0

### DIFF
--- a/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_28_0.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_28_0.java
@@ -136,4 +136,5 @@ public class MigrationV0_28_0 extends BaseMigration implements Migration {
       entry.getValue().forEach(recordConsumer);
     }
   }
+
 }

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_28_0.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_28_0.java
@@ -87,7 +87,7 @@ public class MigrationV0_28_0 extends BaseMigration implements Migration {
 
     final Map<ResourceId, Stream<JsonNode>> inputData = new HashMap<>(inputDataImmutable);
     // process connections.
-    inputData.remove(CONNECTION_RESOURCE_ID).forEach(r -> {
+    inputData.getOrDefault(CONNECTION_RESOURCE_ID, Stream.empty()).forEach(r -> {
       final UUID connectionId = UUID.fromString(r.get("connectionId").asText());
       final UUID sourceId = UUID.fromString(r.get("sourceId").asText());
       connectionIdToSourceId.put(connectionId, sourceId);
@@ -100,16 +100,20 @@ public class MigrationV0_28_0 extends BaseMigration implements Migration {
 
       outputData.get(CONNECTION_RESOURCE_ID).accept(r);
     });
+    inputData.remove(CONNECTION_RESOURCE_ID);
+
     // process sources.
-    inputData.remove(SOURCE_RESOURCE_ID).forEach(r -> {
+    inputData.getOrDefault(SOURCE_RESOURCE_ID, Stream.empty()).forEach(r -> {
       final UUID sourceId = UUID.fromString(r.get("sourceId").asText());
       final UUID workspaceId = UUID.fromString(r.get("workspaceId").asText());
       sourceIdToWorkspaceId.put(sourceId, workspaceId);
 
       outputData.get(SOURCE_RESOURCE_ID).accept(r);
     });
+    inputData.remove(SOURCE_RESOURCE_ID);
+
     // process operations.
-    inputData.remove(OPERATION_RESOURCE_ID).forEach(r -> {
+    inputData.getOrDefault(OPERATION_RESOURCE_ID, Stream.empty()).forEach(r -> {
       final UUID operationId = UUID.fromString(r.get("operationId").asText());
 
       final UUID workspaceId;
@@ -124,6 +128,7 @@ public class MigrationV0_28_0 extends BaseMigration implements Migration {
 
       outputData.get(OPERATION_RESOURCE_ID).accept(r);
     });
+    inputData.remove(OPERATION_RESOURCE_ID);
 
     // process the remaining resources.
     for (final Map.Entry<ResourceId, Stream<JsonNode>> entry : inputData.entrySet()) {
@@ -131,5 +136,4 @@ public class MigrationV0_28_0 extends BaseMigration implements Migration {
       entry.getValue().forEach(recordConsumer);
     }
   }
-
 }

--- a/airbyte-migration/src/test/java/io/airbyte/migrate/migrations/MigrateV0_28_0Test.java
+++ b/airbyte-migration/src/test/java/io/airbyte/migrate/migrations/MigrateV0_28_0Test.java
@@ -39,6 +39,7 @@ import io.airbyte.migrate.Migrations;
 import io.airbyte.migrate.ResourceId;
 import io.airbyte.migrate.ResourceType;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Spliterators;
@@ -90,6 +91,33 @@ public class MigrateV0_28_0Test {
         .put(SOURCE_RESOURCE_ID, getResourceList(INPUT_CONFIG_PATH + "/SOURCE_CONNECTION.yaml"))
         .put(OPERATION_RESOURCE_ID, getResourceList(OUTPUT_CONFIG_PATH + "/STANDARD_SYNC_OPERATION.yaml"))
         .build();
+
+    final Map<ResourceId, List<JsonNode>> expectedOutput = MigrationTestUtils
+        .createExpectedOutput(migration.getOutputSchema().keySet(), expectedOutputOverrides);
+
+    final Map<ResourceId, List<JsonNode>> outputAsList = MigrationTestUtils
+        .collectConsumersToList(outputConsumer);
+
+    assertExpectedOutput(expectedOutput, outputAsList);
+  }
+
+  @Test
+  void testEmptyResourceStreams() throws IOException {
+    final MigrationV0_28_0 migration = (MigrationV0_28_0) Migrations.MIGRATIONS
+        .stream()
+        .filter(m -> m instanceof MigrationV0_28_0)
+        .findAny()
+        .orElse(null);
+    assertNotNull(migration);
+
+    final Map<ResourceId, Stream<JsonNode>> inputConfigs = Collections.emptyMap();
+
+    final Map<ResourceId, ListConsumer<JsonNode>> outputConsumer = MigrationTestUtils
+        .createOutputConsumer(migration.getOutputSchema().keySet());
+
+    migration.migrate(inputConfigs, MigrationUtils.mapRecordConsumerToConsumer(outputConsumer));
+
+    final Map<ResourceId, List<JsonNode>> expectedOutputOverrides = Collections.emptyMap();
 
     final Map<ResourceId, List<JsonNode>> expectedOutput = MigrationTestUtils
         .createExpectedOutput(migration.getOutputSchema().keySet(), expectedOutputOverrides);

--- a/airbyte-migration/src/test/java/io/airbyte/migrate/migrations/MigrateV0_28_0Test.java
+++ b/airbyte-migration/src/test/java/io/airbyte/migrate/migrations/MigrateV0_28_0Test.java
@@ -102,7 +102,7 @@ public class MigrateV0_28_0Test {
   }
 
   @Test
-  void testEmptyResourceStreams() throws IOException {
+  void testEmptyResourceStreams() {
     final MigrationV0_28_0 migration = (MigrationV0_28_0) Migrations.MIGRATIONS
         .stream()
         .filter(m -> m instanceof MigrationV0_28_0)


### PR DESCRIPTION
## What
* reported in [slack convo 1](https://airbytehq.slack.com/archives/C01MFR03D5W/p1627633576012700?thread_ts=1627546155.017500&cid=C01MFR03D5W) and [slack convo 2](https://airbytehq.slack.com/archives/C01MFR03D5W/p1627652430033200?thread_ts=1627588078.101000&cid=C01MFR03D5W)
* The issue is that if any of the keys referenced in the `remove()` methods are null we get an NPE.

## How
* handle null case