### PR TITLE
🐛  handle NPE case in deprecate default workspace migration

### DIFF
--- a/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_28_0.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/migrations/MigrationV0_28_0.java
@@ -50,7 +50,7 @@ public class MigrationV0_28_0 extends BaseMigration implements Migration {
 
   private final Migration previousMigration;
 
-  public MigrationV0_28_0(Migration previousMigration) {
+  public MigrationV0_28_0(final Migration previousMigration) {
     super(previousMigration);
     this.previousMigration = previousMigration;
   }
@@ -68,8 +68,8 @@ public class MigrationV0_28_0 extends BaseMigration implements Migration {
   }
 
   @Override
-  public void migrate(Map<ResourceId, Stream<JsonNode>> inputDataImmutable,
-                      Map<ResourceId, Consumer<JsonNode>> outputData) {
+  public void migrate(final Map<ResourceId, Stream<JsonNode>> inputDataImmutable,
+                      final Map<ResourceId, Consumer<JsonNode>> outputData) {
     // we need to figure out which workspace to associate an operation with. we use the following
     // strategy to avoid ever storing too much info in memory:
     // 1. iterate over connectors stream
@@ -122,7 +122,7 @@ public class MigrationV0_28_0 extends BaseMigration implements Migration {
         workspaceId = DEFAULT_WORKSPACE_ID;
       } else {
         final UUID sourceId = connectionIdToSourceId.get(connectionId);
-        workspaceId = sourceIdToWorkspaceId.get(sourceId);
+        workspaceId = sourceIdToWorkspaceId.getOrDefault(sourceId, DEFAULT_WORKSPACE_ID);
       }
       ((ObjectNode) r).put("workspaceId", workspaceId.toString());
 


### PR DESCRIPTION
## What
user reported issue in slack: https://airbytehq.slack.com/archives/C01MFR03D5W/p1629111483153100
```
2021-08-16 10:48:50 ERROR i.a.s.ServerApp(runAutomaticMigration):260 - {workspace_app_root=/workspace/server/logs} - Automatic Migration failed
java.lang.NullPointerException: null
	at io.airbyte.migrate.migrations.MigrationV0_28_0.lambda$migrate$3(MigrationV0_28_0.java:127) ~[io.airbyte-airbyte-migration-0.29.7-alpha.jar:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183) ~[?:?]
	at java.util.stream.ReferencePipeline$11$1.accept(ReferencePipeline.java:442) ~[?:?]
	at java.util.Iterator.forEachRemaining(Iterator.java:133) ~[?:?]
	at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[?:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497) ~[?:?]
	at io.airbyte.migrate.migrations.MigrationV0_28_0.migrate(MigrationV0_28_0.java:116) ~[io.airbyte-airbyte-migration-0.29.7-alpha.jar:?]
	at io.airbyte.migrate.MigrateWithMetadata.migrate(MigrateWithMetadata.java:52) ~[io.airbyte-airbyte-migration-0.29.7-alpha.jar:?]
	at io.airbyte.migrate.Migrate.runMigration(Migrate.java:150) ~[io.airbyte-airbyte-migration-0.29.7-alpha.jar:?]
	at io.airbyte.migrate.Migrate.run(Migrate.java:113) ~[io.airbyte-airbyte-migration-0.29.7-alpha.jar:?]
	at io.airbyte.migrate.MigrationRunner.run(MigrationRunner.java:76) ~[io.airbyte-airbyte-migration-0.29.7-alpha.jar:?]
	at io.airbyte.server.RunMigration.run(RunMigration.java:77) ~[io.airbyte-airbyte-server-0.29.7-alpha.jar:?]
	at io.airbyte.server.ServerApp.runAutomaticMigration(ServerApp.java:258) [io.airbyte-airbyte-server-0.29.7-alpha.jar:?]
	at io.airbyte.server.ServerApp.getServer(ServerApp.java:208) [io.airbyte-airbyte-server-0.29.7-alpha.jar:?]
	at io.airbyte.server.ServerApp.main(ServerApp.java:240) [io.airbyte-airbyte-server-0.29.7-alpha.jar:?]
```

@subodh1810 diagnosed this:
> Seems like this happens here cause the workspaceId must have been null  and the toString() call must be throwing NPE. This seems to be possible only when the operation  that we are processing
contains a connectionId which was not present in the list of connections that we processed
the connection had a source which was not present in the list of sources that we processed
I could not reproduce this. @charles (airbyte) any ideas why this might be happening (edited) 

I agree with his assessment. It is possible that some record a source, connection, etc that connected this operation got deleted along the ways. 

## How
* The fix seems to be to just fall back on the default workspace. In most cases this is going to be the desired behavior. In the case where we cannot connect an operation to a workspace, then then falling back on the default workspace is going to be our best guess anyway.
* Once this is merged we will need to cut a new release so that the user can get access to this fix.