### PR TITLE
📚 Fixed documentation URLs for all connector sources in the Airbyte UI > Settings > Sources

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/12928b32-bf0a-4f1e-964f-07e12e37153a.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/12928b32-bf0a-4f1e-964f-07e12e37153a.json
@@ -3,6 +3,6 @@
   "name": "Mixpanel",
   "dockerRepository": "airbyte/source-mixpanel",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-mixpanel",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/mixpanel",
   "icon": "mixpanel.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2470e835-feaf-4db6-96f3-70fd645acc77.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2470e835-feaf-4db6-96f3-70fd645acc77.json
@@ -3,6 +3,6 @@
   "name": "Salesforce",
   "dockerRepository": "airbyte/source-salesforce-singer",
   "dockerImageTag": "0.2.5",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-salesforce-singer",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/salesforce",
   "icon": "salesforce.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/253487c0-2246-43ba-a21f-5116b20a2c50.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/253487c0-2246-43ba-a21f-5116b20a2c50.json
@@ -3,5 +3,5 @@
   "name": "Google Ads",
   "dockerRepository": "airbyte/source-google-ads",
   "dockerImageTag": "0.1.5",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-google-ads"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/google-ads"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/29b409d9-30a5-4cc8-ad50-886eb846fea3.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/29b409d9-30a5-4cc8-ad50-886eb846fea3.json
@@ -3,5 +3,5 @@
   "name": "Quickbooks",
   "dockerRepository": "airbyte/source-quickbooks-singer",
   "dockerImageTag": "0.1.2",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-quickbooks-singer"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/quickbooks"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2af123bf-0aaf-4e0d-9784-cb497f23741a.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2af123bf-0aaf-4e0d-9784-cb497f23741a.json
@@ -3,6 +3,6 @@
   "name": "Appstore",
   "dockerRepository": "airbyte/source-appstore-singer",
   "dockerImageTag": "0.2.4",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-appstore-singer",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/appstore",
   "icon": "appstore.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2e875208-0c0b-4ee4-9e92-1cb3156ea799.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/2e875208-0c0b-4ee4-9e92-1cb3156ea799.json
@@ -3,5 +3,5 @@
   "name": "Iterable",
   "dockerRepository": "airbyte/source-iterable",
   "dockerImageTag": "0.1.6",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-iterable"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/iterable"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/36c891d9-4bd9-43ac-bad2-10e12756272c.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/36c891d9-4bd9-43ac-bad2-10e12756272c.json
@@ -3,6 +3,6 @@
   "name": "Hubspot",
   "dockerRepository": "airbyte/source-hubspot",
   "dockerImageTag": "0.1.7",
-  "documentationUrl": "https://https://docs.airbyte.io/integrations/sources/hubspot",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/hubspot",
   "icon": "hubspot.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/374ebc65-6636-4ea0-925c-7d35999a8ffc.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/374ebc65-6636-4ea0-925c-7d35999a8ffc.json
@@ -3,5 +3,5 @@
   "name": "Smartsheets",
   "dockerRepository": "airbyte/source-smartsheets",
   "dockerImageTag": "0.1.5",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-smartsheets"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/smartsheets"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/396e4ca3-8a97-4b85-aa4e-c9d8c2d5f992.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/396e4ca3-8a97-4b85-aa4e-c9d8c2d5f992.json
@@ -3,6 +3,6 @@
   "name": "Braintree",
   "dockerRepository": "airbyte/source-braintree-singer",
   "dockerImageTag": "0.2.3",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-braintree-singer",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/braintree",
   "icon": "braintree.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/39f092a6-8c87-4f6f-a8d9-5cef45b7dbe1.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/39f092a6-8c87-4f6f-a8d9-5cef45b7dbe1.json
@@ -3,6 +3,6 @@
   "name": "Google Analytics",
   "dockerRepository": "airbyte/source-googleanalytics-singer",
   "dockerImageTag": "0.2.6",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-googleanalytics-singer",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/googleanalytics",
   "icon": "google-analytics.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4.json
@@ -3,6 +3,6 @@
   "name": "Zendesk Chat",
   "dockerRepository": "airbyte/source-zendesk-chat",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-zendesk-chat",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/zendesk-chat",
   "icon": "zendesk.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/445831eb-78db-4b1f-8f1f-0d96ad8739e2.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/445831eb-78db-4b1f-8f1f-0d96ad8739e2.json
@@ -3,6 +3,6 @@
   "name": "Drift",
   "dockerRepository": "airbyte/source-drift",
   "dockerImageTag": "0.2.2",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-drift",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/drift",
   "icon": "drift.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/45d2e135-2ede-49e1-939f-3e3ec357a65e.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/45d2e135-2ede-49e1-939f-3e3ec357a65e.json
@@ -3,5 +3,5 @@
   "name": "Recharge",
   "dockerRepository": "airbyte/source-recharge",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-recharge"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/recharge"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/487b930d-7f6a-43ce-8bac-46e6b2de0a55.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/487b930d-7f6a-43ce-8bac-46e6b2de0a55.json
@@ -3,6 +3,6 @@
   "name": "Mongo DB",
   "dockerRepository": "airbyte/source-mongodb",
   "dockerImageTag": "0.3.3",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-mongodb",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/mongodb",
   "icon": "mongodb.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/59f1e50a-331f-4f09-b3e8-2e8d4d355f44.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/59f1e50a-331f-4f09-b3e8-2e8d4d355f44.json
