### PR TITLE
🐛 Keen destination: fix for timestamp inference for complex types

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/81740ce8-d764-4ea7-94df-16bb41de36ae.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/81740ce8-d764-4ea7-94df-16bb41de36ae.json
@@ -2,6 +2,6 @@
   "destinationDefinitionId": "81740ce8-d764-4ea7-94df-16bb41de36ae",
   "name": "Chargify (Keen)",
   "dockerRepository": "airbyte/destination-keen",
-  "dockerImgeTag": "0.1.0",
+  "dockerImageTag": "0.2.0",
   "documentationUrl": "https://docs.airbyte.io/integrations/destinations/keen"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/8aaf41d0-f6d2-46de-9e79-c9540f828142.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_DESTINATION_DEFINITION/8aaf41d0-f6d2-46de-9e79-c9540f828142.json
@@ -2,6 +2,6 @@
   "destinationDefinitionId": "8aaf41d0-f6d2-46de-9e79-c9540f828142",
   "name": "Keen",
   "dockerRepository": "airbyte/destination-keen",
-  "dockerImgeTag": "0.1.0",
+  "dockerImageTag": "0.2.0",
   "documentationUrl": "https://docs.airbyte.io/integrations/destinations/keen"
 }

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -88,12 +88,12 @@
 - destinationDefinitionId: 8aaf41d0-f6d2-46de-9e79-c9540f828142
   name: Keen
   dockerRepository: airbyte/destination-keen
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.2.0
   documentationUrl: https://docs.airbyte.io/integrations/destinations/keen
 - destinationDefinitionId: 81740ce8-d764-4ea7-94df-16bb41de36ae
   name: Chargify (Keen)
   dockerRepository: airbyte/destination-keen
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.2.0
   documentationUrl: https://docs.airbyte.io/integrations/destinations/keen
 - destinationDefinitionId: 8b746512-8c2e-6ac1-4adc-b59faafd473c
   name: MongoDB

--- a/airbyte-integrations/connectors/destination-keen/Dockerfile
+++ b/airbyte-integrations/connectors/destination-keen/Dockerfile
@@ -7,5 +7,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.2.0
 LABEL io.airbyte.name=airbyte/destination-keen

--- a/airbyte-integrations/connectors/destination-keen/src/main/java/io/airbyte/integrations/destination/keen/KeenHttpClient.java
+++ b/airbyte-integrations/connectors/destination-keen/src/main/java/io/airbyte/integrations/destination/keen/KeenHttpClient.java
@@ -26,8 +26,6 @@ package io.airbyte.integrations.destination.keen;
 
 import static io.airbyte.integrations.destination.keen.KeenDestination.KEEN_BASE_API_PATH;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.IOException;
@@ -37,8 +35,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,42 +100,6 @@ public class KeenHttpClient {
     }
 
     return (ArrayNode) objectMapper.readTree(response.body()).get("result");
-  }
-
-  public List<String> getAllCollectionsForProject(String projectId, String apiKey)
-      throws IOException, InterruptedException {
-    URI listCollectionsUri = URI.create(String.format(
-        KEEN_BASE_API_PATH + "/projects/%s/events",
-        projectId));
-
-    HttpRequest request = HttpRequest.newBuilder()
-        .uri(listCollectionsUri)
-        .timeout(Duration.ofSeconds(30))
-        .header("Authorization", apiKey)
-        .header("Content-Type", "application/json")
-        .build();
-
-    HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-
-    List<KeenCollection> keenCollections = objectMapper.readValue(objectMapper.createParser(response.body()),
-        new TypeReference<>() {});
-
-    return keenCollections.stream().map(KeenCollection::getName).collect(Collectors.toList());
-  }
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  private static class KeenCollection {
-
-    private String name;
-
-    public String getName() {
-      return name;
-    }
-
-    public void setName(String name) {
-      this.name = name;
-    }
-
   }
 
 }

