### PR TITLE
publish spec as part of connector publish script

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -173,7 +173,7 @@ jobs:
           SOURCE_BAMBOO_HR_CREDS: ${{ secrets.SOURCE_BAMBOO_HR_CREDS }}
           SOURCE_BIGCOMMERCE_CREDS: ${{ secrets.SOURCE_BIGCOMMERCE_CREDS }}
       - run: |
-          echo ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }} > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
+          echo "hello" > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
           ./tools/integrations/manage.sh publish airbyte-integrations/${{ github.event.inputs.connector }} ${{ github.event.inputs.run-tests }} spec_cache_key_file.json
         name: publish ${{ github.event.inputs.connector }}
         id: publish

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -173,7 +173,7 @@ jobs:
           SOURCE_BAMBOO_HR_CREDS: ${{ secrets.SOURCE_BAMBOO_HR_CREDS }}
           SOURCE_BIGCOMMERCE_CREDS: ${{ secrets.SOURCE_BIGCOMMERCE_CREDS }}
       - run: |
-          ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }} > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
+          echo ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }} > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
           ./tools/integrations/manage.sh publish airbyte-integrations/${{ github.event.inputs.connector }} ${{ github.event.inputs.run-tests }} spec_cache_key_file.json
         name: publish ${{ github.event.inputs.connector }}
         id: publish

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -44,6 +44,11 @@ jobs:
     runs-on: ${{ needs.start-publish-image-runner.outputs.label }}
     environment: more-secrets
     steps:
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }}
+          export_default_credentials: true
       - name: Search for valid connector name format
         id: regex
         uses: AsasInnab/regex-action@v1
@@ -71,7 +76,6 @@ jobs:
       - name: Write Integration Test Credentials # TODO DRY this with test-command.yml
         run: ./tools/bin/ci_credentials.sh
         env:
-          SPEC_CACHE_SERVICE_ACCOUNT_KEY: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }}
           AMAZON_SELLER_PARTNER_TEST_CREDS: ${{ secrets.AMAZON_SELLER_PARTNER_TEST_CREDS }}
           AMAZON_ADS_TEST_CREDS: ${{ secrets.AMAZON_ADS_TEST_CREDS }}
           AMPLITUDE_INTEGRATION_TEST_CREDS: ${{ secrets.AMPLITUDE_INTEGRATION_TEST_CREDS }}
@@ -175,7 +179,7 @@ jobs:
           SOURCE_BIGCOMMERCE_CREDS: ${{ secrets.SOURCE_BIGCOMMERCE_CREDS }}
       - run: |
           echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
-          ./tools/integrations/manage.sh publish airbyte-integrations/${{ github.event.inputs.connector }} ${{ github.event.inputs.run-tests }} spec_cache_key_file.json
+          ./tools/integrations/manage.sh publish airbyte-integrations/${{ github.event.inputs.connector }} ${{ github.event.inputs.run-tests }} --publish_spec_to_cache
         name: publish ${{ github.event.inputs.connector }}
         id: publish
         env:

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -173,8 +173,8 @@ jobs:
           SOURCE_BAMBOO_HR_CREDS: ${{ secrets.SOURCE_BAMBOO_HR_CREDS }}
           SOURCE_BIGCOMMERCE_CREDS: ${{ secrets.SOURCE_BIGCOMMERCE_CREDS }}
       - run: |
-          docker login -u airbytebot -p ${DOCKER_PASSWORD}
-          ./tools/integrations/manage.sh publish airbyte-integrations/${{ github.event.inputs.connector }} ${{ github.event.inputs.run-tests }}
+          ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }} > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
+          ./tools/integrations/manage.sh publish airbyte-integrations/${{ github.event.inputs.connector }} ${{ github.event.inputs.run-tests }} spec_cache_key_file.json
         name: publish ${{ github.event.inputs.connector }}
         id: publish
         env:

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Write Integration Test Credentials # TODO DRY this with test-command.yml
         run: ./tools/bin/ci_credentials.sh
         env:
