### PR TITLE
Bump Airbyte version from 0.29.16-alpha to 0.29.17-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.29.16-alpha
+current_version = 0.29.17-alpha
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.29.16-alpha
+VERSION=0.29.17-alpha
 
 # Airbyte Internal Job Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_USER=docker

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.29.16-alpha",
+  "version": "0.29.17-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.29.16-alpha",
+  "version": "0.29.17-alpha",
   "private": true,
   "scripts": {
     "start": "react-scripts start",

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -81,7 +81,7 @@ If you are upgrading from  (i.e. your current version of Airbyte is) Airbyte ver
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.29.16-alpha --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.29.17-alpha --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/kube/overlays/stable-with-resource-limits/.env
+++ b/kube/overlays/stable-with-resource-limits/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.29.16-alpha
+AIRBYTE_VERSION=0.29.17-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_USER=docker

--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.29.16-alpha
+    newTag: 0.29.17-alpha
   - name: airbyte/scheduler
-    newTag: 0.29.16-alpha
+    newTag: 0.29.17-alpha
   - name: airbyte/server
-    newTag: 0.29.16-alpha
+    newTag: 0.29.17-alpha
   - name: airbyte/webapp
-    newTag: 0.29.16-alpha
+    newTag: 0.29.17-alpha
   - name: airbyte/worker
-    newTag: 0.29.16-alpha
+    newTag: 0.29.17-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.29.16-alpha
+AIRBYTE_VERSION=0.29.17-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_USER=docker

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.29.16-alpha
+    newTag: 0.29.17-alpha
   - name: airbyte/scheduler
-    newTag: 0.29.16-alpha
+    newTag: 0.29.17-alpha
   - name: airbyte/server
-    newTag: 0.29.16-alpha
+    newTag: 0.29.17-alpha
   - name: airbyte/webapp
-    newTag: 0.29.16-alpha
+    newTag: 0.29.17-alpha
   - name: airbyte/worker
-    newTag: 0.29.16-alpha
+    newTag: 0.29.17-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 


### PR DESCRIPTION
Changelog:

7aa4c7162 🐛 Fix cancel not working on Kube deployment since 0.29.13-alpha. (#5850)
dec2c9eb8 Switch logging logs to DEBUG. Add Kube labels to workers. (#5909)
a1dd956db Source Freshdesk: Fix incorrect type for `unique_external_id` in `contacts` schema #5800 (#5871)
e7413de0d Add a variant of the CDK speedrun that uses the PokeAPI (#5780)
8fcaba4fa Fix CDK speedrun stream stub (#5778)
c97798ab9 add acceptance_tests_logs to the common gitignore file (#5914)
ba2203ba3 fix link checker (#5928)

Steps After Merging PR:
1. Pull most recent version of master
2. Run ./tools/bin/tag_version.sh
3. Create a GitHub release with the changelog