### PR TITLE
🐛  Add back seeds for config import

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImporter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImporter.java
@@ -95,10 +95,6 @@ public class ConfigDumpImporter {
     this.configRepository = configRepository;
   }
 
-  public ImportRead importData(String targetVersion, File archive) {
-    return importDataInternal(targetVersion, archive, Optional.empty());
-  }
-
   public ImportRead importDataWithSeed(String targetVersion, File archive, Path seedPath) {
     return importDataInternal(targetVersion, archive, Optional.of(seedPath));
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImporter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImporter.java
@@ -73,7 +73,6 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class ConfigDumpImporter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigDumpImporter.class);
@@ -96,11 +95,6 @@ public class ConfigDumpImporter {
   }
 
   public ImportRead importDataWithSeed(String targetVersion, File archive, Path seedPath) {
-    return importDataInternal(targetVersion, archive, Optional.of(seedPath));
-  }
-
-  // seedPath - if present, merge with the import. otherwise just use the data in the import.
-  private ImportRead importDataInternal(String targetVersion, File archive, Optional<Path> seedPath) {
     Preconditions.checkNotNull(seedPath);
 
     ImportRead result;
@@ -146,7 +140,7 @@ public class ConfigDumpImporter {
     return result;
   }
 
-  private void checkImport(String targetVersion, Path tempFolder, Optional<Path> seed) throws IOException, JsonValidationException {
+  private void checkImport(String targetVersion, Path tempFolder, Path seed) throws IOException, JsonValidationException {
     final Path versionFile = tempFolder.resolve(VERSION_FILE_NAME);
     final String importVersion = Files.readString(versionFile, Charset.defaultCharset())
         .replace("\n", "").strip();
@@ -168,7 +162,7 @@ public class ConfigDumpImporter {
     }
   }
 
-  private <T> void importConfigsFromArchive(final Path sourceRoot, Optional<Path> seedPath, final boolean dryRun)
+  private <T> void importConfigsFromArchive(final Path sourceRoot, Path seedPath, final boolean dryRun)
       throws IOException, JsonValidationException {
     final List<String> sourceDefinitionsToMigrate = new ArrayList<>();
     final List<String> destinationDefinitionsToMigrate = new ArrayList<>();
@@ -181,12 +175,8 @@ public class ConfigDumpImporter {
     Collections.sort(directories);
     final Map<AirbyteConfig, Stream<T>> data = new LinkedHashMap<>();
 
-    final Map<ConfigSchema, Map<String, T>> seed;
-    if (seedPath.isPresent()) {
-      seed = getSeed(seedPath.get());
-    } else {
-      seed = new HashMap<>();
-    }
+    final Map<ConfigSchema, Map<String, T>> seed = getSeed(seedPath);
+
     for (final String directory : directories) {
       final Optional<ConfigSchema> configSchemaOptional = Enums.toEnum(directory.replace(".yaml", ""), ConfigSchema.class);
 

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -53,13 +53,13 @@ import io.airbyte.server.errors.InvalidJsonInputExceptionMapper;
 import io.airbyte.server.errors.KnownExceptionMapper;
 import io.airbyte.server.errors.NotFoundExceptionMapper;
 import io.airbyte.server.errors.UncaughtExceptionMapper;
+import io.airbyte.server.handlers.ArchiveHandler;
 import io.airbyte.server.version_mismatch.VersionMismatchServer;
 import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.temporal.TemporalClient;
 import io.airbyte.workers.temporal.TemporalUtils;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -250,13 +250,12 @@ public class ServerApp implements ServerRunnable {
                                             String airbyteVersion,
                                             String airbyteDatabaseVersion) {
     LOGGER.info("Running Automatic Migration from version : " + airbyteDatabaseVersion + " to version : " + airbyteVersion);
-    final Path latestSeedsPath = Path.of(System.getProperty("user.dir")).resolve("latest_seeds");
-    LOGGER.info("Last seeds dir: {}", latestSeedsPath);
+    LOGGER.info("Last seeds dir: {}", ArchiveHandler.SEEDS_PATH);
     try (final RunMigration runMigration = new RunMigration(
         jobPersistence,
         configRepository,
         airbyteVersion,
-        latestSeedsPath)) {
+        ArchiveHandler.SEEDS_PATH)) {
       runMigration.run();
     } catch (Exception e) {
       LOGGER.error("Automatic Migration failed ", e);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
@@ -43,6 +43,8 @@ public class ArchiveHandler {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArchiveHandler.class);
 
+  public static final Path SEEDS_PATH = Path.of(System.getProperty("user.dir")).resolve("latest_seeds");
+
   private final String version;
   private final ConfigRepository configRepository;
   private final ConfigDumpExporter configDumpExporter;
@@ -96,7 +98,7 @@ public class ArchiveHandler {
     try {
       final Path tempFolder = Files.createTempDirectory(Path.of("/tmp"), "airbyte_archive");
       try {
-        configDumpImporter.importData(version, archive);
+        configDumpImporter.importDataWithSeed(version, archive, SEEDS_PATH);
         result = new ImportRead().status(StatusEnum.SUCCEEDED);
       } finally {
         FileUtils.deleteDirectory(tempFolder.toFile());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -87,7 +87,7 @@ public class ArchiveHandlerTest {
     // make sure it cleans up the file.
     assertFalse(Files.exists(file.toPath()));
 
-    verify(configDumpImporter).importData(VERSION, file);
+    verify(configDumpImporter).importDataWithSeed(VERSION, file, ArchiveHandler.SEEDS_PATH);
   }
 
 }


### PR DESCRIPTION
## What
- This PR resolves #5187.
- When importing the configs, the importer does not import the source and destination definitions from the archive file. Instead, it reads from the seed to try to get the latest definitions for any connector definitions unused by the user.
- However, the seeds are no longer read in the recent refactoring (#4976). So when configs are imported, all of the unused connector definitions are dropped.

## How
- `importData` is replaced with `importDataWithSeed` to always read the seeds.
- Currently the new change is not tested. I will try to unit test it in a separate PR, because the testing is complicated.
- Also the seeds logic will be cleaned up when I work on #4890.

## Recommended reading order
1. `ConfigDumpImporter.java`
2. The rest.