@@ -3,6 +3,6 @@
   "name": "Greenhouse",
   "dockerRepository": "airbyte/source-greenhouse",
   "dockerImageTag": "0.2.3",
-  "documentationUrl": "https://https://docs.airbyte.io/integrations/sources/greenhouse",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/greenhouse",
   "icon": "greenhouse.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/5a1d14c2-d829-49cd-8437-1e87dc9f5368.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/5a1d14c2-d829-49cd-8437-1e87dc9f5368.json
@@ -3,5 +3,5 @@
   "name": "Google Search Console",
   "dockerRepository": "airbyte/source-google-search-console-singer",
   "dockerImageTag": "0.1.3",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-google-search-console-singer"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/google-search-console"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/5e6175e5-68e1-4c17-bff9-56103bbb0d80.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/5e6175e5-68e1-4c17-bff9-56103bbb0d80.json
@@ -3,5 +3,5 @@
   "name": "Gitlab",
   "dockerRepository": "airbyte/source-gitlab",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-gitlab"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/gitlab"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/6371b14b-bc68-4236-bfbd-468e8df8e968.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/6371b14b-bc68-4236-bfbd-468e8df8e968.json
@@ -3,5 +3,5 @@
   "name": "PokeAPI",
   "dockerRepository": "airbyte/source-pokeapi",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-pokeapi"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/pokeapi"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/686473f1-76d9-4994-9cc7-9b13da46147c.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/686473f1-76d9-4994-9cc7-9b13da46147c.json
@@ -3,5 +3,5 @@
   "name": "Chargebee",
   "dockerRepository": "airbyte/source-chargebee",
   "dockerImageTag": "0.1.2",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-chargebee"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/chargebee"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/68e63de2-bb83-4c7e-93fa-a8a9051e3993.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/68e63de2-bb83-4c7e-93fa-a8a9051e3993.json
@@ -3,6 +3,6 @@
   "name": "Jira",
   "dockerRepository": "airbyte/source-jira",
   "dockerImageTag": "0.2.8",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-jira",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/jira",
   "icon": "jira.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/69589781-7828-43c5-9f63-8925b1c1ccc2.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/69589781-7828-43c5-9f63-8925b1c1ccc2.json
@@ -3,5 +3,5 @@
   "name": "S3",
   "dockerRepository": "airbyte/source-s3",
   "dockerImageTag": "0.1.2",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-s3"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/s3"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/6acf6b55-4f1e-4fca-944e-1a3caef8aba8.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/6acf6b55-4f1e-4fca-944e-1a3caef8aba8.json
@@ -3,5 +3,5 @@
   "name": "Instagram",
   "dockerRepository": "airbyte/source-instagram",
   "dockerImageTag": "0.1.7",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-instagram"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/instagram"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/71607ba1-c0ac-4799-8049-7f4b90dd50f7.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/71607ba1-c0ac-4799-8049-7f4b90dd50f7.json
@@ -3,6 +3,6 @@
   "name": "Google Sheets",
   "dockerRepository": "airbyte/source-google-sheets",
   "dockerImageTag": "0.2.3",
-  "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-google-sheets",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/google-sheets",
   "icon": "google-sheets.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/778daa7c-feaf-4db6-96f3-70fd645acc77.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/778daa7c-feaf-4db6-96f3-70fd645acc77.json
@@ -3,6 +3,6 @@
   "name": "File",
   "dockerRepository": "airbyte/source-file",
   "dockerImageTag": "0.2.5",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-file",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/file",
   "icon": "file.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/79c1aa37-dae3-42ae-b333-d1c105477715.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/79c1aa37-dae3-42ae-b333-d1c105477715.json
@@ -3,6 +3,6 @@
   "name": "Zendesk Support",
   "dockerRepository": "airbyte/source-zendesk-support",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-zendesk-support",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/zendesk-support",
   "icon": "zendesk.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/859e501d-2b67-471f-91bb-1c801414d28f.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/859e501d-2b67-471f-91bb-1c801414d28f.json
@@ -3,6 +3,6 @@
   "name": "Mixpanel Singer",
   "dockerRepository": "airbyte/source-mixpanel-singer",
   "dockerImageTag": "0.2.4",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-mixpanel-singer",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/mixpanel",
   "icon": "mixpanel.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9e0556f4-69df-4522-a3fb-03264d36b348.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9e0556f4-69df-4522-a3fb-03264d36b348.json
@@ -3,6 +3,6 @@
   "name": "Marketo",
   "dockerRepository": "airbyte/source-marketo-singer",
   "dockerImageTag": "0.2.3",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-marketo-singer",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/marketo",
   "icon": "marketo.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9fa5862c-da7c-11eb-8d19-0242ac130003.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9fa5862c-da7c-11eb-8d19-0242ac130003.json
@@ -3,5 +3,5 @@
   "name": "Cockroachdb",
   "dockerRepository": "airbyte/source-cockroachdb",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-cockroachdb"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/cockroachdb"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/aea2fd0d-377d-465e-86c0-4fdc4f688e51.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/aea2fd0d-377d-465e-86c0-4fdc4f688e51.json
@@ -3,6 +3,6 @@
   "name": "Zoom",
   "dockerRepository": "airbyte/source-zoom-singer",
   "dockerImageTag": "0.2.4",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-zoom-singer",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/zoom",
   "icon": "zoom.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b03a9f3e-22a5-11eb-adc1-0242ac120002.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b03a9f3e-22a5-11eb-adc1-0242ac120002.json
