### PR TITLE
use spec when persisting source configs

### DIFF
--- a/airbyte-config/persistence/build.gradle
+++ b/airbyte-config/persistence/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation project(':airbyte-db:lib')
     implementation project(':airbyte-db:jooq')
     implementation project(':airbyte-config:models')
+    implementation project(':airbyte-protocol:models')
     implementation project(':airbyte-config:init')
     implementation project(':airbyte-json-validation')
 

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -37,7 +37,9 @@ import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardWorkspace;
+import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
+import io.airbyte.protocol.models.ConnectorSpecification;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -168,7 +170,17 @@ public class ConfigRepository {
     return persistence.getConfig(ConfigSchema.SOURCE_CONNECTION, sourceId.toString(), SourceConnection.class);
   }
 
+  @Deprecated
   public void writeSourceConnection(final SourceConnection source) throws JsonValidationException, IOException {
+    persistence.writeConfig(ConfigSchema.SOURCE_CONNECTION, source.getSourceId().toString(), source);
+  }
+
+  public void writeSourceConnection(final SourceConnection source, final ConnectorSpecification connectorSpecification) throws JsonValidationException, IOException {
+    // START: ONLY FOR SANITY CHECKING I'M PASSING CORRECT VALUES
+    final JsonSchemaValidator validator = new JsonSchemaValidator();
+    validator.ensure(connectorSpecification.getConnectionSpecification(), source.getConfiguration());
+    // END: ONLY FOR SANITY CHECKING I'M PASSING CORRECT VALUES
+
     persistence.writeConfig(ConfigSchema.SOURCE_CONNECTION, source.getSourceId().toString(), source);
   }
 

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -172,11 +172,9 @@ public class ConfigRepository {
 
   public void writeSourceConnection(final SourceConnection source, final ConnectorSpecification connectorSpecification)
       throws JsonValidationException, IOException {
-    System.out.println("connectorSpecification = " + connectorSpecification);
-    // START: ONLY FOR SANITY CHECKING I'M PASSING CORRECT VALUES
+    // actual validation is only for sanity checking
     final JsonSchemaValidator validator = new JsonSchemaValidator();
     validator.ensure(connectorSpecification.getConnectionSpecification(), source.getConfiguration());
-    // END: ONLY FOR SANITY CHECKING I'M PASSING CORRECT VALUES
 
     persistence.writeConfig(ConfigSchema.SOURCE_CONNECTION, source.getSourceId().toString(), source);
   }

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -37,9 +37,9 @@ import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardWorkspace;
+import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
-import io.airbyte.protocol.models.ConnectorSpecification;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -170,12 +170,9 @@ public class ConfigRepository {
     return persistence.getConfig(ConfigSchema.SOURCE_CONNECTION, sourceId.toString(), SourceConnection.class);
   }
 
-  @Deprecated
-  public void writeSourceConnection(final SourceConnection source) throws JsonValidationException, IOException {
-    persistence.writeConfig(ConfigSchema.SOURCE_CONNECTION, source.getSourceId().toString(), source);
-  }
-
-  public void writeSourceConnection(final SourceConnection source, final ConnectorSpecification connectorSpecification) throws JsonValidationException, IOException {
+  public void writeSourceConnection(final SourceConnection source, final ConnectorSpecification connectorSpecification)
+      throws JsonValidationException, IOException {
+    System.out.println("connectorSpecification = " + connectorSpecification);
     // START: ONLY FOR SANITY CHECKING I'M PASSING CORRECT VALUES
     final JsonSchemaValidator validator = new JsonSchemaValidator();
     validator.ensure(connectorSpecification.getConnectionSpecification(), source.getConfiguration());

--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
@@ -27,6 +27,10 @@ package io.airbyte.scheduler.app;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.airbyte.analytics.Deployment;
 import io.airbyte.analytics.TrackingClientSingleton;
+import io.airbyte.api.client.AirbyteApiClient;
+import io.airbyte.api.client.invoker.ApiClient;
+import io.airbyte.api.client.invoker.ApiException;
+import io.airbyte.api.client.model.HealthCheckRead;
 import io.airbyte.commons.concurrency.GracefulShutdownHandler;
 import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.Configs;
@@ -154,7 +158,7 @@ public class SchedulerApp {
 
   public static void waitForServer(Configs configs) throws InterruptedException {
     final AirbyteApiClient apiClient = new AirbyteApiClient(
-        new io.airbyte.api.client.invoker.ApiClient().setScheme("http")
+        new ApiClient().setScheme("http")
             .setHost(configs.getAirbyteApiHost())
             .setPort(configs.getAirbyteApiPort())
             .setBasePath("/api"));

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/WorkspaceHelperTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/WorkspaceHelperTest.java
@@ -43,6 +43,7 @@ import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.FileSystemConfigPersistence;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.models.Job;
 import io.airbyte.scheduler.models.JobStatus;
 import io.airbyte.validation.json.JsonValidationException;
@@ -96,6 +97,7 @@ class WorkspaceHelperTest {
   ConfigRepository configRepository;
   JobPersistence jobPersistence;
   WorkspaceHelper workspaceHelper;
+  ConnectorSpecification emptyConnectorSpec;
 
   @BeforeEach
   public void setup() throws IOException {
@@ -105,6 +107,9 @@ class WorkspaceHelperTest {
     jobPersistence = mock(JobPersistence.class);
 
     workspaceHelper = new WorkspaceHelper(configRepository, jobPersistence);
+
+    emptyConnectorSpec = mock(ConnectorSpecification.class);
+    when(emptyConnectorSpec.getConnectionSpecification()).thenReturn(Jsons.emptyObject());
   }
 
   @Test
@@ -130,13 +135,13 @@ class WorkspaceHelperTest {
   @Test
   public void testSource() throws IOException, JsonValidationException {
     configRepository.writeStandardSource(SOURCE_DEF);
-    configRepository.writeSourceConnection(SOURCE);
+    configRepository.writeSourceConnection(SOURCE, emptyConnectorSpec);
 
     final UUID retrievedWorkspace = workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(SOURCE_ID);
     assertEquals(WORKSPACE_ID, retrievedWorkspace);
 
     // check that caching is working
-    configRepository.writeSourceConnection(Jsons.clone(SOURCE).withWorkspaceId(UUID.randomUUID()));
+    configRepository.writeSourceConnection(Jsons.clone(SOURCE).withWorkspaceId(UUID.randomUUID()), emptyConnectorSpec);
     final UUID retrievedWorkspaceAfterUpdate = workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(SOURCE_ID);
     assertEquals(WORKSPACE_ID, retrievedWorkspaceAfterUpdate);
   }
@@ -158,7 +163,7 @@ class WorkspaceHelperTest {
   @Test
   public void testConnection() throws IOException, JsonValidationException {
     configRepository.writeStandardSource(SOURCE_DEF);
-    configRepository.writeSourceConnection(SOURCE);
+    configRepository.writeSourceConnection(SOURCE, emptyConnectorSpec);
     configRepository.writeStandardDestinationDefinition(DEST_DEF);
     configRepository.writeDestinationConnection(DEST);
 
@@ -175,7 +180,7 @@ class WorkspaceHelperTest {
 
     // check that caching is working
     final UUID newWorkspace = UUID.randomUUID();
-    configRepository.writeSourceConnection(Jsons.clone(SOURCE).withWorkspaceId(newWorkspace));
+    configRepository.writeSourceConnection(Jsons.clone(SOURCE).withWorkspaceId(newWorkspace), emptyConnectorSpec);
     configRepository.writeDestinationConnection(Jsons.clone(DEST).withWorkspaceId(newWorkspace));
     final UUID retrievedWorkspaceAfterUpdate = workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(DEST_ID);
     assertEquals(WORKSPACE_ID, retrievedWorkspaceAfterUpdate);
@@ -198,7 +203,7 @@ class WorkspaceHelperTest {
   @Test
   public void testConnectionAndJobs() throws IOException, JsonValidationException {
     configRepository.writeStandardSource(SOURCE_DEF);
-    configRepository.writeSourceConnection(SOURCE);
+    configRepository.writeSourceConnection(SOURCE, emptyConnectorSpec);
     configRepository.writeStandardDestinationDefinition(DEST_DEF);
     configRepository.writeDestinationConnection(DEST);
     configRepository.writeStandardSync(CONNECTION);

--- a/airbyte-server/src/main/java/io/airbyte/server/RunMigration.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/RunMigration.java
@@ -29,6 +29,7 @@ import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.migrate.MigrateConfig;
 import io.airbyte.migrate.MigrationRunner;
 import io.airbyte.scheduler.persistence.JobPersistence;
+import io.airbyte.server.converters.SpecFetcher;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.File;
 import java.io.IOException;
@@ -52,11 +53,12 @@ public class RunMigration implements Runnable, AutoCloseable {
   public RunMigration(JobPersistence jobPersistence,
                       ConfigRepository configRepository,
                       String targetVersion,
-                      ConfigPersistence seedPersistence) {
+                      ConfigPersistence seedPersistence,
+                      SpecFetcher specFetcher) {
     this.targetVersion = targetVersion;
     this.seedPersistence = seedPersistence;
     this.configDumpExporter = new ConfigDumpExporter(configRepository, jobPersistence, null);
-    this.configDumpImporter = new ConfigDumpImporter(configRepository, jobPersistence, null);
+    this.configDumpImporter = new ConfigDumpImporter(configRepository, jobPersistence, null, specFetcher);
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -197,7 +197,8 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
     webBackendSourcesHandler = new WebBackendSourcesHandler(sourceHandler, configRepository);
     webBackendDestinationsHandler = new WebBackendDestinationsHandler(destinationHandler, configRepository);
     healthCheckHandler = new HealthCheckHandler(configRepository);
-    archiveHandler = new ArchiveHandler(configs.getAirbyteVersion(), configRepository, jobPersistence, workspaceHelper, archiveTtlManager);
+    archiveHandler =
+        new ArchiveHandler(configs.getAirbyteVersion(), configRepository, jobPersistence, workspaceHelper, archiveTtlManager, specFetcher);
     logsHandler = new LogsHandler();
     openApiConfigHandler = new OpenApiConfigHandler();
     dbMigrationHandler = new DbMigrationHandler(configsDatabase, jobsDatabase);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
@@ -37,6 +37,7 @@ import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.scheduler.persistence.WorkspaceHelper;
 import io.airbyte.server.ConfigDumpExporter;
 import io.airbyte.server.ConfigDumpImporter;
+import io.airbyte.server.converters.SpecFetcher;
 import io.airbyte.server.errors.InternalServerKnownException;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.File;
@@ -58,12 +59,13 @@ public class ArchiveHandler {
                         final ConfigRepository configRepository,
                         final JobPersistence jobPersistence,
                         final WorkspaceHelper workspaceHelper,
-                        final FileTtlManager fileTtlManager) {
+                        final FileTtlManager fileTtlManager,
+                        final SpecFetcher specFetcher) {
     this(
         version,
         fileTtlManager,
         new ConfigDumpExporter(configRepository, jobPersistence, workspaceHelper),
-        new ConfigDumpImporter(configRepository, jobPersistence, workspaceHelper));
+        new ConfigDumpImporter(configRepository, jobPersistence, workspaceHelper, specFetcher));
   }
 
   public ArchiveHandler(final String version,

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -237,10 +237,14 @@ public class SourceHandler {
 
   private ConnectorSpecification getSpecFromSourceDefinitionId(UUID sourceDefId)
       throws IOException, JsonValidationException, ConfigNotFoundException {
-    final StandardSourceDefinition sourceDef = configRepository
-        .getStandardSourceDefinition(sourceDefId);
+    final StandardSourceDefinition sourceDef = configRepository.getStandardSourceDefinition(sourceDefId);
+    return getSpecFromSourceDefinitionId(specFetcher, sourceDef);
+  }
+
+  public static ConnectorSpecification getSpecFromSourceDefinitionId(SpecFetcher specFetcher, StandardSourceDefinition sourceDefinition)
+      throws IOException, ConfigNotFoundException {
     final String imageName = DockerUtils
-        .getTaggedImageName(sourceDef.getDockerRepository(), sourceDef.getDockerImageTag());
+        .getTaggedImageName(sourceDefinition.getDockerRepository(), sourceDefinition.getDockerImageTag());
     return specFetcher.execute(imageName);
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -93,7 +93,7 @@ public class SourceHandler {
   public SourceRead createSource(SourceCreate sourceCreate)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     // validate configuration
-    ConnectorSpecification spec = getSpecFromSourceDefinitionId(
+    final ConnectorSpecification spec = getSpecFromSourceDefinitionId(
         sourceCreate.getSourceDefinitionId());
     validateSource(spec, sourceCreate.getConnectionConfiguration());
 
@@ -105,7 +105,8 @@ public class SourceHandler {
         sourceCreate.getWorkspaceId(),
         sourceId,
         false,
-        sourceCreate.getConnectionConfiguration());
+        sourceCreate.getConnectionConfiguration(),
+        spec);
 
     // read configuration from db
     return buildSourceRead(sourceId, spec);
@@ -117,7 +118,7 @@ public class SourceHandler {
     final SourceConnection updatedSource = configurationUpdate
         .source(sourceUpdate.getSourceId(), sourceUpdate.getName(),
             sourceUpdate.getConnectionConfiguration());
-    ConnectorSpecification spec = getSpecFromSourceId(updatedSource.getSourceId());
+    final ConnectorSpecification spec = getSpecFromSourceId(updatedSource.getSourceId());
     validateSource(spec, sourceUpdate.getConnectionConfiguration());
 
     // persist
@@ -127,7 +128,8 @@ public class SourceHandler {
         updatedSource.getWorkspaceId(),
         updatedSource.getSourceId(),
         updatedSource.getTombstone(),
-        updatedSource.getConfiguration());
+        updatedSource.getConfiguration(),
+        spec);
 
     // read configuration from db
     return buildSourceRead(sourceUpdate.getSourceId(), spec);
@@ -185,6 +187,9 @@ public class SourceHandler {
       connectionsHandler.deleteConnection(connectionRead);
     }
 
+    final ConnectorSpecification spec = getSpecFromSourceId(source.getSourceId());
+    validateSource(spec, source.getConnectionConfiguration());
+
     // persist
     persistSourceConnection(
         source.getName(),
@@ -192,7 +197,8 @@ public class SourceHandler {
         source.getWorkspaceId(),
         source.getSourceId(),
         true,
-        source.getConnectionConfiguration());
+        source.getConnectionConfiguration(),
+        spec);
   }
 
   private SourceRead buildSourceRead(UUID sourceId)
@@ -243,7 +249,8 @@ public class SourceHandler {
                                        final UUID workspaceId,
                                        final UUID sourceId,
                                        final boolean tombstone,
-                                       final JsonNode configurationJson)
+                                       final JsonNode configurationJson,
+                                       final ConnectorSpecification spec)
       throws JsonValidationException, IOException {
     final SourceConnection sourceConnection = new SourceConnection()
         .withName(name)
@@ -253,7 +260,7 @@ public class SourceHandler {
         .withTombstone(tombstone)
         .withConfiguration(configurationJson);
 
-    configRepository.writeSourceConnection(sourceConnection);
+    configRepository.writeSourceConnection(sourceConnection, spec);
   }
 
   private SourceRead toSourceRead(final SourceConnection sourceConnection,

--- a/airbyte-server/src/test/java/io/airbyte/server/ConfigDumpImporterTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/ConfigDumpImporterTest.java
@@ -44,9 +44,11 @@ import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncOperation.OperatorType;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.persistence.DefaultJobPersistence;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.scheduler.persistence.WorkspaceHelper;
+import io.airbyte.server.converters.SpecFetcher;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.File;
@@ -76,13 +78,21 @@ class ConfigDumpImporterTest {
   private DestinationConnection destinationConnection;
   private StandardSyncOperation operation;
   private StandardSync connection;
+  private ConnectorSpecification emptyConnectorSpec;
+  private SpecFetcher specFetcher;
 
   @BeforeEach
   public void setup() throws IOException, JsonValidationException, ConfigNotFoundException {
     configRepository = mock(ConfigRepository.class);
     jobPersistence = mock(JobPersistence.class);
     workspaceHelper = mock(WorkspaceHelper.class);
-    configDumpImporter = new ConfigDumpImporter(configRepository, jobPersistence, workspaceHelper, mock(JsonSchemaValidator.class));
+
+    specFetcher = mock(SpecFetcher.class);
+    emptyConnectorSpec = mock(ConnectorSpecification.class);
+    when(emptyConnectorSpec.getConnectionSpecification()).thenReturn(Jsons.emptyObject());
+    when(specFetcher.execute(any())).thenReturn(emptyConnectorSpec);
+
+    configDumpImporter = new ConfigDumpImporter(configRepository, jobPersistence, workspaceHelper, mock(JsonSchemaValidator.class), specFetcher);
     configDumpExporter = new ConfigDumpExporter(configRepository, jobPersistence, workspaceHelper);
 
     workspaceId = UUID.randomUUID();
@@ -176,7 +186,9 @@ class ConfigDumpImporterTest {
     configDumpImporter.importIntoWorkspace(TEST_VERSION, newWorkspaceId, archive);
 
     verify(configRepository)
-        .writeSourceConnection(Jsons.clone(sourceConnection).withWorkspaceId(newWorkspaceId).withSourceId(not(eq(sourceConnection.getSourceId()))));
+        .writeSourceConnection(
+            Jsons.clone(sourceConnection).withWorkspaceId(newWorkspaceId).withSourceId(not(eq(sourceConnection.getSourceId()))),
+            eq(emptyConnectorSpec));
     verify(configRepository).writeDestinationConnection(
         Jsons.clone(destinationConnection).withWorkspaceId(newWorkspaceId).withDestinationId(not(eq(destinationConnection.getDestinationId()))));
     verify(configRepository)
@@ -226,7 +238,9 @@ class ConfigDumpImporterTest {
     final UUID newWorkspaceId = UUID.randomUUID();
     configDumpImporter.importIntoWorkspace(TEST_VERSION, newWorkspaceId, archive);
 
-    verify(configRepository).writeSourceConnection(Jsons.clone(sourceConnection).withWorkspaceId(newWorkspaceId));
+    verify(configRepository).writeSourceConnection(
+        Jsons.clone(sourceConnection).withWorkspaceId(newWorkspaceId),
+        emptyConnectorSpec);
     verify(configRepository).writeDestinationConnection(Jsons.clone(destinationConnection).withWorkspaceId(newWorkspaceId));
     verify(configRepository).writeStandardSyncOperation(Jsons.clone(operation).withWorkspaceId(newWorkspaceId));
     verify(configRepository).writeStandardSync(connection);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -27,6 +27,7 @@ package io.airbyte.server.handlers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -130,13 +131,18 @@ public class ArchiveHandlerTest {
 
     jobPersistence.setVersion(VERSION);
 
+    final SpecFetcher specFetcher = mock(SpecFetcher.class);
+    final ConnectorSpecification emptyConnectorSpec = mock(ConnectorSpecification.class);
+    when(emptyConnectorSpec.getConnectionSpecification()).thenReturn(Jsons.emptyObject());
+    when(specFetcher.execute(any())).thenReturn(emptyConnectorSpec);
+
     archiveHandler = new ArchiveHandler(
         VERSION,
         configRepository,
         jobPersistence,
         new WorkspaceHelper(configRepository, jobPersistence),
         new NoOpFileTtlManager(),
-        mock(SpecFetcher.class));
+        specFetcher);
   }
 
   @AfterEach

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -55,6 +55,7 @@ import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.persistence.DefaultJobPersistence;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.scheduler.persistence.WorkspaceHelper;
+import io.airbyte.server.converters.SpecFetcher;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.File;
 import java.io.IOException;
@@ -134,7 +135,8 @@ public class ArchiveHandlerTest {
         configRepository,
         jobPersistence,
         new WorkspaceHelper(configRepository, jobPersistence),
-        new NoOpFileTtlManager());
+        new NoOpFileTtlManager(),
+        mock(SpecFetcher.class));
   }
 
   @AfterEach
@@ -257,12 +259,12 @@ public class ArchiveHandlerTest {
         .collect(Collectors.toList()).get(0);
 
     final SourceConnection sourceConnection = new SourceConnection()
-            .withWorkspaceId(secondWorkspaceId)
-            .withSourceId(secondSourceId)
-            .withName("Some new names")
-            .withSourceDefinitionId(UUID.randomUUID())
-            .withTombstone(false)
-            .withConfiguration(Jsons.emptyObject());
+        .withWorkspaceId(secondWorkspaceId)
+        .withSourceId(secondSourceId)
+        .withName("Some new names")
+        .withSourceDefinitionId(UUID.randomUUID())
+        .withTombstone(false)
+        .withConfiguration(Jsons.emptyObject());
 
     ConnectorSpecification emptyConnectorSpec = mock(ConnectorSpecification.class);
     when(emptyConnectorSpec.getConnectionSpecification()).thenReturn(Jsons.emptyObject());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
@@ -138,7 +138,7 @@ class SourceHandlerTest {
     assertEquals(expectedSourceRead, actualSourceRead);
 
     verify(secretsProcessor).maskSecrets(sourceCreate.getConnectionConfiguration(), sourceDefinitionSpecificationRead.getConnectionSpecification());
-    verify(configRepository).writeSourceConnection(sourceConnection);
+    verify(configRepository).writeSourceConnection(sourceConnection, connectorSpecification);
     verify(validator).ensure(sourceDefinitionSpecificationRead.getConnectionSpecification(), sourceConnection.getConfiguration());
   }
 
@@ -180,7 +180,7 @@ class SourceHandlerTest {
     assertEquals(expectedSourceRead, actualSourceRead);
 
     verify(secretsProcessor).maskSecrets(newConfiguration, sourceDefinitionSpecificationRead.getConnectionSpecification());
-    verify(configRepository).writeSourceConnection(expectedSourceConnection);
+    verify(configRepository).writeSourceConnection(expectedSourceConnection, connectorSpecification);
     verify(validator).ensure(sourceDefinitionSpecificationRead.getConnectionSpecification(), newConfiguration);
   }
 
@@ -261,7 +261,7 @@ class SourceHandlerTest {
 
     sourceHandler.deleteSource(sourceIdRequestBody);
 
-    verify(configRepository).writeSourceConnection(expectedSourceConnection);
+    verify(configRepository).writeSourceConnection(expectedSourceConnection, connectorSpecification);
     verify(connectionsHandler).listConnectionsForWorkspace(workspaceIdRequestBody);
     verify(connectionsHandler).deleteConnection(connectionRead);
   }

--- a/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.io.Resources;
 import io.airbyte.commons.io.Archives;
@@ -51,6 +52,7 @@ import io.airbyte.migrate.Migrations;
 import io.airbyte.scheduler.persistence.DefaultJobPersistence;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.server.RunMigration;
+import io.airbyte.server.converters.SpecFetcher;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.File;
 import java.io.IOException;
@@ -308,7 +310,10 @@ public class RunMigrationTest {
         jobPersistence,
         new ConfigRepository(FileSystemConfigPersistence.createWithValidation(configRoot)),
         TARGET_VERSION,
-        YamlSeedConfigPersistence.get())) {
+        YamlSeedConfigPersistence.get(),
+        mock(SpecFetcher.class) // this test was disabled/broken when this fetcher mock was added. apologies if you have to fix this
+                                // in the future.
+    )) {
       runMigration.run();
     }
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -24,9 +24,6 @@
 
 package io.airbyte.workers;
 
-import io.airbyte.api.client.AirbyteApiClient;
-import io.airbyte.api.client.invoker.ApiException;
-import io.airbyte.api.client.model.HealthCheckRead;
 import io.airbyte.config.Configs;
 import io.airbyte.config.EnvConfigs;
 import io.airbyte.config.MaxWorkersConfig;
@@ -133,25 +130,6 @@ public class WorkerApp {
     }
   }
 
-  public static void waitForServer(Configs configs) throws InterruptedException {
-    final AirbyteApiClient apiClient = new AirbyteApiClient(
-        new io.airbyte.api.client.invoker.ApiClient().setScheme("http")
-            .setHost(configs.getAirbyteApiHost())
-            .setPort(configs.getAirbyteApiPort())
-            .setBasePath("/api"));
-
-    boolean isHealthy = false;
-    while (!isHealthy) {
-      try {
-        HealthCheckRead healthCheck = apiClient.getHealthApi().getHealthCheck();
-        isHealthy = healthCheck.getDb();
-      } catch (ApiException e) {
-        LOGGER.info("Waiting for server to become available...");
-        Thread.sleep(2000);
-      }
-    }
-  }
-
   private static final WorkerOptions getWorkerOptions(int max) {
     return WorkerOptions.newBuilder()
         .setMaxConcurrentActivityExecutionSize(max)
@@ -160,8 +138,6 @@ public class WorkerApp {
 
   public static void main(String[] args) throws IOException, InterruptedException {
     final Configs configs = new EnvConfigs();
-
-    waitForServer(configs);
 
     LogClientSingleton.setWorkspaceMdc(LogClientSingleton.getSchedulerLogsRoot(configs));
 


### PR DESCRIPTION
In order to determine which fields of a config we are persisting are secrets, we need to read the spec for the config. This PR doesn't do anything with the spec yet, it's just changing the interface to support the case in the future where the config repository will need to handle each secret field in a config.

This PR handles passing the spec in for **source** configs. If this looks good, I'll do the same for destination configs.

Reading order:
1. `ConfigRepository`
2. Everywhere else that now has to handle passing in a spec.