### PR TITLE
GAds oauth demo

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1184,6 +1184,29 @@ paths:
           $ref: "#/components/responses/NotFoundResponse"
         "422":
           $ref: "#/components/responses/InvalidInputResponse"
+  /v1/source_oauths/oauth_params/create:
+    post:
+      tags:
+        - oauth
+      summary: >
+        Sets instancewide variables to be used for the oauth flow when creating this source. When set, these variables will be injected
+        into a connector's configuration before any interaction with the connector image itself. This enables running oauth flows with
+        consistent variables e.g: the company's Google Ads developer_token, client_id, and client_secret without the user having to know
+        about these variables.
+      operationId: setInstancewideSourceOauthParams
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetInstancewideSourceOauthParamsRequestBody"
+        required: true
+      responses:
+        "200":
+          description: Successful
+        "400":
+          $ref: "#/components/responses/ExceptionResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
   /v1/source_oauths/get_consent_url:
     post:
       tags:
@@ -1276,6 +1299,29 @@ paths:
           $ref: "#/components/responses/NotFoundResponse"
         "422":
           $ref: "#/components/responses/InvalidInputResponse"
+  /v1/destination_oauths/oauth_params/create:
+    post:
+      tags:
+        - oauth
+      summary: >
+        Sets instancewide variables to be used for the oauth flow when creating this destination. When set, these variables will be injected
+        into a connector's configuration before any interaction with the connector image itself. This enables running oauth flows with
+        consistent variables e.g: the company's Google Ads developer_token, client_id, and client_secret without the user having to know
+        about these variables.
+      operationId: setInstancewideDestinationOauthParams
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetInstancewideDestinationOauthParamsRequestBody"
+        required: true
+      responses:
+        "200":
+          description: Successful
+        "400":
+          $ref: "#/components/responses/ExceptionResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
   /v1/web_backend/connections/list:
     post:
       tags:
@@ -1618,52 +1664,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ImportRead"
-        "404":
-          $ref: "#/components/responses/NotFoundResponse"
-  /v1/source_oauths/oauth_params/create:
-    post:
-      tags:
-        - oauth
-      summary: >
-        Sets instancewide variables to be used for the oauth flow when creating this source. When set, these variables will be injected
-        into a connector's configuration before any interaction with the connector image itself. This enables running oauth flows with
-        consistent variables e.g: the company's Google Ads developer_token, client_id, and client_secret without the user having to know
-        about these variables.
-      operationId: setInstancewideSourceOauthParams
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SetInstancewideSourceOauthParamsRequestBody"
-        required: true
-      responses:
-        "200":
-          description: Successful
-        "400":
-          $ref: "#/components/responses/ExceptionResponse"
-        "404":
-          $ref: "#/components/responses/NotFoundResponse"
-  /v1/destination_oauths/oauth_params/create:
-    post:
-      tags:
-        - oauth
-      summary: >
-        Sets instancewide variables to be used for the oauth flow when creating this destination. When set, these variables will be injected
-        into a connector's configuration before any interaction with the connector image itself. This enables running oauth flows with
-        consistent variables e.g: the company's Google Ads developer_token, client_id, and client_secret without the user having to know
-        about these variables.
-      operationId: setInstancewideDestinationOauthParams
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SetInstancewideDestinationOauthParamsRequestBody"
-        required: true
-      responses:
-        "200":
-          description: Successful
-        "400":
-          $ref: "#/components/responses/ExceptionResponse"
         "404":
           $ref: "#/components/responses/NotFoundResponse"
 components:

--- a/airbyte-oauth/build.gradle
+++ b/airbyte-oauth/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     implementation project(':airbyte-config:models')
     implementation project(':airbyte-config:persistence')
+    testImplementation project(':airbyte-oauth')
     implementation project(':airbyte-json-validation')
 
-    testImplementation project(':airbyte-oauth')
 }

