### PR TITLE
404 Exception Handling.

### DIFF
--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobNotifier.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobNotifier.java
@@ -98,7 +98,7 @@ public class JobNotifier {
       final String jobDescription =
           String.format("sync started on %s, running for%s, as the %s.", formatter.format(jobStartedDate), durationString, reason);
       final String logUrl = connectionPageUrl + connectionId;
-      final UUID workspaceId = workspaceHelper.getWorkspaceForJobId(job.getId());
+      final UUID workspaceId = workspaceHelper.getWorkspaceForJobIdIgnoreExceptions(job.getId());
       final StandardWorkspace workspace = configRepository.getStandardWorkspace(workspaceId, true);
       final ImmutableMap<String, Object> jobMetadata = TrackingMetadata.generateJobAttemptMetadata(job);
       final ImmutableMap<String, Object> sourceMetadata = TrackingMetadata.generateSourceDefinitionMetadata(sourceDefinition);

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/WorkspaceHelper.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/WorkspaceHelper.java
@@ -88,7 +88,7 @@ public class WorkspaceHelper {
         final StandardSync connection = configRepository.getStandardSync(connectionId);
         final UUID sourceId = connection.getSourceId();
         final UUID destinationId = connection.getDestinationId();
-        return getWorkspaceForConnection(sourceId, destinationId);
+        return getWorkspaceForConnectionIgnoreExceptions(sourceId, destinationId);
       }
 
     });
