### PR TITLE
add randomness to slug if dupe

### DIFF
--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -47,13 +47,13 @@ public class ConfigRepository {
 
   private final ConfigPersistence persistence;
 
-  public ConfigRepository(ConfigPersistence persistence) {
+  public ConfigRepository(final ConfigPersistence persistence) {
     this.persistence = persistence;
   }
 
-  public StandardWorkspace getStandardWorkspace(final UUID workspaceId, boolean includeTombstone)
+  public StandardWorkspace getStandardWorkspace(final UUID workspaceId, final boolean includeTombstone)
       throws JsonValidationException, IOException, ConfigNotFoundException {
-    StandardWorkspace workspace = persistence.getConfig(ConfigSchema.STANDARD_WORKSPACE, workspaceId.toString(), StandardWorkspace.class);
+    final StandardWorkspace workspace = persistence.getConfig(ConfigSchema.STANDARD_WORKSPACE, workspaceId.toString(), StandardWorkspace.class);
 
     if (!MoreBooleans.isTruthy(workspace.getTombstone()) || includeTombstone) {
       return workspace;
@@ -62,9 +62,9 @@ public class ConfigRepository {
     throw new ConfigNotFoundException(ConfigSchema.STANDARD_WORKSPACE, workspaceId.toString());
   }
 
-  public StandardWorkspace getWorkspaceBySlug(String slug, boolean includeTombstone)
+  public StandardWorkspace getWorkspaceBySlug(final String slug, final boolean includeTombstone)
       throws JsonValidationException, IOException, ConfigNotFoundException {
-    for (StandardWorkspace workspace : listStandardWorkspaces(includeTombstone)) {
+    for (final StandardWorkspace workspace : listStandardWorkspaces(includeTombstone)) {
       if (workspace.getSlug().equals(slug)) {
         return workspace;
       }
@@ -73,12 +73,11 @@ public class ConfigRepository {
     throw new ConfigNotFoundException(ConfigSchema.STANDARD_WORKSPACE, slug);
   }
 
-  public List<StandardWorkspace> listStandardWorkspaces(boolean includeTombstone)
-      throws JsonValidationException, IOException {
+  public List<StandardWorkspace> listStandardWorkspaces(final boolean includeTombstone) throws JsonValidationException, IOException {
 
-    List<StandardWorkspace> workspaces = new ArrayList<StandardWorkspace>();
+    final List<StandardWorkspace> workspaces = new ArrayList<>();
 
-    for (StandardWorkspace workspace : persistence.listConfigs(ConfigSchema.STANDARD_WORKSPACE, StandardWorkspace.class)) {
+    for (final StandardWorkspace workspace : persistence.listConfigs(ConfigSchema.STANDARD_WORKSPACE, StandardWorkspace.class)) {
       if (!MoreBooleans.isTruthy(workspace.getTombstone()) || includeTombstone) {
         workspaces.add(workspace);
       }
@@ -96,20 +95,20 @@ public class ConfigRepository {
     return persistence.getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, sourceDefinitionId.toString(), StandardSourceDefinition.class);
   }
 
-  public StandardSourceDefinition getSourceDefinitionFromSource(UUID sourceId) {
+  public StandardSourceDefinition getSourceDefinitionFromSource(final UUID sourceId) {
     try {
       final SourceConnection source = getSourceConnection(sourceId);
       return getStandardSourceDefinition(source.getSourceDefinitionId());
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new RuntimeException(e);
     }
   }
 
-  public StandardSourceDefinition getSourceDefinitionFromConnection(UUID connectionId) {
+  public StandardSourceDefinition getSourceDefinitionFromConnection(final UUID connectionId) {
     try {
       final StandardSync sync = getStandardSync(connectionId);
       return getSourceDefinitionFromSource(sync.getSourceId());
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new RuntimeException(e);
     }
   }
@@ -128,20 +127,20 @@ public class ConfigRepository {
         StandardDestinationDefinition.class);
   }
 
-  public StandardDestinationDefinition getDestinationDefinitionFromDestination(UUID destinationId) {
+  public StandardDestinationDefinition getDestinationDefinitionFromDestination(final UUID destinationId) {
     try {
       final DestinationConnection destination = getDestinationConnection(destinationId);
       return getStandardDestinationDefinition(destination.getDestinationDefinitionId());
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new RuntimeException(e);
     }
   }
 
-  public StandardDestinationDefinition getDestinationDefinitionFromConnection(UUID connectionId) {
+  public StandardDestinationDefinition getDestinationDefinitionFromConnection(final UUID connectionId) {
     try {
       final StandardSync sync = getStandardSync(connectionId);
       return getDestinationDefinitionFromDestination(sync.getDestinationId());
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new RuntimeException(e);
     }
   }
@@ -175,7 +174,7 @@ public class ConfigRepository {
     return persistence.getConfig(ConfigSchema.DESTINATION_CONNECTION, destinationId.toString(), DestinationConnection.class);
   }
 
-  public void writeDestinationConnection(DestinationConnection destinationConnection) throws JsonValidationException, IOException {
+  public void writeDestinationConnection(final DestinationConnection destinationConnection) throws JsonValidationException, IOException {
     persistence.writeConfig(ConfigSchema.DESTINATION_CONNECTION, destinationConnection.getDestinationId().toString(), destinationConnection);
   }
 
@@ -207,7 +206,7 @@ public class ConfigRepository {
     return persistence.listConfigs(ConfigSchema.STANDARD_SYNC_OPERATION, StandardSyncOperation.class);
   }
 
-  public <T> void replaceAllConfigs(Map<AirbyteConfig, Stream<T>> configs, boolean dryRun) throws IOException {
+  public <T> void replaceAllConfigs(final Map<AirbyteConfig, Stream<T>> configs, final boolean dryRun) throws IOException {
     persistence.replaceAllConfigs(configs, dryRun);
   }
 

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -62,15 +63,17 @@ public class ConfigRepository {
     throw new ConfigNotFoundException(ConfigSchema.STANDARD_WORKSPACE, workspaceId.toString());
   }
 
-  public StandardWorkspace getWorkspaceBySlug(final String slug, final boolean includeTombstone)
-      throws JsonValidationException, IOException, ConfigNotFoundException {
+  public Optional<StandardWorkspace> getWorkspaceBySlugOptional(final String slug, final boolean includeTombstone) throws JsonValidationException, IOException {
     for (final StandardWorkspace workspace : listStandardWorkspaces(includeTombstone)) {
       if (workspace.getSlug().equals(slug)) {
-        return workspace;
+        return Optional.of(workspace);
       }
     }
+    return Optional.empty();
+  }
 
-    throw new ConfigNotFoundException(ConfigSchema.STANDARD_WORKSPACE, slug);
+  public StandardWorkspace getWorkspaceBySlug(final String slug, final boolean includeTombstone) throws JsonValidationException, IOException, ConfigNotFoundException {
+    return getWorkspaceBySlugOptional(slug, includeTombstone).orElseThrow(() -> new ConfigNotFoundException(ConfigSchema.STANDARD_WORKSPACE, slug));
   }
 
   public List<StandardWorkspace> listStandardWorkspaces(final boolean includeTombstone) throws JsonValidationException, IOException {

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -63,7 +63,8 @@ public class ConfigRepository {
     throw new ConfigNotFoundException(ConfigSchema.STANDARD_WORKSPACE, workspaceId.toString());
   }
 
-  public Optional<StandardWorkspace> getWorkspaceBySlugOptional(final String slug, final boolean includeTombstone) throws JsonValidationException, IOException {
+  public Optional<StandardWorkspace> getWorkspaceBySlugOptional(final String slug, final boolean includeTombstone)
+      throws JsonValidationException, IOException {
     for (final StandardWorkspace workspace : listStandardWorkspaces(includeTombstone)) {
       if (workspace.getSlug().equals(slug)) {
         return Optional.of(workspace);
@@ -72,7 +73,8 @@ public class ConfigRepository {
     return Optional.empty();
   }
 
-  public StandardWorkspace getWorkspaceBySlug(final String slug, final boolean includeTombstone) throws JsonValidationException, IOException, ConfigNotFoundException {
+  public StandardWorkspace getWorkspaceBySlug(final String slug, final boolean includeTombstone)
+      throws JsonValidationException, IOException, ConfigNotFoundException {
     return getWorkspaceBySlugOptional(slug, includeTombstone).orElseThrow(() -> new ConfigNotFoundException(ConfigSchema.STANDARD_WORKSPACE, slug));
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WorkspacesHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WorkspacesHandler.java
@@ -220,7 +220,7 @@ public class WorkspacesHandler {
       // same slug in two different threads. this should be very unlikely. we can fix this by exposing
       // database transaction, but that is not something we can do quickly.
       resolvedSlug = proposedSlug + "-" + RandomStringUtils.randomAlphabetic(8);
-      isSlugUsed = configRepository.getWorkspaceBySlugOptional(proposedSlug, true).isPresent();
+      isSlugUsed = configRepository.getWorkspaceBySlugOptional(resolvedSlug, true).isPresent();
       if (count++ > MAX_ATTEMPTS) {
         throw new InternalServerKnownException(String.format("could not generate a valid slug after %s tries.", MAX_ATTEMPTS));
       }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WorkspacesHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WorkspacesHandlerTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -63,6 +64,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class WorkspacesHandlerTest {
 
@@ -188,6 +190,13 @@ class WorkspacesHandlerTest {
     assertTrue(actualRead.getSlug().startsWith(workspace.getSlug()));
     assertNotEquals(workspace.getSlug(), actualRead.getSlug());
     assertEquals(Jsons.clone(expectedRead).slug(null), Jsons.clone(actualRead).slug(null));
+    final ArgumentCaptor<String> slugCaptor = ArgumentCaptor.forClass(String.class);
+    verify(configRepository, times(3)).getWorkspaceBySlugOptional(slugCaptor.capture(), eq(true));
+    assertEquals(3, slugCaptor.getAllValues().size());
+    assertEquals(workspace.getSlug(), slugCaptor.getAllValues().get(0));
+    assertTrue(slugCaptor.getAllValues().get(1).startsWith(workspace.getSlug()));
+    assertTrue(slugCaptor.getAllValues().get(2).startsWith(workspace.getSlug()));
+
   }
 
   @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WorkspacesHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WorkspacesHandlerTest.java
@@ -192,11 +192,9 @@ class WorkspacesHandlerTest {
     final DestinationRead destination = new DestinationRead();
     final SourceRead source = new SourceRead();
 
-    when(configRepository.getStandardWorkspace(workspace.getWorkspaceId(), false))
-        .thenReturn(workspace);
+    when(configRepository.getStandardWorkspace(workspace.getWorkspaceId(), false)).thenReturn(workspace);
 
-    when(configRepository.listStandardWorkspaces(false))
-        .thenReturn(Collections.singletonList(workspace));
+    when(configRepository.listStandardWorkspaces(false)).thenReturn(Collections.singletonList(workspace));
 
     when(connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody))
         .thenReturn(new ConnectionReadList().connections(Collections.singletonList(connection)));
@@ -218,8 +216,7 @@ class WorkspacesHandlerTest {
   void testListWorkspaces() throws JsonValidationException, IOException {
     final StandardWorkspace workspace2 = generateWorkspace();
 
-    when(configRepository.listStandardWorkspaces(false))
-        .thenReturn(Lists.newArrayList(workspace, workspace2));
+    when(configRepository.listStandardWorkspaces(false)).thenReturn(Lists.newArrayList(workspace, workspace2));
 
     final WorkspaceRead expectedWorkspaceRead1 = new WorkspaceRead()
         .workspaceId(workspace.getWorkspaceId())

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WorkspacesHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WorkspacesHandlerTest.java
@@ -27,6 +27,8 @@ package io.airbyte.server.handlers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -56,6 +58,7 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -150,7 +153,10 @@ class WorkspacesHandlerTest {
 
   @Test
   void testCreateWorkspaceDuplicateSlug() throws JsonValidationException, IOException {
-    when(configRepository.listStandardWorkspaces(true)).thenReturn(Collections.singletonList(workspace));
+    when(configRepository.getWorkspaceBySlugOptional(any(String.class), eq(true)))
+        .thenReturn(Optional.of(workspace))
+        .thenReturn(Optional.of(workspace))
+        .thenReturn(Optional.empty());
 
     final UUID uuid = UUID.randomUUID();
     when(uuidSupplier.get()).thenReturn(uuid);
@@ -261,7 +267,7 @@ class WorkspacesHandlerTest {
         .customerId(workspace.getCustomerId())
         .email("test@airbyte.io")
         .name("test workspace")
-        .slug("default")
+        .slug("test-workspace")
         .initialSetupComplete(false)
         .displaySetupWizard(true)
         .news(false)
@@ -313,7 +319,7 @@ class WorkspacesHandlerTest {
         .withCustomerId(workspace.getCustomerId())
         .withEmail("test@airbyte.io")
         .withName("test workspace")
-        .withSlug("default")
+        .withSlug("test-workspace")
         .withAnonymousDataCollection(true)
         .withSecurityUpdates(false)
         .withNews(false)
@@ -335,7 +341,7 @@ class WorkspacesHandlerTest {
         .customerId(workspace.getCustomerId())
         .email("test@airbyte.io")
         .name("test workspace")
-        .slug("default")
+        .slug("test-workspace")
         .initialSetupComplete(true)
         .displaySetupWizard(false)
         .news(false)


### PR DESCRIPTION
## What
* If there is a duplicate slug we currently fail.
* This doesn't really make sense since we just generate slugs from the name. so it is definitely opaque to the user.
* Instead if the generate slug is a duplicate then we add some randomness to the end.