--- a/airbyte-oauth/build.gradle
+++ b/airbyte-oauth/build.gradle
@@ -6,7 +6,6 @@ plugins {
 dependencies {
     implementation project(':airbyte-config:models')
     implementation project(':airbyte-config:persistence')
-    testImplementation project(':airbyte-oauth')
     implementation project(':airbyte-json-validation')
-
+    testImplementation project(':airbyte-oauth')
 }

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/OAuthImplementationFactory.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/OAuthImplementationFactory.java
@@ -28,8 +28,6 @@ import com.google.common.collect.ImmutableMap;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.oauth.google.GoogleAdsOauthFlow;
 import io.airbyte.oauth.google.GoogleAnalyticsOauthFlow;
-import io.airbyte.oauth.google.GoogleOAuthFlow;
-
 import java.util.Map;
 
 public class OAuthImplementationFactory {

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/OAuthImplementationFactory.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/OAuthImplementationFactory.java
@@ -26,6 +26,10 @@ package io.airbyte.oauth;
 
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.oauth.google.GoogleAdsOauthFlow;
+import io.airbyte.oauth.google.GoogleAnalyticsOauthFlow;
+import io.airbyte.oauth.google.GoogleOAuthFlow;
+
 import java.util.Map;
 
 public class OAuthImplementationFactory {
@@ -34,7 +38,8 @@ public class OAuthImplementationFactory {
 
   public OAuthImplementationFactory(ConfigRepository configRepository) {
     OAUTH_FLOW_MAPPING = ImmutableMap.<String, OAuthFlowImplementation>builder()
-        .put("airbyte/source-google-analytics-v4", new GoogleOAuthFlow(configRepository))
+        .put("airbyte/source-google-analytics-v4", new GoogleAnalyticsOauthFlow(configRepository))
+        .put("airbyte/source-google-ads", new GoogleAdsOauthFlow(configRepository))
         .build();
   }
 

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAdsOauthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAdsOauthFlow.java
@@ -1,9 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.airbyte.oauth.google;
 
 import io.airbyte.config.persistence.ConfigRepository;
 
 public class GoogleAdsOauthFlow extends GoogleOAuthFlow {
+
   public GoogleAdsOauthFlow(ConfigRepository configRepository) {
     super(configRepository, "https://www.googleapis.com/auth/adwords");
   }
+
 }

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAdsOauthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAdsOauthFlow.java
@@ -24,12 +24,25 @@
 
 package io.airbyte.oauth.google;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.config.persistence.ConfigRepository;
 
 public class GoogleAdsOauthFlow extends GoogleOAuthFlow {
 
   public GoogleAdsOauthFlow(ConfigRepository configRepository) {
     super(configRepository, "https://www.googleapis.com/auth/adwords");
+  }
+
+  @Override
+  protected String getClientIdUnsafe(JsonNode config) {
+    // the config object containing client ID and secret is nested inside the "credentials" object
+    return super.getClientIdUnsafe(config.get("credentials"));
+  }
+
+  @Override
+  protected String getClientSecretUnsafe(JsonNode config) {
+    // the config object containing client ID and secret is nested inside the "credentials" object
+    return super.getClientSecretUnsafe(config.get("credentials"));
   }
 
 }

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAdsOauthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAdsOauthFlow.java
@@ -1,0 +1,9 @@
+package io.airbyte.oauth.google;
+
+import io.airbyte.config.persistence.ConfigRepository;
+
+public class GoogleAdsOauthFlow extends GoogleOAuthFlow {
+  public GoogleAdsOauthFlow(ConfigRepository configRepository) {
+    super(configRepository, "https://www.googleapis.com/auth/adwords");
+  }
+}

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAnalyticsOauthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAnalyticsOauthFlow.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.airbyte.oauth.google;
 
 import io.airbyte.config.persistence.ConfigRepository;
@@ -7,4 +31,5 @@ public class GoogleAnalyticsOauthFlow extends GoogleOAuthFlow {
   public GoogleAnalyticsOauthFlow(ConfigRepository configRepository) {
     super(configRepository, "https%3A//www.googleapis.com/auth/analytics.readonly");
   }
+
 }

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAnalyticsOauthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAnalyticsOauthFlow.java
@@ -1,0 +1,10 @@
+package io.airbyte.oauth.google;
+
+import io.airbyte.config.persistence.ConfigRepository;
+
+public class GoogleAnalyticsOauthFlow extends GoogleOAuthFlow {
+
+  public GoogleAnalyticsOauthFlow(ConfigRepository configRepository) {
+    super(configRepository, "https%3A//www.googleapis.com/auth/analytics.readonly");
+  }
+}

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAnalyticsOauthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAnalyticsOauthFlow.java
@@ -29,7 +29,7 @@ import io.airbyte.config.persistence.ConfigRepository;
 public class GoogleAnalyticsOauthFlow extends GoogleOAuthFlow {
 
   public GoogleAnalyticsOauthFlow(ConfigRepository configRepository) {
-    super(configRepository, "https%3A//www.googleapis.com/auth/analytics.readonly");
+    super(configRepository, "https://www.googleapis.com/auth/analytics.readonly");
   }
 
 }

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleOAuthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleOAuthFlow.java
@@ -37,7 +37,6 @@ import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.oauth.MoreOAuthParameters;
 import io.airbyte.oauth.OAuthFlowImplementation;
 import io.airbyte.validation.json.JsonValidationException;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -101,7 +100,8 @@ public class GoogleOAuthFlow implements OAuthFlowImplementation {
       result.append(queryParameter).append("&");
     }
     return result
-        // TODO state should be randomly generated, and the 2nd step of oauth should verify its value matches the initially generated state value
+        // TODO state should be randomly generated, and the 2nd step of oauth should verify its value
+        // matches the initially generated state value
         .append("state=").append(definitionId.toString()).append("&")
         .append("client_id=").append(clientId).append("&")
         .append("redirect_uri=").append(redirectUrl)
@@ -206,8 +206,8 @@ public class GoogleOAuthFlow implements OAuthFlowImplementation {
   }
 
   /**
-   * Throws an exception if the client ID cannot be extracted.
-   * Subclasses should override this to parse the config differently.
+   * Throws an exception if the client ID cannot be extracted. Subclasses should override this to
+   * parse the config differently.
    *
    * @return
    */
@@ -220,8 +220,8 @@ public class GoogleOAuthFlow implements OAuthFlowImplementation {
   }
 
   /**
-   * Throws an exception if the client secret cannot be extracted.
-   * Subclasses should override this to parse the config differently.
+   * Throws an exception if the client secret cannot be extracted. Subclasses should override this to
+   * parse the config differently.
    *
    * @return
    */

--- a/airbyte-oauth/src/test-integration/java/io.airbyte.oauth/GoogleOAuthFlowIntegrationTest.java
+++ b/airbyte-oauth/src/test-integration/java/io.airbyte.oauth/GoogleOAuthFlowIntegrationTest.java
@@ -37,6 +37,8 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.SourceOAuthParameter;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.oauth.google.GoogleAnalyticsOauthFlow;
+import io.airbyte.oauth.google.GoogleOAuthFlow;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -71,7 +73,7 @@ public class GoogleOAuthFlowIntegrationTest {
           "Must provide path to a oauth credentials file.");
     }
     configRepository = mock(ConfigRepository.class);
-    googleOAuthFlow = new GoogleOAuthFlow(configRepository);
+    googleOAuthFlow = new GoogleAnalyticsOauthFlow(configRepository);
 
     server = HttpServer.create(new InetSocketAddress(80), 0);
     server.setExecutor(null); // creates a default executor

--- a/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleOAuthFlowTest.java
+++ b/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleOAuthFlowTest.java
@@ -93,8 +93,8 @@ public class GoogleOAuthFlowTest {
         .withDestinationDefinitionId(definitionId)
         .withWorkspaceId(workspaceId)
         .withConfiguration(Jsons.emptyObject())));
-    assertThrows(IOException.class, () -> googleOAuthFlow.getSourceConsentUrl(workspaceId, definitionId, REDIRECT_URL));
-    assertThrows(IOException.class, () -> googleOAuthFlow.getDestinationConsentUrl(workspaceId, definitionId, REDIRECT_URL));
+    assertThrows(IllegalArgumentException.class, () -> googleOAuthFlow.getSourceConsentUrl(workspaceId, definitionId, REDIRECT_URL));
+    assertThrows(IllegalArgumentException.class, () -> googleOAuthFlow.getDestinationConsentUrl(workspaceId, definitionId, REDIRECT_URL));
   }
 
   @Test

--- a/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleOAuthFlowTest.java
+++ b/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleOAuthFlowTest.java
@@ -22,13 +22,7 @@
  * SOFTWARE.
  */
 
-package io.airbyte.oauth;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+package io.airbyte.oauth.google;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
@@ -38,6 +32,11 @@ import io.airbyte.config.SourceOAuthParameter;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.validation.json.JsonValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
@@ -46,16 +45,19 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class GoogleOAuthFlowTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GoogleOAuthFlowTest.class);
   private static final Path CREDENTIALS_PATH = Path.of("secrets/credentials.json");
   private static final String REDIRECT_URL = "https%3A//airbyte.io";
