### PR TITLE
Add link to the FAQ from Quickstart Deploy

### DIFF
--- a/docs/quickstart/deploy-airbyte.md
+++ b/docs/quickstart/deploy-airbyte.md
@@ -11,6 +11,14 @@ docker-compose up
 
 * Once you see an Airbyte banner, the UI is ready to go at [http://localhost:8000](http://localhost:8000)!
 
+## FAQ
+
+If you have any questions about the Airbyte setup and deployment process, head over to our [Getting Started FAQ](../faq/getting-started.md) that answers the following questions and more:
+
+- How long does it take to set up Airbyte?
+- Where can I see my data once I've run a sync?
+- Can I set a start time for my sync?
+
 ----
 
 If you want to schedule a 20-min call with our team to get you set up, don't hesitate to select [some time here](https://calendly.com/nataliekwong/airbyte-onboarding). 


### PR DESCRIPTION
## Main Changes
- It makes a lot of sense to link to the Getting Started FAQ in the Getting Started guide, so we do that now.