### PR TITLE
bump KIND Github Action version

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -435,7 +435,7 @@ jobs:
           sudo apt-get install socat
 
       - name: KIND Kubernetes Cluster Setup
-        uses: helm/kind-action@v1.1.0
+        uses: helm/kind-action@v1.2.0
         # In case of self-hosted EC2 errors, remove this env block.
         env:
           USER: root


### PR DESCRIPTION
In the cloud build (which uses Github Action runners directly) I was seeing some failures to spin up Kubernetes properly. I think we're not seeing these on the OSS build since we're using EC2 runners. 

Bumping this pre-emptively in case we ever need to run on EC2 again in the future.

see https://github.com/helm/kind-action/issues/42 for more info