### PR TITLE
🐞 Fix db config persistence unique constraint conflict

### DIFF
--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -40,6 +40,7 @@ import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.db.Database;
 import io.airbyte.db.ExceptionWrappingDatabase;
+import io.airbyte.db.instance.configs.jooq.Indexes;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.sql.SQLException;
@@ -227,6 +228,10 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
         .set(AIRBYTE_CONFIGS.CONFIG_TYPE, configType)
         .set(AIRBYTE_CONFIGS.CONFIG_BLOB, JSONB.valueOf(Jsons.serialize(configJson)))
         .set(AIRBYTE_CONFIGS.CREATED_AT, timestamp)
+        .set(AIRBYTE_CONFIGS.UPDATED_AT, timestamp)
+        .onConflict(AIRBYTE_CONFIGS.CONFIG_TYPE, AIRBYTE_CONFIGS.CONFIG_ID)
+        .doUpdate()
+        .set(AIRBYTE_CONFIGS.CONFIG_BLOB, JSONB.valueOf(Jsons.serialize(configJson)))
         .set(AIRBYTE_CONFIGS.UPDATED_AT, timestamp)
         .execute();
     return 1;

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -338,8 +338,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
       }
 
       if (!connectorRepositoryToIdVersionMap.containsKey(repository)) {
-        writeConfig(configType, configType.getId(latestDefinition), latestDefinition);
-        newCount += 1;
+        newCount += insertConfigRecord(ctx, timestamp, configType.name(), configJson, configType.getIdFieldName());
         continue;
       }
 

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -327,7 +327,8 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                                                           AirbyteConfig configType,
                                                           List<T> latestDefinitions,
                                                           Set<String> connectorRepositoriesInUse,
-                                                          Map<String, ConnectorInfo> connectorRepositoryToIdVersionMap) throws IOException {
+                                                          Map<String, ConnectorInfo> connectorRepositoryToIdVersionMap)
+      throws IOException {
     int newCount = 0;
     int updatedCount = 0;
     for (T latestDefinition : latestDefinitions) {

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -380,6 +380,8 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
             (c1, c2) -> {
               AirbyteVersion v1 = new AirbyteVersion(c1.dockerImageTag);
               AirbyteVersion v2 = new AirbyteVersion(c2.dockerImageTag);
+              LOGGER.warn("Duplicated connector version found: {} ({}) vs {} ({})",
+                  c1.dockerImageTag, c1.connectorDefinitionId, c2.dockerImageTag, c2.connectorDefinitionId);
               int comparison = v1.patchVersionCompareTo(v2);
               if (comparison >= 0) {
                 return c1;

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -40,7 +40,6 @@ import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.db.Database;
 import io.airbyte.db.ExceptionWrappingDatabase;
-import io.airbyte.db.instance.configs.jooq.Indexes;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.sql.SQLException;

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceLoadDataTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceLoadDataTest.java
@@ -128,9 +128,10 @@ public class DatabaseConfigPersistenceLoadDataTest extends BaseDatabaseConfigPer
 
     // create a sync to mark the destination as used
     StandardSync s3Sync = new StandardSync()
+        .withConnectionId(UUID.randomUUID())
         .withSourceId(SOURCE_GITHUB.getSourceDefinitionId())
         .withDestinationId(destinationS3V2.getDestinationDefinitionId());
-    configPersistence.writeConfig(ConfigSchema.STANDARD_SYNC, UUID.randomUUID().toString(), s3Sync);
+    configPersistence.writeConfig(ConfigSchema.STANDARD_SYNC, s3Sync.getConnectionId().toString(), s3Sync);
 
     configPersistence.loadData(seedPersistence);
     // s3 destination is not updated

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
@@ -156,12 +156,13 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
         .withSourceDefinitionId(definitionId)
         .withDockerRepository(connectorRepository)
         .withDockerImageTag("0.1.2");
-    database.query(ctx -> configPersistence.insertConfigRecord(
+    int insertionCount = database.query(ctx -> configPersistence.insertConfigRecord(
         ctx,
         timestamp,
         ConfigSchema.STANDARD_SOURCE_DEFINITION.name(),
         Jsons.jsonNode(source1),
         ConfigSchema.STANDARD_SOURCE_DEFINITION.getIdFieldName()));
+    assertEquals(1, insertionCount);
     // write an irrelevant source to make sure that it is not changed
     writeSource(configPersistence, SOURCE_GITHUB);
     assertRecordCount(2);
@@ -173,12 +174,13 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
         .withSourceDefinitionId(definitionId)
         .withDockerRepository(connectorRepository)
         .withDockerImageTag("0.1.5");
-    database.query(ctx -> configPersistence.insertConfigRecord(
+    insertionCount = database.query(ctx -> configPersistence.insertConfigRecord(
         ctx,
         timestamp,
         ConfigSchema.STANDARD_SOURCE_DEFINITION.name(),
         Jsons.jsonNode(source2),
         ConfigSchema.STANDARD_SOURCE_DEFINITION.getIdFieldName()));
+    assertEquals(0, insertionCount);
     assertRecordCount(2);
     assertHasSource(source1);
     assertHasSource(SOURCE_GITHUB);

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
@@ -168,7 +168,7 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
     assertHasSource(source1);
     assertHasSource(SOURCE_GITHUB);
 
-    // when the record already exists, it is updated
+    // when the record already exists, it is ignored
     StandardSourceDefinition source2 = new StandardSourceDefinition()
         .withSourceDefinitionId(definitionId)
         .withDockerRepository(connectorRepository)
@@ -180,7 +180,7 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
         Jsons.jsonNode(source2),
         ConfigSchema.STANDARD_SOURCE_DEFINITION.getIdFieldName()));
     assertRecordCount(2);
-    assertHasSource(source2);
+    assertHasSource(source1);
     assertHasSource(SOURCE_GITHUB);
   }
 

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
@@ -46,7 +46,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * The {@link DatabaseConfigPersistence#loadData} method is tested in {@link DatabaseConfigPersistenceLoadDataTest}.
+ * The {@link DatabaseConfigPersistence#loadData} method is tested in
+ * {@link DatabaseConfigPersistenceLoadDataTest}.
  */
 public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistenceTest {
 
@@ -139,7 +140,8 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
     writeSource(configPersistence, source1);
     writeSource(configPersistence, source2);
     Map<String, ConnectorInfo> result = database.query(ctx -> configPersistence.getConnectorRepositoryToInfoMap(ctx));
-    // when there are duplicated connector definitions, the one with the latest version should be retrieved
+    // when there are duplicated connector definitions, the one with the latest version should be
+    // retrieved
     assertEquals(newVersion, result.get(connectorRepository).dockerImageTag);
   }
 


### PR DESCRIPTION
## What
- There can be duplicated connector definitions (e.g. https://github.com/airbytehq/airbyte/pull/5450#issuecomment-912992094), resulting in unique constraint conflict in the `airbyte_configs` table.
- Also it is reported in https://github.com/airbytehq/airbyte/pull/5723#issuecomment-912985709 that there can be conflict when updating the connector definition. Although the root cause is unclear, it is safer to prevent such cases by leveraging postgres' [ON CONFLICT clause](https://www.postgresql.org/docs/current/sql-insert.html#SQL-ON-CONFLICT).
