### PR TITLE
allow injecting deployment mode via env variable

### DIFF
--- a/airbyte-analytics/src/main/java/io/airbyte/analytics/Deployment.java
+++ b/airbyte-analytics/src/main/java/io/airbyte/analytics/Deployment.java
@@ -26,15 +26,11 @@ package io.airbyte.analytics;
 
 import com.google.common.base.Preconditions;
 import io.airbyte.config.Configs;
+import io.airbyte.config.Configs.DeploymentMode;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import java.util.UUID;
 
 public class Deployment {
-
-  public enum DeploymentMode {
-    OSS,
-    CLOUD
-  }
 
   /**
    * deployment - deployment tracking info.

--- a/airbyte-analytics/src/test/java/io/airbyte/analytics/SegmentTrackingClientTest.java
+++ b/airbyte-analytics/src/test/java/io/airbyte/analytics/SegmentTrackingClientTest.java
@@ -33,7 +33,7 @@ import com.google.common.collect.ImmutableMap;
 import com.segment.analytics.Analytics;
 import com.segment.analytics.messages.IdentifyMessage;
 import com.segment.analytics.messages.TrackMessage;
-import io.airbyte.analytics.Deployment.DeploymentMode;
+import io.airbyte.config.Configs;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import java.util.Map;
 import java.util.UUID;
@@ -46,7 +46,7 @@ import org.mockito.ArgumentCaptor;
 class SegmentTrackingClientTest {
 
   private static final String AIRBYTE_VERSION = "dev";
-  private static final Deployment DEPLOYMENT = new Deployment(DeploymentMode.OSS, UUID.randomUUID(), WorkerEnvironment.DOCKER);
+  private static final Deployment DEPLOYMENT = new Deployment(Configs.DeploymentMode.OSS, UUID.randomUUID(), WorkerEnvironment.DOCKER);
   private static final String EMAIL = "a@airbyte.io";
   private static final TrackingIdentity IDENTITY = new TrackingIdentity(AIRBYTE_VERSION, UUID.randomUUID(), EMAIL, false, false, true);
   private static final UUID WORKSPACE_ID = UUID.randomUUID();

--- a/airbyte-analytics/src/test/java/io/airbyte/analytics/TrackingClientSingletonTest.java
+++ b/airbyte-analytics/src/test/java/io/airbyte/analytics/TrackingClientSingletonTest.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.airbyte.analytics.Deployment.DeploymentMode;
 import io.airbyte.config.Configs;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.StandardWorkspace;
@@ -47,7 +46,7 @@ class TrackingClientSingletonTest {
   private static final UUID WORKSPACE_ID = UUID.randomUUID();
   private static final String AIRBYTE_VERSION = "dev";
   private static final String EMAIL = "a@airbyte.io";
-  private static final Deployment DEPLOYMENT = new Deployment(DeploymentMode.OSS, UUID.randomUUID(), WorkerEnvironment.DOCKER);
+  private static final Deployment DEPLOYMENT = new Deployment(Configs.DeploymentMode.OSS, UUID.randomUUID(), WorkerEnvironment.DOCKER);
   private static final TrackingIdentity IDENTITY = new TrackingIdentity(AIRBYTE_VERSION, UUID.randomUUID(), EMAIL, false, false, true);
   private static final Function<UUID, TrackingIdentity> MOCK_TRACKING_IDENTITY = (workspaceId) -> IDENTITY;
 

--- a/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
@@ -71,6 +71,8 @@ public interface Configs {
 
   TrackingStrategy getTrackingStrategy();
 
+  DeploymentMode getDeploymentMode();
+
   WorkerEnvironment getWorkerEnvironment();
 
   WorkspaceRetentionConfig getWorkspaceRetentionConfig();
@@ -115,6 +117,11 @@ public interface Configs {
   enum WorkerEnvironment {
     DOCKER,
     KUBERNETES
+  }
+
+  enum DeploymentMode {
+    OSS,
+    CLOUD
   }
 
 }

--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -51,6 +51,7 @@ public class EnvConfigs implements Configs {
   public static final String CONFIG_ROOT = "CONFIG_ROOT";
   public static final String DOCKER_NETWORK = "DOCKER_NETWORK";
   public static final String TRACKING_STRATEGY = "TRACKING_STRATEGY";
+  public static final String DEPLOYMENT_MODE = "DEPLOYMENT_MODE";
   public static final String DATABASE_USER = "DATABASE_USER";
   public static final String DATABASE_PASSWORD = "DATABASE_PASSWORD";
   public static final String DATABASE_URL = "DATABASE_URL";
@@ -198,9 +199,21 @@ public class EnvConfigs implements Configs {
     return getEnvOrDefault(TRACKING_STRATEGY, TrackingStrategy.LOGGING, s -> {
       try {
         return TrackingStrategy.valueOf(s.toUpperCase());
-      } catch (IllegalArgumentException e) {
+      } catch (final IllegalArgumentException e) {
         LOGGER.info(s + " not recognized, defaulting to " + TrackingStrategy.LOGGING);
         return TrackingStrategy.LOGGING;
+      }
+    });
+  }
+
+  @Override
+  public DeploymentMode getDeploymentMode() {
+    return getEnvOrDefault(DEPLOYMENT_MODE, DeploymentMode.OSS, s -> {
+      try {
+        return DeploymentMode.valueOf(s);
+      } catch (final IllegalArgumentException e) {
+        LOGGER.info(s + " not recognized, defaulting to " + DeploymentMode.OSS);
+        return DeploymentMode.OSS;
       }
     });
   }

--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
@@ -26,7 +26,6 @@ package io.airbyte.scheduler.app;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.airbyte.analytics.Deployment;
-import io.airbyte.analytics.Deployment.DeploymentMode;
 import io.airbyte.analytics.TrackingClientSingleton;
 import io.airbyte.commons.concurrency.GracefulShutdownHandler;
 import io.airbyte.commons.version.AirbyteVersion;
@@ -259,9 +258,7 @@ public class SchedulerApp {
 
     TrackingClientSingleton.initialize(
         configs.getTrackingStrategy(),
-        // todo (cgardens) - we need to do the `#runServer` pattern here that we do in `ServerApp` so that
-        // the deployment mode can be set by the cloud version.
-        new Deployment(DeploymentMode.OSS, jobPersistence.getDeployment().orElseThrow(), configs.getWorkerEnvironment()),
+        new Deployment(configs.getDeploymentMode(), jobPersistence.getDeployment().orElseThrow(), configs.getWorkerEnvironment()),
         configs.getAirbyteRole(),
         configs.getAirbyteVersion(),
         configRepository);

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -25,7 +25,6 @@
 package io.airbyte.server;
 
 import io.airbyte.analytics.Deployment;
-import io.airbyte.analytics.Deployment.DeploymentMode;
 import io.airbyte.analytics.TrackingClientSingleton;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.version.AirbyteVersion;
@@ -185,7 +184,7 @@ public class ServerApp implements ServerRunnable {
     // must happen after deployment id is set
     TrackingClientSingleton.initialize(
         configs.getTrackingStrategy(),
-        new Deployment(DeploymentMode.OSS, jobPersistence.getDeployment().orElseThrow(), configs.getWorkerEnvironment()),
+        new Deployment(configs.getDeploymentMode(), jobPersistence.getDeployment().orElseThrow(), configs.getWorkerEnvironment()),
         configs.getAirbyteRole(),
         configs.getAirbyteVersion(),
         configRepository);

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -163,7 +163,7 @@ public class ServerApp implements ServerRunnable {
     TrackingClientSingleton.get().identify(workspaceId);
   }
 
-  public static ServerRunnable getServer(final ServerFactory apiFactory, final DeploymentMode deploymentMode) throws Exception {
+  public static ServerRunnable getServer(ServerFactory apiFactory) throws Exception {
     final Configs configs = new EnvConfigs();
 
     MDC.put(LogClientSingleton.WORKSPACE_MDC_KEY, LogClientSingleton.getServerLogsRoot(configs).toString());
@@ -185,7 +185,7 @@ public class ServerApp implements ServerRunnable {
     // must happen after deployment id is set
     TrackingClientSingleton.initialize(
         configs.getTrackingStrategy(),
-        new Deployment(deploymentMode, jobPersistence.getDeployment().orElseThrow(), configs.getWorkerEnvironment()),
+        new Deployment(DeploymentMode.OSS, jobPersistence.getDeployment().orElseThrow(), configs.getWorkerEnvironment()),
         configs.getAirbyteRole(),
         configs.getAirbyteVersion(),
         configRepository);
@@ -237,8 +237,8 @@ public class ServerApp implements ServerRunnable {
     }
   }
 
-  public static void main(final String[] args) throws Exception {
-    getServer(new ServerFactory.Api(), DeploymentMode.OSS).start();
+  public static void main(String[] args) throws Exception {
+    getServer(new ServerFactory.Api()).start();
   }
 
   /**

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -163,7 +163,7 @@ public class ServerApp implements ServerRunnable {
     TrackingClientSingleton.get().identify(workspaceId);
   }
 
-  public static ServerRunnable getServer(ServerFactory apiFactory) throws Exception {
+  public static ServerRunnable getServer(final ServerFactory apiFactory, final DeploymentMode deploymentMode) throws Exception {
     final Configs configs = new EnvConfigs();
 
     MDC.put(LogClientSingleton.WORKSPACE_MDC_KEY, LogClientSingleton.getServerLogsRoot(configs).toString());
@@ -185,7 +185,7 @@ public class ServerApp implements ServerRunnable {
     // must happen after deployment id is set
     TrackingClientSingleton.initialize(
         configs.getTrackingStrategy(),
-        new Deployment(DeploymentMode.OSS, jobPersistence.getDeployment().orElseThrow(), configs.getWorkerEnvironment()),
+        new Deployment(deploymentMode, jobPersistence.getDeployment().orElseThrow(), configs.getWorkerEnvironment()),
         configs.getAirbyteRole(),
         configs.getAirbyteVersion(),
         configRepository);
@@ -237,8 +237,8 @@ public class ServerApp implements ServerRunnable {
     }
   }
 
-  public static void main(String[] args) throws Exception {
-    getServer(new ServerFactory.Api()).start();
+  public static void main(final String[] args) throws Exception {
+    getServer(new ServerFactory.Api(), DeploymentMode.OSS).start();
   }
 
   /**


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/5189

## What
* issue (above) explains this pretty well

## How
* originally, I wanted to set this in the "wrapped" version of the java code in the airbyte-cloud project. This was straightforward to do for the server. We do not wrap the scheduler app, however, and I did not want to add that level of complexity now (@jrhizor and I agreed on this in this [convo](https://airbytehq.slack.com/archives/C0229LM09T4/p1628204159111200)). So instead, this metadata is being injected via an env variable. The problem with this is that it would be easy for an OSS user to set this if they wanted to and confuse our tracking, but in the short term that risk is acceptable. Ultimately all of our product tracking is susceptible to these sorts of issue, but this is particularly easy to mess with.

## Follow on work
- [x] set the env variable in airbyte cloud (PR: https://github.com/airbytehq/airbyte-cloud/pull/117)