@@ -3,6 +3,6 @@
   "name": "Mailchimp",
   "dockerRepository": "airbyte/source-mailchimp",
   "dockerImageTag": "0.2.7",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-mailchimp",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/mailchimp",
   "icon": "mailchimp.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b39a7370-74c3-45a6-ac3a-380d48520a83.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b39a7370-74c3-45a6-ac3a-380d48520a83.json
@@ -3,5 +3,5 @@
   "name": "Oracle DB",
   "dockerRepository": "airbyte/source-oracle",
   "dockerImageTag": "0.3.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-oracle"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/oracle"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b5ea17b1-f170-46dc-bc31-cc744ca984c1.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b5ea17b1-f170-46dc-bc31-cc744ca984c1.json
@@ -3,6 +3,6 @@
   "name": "Microsoft SQL Server (MSSQL)",
   "dockerRepository": "airbyte/source-mssql",
   "dockerImageTag": "0.3.3",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-mssql",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/mssql",
   "icon": "mssql.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b9dc6155-672e-42ea-b10d-9f1f1fb95ab1.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/b9dc6155-672e-42ea-b10d-9f1f1fb95ab1.json
@@ -3,5 +3,5 @@
   "name": "Twilio",
   "dockerRepository": "airbyte/source-twilio",
   "dockerImageTag": "0.1.0",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-twilio"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/twilio"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/bad83517-5e54-4a3d-9b53-63e85fbd4d7c.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/bad83517-5e54-4a3d-9b53-63e85fbd4d7c.json
@@ -3,5 +3,5 @@
   "name": "ClickHouse",
   "dockerRepository": "airbyte/source-clickhouse",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-clickhouse"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/clickhouse"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/c2281cee-86f9-4a86-bb48-d23286b4c7bd.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/c2281cee-86f9-4a86-bb48-d23286b4c7bd.json
@@ -3,6 +3,6 @@
   "name": "Slack",
   "dockerRepository": "airbyte/source-slack",
   "dockerImageTag": "0.1.9",
-  "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-slack",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/slack",
   "icon": "slack.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/c8630570-086d-4a40-99ae-ea5b18673071.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/c8630570-086d-4a40-99ae-ea5b18673071.json
@@ -3,5 +3,5 @@
   "name": "Zendesk Talk",
   "dockerRepository": "airbyte/source-zendesk-talk",
   "dockerImageTag": "0.1.2",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-zendesk-talk"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/zendesk-talk"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/cd42861b-01fc-4658-a8ab-5d11d0510f01.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/cd42861b-01fc-4658-a8ab-5d11d0510f01.json
@@ -3,6 +3,6 @@
   "name": "Recurly",
   "dockerRepository": "airbyte/source-recurly",
   "dockerImageTag": "0.2.4",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-recurly",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/recurly",
   "icon": "recurly.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d0243522-dccf-4978-8ba0-37ed47a0bdbf.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d0243522-dccf-4978-8ba0-37ed47a0bdbf.json
@@ -3,5 +3,5 @@
   "name": "Asana",
   "dockerRepository": "airbyte/source-asana",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-asana"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/asana"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d19ae824-e289-4b14-995a-0632eb46d246.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d19ae824-e289-4b14-995a-0632eb46d246.json
@@ -3,5 +3,5 @@
   "name": "Google Directory",
   "dockerRepository": "airbyte/source-google-directory",
   "dockerImageTag": "0.1.3",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-google-directory"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/google-directory"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d1aa448b-7c54-498e-ad95-263cbebcd2db.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d1aa448b-7c54-498e-ad95-263cbebcd2db.json
@@ -3,5 +3,5 @@
   "name": "Tempo",
   "dockerRepository": "airbyte/source-tempo",
   "dockerImageTag": "0.2.3",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-tempo"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/tempo"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d8286229-c680-4063-8c59-23b9b391c700.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d8286229-c680-4063-8c59-23b9b391c700.json
@@ -3,5 +3,5 @@
   "name": "Pipedrive",
   "dockerRepository": "airbyte/source-pipedrive",
   "dockerImageTag": "0.1.2",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-pipedrive"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/pipedrive"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d8313939-3782-41b0-be29-b3ca20d8dd3a.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d8313939-3782-41b0-be29-b3ca20d8dd3a.json
@@ -3,6 +3,6 @@
   "name": "Intercom",
   "dockerRepository": "airbyte/source-intercom",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-intercom",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/intercom",
   "icon": "intercom.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/decd338e-5647-4c0b-adf4-da0e75f5a750.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/decd338e-5647-4c0b-adf4-da0e75f5a750.json
@@ -3,6 +3,6 @@
   "name": "Postgres",
   "dockerRepository": "airbyte/source-postgres",
   "dockerImageTag": "0.3.7",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-postgres",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/postgres",
   "icon": "postgresql.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e094cb9a-26de-4645-8761-65c0c425d1de.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e094cb9a-26de-4645-8761-65c0c425d1de.json
@@ -3,6 +3,6 @@
   "name": "Stripe",
   "dockerRepository": "airbyte/source-stripe",
   "dockerImageTag": "0.1.16",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-stripe",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/stripe",
   "icon": "stripe.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e2b40e36-aa0e-4bed-b41b-bcea6fa348b1.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e2b40e36-aa0e-4bed-b41b-bcea6fa348b1.json
@@ -3,6 +3,6 @@
   "name": "Exchange Rates Api",
   "dockerRepository": "airbyte/source-exchange-rates",
   "dockerImageTag": "0.2.3",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-exchange-rates",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/exchangeratesapi",
   "icon": "exchangeratesapi.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e55879a8-0ef8-4557-abcf-ab34c53ec460.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e55879a8-0ef8-4557-abcf-ab34c53ec460.json
