### PR TITLE
add build timeouts

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-report:
     name: Build Report
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     environment: more-secrets

--- a/.github/workflows/connector_integration_tests.yml
+++ b/.github/workflows/connector_integration_tests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   launch_integration_tests:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:

--- a/.github/workflows/doc-link-check-full.yml
+++ b/.github/workflows/doc-link-check-full.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   markdown-link-check:
+    timeout-minutes: 50
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/doc-link-check-pr.yml
+++ b/.github/workflows/doc-link-check-pr.yml
@@ -5,6 +5,7 @@ on: [ pull_request ]
 
 jobs:
   markdown-link-check:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/gke-kube-test-command.yml
+++ b/.github/workflows/gke-kube-test-command.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   start-gke-kube-acceptance-test-runner:
+    timeout-minutes: 10
     name: Start GKE Kube Acceptance Test EC2 Runner
     runs-on: ubuntu-latest
     outputs:
@@ -37,6 +38,7 @@ jobs:
     needs: start-gke-kube-acceptance-test-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-gke-kube-acceptance-test-runner.outputs.label }} # run the job on the newly created runner
     name: GKE Acceptance Tests (Kube)
+    timeout-minutes: 90
     steps:
       - name: Link comment to workflow run
         if: github.event.inputs.comment-id
@@ -119,6 +121,7 @@ jobs:
   # In case of self-hosted EC2 errors, remove this block.
   stop-gke-kube-acceptance-test-runner:
     name: Stop GKE Kube Acceptance Test EC2 Runner
+    timeout-minutes: 10
     needs:
       - start-gke-kube-acceptance-test-runner # required to get output from the start-runner job
       - gke-kube-acceptance-test # required to wait when the main job is done

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,6 +10,7 @@ jobs:
   # In case of self-hosted EC2 errors, remove this block.
   start-connectors-base-build-runner:
     name: "Connectors Base: Start Build EC2 Runner"
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
@@ -34,6 +35,7 @@ jobs:
 
   ensure-images-exist:
     name: "Ensure all required Docker images exist on Dockerhub"
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Airbyte
@@ -47,6 +49,7 @@ jobs:
     needs: start-connectors-base-build-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-connectors-base-build-runner.outputs.label }} # run the job on the newly created runner
     name: "Connectors Base: Build"
+    timeout-minutes: 90
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
@@ -128,6 +131,7 @@ jobs:
   # In case of self-hosted EC2 errors, remove this block.
   stop-connectors-base-build-runner:
     name: "Connectors Base: Stop Build EC2 Runner"
+    timeout-minutes: 10
     needs:
       - start-connectors-base-build-runner # required to get output from the start-runner job
       - build-connectors-base # required to wait when the main job is done
@@ -152,6 +156,7 @@ jobs:
   # In case of self-hosted EC2 errors, remove this block.
   start-platform-build-runner:
     name: "Platform: Start Build EC2 Runner"
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
@@ -178,6 +183,7 @@ jobs:
     needs: start-platform-build-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-platform-build-runner.outputs.label }} # run the job on the newly created runner
     name: "Platform: Build"
+    timeout-minutes: 90
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
@@ -275,6 +281,7 @@ jobs:
   # In case of self-hosted EC2 errors, remove this block.
   stop-platform-build-runner:
     name: "Platform: Stop Build EC2 Runner"
+    timeout-minutes: 10
     needs:
       - start-platform-build-runner # required to get output from the start-runner job
       - platform-build # required to wait when the main job is done
@@ -300,6 +307,7 @@ jobs:
   # In case of self-hosted EC2 errors, remove this block.
   start-frontend-test-runner:
     name: Start Frontend Test EC2 Runner
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
@@ -325,6 +333,7 @@ jobs:
     needs: start-frontend-test-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-frontend-test-runner.outputs.label }} # run the job on the newly created runner
     name: Run Frontend Test
+    timeout-minutes: 120
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
@@ -355,6 +364,7 @@ jobs:
   # In case of self-hosted EC2 errors, remove this block.
   stop-frontend-test-runner:
     name: Stop Frontend Test EC2 Runner
+    timeout-minutes: 10
     needs:
       - start-frontend-test-runner # required to get output from the start-runner job
       - frontend-test # required to wait when the main job is done
@@ -380,6 +390,7 @@ jobs:
   # Docker acceptance tests run as part of the build job.
   start-kube-acceptance-test-runner:
     name: Start Kube Acceptance Test EC2 Runner
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
@@ -406,6 +417,7 @@ jobs:
     needs: start-kube-acceptance-test-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-kube-acceptance-test-runner.outputs.label }} # run the job on the newly created runner
     name: Acceptance Tests (Kube)
+    timeout-minutes: 90
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
@@ -461,6 +473,7 @@ jobs:
   # In case of self-hosted EC2 errors, remove this block.
   stop-kube-acceptance-test-runner:
     name: Stop Kube Acceptance Test EC2 Runner
+    timeout-minutes: 10
     needs:
       - start-kube-acceptance-test-runner # required to get output from the start-runner job
       - kube-acceptance-test # required to wait when the main job is done

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   start-test-runner:
     name: Start Build EC2 Runner
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
@@ -38,6 +39,7 @@ jobs:
           subnet-id: subnet-0469a9e68a379c1d3
           security-group-id: sg-0793f3c9413f21970
   integration-test:
+    timeout-minutes: 240
     needs: start-test-runner
     runs-on: ${{ needs.start-test-runner.outputs.label }}
     environment: more-secrets
@@ -193,6 +195,7 @@ jobs:
   # In case of self-hosted EC2 errors, remove this block.
   stop-test-runner:
     name: Stop Build EC2 Runner
+    timeout-minutes: 10
     needs:
       - start-test-runner # required to get output from the start-runner job
       - integration-test # required to wait when the main job is done


### PR DESCRIPTION
Adding a sanity check to make sure we aren't spending way too much time on certain activities. 

I tried to greatly overestimate the time it should take for these; this is mostly just to make sure we aren't running something infinitely looping overnight.