### PR TITLE
🎉 CDK: Allow setting request non-JSON data

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/exceptions.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/exceptions.py
@@ -32,7 +32,7 @@ class BaseBackoffException(requests.exceptions.HTTPError):
     pass
 
 
-class RequestBodyException(requests.exceptions.HTTPError):
+class RequestBodyException(Exception):
     """
     Raises when there are some issues of request body
     """

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/exceptions.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/exceptions.py
@@ -32,6 +32,12 @@ class BaseBackoffException(requests.exceptions.HTTPError):
     pass
 
 
+class RequestBodyException(requests.exceptions.HTTPError):
+    """
+    Raises when there are some issues of request body
+    """
+
+
 class UserDefinedBackoffException(BaseBackoffException):
     """
     An exception that exposes how long it attempted to backoff

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/exceptions.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/exceptions.py
@@ -34,7 +34,7 @@ class BaseBackoffException(requests.exceptions.HTTPError):
 
 class RequestBodyException(Exception):
     """
-    Raises when there are some issues of request body
+    Raised when there are issues in configuring a request body
     """
 
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
@@ -31,8 +31,15 @@ from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.streams.core import Stream
 
 from .auth.core import HttpAuthenticator, NoAuth
-from .exceptions import DefaultBackoffException, UserDefinedBackoffException
+from .exceptions import (
+    DefaultBackoffException,
+    UserDefinedBackoffException,
+    RequestBodyException
+)
 from .rate_limiting import default_backoff_handler, user_defined_backoff_handler
+
+# list of all possible HTTP methods which can be used for sending of request bodies
+BODY_REQUEST_METHODS = ("POST", "PUT", "PATCH")
 
 
 class HttpStream(Stream, ABC):
@@ -56,7 +63,7 @@ class HttpStream(Stream, ABC):
     @property
     def http_method(self) -> str:
         """
-        Override if needed. See get_request_data if using POST.
+        Override if needed. See get_request_data/get_request_json if using POST/PUT/PATCH.
         """
         return "GET"
 
@@ -99,12 +106,29 @@ class HttpStream(Stream, ABC):
         return {}
 
     def request_headers(
-        self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
+        self,
+        stream_state: Mapping[str, Any],
+        stream_slice: Mapping[str, Any] = None,
+        next_page_token: Mapping[str, Any] = None
     ) -> Mapping[str, Any]:
         """
         Override to return any non-auth headers. Authentication headers will overwrite any overlapping headers returned from this method.
         """
         return {}
+
+    def request_body_data(
+        self,
+        stream_state: Mapping[str, Any],
+        stream_slice: Mapping[str, Any] = None,
+        next_page_token: Mapping[str, Any] = None,
+    ) -> str:
+        """
+        Override when creating POST/PUT/PATCH requests to populate the body of the request with a non-JSON payload.
+
+        Returns a ready text that it will be sent as is.
+        At the same time only one of the 'request_body_data' and 'request_body_json' functions can be overridden.
+        """
+        return None
 
     def request_body_json(
         self,
@@ -113,8 +137,9 @@ class HttpStream(Stream, ABC):
         next_page_token: Mapping[str, Any] = None,
     ) -> Optional[Mapping]:
         """
-        TODO make this possible to do for non-JSON APIs
-        Override when creating POST requests to populate the body of the request with a JSON payload.
+        Override when creating POST/PUT/PATCH requests to populate the body of the request with a JSON payload.
+
+        At the same time only one of the 'request_body_data' and 'request_body_json' functions can be overridden.
         """
         return None
 
@@ -171,13 +196,27 @@ class HttpStream(Stream, ABC):
         return None
 
     def _create_prepared_request(
-        self, path: str, headers: Mapping = None, params: Mapping = None, json: Any = None
+        self,
+        path: str,
+        headers: Mapping = None,
+        params: Mapping = None,
+        json: Any = None,
+        data: Any = None
     ) -> requests.PreparedRequest:
-        args = {"method": self.http_method, "url": self.url_base + path, "headers": headers, "params": params}
-
-        if self.http_method.upper() == "POST":
-            # TODO support non-json bodies
-            args["json"] = json
+        args = {
+            "method": self.http_method,
+            "url": self.url_base + path,
+            "headers": headers,
+            "params": params
+        }
+        if self.http_method.upper() in BODY_REQUEST_METHODS:
+            if json and data:
+                raise RequestBodyException("At the same time only one of the 'request_body_data' and "
+                                           "'request_body_json' functions can return data")
+            elif json:
+                args["json"] = json
+            elif data:
+                args["data"] = data
 
         return self._session.prepare_request(requests.Request(**args))
 
@@ -235,6 +274,7 @@ class HttpStream(Stream, ABC):
                 headers=dict(request_headers, **self.authenticator.get_auth_header()),
                 params=self.request_params(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token),
                 json=self.request_body_json(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token),
+                data=self.request_body_data(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token),
             )
             request_kwargs = self.request_kwargs(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
             response = self._send_request(request, request_kwargs)

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
@@ -114,7 +114,7 @@ class HttpStream(Stream, ABC):
         stream_state: Mapping[str, Any],
         stream_slice: Mapping[str, Any] = None,
         next_page_token: Mapping[str, Any] = None,
-    ) -> str:
+    ) -> Optional[str]:
         """
         Override when creating POST/PUT/PATCH requests to populate the body of the request with a non-JSON payload.
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
@@ -31,11 +31,7 @@ from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.streams.core import Stream
 
 from .auth.core import HttpAuthenticator, NoAuth
