### PR TITLE
:bug: Connector templates: failure of CI 

### DIFF
--- a/airbyte-integrations/connector-templates/generator/generate.sh
+++ b/airbyte-integrations/connector-templates/generator/generate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
-UID=$(id -u)
-GID=$(id -g)
+_UID=$(id -u)
+_GID=$(id -g)
 # Remove container if already exist
 echo "Removing previous generator if it exists..."
 docker container rm -f airbyte-connector-bootstrap >/dev/null 2>&1
@@ -10,15 +10,15 @@ docker container rm -f airbyte-connector-bootstrap >/dev/null 2>&1
 # Specify the host system user UID and GID to chown the generated files to host system user.
 # This is done because all generated files in container with mounted folders has root owner
 echo "Building generator docker image..."
-docker build --build-arg UID="$UID" --build-arg GID="$GID" . -t airbyte/connector-bootstrap
+docker build --build-arg UID="$_UID" --build-arg GID="$_GID" . -t airbyte/connector-bootstrap
 
 # Run the container and mount the airbyte folder
 if [ $# -eq 2 ]; then
   echo "2 arguments supplied: 1=$1 2=$2"
-  docker run --name airbyte-connector-bootstrap --user $UID:$GID -e package_desc="$1" -e package_name="$2" -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
+  docker run --name airbyte-connector-bootstrap --user $_UID:$_GID -e package_desc="$1" -e package_name="$2" -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
 else
   echo "Running generator..."
-  docker run --rm -it --name airbyte-connector-bootstrap --user $UID:$GID -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
+  docker run --rm -it --name airbyte-connector-bootstrap --user $_UID:$_GID -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
 fi
 
 echo "Finished running generator"


### PR DESCRIPTION
CI returns the following error:
`./generate.sh: line 3: UID: readonly variable`
The root cause is the Linux Shell can't change reserved GID/UID values because they are read-only and they can't be changed by scripts.
**Solution**: Using custom variables 

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [x] Issue acceptance criteria met
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [x] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [x] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [x] Documentation which references the generator is updated as needed.
</p>
</details>