### PR TITLE
Add clear explanations for Full Refresh sync modes

### DIFF
--- a/docs/understanding-airbyte/connections/full-refresh-append.md
+++ b/docs/understanding-airbyte/connections/full-refresh-append.md
@@ -1,6 +1,12 @@
 # Full Refresh - Append
 
-This readme describes Airbyte conventions around the "full refresh - Append" concept.
+## Overview
+
+The **Full Refresh** modes are the simplest methods that Airbyte uses to sync data, as they always retrieve all available data requested from the source, regardless of whether it has been synced before. This contrasts with [**Incremental sync**](./incremental-append.md), which does not sync data that has already been synced before.
+
+In the **Append** variant, new syncs will take all data from the sync and append it to the destination table. Therefore, if syncing similar information multiple times, every sync will create duplicates of already existing data.
+
+## Example Behavior
 
 On the nth sync of a full refresh connection:
 

--- a/docs/understanding-airbyte/connections/full-refresh-overwrite.md
+++ b/docs/understanding-airbyte/connections/full-refresh-overwrite.md
@@ -1,6 +1,12 @@
 # Full Refresh - Overwrite
 
-This readme describes Airbyte conventions around the "full refresh - Overwrite" concept.
+## Overview
+
+The **Full Refresh** modes are the simplest methods that Airbyte uses to sync data, as they always retrieve all available information requested from the source, regardless of whether it has been synced before. This contrasts with [**Incremental sync**](./incremental-append.md), which does not sync data that has already been synced before.
+
+In the **Overwrite** variant, new syncs will destroy all data in the existing destination table and then pull the new data in. Therefore, data that has been removed from the source after an old sync will be deleted in the destination table.
+
+## Example Behavior
 
 On the nth sync of a full refresh connection:
 


### PR DESCRIPTION
## Main Changes
- We didn't have clear, non-example, definitions for the `Full Refresh` sync modes, so I added them in.