@@ -3,5 +3,5 @@
   "name": "Amazon Seller Partner",
   "dockerRepository": "airbyte/source-amazon-seller-partner",
   "dockerImageTag": "0.1.3",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-amazon-seller-partner"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/amazon-seller-partner"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e7778cfc-e97c-4458-9ecb-b4f2bba8946c.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e7778cfc-e97c-4458-9ecb-b4f2bba8946c.json
@@ -3,6 +3,6 @@
   "name": "Facebook Marketing",
   "dockerRepository": "airbyte/source-facebook-marketing",
   "dockerImageTag": "0.2.14",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-facebook-marketing",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/facebook-marketing",
   "icon": "facebook.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e87ffa8e-a3b5-f69c-9076-6011339de1f6.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e87ffa8e-a3b5-f69c-9076-6011339de1f6.json
@@ -3,6 +3,6 @@
   "name": "Redshift",
   "dockerRepository": "airbyte/source-redshift",
   "dockerImageTag": "0.3.1",
-  "documentationUrl": "https://hub.docker.com/repository/docker/airbyte/source-redshift",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/redshift",
   "icon": "redshift.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/eaf50f04-21dd-4620-913b-2a83f5635227.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/eaf50f04-21dd-4620-913b-2a83f5635227.json
@@ -3,6 +3,6 @@
   "name": "Microsoft teams",
   "dockerRepository": "airbyte/source-microsoft-teams",
   "dockerImageTag": "0.2.2",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-microsoft-teams",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/microsoft-teams",
   "icon": "microsoft-teams.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ec4b9503-13cb-48ab-a4ab-6ade4be46567.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ec4b9503-13cb-48ab-a4ab-6ade4be46567.json
@@ -3,6 +3,6 @@
   "name": "Freshdesk",
   "dockerRepository": "airbyte/source-freshdesk",
   "dockerImageTag": "0.2.5",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-freshdesk",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/freshdesk",
   "icon": "freshdesk.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ed799e2b-2158-4c66-8da4-b40fe63bc72a.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ed799e2b-2158-4c66-8da4-b40fe63bc72a.json
@@ -3,6 +3,6 @@
   "name": "Plaid",
   "dockerRepository": "airbyte/source-plaid",
   "dockerImageTag": "0.2.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-plaid",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/plaid",
   "icon": "plaid.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ed9dfefa-1bbc-419d-8c5e-4d78f0ef6734.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/ed9dfefa-1bbc-419d-8c5e-4d78f0ef6734.json
@@ -3,5 +3,5 @@
   "name": "Google Workspace Admin Reports",
   "dockerRepository": "airbyte/source-google-workspace-admin-reports",
   "dockerImageTag": "0.1.4",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-google-workspace-admin-reports"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/google-workspace-admin-reports"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fa9f58c6-2d03-4237-aaa4-07d75e0c1396.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fa9f58c6-2d03-4237-aaa4-07d75e0c1396.json
@@ -3,5 +3,5 @@
   "name": "Amplitude",
   "dockerRepository": "airbyte/source-amplitude",
   "dockerImageTag": "0.1.1",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-amplitude"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/amplitude"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87.json
@@ -3,6 +3,6 @@
   "name": "Sendgrid",
   "dockerRepository": "airbyte/source-sendgrid",
   "dockerImageTag": "0.2.6",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-sendgrid",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/sendgrid",
   "icon": "sendgrid.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fdc8b827-3257-4b33-83cc-106d234c34d4.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fdc8b827-3257-4b33-83cc-106d234c34d4.json
@@ -3,6 +3,6 @@
   "name": "Google Adwords (Deprecated)",
   "dockerRepository": "airbyte/source-google-adwords-singer",
   "dockerImageTag": "0.2.6",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-google-adwords-singer",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/google-adwords",
   "icon": "google-adwords.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fe2b4084-3386-4d3b-9ad6-308f61a6f1e6.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/fe2b4084-3386-4d3b-9ad6-308f61a6f1e6.json
@@ -3,5 +3,5 @@
   "name": "Harvest",
   "dockerRepository": "airbyte/source-harvest",
   "dockerImageTag": "0.1.3",
-  "documentationUrl": "https://hub.docker.com/r/airbyte/source-harvest"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/harvest"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -2,39 +2,39 @@
   name: Amazon Seller Partner
   dockerRepository: airbyte/source-amazon-seller-partner
   dockerImageTag: 0.1.3
-  documentationUrl: https://hub.docker.com/r/airbyte/source-amazon-seller-partner
+  documentationUrl: https://docs.airbyte.io/integrations/sources/amazon-seller-partner
 - sourceDefinitionId: d0243522-dccf-4978-8ba0-37ed47a0bdbf
   name: Asana
   dockerRepository: airbyte/source-asana
   dockerImageTag: 0.1.1
-  documentationUrl: https://hub.docker.com/r/airbyte/source-asana
+  documentationUrl: https://docs.airbyte.io/integrations/sources/asana
 - sourceDefinitionId: 686473f1-76d9-4994-9cc7-9b13da46147c
   name: Chargebee
   dockerRepository: airbyte/source-chargebee
   dockerImageTag: 0.1.2
