### PR TITLE
remove 5s wait for kube pod processes

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -158,7 +158,7 @@ public class KubePodProcess extends Process {
       initEntrypointStr = String.format("mkfifo %s && ", STDIN_PIPE_FILE) + initEntrypointStr;
     }
 
-    initEntrypointStr = initEntrypointStr + String.format(" && until [ -f %s ]; do sleep 5; done;", SUCCESS_FILE_NAME);
+    initEntrypointStr = initEntrypointStr + String.format(" && until [ -f %s ]; do sleep 0.00001; done;", SUCCESS_FILE_NAME);
 
     return new ContainerBuilder()
         .withName(INIT_CONTAINER_NAME)


### PR DESCRIPTION
This seems to be the most egregious waste of time in our `KubePodProcess`.

Originally I thought we had this since we needed to be able to detect that the init container completed properly. Since then, I believe we changed our detection of init container completion to actually catch the case where the init container finishes nearly instantly, so this wait should no longer be necessary.

@davinchia does that seem reasonable?