### PR TITLE
Fix airbyte version comparison

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/version/AirbyteVersion.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/version/AirbyteVersion.java
@@ -80,11 +80,11 @@ public class AirbyteVersion {
   public int compatibleVersionCompareTo(final AirbyteVersion another) {
     if (version.equals(DEV_VERSION) || another.version.equals(DEV_VERSION))
       return 0;
-    final int majorDiff = major.compareTo(another.major);
+    final int majorDiff = compareVersion(major, another.major);
     if (majorDiff != 0) {
       return majorDiff;
     }
-    return minor.compareTo(another.minor);
+    return compareVersion(minor, another.minor);
   }
 
   /**
@@ -94,15 +94,24 @@ public class AirbyteVersion {
     if (version.equals(DEV_VERSION) || another.version.equals(DEV_VERSION)) {
       return 0;
     }
-    final int majorDiff = major.compareTo(another.major);
+    final int majorDiff = compareVersion(major, another.major);
     if (majorDiff != 0) {
       return majorDiff;
     }
-    final int minorDiff = minor.compareTo(another.minor);
+    final int minorDiff = compareVersion(minor, another.minor);
     if (minorDiff != 0) {
       return minorDiff;
     }
-    return patch.compareTo(another.patch);
+    return compareVersion(patch, another.patch);
+  }
+
+  /**
+   * Version string needs to be converted to integer for comparison, because string comparison
+   * does not handle version string with different digits correctly.
+   * For example: {@code "11".compare("3") < 0}, while {@code Integer.compare(11, 3) > 0}.
+   */
+  private static int compareVersion(String v1, String v2) {
+    return Integer.compare(Integer.parseInt(v1), Integer.parseInt(v2));
   }
 
   public static void assertIsCompatible(final String version1, final String version2) throws IllegalStateException {

--- a/airbyte-commons/src/main/java/io/airbyte/commons/version/AirbyteVersion.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/version/AirbyteVersion.java
@@ -106,9 +106,9 @@ public class AirbyteVersion {
   }
 
   /**
-   * Version string needs to be converted to integer for comparison, because string comparison
-   * does not handle version string with different digits correctly.
-   * For example: {@code "11".compare("3") < 0}, while {@code Integer.compare(11, 3) > 0}.
+   * Version string needs to be converted to integer for comparison, because string comparison does
+   * not handle version string with different digits correctly. For example:
+   * {@code "11".compare("3") < 0}, while {@code Integer.compare(11, 3) > 0}.
    */
   private static int compareVersion(String v1, String v2) {
     return Integer.compare(Integer.parseInt(v1), Integer.parseInt(v2));

--- a/airbyte-commons/src/test/java/io/airbyte/commons/version/TestAirbyteVersion.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/version/TestAirbyteVersion.java
@@ -53,6 +53,8 @@ public class TestAirbyteVersion {
     assertEquals(0, new AirbyteVersion("6.7.8-omega").compatibleVersionCompareTo(new AirbyteVersion("6.7.8-gamma")));
     assertEquals(0, new AirbyteVersion("6.7.8-alpha").compatibleVersionCompareTo(new AirbyteVersion("6.7.9-alpha")));
     assertTrue(0 < new AirbyteVersion("6.8.0-alpha").compatibleVersionCompareTo(new AirbyteVersion("6.7.8-alpha")));
+    assertTrue(0 < new AirbyteVersion("11.8.0-alpha").compatibleVersionCompareTo(new AirbyteVersion("6.7.8-alpha")));
+    assertTrue(0 < new AirbyteVersion("6.11.0-alpha").compatibleVersionCompareTo(new AirbyteVersion("6.7.8-alpha")));
     assertTrue(0 > new AirbyteVersion("0.8.0-alpha").compatibleVersionCompareTo(new AirbyteVersion("6.7.8-alpha")));
     assertEquals(0, new AirbyteVersion("1.2.3-prod").compatibleVersionCompareTo(new AirbyteVersion("dev")));
     assertEquals(0, new AirbyteVersion("dev").compatibleVersionCompareTo(new AirbyteVersion("1.2.3-prod")));
@@ -62,8 +64,11 @@ public class TestAirbyteVersion {
   public void testPatchVersionCompareTo() {
     assertEquals(0, new AirbyteVersion("6.7.8-omega").patchVersionCompareTo(new AirbyteVersion("6.7.8-gamma")));
     assertTrue(0 > new AirbyteVersion("6.7.8-alpha").patchVersionCompareTo(new AirbyteVersion("6.7.9-alpha")));
+    assertTrue(0 > new AirbyteVersion("6.7.8-alpha").patchVersionCompareTo(new AirbyteVersion("6.7.11-alpha")));
     assertTrue(0 < new AirbyteVersion("6.8.0-alpha").patchVersionCompareTo(new AirbyteVersion("6.7.8-alpha")));
-    assertTrue(0 > new AirbyteVersion("0.8.0-alpha").patchVersionCompareTo(new AirbyteVersion("6.7.8-alpha")));
+    assertTrue(0 < new AirbyteVersion("6.11.0-alpha").patchVersionCompareTo(new AirbyteVersion("6.7.8-alpha")));
+    assertTrue(0 > new AirbyteVersion("3.8.0-alpha").patchVersionCompareTo(new AirbyteVersion("6.7.8-alpha")));
+    assertTrue(0 > new AirbyteVersion("3.8.0-alpha").patchVersionCompareTo(new AirbyteVersion("11.7.8-alpha")));
     assertEquals(0, new AirbyteVersion("1.2.3-prod").patchVersionCompareTo(new AirbyteVersion("dev")));
     assertEquals(0, new AirbyteVersion("dev").patchVersionCompareTo(new AirbyteVersion("1.2.3-prod")));
   }


### PR DESCRIPTION
## What
- Current we do string comparison, which is incorrect when the two versions have different number of digits.
- For example, `11 > 3`, however, `"11".compare("3") < 0`.

## How
- Convert the version string to integer and then perform the comparison.