-  documentationUrl: https://hub.docker.com/r/airbyte/source-chargebee
+  documentationUrl: https://docs.airbyte.io/integrations/sources/chargebee
 - sourceDefinitionId: e2b40e36-aa0e-4bed-b41b-bcea6fa348b1
   name: Exchange Rates Api
   dockerRepository: airbyte/source-exchange-rates
   dockerImageTag: 0.2.3
-  documentationUrl: https://hub.docker.com/r/airbyte/source-exchange-rates
+  documentationUrl: https://docs.airbyte.io/integrations/sources/exchangeratesapi
   icon: exchangeratesapi.svg
 - sourceDefinitionId: 778daa7c-feaf-4db6-96f3-70fd645acc77
   name: File
   dockerRepository: airbyte/source-file
   dockerImageTag: 0.2.5
-  documentationUrl: https://hub.docker.com/r/airbyte/source-file
+  documentationUrl: https://docs.airbyte.io/integrations/sources/file
   icon: file.svg
 - sourceDefinitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
   name: Google Ads
   dockerRepository: airbyte/source-google-ads
   dockerImageTag: 0.1.5
-  documentationUrl: https://hub.docker.com/r/airbyte/source-google-ads
+  documentationUrl: https://docs.airbyte.io/integrations/sources/google-ads
 - sourceDefinitionId: fdc8b827-3257-4b33-83cc-106d234c34d4
   name: Google Adwords (Deprecated)
   dockerRepository: airbyte/source-google-adwords-singer
   dockerImageTag: 0.2.6
-  documentationUrl: https://hub.docker.com/r/airbyte/source-google-adwords-singer
+  documentationUrl: https://docs.airbyte.io/integrations/sources/google-adwords
   icon: google-adwords.svg
 - sourceDefinitionId: ef69ef6e-aa7f-4af1-a01d-ef775033524e
   name: GitHub
@@ -46,24 +46,24 @@
   name: Microsoft SQL Server (MSSQL)
   dockerRepository: airbyte/source-mssql
   dockerImageTag: 0.3.3
-  documentationUrl: https://hub.docker.com/r/airbyte/source-mssql
+  documentationUrl: https://docs.airbyte.io/integrations/sources/mssql
   icon: mssql.svg
 - sourceDefinitionId: d8286229-c680-4063-8c59-23b9b391c700
   name: Pipedrive
   dockerRepository: airbyte/source-pipedrive
   dockerImageTag: 0.1.2
-  documentationUrl: https://hub.docker.com/r/airbyte/source-pipedrive
+  documentationUrl: https://docs.airbyte.io/integrations/sources/pipedrive
 - sourceDefinitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
   name: Postgres
   dockerRepository: airbyte/source-postgres
   dockerImageTag: 0.3.7
-  documentationUrl: https://hub.docker.com/r/airbyte/source-postgres
+  documentationUrl: https://docs.airbyte.io/integrations/sources/postgres
   icon: postgresql.svg
 - sourceDefinitionId: 9fa5862c-da7c-11eb-8d19-0242ac130003
   name: Cockroachdb
   dockerRepository: airbyte/source-cockroachdb
   dockerImageTag: 0.1.1
-  documentationUrl: https://hub.docker.com/r/airbyte/source-cockroachdb
+  documentationUrl: https://docs.airbyte.io/integrations/sources/cockroachdb
 - sourceDefinitionId: af6d50ee-dddf-4126-a8ee-7faee990774f
   name: PostHog
   dockerRepository: airbyte/source-posthog
@@ -73,30 +73,30 @@
   name: Recurly
   dockerRepository: airbyte/source-recurly
   dockerImageTag: 0.2.4
-  documentationUrl: https://hub.docker.com/r/airbyte/source-recurly
+  documentationUrl: https://docs.airbyte.io/integrations/sources/recurly
   icon: recurly.svg
 - sourceDefinitionId: 69589781-7828-43c5-9f63-8925b1c1ccc2
   name: S3
   dockerRepository: airbyte/source-s3
   dockerImageTag: 0.1.2
-  documentationUrl: https://hub.docker.com/r/airbyte/source-s3
+  documentationUrl: https://docs.airbyte.io/integrations/sources/s3
 - sourceDefinitionId: fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87
   name: Sendgrid
   dockerRepository: airbyte/source-sendgrid
   dockerImageTag: 0.2.6
-  documentationUrl: https://hub.docker.com/r/airbyte/source-sendgrid
+  documentationUrl: https://docs.airbyte.io/integrations/sources/sendgrid
   icon: sendgrid.svg
 - sourceDefinitionId: 9e0556f4-69df-4522-a3fb-03264d36b348
   name: Marketo
   dockerRepository: airbyte/source-marketo-singer
   dockerImageTag: 0.2.3
-  documentationUrl: https://hub.docker.com/r/airbyte/source-marketo-singer
+  documentationUrl: https://docs.airbyte.io/integrations/sources/marketo
   icon: marketo.svg
 - sourceDefinitionId: 71607ba1-c0ac-4799-8049-7f4b90dd50f7
   name: Google Sheets
   dockerRepository: airbyte/source-google-sheets
   dockerImageTag: 0.2.3
-  documentationUrl: https://hub.docker.com/repository/docker/airbyte/source-google-sheets
+  documentationUrl: https://docs.airbyte.io/integrations/sources/google-sheets
   icon: google-sheets.svg
 - sourceDefinitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
   name: MySQL
@@ -108,37 +108,37 @@
   name: Salesforce
   dockerRepository: airbyte/source-salesforce-singer
   dockerImageTag: 0.2.5
