### PR TITLE
Add warning about the airbyte_raw prefix for the MSSQL destination

### DIFF
--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -8,6 +8,10 @@ The Airbyte MS SQL Server destination allows you to sync data to SQL Server data
 
 #### Output schema
 
+{% hint style="warning" %}
+Tables in MSSQL destinations will be prefixed by `_airbyte_raw` due to the fact that MSSQL does not currently support basic normalization. This prefix cannot be removed and this is normal behavior.
+{% endhint %}
+
 Each stream will be output into its own table in SQL Server. Each table will contain 3 columns:
 
 * `_airbyte_ab_id`: a uuid assigned by Airbyte to each event that is processed. The column type in SQL Server is `VARCHAR(64)`.


### PR DESCRIPTION
## Main Changes
- Users are sorta confused at the fact that we use the `_airbyte_raw` prefix for some tables and not others, so this is adding an explanation for why it appears with the MSSQL destination.