### PR TITLE
Add Bing Ads to connector grading table

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -20,6 +20,7 @@ Airbyte uses a grading system for connectors to help users understand what to ex
 |[AWS CloudTrail](./sources/aws-cloudtrail.md)| Beta |
 |[Braintree](./sources/braintree.md)| Alpha |
 |[BigQuery](./sources/bigquery.md)| Beta |
+|[Bing Ads](./sources/bing-ads.md)| Beta |
 |[Cart](./sources/cart.md)| Beta |
 |[Chargebee](./sources/chargebee.md)| Alpha |
 |[ClickHouse](./sources/clickhouse.md)| Beta |

--- a/docs/integrations/sources/shortio.md
+++ b/docs/integrations/sources/shortio.md
@@ -1,4 +1,4 @@
-# Shortio
+# Short.io
 
 ## Sync overview
 


### PR DESCRIPTION
## Main Changes
- Bing Ads seems to be missing from the Connector Grading table

## Secondary Changes
- Fix title of Short.io to add the period