--- a/airbyte-integrations/connectors/destination-keen/src/main/java/io/airbyte/integrations/destination/keen/KeenTimestampService.java
+++ b/airbyte-integrations/connectors/destination-keen/src/main/java/io/airbyte/integrations/destination/keen/KeenTimestampService.java
@@ -30,13 +30,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.joestelmach.natty.Parser;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
-import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -49,12 +46,6 @@ import org.slf4j.LoggerFactory;
  */
 public class KeenTimestampService {
 
-  public enum CursorType {
-    STRING,
-    NUMBER,
-    UNRECOGNIZED
-  }
-
   private static final Logger LOGGER = LoggerFactory.getLogger(KeenRecordsConsumer.class);
 
   private static final long SECONDS_FROM_EPOCH_THRESHOLD = 1_000_000_000L;
@@ -62,7 +53,7 @@ public class KeenTimestampService {
   private static final long MILLIS_FROM_EPOCH_THRESHOLD = 10_000_000_000L;
 
   // Map containing stream names paired with their cursor fields
-  private Map<String, CursorField> streamCursorFields;
+  private Map<String, List<String>> streamCursorFields;
   private final Parser parser;
   private final boolean timestampInferenceEnabled;
 
@@ -76,27 +67,24 @@ public class KeenTimestampService {
       streamCursorFields = catalog.getStreams()
           .stream()
           .filter(stream -> stream.getCursorField().size() > 0)
-          .map(s -> Pair.of(s.getStream().getName(), CursorField.fromStream(s)))
-          .filter(
-              pair -> pair.getRight() != null && pair.getRight().type != CursorType.UNRECOGNIZED)
+          .map(s -> Pair.of(s.getStream().getName(), s.getCursorField()))
           .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
     }
   }
 
   /**
    * Tries to inject keen.timestamp field to the given message data. If the stream contains cursor
-   * fields of types NUMBER or STRING, this value is tried to be parsed to a timestamp. If this
-   * procedure fails, stream is removed from timestamp-parsable stream map, so parsing is not tried
-   * for future messages in the same stream. If parsing succeeds, keen.timestamp field is put as a
-   * JSON node to the message data and whole data is returned. Otherwise, keen.timestamp is set to
-   * emittedAt value
+   * field, it's value is tried to be parsed to timestamp. If this procedure fails, stream is removed
+   * from timestamp-parsable stream map, so parsing is not tried for future messages in the same stream.
+   * If parsing succeeds, keen.timestamp field is put as a JSON node to the message data and whole data
+   * is returned. Otherwise, keen.timestamp is set to emittedAt value
    *
    * @param message AirbyteRecordMessage containing record data
    * @return Record data together with keen.timestamp field
    */
   public JsonNode injectTimestamp(AirbyteRecordMessage message) {
     String streamName = message.getStream();
-    CursorField cursorField = streamCursorFields.get(streamName);
+    List<String> cursorField = streamCursorFields.get(streamName);
     JsonNode data = message.getData();
     if (timestampInferenceEnabled && cursorField != null) {
       try {
@@ -105,7 +93,7 @@ public class KeenTimestampService {
       } catch (Exception e) {
         // If parsing of timestamp has failed, remove stream from timestamp-parsable stream map,
         // so it won't be parsed for future messages.
-        LOGGER.info("Unable to parse timestamp field: {}", cursorField.path);
+        LOGGER.info("Unable to parse cursor field: {} into a keen.timestamp", cursorField);
         streamCursorFields.remove(streamName);
         injectTimestamp(data, Instant.ofEpochMilli(message.getEmittedAt()).toString());
       }
@@ -120,27 +108,26 @@ public class KeenTimestampService {
     root.set("keen", JsonNodeFactory.instance.objectNode().put("timestamp", timestamp));
   }
 
-  private String parseTimestamp(CursorField cursorField, JsonNode data) {
-    return switch (cursorField.type) {
-      case NUMBER -> dateFromNumber(
-          getNestedNode(data, cursorField.path)
-              .asLong());
-      case STRING -> parser
-          .parse(getNestedNode(data, cursorField.path)
-              .asText())
+  private String parseTimestamp(List<String> cursorField, JsonNode data) {
+    JsonNode timestamp = getNestedNode(data, cursorField);
+    long numberTimestamp = timestamp.asLong();
+    // if cursor value is below given threshold, assume that it's not epoch timestamp but ordered id
+    if (numberTimestamp >= SECONDS_FROM_EPOCH_THRESHOLD) {
+      return dateFromNumber(numberTimestamp);
+    }
+    // if timestamp is 0, then parsing it to long failed - let's try with String now
+    if (numberTimestamp == 0) {
+      return parser
+          .parse(timestamp.asText())
           .get(0).getDates()
           .get(0)
           .toInstant()
           .toString();
-      default -> throw new IllegalStateException("Unexpected value: " + cursorField.type);
-    };
+    }
+    throw new IllegalStateException();
   }
 
   private String dateFromNumber(Long timestamp) {
-    // if cursor value is below given threshold, assume that it's not epoch timestamp but ordered id
-    if (timestamp < SECONDS_FROM_EPOCH_THRESHOLD) {
-      throw new IllegalArgumentException("Number cursor field below threshold: " + timestamp);
-    }
     // if cursor value is above given threshold, then assume that it's Unix timestamp in milliseconds
     if (timestamp > MILLIS_FROM_EPOCH_THRESHOLD) {
       return Instant.ofEpochMilli(timestamp).toString();
@@ -148,76 +135,11 @@ public class KeenTimestampService {
     return Instant.ofEpochSecond(timestamp).toString();
   }
 
-  public static class CursorField {
-
-    private static final Set<String> STRING_TYPES = Set.of(
-        "STRING", "CHAR", "NCHAR", "NVARCHAR", "VARCHAR", "LONGVARCHAR", "DATE",
-        "TIME", "TIMESTAMP");
-    private static final Set<String> NUMBER_TYPES = Set.of(
-        "NUMBER", "TINYINT", "SMALLINT", "INT", "INTEGER", "BIGINT", "FLOAT", "DOUBLE",
-        "REAL", "NUMERIC", "DECIMAL");
-
-    private final List<String> path;
-    private final CursorType type;
-
-    public CursorField(List<String> path, CursorType type) {
-      this.path = path;
-      this.type = type;
-    }
-
-    protected static CursorField fromStream(ConfiguredAirbyteStream stream) {
-      List<String> cursorFieldList = stream.getCursorField();
-      JsonNode typeNode = getNestedNode(stream.getStream().getJsonSchema()
-          .get("properties"), cursorFieldList).get("type");
-      return new CursorField(cursorFieldList, getType(typeNode));
-    }
-
-    private static CursorType getType(JsonNode typeNode) {
-      CursorType type = CursorType.UNRECOGNIZED;
-      if (typeNode.isArray()) {
-        for (JsonNode e : typeNode) {
-          type = getType(e.asText().toUpperCase());
-          if (type != CursorType.UNRECOGNIZED) {
-            break;
-          }
-        }
-        return type;
-      }
-      return getType(typeNode.asText().toUpperCase());
-    }
-
-    private static CursorType getType(String typeString) {
-      if (STRING_TYPES.contains(typeString)) {
-        return CursorType.STRING;
-      }
-      if (NUMBER_TYPES.contains(typeString)) {
-        return CursorType.NUMBER;
-      }
-      return CursorType.UNRECOGNIZED;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o)
-        return true;
-      if (o == null || getClass() != o.getClass())
-        return false;
-      CursorField that = (CursorField) o;
-      return Objects.equals(path, that.path) && type == that.type;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(path, type);
-    }
-
-  }
-
   private static JsonNode getNestedNode(JsonNode data, List<String> fieldNames) {
     return fieldNames.stream().reduce(data, JsonNode::get, (first, second) -> second);
   }
 
-  public Map<String, CursorField> getStreamCursorFields() {
+  public Map<String, List<String>> getStreamCursorFields() {
     return streamCursorFields;
   }
 

--- a/airbyte-integrations/connectors/destination-keen/src/test-integration/java/io/airbyte/integrations/destination/keen/KeenDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-keen/src/test-integration/java/io/airbyte/integrations/destination/keen/KeenDestinationTest.java
@@ -54,7 +54,7 @@ public class KeenDestinationTest extends DestinationAcceptanceTest {
 
   @Override
   protected String getImageName() {
-    return "airbyte/destination-keen:dev";
+    return "airbyte/destination-keen:0.2";
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-keen/src/test-integration/java/io/airbyte/integrations/destination/keen/KeenDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-keen/src/test-integration/java/io/airbyte/integrations/destination/keen/KeenDestinationTest.java
@@ -57,7 +57,7 @@ public class KeenDestinationTest extends DestinationAcceptanceTest {
 
   @Override
   protected String getImageName() {
-    return "airbyte/destination-keen:0.2";
+    return "airbyte/destination-keen:dev";
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-keen/src/test/java/KeenTimestampServiceTest.java
+++ b/airbyte-integrations/connectors/destination-keen/src/test/java/KeenTimestampServiceTest.java
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
-import io.airbyte.integrations.destination.keen.KeenTimestampService.CursorField;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
@@ -54,22 +53,20 @@ public class KeenTimestampServiceTest {
   void shouldInitializeCursorFieldsFromCatalog() throws IOException {
     ConfiguredAirbyteCatalog configuredCatalog = readConfiguredCatalogFromFile("cursors_catalog.json");
 
-    Map<String, KeenTimestampService.CursorField> expectedCursorFieldsMap = Map.ofEntries(
-        entry("StringTypeStream1", new KeenTimestampService.CursorField(List.of("property1"), KeenTimestampService.CursorType.STRING)),
-        entry("StringTypeStream2", new KeenTimestampService.CursorField(List.of("property1"), KeenTimestampService.CursorType.STRING)),
-        entry("StringTypeStream3", new KeenTimestampService.CursorField(List.of("property1"), KeenTimestampService.CursorType.STRING)),
-        entry("NumberTypeStream1", new KeenTimestampService.CursorField(List.of("property1"), KeenTimestampService.CursorType.NUMBER)),
-        entry("NumberTypeStream2", new KeenTimestampService.CursorField(List.of("property1"), KeenTimestampService.CursorType.NUMBER)),
-        entry("ArrayTypeStream1", new KeenTimestampService.CursorField(List.of("property1"), KeenTimestampService.CursorType.NUMBER)),
-        entry("ArrayTypeStream2", new KeenTimestampService.CursorField(List.of("property1"), KeenTimestampService.CursorType.NUMBER)),
-        entry("ArrayTypeStream3", new KeenTimestampService.CursorField(List.of("property1"), KeenTimestampService.CursorType.NUMBER)),
-        entry("NestedCursorStream", new KeenTimestampService.CursorField(List.of("property1", "inside"), KeenTimestampService.CursorType.NUMBER))
-
-    );
+    Map<String, List<String>> expectedCursorFieldsMap = Map.ofEntries(
+        entry("StringTypeStream1", List.of("property1")),
+        entry("StringTypeStream2", List.of("property1")),
+        entry("StringTypeStream3", List.of("property1")),
+        entry("NumberTypeStream1", List.of("property1")),
+        entry("NumberTypeStream2", List.of("property1")),
+        entry("ArrayTypeStream1", List.of("property1")),
+        entry("ArrayTypeStream2", List.of("property1")),
+        entry("ArrayTypeStream3", List.of("property1")),
+        entry("NestedCursorStream", List.of("property1", "inside")));
 
     KeenTimestampService keenTimestampService = new KeenTimestampService(configuredCatalog, true);
 
-    Map<String, KeenTimestampService.CursorField> cursorFieldMap = keenTimestampService.getStreamCursorFields();
+    Map<String, List<String>> cursorFieldMap = keenTimestampService.getStreamCursorFields();
     Assertions.assertEquals(expectedCursorFieldsMap, cursorFieldMap);
   }
 
@@ -134,7 +131,7 @@ public class KeenTimestampServiceTest {
 
     KeenTimestampService keenTimestampService = new KeenTimestampService(configuredCatalog, true);
 
-    Map<String, CursorField> cursorFieldMap = keenTimestampService.getStreamCursorFields();
+    Map<String, List<String>> cursorFieldMap = keenTimestampService.getStreamCursorFields();
     Assertions.assertEquals(cursorFieldMap.size(), 1);
 
     AirbyteMessage message = buildMessageWithCursorValue(configuredCatalog, "some_text");

--- a/airbyte-integrations/connectors/destination-keen/src/test/resources/cursors_catalog.json
+++ b/airbyte-integrations/connectors/destination-keen/src/test/resources/cursors_catalog.json
@@ -11,30 +11,6 @@
       }
     },
     {
-      "name": "WrongTypeStream",
-      "source_defined_cursor": true,
-      "default_cursor_field": ["property1"],
-      "json_schema": {
-        "properties": {
-          "property1": {
-            "type": "wrong"
-          }
-        }
-      }
-    },
-    {
-      "name": "BooleanTypeStream",
-      "source_defined_cursor": true,
-      "default_cursor_field": ["property1"],
-      "json_schema": {
-        "properties": {
-          "property1": {
-            "type": "boolean"
-          }
-        }
-      }
-    },
-    {
       "name": "StringTypeStream1",
       "source_defined_cursor": true,
       "default_cursor_field": ["property1"],

--- a/docs/integrations/destinations/keen.md
+++ b/docs/integrations/destinations/keen.md
@@ -62,3 +62,8 @@ Now you should have all the parameters needed to configure Keen destination.
 
 ## CHANGELOG
 
+| Version | Date       | Pull Request | Subject |
+| :------ | :--------  | :-----       | :------ |
+| 0.2.0   | 2021-09-10 | [#5973](https://github.com/airbytehq/airbyte/pull/5973) | Fix timestamp inference for complex schemas |
+| 0.1.0   | 2021-08-18 | [#5339](https://github.com/airbytehq/airbyte/pull/5339) | Keen Destination Release! |
+


### PR DESCRIPTION
## What
Fixed bug, when destination initialization during syncrhonization was failing for some particular sources which use schema composition for their field's types ( "allOf", "anyOf", "oneOf").
Also race condition causing randomly failing test runs should be finally fixed.

## How
Simplified process of timestamp inference, now the map containing streams to cursorfFields mappings doesn't keep track of cursor's type. In process of inference, first the cursor is always tried to be parsed into number, if this fails then it's tried to be parsed into string.

## Recommended reading order
1. `x.java`
2. `y.python`

## Pre-merge Checklist

<summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [x] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</p>
