### PR TITLE
Make the scheduler wait for the server early on

### DIFF
--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
@@ -194,18 +194,7 @@ public class SchedulerApp {
     }
   }
 
-  public static void main(String[] args) throws IOException, InterruptedException {
-
-    final Configs configs = new EnvConfigs();
-
-    MDC.put(LogClientSingleton.WORKSPACE_MDC_KEY, LogClientSingleton.getSchedulerLogsRoot(configs).toString());
-
-    final Path workspaceRoot = configs.getWorkspaceRoot();
-    LOGGER.info("workspaceRoot = " + workspaceRoot);
-
-    final String temporalHost = configs.getTemporalHost();
-    LOGGER.info("temporalHost = " + temporalHost);
-
+  private static void waitForServer(Configs configs) throws InterruptedException {
     final AirbyteApiClient apiClient = new AirbyteApiClient(
         new io.airbyte.api.client.invoker.ApiClient().setScheme("http")
             .setHost(configs.getAirbyteApiHost())
@@ -222,6 +211,22 @@ public class SchedulerApp {
         Thread.sleep(2000);
       }
     }
+  }
+
+  public static void main(String[] args) throws IOException, InterruptedException {
+
+    final Configs configs = new EnvConfigs();
+
+    MDC.put(LogClientSingleton.WORKSPACE_MDC_KEY, LogClientSingleton.getSchedulerLogsRoot(configs).toString());
+
+    final Path workspaceRoot = configs.getWorkspaceRoot();
+    LOGGER.info("workspaceRoot = " + workspaceRoot);
+
+    final String temporalHost = configs.getTemporalHost();
+    LOGGER.info("temporalHost = " + temporalHost);
+
+    // Wait for the server to initialize the database and run migration
+    waitForServer(configs);
 
     LOGGER.info("Creating Job DB connection pool...");
     final Database jobDatabase = new JobsDatabaseInstance(

--- a/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/DefaultSynchronousSchedulerClient.java
+++ b/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/DefaultSynchronousSchedulerClient.java
@@ -87,7 +87,6 @@ public class DefaultSynchronousSchedulerClient implements SynchronousSchedulerCl
         .withConnectionConfiguration(source.getConfiguration())
         .withDockerImage(dockerImage);
 
-
     return execute(
         ConfigType.DISCOVER_SCHEMA,
         source.getSourceDefinitionId(),

--- a/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/DefaultSynchronousSchedulerClient.java
+++ b/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/DefaultSynchronousSchedulerClient.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.UUID;
 import java.util.function.Function;
+import javax.annotation.Nullable;
 
 public class DefaultSynchronousSchedulerClient implements SynchronousSchedulerClient {
 
@@ -61,9 +62,8 @@ public class DefaultSynchronousSchedulerClient implements SynchronousSchedulerCl
 
     return execute(
         ConfigType.CHECK_CONNECTION_SOURCE,
-        source.getSourceId(),
-        jobId -> temporalClient.submitCheckConnection(UUID.randomUUID(), 0, jobCheckConnectionConfig),
         source.getSourceDefinitionId(),
+        jobId -> temporalClient.submitCheckConnection(UUID.randomUUID(), 0, jobCheckConnectionConfig),
         source.getWorkspaceId());
   }
 
@@ -76,9 +76,8 @@ public class DefaultSynchronousSchedulerClient implements SynchronousSchedulerCl
 
     return execute(
         ConfigType.CHECK_CONNECTION_DESTINATION,
-        destination.getDestinationId(),
-        jobId -> temporalClient.submitCheckConnection(UUID.randomUUID(), 0, jobCheckConnectionConfig),
         destination.getDestinationDefinitionId(),
+        jobId -> temporalClient.submitCheckConnection(UUID.randomUUID(), 0, jobCheckConnectionConfig),
         destination.getWorkspaceId());
   }
 
@@ -88,11 +87,11 @@ public class DefaultSynchronousSchedulerClient implements SynchronousSchedulerCl
         .withConnectionConfiguration(source.getConfiguration())
         .withDockerImage(dockerImage);
 
+
     return execute(
         ConfigType.DISCOVER_SCHEMA,
-        source.getSourceId(),
-        jobId -> temporalClient.submitDiscoverSchema(UUID.randomUUID(), 0, jobDiscoverCatalogConfig),
         source.getSourceDefinitionId(),
+        jobId -> temporalClient.submitDiscoverSchema(UUID.randomUUID(), 0, jobDiscoverCatalogConfig),
         source.getWorkspaceId());
   }
 
@@ -104,54 +103,54 @@ public class DefaultSynchronousSchedulerClient implements SynchronousSchedulerCl
         ConfigType.GET_SPEC,
         null,
         jobId -> temporalClient.submitGetSpec(UUID.randomUUID(), 0, jobSpecConfig),
-        null,
         null);
   }
 
