### PR TITLE
SAT: Bump version to `0.1.16` and publish

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.16
+Fix for flake8-ckeck for acceptance-tests: https://github.com/airbytehq/airbyte/pull/5785
+
 ## 0.1.15
 Add detailed logging for acceptance tests: https://github.com/airbytehq/airbyte/pull/5392
 
@@ -34,3 +37,4 @@ Add test whether PKs present and not None if `source_defined_primary_key` define
 
 ## 0.1.5
 Add configurable timeout for the acceptance tests: https://github.com/airbytehq/airbyte/pull/4296
+

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -9,7 +9,7 @@ COPY setup.py ./
 COPY pytest.ini ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.15
+LABEL io.airbyte.version=0.1.16
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin"]


### PR DESCRIPTION
## What
Bumped the version of SAT after: [5785](https://github.com/airbytehq/airbyte/pull/5785)

It was hot fix described in pull request.