### PR TITLE
Added HOME to fix npm install bug. Improved error reporting to avoid silent failures.

### DIFF
--- a/airbyte-integrations/connector-templates/generator/generate.sh
+++ b/airbyte-integrations/connector-templates/generator/generate.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env sh
 
+function error_handler {
+  echo "While trying to generate a connector, an error occurred on line $1 of generate.sh and the process aborted early.  This is probably a bug."
+}
+trap 'error_handler $LINENO' ERR
+
+set -e
 _UID=$(id -u)
 _GID=$(id -g)
 # Remove container if already exist
@@ -15,10 +21,10 @@ docker build --build-arg UID="$_UID" --build-arg GID="$_GID" . -t airbyte/connec
 # Run the container and mount the airbyte folder
 if [ $# -eq 2 ]; then
   echo "2 arguments supplied: 1=$1 2=$2"
-  docker run --name airbyte-connector-bootstrap --user $_UID:$_GID -e package_desc="$1" -e package_name="$2" -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
+  docker run --name airbyte-connector-bootstrap --user $_UID:$_GID -e HOME=/tmp -e package_desc="$1" -e package_name="$2" -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
 else
   echo "Running generator..."
-  docker run --rm -it --name airbyte-connector-bootstrap --user $_UID:$_GID -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
+  docker run --rm -it --name airbyte-connector-bootstrap --user $_UID:$_GID -e HOME=/tmp -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
 fi
 
 echo "Finished running generator"

--- a/airbyte-integrations/connector-templates/generator/generate.sh
+++ b/airbyte-integrations/connector-templates/generator/generate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-function error_handler {
+error_handler() {
   echo "While trying to generate a connector, an error occurred on line $1 of generate.sh and the process aborted early.  This is probably a bug."
 }
 trap 'error_handler $LINENO' ERR


### PR DESCRIPTION
Added HOME to make npm happy during install. Improved error reporting to reduce silent failures.

## What
1. NPM began to fail at some point because it couldn't use the /.npm directory any more due to permissions issues.  Setting HOME='.' is the recommended solution online, but that puts it in a weird spot in our project, so I set HOME=/tmp instead, letting npm dump locks and log files there.
2. The generate.sh script was ignoring error exit codes from subprocesses, and providing no output to the user to indicate that a failure had occurred - very confusing.  I added an error handler to the script to make it vividly obvious when any part of the script fails.

## How
Modified generate.sh bash script to improve error handling and add a `-e HOME=/tmp` to the docker command lines.

Closes #5553 
