### PR TITLE
remove unused spec/check/discover job persistence helpers

### DIFF
--- a/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/DefaultSchedulerJobClient.java
+++ b/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/DefaultSchedulerJobClient.java
@@ -32,7 +32,6 @@ import io.airbyte.scheduler.models.Job;
 import io.airbyte.scheduler.persistence.JobCreator;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -40,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 public class DefaultSchedulerJobClient implements SchedulerJobClient {
 
-  private static final Duration REQUEST_TIMEOUT = Duration.ofMinutes(30);
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSchedulerJobClient.class);
 
   private final JobPersistence jobPersistence;

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
@@ -25,11 +25,8 @@
 package io.airbyte.scheduler.persistence;
 
 import io.airbyte.config.DestinationConnection;
-import io.airbyte.config.JobCheckConnectionConfig;
 import io.airbyte.config.JobConfig;
 import io.airbyte.config.JobConfig.ConfigType;
-import io.airbyte.config.JobDiscoverCatalogConfig;
-import io.airbyte.config.JobGetSpecConfig;
 import io.airbyte.config.JobResetConnectionConfig;
 import io.airbyte.config.JobSyncConfig;
 import io.airbyte.config.SourceConnection;
@@ -48,57 +45,6 @@ public class DefaultJobCreator implements JobCreator {
 
   public DefaultJobCreator(JobPersistence jobPersistence) {
     this.jobPersistence = jobPersistence;
-  }
-
-  @Override
-  public long createSourceCheckConnectionJob(SourceConnection source, String dockerImageName) throws IOException {
-    final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig()
-        .withConnectionConfiguration(source.getConfiguration())
-        .withDockerImage(dockerImageName);
-
-    final JobConfig jobConfig = new JobConfig()
-        .withConfigType(ConfigType.CHECK_CONNECTION_SOURCE)
-        .withCheckConnection(jobCheckConnectionConfig);
-
-    final String sourceId = source.getSourceId() != null ? source.getSourceId().toString() : "";
-    return jobPersistence.enqueueJob(sourceId, jobConfig).orElseThrow();
-  }
-
-  @Override
-  public long createDestinationCheckConnectionJob(DestinationConnection destination, String dockerImageName) throws IOException {
-    final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig()
-        .withConnectionConfiguration(destination.getConfiguration())
-        .withDockerImage(dockerImageName);
-
-    final JobConfig jobConfig = new JobConfig()
-        .withConfigType(ConfigType.CHECK_CONNECTION_DESTINATION)
-        .withCheckConnection(jobCheckConnectionConfig);
-
-    final String destinationId = destination.getDestinationId() != null ? destination.getDestinationId().toString() : "";
-    return jobPersistence.enqueueJob(destinationId, jobConfig).orElseThrow();
-  }
-
-  @Override
-  public long createDiscoverSchemaJob(SourceConnection source, String dockerImageName) throws IOException {
-    final JobDiscoverCatalogConfig jobDiscoverCatalogConfig = new JobDiscoverCatalogConfig()
-        .withConnectionConfiguration(source.getConfiguration())
-        .withDockerImage(dockerImageName);
-
-    final JobConfig jobConfig = new JobConfig()
-        .withConfigType(ConfigType.DISCOVER_SCHEMA)
-        .withDiscoverCatalog(jobDiscoverCatalogConfig);
-
-    final String sourceId = source.getSourceId() != null ? source.getSourceId().toString() : "";
-    return jobPersistence.enqueueJob(sourceId, jobConfig).orElseThrow();
-  }
-
-  @Override
-  public long createGetSpecJob(String integrationImage) throws IOException {
-    final JobConfig jobConfig = new JobConfig()
-        .withConfigType(ConfigType.GET_SPEC)
-        .withGetSpec(new JobGetSpecConfig().withDockerImage(integrationImage));
-
-    return jobPersistence.enqueueJob(integrationImage, jobConfig).orElseThrow();
   }
 
   @Override

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobCreator.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobCreator.java
@@ -34,14 +34,6 @@ import java.util.Optional;
 
 public interface JobCreator {
 
-  long createSourceCheckConnectionJob(SourceConnection source, String dockerImage) throws IOException;
-
-  long createDestinationCheckConnectionJob(DestinationConnection destination, String dockerImage) throws IOException;
-
-  long createDiscoverSchemaJob(SourceConnection source, String dockerImage) throws IOException;
-
-  long createGetSpecJob(String integrationImage) throws IOException;
-
   /**
    *
    * @param source db model representing where data comes from

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
@@ -33,11 +33,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.DestinationConnection;
-import io.airbyte.config.JobCheckConnectionConfig;
 import io.airbyte.config.JobConfig;
 import io.airbyte.config.JobConfig.ConfigType;
-import io.airbyte.config.JobDiscoverCatalogConfig;
-import io.airbyte.config.JobGetSpecConfig;
 import io.airbyte.config.JobResetConnectionConfig;
 import io.airbyte.config.JobSyncConfig;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
@@ -135,71 +132,6 @@ public class DefaultJobCreatorTest {
   void setup() {
     jobPersistence = mock(JobPersistence.class);
     jobCreator = new DefaultJobCreator(jobPersistence);
-  }
-
-  @Test
-  void testCreateSourceCheckConnectionJob() throws IOException {
-    final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig()
-        .withConnectionConfiguration(SOURCE_CONNECTION.getConfiguration())
-        .withDockerImage(SOURCE_IMAGE_NAME);
-
-    final JobConfig jobConfig = new JobConfig()
-        .withConfigType(JobConfig.ConfigType.CHECK_CONNECTION_SOURCE)
-        .withCheckConnection(jobCheckConnectionConfig);
-
-    final String expectedScope = SOURCE_CONNECTION.getSourceId().toString();
-    when(jobPersistence.enqueueJob(expectedScope, jobConfig)).thenReturn(Optional.of(JOB_ID));
-
-    final long jobId = jobCreator.createSourceCheckConnectionJob(SOURCE_CONNECTION, SOURCE_IMAGE_NAME);
-    assertEquals(JOB_ID, jobId);
-  }
-
-  @Test
-  void testCreateDestinationCheckConnectionJob() throws IOException {
-    final JobCheckConnectionConfig jobCheckConnectionConfig = new JobCheckConnectionConfig()
-        .withConnectionConfiguration(DESTINATION_CONNECTION.getConfiguration())
-        .withDockerImage(DESTINATION_IMAGE_NAME);
-
-    final JobConfig jobConfig = new JobConfig()
-        .withConfigType(JobConfig.ConfigType.CHECK_CONNECTION_DESTINATION)
-        .withCheckConnection(jobCheckConnectionConfig);
-
-    final String expectedScope = DESTINATION_CONNECTION.getDestinationId().toString();
-    when(jobPersistence.enqueueJob(expectedScope, jobConfig)).thenReturn(Optional.of(JOB_ID));
-
-    final long jobId = jobCreator.createDestinationCheckConnectionJob(DESTINATION_CONNECTION, DESTINATION_IMAGE_NAME);
-    assertEquals(JOB_ID, jobId);
-  }
-
-  @Test
-  void testCreateDiscoverSchemaJob() throws IOException {
-    final JobDiscoverCatalogConfig jobDiscoverCatalogConfig = new JobDiscoverCatalogConfig()
-        .withConnectionConfiguration(SOURCE_CONNECTION.getConfiguration())
-        .withDockerImage(SOURCE_IMAGE_NAME);
-
-    final JobConfig jobConfig = new JobConfig()
-        .withConfigType(JobConfig.ConfigType.DISCOVER_SCHEMA)
-        .withDiscoverCatalog(jobDiscoverCatalogConfig);
-
-    final String expectedScope = SOURCE_CONNECTION.getSourceId().toString();
-    when(jobPersistence.enqueueJob(expectedScope, jobConfig)).thenReturn(Optional.of(JOB_ID));
-
-    final long jobId = jobCreator.createDiscoverSchemaJob(SOURCE_CONNECTION, SOURCE_IMAGE_NAME);
-    assertEquals(JOB_ID, jobId);
-  }
-
-  @Test
-  void testCreateGetSpecJob() throws IOException {
-    final String integrationImage = "pg/pg-3000";
-
-    final JobConfig jobConfig = new JobConfig()
-        .withConfigType(JobConfig.ConfigType.GET_SPEC)
-        .withGetSpec(new JobGetSpecConfig().withDockerImage(integrationImage));
-
-    when(jobPersistence.enqueueJob(integrationImage, jobConfig)).thenReturn(Optional.of(JOB_ID));
-
-    final long jobId = jobCreator.createGetSpecJob(integrationImage);
-    assertEquals(JOB_ID, jobId);
   }
 
   @Test


### PR DESCRIPTION
It turns out that while the persistence layers did have references to storing spec/check/discover job configurations, in practice we don't actually use it; we purely use Temporal for managing state.

This means that for spec/check/discover jobs we don't have to do anything special to prevent secrets persistence to the db (outside of encrypting Temporal of course).

I'm removing the helpers here but not the enum within `JobConfig`, since that's used for job tracking. Also the underlying objects (`JobGetSpecConfig` / `JobCheckConnectionConfig` / `JobDiscoverCatalogConfig`) are used as the interface with Temporal, and it seemed better and easier to leave that interface consistent.