-from .exceptions import (
-    DefaultBackoffException,
-    UserDefinedBackoffException,
-    RequestBodyException
-)
+from .exceptions import DefaultBackoffException, RequestBodyException, UserDefinedBackoffException
 from .rate_limiting import default_backoff_handler, user_defined_backoff_handler
 
 # list of all possible HTTP methods which can be used for sending of request bodies
@@ -106,10 +102,7 @@ class HttpStream(Stream, ABC):
         return {}
 
     def request_headers(
-        self,
-        stream_state: Mapping[str, Any],
-        stream_slice: Mapping[str, Any] = None,
-        next_page_token: Mapping[str, Any] = None
+        self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
     ) -> Mapping[str, Any]:
         """
         Override to return any non-auth headers. Authentication headers will overwrite any overlapping headers returned from this method.
@@ -196,23 +189,14 @@ class HttpStream(Stream, ABC):
         return None
 
     def _create_prepared_request(
-        self,
-        path: str,
-        headers: Mapping = None,
-        params: Mapping = None,
-        json: Any = None,
-        data: Any = None
+        self, path: str, headers: Mapping = None, params: Mapping = None, json: Any = None, data: Any = None
     ) -> requests.PreparedRequest:
-        args = {
-            "method": self.http_method,
-            "url": self.url_base + path,
-            "headers": headers,
-            "params": params
-        }
+        args = {"method": self.http_method, "url": self.url_base + path, "headers": headers, "params": params}
         if self.http_method.upper() in BODY_REQUEST_METHODS:
             if json and data:
-                raise RequestBodyException("At the same time only one of the 'request_body_data' and "
-                                           "'request_body_json' functions can return data")
+                raise RequestBodyException(
+                    "At the same time only one of the 'request_body_data' and 'request_body_json' functions can return data"
+                )
             elif json:
                 args["json"] = json
             elif data:

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
@@ -24,7 +24,7 @@
 
 
 from abc import ABC, abstractmethod
-from typing import Any, Iterable, List, Mapping, MutableMapping, Optional
+from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Union
 
 import requests
 from airbyte_cdk.models import SyncMode
@@ -114,11 +114,14 @@ class HttpStream(Stream, ABC):
         stream_state: Mapping[str, Any],
         stream_slice: Mapping[str, Any] = None,
         next_page_token: Mapping[str, Any] = None,
-    ) -> Optional[str]:
+    ) -> Optional[Union[Mapping, str]]:
         """
         Override when creating POST/PUT/PATCH requests to populate the body of the request with a non-JSON payload.
 