@@ -106,10 +106,13 @@ public class WorkspaceHelper {
     this.jobToWorkspaceCache = getExpiringCache(new CacheLoader<>() {
 
       @Override
-      public UUID load(@NonNull Long jobId) throws IOException {
+      public UUID load(@NonNull Long jobId) throws ConfigNotFoundException, IOException {
         final Job job = jobPersistence.getJob(jobId);
+        if (job == null) {
+          throw new ConfigNotFoundException(Job.class.toString(), jobId.toString());
+        }
         if (job.getConfigType() == JobConfig.ConfigType.SYNC || job.getConfigType() == JobConfig.ConfigType.RESET_CONNECTION) {
-          return getWorkspaceForConnectionId(UUID.fromString(job.getScope()));
+          return getWorkspaceForConnectionIdIgnoreExceptions(UUID.fromString(job.getScope()));
         } else {
           throw new IllegalArgumentException("Only sync/reset jobs are associated with workspaces! A " + job.getConfigType() + " job was requested!");
         }
@@ -118,35 +121,72 @@ public class WorkspaceHelper {
     });
   }
 
+  /**
+   * There are generally two kinds of helper methods present here. The first kind propagate exceptions
+   * for the method backing the cache. The second ignores them. The former is meant to be used with
+   * proper api calls, while the latter is meant to be use with asserts and precondtions checks.
+   *
+   * In API calls, distinguishing between various exceptions helps return the correct status code.
+   */
+
+  // SOURCE ID
   public UUID getWorkspaceForSourceId(UUID sourceId) throws ConfigNotFoundException, JsonValidationException {
     return handleCacheExceptions(() -> sourceToWorkspaceCache.get(sourceId));
   }
 
-  public UUID getWorkspaceForSourceIdNoExceptions(UUID sourceId) {
+  public UUID getWorkspaceForSourceIdIgnoreExceptions(UUID sourceId) {
     return swallowExecutionException(() -> getWorkspaceForSourceId(sourceId));
   }
 
-  public UUID getWorkspaceForDestinationId(UUID destinationId) {
+  // DESTINATION ID
+  public UUID getWorkspaceForDestinationId(UUID destinationId) throws JsonValidationException, ConfigNotFoundException {
+    return handleCacheExceptions(() -> destinationToWorkspaceCache.get(destinationId));
+  }
+
+  public UUID getWorkspaceForDestinationIdIgnoreExceptions(UUID destinationId) {
     return swallowExecutionException(() -> destinationToWorkspaceCache.get(destinationId));
   }
 
-  public UUID getWorkspaceForJobId(Long jobId) {
+  // JOB ID
+  public UUID getWorkspaceForJobId(Long jobId) throws JsonValidationException, ConfigNotFoundException {
+    return handleCacheExceptions(() -> jobToWorkspaceCache.get(jobId));
+  }
+
+  public UUID getWorkspaceForJobIdIgnoreExceptions(Long jobId) {
     return swallowExecutionException(() -> jobToWorkspaceCache.get(jobId));
   }
 
-  public UUID getWorkspaceForConnection(UUID sourceId, UUID destinationId) {
-    final UUID sourceWorkspace = getWorkspaceForSourceIdNoExceptions(sourceId);
+  // CONNECTION ID
+  public UUID getWorkspaceForConnection(UUID sourceId, UUID destinationId) throws JsonValidationException, ConfigNotFoundException {
+    final UUID sourceWorkspace = getWorkspaceForSourceId(sourceId);
     final UUID destinationWorkspace = getWorkspaceForDestinationId(destinationId);
 
     Preconditions.checkArgument(Objects.equals(sourceWorkspace, destinationWorkspace), "Source and destination must be from the same workspace!");
-    return swallowExecutionException(() -> sourceWorkspace);
+    return sourceWorkspace;
   }
 
-  public UUID getWorkspaceForConnectionId(UUID connectionId) {
+  public UUID getWorkspaceForConnectionIgnoreExceptions(UUID sourceId, UUID destinationId) {
+    final UUID sourceWorkspace = getWorkspaceForSourceIdIgnoreExceptions(sourceId);
+    final UUID destinationWorkspace = getWorkspaceForDestinationIdIgnoreExceptions(destinationId);
+
+    Preconditions.checkArgument(Objects.equals(sourceWorkspace, destinationWorkspace), "Source and destination must be from the same workspace!");
+    return sourceWorkspace;
+  }
+
+  public UUID getWorkspaceForConnectionId(UUID connectionId) throws JsonValidationException, ConfigNotFoundException {
+    return handleCacheExceptions(() -> connectionToWorkspaceCache.get(connectionId));
+  }
+
+  public UUID getWorkspaceForConnectionIdIgnoreExceptions(UUID connectionId) {
     return swallowExecutionException(() -> connectionToWorkspaceCache.get(connectionId));
   }
 
-  public UUID getWorkspaceForOperationId(UUID operationId) {
+  // OPERATION ID
+  public UUID getWorkspaceForOperationId(UUID operationId) throws JsonValidationException, ConfigNotFoundException {
+    return handleCacheExceptions(() -> operationToWorkspaceCache.get(operationId));
+  }
+
+  public UUID getWorkspaceForOperationIdIgnoreExceptions(UUID operationId) {
     return swallowExecutionException(() -> operationToWorkspaceCache.get(operationId));
   }
 
@@ -166,8 +206,6 @@ public class WorkspaceHelper {
     }
   }
 
-  // the ExecutionException is an implementation detail the helper and does not need to be handled by
-  // callers.
   private static UUID swallowExecutionException(CheckedSupplier<UUID, Throwable> supplier) {
     try {
       return supplier.get();

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -146,7 +146,7 @@ public class JobTracker {
       final Map<String, Object> stateMetadata = generateStateMetadata(jobState);
       final Map<String, Object> syncConfigMetadata = generateSyncConfigMetadata(job.getConfig());
 
-      final UUID workspaceId = workspaceHelper.getWorkspaceForJobId(jobId);
+      final UUID workspaceId = workspaceHelper.getWorkspaceForJobIdIgnoreExceptions(jobId);
       track(workspaceId,
           MoreMaps.merge(
               jobMetadata,

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/JobNotifierTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/JobNotifierTest.java
@@ -102,7 +102,7 @@ class JobNotifierTest {
     when(configRepository.getStandardSourceDefinition(any())).thenReturn(sourceDefinition);
     when(configRepository.getStandardDestinationDefinition(any())).thenReturn(destinationDefinition);
     when(configRepository.getStandardWorkspace(WORKSPACE_ID, true)).thenReturn(getWorkspace());
-    when(workspaceHelper.getWorkspaceForJobId(job.getId())).thenReturn(WORKSPACE_ID);
+    when(workspaceHelper.getWorkspaceForJobIdIgnoreExceptions(job.getId())).thenReturn(WORKSPACE_ID);
     when(notificationClient.notifyJobFailure(anyString(), anyString(), anyString(), anyString())).thenReturn(true);
 
     jobNotifier.failJob("JobNotifierTest was running", job);

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/WorkspaceHelperTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/WorkspaceHelperTest.java
@@ -108,13 +108,23 @@ class WorkspaceHelperTest {
   }
 
   @Test
-  public void testObjectsThatDoNotExist() {
-    assertThrows(RuntimeException.class, () -> workspaceHelper.getWorkspaceForSourceIdNoExceptions(UUID.randomUUID()));
-    assertThrows(RuntimeException.class, () -> workspaceHelper.getWorkspaceForDestinationId(UUID.randomUUID()));
-    assertThrows(RuntimeException.class, () -> workspaceHelper.getWorkspaceForConnectionId(UUID.randomUUID()));
-    assertThrows(RuntimeException.class, () -> workspaceHelper.getWorkspaceForConnection(UUID.randomUUID(), UUID.randomUUID()));
-    assertThrows(RuntimeException.class, () -> workspaceHelper.getWorkspaceForOperationId(UUID.randomUUID()));
-    assertThrows(RuntimeException.class, () -> workspaceHelper.getWorkspaceForJobId(0L));
+  public void testMissingObjectsRuntimeException() {
+    assertThrows(RuntimeException.class, () -> workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(UUID.randomUUID()));
+    assertThrows(RuntimeException.class, () -> workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(UUID.randomUUID()));
+    assertThrows(RuntimeException.class, () -> workspaceHelper.getWorkspaceForConnectionIdIgnoreExceptions(UUID.randomUUID()));
+    assertThrows(RuntimeException.class, () -> workspaceHelper.getWorkspaceForConnectionIgnoreExceptions(UUID.randomUUID(), UUID.randomUUID()));
+    assertThrows(RuntimeException.class, () -> workspaceHelper.getWorkspaceForOperationIdIgnoreExceptions(UUID.randomUUID()));
+    assertThrows(RuntimeException.class, () -> workspaceHelper.getWorkspaceForJobIdIgnoreExceptions(0L));
+  }
+
+  @Test
+  public void testMissingObjectsProperException() {
+    assertThrows(ConfigNotFoundException.class, () -> workspaceHelper.getWorkspaceForSourceId(UUID.randomUUID()));
+    assertThrows(ConfigNotFoundException.class, () -> workspaceHelper.getWorkspaceForDestinationId(UUID.randomUUID()));
+    assertThrows(ConfigNotFoundException.class, () -> workspaceHelper.getWorkspaceForConnectionId(UUID.randomUUID()));
+    assertThrows(ConfigNotFoundException.class, () -> workspaceHelper.getWorkspaceForConnection(UUID.randomUUID(), UUID.randomUUID()));
+    assertThrows(ConfigNotFoundException.class, () -> workspaceHelper.getWorkspaceForOperationId(UUID.randomUUID()));
+    assertThrows(ConfigNotFoundException.class, () -> workspaceHelper.getWorkspaceForJobId(0L));
   }
 
   @Test
@@ -122,18 +132,13 @@ class WorkspaceHelperTest {
     configRepository.writeStandardSource(SOURCE_DEF);
     configRepository.writeSourceConnection(SOURCE);
 
-    final UUID retrievedWorkspace = workspaceHelper.getWorkspaceForSourceIdNoExceptions(SOURCE_ID);
+    final UUID retrievedWorkspace = workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(SOURCE_ID);
     assertEquals(WORKSPACE_ID, retrievedWorkspace);
 
     // check that caching is working
     configRepository.writeSourceConnection(Jsons.clone(SOURCE).withWorkspaceId(UUID.randomUUID()));
-    final UUID retrievedWorkspaceAfterUpdate = workspaceHelper.getWorkspaceForSourceIdNoExceptions(SOURCE_ID);
+    final UUID retrievedWorkspaceAfterUpdate = workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(SOURCE_ID);
     assertEquals(WORKSPACE_ID, retrievedWorkspaceAfterUpdate);
-  }
-
-  @Test
-  public void testSourceMissing() {
-    assertThrows(ConfigNotFoundException.class, () -> workspaceHelper.getWorkspaceForSourceId(UUID.randomUUID()));
   }
 
   @Test
@@ -141,12 +146,12 @@ class WorkspaceHelperTest {
     configRepository.writeStandardDestinationDefinition(DEST_DEF);
     configRepository.writeDestinationConnection(DEST);
 
-    final UUID retrievedWorkspace = workspaceHelper.getWorkspaceForDestinationId(DEST_ID);
+    final UUID retrievedWorkspace = workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(DEST_ID);
     assertEquals(WORKSPACE_ID, retrievedWorkspace);
 
     // check that caching is working
     configRepository.writeDestinationConnection(Jsons.clone(DEST).withWorkspaceId(UUID.randomUUID()));
-    final UUID retrievedWorkspaceAfterUpdate = workspaceHelper.getWorkspaceForDestinationId(DEST_ID);
+    final UUID retrievedWorkspaceAfterUpdate = workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(DEST_ID);
     assertEquals(WORKSPACE_ID, retrievedWorkspaceAfterUpdate);
   }
 
@@ -161,18 +166,18 @@ class WorkspaceHelperTest {
     configRepository.writeStandardSync(CONNECTION);
 
     // test retrieving by connection id
-    final UUID retrievedWorkspace = workspaceHelper.getWorkspaceForConnectionId(CONNECTION_ID);
+    final UUID retrievedWorkspace = workspaceHelper.getWorkspaceForConnectionIdIgnoreExceptions(CONNECTION_ID);
     assertEquals(WORKSPACE_ID, retrievedWorkspace);
 
     // test retrieving by source and destination ids
-    final UUID retrievedWorkspaceBySourceAndDestination = workspaceHelper.getWorkspaceForConnectionId(CONNECTION_ID);
+    final UUID retrievedWorkspaceBySourceAndDestination = workspaceHelper.getWorkspaceForConnectionIdIgnoreExceptions(CONNECTION_ID);
     assertEquals(WORKSPACE_ID, retrievedWorkspaceBySourceAndDestination);
 
     // check that caching is working
     final UUID newWorkspace = UUID.randomUUID();
     configRepository.writeSourceConnection(Jsons.clone(SOURCE).withWorkspaceId(newWorkspace));
     configRepository.writeDestinationConnection(Jsons.clone(DEST).withWorkspaceId(newWorkspace));
-    final UUID retrievedWorkspaceAfterUpdate = workspaceHelper.getWorkspaceForDestinationId(DEST_ID);
+    final UUID retrievedWorkspaceAfterUpdate = workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(DEST_ID);
     assertEquals(WORKSPACE_ID, retrievedWorkspaceAfterUpdate);
   }
 
@@ -181,12 +186,12 @@ class WorkspaceHelperTest {
     configRepository.writeStandardSyncOperation(OPERATION);
 
     // test retrieving by connection id
-    final UUID retrievedWorkspace = workspaceHelper.getWorkspaceForOperationId(OPERATION_ID);
+    final UUID retrievedWorkspace = workspaceHelper.getWorkspaceForOperationIdIgnoreExceptions(OPERATION_ID);
     assertEquals(WORKSPACE_ID, retrievedWorkspace);
 
     // check that caching is working
     configRepository.writeStandardSyncOperation(Jsons.clone(OPERATION).withWorkspaceId(UUID.randomUUID()));
-    final UUID retrievedWorkspaceAfterUpdate = workspaceHelper.getWorkspaceForOperationId(OPERATION_ID);
+    final UUID retrievedWorkspaceAfterUpdate = workspaceHelper.getWorkspaceForOperationIdIgnoreExceptions(OPERATION_ID);
     assertEquals(WORKSPACE_ID, retrievedWorkspaceAfterUpdate);
   }
 
@@ -212,7 +217,7 @@ class WorkspaceHelperTest {
         System.currentTimeMillis());
     when(jobPersistence.getJob(jobId)).thenReturn(job);
 
-    final UUID jobWorkspace = workspaceHelper.getWorkspaceForJobId(jobId);
+    final UUID jobWorkspace = workspaceHelper.getWorkspaceForJobIdIgnoreExceptions(jobId);
     assertEquals(WORKSPACE_ID, jobWorkspace);
   }
 

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
@@ -225,7 +225,7 @@ class JobTrackerTest {
       throws ConfigNotFoundException, IOException, JsonValidationException {
     // for sync the job id is a long not a uuid.
     final long jobId = 10L;
-    when(workspaceHelper.getWorkspaceForJobId(jobId)).thenReturn(WORKSPACE_ID);
+    when(workspaceHelper.getWorkspaceForJobIdIgnoreExceptions(jobId)).thenReturn(WORKSPACE_ID);
 
     final ImmutableMap<String, Object> metadata = getJobMetadata(configType, jobId);
     final Job job = getJobMock(configType, jobId);
@@ -287,7 +287,7 @@ class JobTrackerTest {
     final Job job = getJobWithAttemptsMock(configType, jobId);
     // test when frequency is manual.
     when(configRepository.getStandardSync(CONNECTION_ID)).thenReturn(new StandardSync().withConnectionId(CONNECTION_ID).withManual(true));
-    when(workspaceHelper.getWorkspaceForJobId(jobId)).thenReturn(WORKSPACE_ID);
+    when(workspaceHelper.getWorkspaceForJobIdIgnoreExceptions(jobId)).thenReturn(WORKSPACE_ID);
     final Map<String, Object> manualMetadata = MoreMaps.merge(
         ATTEMPT_METADATA,
         metadata,

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -1,5 +1,46 @@
 plugins {
     id 'application'
+    id 'maven-publish'
+    id 'com.github.johnrengelman.shadow' version '6.1.0'
+}
+
+shadowJar {
+    zip64 true
+    mergeServiceFiles()
+    exclude 'META-INF/*.RSA'
+    exclude 'META-INF/*.SF'
+    exclude 'META-INF/*.DSA'
+    // Not stubbing this out adds 'all' to the end of the jar's name.
+    classifier = ''
+}
+
+publishing {
+    publications {
+        shadow(MavenPublication) { publication ->
+            project.shadow.component(publication)
+        }
+    }
+    repositories {
+        publications {
+            // This block is present so Gradle knows to publish a Maven jar.
+            maven(MavenPublication) {
+                from components.java
+                // Gradle will by default use the subproject path as the group id and the subproject name as the artifact id.
+                // e.g. the subproject :airbyte-scheduler:models is imported at io.airbyte.airbyte-config:persistence:<version-number>.
+            }
+        }
+
+        maven {
+            credentials {
+                name 'cloudrepo'
+                username System.getenv('CLOUDREPO_USER')
+                password System.getenv('CLOUDREPO_PASSWORD')
+            }
+            url 'https://airbyte.mycloudrepo.io/repositories/airbyte-public-jars'
+        }
+
+        mavenLocal()
+    }
 }
 
 dependencies {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -85,7 +85,7 @@ public class ConnectionsHandler {
   }
 
   private void validateWorkspace(UUID sourceId, UUID destinationId, Set<UUID> operationIds) {
-    final UUID sourceWorkspace = workspaceHelper.getWorkspaceForSourceId(sourceId);
+    final UUID sourceWorkspace = workspaceHelper.getWorkspaceForSourceIdNoExceptions(sourceId);
     final UUID destinationWorkspace = workspaceHelper.getWorkspaceForDestinationId(destinationId);
 
     Preconditions.checkArgument(

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -85,8 +85,8 @@ public class ConnectionsHandler {
   }
 
   private void validateWorkspace(UUID sourceId, UUID destinationId, Set<UUID> operationIds) {
-    final UUID sourceWorkspace = workspaceHelper.getWorkspaceForSourceIdNoExceptions(sourceId);
-    final UUID destinationWorkspace = workspaceHelper.getWorkspaceForDestinationId(destinationId);
+    final UUID sourceWorkspace = workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(sourceId);
+    final UUID destinationWorkspace = workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(destinationId);
 
     Preconditions.checkArgument(
         sourceWorkspace.equals(destinationWorkspace),
@@ -98,7 +98,7 @@ public class ConnectionsHandler {
             destinationWorkspace));
 
     for (UUID operationId : operationIds) {
-      final UUID operationWorkspace = workspaceHelper.getWorkspaceForOperationId(operationId);
+      final UUID operationWorkspace = workspaceHelper.getWorkspaceForOperationIdIgnoreExceptions(operationId);
       Preconditions.checkArgument(
           sourceWorkspace.equals(operationWorkspace),
           String.format(
@@ -165,7 +165,7 @@ public class ConnectionsHandler {
 
   private void trackNewConnection(final StandardSync standardSync) {
     try {
-      final UUID workspaceId = workspaceHelper.getWorkspaceForConnectionId(standardSync.getConnectionId());
+      final UUID workspaceId = workspaceHelper.getWorkspaceForConnectionIdIgnoreExceptions(standardSync.getConnectionId());
       final Builder<String, Object> metadataBuilder = generateMetadata(standardSync);
       TrackingClientSingleton.get().track(workspaceId, "New Connection - Backend", metadataBuilder.build());
     } catch (Exception e) {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendDestinationHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendDestinationHandler.java
@@ -60,7 +60,8 @@ public class WebBackendDestinationHandler {
   public DestinationRead webBackendRecreateDestinationAndCheck(DestinationRecreate destinationRecreate)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     Preconditions.checkArgument(
-        workspaceHelper.getWorkspaceForDestinationId(destinationRecreate.getDestinationId()).equals(destinationRecreate.getWorkspaceId()));
+        workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(destinationRecreate.getDestinationId())
+            .equals(destinationRecreate.getWorkspaceId()));
 
     final DestinationCreate destinationCreate = new DestinationCreate();
     destinationCreate.setConnectionConfiguration(destinationRecreate.getConnectionConfiguration());

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendSourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendSourceHandler.java
@@ -57,7 +57,8 @@ public class WebBackendSourceHandler {
 
   public SourceRead webBackendRecreateSourceAndCheck(SourceRecreate sourceRecreate)
       throws ConfigNotFoundException, IOException, JsonValidationException {
-    Preconditions.checkArgument(workspaceHelper.getWorkspaceForSourceId(sourceRecreate.getSourceId()).equals(sourceRecreate.getWorkspaceId()));
+    Preconditions
+        .checkArgument(workspaceHelper.getWorkspaceForSourceIdNoExceptions(sourceRecreate.getSourceId()).equals(sourceRecreate.getWorkspaceId()));
 
     final SourceCreate sourceCreate = new SourceCreate();
     sourceCreate.setConnectionConfiguration(sourceRecreate.getConnectionConfiguration());

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendSourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendSourceHandler.java
@@ -58,7 +58,7 @@ public class WebBackendSourceHandler {
   public SourceRead webBackendRecreateSourceAndCheck(SourceRecreate sourceRecreate)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     Preconditions
-        .checkArgument(workspaceHelper.getWorkspaceForSourceIdNoExceptions(sourceRecreate.getSourceId()).equals(sourceRecreate.getWorkspaceId()));
+        .checkArgument(workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(sourceRecreate.getSourceId()).equals(sourceRecreate.getWorkspaceId()));
 
     final SourceCreate sourceCreate = new SourceCreate();
     sourceCreate.setConnectionConfiguration(sourceRecreate.getConnectionConfiguration());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -132,9 +132,9 @@ class ConnectionsHandlerTest {
     workspaceHelper = mock(WorkspaceHelper.class);
     connectionsHandler = new ConnectionsHandler(configRepository, uuidGenerator, workspaceHelper);
 
-    when(workspaceHelper.getWorkspaceForSourceIdNoExceptions(sourceId)).thenReturn(workspaceId);
-    when(workspaceHelper.getWorkspaceForDestinationId(destinationId)).thenReturn(workspaceId);
-    when(workspaceHelper.getWorkspaceForOperationId(operationId)).thenReturn(workspaceId);
+    when(workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(sourceId)).thenReturn(workspaceId);
+    when(workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(destinationId)).thenReturn(workspaceId);
+    when(workspaceHelper.getWorkspaceForOperationIdIgnoreExceptions(operationId)).thenReturn(workspaceId);
   }
 
   @Test
@@ -180,7 +180,7 @@ class ConnectionsHandlerTest {
 
   @Test
   void testValidateConnectionCreateSourceAndDestinationInDifferenceWorkspace() {
-    when(workspaceHelper.getWorkspaceForDestinationId(destinationId)).thenReturn(UUID.randomUUID());
+    when(workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(destinationId)).thenReturn(UUID.randomUUID());
 
     final ConnectionCreate connectionCreate = new ConnectionCreate()
         .sourceId(standardSync.getSourceId())
@@ -191,7 +191,7 @@ class ConnectionsHandlerTest {
 
   @Test
   void testValidateConnectionCreateOperationInDifferentWorkspace() {
-    when(workspaceHelper.getWorkspaceForOperationId(operationId)).thenReturn(UUID.randomUUID());
+    when(workspaceHelper.getWorkspaceForOperationIdIgnoreExceptions(operationId)).thenReturn(UUID.randomUUID());
 
     final ConnectionCreate connectionCreate = new ConnectionCreate()
         .sourceId(standardSync.getSourceId())
@@ -309,7 +309,7 @@ class ConnectionsHandlerTest {
 
   @Test
   void testValidateConnectionUpdateOperationInDifferentWorkspace() throws JsonValidationException, ConfigNotFoundException, IOException {
-    when(workspaceHelper.getWorkspaceForOperationId(operationId)).thenReturn(UUID.randomUUID());
+    when(workspaceHelper.getWorkspaceForOperationIdIgnoreExceptions(operationId)).thenReturn(UUID.randomUUID());
     when(configRepository.getStandardSync(standardSync.getConnectionId())).thenReturn(standardSync);
 
     final ConnectionUpdate connectionUpdate = new ConnectionUpdate()
@@ -380,8 +380,8 @@ class ConnectionsHandlerTest {
 
   @Test
   void failOnUnmatchedWorkspacesInCreate() throws JsonValidationException, ConfigNotFoundException, IOException {
-    when(workspaceHelper.getWorkspaceForSourceIdNoExceptions(standardSync.getSourceId())).thenReturn(UUID.randomUUID());
-    when(workspaceHelper.getWorkspaceForDestinationId(standardSync.getDestinationId())).thenReturn(UUID.randomUUID());
+    when(workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(standardSync.getSourceId())).thenReturn(UUID.randomUUID());
+    when(workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(standardSync.getDestinationId())).thenReturn(UUID.randomUUID());
 
     when(uuidGenerator.get()).thenReturn(standardSync.getConnectionId());
     final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -132,7 +132,7 @@ class ConnectionsHandlerTest {
     workspaceHelper = mock(WorkspaceHelper.class);
     connectionsHandler = new ConnectionsHandler(configRepository, uuidGenerator, workspaceHelper);
 
-    when(workspaceHelper.getWorkspaceForSourceId(sourceId)).thenReturn(workspaceId);
+    when(workspaceHelper.getWorkspaceForSourceIdNoExceptions(sourceId)).thenReturn(workspaceId);
     when(workspaceHelper.getWorkspaceForDestinationId(destinationId)).thenReturn(workspaceId);
     when(workspaceHelper.getWorkspaceForOperationId(operationId)).thenReturn(workspaceId);
   }
@@ -380,7 +380,7 @@ class ConnectionsHandlerTest {
 
   @Test
   void failOnUnmatchedWorkspacesInCreate() throws JsonValidationException, ConfigNotFoundException, IOException {
-    when(workspaceHelper.getWorkspaceForSourceId(standardSync.getSourceId())).thenReturn(UUID.randomUUID());
+    when(workspaceHelper.getWorkspaceForSourceIdNoExceptions(standardSync.getSourceId())).thenReturn(UUID.randomUUID());
     when(workspaceHelper.getWorkspaceForDestinationId(standardSync.getDestinationId())).thenReturn(UUID.randomUUID());
 
     when(uuidGenerator.get()).thenReturn(standardSync.getConnectionId());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendDestinationHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendDestinationHandlerTest.java
@@ -73,7 +73,8 @@ public class WebBackendDestinationHandlerTest {
         DestinationHelpers.generateDestination(UUID.randomUUID());
     destinationRead = DestinationHelpers.getDestinationRead(destination, standardDestinationDefinition);
 
-    when(workspaceHelper.getWorkspaceForDestinationId(destinationRead.getDestinationId())).thenReturn(destinationRead.getWorkspaceId());
+    when(workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(destinationRead.getDestinationId()))
+        .thenReturn(destinationRead.getWorkspaceId());
   }
 
   @Test
@@ -150,7 +151,7 @@ public class WebBackendDestinationHandlerTest {
 
   @Test
   public void testUnmatchedWorkspaces() throws IOException, JsonValidationException, ConfigNotFoundException {
-    when(workspaceHelper.getWorkspaceForDestinationId(destinationRead.getDestinationId())).thenReturn(UUID.randomUUID());
+    when(workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(destinationRead.getDestinationId())).thenReturn(UUID.randomUUID());
 
     DestinationCreate destinationCreate = new DestinationCreate();
     destinationCreate.setName(destinationRead.getName());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendSourceHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendSourceHandlerTest.java
@@ -72,7 +72,7 @@ public class WebBackendSourceHandlerTest {
     SourceConnection source = SourceHelpers.generateSource(UUID.randomUUID());
     sourceRead = SourceHelpers.getSourceRead(source, standardSourceDefinition);
 
-    when(workspaceHelper.getWorkspaceForSourceId(sourceRead.getSourceId())).thenReturn(sourceRead.getWorkspaceId());
+    when(workspaceHelper.getWorkspaceForSourceIdNoExceptions(sourceRead.getSourceId())).thenReturn(sourceRead.getWorkspaceId());
   }
 
   @Test
@@ -148,7 +148,7 @@ public class WebBackendSourceHandlerTest {
 
   @Test
   public void testUnmatchedWorkspaces() throws IOException, JsonValidationException, ConfigNotFoundException {
-    when(workspaceHelper.getWorkspaceForSourceId(sourceRead.getSourceId())).thenReturn(UUID.randomUUID());
+    when(workspaceHelper.getWorkspaceForSourceIdNoExceptions(sourceRead.getSourceId())).thenReturn(UUID.randomUUID());
 
     SourceCreate sourceCreate = new SourceCreate();
     sourceCreate.setName(sourceRead.getName());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendSourceHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendSourceHandlerTest.java
@@ -72,7 +72,7 @@ public class WebBackendSourceHandlerTest {
     SourceConnection source = SourceHelpers.generateSource(UUID.randomUUID());
     sourceRead = SourceHelpers.getSourceRead(source, standardSourceDefinition);
 
-    when(workspaceHelper.getWorkspaceForSourceIdNoExceptions(sourceRead.getSourceId())).thenReturn(sourceRead.getWorkspaceId());
+    when(workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(sourceRead.getSourceId())).thenReturn(sourceRead.getWorkspaceId());
   }
 
   @Test
@@ -148,7 +148,7 @@ public class WebBackendSourceHandlerTest {
 
   @Test
   public void testUnmatchedWorkspaces() throws IOException, JsonValidationException, ConfigNotFoundException {
-    when(workspaceHelper.getWorkspaceForSourceIdNoExceptions(sourceRead.getSourceId())).thenReturn(UUID.randomUUID());
+    when(workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(sourceRead.getSourceId())).thenReturn(UUID.randomUUID());
 
     SourceCreate sourceCreate = new SourceCreate();
     sourceCreate.setName(sourceRead.getName());

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -297,7 +297,7 @@ public class AcceptanceTests {
   }
 
   @Test
-  @Order(-1)
+  @Order(-2)
   @DisabledIfEnvironmentVariable(named = "KUBE",
                                  matches = "true")
   public void testGetDestinationSpec() throws ApiException {
@@ -306,6 +306,15 @@ public class AcceptanceTests {
         .getDestinationDefinitionSpecification(new DestinationDefinitionIdRequestBody().destinationDefinitionId(destinationDefinitionId));
     assertEquals(destinationDefinitionId, spec.getDestinationDefinitionId());
     assertNotNull(spec.getConnectionSpecification());
+  }
+
+  @Test
+  @Order(-1)
+  @DisabledIfEnvironmentVariable(named = "KUBE",
+                                 matches = "true")
+  public void testFailedGet404() throws ApiException {
+    var spec = apiClient.getDestinationDefinitionSpecificationApi()
+        .getDestinationDefinitionSpecification(new DestinationDefinitionIdRequestBody().destinationDefinitionId(UUID.randomUUID()));
   }
 
   @Test

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -312,9 +313,10 @@ public class AcceptanceTests {
   @Order(-1)
   @DisabledIfEnvironmentVariable(named = "KUBE",
                                  matches = "true")
-  public void testFailedGet404() throws ApiException {
-    var spec = apiClient.getDestinationDefinitionSpecificationApi()
-        .getDestinationDefinitionSpecification(new DestinationDefinitionIdRequestBody().destinationDefinitionId(UUID.randomUUID()));
+  public void testFailedGet404() {
+    var e = assertThrows(ApiException.class, () -> apiClient.getDestinationDefinitionSpecificationApi()
+        .getDestinationDefinitionSpecification(new DestinationDefinitionIdRequestBody().destinationDefinitionId(UUID.randomUUID())));
+    assertEquals(404, e.getCode());
   }
 
   @Test

--- a/build.gradle
+++ b/build.gradle
@@ -291,50 +291,51 @@ tasks.withType(AbstractArchiveTask) {
     reproducibleFileOrder = true
 }
 
-// Configure what subprojects to publish.
-String[] toPublish = [
-        ':airbyte-analytics',
-        ':airbyte-api',
-        ':airbyte-commons',
-        ':airbyte-commons-docker',
-        ':airbyte-config:init',
-        ':airbyte-config:models',
-        ':airbyte-config:persistence',
-        ':airbyte-db',
-        ':airbyte-json-validation',
-        ':airbyte-migration',
-        ':airbyte-notification',
-        ':airbyte-protocol:models',
-        ':airbyte-scheduler:client',
-        ':airbyte-scheduler:models',
-        ':airbyte-scheduler:persistence',
-        ':airbyte-server',
-        ':airbyte-workers'
-]
-configure(subprojects.findAll { toPublish.contains(it.getPath()) }) {
-    apply plugin: 'maven-publish'
-
-    publishing {
-        repositories {
-            publications {
-                // This block is present so Gradle knows to publish a Maven jar.
-                maven(MavenPublication) {
-                    from components.java
-                    // Gradle will by default use the subproject path as the group id and the subproject name as the artifact id.
-                    // e.g. the subproject :airbyte-scheduler:models is imported at io.airbyte.airbyte-config:persistence:<version-number>.
-                }
-            }
-
-            maven {
-                credentials {
-                    name 'cloudrepo'
-                    username System.getenv('CLOUDREPO_USER')
-                    password System.getenv('CLOUDREPO_PASSWORD')
-                }
-                url 'https://airbyte.mycloudrepo.io/repositories/airbyte-public-jars'
-            }
-
-            mavenLocal()
-        }
-    }
-}
+// TODO: Davin will turn this back on.
+//// Configure what subprojects to publish.
+//String[] toPublish = [
+//        ':airbyte-analytics',
+//        ':airbyte-api',
+//        ':airbyte-commons',
+//        ':airbyte-commons-docker',
+//        ':airbyte-config:init',
+//        ':airbyte-config:models',
+//        ':airbyte-config:persistence',
+//        ':airbyte-db',
+//        ':airbyte-json-validation',
+//        ':airbyte-migration',
+//        ':airbyte-notification',
+//        ':airbyte-protocol:models',
+//        ':airbyte-scheduler:client',
+//        ':airbyte-scheduler:models',
+//        ':airbyte-scheduler:persistence',
+//        ':airbyte-server',
+//        ':airbyte-workers'
+//]
+//configure(subprojects.findAll { toPublish.contains(it.getPath()) }) {
+//    apply plugin: 'maven-publish'
+//
+//    publishing {
+//        repositories {
+//            publications {
+//                // This block is present so Gradle knows to publish a Maven jar.
+//                maven(MavenPublication) {
+//                    from components.java
+//                    // Gradle will by default use the subproject path as the group id and the subproject name as the artifact id.
+//                    // e.g. the subproject :airbyte-scheduler:models is imported at io.airbyte.airbyte-config:persistence:<version-number>.
+//                }
+//            }
+//
+//            maven {
+//                credentials {
+//                    name 'cloudrepo'
+//                    username System.getenv('CLOUDREPO_USER')
+//                    password System.getenv('CLOUDREPO_PASSWORD')
+//                }
+//                url 'https://airbyte.mycloudrepo.io/repositories/airbyte-public-jars'
+//            }
+//
+//            mavenLocal()
+//        }
+//    }
+//}


### PR DESCRIPTION
## What
This is a lot going on in this PR.

The main gist is:
- add a 404 test to sanity check we return 404 when queried for non-existent resources.
- WorkspaceHelpers currently always swallow exception. This is suboptimal for Cloud since the exception rethrown is a generic RTE, which does not help us know what specific status code to return. Refactor this so we have both kinds of functions.

Lastly, disable normal publishing and return to publishing shadow jars. This is because of  [this PR](https://github.com/airbytehq/airbyte/pull/5097#issuecomment-894604521) that we are iterating on. I don't want to block anyone in the mean time.

## Recommended reading order
1. `build.gradle` and `api-server/build.gradle` - to see build changes.
2. `WorkspaceHelpers.java` - to see refactoring and new workspace methods that throw exceptions.
3. `AcceptanceTest.java` - to see sanity check 404 test.

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> New Connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector added to connector index like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
   
</p>
</details>


<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</p>
</details>

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
