### PR TITLE
Patch migration dev center to fix migration directory

### DIFF
--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseMigrationDevCenter.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseMigrationDevCenter.java
@@ -36,7 +36,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 public class ConfigsDatabaseMigrationDevCenter extends MigrationDevCenter {
 
   public ConfigsDatabaseMigrationDevCenter() {
-    super("src/main/resources/configs_database/schema_dump.txt");
+    super("configs", "src/main/resources/configs_database/schema_dump.txt");
   }
 
   @Override

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/development/MigrationDevCenter.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/development/MigrationDevCenter.java
@@ -47,15 +47,11 @@ public abstract class MigrationDevCenter {
     DUMP_SCHEMA
   }
 
-  /**
-   * Directory under which a new migration will be created. This should match the database's name and
-   * match the {@link Db} enum. Set in main to enforce correct implementation.
-   */
-  private static String migrationDirectory;
-
+  private final String dbIdentifier;
   private final String schemaDumpFile;
 
-  protected MigrationDevCenter(String schemaDumpFile) {
+  protected MigrationDevCenter(String dbIdentifier, String schemaDumpFile) {
+    this.dbIdentifier = dbIdentifier;
     this.schemaDumpFile = schemaDumpFile;
   }
 
@@ -75,7 +71,7 @@ public abstract class MigrationDevCenter {
   private void createMigration() {
     try (PostgreSQLContainer<?> container = createContainer(); Database database = getDatabase(container)) {
       FlywayDatabaseMigrator migrator = getMigrator(database);
-      MigrationDevHelper.createNextMigrationFile(migrationDirectory, migrator);
+      MigrationDevHelper.createNextMigrationFile(dbIdentifier, migrator);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -109,14 +105,8 @@ public abstract class MigrationDevCenter {
 
     Db db = Db.valueOf(args[0].toUpperCase());
     switch (db) {
-      case CONFIGS -> {
-        devCenter = new ConfigsDatabaseMigrationDevCenter();
-        migrationDirectory = "configs";
-      }
-      case JOBS -> {
-        devCenter = new JobsDatabaseMigrationDevCenter();
-        migrationDirectory = "jobs";
-      }
+      case CONFIGS -> devCenter = new ConfigsDatabaseMigrationDevCenter();
+      case JOBS -> devCenter = new JobsDatabaseMigrationDevCenter();
       default -> throw new IllegalArgumentException("Unexpected database: " + args[0]);
     }
 

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseMigrationDevCenter.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseMigrationDevCenter.java
@@ -36,7 +36,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 public class JobsDatabaseMigrationDevCenter extends MigrationDevCenter {
 
   public JobsDatabaseMigrationDevCenter() {
-    super("src/main/resources/jobs_database/schema_dump.txt");
+    super("jobs", "src/main/resources/jobs_database/schema_dump.txt");
   }
 
   @Override


### PR DESCRIPTION
@davinchia, I think it's probably better to replace the static class variable with an instance variable to set the correct db identifier. Thank you for spotting this issue.
