### PR TITLE
:bug: Python tempales: add default timezone for Alpine images

### DIFF
--- a/airbyte-integrations/connector-templates/destination-python/Dockerfile
+++ b/airbyte-integrations/connector-templates/destination-python/Dockerfile
@@ -1,25 +1,30 @@
 FROM python:3.7.11-alpine3.14 as base
 
-# build and load all requirements 
+# build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
 # upgrade pip to the latest version
 RUN apk --no-cache upgrade \
-    && pip install --upgrade pip
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata
+
 
 COPY setup.py ./
-# install necessary packages to a temporary folder 
+# install necessary packages to a temporary folder
 RUN pip install --prefix=/install .
 
-# build a clean environment  
+# build a clean environment
 FROM base
 WORKDIR /airbyte/integration_code
 
 # copy all loaded and built libraries to a pure basic image
 COPY --from=builder /install /usr/local
+# add default timezone settings
+COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN echo "Etc/UTC" > /etc/timezone
 
-# Bash is installed for more convenient debugging.
+# bash is installed for more convenient debugging.
 RUN apk --no-cache add bash
 
 # copy payload code only

--- a/airbyte-integrations/connector-templates/source-python-http-api/Dockerfile
+++ b/airbyte-integrations/connector-templates/source-python-http-api/Dockerfile
@@ -1,25 +1,30 @@
 FROM python:3.7.11-alpine3.14 as base
 
-# build and load all requirements 
+# build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
 # upgrade pip to the latest version
 RUN apk --no-cache upgrade \
-    && pip install --upgrade pip
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata
+
 
 COPY setup.py ./
-# install necessary packages to a temporary folder 
+# install necessary packages to a temporary folder
 RUN pip install --prefix=/install .
 
-# build a clean environment  
+# build a clean environment
 FROM base
 WORKDIR /airbyte/integration_code
 
 # copy all loaded and built libraries to a pure basic image
 COPY --from=builder /install /usr/local
+# add default timezone settings
+COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN echo "Etc/UTC" > /etc/timezone
 
-# Bash is installed for more convenient debugging.
+# bash is installed for more convenient debugging.
 RUN apk --no-cache add bash
 
 # copy payload code only

--- a/airbyte-integrations/connector-templates/source-python/Dockerfile
+++ b/airbyte-integrations/connector-templates/source-python/Dockerfile
@@ -6,7 +6,9 @@ WORKDIR /airbyte/integration_code
 
 # upgrade pip to the latest version
 RUN apk --no-cache upgrade \
-    && pip install --upgrade pip
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata
+
 
 COPY setup.py ./
 # install necessary packages to a temporary folder
@@ -18,8 +20,11 @@ WORKDIR /airbyte/integration_code
 
 # copy all loaded and built libraries to a pure basic image
 COPY --from=builder /install /usr/local
+# add default timezone settings
+COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN echo "Etc/UTC" > /etc/timezone
 
-# Bash is installed for more convenient debugging.
+# bash is installed for more convenient debugging.
 RUN apk --no-cache add bash
 
 # copy payload code only

--- a/airbyte-integrations/connectors/source-scaffold-source-http/Dockerfile
+++ b/airbyte-integrations/connectors/source-scaffold-source-http/Dockerfile
@@ -1,25 +1,30 @@
 FROM python:3.7.11-alpine3.14 as base
 
-# build and load all requirements 
+# build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
 # upgrade pip to the latest version
 RUN apk --no-cache upgrade \
-    && pip install --upgrade pip
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata
+
 
 COPY setup.py ./
-# install necessary packages to a temporary folder 
+# install necessary packages to a temporary folder
 RUN pip install --prefix=/install .
 
-# build a clean environment  
+# build a clean environment
 FROM base
 WORKDIR /airbyte/integration_code
 
 # copy all loaded and built libraries to a pure basic image
 COPY --from=builder /install /usr/local
+# add default timezone settings
+COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN echo "Etc/UTC" > /etc/timezone
 
-# Bash is installed for more convenient debugging.
+# bash is installed for more convenient debugging.
 RUN apk --no-cache add bash
 
 # copy payload code only

--- a/airbyte-integrations/connectors/source-scaffold-source-python/Dockerfile
+++ b/airbyte-integrations/connectors/source-scaffold-source-python/Dockerfile
@@ -6,7 +6,9 @@ WORKDIR /airbyte/integration_code
 
 # upgrade pip to the latest version
 RUN apk --no-cache upgrade \
-    && pip install --upgrade pip
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata
+
 
 COPY setup.py ./
 # install necessary packages to a temporary folder
@@ -18,8 +20,11 @@ WORKDIR /airbyte/integration_code
 
 # copy all loaded and built libraries to a pure basic image
 COPY --from=builder /install /usr/local
+# add default timezone settings
+COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN echo "Etc/UTC" > /etc/timezone
 
-# Bash is installed for more convenient debugging.
+# bash is installed for more convenient debugging.
 RUN apk --no-cache add bash
 
 # copy payload code only


### PR DESCRIPTION
## What
By default the Alpine base image doesn't include any timezone information thus the lib 'pendulum' returns the following errors for all timezone operations.
`RuntimeError('Unable to find any timezone configuration')`

## How
We can add missing settings to all Python Alpine base images. The default timezone value: "Etc/UTC" as for standard "slim" Docker images.



## Pre-merge Checklist

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [x] Issue acceptance criteria met
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [x] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [x] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [x] Documentation which references the generator is updated as needed.
</p>
</details>