+  private static final String SCOPE = "https%3A//www.googleapis.com/auth/analytics.readonly";
 
   private HttpClient httpClient;
   private ConfigRepository configRepository;
@@ -68,7 +70,7 @@ public class GoogleOAuthFlowTest {
   public void setup() {
     httpClient = mock(HttpClient.class);
     configRepository = mock(ConfigRepository.class);
-    googleOAuthFlow = new GoogleOAuthFlow(configRepository, httpClient);
+    googleOAuthFlow = new GoogleOAuthFlow(configRepository, SCOPE, httpClient);
 
     workspaceId = UUID.randomUUID();
     definitionId = UUID.randomUUID();
@@ -108,7 +110,7 @@ public class GoogleOAuthFlowTest {
     final String actualSourceUrl = googleOAuthFlow.getSourceConsentUrl(workspaceId, definitionId, REDIRECT_URL);
     final String expectedSourceUrl = String.format(
         "https://accounts.google.com/o/oauth2/v2/auth?scope=%s&access_type=offline&include_granted_scopes=true&response_type=code&prompt=consent&state=%s&client_id=%s&redirect_uri=%s",
-        GoogleOAuthFlow.GOOGLE_ANALYTICS_SCOPE,
+        SCOPE,
         definitionId,
         getClientId(),
         REDIRECT_URL);
@@ -128,7 +130,7 @@ public class GoogleOAuthFlowTest {
     final String actualDestinationUrl = googleOAuthFlow.getDestinationConsentUrl(workspaceId, definitionId, REDIRECT_URL);
     final String expectedDestinationUrl = String.format(
         "https://accounts.google.com/o/oauth2/v2/auth?scope=%s&access_type=offline&include_granted_scopes=true&response_type=code&prompt=consent&state=%s&client_id=%s&redirect_uri=%s",
-        GoogleOAuthFlow.GOOGLE_ANALYTICS_SCOPE,
+        SCOPE,
         definitionId,
         getClientId(),
         REDIRECT_URL);

--- a/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleOAuthFlowTest.java
+++ b/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleOAuthFlowTest.java
@@ -24,6 +24,12 @@
 
 package io.airbyte.oauth.google;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
@@ -32,11 +38,6 @@ import io.airbyte.config.SourceOAuthParameter;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.validation.json.JsonValidationException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
@@ -45,12 +46,10 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GoogleOAuthFlowTest {
 

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplier.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplier.java
@@ -26,13 +26,17 @@ package io.airbyte.scheduler.persistence.job_factory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.oauth.MoreOAuthParameters;
 import io.airbyte.validation.json.JsonValidationException;
+
 import java.io.IOException;
 import java.util.UUID;
+
+import static com.fasterxml.jackson.databind.node.JsonNodeType.OBJECT;
 
 public class OAuthConfigSupplier {
 
@@ -48,6 +52,7 @@ public class OAuthConfigSupplier {
   public JsonNode injectSourceOAuthParameters(UUID sourceDefinitionId, UUID workspaceId, JsonNode sourceConnectorConfig)
       throws IOException {
     try {
+      // TODO there will be cases where we shouldn't write oauth params. See https://github.com/airbytehq/airbyte/issues/5989
       MoreOAuthParameters.getSourceOAuthParameter(configRepository.listSourceOAuthParam().stream(), workspaceId, sourceDefinitionId)
           .ifPresent(
               sourceOAuthParameter -> injectJsonNode((ObjectNode) sourceConnectorConfig, (ObjectNode) sourceOAuthParameter.getConfiguration()));
@@ -69,15 +74,31 @@ public class OAuthConfigSupplier {
     }
   }
 
-  private void injectJsonNode(ObjectNode config, ObjectNode fromConfig) {
+  @VisibleForTesting
+  void injectJsonNode(ObjectNode mainConfig, ObjectNode fromConfig) {
+    // TODO this method might make sense to have as a general utility in Jsons
     for (String key : Jsons.keys(fromConfig)) {
-      if (maskSecrets) {
-        config.set(key, Jsons.jsonNode(SECRET_MASK));
+      if (fromConfig.get(key).getNodeType() == OBJECT) {
+        // nested objects are merged rather than overwrite the contents of the equivalent object in config
+        if (mainConfig.get(key) == null) {
+          injectJsonNode(mainConfig.putObject(key), (ObjectNode)fromConfig.get(key));
+        } else if (mainConfig.get(key).getNodeType() == OBJECT) {
+          injectJsonNode((ObjectNode) mainConfig.get(key), (ObjectNode) fromConfig.get(key));
+        } else {
+          throw new IllegalStateException("Can't merge an object node into a non-object node!");
+        }
       } else {
-        if (!config.has(key) || isSecretMask(config.get(key).asText())) {
-          config.set(key, fromConfig.get(key));
+        if (maskSecrets) {
+          // TODO secrets should be masked with the correct type https://github.com/airbytehq/airbyte/issues/5990
+          //  In the short-term this is not world-ending as all secret fields are currently strings
+          mainConfig.set(key, Jsons.jsonNode(SECRET_MASK));
+        } else {
+          if (!mainConfig.has(key) || isSecretMask(mainConfig.get(key).asText())) {
+            mainConfig.set(key, fromConfig.get(key));
+          }
         }
       }
+
     }
   }
 

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplier.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplier.java
@@ -24,6 +24,8 @@
 
 package io.airbyte.scheduler.persistence.job_factory;
 
+import static com.fasterxml.jackson.databind.node.JsonNodeType.OBJECT;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
@@ -32,11 +34,8 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.oauth.MoreOAuthParameters;
 import io.airbyte.validation.json.JsonValidationException;
-
 import java.io.IOException;
 import java.util.UUID;
-
-import static com.fasterxml.jackson.databind.node.JsonNodeType.OBJECT;
 
 public class OAuthConfigSupplier {
 
@@ -52,7 +51,8 @@ public class OAuthConfigSupplier {
   public JsonNode injectSourceOAuthParameters(UUID sourceDefinitionId, UUID workspaceId, JsonNode sourceConnectorConfig)
       throws IOException {
     try {
-      // TODO there will be cases where we shouldn't write oauth params. See https://github.com/airbytehq/airbyte/issues/5989
+      // TODO there will be cases where we shouldn't write oauth params. See
+      // https://github.com/airbytehq/airbyte/issues/5989
       MoreOAuthParameters.getSourceOAuthParameter(configRepository.listSourceOAuthParam().stream(), workspaceId, sourceDefinitionId)
           .ifPresent(
               sourceOAuthParameter -> injectJsonNode((ObjectNode) sourceConnectorConfig, (ObjectNode) sourceOAuthParameter.getConfiguration()));
@@ -81,7 +81,7 @@ public class OAuthConfigSupplier {
       if (fromConfig.get(key).getNodeType() == OBJECT) {
         // nested objects are merged rather than overwrite the contents of the equivalent object in config
         if (mainConfig.get(key) == null) {
-          injectJsonNode(mainConfig.putObject(key), (ObjectNode)fromConfig.get(key));
+          injectJsonNode(mainConfig.putObject(key), (ObjectNode) fromConfig.get(key));
         } else if (mainConfig.get(key).getNodeType() == OBJECT) {
           injectJsonNode((ObjectNode) mainConfig.get(key), (ObjectNode) fromConfig.get(key));
         } else {
@@ -89,8 +89,9 @@ public class OAuthConfigSupplier {
         }
       } else {
         if (maskSecrets) {
-          // TODO secrets should be masked with the correct type https://github.com/airbytehq/airbyte/issues/5990
-          //  In the short-term this is not world-ending as all secret fields are currently strings
+          // TODO secrets should be masked with the correct type
+          // https://github.com/airbytehq/airbyte/issues/5990
+          // In the short-term this is not world-ending as all secret fields are currently strings
           mainConfig.set(key, Jsons.jsonNode(SECRET_MASK));
         } else {
           if (!mainConfig.has(key) || isSecretMask(mainConfig.get(key).asText())) {

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplierTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplierTest.java
@@ -29,18 +29,28 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.api.client.json.Json;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.SourceOAuthParameter;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.validation.json.JsonValidationException;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class OAuthConfigSupplierTest {
 
@@ -142,8 +152,8 @@ public class OAuthConfigSupplierTest {
     assertEquals(expectedConfig, actualConfig);
   }
 
-  private JsonNode generateJsonConfig() {
-    return Jsons.jsonNode(ImmutableMap.builder()
+  private ObjectNode generateJsonConfig() {
+    return (ObjectNode) Jsons.jsonNode(ImmutableMap.builder()
         .put("apiSecret", "123")
         .put("client", "testing")
         .build());
@@ -154,6 +164,104 @@ public class OAuthConfigSupplierTest {
         .put("api_secret", "mysecret")
         .put("api_client", UUID.randomUUID().toString())
         .build();
+  }
+
+  private void maskAllValues(ObjectNode node){
+    for (String key : Jsons.keys(node)) {
+      if (node.get(key).getNodeType() == JsonNodeType.OBJECT) {
+        maskAllValues((ObjectNode) node.get(key));
+      } else {
+        node.set(key, Jsons.jsonNode(OAuthConfigSupplier.SECRET_MASK));
+      }
+    }
+  }
+
+  @Test
+  void testInjectUnnestedNode_Masked() {
+    OAuthConfigSupplier supplier = new OAuthConfigSupplier(configRepository, true);
+    ObjectNode oauthParams = (ObjectNode)Jsons.jsonNode(generateOAuthParameters());
+    ObjectNode maskedOauthParams = Jsons.clone(oauthParams);
+    maskAllValues(maskedOauthParams);
+    ObjectNode actual = generateJsonConfig();
+    ObjectNode expected = Jsons.clone(actual);
+    expected.setAll(maskedOauthParams);
+
+    supplier.injectJsonNode(actual, oauthParams);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testInjectUnnestedNode_Unmasked() {
+    OAuthConfigSupplier supplier = new OAuthConfigSupplier(configRepository, false);
+    ObjectNode oauthParams = (ObjectNode)Jsons.jsonNode(generateOAuthParameters());
+
+
+    ObjectNode actual = generateJsonConfig();
+    ObjectNode expected = Jsons.clone(actual);
+    expected.setAll(oauthParams);
+
+    supplier.injectJsonNode(actual, oauthParams);
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testInjectNewNestedNode_Masked() {
+    OAuthConfigSupplier supplier = new OAuthConfigSupplier(configRepository, true);
+    ObjectNode oauthParams = (ObjectNode)Jsons.jsonNode(generateOAuthParameters());
+    ObjectNode maskedOauthParams = Jsons.clone(oauthParams);
+    maskAllValues(maskedOauthParams);
+    ObjectNode nestedConfig = (ObjectNode) Jsons.jsonNode(ImmutableMap.builder()
+        .put("oauth_credentials", oauthParams)
+        .build()
+    );
+
+    // nested node does not exist in actual object
+    ObjectNode actual = generateJsonConfig();
+    ObjectNode expected = Jsons.clone(actual);
+    expected.putObject("oauth_credentials").setAll(maskedOauthParams);
+
+    supplier.injectJsonNode(actual, nestedConfig);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  @DisplayName("A nested config should be inserted with the same nesting structure")
+  void testInjectNewNestedNode_Unmasked() {
+    OAuthConfigSupplier supplier = new OAuthConfigSupplier(configRepository, false);
+    ObjectNode oauthParams = (ObjectNode)Jsons.jsonNode(generateOAuthParameters());
+    ObjectNode nestedConfig = (ObjectNode) Jsons.jsonNode(ImmutableMap.builder()
+        .put("oauth_credentials", oauthParams)
+        .build()
+    );
+
+    // nested node does not exist in actual object
+    ObjectNode actual = generateJsonConfig();
+    ObjectNode expected = Jsons.clone(actual);
+    expected.putObject("oauth_credentials").setAll(oauthParams);
+
+    supplier.injectJsonNode(actual, nestedConfig);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  @DisplayName("A nested node which partially exists in the main config should be merged into the main config, not overwrite the whole nested object")
+  void testInjectedPartiallyExistingNestedNode_Unmasked(){
+    OAuthConfigSupplier supplier = new OAuthConfigSupplier(configRepository, false);
+    ObjectNode oauthParams = (ObjectNode)Jsons.jsonNode(generateOAuthParameters());
+    ObjectNode nestedConfig = (ObjectNode) Jsons.jsonNode(ImmutableMap.builder()
+        .put("oauth_credentials", oauthParams)
+        .build()
+    );
+
+    // nested node partially exists in actual object
+    ObjectNode actual = generateJsonConfig();
+    actual.putObject("oauth_credentials").put("irrelevant_field", "_");
+    ObjectNode expected = Jsons.clone(actual);
+    ((ObjectNode)expected.get("oauth_credentials")).setAll(oauthParams);
+
+    supplier.injectJsonNode(actual, nestedConfig);
+    assertEquals(expected, actual);
   }
 
 }

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplierTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplierTest.java
@@ -31,26 +31,18 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.api.client.json.Json;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.SourceOAuthParameter;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.validation.json.JsonValidationException;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Stream;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 public class OAuthConfigSupplierTest {
 
@@ -166,7 +158,7 @@ public class OAuthConfigSupplierTest {
         .build();
   }
 
-  private void maskAllValues(ObjectNode node){
+  private void maskAllValues(ObjectNode node) {
     for (String key : Jsons.keys(node)) {
       if (node.get(key).getNodeType() == JsonNodeType.OBJECT) {
         maskAllValues((ObjectNode) node.get(key));
@@ -179,7 +171,7 @@ public class OAuthConfigSupplierTest {
   @Test
   void testInjectUnnestedNode_Masked() {
     OAuthConfigSupplier supplier = new OAuthConfigSupplier(configRepository, true);
-    ObjectNode oauthParams = (ObjectNode)Jsons.jsonNode(generateOAuthParameters());
+    ObjectNode oauthParams = (ObjectNode) Jsons.jsonNode(generateOAuthParameters());
     ObjectNode maskedOauthParams = Jsons.clone(oauthParams);
     maskAllValues(maskedOauthParams);
     ObjectNode actual = generateJsonConfig();
@@ -193,8 +185,7 @@ public class OAuthConfigSupplierTest {
   @Test
   void testInjectUnnestedNode_Unmasked() {
     OAuthConfigSupplier supplier = new OAuthConfigSupplier(configRepository, false);
-    ObjectNode oauthParams = (ObjectNode)Jsons.jsonNode(generateOAuthParameters());
-
+    ObjectNode oauthParams = (ObjectNode) Jsons.jsonNode(generateOAuthParameters());
 
     ObjectNode actual = generateJsonConfig();
     ObjectNode expected = Jsons.clone(actual);
@@ -208,13 +199,12 @@ public class OAuthConfigSupplierTest {
   @Test
   void testInjectNewNestedNode_Masked() {
     OAuthConfigSupplier supplier = new OAuthConfigSupplier(configRepository, true);
-    ObjectNode oauthParams = (ObjectNode)Jsons.jsonNode(generateOAuthParameters());
+    ObjectNode oauthParams = (ObjectNode) Jsons.jsonNode(generateOAuthParameters());
     ObjectNode maskedOauthParams = Jsons.clone(oauthParams);
     maskAllValues(maskedOauthParams);
     ObjectNode nestedConfig = (ObjectNode) Jsons.jsonNode(ImmutableMap.builder()
         .put("oauth_credentials", oauthParams)
-        .build()
-    );
+        .build());
 
     // nested node does not exist in actual object
     ObjectNode actual = generateJsonConfig();
@@ -229,11 +219,10 @@ public class OAuthConfigSupplierTest {
   @DisplayName("A nested config should be inserted with the same nesting structure")
   void testInjectNewNestedNode_Unmasked() {
     OAuthConfigSupplier supplier = new OAuthConfigSupplier(configRepository, false);
-    ObjectNode oauthParams = (ObjectNode)Jsons.jsonNode(generateOAuthParameters());
+    ObjectNode oauthParams = (ObjectNode) Jsons.jsonNode(generateOAuthParameters());
     ObjectNode nestedConfig = (ObjectNode) Jsons.jsonNode(ImmutableMap.builder()
         .put("oauth_credentials", oauthParams)
-        .build()
-    );
+        .build());
 
     // nested node does not exist in actual object
     ObjectNode actual = generateJsonConfig();
@@ -246,19 +235,18 @@ public class OAuthConfigSupplierTest {
 
   @Test
   @DisplayName("A nested node which partially exists in the main config should be merged into the main config, not overwrite the whole nested object")
-  void testInjectedPartiallyExistingNestedNode_Unmasked(){
+  void testInjectedPartiallyExistingNestedNode_Unmasked() {
     OAuthConfigSupplier supplier = new OAuthConfigSupplier(configRepository, false);
-    ObjectNode oauthParams = (ObjectNode)Jsons.jsonNode(generateOAuthParameters());
+    ObjectNode oauthParams = (ObjectNode) Jsons.jsonNode(generateOAuthParameters());
     ObjectNode nestedConfig = (ObjectNode) Jsons.jsonNode(ImmutableMap.builder()
         .put("oauth_credentials", oauthParams)
-        .build()
-    );
+        .build());
 
     // nested node partially exists in actual object
     ObjectNode actual = generateJsonConfig();
     actual.putObject("oauth_credentials").put("irrelevant_field", "_");
     ObjectNode expected = Jsons.clone(actual);
-    ((ObjectNode)expected.get("oauth_credentials")).setAll(oauthParams);
+    ((ObjectNode) expected.get("oauth_credentials")).setAll(oauthParams);
 
     supplier.injectJsonNode(actual, nestedConfig);
     assertEquals(expected, actual);


### PR DESCRIPTION
## What
This branch contains working code for demoing oauth with Google Ads. It builds on the branch `chris/google-analytics-oauth` (https://github.com/airbytehq/airbyte/pull/5911). 

## How
1. It uses Google Ads instead of Google Analytics because I realized the analytics connector doesn't support webflow oauth yet. airbytehq/airbyte#4850 
2. It makes changes to allow using the `GoogleOauthFlow` as a superclass to perform oauth for all google connectors. The main changes are: injecting `scope` from the child class, and allowing the child class to specify how to parse the instancewide config to get client ID and client secret. 
3. Changes `OauthConfigSupplier.injectConfig` to handle merging nested configs. Previously it overwrote any keys. Now it merges any objects with their equivalent objects if they exist, prioritizing the `fromConfig`. This was needed to work with google ads as the connector nests its credentials inside the config. 

## Recommended reading order
For points 1 & 2: 
1. `GoogleAnalyticsOauthFlow.java`
2. `GoogleAdsOauthFlow.java`
3. `GoogleOauthFlow.java`

For point 3: 
1. `OAuthConfigSupplier.java`, `OAuthConfigSupplierTest.java`

### Important Learnings from this PR 
It uncovered a few points for improvement: 
1. Instancewide secrets should probably be tied to connector version https://github.com/airbytehq/airbyte-internal-issues/issues/237
2. Instancewide secrets masks should applied with the correct type https://github.com/airbytehq/airbyte-internal-issues/issues/236
3. The current assumption that instancewide secrets should always be injected is not necessarily correct. We should clarify the story around this https://github.com/airbytehq/airbyte/issues/5989. 
4. We consciously made this tradeoff to reduce delivery risk, but right now the fact that oauth logic for particular connectors is encoded in the server is pretty fragile. A single change in a connector's spec could cause a breaking change. 
5. We might want to have a spec that describes the instancewide variables schema expected for a particular connector/version. I don't love that the schema is not described anywhere. 