+          SPEC_CACHE_SERVICE_ACCOUNT_KEY: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }}
           AMAZON_SELLER_PARTNER_TEST_CREDS: ${{ secrets.AMAZON_SELLER_PARTNER_TEST_CREDS }}
           AMAZON_ADS_TEST_CREDS: ${{ secrets.AMAZON_ADS_TEST_CREDS }}
           AMPLITUDE_INTEGRATION_TEST_CREDS: ${{ secrets.AMPLITUDE_INTEGRATION_TEST_CREDS }}
@@ -173,7 +174,7 @@ jobs:
           SOURCE_BAMBOO_HR_CREDS: ${{ secrets.SOURCE_BAMBOO_HR_CREDS }}
           SOURCE_BIGCOMMERCE_CREDS: ${{ secrets.SOURCE_BIGCOMMERCE_CREDS }}
       - run: |
-          echo "hello" > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
+          echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
           ./tools/integrations/manage.sh publish airbyte-integrations/${{ github.event.inputs.connector }} ${{ github.event.inputs.run-tests }} spec_cache_key_file.json
         name: publish ${{ github.event.inputs.connector }}
         id: publish

--- a/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/BucketSpecCacheSchedulerClient.java
+++ b/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/BucketSpecCacheSchedulerClient.java
@@ -90,15 +90,19 @@ public class BucketSpecCacheSchedulerClient implements SynchronousSchedulerClien
 
   @Override
   public SynchronousResponse<ConnectorSpecification> createGetSpecJob(final String dockerImage) throws IOException {
+    LOGGER.debug("getting spec!");
     Optional<ConnectorSpecification> cachedSpecOptional;
     // never want to fail because we could not fetch from off board storage.
     try {
       cachedSpecOptional = bucketSpecFetcher.apply(dockerImage);
+      LOGGER.debug("Spec bucket cache: Call to cache did not fail.");
     } catch (final RuntimeException e) {
       cachedSpecOptional = Optional.empty();
+      LOGGER.debug("Spec bucket cache: Call to cache failed.");
     }
 
     if (cachedSpecOptional.isPresent()) {
+      LOGGER.debug("Spec bucket cache: Cache hit.");
       final long now = Instant.now().toEpochMilli();
       final SynchronousJobMetadata mockMetadata = new SynchronousJobMetadata(
           UUID.randomUUID(),
@@ -110,6 +114,7 @@ public class BucketSpecCacheSchedulerClient implements SynchronousSchedulerClien
           Path.of(""));
       return new SynchronousResponse<>(cachedSpecOptional.get(), mockMetadata);
     } else {
+      LOGGER.debug("Spec bucket cache: Cache miss.");
       return client.createGetSpecJob(dockerImage);
     }
   }
@@ -127,12 +132,14 @@ public class BucketSpecCacheSchedulerClient implements SynchronousSchedulerClien
     Preconditions.checkArgument(dockerImageComponents.length == 2, "Invalidate docker image: " + dockerImage);
     final String dockerImageName = dockerImageComponents[0];
     final String dockerImageTag = dockerImageComponents[1];