-  documentationUrl: https://hub.docker.com/r/airbyte/source-salesforce-singer
+  documentationUrl: https://docs.airbyte.io/integrations/sources/salesforce
   icon: salesforce.svg
 - sourceDefinitionId: e094cb9a-26de-4645-8761-65c0c425d1de
   name: Stripe
   dockerRepository: airbyte/source-stripe
   dockerImageTag: 0.1.16
-  documentationUrl: https://hub.docker.com/r/airbyte/source-stripe
+  documentationUrl: https://docs.airbyte.io/integrations/sources/stripe
   icon: stripe.svg
 - sourceDefinitionId: b03a9f3e-22a5-11eb-adc1-0242ac120002
   name: Mailchimp
   dockerRepository: airbyte/source-mailchimp
   dockerImageTag: 0.2.7
-  documentationUrl: https://hub.docker.com/r/airbyte/source-mailchimp
+  documentationUrl: https://docs.airbyte.io/integrations/sources/mailchimp
   icon: mailchimp.svg
 - sourceDefinitionId: 39f092a6-8c87-4f6f-a8d9-5cef45b7dbe1
   name: Google Analytics
   dockerRepository: airbyte/source-googleanalytics-singer
   dockerImageTag: 0.2.6
-  documentationUrl: https://hub.docker.com/r/airbyte/source-googleanalytics-singer
+  documentationUrl: https://docs.airbyte.io/integrations/sources/googleanalytics
   icon: google-analytics.svg
 - sourceDefinitionId: e7778cfc-e97c-4458-9ecb-b4f2bba8946c
   name: Facebook Marketing
   dockerRepository: airbyte/source-facebook-marketing
   dockerImageTag: 0.2.14
-  documentationUrl: https://hub.docker.com/r/airbyte/source-facebook-marketing
+  documentationUrl: https://docs.airbyte.io/integrations/sources/facebook-marketing
   icon: facebook.svg
 - sourceDefinitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
   name: Hubspot
   dockerRepository: airbyte/source-hubspot
   dockerImageTag: 0.1.7
-  documentationUrl: https://https://docs.airbyte.io/integrations/sources/hubspot
+  documentationUrl: https://docs.airbyte.io/integrations/sources/hubspot
   icon: hubspot.svg
 - sourceDefinitionId: 95e8cffd-b8c4-4039-968e-d32fb4a69bde
   name: Klaviyo
@@ -154,85 +154,84 @@
   name: Redshift
   dockerRepository: airbyte/source-redshift
   dockerImageTag: 0.3.1
-  documentationUrl: https://hub.docker.com/repository/docker/airbyte/source-redshift
+  documentationUrl: https://docs.airbyte.io/integrations/sources/redshift
   icon: redshift.svg
 - sourceDefinitionId: b9dc6155-672e-42ea-b10d-9f1f1fb95ab1
   name: Twilio
   dockerRepository: airbyte/source-twilio
   dockerImageTag: 0.1.0
-  documentationUrl: https://hub.docker.com/r/airbyte/source-twilio
+  documentationUrl: https://docs.airbyte.io/integrations/sources/twilio
 - sourceDefinitionId: ec4b9503-13cb-48ab-a4ab-6ade4be46567
   name: Freshdesk
   dockerRepository: airbyte/source-freshdesk
   dockerImageTag: 0.2.5
-  documentationUrl: https://hub.docker.com/r/airbyte/source-freshdesk
+  documentationUrl: https://docs.airbyte.io/integrations/sources/freshdesk
   icon: freshdesk.svg
 - sourceDefinitionId: 396e4ca3-8a97-4b85-aa4e-c9d8c2d5f992
   name: Braintree
   dockerRepository: airbyte/source-braintree-singer
   dockerImageTag: 0.2.3
-  documentationUrl: https://hub.docker.com/r/airbyte/source-braintree-singer
+  documentationUrl: https://docs.airbyte.io/integrations/sources/braintree
   icon: braintree.svg
 - sourceDefinitionId: 59f1e50a-331f-4f09-b3e8-2e8d4d355f44
   name: Greenhouse
   dockerRepository: airbyte/source-greenhouse
   dockerImageTag: 0.2.3
-  documentationUrl: https://https://docs.airbyte.io/integrations/sources/greenhouse
+  documentationUrl: https://docs.airbyte.io/integrations/sources/greenhouse
   icon: greenhouse.svg
 - sourceDefinitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
   name: Zendesk Chat
   dockerRepository: airbyte/source-zendesk-chat
   dockerImageTag: 0.1.1
-  documentationUrl: https://hub.docker.com/r/airbyte/source-zendesk-chat
+  documentationUrl: https://docs.airbyte.io/integrations/sources/zendesk-chat
   icon: zendesk.svg
 - sourceDefinitionId: 79c1aa37-dae3-42ae-b333-d1c105477715
   name: Zendesk Support
   dockerRepository: airbyte/source-zendesk-support
   dockerImageTag: 0.1.0
-  documentationUrl: https://hub.docker.com/r/airbyte/source-zendesk-support
+  documentationUrl: https://docs.airbyte.io/integrations/sources/zendesk-support
   icon: zendesk.svg
-
 - sourceDefinitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
   name: Intercom
   dockerRepository: airbyte/source-intercom
   dockerImageTag: 0.1.1
-  documentationUrl: https://hub.docker.com/r/airbyte/source-intercom
+  documentationUrl: https://docs.airbyte.io/integrations/sources/intercom
   icon: intercom.svg
 - sourceDefinitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993
   name: Jira
   dockerRepository: airbyte/source-jira
   dockerImageTag: 0.2.8
