### PR TITLE
Clean up json schema in code generators

### DIFF
--- a/airbyte-integrations/connector-templates/source-python-http-api/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connector-templates/source-python-http-api/integration_tests/configured_catalog.json
@@ -1,25 +1,9 @@
-// TODO: Construct a configured catalog that can be used for testing. Each stream's `json_schema` field should match the corresponding json schema file.
 {
   "streams": [
     {
       "stream": {
         "name": "customers",
-        "json_schema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": ["null", "string"]
-            },
-            "name": {
-              "type": ["null", "string"]
-            },
-            "signup_date": {
-              "type": ["null", "string"],
-              "format": "date-time"
-            }
-          }
-        },
+        "json_schema": {},
         "supported_sync_modes": ["full_refresh"]
       },
       "sync_mode": "full_refresh",
@@ -28,25 +12,7 @@
     {
       "stream": {
         "name": "employees",
-        "json_schema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": ["null", "string"]
-            },
-            "name": {
-              "type": ["null", "string"]
-            },
-            "years_of_service": {
-              "type": ["null", "integer"]
-            },
-            "start_date": {
-              "type": ["null", "string"],
-              "format": "date-time"
-            }
-          }
-        },
+        "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",

--- a/airbyte-integrations/connector-templates/source-python/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connector-templates/source-python/integration_tests/configured_catalog.json
@@ -3,15 +3,7 @@
     {
       "stream": {
         "name": "table_name",
-        "json_schema": {
-          "properties": {
-            "column_name": {
-              "type": "string"
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
-        },
+        "json_schema": {},
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false,
         "default_cursor_field": ["column_name"]

--- a/airbyte-integrations/connector-templates/source-singer/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connector-templates/source-singer/integration_tests/configured_catalog.json
@@ -3,15 +3,7 @@
     {
       "stream": {
         "name": "table_name",
-        "json_schema": {
-          "properties": {
-            "column_name": {
-              "type": "string"
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
-        },
+        "json_schema": {},
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false,
         "default_cursor_field": ["column_name"]

--- a/airbyte-integrations/connectors/source-scaffold-source-http/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-scaffold-source-http/integration_tests/configured_catalog.json
@@ -1,25 +1,9 @@
-// TODO: Construct a configured catalog that can be used for testing. Each stream's `json_schema` field should match the corresponding json schema file.
 {
   "streams": [
     {
       "stream": {
         "name": "customers",
-        "json_schema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": ["null", "string"]
-            },
-            "name": {
-              "type": ["null", "string"]
-            },
-            "signup_date": {
-              "type": ["null", "string"],
-              "format": "date-time"
-            }
-          }
-        },
+        "json_schema": {},
         "supported_sync_modes": ["full_refresh"]
       },
       "sync_mode": "full_refresh",
@@ -28,25 +12,7 @@
     {
       "stream": {
         "name": "employees",
-        "json_schema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": ["null", "string"]
-            },
-            "name": {
-              "type": ["null", "string"]
-            },
-            "years_of_service": {
-              "type": ["null", "integer"]
-            },
-            "start_date": {
-              "type": ["null", "string"],
-              "format": "date-time"
-            }
-          }
-        },
+        "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",

--- a/airbyte-integrations/connectors/source-scaffold-source-python/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-scaffold-source-python/integration_tests/configured_catalog.json
@@ -3,15 +3,7 @@
     {
       "stream": {
         "name": "table_name",
-        "json_schema": {
-          "properties": {
-            "column_name": {
-              "type": "string"
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
-        },
+        "json_schema": {},
         "supported_sync_modes": ["full_refresh"],
         "source_defined_cursor": false,
         "default_cursor_field": ["column_name"]


### PR DESCRIPTION
## What
- A follow up on #4907.
- `json_schema` is no longer needed in `source-acceptance-test`. It should be removed from the template as well.
