### PR TITLE
:test_tube:  gitignore acceptance_tests_logs folders generated by SAT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ data
 secrets
 !airbyte-integrations/connector-templates/**/secrets
 
+# Test logs
+acceptance_tests_logs
+
 # Python
 *.egg-info
 __pycache__


### PR DESCRIPTION
## What
A local tests can generate a local acceptance_tests_logs folder and sometime it is captured by diff PRs.

## How
add acceptance_tests_logs to the .gitignore file