-    final Blob specAsBlob =
-        storage.get(bucketName, Path.of("specs").resolve(dockerImageName).resolve(dockerImageTag).resolve("spec.json").toString());
+
+    final Path specPath = Path.of("specs").resolve(dockerImageName).resolve(dockerImageTag).resolve("spec.json");
+    LOGGER.debug("Checking path for cached spec: {} {}", bucketName, specPath);
+    final Blob specAsBlob = storage.get(bucketName, specPath.toString());
 
     // if null it means the object was not found.
     if (specAsBlob == null) {
-      LOGGER.warn("Spec not found in bucket storage");
+      LOGGER.debug("Spec not found in bucket storage");
       return Optional.empty();
     }
 

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -90,7 +90,6 @@ cmd_publish() {
   docker push "$versioned_image"
   docker push "$latest_image"
 
-
   if [[ "true" == "${publish_spec_to_cache}" ]]; then
     echo "Publishing and writing to spec cache."
 

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -69,6 +69,12 @@ cmd_publish() {
   echo "Publishing new version ($versioned_image)"
   docker push "$versioned_image"
   docker push "$latest_image"
+
+  # publish spec to cache. do so, by running get spec locally and then pushing it to gcs.
+  local tmp_spec_file; tmp_spec_file=$(mktemp)
+  docker run --rm "$versioned_image" spec | jq .spec > "$tmp_spec_file"
+  gcloud auth activate-service-account --key-file /Users/charles/Downloads/prod-ab-cloud-proj-bdb658ebbe5a.json
+  gsutil cp "$tmp_spec_file" gs://io-airbyte-cloud-spec-cache/specs/"$image_name"/"$image_version"/spec.json
 }
 
 main() {

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -68,7 +68,7 @@ cmd_publish() {
     esac
   done
 
-#  cmd_build "$path" "$run_tests"
+  cmd_build "$path" "$run_tests"
 
   local image_name; image_name=$(_get_docker_image_name "$path"/Dockerfile)
   local image_version; image_version=$(_get_docker_image_version "$path"/Dockerfile)
@@ -79,16 +79,16 @@ cmd_publish() {
   echo "$versioned_image $versioned_image"
   echo "latest_image $latest_image"
 
-#  docker tag "$image_name:dev" "$versioned_image"
-#  docker tag "$image_name:dev" "$latest_image"
+  docker tag "$image_name:dev" "$versioned_image"
+  docker tag "$image_name:dev" "$latest_image"
 
-#  if _check_tag_exists "$versioned_image"; then
-#    error "You're trying to push a version that was already released ($versioned_image). Make sure you bump it up."
-#  fi
+  if _check_tag_exists "$versioned_image"; then
+    error "You're trying to push a version that was already released ($versioned_image). Make sure you bump it up."
+  fi
 
   echo "Publishing new version ($versioned_image)"
-#  docker push "$versioned_image"
-#  docker push "$latest_image"
+  docker push "$versioned_image"
+  docker push "$latest_image"
 
 
   if [[ "true" == "${publish_spec_to_cache}" ]]; then

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -50,7 +50,7 @@ cmd_publish() {
   local run_tests=$1; shift || run_tests=true
   local spec_cache_service_account_key_file_path=$1; shift || spec_cache_service_account_key_file_path=
 
-  cmd_build "$path" "$run_tests"
+#  cmd_build "$path" "$run_tests"
 
   local image_name; image_name=$(_get_docker_image_name "$path"/Dockerfile)
   local image_version; image_version=$(_get_docker_image_version "$path"/Dockerfile)
@@ -61,16 +61,16 @@ cmd_publish() {
   echo "$versioned_image $versioned_image"
   echo "latest_image $latest_image"
 
-  docker tag "$image_name:dev" "$versioned_image"
-  docker tag "$image_name:dev" "$latest_image"
+#  docker tag "$image_name:dev" "$versioned_image"
+#  docker tag "$image_name:dev" "$latest_image"
 
-  if _check_tag_exists "$versioned_image"; then
-    error "You're trying to push a version that was already released ($versioned_image). Make sure you bump it up."
-  fi
+#  if _check_tag_exists "$versioned_image"; then
+#    error "You're trying to push a version that was already released ($versioned_image). Make sure you bump it up."
+#  fi
 
   echo "Publishing new version ($versioned_image)"
-  docker push "$versioned_image"
-  docker push "$latest_image"
+#  docker push "$versioned_image"
+#  docker push "$latest_image"
 
   if [[ -n "${spec_cache_service_account_key_file_path}" ]]; then
     echo "Publishing and writing to spec cache."


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/5266

## What
* This PR is the second half of the project that was stared in this PR: https://github.com/airbytehq/airbyte/pull/5605
* Our goal is to publish to a cache the spec for a connector when we release a new version of it. This cache can then be used by the app to pull specs without having to run a docker container. The previous PR handled setting up _reading_ from the cache (and falling back on running the spec job if there was a cache miss). This PR handles _writing_ to the cache when we publish a connector.
*It helps to add screenshots if it affects the frontend.*

## How
* In the `manage.sh` script add logic to push to our GCS bucket cache.
* Note: I have sanity checked that this actually works locally.

## Recommended reading order
1. `tools/integrations/manage.sh`

## Pre-merge Checklist
- [x] _resolve open question below_

## Open Question
* I'm not entirely sure of the most ergonomic way to handle the service account key that is needed to make this script work. See in-line comment below.