### PR TITLE
fixed the invalid seq for flake8

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/asserts.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/asserts.py
@@ -31,10 +31,10 @@ from typing import List, Mapping
 from airbyte_cdk.models import AirbyteRecordMessage, ConfiguredAirbyteCatalog
 from jsonschema import Draft7Validator, FormatChecker, ValidationError, FormatError
 
-timestamp_regex = re.compile(("^\d{4}-\d?\d-\d?\d" # date
-                              "(\s|T)" # separator
-                              "\d?\d:\d?\d:\d?\d(.\d+)?" # time
-                              ".*$" #timezone
+timestamp_regex = re.compile((r"^\d{4}-\d?\d-\d?\d" # date
+                              r"(\s|T)" # separator
+                              r"\d?\d:\d?\d:\d?\d(.\d+)?" # time
+                              r".*$" #timezone
                              ))
 
 

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/asserts.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/asserts.py
@@ -31,7 +31,12 @@ import pendulum
 from airbyte_cdk.models import AirbyteRecordMessage, ConfiguredAirbyteCatalog
 from jsonschema import Draft7Validator, FormatChecker, FormatError, ValidationError
 
-timestamp_regex = re.compile((r"^\d{4}-\d?\d-\d?\d" r"(\s|T)" r"\d?\d:\d?\d:\d?\d(.\d+)?" r".*$"))  # date  # separator  # time  # timezone
+# fmt: off
+timestamp_regex = re.compile((r"^\d{4}-\d?\d-\d?\d"  # date
+                              r"(\s|T)"  # separator
+                              r"\d?\d:\d?\d:\d?\d(.\d+)?"  # time
+                              r".*$"))  # timezone
+# fmt: on
 
 
 class CustomFormatChecker(FormatChecker):

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/asserts.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/asserts.py
@@ -24,22 +24,17 @@
 
 import logging
 import re
-import pendulum
 from collections import defaultdict
 from typing import List, Mapping
 
+import pendulum
 from airbyte_cdk.models import AirbyteRecordMessage, ConfiguredAirbyteCatalog
-from jsonschema import Draft7Validator, FormatChecker, ValidationError, FormatError
+from jsonschema import Draft7Validator, FormatChecker, FormatError, ValidationError
 
-timestamp_regex = re.compile((r"^\d{4}-\d?\d-\d?\d" # date
-                              r"(\s|T)" # separator
-                              r"\d?\d:\d?\d:\d?\d(.\d+)?" # time
-                              r".*$" #timezone
-                             ))
+timestamp_regex = re.compile((r"^\d{4}-\d?\d-\d?\d" r"(\s|T)" r"\d?\d:\d?\d:\d?\d(.\d+)?" r".*$"))  # date  # separator  # time  # timezone
 
 
 class CustomFormatChecker(FormatChecker):
-
     @staticmethod
     def check_datetime(value: str) -> bool:
         valid_format = timestamp_regex.match(value)
@@ -57,7 +52,6 @@ class CustomFormatChecker(FormatChecker):
                 raise FormatError(f"{instance} has invalid datetime format")
         else:
             return super().check(instance, format)
-
 
 
 def verify_records_schema(


### PR DESCRIPTION
## What
Based on 
`SAT: check records to comply jsonschema format field` pull, the Flake8 check was broken.
(https://github.com/airbytehq/airbyte/pull/5661)
THE ACTUAL ISSUE IS:
https://github.com/airbytehq/airbyte/runs/3483447795?check_suite_focus=true#step:8:1130

## How
Added the `r` specificator to string to the `timestamp_regex` variable inside of `asserts.py`

HOTFIX!