### PR TITLE
🐛 Source Facebook Marketing: fix unpack ValueError in remove_params_from_url

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams.py
@@ -50,9 +50,10 @@ def remove_params_from_url(url, params):
     parsed_url = urlparse.urlparse(url)
     res_query = []
     for q in parsed_url.query.split("&"):
-        key, value = q.split("=")
-        if key not in params:
-            res_query.append(f"{key}={value}")
+        if len(q.split("=")) == 2:
+            key, value = q.split("=")
+            if key not in params:
+                res_query.append(f"{key}={value}")
 
     parse_result = parsed_url._replace(query="&".join(res_query))
     return urlparse.urlunparse(parse_result)


### PR DESCRIPTION

## What
According to [comment](https://github.com/airbytehq/airbyte/issues/5190#issuecomment-893878025) in issue #5190  jobs are failing in `streams.remove_params_from_url`:
```
 ERROR () LineGobbler(voidCall):85 -     record["thumbnail_url"] = remove_params_from_url(thumbnail_url, ["_nc_hash", "d"])
2021-08-03 20:02:54 ERROR () LineGobbler(voidCall):85 -   File "/airbyte/integration_code/source_facebook_marketing/streams.py", line 53, in remove_params_from_url
2021-08-03 20:02:54 ERROR () LineGobbler(voidCall):85 -     key, value = q.split("=")
2021-08-03 20:02:54 ERROR () LineGobbler(voidCall):85 - ValueError: not enough values to unpack (expected 2, got 1)
```
`remove_params_from_url` method is used while syncing ad creatives streams. Its records contains thumbnail url, which have query parameters. Some URLs has random values, these values doesn't affect validity of URLs, but breaks SAT, therefore parameters with this values are removed. Error occurred when parameters didn't have values. Additional checking was added.