-        Returns a ready text that it will be sent as is.
+        If returns a ready text that it will be sent as is.
+        If returns a dict that it will be converted to a urlencoded form.
+           E.g. {"key1": "value1", "key2": "value2"} => "key1=value1&key2=value2"
+
         At the same time only one of the 'request_body_data' and 'request_body_json' functions can be overridden.
         """
         return None

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
@@ -41,8 +41,8 @@ logger = AirbyteLogger()
 def default_backoff_handler(max_tries: int, factor: int, **kwargs):
     def log_retry_attempt(details):
         _, exc, _ = sys.exc_info()
-        logger.info(str(exc))
-        logger.info(f"Caught retryable error after {details['tries']} tries. Waiting {details['wait']} seconds then retrying...")
+        logger.info(f"Caught retryable error '{str(exc)}' after {details['tries']} tries. "
+                    f"Waiting {details['wait']} seconds then retrying...")
 
     def should_give_up(exc):
         # If a non-rate-limiting related 4XX error makes it this far, it means it was unexpected and probably consistent, so we shouldn't back off

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
@@ -41,8 +41,9 @@ logger = AirbyteLogger()
 def default_backoff_handler(max_tries: int, factor: int, **kwargs):
     def log_retry_attempt(details):
         _, exc, _ = sys.exc_info()
-        logger.info(f"Caught retryable error '{str(exc)}' after {details['tries']} tries. "
-                    f"Waiting {details['wait']} seconds then retrying...")
+        logger.info(
+            f"Caught retryable error '{str(exc)}' after {details['tries']} tries. Waiting {details['wait']} seconds then retrying..."
+        )
 
     def should_give_up(exc):
         # If a non-rate-limiting related 4XX error makes it this far, it means it was unexpected and probably consistent, so we shouldn't back off

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -35,7 +35,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.6",
+    version="0.1.7",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -66,7 +66,7 @@ setup(
     packages=find_packages(exclude=("unit_tests",)),
     install_requires=[
         "backoff",
-        "jsonschema==2.6.0",
+        "jsonschema==3.2.0",
         "pendulum",
         "pydantic~=1.6",
         "PyYAML~=5.4",

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -66,7 +66,7 @@ setup(
     packages=find_packages(exclude=("unit_tests",)),
     install_requires=[
         "backoff",
-        "jsonschema==3.2.0",
+        "jsonschema~=3.2.0",
         "pendulum",
         "pydantic~=1.6",
         "PyYAML~=5.4",

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/test_http.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/test_http.py
@@ -23,18 +23,15 @@
 #
 
 
+import json
 from typing import Any, Iterable, Mapping, Optional
 from unittest.mock import ANY
 
 import pytest
 import requests
-import json
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.streams.http import HttpStream
-from airbyte_cdk.sources.streams.http.exceptions import (
-    UserDefinedBackoffException,
-    RequestBodyException
-)
+from airbyte_cdk.sources.streams.http.exceptions import RequestBodyException, UserDefinedBackoffException
 
 
 class StubBasicReadHttpStream(HttpStream):
@@ -162,27 +159,19 @@ def test_stub_custom_backoff_http_stream(mocker):
 class PostHttpStream(StubBasicReadHttpStream):
     http_method = "POST"
 
-    def parse_response(
-        self,
-        response: requests.Response,
-        **kwargs
-    ) -> Iterable[Mapping]:
+    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
         """Returns response data as is"""
         yield response.json()
 
 
 class TestRequestBody:
     """Suite of different tests for request bodies"""
-    json_body = {
-        "key": "value"
-    }
+
+    json_body = {"key": "value"}
     data_body = "key:value"
 
     def request2response(self, request, context):
-        return json.dumps({
-            "body": request.text,
-            "content_type": request.headers.get("Content-Type")
-        })
+        return json.dumps({"body": request.text, "content_type": request.headers.get("Content-Type")})
 
     def test_json_body(self, mocker, requests_mock):
 
@@ -192,8 +181,8 @@ class TestRequestBody:
         requests_mock.register_uri("POST", stream.url_base, text=self.request2response)
         response = list(stream.read_records(sync_mode=SyncMode.full_refresh))[0]
 
-        assert response['content_type'] == 'application/json'
-        assert json.loads(response['body']) == self.json_body
+        assert response["content_type"] == "application/json"
+        assert json.loads(response["body"]) == self.json_body
 
     def test_text_body(self, mocker, requests_mock):
 
@@ -203,8 +192,8 @@ class TestRequestBody:
         requests_mock.register_uri("POST", stream.url_base, text=self.request2response)
         response = list(stream.read_records(sync_mode=SyncMode.full_refresh))[0]
 
-        assert response['content_type'] is None
-        assert response['body'] == self.data_body
+        assert response["content_type"] is None
+        assert response["body"] == self.data_body
 
     def test_text_json_body(self, mocker, requests_mock):
         """checks a exception if both functions were overridden"""
@@ -232,6 +221,6 @@ class TestRequestBody:
             requests_mock.register_uri(method, stream.url_base, text=self.request2response)
             response = list(stream.read_records(sync_mode=SyncMode.full_refresh))[0]
             if with_body:
-                assert response['body'] == self.data_body
+                assert response["body"] == self.data_body
             else:
-                assert response['body'] is None
+                assert response["body"] is None

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/test_http.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/test_http.py
@@ -28,9 +28,13 @@ from unittest.mock import ANY
 
 import pytest
 import requests
+import json
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.streams.http import HttpStream
-from airbyte_cdk.sources.streams.http.exceptions import UserDefinedBackoffException
+from airbyte_cdk.sources.streams.http.exceptions import (
+    UserDefinedBackoffException,
+    RequestBodyException
+)
 
 
 class StubBasicReadHttpStream(HttpStream):
@@ -153,3 +157,81 @@ def test_stub_custom_backoff_http_stream(mocker):
         list(stream.read_records(SyncMode.full_refresh))
 
     # TODO(davin): Figure out how to assert calls.
+
+
+class PostHttpStream(StubBasicReadHttpStream):
+    http_method = "POST"
+
+    def parse_response(
+        self,
+        response: requests.Response,
+        **kwargs
+    ) -> Iterable[Mapping]:
+        """Returns response data as is"""
+        yield response.json()
+
+
+class TestRequestBody:
+    """Suite of different tests for request bodies"""
+    json_body = {
+        "key": "value"
+    }
+    data_body = "key:value"
+
+    def request2response(self, request, context):
+        return json.dumps({
+            "body": request.text,
+            "content_type": request.headers.get("Content-Type")
+        })
+
+    def test_json_body(self, mocker, requests_mock):
+
+        stream = PostHttpStream()
+        mocker.patch.object(stream, "request_body_json", return_value=self.json_body)
+
+        requests_mock.register_uri("POST", stream.url_base, text=self.request2response)
+        response = list(stream.read_records(sync_mode=SyncMode.full_refresh))[0]
+
+        assert response['content_type'] == 'application/json'
+        assert json.loads(response['body']) == self.json_body
+
+    def test_text_body(self, mocker, requests_mock):
+
+        stream = PostHttpStream()
+        mocker.patch.object(stream, "request_body_data", return_value=self.data_body)
+
+        requests_mock.register_uri("POST", stream.url_base, text=self.request2response)
+        response = list(stream.read_records(sync_mode=SyncMode.full_refresh))[0]
+
+        assert response['content_type'] is None
+        assert response['body'] == self.data_body
+
+    def test_text_json_body(self, mocker, requests_mock):
+        """checks a exception if both functions were overridden"""
+        stream = PostHttpStream()
+        mocker.patch.object(stream, "request_body_data", return_value=self.data_body)
+        mocker.patch.object(stream, "request_body_json", return_value=self.json_body)
+        requests_mock.register_uri("POST", stream.url_base, text=self.request2response)
+        with pytest.raises(RequestBodyException):
+            list(stream.read_records(sync_mode=SyncMode.full_refresh))
+
+    def test_body_for_all_methods(self, mocker, requests_mock):
+        """Stream must send a body for POST/PATCH/PUT methods only"""
+        stream = PostHttpStream()
+        methods = {
+            "POST": True,
+            "PUT": True,
+            "PATCH": True,
+            "GET": False,
+            "DELETE": False,
+            "OPTIONS": False,
+        }
+        for method, with_body in methods.items():
+            stream.http_method = method
+            mocker.patch.object(stream, "request_body_data", return_value=self.data_body)
+            requests_mock.register_uri(method, stream.url_base, text=self.request2response)
+            response = list(stream.read_records(sync_mode=SyncMode.full_refresh))[0]
+            if with_body:
+                assert response['body'] == self.data_body
+            else:
+                assert response['body'] is None


### PR DESCRIPTION
## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
### Refactoring
 `airbyte_cdk/sources/streams/http/rate_limiting.py`
### Upgrading
`setup.py`
The version of the lib 'jsonschema' was updated because there were warnings about the future incompatibility 
### Features
1. `airbyte_cdk/sources/streams/http/http.py`
2. `airbyte_cdk/sources/streams/http/exceptions.py`
### Tests
`unit_tests/sources/streams/http/test_http.py`

## Pre-merge Checklist
Expand the checklist which is relevant for this PR. 

<details><summary> <strong> Connector checklist </strong> </summary>
<p>

- [x] Issue acceptance criteria met
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [x] Secrets are annotated with `airbyte_secret` in the connector's spec
- [x] Credentials added to Github CI if needed and not already present. [instructions for injecting secrets into CI](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#using-credentials-in-ci). 
- [x] Unit & integration tests added as appropriate (and are passing)
    * Community members: please provide proof of this succeeding locally e.g: screenshot or copy-paste acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [x] `/test connector=connectors/<name>` command as documented [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-an-existing-connector) is passing. 
    * Community members can skip this, Airbyters will run this for you. 
- [ ] Code reviews completed
- [x] Documentation updated 
    - [x] `README.md`
    - [x] `docs/SUMMARY.md` if it's a new connector
    - [x] Created or updated reference docs in `docs/integrations/<source or destination>/<name>`.
    - [x] Changelog in the appropriate page in `docs/integrations/...`. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [x] `docs/integrations/README.md` contains a reference to the new connector
    - [x] Build status added to [build page](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/builds.md)
- [ ] Build is successful
- [x] Connector version bumped like described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [x] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/contributing-to-airbyte/building-new-connector#updating-a-connector)
- [x] No major blockers
- [x] PR merged into master branch
- [x] Follow up tickets have been created
- [x] Associated tickets have been closed & stakeholders notified
</p>
</details>

<details><summary> <strong> Connector Generator checklist </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