-  documentationUrl: https://hub.docker.com/r/airbyte/source-jira
+  documentationUrl: https://docs.airbyte.io/integrations/sources/jira
   icon: jira.svg
 - sourceDefinitionId: 12928b32-bf0a-4f1e-964f-07e12e37153a
   name: Mixpanel
   dockerRepository: airbyte/source-mixpanel
   dockerImageTag: 0.1.0
-  documentationUrl: https://hub.docker.com/r/airbyte/source-mixpanel
+  documentationUrl: https://docs.airbyte.io/integrations/sources/mixpanel
   icon: mixpanel.svg
 - sourceDefinitionId: 859e501d-2b67-471f-91bb-1c801414d28f
   name: Mixpanel Singer
   dockerRepository: airbyte/source-mixpanel-singer
   dockerImageTag: 0.2.4
-  documentationUrl: https://hub.docker.com/r/airbyte/source-mixpanel-singer
+  documentationUrl: https://docs.airbyte.io/integrations/sources/mixpanel
   icon: mixpanel.svg
 - sourceDefinitionId: aea2fd0d-377d-465e-86c0-4fdc4f688e51
   name: Zoom
   dockerRepository: airbyte/source-zoom-singer
   dockerImageTag: 0.2.4
-  documentationUrl: https://hub.docker.com/r/airbyte/source-zoom-singer
+  documentationUrl: https://docs.airbyte.io/integrations/sources/zoom
   icon: zoom.svg
 - sourceDefinitionId: eaf50f04-21dd-4620-913b-2a83f5635227
   name: Microsoft teams
   dockerRepository: airbyte/source-microsoft-teams
   dockerImageTag: 0.2.2
-  documentationUrl: https://hub.docker.com/r/airbyte/source-microsoft-teams
+  documentationUrl: https://docs.airbyte.io/integrations/sources/microsoft-teams
   icon: microsoft-teams.svg
 - sourceDefinitionId: 445831eb-78db-4b1f-8f1f-0d96ad8739e2
   name: Drift
   dockerRepository: airbyte/source-drift
   dockerImageTag: 0.2.2
-  documentationUrl: https://hub.docker.com/r/airbyte/source-drift
+  documentationUrl: https://docs.airbyte.io/integrations/sources/drift
   icon: drift.svg
 - sourceDefinitionId: 00405b19-9768-4e0c-b1ae-9fc2ee2b2a8c
   name: Looker
@@ -244,100 +243,100 @@
   name: Plaid
   dockerRepository: airbyte/source-plaid
   dockerImageTag: 0.2.1
-  documentationUrl: https://hub.docker.com/r/airbyte/source-plaid
+  documentationUrl: https://docs.airbyte.io/integrations/sources/plaid
   icon: plaid.svg
 - sourceDefinitionId: 2af123bf-0aaf-4e0d-9784-cb497f23741a
   name: Appstore
   dockerRepository: airbyte/source-appstore-singer
   dockerImageTag: 0.2.4
-  documentationUrl: https://hub.docker.com/r/airbyte/source-appstore-singer
+  documentationUrl: https://docs.airbyte.io/integrations/sources/appstore
   icon: appstore.svg
 - sourceDefinitionId: 487b930d-7f6a-43ce-8bac-46e6b2de0a55
   name: Mongo DB
   dockerRepository: airbyte/source-mongodb
   dockerImageTag: 0.3.3
-  documentationUrl: https://hub.docker.com/r/airbyte/source-mongodb
+  documentationUrl: https://docs.airbyte.io/integrations/sources/mongodb
   icon: mongodb.svg
 - sourceDefinitionId: d19ae824-e289-4b14-995a-0632eb46d246
   name: Google Directory
   dockerRepository: airbyte/source-google-directory
   dockerImageTag: 0.1.3
-  documentationUrl: https://hub.docker.com/r/airbyte/source-google-directory
+  documentationUrl: https://docs.airbyte.io/integrations/sources/google-directory
 - sourceDefinitionId: 6acf6b55-4f1e-4fca-944e-1a3caef8aba8
   name: Instagram
   dockerRepository: airbyte/source-instagram
   dockerImageTag: 0.1.7
-  documentationUrl: https://hub.docker.com/r/airbyte/source-instagram
+  documentationUrl: https://docs.airbyte.io/integrations/sources/instagram
 - sourceDefinitionId: 5e6175e5-68e1-4c17-bff9-56103bbb0d80
   name: Gitlab
   dockerRepository: airbyte/source-gitlab
   dockerImageTag: 0.1.0
-  documentationUrl: https://hub.docker.com/r/airbyte/source-gitlab
+  documentationUrl: https://docs.airbyte.io/integrations/sources/gitlab
 - sourceDefinitionId: ed9dfefa-1bbc-419d-8c5e-4d78f0ef6734
   name: Google Workspace Admin Reports
   dockerRepository: airbyte/source-google-workspace-admin-reports
   dockerImageTag: 0.1.4
-  documentationUrl: https://hub.docker.com/r/airbyte/source-google-workspace-admin-reports
+  documentationUrl: https://docs.airbyte.io/integrations/sources/google-workspace-admin-reports
 - sourceDefinitionId: d1aa448b-7c54-498e-ad95-263cbebcd2db
   name: Tempo
   dockerRepository: airbyte/source-tempo
   dockerImageTag: 0.2.3
