### PR TITLE
Implement databricks connector as a copy destination

### DIFF
--- a/airbyte-integrations/connectors/destination-databricks/build.gradle
+++ b/airbyte-integrations/connectors/destination-databricks/build.gradle
@@ -15,6 +15,14 @@ dependencies {
     implementation project(':airbyte-integrations:bases:base-java')
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     implementation project(':airbyte-integrations:connectors:destination-jdbc')
+    implementation project(':airbyte-integrations:connectors:destination-s3')
+
+    // parquet
+    implementation group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.0'
+    implementation group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.3.0'
+    implementation group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: '3.3.0'
+    implementation group: 'org.apache.parquet', name: 'parquet-avro', version: '1.12.0'
+    implementation group: 'tech.allegro.schema.json2avro', name: 'converter', version: '0.2.10'
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-databricks')

--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksStreamCopier.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksStreamCopier.java
@@ -1,0 +1,114 @@
+package io.airbyte.integrations.destination.databricks;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airbyte.db.jdbc.JdbcDatabase;
+import io.airbyte.integrations.destination.ExtendedNameTransformer;
+import io.airbyte.integrations.destination.jdbc.SqlOperations;
+import io.airbyte.integrations.destination.jdbc.copy.StreamCopier;
+import io.airbyte.integrations.destination.jdbc.copy.s3.S3Config;
+import io.airbyte.integrations.destination.s3.S3DestinationConfig;
+import io.airbyte.integrations.destination.s3.parquet.S3ParquetFormatConfig;
+import io.airbyte.integrations.destination.s3.parquet.S3ParquetWriter;
+import io.airbyte.integrations.destination.s3.writer.S3WriterFactory;
+import io.airbyte.protocol.models.AirbyteRecordMessage;
+import io.airbyte.protocol.models.AirbyteStream;
+import io.airbyte.protocol.models.ConfiguredAirbyteStream;
+import java.sql.Timestamp;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This implementation is similar to {@link io.airbyte.integrations.destination.jdbc.copy.s3.S3StreamCopier}.
+ * The difference is that this implementation creates Parquet staging files, instead of CSV ones.
+ */
+public class DatabricksStreamCopier implements StreamCopier {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DatabricksStreamCopier.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final AmazonS3 s3Client;
+  private final S3Config s3Config;
+  private final String tmpTableName;
+  private final AirbyteStream stream;
+  private final JdbcDatabase db;
+  private final ExtendedNameTransformer nameTransformer;
+  private final SqlOperations sqlOperations;
+  private final S3ParquetWriter parquetWriter;
+
+  public DatabricksStreamCopier(String stagingFolder,
+                                String schema,
+                                ConfiguredAirbyteStream configuredStream,
+                                AmazonS3 s3Client,
+                                JdbcDatabase db,
+                                S3Config s3Config,
+                                ExtendedNameTransformer nameTransformer,
+                                SqlOperations sqlOperations,
+                                S3WriterFactory writerFactory,
+                                Timestamp uploadTime) throws Exception {
+    this.stream = configuredStream.getStream();
+    this.db = db;
+    this.nameTransformer = nameTransformer;
+    this.sqlOperations = sqlOperations;
+    this.tmpTableName = nameTransformer.getTmpTableName(stream.getName());
+    this.s3Client = s3Client;
+    this.s3Config = s3Config;
+    this.parquetWriter = (S3ParquetWriter) writerFactory
+        .create(getS3DestinationConfig(s3Config, stagingFolder), s3Client, configuredStream, uploadTime);
+  }
+
+  @Override
+  public void write(UUID id, AirbyteRecordMessage recordMessage) throws Exception {
+    parquetWriter.write(id, recordMessage);
+  }
+
+  @Override
+  public void closeStagingUploader(boolean hasFailed) throws Exception {
+    parquetWriter.close(hasFailed);
+  }
+
+  @Override
+  public void createTemporaryTable() throws Exception {
+
+  }
+
+  @Override
+  public void copyStagingFileToTemporaryTable() throws Exception {
+
+  }
+
+  @Override
+  public void createDestinationSchema() throws Exception {
+
+  }
+
+  @Override
+  public String createDestinationTable() throws Exception {
+    return null;
+  }
+
+  @Override
+  public String generateMergeStatement(String destTableName) throws Exception {
+    return null;
+  }
+
+  @Override
+  public void removeFileAndDropTmpTable() throws Exception {
+
+  }
+
+  private S3DestinationConfig getS3DestinationConfig(S3Config s3Config, String stagingFolder) {
+    return new S3DestinationConfig(
+        s3Config.getEndpoint(),
+        s3Config.getBucketName(),
+        stagingFolder,
+        s3Config.getRegion(),
+        s3Config.getAccessKeyId(),
+        s3Config.getSecretAccessKey(),
+        // use default parquet format config
+        new S3ParquetFormatConfig(MAPPER.createObjectNode())
+    );
+  }
+
+}

--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksStreamCopierFactory.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksStreamCopierFactory.java
@@ -1,0 +1,43 @@
+package io.airbyte.integrations.destination.databricks;
+
+import com.amazonaws.services.s3.AmazonS3;
+import io.airbyte.db.jdbc.JdbcDatabase;
+import io.airbyte.integrations.destination.ExtendedNameTransformer;
+import io.airbyte.integrations.destination.jdbc.SqlOperations;
+import io.airbyte.integrations.destination.jdbc.copy.StreamCopier;
+import io.airbyte.integrations.destination.jdbc.copy.StreamCopierFactory;
+import io.airbyte.integrations.destination.jdbc.copy.s3.S3Config;
+import io.airbyte.integrations.destination.jdbc.copy.s3.S3StreamCopier;
+import io.airbyte.integrations.destination.s3.parquet.S3ParquetWriter;
+import io.airbyte.integrations.destination.s3.writer.ProductionWriterFactory;
+import io.airbyte.integrations.destination.s3.writer.S3WriterFactory;
+import io.airbyte.protocol.models.AirbyteStream;
+import io.airbyte.protocol.models.ConfiguredAirbyteStream;
+import java.sql.Timestamp;
+
+public class DatabricksStreamCopierFactory implements StreamCopierFactory<S3Config> {
+
+  @Override
+  public StreamCopier create(String configuredSchema,
+                             S3Config s3Config,
+                             String stagingFolder,
+                             ConfiguredAirbyteStream configuredStream,
+                             ExtendedNameTransformer nameTransformer,
+                             JdbcDatabase db,
+                             SqlOperations sqlOperations) {
+    try {
+      AirbyteStream stream = configuredStream.getStream();
+      String schema = StreamCopierFactory.getSchema(stream, configuredSchema, nameTransformer);
+      AmazonS3 s3Client = S3StreamCopier.getAmazonS3(s3Config);
+      S3WriterFactory writerFactory = new ProductionWriterFactory();
+      Timestamp uploadTimestamp = new Timestamp(System.currentTimeMillis());
+
+      return new DatabricksStreamCopier(
+          stagingFolder, schema, configuredStream, s3Client, db, s3Config, nameTransformer, sqlOperations, writerFactory, uploadTimestamp);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+  }
+
+}

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/CopyConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/CopyConsumerFactory.java
@@ -24,7 +24,6 @@
 
 package io.airbyte.integrations.destination.jdbc.copy;
 
-import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
 import io.airbyte.integrations.base.AirbyteStreamNameNamespacePair;
@@ -37,8 +36,6 @@ import io.airbyte.integrations.destination.jdbc.SqlOperations;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
-import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -94,8 +91,7 @@ public class CopyConsumerFactory {
     for (var configuredStream : catalog.getStreams()) {
       var stream = configuredStream.getStream();
       var pair = AirbyteStreamNameNamespacePair.fromAirbyteSteam(stream);
-      var syncMode = configuredStream.getDestinationSyncMode();
-      var copier = streamCopierFactory.create(defaultSchema, config, stagingFolder, syncMode, stream, namingResolver, database, sqlOperations);
+      var copier = streamCopierFactory.create(defaultSchema, config, stagingFolder, configuredStream, namingResolver, database, sqlOperations);
 
       pairToCopier.put(pair, copier);
     }
@@ -116,8 +112,7 @@ public class CopyConsumerFactory {
         if (sqlOperations.isValidData(recordMessage.getData())) {
           // TODO Truncate json data instead of throwing whole record away?
           // or should we upload it into a special rejected record folder in s3 instead?
-          var emittedAt = Timestamp.from(Instant.ofEpochMilli(recordMessage.getEmittedAt()));
-          pairToCopier.get(pair).write(id, Jsons.serialize(recordMessage.getData()), emittedAt);
+          pairToCopier.get(pair).write(id, recordMessage);
         } else {
           pairToIgnoredRecordCount.put(pair, pairToIgnoredRecordCount.getOrDefault(pair, 0L) + 1L);
         }

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/StreamCopier.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/StreamCopier.java
@@ -24,6 +24,7 @@
 
 package io.airbyte.integrations.destination.jdbc.copy;
 
+import io.airbyte.protocol.models.AirbyteRecordMessage;
 import java.sql.Timestamp;
 import java.util.UUID;
 
@@ -36,7 +37,7 @@ public interface StreamCopier {
   /**
    * Writes a value to a staging file for the stream.
    */
-  void write(UUID id, String jsonDataString, Timestamp emittedAt) throws Exception;
+  void write(UUID id, AirbyteRecordMessage recordMessage) throws Exception;
 
   /**
    * Closes the writer for the stream to the staging persistence. This method should block until all

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/StreamCopierFactory.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/StreamCopierFactory.java
@@ -28,6 +28,7 @@ import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.destination.ExtendedNameTransformer;
 import io.airbyte.integrations.destination.jdbc.SqlOperations;
 import io.airbyte.protocol.models.AirbyteStream;
+import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.DestinationSyncMode;
 
 public interface StreamCopierFactory<T> {
@@ -35,10 +36,17 @@ public interface StreamCopierFactory<T> {
   StreamCopier create(String configuredSchema,
                       T config,
                       String stagingFolder,
-                      DestinationSyncMode syncMode,
-                      AirbyteStream stream,
+                      ConfiguredAirbyteStream configuredStream,
                       ExtendedNameTransformer nameTransformer,
                       JdbcDatabase db,
                       SqlOperations sqlOperations);
+
+  static String getSchema(AirbyteStream stream, String configuredSchema, ExtendedNameTransformer nameTransformer) {
+    if (stream.getNamespace() != null) {
+      return nameTransformer.convertStreamName(stream.getNamespace());
+    } else {
+      return nameTransformer.convertStreamName(configuredSchema);
+    }
+  }
 
 }

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/gcs/GcsStreamCopier.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/gcs/GcsStreamCopier.java
@@ -30,10 +30,12 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.destination.ExtendedNameTransformer;
 import io.airbyte.integrations.destination.jdbc.SqlOperations;
 import io.airbyte.integrations.destination.jdbc.copy.StreamCopier;
+import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.protocol.models.DestinationSyncMode;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -44,6 +46,7 @@ import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.UUID;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
@@ -103,8 +106,10 @@ public abstract class GcsStreamCopier implements StreamCopier {
   }
 
   @Override
-  public void write(UUID id, String jsonDataString, Timestamp emittedAt) throws Exception {
-    csvPrinter.printRecord(id, jsonDataString, emittedAt);
+  public void write(UUID id, AirbyteRecordMessage recordMessage) throws Exception {
+    csvPrinter.printRecord(id,
+        Jsons.serialize(recordMessage.getData()),
+        Timestamp.from(Instant.ofEpochMilli(recordMessage.getEmittedAt())));
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/gcs/GcsStreamCopierFactory.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/gcs/GcsStreamCopierFactory.java
@@ -28,12 +28,12 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import io.airbyte.db.jdbc.JdbcDatabase;
-import io.airbyte.integrations.base.AirbyteStreamNameNamespacePair;
 import io.airbyte.integrations.destination.ExtendedNameTransformer;
 import io.airbyte.integrations.destination.jdbc.SqlOperations;
 import io.airbyte.integrations.destination.jdbc.copy.StreamCopier;
 import io.airbyte.integrations.destination.jdbc.copy.StreamCopierFactory;
 import io.airbyte.protocol.models.AirbyteStream;
+import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.DestinationSyncMode;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -47,14 +47,14 @@ public abstract class GcsStreamCopierFactory implements StreamCopierFactory<GcsC
   public StreamCopier create(String configuredSchema,
                              GcsConfig gcsConfig,
                              String stagingFolder,
-                             DestinationSyncMode syncMode,
-                             AirbyteStream stream,
+                             ConfiguredAirbyteStream configuredStream,
                              ExtendedNameTransformer nameTransformer,
                              JdbcDatabase db,
                              SqlOperations sqlOperations) {
     try {
-      var pair = AirbyteStreamNameNamespacePair.fromAirbyteSteam(stream);
-      var schema = getSchema(stream, configuredSchema, nameTransformer);
+      AirbyteStream stream = configuredStream.getStream();
+      DestinationSyncMode syncMode = configuredStream.getDestinationSyncMode();
+      String schema = StreamCopierFactory.getSchema(stream, configuredSchema, nameTransformer);
 
       InputStream credentialsInputStream = new ByteArrayInputStream(gcsConfig.getCredentialsJson().getBytes());
       GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsInputStream);
@@ -64,7 +64,7 @@ public abstract class GcsStreamCopierFactory implements StreamCopierFactory<GcsC
           .build()
           .getService();
 
-      return create(stagingFolder, syncMode, schema, pair.getName(), storageClient, db, gcsConfig, nameTransformer, sqlOperations);
+      return create(stagingFolder, syncMode, schema, stream.getName(), storageClient, db, gcsConfig, nameTransformer, sqlOperations);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -83,13 +83,5 @@ public abstract class GcsStreamCopierFactory implements StreamCopierFactory<GcsC
                                       ExtendedNameTransformer nameTransformer,
                                       SqlOperations sqlOperations)
       throws Exception;
-
-  private String getSchema(AirbyteStream stream, String configuredSchema, ExtendedNameTransformer nameTransformer) {
-    if (stream.getNamespace() != null) {
-      return nameTransformer.convertStreamName(stream.getNamespace());
-    } else {
-      return nameTransformer.convertStreamName(configuredSchema);
-    }
-  }
 
 }

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3StreamCopier.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3StreamCopier.java
@@ -32,16 +32,19 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.destination.ExtendedNameTransformer;
 import io.airbyte.integrations.destination.jdbc.SqlOperations;
 import io.airbyte.integrations.destination.jdbc.copy.StreamCopier;
+import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.protocol.models.DestinationSyncMode;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.UUID;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
@@ -119,8 +122,10 @@ public abstract class S3StreamCopier implements StreamCopier {
   }
 
   @Override
-  public void write(UUID id, String jsonDataString, Timestamp emittedAt) throws Exception {
-    csvPrinter.printRecord(id, jsonDataString, emittedAt);
+  public void write(UUID id, AirbyteRecordMessage recordMessage) throws Exception {
+    csvPrinter.printRecord(id,
+        Jsons.serialize(recordMessage.getData()),
+        Timestamp.from(Instant.ofEpochMilli(recordMessage.getEmittedAt())));
   }
 
   @Override
@@ -161,7 +166,7 @@ public abstract class S3StreamCopier implements StreamCopier {
   }
 
   @Override
-  public String generateMergeStatement(String destTableName) throws Exception {
+  public String generateMergeStatement(String destTableName) {
     LOGGER.info("Preparing to merge tmp table {} to dest table: {}, schema: {}, in destination.", tmpTableName, destTableName, schemaName);
     var queries = new StringBuilder();
     if (destSyncMode.equals(DestinationSyncMode.OVERWRITE)) {

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3StreamCopierFactory.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3StreamCopierFactory.java
@@ -26,12 +26,12 @@ package io.airbyte.integrations.destination.jdbc.copy.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
 import io.airbyte.db.jdbc.JdbcDatabase;
-import io.airbyte.integrations.base.AirbyteStreamNameNamespacePair;
 import io.airbyte.integrations.destination.ExtendedNameTransformer;
 import io.airbyte.integrations.destination.jdbc.SqlOperations;
 import io.airbyte.integrations.destination.jdbc.copy.StreamCopier;
 import io.airbyte.integrations.destination.jdbc.copy.StreamCopierFactory;
 import io.airbyte.protocol.models.AirbyteStream;
+import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.DestinationSyncMode;
 
 public abstract class S3StreamCopierFactory implements StreamCopierFactory<S3Config> {
@@ -43,17 +43,17 @@ public abstract class S3StreamCopierFactory implements StreamCopierFactory<S3Con
   public StreamCopier create(String configuredSchema,
                              S3Config s3Config,
                              String stagingFolder,
-                             DestinationSyncMode syncMode,
-                             AirbyteStream stream,
+                             ConfiguredAirbyteStream configuredStream,
                              ExtendedNameTransformer nameTransformer,
                              JdbcDatabase db,
                              SqlOperations sqlOperations) {
     try {
-      var pair = AirbyteStreamNameNamespacePair.fromAirbyteSteam(stream);
-      var schema = getSchema(stream, configuredSchema, nameTransformer);
-      var s3Client = S3StreamCopier.getAmazonS3(s3Config);
+      AirbyteStream stream = configuredStream.getStream();
+      DestinationSyncMode syncMode = configuredStream.getDestinationSyncMode();
+      String schema = StreamCopierFactory.getSchema(stream, configuredSchema, nameTransformer);
+      AmazonS3 s3Client = S3StreamCopier.getAmazonS3(s3Config);
 
-      return create(stagingFolder, syncMode, schema, pair.getName(), s3Client, db, s3Config, nameTransformer, sqlOperations);
+      return create(stagingFolder, syncMode, schema, stream.getName(), s3Client, db, s3Config, nameTransformer, sqlOperations);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -72,13 +72,5 @@ public abstract class S3StreamCopierFactory implements StreamCopierFactory<S3Con
                                       ExtendedNameTransformer nameTransformer,
                                       SqlOperations sqlOperations)
       throws Exception;
-
-  private String getSchema(AirbyteStream stream, String configuredSchema, ExtendedNameTransformer nameTransformer) {
-    if (stream.getNamespace() != null) {
-      return nameTransformer.convertStreamName(stream.getNamespace());
-    } else {
-      return nameTransformer.convertStreamName(configuredSchema);
-    }
-  }
 
 }


### PR DESCRIPTION
- Change the implementation from `JdbcDestination` to `CopyDestination`.
- Follow up PR for #5629.
