### PR TITLE
Bump version: 0.29.6-alpha → 0.29.7-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.29.6-alpha
+current_version = 0.29.7-alpha
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.29.6-alpha
+VERSION=0.29.7-alpha
 
 # Airbyte Internal Job Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_USER=docker

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.29.6-alpha",
+  "version": "0.29.7-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.29.6-alpha",
+  "version": "0.29.7-alpha",
   "private": true,
   "scripts": {
     "start": "react-scripts start",

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -81,7 +81,7 @@ If you are upgrading from  (i.e. your current version of Airbyte is) Airbyte ver
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.29.6-alpha --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.29.7-alpha --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/kube/overlays/stable-with-resource-limits/.env
+++ b/kube/overlays/stable-with-resource-limits/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.29.6-alpha
+AIRBYTE_VERSION=0.29.7-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_USER=docker

--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/seed
-    newTag: 0.29.6-alpha
+    newTag: 0.29.7-alpha
   - name: airbyte/db
-    newTag: 0.29.6-alpha
+    newTag: 0.29.7-alpha
   - name: airbyte/scheduler
-    newTag: 0.29.6-alpha
+    newTag: 0.29.7-alpha
   - name: airbyte/server
-    newTag: 0.29.6-alpha
+    newTag: 0.29.7-alpha
   - name: airbyte/webapp
-    newTag: 0.29.6-alpha
+    newTag: 0.29.7-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.29.6-alpha
+AIRBYTE_VERSION=0.29.7-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_USER=docker

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/seed
-    newTag: 0.29.6-alpha
+    newTag: 0.29.7-alpha
   - name: airbyte/db
-    newTag: 0.29.6-alpha
+    newTag: 0.29.7-alpha
   - name: airbyte/scheduler
-    newTag: 0.29.6-alpha
+    newTag: 0.29.7-alpha
   - name: airbyte/server
-    newTag: 0.29.6-alpha
+    newTag: 0.29.7-alpha
   - name: airbyte/webapp
-    newTag: 0.29.6-alpha
+    newTag: 0.29.7-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 


### PR DESCRIPTION
this release is happening because of a mistake due to an errant env variable in release 0.29.6-alpha. 0.29.6-alpha was re-released as well with the env variable problem fixed.