### PR TITLE
Link to Slack community from Getting Started and the Python CDK docs

### DIFF
--- a/docs/connector-development/cdk-python/README.md
+++ b/docs/connector-development/cdk-python/README.md
@@ -10,6 +10,8 @@ The CDK provides an improved developer experience by providing basic implementat
 
 This document is a general introduction to the CDK. Readers should have basic familiarity with the [Airbyte Specification](https://docs.airbyte.io/architecture/airbyte-specification) before proceeding.
 
+If you have any issues with troubleshooting or want to learn more about the CDK from the Airbyte team, head to the #connector-development channel in [our Slack](https://airbytehq.slack.com/ssb/redirect) to inquire further!
+
 ## Getting Started
 
 Generate an empty connector using the code generator. First clone the Airbyte repository then from the repository root run

--- a/docs/quickstart/deploy-airbyte.md
+++ b/docs/quickstart/deploy-airbyte.md
@@ -19,6 +19,8 @@ If you have any questions about the Airbyte setup and deployment process, head o
 - Where can I see my data once I've run a sync?
 - Can I set a start time for my sync?
 
+If there are any questions that we couldn't answer here, we'd love to help you get started. [Join our Slack](https://airbytehq.slack.com/ssb/redirect) and feel free to ask your questions in the #getting-started channel.
+
 ----
 
 If you want to schedule a 20-min call with our team to get you set up, don't hesitate to select [some time here](https://calendly.com/nataliekwong/airbyte-onboarding). 


### PR DESCRIPTION
## Main Changes
- We now link to our Slack from two places that made a lot of sense to link to our Slack from. Calls to Action are great.