### PR TITLE
Fix the format of the data returned by Google Ads oauth to match the config accepted by the connector

### DIFF
--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAdsOauthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAdsOauthFlow.java
@@ -27,6 +27,10 @@ package io.airbyte.oauth.google;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.config.persistence.ConfigRepository;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
 public class GoogleAdsOauthFlow extends GoogleOAuthFlow {
 
   public GoogleAdsOauthFlow(ConfigRepository configRepository) {
@@ -45,4 +49,12 @@ public class GoogleAdsOauthFlow extends GoogleOAuthFlow {
     return super.getClientSecretUnsafe(config.get("credentials"));
   }
 
+  @Override
+  protected Map<String, Object> completeOAuthFlow(String clientId, String clientSecret, String code, String redirectUrl) throws IOException {
+    // the config object containing refresh token is nested inside the "credentials" object
+    Map<String, Object> oauthFlowOutput = super.completeOAuthFlow(clientId, clientSecret, code, redirectUrl);
+    HashMap<String, Object> nestedOutput = new HashMap<>();
+    nestedOutput.put("credentials", oauthFlowOutput);
+    return nestedOutput;
+  }
 }

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAdsOauthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAdsOauthFlow.java
@@ -28,10 +28,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.airbyte.config.persistence.ConfigRepository;
-
 import java.io.IOException;
 import java.net.http.HttpClient;
-import java.util.HashMap;
 import java.util.Map;
 
 public class GoogleAdsOauthFlow extends GoogleOAuthFlow {
@@ -43,7 +41,8 @@ public class GoogleAdsOauthFlow extends GoogleOAuthFlow {
     super(configRepository, SCOPE);
   }
 
-  @VisibleForTesting GoogleAdsOauthFlow(ConfigRepository configRepository, HttpClient client) {
+  @VisibleForTesting
+  GoogleAdsOauthFlow(ConfigRepository configRepository, HttpClient client) {
     super(configRepository, SCOPE, client);
   }
 
@@ -66,4 +65,5 @@ public class GoogleAdsOauthFlow extends GoogleOAuthFlow {
     // the config object containing refresh token is nested inside the "credentials" object
     return Map.of("credentials", super.completeOAuthFlow(clientId, clientSecret, code, redirectUrl));
   }
+
 }

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAdsOauthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAdsOauthFlow.java
@@ -25,27 +25,39 @@
 package io.airbyte.oauth.google;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import io.airbyte.config.persistence.ConfigRepository;
 
 import java.io.IOException;
+import java.net.http.HttpClient;
 import java.util.HashMap;
 import java.util.Map;
 
 public class GoogleAdsOauthFlow extends GoogleOAuthFlow {
+  @VisibleForTesting
+  static final String SCOPE = "https://www.googleapis.com/auth/adwords";
 
   public GoogleAdsOauthFlow(ConfigRepository configRepository) {
-    super(configRepository, "https://www.googleapis.com/auth/adwords");
+    super(configRepository, SCOPE);
+  }
+
+  @VisibleForTesting
+  GoogleAdsOauthFlow(ConfigRepository configRepository, HttpClient client) {
+    super(configRepository, SCOPE, client);
   }
 
   @Override
   protected String getClientIdUnsafe(JsonNode config) {
     // the config object containing client ID and secret is nested inside the "credentials" object
+    Preconditions.checkArgument(config.hasNonNull("credentials"));
     return super.getClientIdUnsafe(config.get("credentials"));
   }
 
   @Override
   protected String getClientSecretUnsafe(JsonNode config) {
     // the config object containing client ID and secret is nested inside the "credentials" object
+    Preconditions.checkArgument(config.hasNonNull("credentials"));
     return super.getClientSecretUnsafe(config.get("credentials"));
   }
 

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAdsOauthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleAdsOauthFlow.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class GoogleAdsOauthFlow extends GoogleOAuthFlow {
+
   @VisibleForTesting
   static final String SCOPE = "https://www.googleapis.com/auth/adwords";
 
@@ -42,8 +43,7 @@ public class GoogleAdsOauthFlow extends GoogleOAuthFlow {
     super(configRepository, SCOPE);
   }
 
-  @VisibleForTesting
-  GoogleAdsOauthFlow(ConfigRepository configRepository, HttpClient client) {
+  @VisibleForTesting GoogleAdsOauthFlow(ConfigRepository configRepository, HttpClient client) {
     super(configRepository, SCOPE, client);
   }
 
@@ -64,9 +64,6 @@ public class GoogleAdsOauthFlow extends GoogleOAuthFlow {
   @Override
   protected Map<String, Object> completeOAuthFlow(String clientId, String clientSecret, String code, String redirectUrl) throws IOException {
     // the config object containing refresh token is nested inside the "credentials" object
-    Map<String, Object> oauthFlowOutput = super.completeOAuthFlow(clientId, clientSecret, code, redirectUrl);
-    HashMap<String, Object> nestedOutput = new HashMap<>();
-    nestedOutput.put("credentials", oauthFlowOutput);
-    return nestedOutput;
+    return Map.of("credentials", super.completeOAuthFlow(clientId, clientSecret, code, redirectUrl));
   }
 }

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleOAuthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/google/GoogleOAuthFlow.java
@@ -141,7 +141,7 @@ public class GoogleOAuthFlow implements OAuthFlowImplementation {
     }
   }
 
-  private Map<String, Object> completeOAuthFlow(String clientId, String clientSecret, String code, String redirectUrl) throws IOException {
+  protected Map<String, Object> completeOAuthFlow(String clientId, String clientSecret, String code, String redirectUrl) throws IOException {
     final ImmutableMap<String, String> body = new Builder<String, String>()
         .put("client_id", clientId)
         .put("client_secret", clientSecret)

--- a/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleAdsOauthFlowTest.java
+++ b/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleAdsOauthFlowTest.java
@@ -1,4 +1,34 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.airbyte.oauth.google;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
@@ -7,21 +37,14 @@ import io.airbyte.config.SourceOAuthParameter;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.validation.json.JsonValidationException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GoogleAdsOauthFlowTest {
 
@@ -106,4 +129,5 @@ public class GoogleAdsOauthFlowTest {
     assertThrows(IllegalArgumentException.class, () -> googleAdsOauthFlow.getClientSecretUnsafe(Jsons.jsonNode(clientIdMap)));
     assertEquals(clientSecret, googleAdsOauthFlow.getClientSecretUnsafe(Jsons.jsonNode(nestedConfig)));
   }
+
 }

--- a/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleAdsOauthFlowTest.java
+++ b/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleAdsOauthFlowTest.java
@@ -1,0 +1,109 @@
+package io.airbyte.oauth.google;
+
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.DestinationOAuthParameter;
+import io.airbyte.config.SourceOAuthParameter;
+import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.validation.json.JsonValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GoogleAdsOauthFlowTest {
+
+  private static final String SCOPE = "https%3A//www.googleapis.com/auth/analytics.readonly";
+  private static final String REDIRECT_URL = "https://airbyte.io";
+
+  private HttpClient httpClient;
+  private ConfigRepository configRepository;
+  private GoogleAdsOauthFlow googleAdsOauthFlow;
+
+  private UUID workspaceId;
+  private UUID definitionId;
+
+  @BeforeEach
+  public void setup() {
+    httpClient = mock(HttpClient.class);
+    configRepository = mock(ConfigRepository.class);
+    googleAdsOauthFlow = new GoogleAdsOauthFlow(configRepository, httpClient);
+
+    workspaceId = UUID.randomUUID();
+    definitionId = UUID.randomUUID();
+  }
+
+  @Test
+  public void testCompleteSourceOAuth() throws IOException, ConfigNotFoundException, JsonValidationException, InterruptedException {
+    when(configRepository.listSourceOAuthParam()).thenReturn(List.of(new SourceOAuthParameter()
+        .withOauthParameterId(UUID.randomUUID())
+        .withSourceDefinitionId(definitionId)
+        .withWorkspaceId(workspaceId)
+        .withConfiguration(Jsons.jsonNode(Map.of("credentials", ImmutableMap.builder()
+            .put("client_id", "test_client_id")
+            .put("client_secret", "test_client_secret")
+            .build())))));
+
+    Map<String, String> returnedCredentials = Map.of("refresh_token", "refresh_token_response");
+    final HttpResponse response = mock(HttpResponse.class);
+    when(response.body()).thenReturn(Jsons.serialize(returnedCredentials));
+    when(httpClient.send(any(), any())).thenReturn(response);
+    final Map<String, Object> queryParams = Map.of("code", "test_code");
+    final Map<String, Object> actualQueryParams = googleAdsOauthFlow.completeSourceOAuth(workspaceId, definitionId, queryParams, REDIRECT_URL);
+
+    assertEquals(Jsons.serialize(Map.of("credentials", returnedCredentials)), Jsons.serialize(actualQueryParams));
+  }
+
+  @Test
+  public void testCompleteDestinationOAuth() throws IOException, ConfigNotFoundException, JsonValidationException, InterruptedException {
+    when(configRepository.listDestinationOAuthParam()).thenReturn(List.of(new DestinationOAuthParameter()
+        .withOauthParameterId(UUID.randomUUID())
+        .withDestinationDefinitionId(definitionId)
+        .withWorkspaceId(workspaceId)
+        .withConfiguration(Jsons.jsonNode(Map.of("credentials", ImmutableMap.builder()
+            .put("client_id", "test_client_id")
+            .put("client_secret", "test_client_secret")
+            .build())))));
+
+    Map<String, String> returnedCredentials = Map.of("refresh_token", "refresh_token_response");
+    final HttpResponse response = mock(HttpResponse.class);
+    when(response.body()).thenReturn(Jsons.serialize(returnedCredentials));
+    when(httpClient.send(any(), any())).thenReturn(response);
+    final Map<String, Object> queryParams = Map.of("code", "test_code");
+    final Map<String, Object> actualQueryParams = googleAdsOauthFlow.completeDestinationOAuth(workspaceId, definitionId, queryParams, REDIRECT_URL);
+
+    assertEquals(Jsons.serialize(Map.of("credentials", returnedCredentials)), Jsons.serialize(actualQueryParams));
+  }
+
+  @Test
+  public void testGetClientIdUnsafe() {
+    String clientId = "123";
+    Map<String, String> clientIdMap = Map.of("client_id", clientId);
+    Map<String, Map<String, String>> nestedConfig = Map.of("credentials", clientIdMap);
+
+    assertThrows(IllegalArgumentException.class, () -> googleAdsOauthFlow.getClientIdUnsafe(Jsons.jsonNode(clientIdMap)));
+    assertEquals(clientId, googleAdsOauthFlow.getClientIdUnsafe(Jsons.jsonNode(nestedConfig)));
+  }
+
+  @Test
+  public void testGetClientSecretUnsafe() {
+    String clientSecret = "secret";
+    Map<String, String> clientIdMap = Map.of("client_secret", clientSecret);
+    Map<String, Map<String, String>> nestedConfig = Map.of("credentials", clientIdMap);
+
+    assertThrows(IllegalArgumentException.class, () -> googleAdsOauthFlow.getClientSecretUnsafe(Jsons.jsonNode(clientIdMap)));
+    assertEquals(clientSecret, googleAdsOauthFlow.getClientSecretUnsafe(Jsons.jsonNode(nestedConfig)));
+  }
+}

--- a/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleOAuthFlowTest.java
+++ b/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleOAuthFlowTest.java
@@ -200,4 +200,5 @@ public class GoogleOAuthFlowTest {
       return credentialsJson.get("client_id").asText();
     }
   }
+
 }

--- a/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleOAuthFlowTest.java
+++ b/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleOAuthFlowTest.java
@@ -55,8 +55,8 @@ public class GoogleOAuthFlowTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GoogleOAuthFlowTest.class);
   private static final Path CREDENTIALS_PATH = Path.of("secrets/credentials.json");
-  private static final String REDIRECT_URL = "https%3A//airbyte.io";
-  private static final String SCOPE = "https%3A//www.googleapis.com/auth/analytics.readonly";
+  private static final String REDIRECT_URL = "https://airbyte.io";
+  private static final String SCOPE = "https://www.googleapis.com/auth/analytics.readonly";
 
   private HttpClient httpClient;
   private ConfigRepository configRepository;

--- a/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleOAuthFlowTest.java
+++ b/airbyte-oauth/src/test/java/io/airbyte/oauth/google/GoogleOAuthFlowTest.java
@@ -200,5 +200,4 @@ public class GoogleOAuthFlowTest {
       return credentialsJson.get("client_id").asText();
     }
   }
-
 }


### PR DESCRIPTION
## What
The oauth flow for google ads currently returns an object in the format 

```
{refresh_token: abc}
```

but the config for the connector accepts: 

```
{ credentials: {refresh_token: abc}}
```

This PR changes the format and adds tests for the Google Ads flow. 

