### PR TITLE
Clarified wording that confused a new connector developer

### DIFF
--- a/docs/connector-development/README.md
+++ b/docs/connector-development/README.md
@@ -49,7 +49,7 @@ cd airbyte-integrations/connector-templates/generator
 ./generate.sh
 ```
 
-and choose the relevant template. This will generate a new connector in the `airbyte-integrations/connectors/<your-connector>` directory.
+and choose the relevant template by using the arrow keys. This will generate a new connector in the `airbyte-integrations/connectors/<your-connector>` directory.
 
 Search the generated directory for "TODO"s and follow them to implement your connector. For more detailed walkthroughs and instructions, follow the relevant tutorial:
 

--- a/docs/connector-development/tutorials/cdk-tutorial-python-http/1-creating-the-source.md
+++ b/docs/connector-development/tutorials/cdk-tutorial-python-http/1-creating-the-source.md
@@ -8,7 +8,9 @@ $ cd airbyte-integrations/connector-templates/generator # assumes you are starti
 $ ./generate.sh
 ```
 
-Select the `Python HTTP API Source` template and then input the name of your connector. For this walk-through we will refer to our source as `python-http-example`. The finalized source code for this tutorial can be found [here](https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors/source-python-http-tutorial).
+This will bring up an interactive helper application.  Use the arrow keys to pick a template from the list.  Select the `Python HTTP API Source` template and then input the name of your connector.  The application will create a new directory in airbyte/airbyte-integrations/connectors/ with the name of your new connector.
+
+For this walk-through we will refer to our source as `python-http-example`. The finalized source code for this tutorial can be found [here](https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors/source-python-http-tutorial).
 
 The source we will build in this tutorial will pull data from the [Rates API](https://exchangeratesapi.io/), a free and open API which documents historical exchange rates for fiat currencies.
 


### PR DESCRIPTION
## What
New connector developer was confused by instructions during the time when the source connector generator wasn't working.  This wording change makes it more apparent what's expected to happen even if they can't currently run the code.

## How
Clarified that the generator is interactive (this is not inherently obvious when it's failing on some error) and made it extra clear that it's expecting to give them a list to pick from interactively.  Also made it more obvious where it's expecting to put the generated code directory. 


