### PR TITLE
🎉 Redshift Destination: Disable STATUPDATE flag when using S3 staging to speed up performance

### DIFF
--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftStreamCopier.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftStreamCopier.java
@@ -53,7 +53,8 @@ public class RedshiftStreamCopier extends S3StreamCopier {
     final var copyQuery = String.format(
         "COPY %s.%s FROM '%s'\n"
             + "CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'\n"
-            + "CSV REGION '%s' TIMEFORMAT 'auto';\n",
+            + "CSV REGION '%s' TIMEFORMAT 'auto'\n"
+            + "STATUPDATE OFF;\n",
         schema,
         tableName,
         s3FileLocation,


### PR DESCRIPTION
## What
*Describe what the change is solving*

Apply optimization to redshift    
#4871 
## How
*Describe the solution*

I changed the Redshift COPY command to speed up the process to copy csv files from staging s3 bucket to redshift. Specifically, I set the STATUPDATE parameter flag to be off. The STATUPDATE flag is responsible for running statistical computation to optimize future queries on the table. Since the table in our use case is temporary and the queries, computing these statisitics creates an unnecessary overhead. The performance saw an around 10% boost during my test runs.

<img width="829" alt="redshift-improvement" src="https://user-images.githubusercontent.com/12986649/131418288-ce49b49f-9474-4ac1-a1e5-75fe63ea3c26.png">
## Recommended reading order
1. `RedshiftStreamCopier.java`

## Pre-merge Checklist
#### Community member or Airbyter
  
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [x] Code reviews completed
- [x] Documentation updated 
    - [x] Connector's `README.md`
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [x] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [x] Create a non-forked branch based on this PR and test the below items on it
- [x] Build is successful
- [x] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [x] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [x] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)