-  // config id can be empty
   @VisibleForTesting
   <T> SynchronousResponse<T> execute(ConfigType configType,
-                                     UUID configId,
+                                     @Nullable UUID connectorDefinitionId,
                                      Function<UUID, TemporalResponse<T>> executor,
-                                     UUID jobTrackerId,
                                      UUID workspaceId) {
     final long createdAt = Instant.now().toEpochMilli();
     final UUID jobId = UUID.randomUUID();
     try {
-      track(jobId, configType, jobTrackerId, workspaceId, JobState.STARTED, null);
+      track(jobId, configType, connectorDefinitionId, workspaceId, JobState.STARTED, null);
       final TemporalResponse<T> operationOutput = executor.apply(jobId);
       JobState outputState = operationOutput.getMetadata().isSucceeded() ? JobState.SUCCEEDED : JobState.FAILED;
-      track(jobId, configType, jobTrackerId, workspaceId, outputState, operationOutput.getOutput().orElse(null));
+      track(jobId, configType, connectorDefinitionId, workspaceId, outputState, operationOutput.getOutput().orElse(null));
       final long endedAt = Instant.now().toEpochMilli();
 
       return SynchronousResponse.fromTemporalResponse(
           operationOutput,
           jobId,
           configType,
-          configId,
+          connectorDefinitionId,
           createdAt,
           endedAt);
     } catch (RuntimeException e) {
-      track(jobId, configType, jobTrackerId, workspaceId, JobState.FAILED, null);
+      track(jobId, configType, connectorDefinitionId, workspaceId, JobState.FAILED, null);
       throw e;
     }
   }
 
