### PR TITLE
🐛 Create workspace before initializing tracking client

### DIFF
--- a/airbyte-analytics/src/main/java/io/airbyte/analytics/TrackingIdentity.java
+++ b/airbyte-analytics/src/main/java/io/airbyte/analytics/TrackingIdentity.java
@@ -101,4 +101,16 @@ public class TrackingIdentity {
     return Objects.hash(customerId, email, anonymousDataCollection, news, securityUpdates);
   }
 
+  @Override
+  public String toString() {
+    return "class TrackingIdentity {"
+        + "airbyteVersion: " + airbyteVersion + ", "
+        + "customerId: " + customerId + ", "
+        + "email: " + email + ", "
+        + "anonymousDataCollection: " + anonymousDataCollection + ", "
+        + "news: " + news + ", "
+        + "securityUpdates: " + securityUpdates
+        + "}";
+  }
+
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -195,7 +195,7 @@ public class ServerApp implements ServerRunnable {
         configs.getAirbyteVersion(),
         configRepository);
 
-    // must happen after the tracking client is initialized.
+    // this is only necessary for new workspace; must happen after the tracking client is initialized.
     newWorkspace.ifPresent(workspace -> TrackingClientSingleton.get().identify(workspace.getWorkspaceId()));
 
     final String airbyteVersion = configs.getAirbyteVersion();


### PR DESCRIPTION
## What
- In #5009, the workspace is created after the tracking client is initialized.
- However, the initialization of the tracking client requires a workspace. Otherwise, the `customerId` will be `null`, which will leads to an NPE for a brand new server launch.
- This PR fixes this issue.

## How
The correct order is:
1. Create deployment ID.
2. Create a new workspace if necessary.
3. Create tracking client (depending on 1 & 2).
4. Track the new workspace if necessary (depending on 3).
