### PR TITLE
Revert "add data volume again (#5715)"

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,7 +70,6 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - workspace:${WORKSPACE_ROOT}
       - ${LOCAL_ROOT}:${LOCAL_ROOT}
-      - data:${CONFIG_ROOT}
   server:
     image: airbyte/server:${VERSION}
     logging: *default-logging

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -144,6 +144,9 @@ services:
 volumes:
   workspace:
     name: ${WORKSPACE_DOCKER_MOUNT}
+  # the data volume is only needed for backward compatibility; when users upgrade
+  # from an old Airbyte version that relies on file-based configs, the server needs
+  # to read this volume to copy their configs to the database
   data:
     name: ${DATA_DOCKER_MOUNT}
   db:


### PR DESCRIPTION
This reverts commit 32c2a6b1ad4c14ee0c1456888603523a053aca6c. Since we have a new release, v0.29.13-alpha, this temporary fix is no longer needed.