-  private <T> void track(UUID jobId, ConfigType configType, UUID jobTrackerId, UUID workspaceId, JobState jobState, T value) {
+  /**
+   * @param connectorDefinitionId either source or destination definition id
+   */
+  private <T> void track(UUID jobId, ConfigType configType, UUID connectorDefinitionId, UUID workspaceId, JobState jobState, T value) {
     switch (configType) {
       case CHECK_CONNECTION_SOURCE -> jobTracker.trackCheckConnectionSource(
           jobId,
-          jobTrackerId,
+          connectorDefinitionId,
           workspaceId,
           jobState,
           (StandardCheckConnectionOutput) value);
       case CHECK_CONNECTION_DESTINATION -> jobTracker.trackCheckConnectionDestination(
           jobId,
+          connectorDefinitionId,
           workspaceId,
-          jobTrackerId,
           jobState,
           (StandardCheckConnectionOutput) value);
-      case DISCOVER_SCHEMA -> jobTracker.trackDiscover(jobId, jobTrackerId, workspaceId, jobState);
+      case DISCOVER_SCHEMA -> jobTracker.trackDiscover(jobId, connectorDefinitionId, workspaceId, jobState);
       case GET_SPEC -> {
         // skip tracking for get spec to avoid noise.
       }

--- a/airbyte-scheduler/client/src/test/java/io/airbyte/scheduler/client/DefaultSynchronousSchedulerClientTest.java
+++ b/airbyte-scheduler/client/src/test/java/io/airbyte/scheduler/client/DefaultSynchronousSchedulerClientTest.java
@@ -109,63 +109,60 @@ class DefaultSynchronousSchedulerClientTest {
     @SuppressWarnings("unchecked")
     @Test
     void testExecuteJobSuccess() {
-      final UUID configId = UUID.randomUUID();
-      final UUID jobTrackingId = UUID.randomUUID();
+      final UUID sourceDefinitionId = UUID.randomUUID();
       final Function<UUID, TemporalResponse<String>> function = mock(Function.class);
       when(function.apply(any(UUID.class))).thenReturn(new TemporalResponse<>("hello", createMetadata(true)));
 
       final SynchronousResponse<String> response = schedulerClient
-          .execute(ConfigType.DISCOVER_SCHEMA, configId, function, jobTrackingId, WORKSPACE_ID);
+          .execute(ConfigType.DISCOVER_SCHEMA, sourceDefinitionId, function, WORKSPACE_ID);
 
       assertNotNull(response);
       assertEquals("hello", response.getOutput());
       assertEquals(ConfigType.DISCOVER_SCHEMA, response.getMetadata().getConfigType());
       assertTrue(response.getMetadata().getConfigId().isPresent());
-      assertEquals(configId, response.getMetadata().getConfigId().get());
+      assertEquals(sourceDefinitionId, response.getMetadata().getConfigId().get());
       assertTrue(response.getMetadata().isSucceeded());
       assertEquals(LOG_PATH, response.getMetadata().getLogPath());
 
-      verify(jobTracker).trackDiscover(any(UUID.class), eq(jobTrackingId), eq(WORKSPACE_ID), eq(JobState.STARTED));
-      verify(jobTracker).trackDiscover(any(UUID.class), eq(jobTrackingId), eq(WORKSPACE_ID), eq(JobState.SUCCEEDED));
+      verify(jobTracker).trackDiscover(any(UUID.class), eq(sourceDefinitionId), eq(WORKSPACE_ID), eq(JobState.STARTED));
+      verify(jobTracker).trackDiscover(any(UUID.class), eq(sourceDefinitionId), eq(WORKSPACE_ID), eq(JobState.SUCCEEDED));
     }
 
     @SuppressWarnings("unchecked")
     @Test
     void testExecuteJobFailure() {
-      final UUID configId = UUID.randomUUID();
-      final UUID jobTrackingId = UUID.randomUUID();
+      final UUID sourceDefinitionId = UUID.randomUUID();
       final Function<UUID, TemporalResponse<String>> function = mock(Function.class);
       when(function.apply(any(UUID.class))).thenReturn(new TemporalResponse<>(null, createMetadata(false)));
 
       final SynchronousResponse<String> response = schedulerClient
-          .execute(ConfigType.DISCOVER_SCHEMA, configId, function, jobTrackingId, WORKSPACE_ID);
+          .execute(ConfigType.DISCOVER_SCHEMA, sourceDefinitionId, function, WORKSPACE_ID);
 
       assertNotNull(response);
       assertNull(response.getOutput());
       assertEquals(ConfigType.DISCOVER_SCHEMA, response.getMetadata().getConfigType());
       assertTrue(response.getMetadata().getConfigId().isPresent());
-      assertEquals(configId, response.getMetadata().getConfigId().get());
+      assertEquals(sourceDefinitionId, response.getMetadata().getConfigId().get());
       assertFalse(response.getMetadata().isSucceeded());
       assertEquals(LOG_PATH, response.getMetadata().getLogPath());
 
-      verify(jobTracker).trackDiscover(any(UUID.class), eq(jobTrackingId), eq(WORKSPACE_ID), eq(JobState.STARTED));
-      verify(jobTracker).trackDiscover(any(UUID.class), eq(jobTrackingId), eq(WORKSPACE_ID), eq(JobState.FAILED));
+      verify(jobTracker).trackDiscover(any(UUID.class), eq(sourceDefinitionId), eq(WORKSPACE_ID), eq(JobState.STARTED));
+      verify(jobTracker).trackDiscover(any(UUID.class), eq(sourceDefinitionId), eq(WORKSPACE_ID), eq(JobState.FAILED));
     }
 
     @SuppressWarnings("unchecked")
     @Test
     void testExecuteRuntimeException() {
-      final UUID configId = UUID.randomUUID();
-      final UUID jobTrackingId = UUID.randomUUID();
+      final UUID sourceDefinitionId = UUID.randomUUID();
       final Function<UUID, TemporalResponse<String>> function = mock(Function.class);
       when(function.apply(any(UUID.class))).thenThrow(new RuntimeException());
 
       assertThrows(
           RuntimeException.class,
-          () -> schedulerClient.execute(ConfigType.DISCOVER_SCHEMA, configId, function, jobTrackingId, WORKSPACE_ID));
+          () -> schedulerClient.execute(ConfigType.DISCOVER_SCHEMA, sourceDefinitionId, function, WORKSPACE_ID));
 
-      verify(jobTracker).trackDiscover(any(UUID.class), eq(jobTrackingId), eq(WORKSPACE_ID), eq(JobState.STARTED));
-      verify(jobTracker).trackDiscover(any(UUID.class), eq(jobTrackingId), eq(WORKSPACE_ID), eq(JobState.FAILED));
+      verify(jobTracker).trackDiscover(any(UUID.class), eq(sourceDefinitionId), eq(WORKSPACE_ID), eq(JobState.STARTED));
+      verify(jobTracker).trackDiscover(any(UUID.class), eq(sourceDefinitionId), eq(WORKSPACE_ID), eq(JobState.FAILED));
     }
 
   }


### PR DESCRIPTION
## What
- Make the schedule to wait for the server before it constructs any database.
- Fix a bug in the job tracker that passes in workspace id as connector definition id.
