### PR TITLE
:bug: CI templates: update scaffold examples

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/utils/schema_helpers.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/utils/schema_helpers.py
@@ -30,7 +30,6 @@ import sys
 from typing import Any, Dict, Mapping
 
 import pkg_resources
-
 from airbyte_cdk.logger import AirbyteLogger
 from airbyte_cdk.models import ConnectorSpecification
 from jsonschema import RefResolver, validate

--- a/airbyte-integrations/connectors/destination-scaffold-destination-python/Dockerfile
+++ b/airbyte-integrations/connectors/destination-scaffold-destination-python/Dockerfile
@@ -1,13 +1,30 @@
-FROM python:3.7.11-alpine3.14
+FROM python:3.7.11-alpine3.14 as base
+
+# build and load all requirements 
+FROM base as builder
+WORKDIR /airbyte/integration_code
+
+# upgrade pip to the latest version
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip
+
+COPY setup.py ./
+# install necessary packages to a temporary folder 
+RUN pip install --prefix=/install .
+
+# build a clean environment  
+FROM base
+WORKDIR /airbyte/integration_code
+
+# copy all loaded and built libraries to a pure basic image
+COPY --from=builder /install /usr/local
 
 # Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+RUN apk --no-cache add bash
 
-WORKDIR /airbyte/integration_code
-COPY destination_scaffold_destination_python ./destination_scaffold_destination_python
+# copy payload code only
 COPY main.py ./
-COPY setup.py ./
-RUN pip install .
+COPY destination_scaffold_destination_python ./destination_scaffold_destination_python
 
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]

--- a/airbyte-integrations/connectors/source-github/source_github/source.py
+++ b/airbyte-integrations/connectors/source-github/source_github/source.py
@@ -52,7 +52,6 @@ from .streams import (
     Teams,
 )
 
-
 TOKEN_SEPARATOR = ","
 
 

--- a/airbyte-integrations/connectors/source-scaffold-source-http/Dockerfile
+++ b/airbyte-integrations/connectors/source-scaffold-source-http/Dockerfile
@@ -1,13 +1,30 @@
-FROM python:3.7-slim
+FROM python:3.7.11-alpine3.14 as base
+
+# build and load all requirements 
+FROM base as builder
+WORKDIR /airbyte/integration_code
+
+# upgrade pip to the latest version
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip
+
+COPY setup.py ./
+# install necessary packages to a temporary folder 
+RUN pip install --prefix=/install .
+
+# build a clean environment  
+FROM base
+WORKDIR /airbyte/integration_code
+
+# copy all loaded and built libraries to a pure basic image
+COPY --from=builder /install /usr/local
 
 # Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+RUN apk --no-cache add bash
 
-WORKDIR /airbyte/integration_code
-COPY source_scaffold_source_http ./source_scaffold_source_http
+# copy payload code only
 COPY main.py ./
-COPY setup.py ./
-RUN pip install .
+COPY source_scaffold_source_http ./source_scaffold_source_http
 
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]

--- a/airbyte-integrations/connectors/source-scaffold-source-python/Dockerfile
+++ b/airbyte-integrations/connectors/source-scaffold-source-python/Dockerfile
@@ -1,13 +1,30 @@
-FROM python:3.7-slim
+FROM python:3.7.11-alpine3.14 as base
+
+# build and load all requirements 
+FROM base as builder
+WORKDIR /airbyte/integration_code
+
+# upgrade pip to the latest version
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip
+
+COPY setup.py ./
+# install necessary packages to a temporary folder 
+RUN pip install --prefix=/install .
+
+# build a clean environment  
+FROM base
+WORKDIR /airbyte/integration_code
+
+# copy all loaded and built libraries to a pure basic image
+COPY --from=builder /install /usr/local
 
 # Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+RUN apk --no-cache add bash
 
-WORKDIR /airbyte/integration_code
-COPY source_scaffold_source_python ./source_scaffold_source_python
+# copy payload code only
 COPY main.py ./
-COPY setup.py ./
-RUN pip install .
+COPY source_scaffold_source_python ./source_scaffold_source_python
 
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]


### PR DESCRIPTION
CI is failed by comparison of scaffold examples with new templates


## Pre-merge Checklist

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [x] Issue acceptance criteria met
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [x] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [x] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [x] Documentation which references the generator is updated as needed.
</p>
</details>