-  documentationUrl: https://hub.docker.com/r/airbyte/source-tempo
+  documentationUrl: https://docs.airbyte.io/integrations/sources/tempo
 - sourceDefinitionId: 374ebc65-6636-4ea0-925c-7d35999a8ffc
   name: Smartsheets
   dockerRepository: airbyte/source-smartsheets
   dockerImageTag: 0.1.5
-  documentationUrl: https://hub.docker.com/r/airbyte/source-smartsheets
+  documentationUrl: https://docs.airbyte.io/integrations/sources/smartsheets
 - sourceDefinitionId: b39a7370-74c3-45a6-ac3a-380d48520a83
   name: Oracle DB
   dockerRepository: airbyte/source-oracle
   dockerImageTag: 0.3.1
-  documentationUrl: https://hub.docker.com/r/airbyte/source-oracle
+  documentationUrl: https://docs.airbyte.io/integrations/sources/oracle
 - sourceDefinitionId: c8630570-086d-4a40-99ae-ea5b18673071
   name: Zendesk Talk
   dockerRepository: airbyte/source-zendesk-talk
   dockerImageTag: 0.1.2
-  documentationUrl: https://hub.docker.com/r/airbyte/source-zendesk-talk
+  documentationUrl: https://docs.airbyte.io/integrations/sources/zendesk-talk
 - sourceDefinitionId: 29b409d9-30a5-4cc8-ad50-886eb846fea3
   name: Quickbooks
   dockerRepository: airbyte/source-quickbooks-singer
   dockerImageTag: 0.1.2
-  documentationUrl: https://hub.docker.com/r/airbyte/source-quickbooks-singer
+  documentationUrl: https://docs.airbyte.io/integrations/sources/quickbooks
 - sourceDefinitionId: 2e875208-0c0b-4ee4-9e92-1cb3156ea799
   name: Iterable
   dockerRepository: airbyte/source-iterable
   dockerImageTag: 0.1.6
-  documentationUrl: https://hub.docker.com/r/airbyte/source-iterable
+  documentationUrl: https://docs.airbyte.io/integrations/sources/iterable
 - sourceDefinitionId: 6371b14b-bc68-4236-bfbd-468e8df8e968
   name: PokeAPI
   dockerRepository: airbyte/source-pokeapi
   dockerImageTag: 0.1.1
-  documentationUrl: https://hub.docker.com/r/airbyte/source-pokeapi
+  documentationUrl: https://docs.airbyte.io/integrations/sources/pokeapi
 - sourceDefinitionId: 5a1d14c2-d829-49cd-8437-1e87dc9f5368
   name: Google Search Console
   dockerRepository: airbyte/source-google-search-console-singer
   dockerImageTag: 0.1.3
-  documentationUrl: https://hub.docker.com/r/airbyte/source-google-search-console-singer
+  documentationUrl: https://docs.airbyte.io/integrations/sources/google-search-console
 - sourceDefinitionId: bad83517-5e54-4a3d-9b53-63e85fbd4d7c
   name: ClickHouse
   dockerRepository: airbyte/source-clickhouse
   dockerImageTag: 0.1.1
-  documentationUrl: https://hub.docker.com/r/airbyte/source-clickhouse
+  documentationUrl: https://docs.airbyte.io/integrations/sources/clickhouse
 - sourceDefinitionId: 45d2e135-2ede-49e1-939f-3e3ec357a65e
   name: Recharge
   dockerRepository: airbyte/source-recharge
   dockerImageTag: 0.1.1
-  documentationUrl: https://hub.docker.com/r/airbyte/source-recharge
+  documentationUrl: https://docs.airbyte.io/integrations/sources/recharge
 - sourceDefinitionId: fe2b4084-3386-4d3b-9ad6-308f61a6f1e6
   name: Harvest
   dockerRepository: airbyte/source-harvest
   dockerImageTag: 0.1.3
-  documentationUrl: https://hub.docker.com/r/airbyte/source-harvest
+  documentationUrl: https://docs.airbyte.io/integrations/sources/harvest
 - sourceDefinitionId: fa9f58c6-2d03-4237-aaa4-07d75e0c1396
   name: Amplitude
   dockerRepository: airbyte/source-amplitude
   dockerImageTag: 0.1.1
-  documentationUrl: https://hub.docker.com/r/airbyte/source-amplitude
+  documentationUrl: https://docs.airbyte.io/integrations/sources/amplitude
 - sourceDefinitionId: e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2
   name: Snowflake
   dockerRepository: airbyte/source-snowflake
@@ -352,7 +351,7 @@
   name: Slack
   dockerRepository: airbyte/source-slack
   dockerImageTag: 0.1.9
-  documentationUrl: https://hub.docker.com/repository/docker/airbyte/source-slack
+  documentationUrl: https://docs.airbyte.io/integrations/sources/slack
   icon: slack.svg
 - sourceDefinitionId: 6ff047c0-f5d5-4ce5-8c81-204a830fa7e1
   name: AWS CloudTrail


### PR DESCRIPTION
## What
#4094 - documentation urls for connectors should not be docker urls

## How
- changed the `airbyte/airbyte-config/init/bin/main/seed/source_definitions.yaml'`
- changed `documentationURL` in every source UUID.json to use the `https://docs.airbyte.io/integrations/sources/<connector-name>` equivalent

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> Documentation </strong></summary>
<p>
    
- [X] Documentation updated 
    - `airbyte/airbyte-config/init/bin/main/seed/source_definitions.yaml'`
    - `UUID of every source definition`
- [X] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
