### PR TITLE
[protocol] add oauth params to connector specification

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.16
+Update generated AirbyteProtocol models to contain [Oauth changes](https://github.com/airbytehq/airbyte/pull/5776). 
+
 ## 0.1.15
 Add \_limit and \_page_size as internal config parameters for SAT
 

--- a/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
+++ b/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
@@ -103,6 +103,25 @@ class DestinationSyncMode(Enum):
     append_dedup = "append_dedup"
 
 
+class OAuth2Specification(BaseModel):
+    oauthFlowInitParameters: Optional[List[List[str]]] = Field(
+        None,
+        description="Pointers to the fields in the ConnectorSpecification which are needed to obtain the initial refresh/access tokens for the OAuth flow. Each inner array represents the path in the ConnectorSpecification of the referenced field.\nFor example.\nAssume the ConnectorSpecification contains params 'app_secret', 'app_id' which are needed to get the initial refresh token. If they are not nested in the config, then the array would look like this [['app_secret'], ['app_id']] If they are nested inside, say, an object called 'auth_params' then this array would be [['auth_params', 'app_secret'], ['auth_params', 'app_id']]",
+    )
+
+
+class AuthType(Enum):
+    oauth2_0 = "oauth2.0"
+
+
+class AuthSpecification(BaseModel):
+    auth_type: Optional[AuthType] = None
+    oauth2Specification: Optional[OAuth2Specification] = Field(
+        None,
+        description="If the connector supports OAuth, this field should be non-null.",
+    )
+
+
 class ConnectorSpecification(BaseModel):
     class Config:
         extra = Extra.allow
@@ -119,6 +138,7 @@ class ConnectorSpecification(BaseModel):
     supported_destination_sync_modes: Optional[List[DestinationSyncMode]] = Field(
         None, description="List of destination sync modes supported by the connector"
     )
+    authSpecification: Optional[AuthSpecification] = None
 
 
 class AirbyteStream(BaseModel):

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -35,7 +35,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.15",
+    version="0.1.16",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -208,6 +208,25 @@ definitions:
       - overwrite
       #- upsert_dedup # TODO chris: SCD Type 1 can be implemented later
       - append_dedup # SCD Type 1 & 2
+  OAuth2Specification:
+    description: An object containing any metadata needed to describe this connector's Oauth flow
+    type: object
+    properties:
+      oauthFlowInitParameters:
+        description: "Pointers to the fields in the ConnectorSpecification which are needed to obtain the initial refresh/access tokens for the OAuth flow.
+        Each inner array represents the path in the ConnectorSpecification of the referenced field.
+
+        For example.
+
+        Assume the ConnectorSpecification contains params 'app_secret', 'app_id' which are needed to get the initial refresh token.
+        If they are not nested in the config, then the array would look like this [['app_secret'], ['app_id']]
+        If they are nested inside, say, an object called 'auth_params' then this array would be [['auth_params', 'app_secret'], ['auth_params', 'app_id']]"
+        type: array
+        items:
+          description: A list of strings which describe the path inside a JSON object for finding the
+          type: array
+          items:
+            type: string
   ConnectorSpecification:
     description: Specification of a connector (source/destination)
     type: object
@@ -250,3 +269,12 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/DestinationSyncMode"
+      authSpecification:
+        type: object
+        properties:
+          auth_type:
+            type: string
+            enum: ["oauth2.0"] # Future auth types should be added here
+          oauth2Specification:
+            description: If the connector supports OAuth, this field should be non-null.
+            "$ref": "#/definitions/OAuth2Specification"


### PR DESCRIPTION
## What
Add Oauth params to connector specification. This will be used by other processes e.g: UI to hide these fields from being user input. In the future this block could be extended to contain a DSL description of a connector's Oauth process, like described [here](https://docs.google.com/document/d/1NQxErM9I_tnnB-juQRGKtNtPhnEg6uE9QCaYcntcPV8/edit?usp=drivesdk).

closes #5632 

## How
Adds the following structs

`authSpecification`: top-level object containing metadata depending on the type of auth a connector follows. Right now this is only oauth2.0. In the future it could be oauth2.1 or openauth. 
`oauth2Specification`: an object containing a 2d list which describes the parameters needed to kick off an oauth2 flow for a connector

## Recommended reading order
There is but one file. 

## Pre-merge Checklist
- [ ] Generate python types in the CDK #5777 