### PR TITLE
🐛 SAT: fix for handling `None/null` values of format `date-time`

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.18
+Fixed handling of `None`/null values of `date-time` format: https://github.com/airbytehq/airbyte/pull/5855
+
 ## 0.1.17
 Fix serialize function for acceptance-tests: https://github.com/airbytehq/airbyte/pull/5738
 

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -9,7 +9,7 @@ COPY setup.py ./
 COPY pytest.ini ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.17
+LABEL io.airbyte.version=0.1.18
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin"]

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/asserts.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/asserts.py
@@ -53,7 +53,7 @@ class CustomFormatChecker(FormatChecker):
 
     def check(self, instance, format):
         if format == "date-time":
-            if not self.check_datetime(instance):
+            if instance and not self.check_datetime(instance):
                 raise FormatError(f"{instance} has invalid datetime format")
         else:
             return super().check(instance, format)

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_asserts.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_asserts.py
@@ -104,6 +104,12 @@ def test_verify_records_schema(configured_catalog: ConfiguredAirbyteCatalog):
     [
         # Send null data
         ({"a": None}, {"type": "object", "properties": {"a": {"type": "string", "format": "time"}}}, False),
+        ({"a": None}, {"type": "object", "properties": {"a": {"type": "string", "format": "date"}}}, False),
+        ({"a": None}, {"type": "object", "properties": {"a": {"type": "string", "format": "date-time"}}}, False),
+        ({"a": None}, {"type": "object", "properties": {"a": {"type": "string", "format": "email"}}}, False),
+        ({"a": None}, {"type": "object", "properties": {"a": {"type": "string", "format": "hostname"}}}, False),
+        ({"a": None}, {"type": "object", "properties": {"a": {"type": "string", "format": "ipv4"}}}, False),
+        ({"a": None}, {"type": "object", "properties": {"a": {"type": "string", "format": "ipv6"}}}, False),
         # time
         ({"a": "sdf"}, {"type": "object", "properties": {"a": {"type": "string", "format": "time"}}}, False),
         ({"a": "12:00"}, {"type": "object", "properties": {"a": {"type": "string", "format": "time"}}}, False),


### PR DESCRIPTION
## What
#5854 - SAT: cannot handle None/null with format date-time

## How
- added 1 line to `check_datetime` method.
- added unit_test cases to cover the issue.


## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter

- [ ] Code reviews completed
- [X] Documentation updated 
    - [X] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [X] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</p>
</details>