### PR TITLE
Source Facebook Marketing: added optional end_date configuration

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json
@@ -26,7 +26,7 @@
       },
       "end_date": {
         "title": "End Date",
-        "description": "The end date from which you'd like to replicate data for AdCreatives and AdInsights APIs, in the format YYYY-MM-DDT00:00:00Z. All data generated up to this date will be replicated.",
+        "description": "The end date until which you'd like to replicate data for AdCreatives and AdInsights APIs, in the format YYYY-MM-DDT00:00:00Z. All data generated between start_date and this date will be replicated.",
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
         "examples": ["2017-01-25T00:00:00Z"],
         "type": "string",

--- a/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json
@@ -24,6 +24,14 @@
         "type": "string",
         "format": "date-time"
       },
+      "end_date": {
+        "title": "End Date",
+        "description": "The end date from which you'd like to replicate data for AdCreatives and AdInsights APIs, in the format YYYY-MM-DDT00:00:00Z. All data generated up to this date will be replicated.",
+        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+        "examples": ["2017-01-25T00:00:00Z"],
+        "type": "string",
+        "format": "date-time"
+      },
       "include_deleted": {
         "title": "Include Deleted",
         "description": "Include data from deleted campaigns, ads, and adsets.",

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
@@ -23,6 +23,7 @@
 #
 
 from datetime import datetime
+import pendulum
 from typing import Any, List, Mapping, Tuple, Type
 
 from airbyte_cdk.models import ConnectorSpecification, DestinationSyncMode
@@ -61,6 +62,14 @@ class ConnectorConfig(BaseModel):
         pattern="^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
         examples=["2017-01-25T00:00:00Z"],
     )
+
+    end_date: datetime = Field(
+        default=pendulum.now(),
+        description="The date until which you'd like to replicate data for AdCreatives and AdInsights APIs, in the format YYYY-MM-DDT00:00:00Z. All data generated between start_date and this date will be replicated.",
+        pattern="^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+        examples=["2017-01-26T00:00:00Z"],
+    )
+
 
     include_deleted: bool = Field(default=False, description="Include data from deleted campaigns, ads, and adsets.")
 
@@ -110,15 +119,15 @@ class SourceFacebookMarketing(AbstractSource):
         insights_args = dict(
             api=api,
             start_date=config.start_date,
+            end_date=config.end_date,
             buffer_days=config.insights_lookback_window,
             days_per_job=config.insights_days_per_job,
         )
 
         return [
-            Campaigns(api=api, start_date=config.start_date, include_deleted=config.include_deleted),
-            AdSets(api=api, start_date=config.start_date, include_deleted=config.include_deleted),
-            Ads(api=api, start_date=config.start_date, include_deleted=config.include_deleted),
-            AdCreatives(api=api),
+            Campaigns(api=api, start_date=config.start_date, end_date=config.end_date, include_deleted=config.include_deleted),
+            AdSets(api=api, start_date=config.start_date, end_date=config.end_date, include_deleted=config.include_deleted),
+            Ads(api=api, start_date=config.start_date, end_date=config.end_date, include_deleted=config.include_deleted), 
             AdsInsights(**insights_args),
             AdsInsightsAgeAndGender(**insights_args),
             AdsInsightsCountry(**insights_args),

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
@@ -65,7 +65,7 @@ class ConnectorConfig(BaseModel):
 
     end_date: datetime = Field(
         default=pendulum.now(),
-        description="The date until which you'd like to replicate data for AdCreatives and AdInsights APIs, in the format YYYY-MM-DDT00:00:00Z. All data generated between start_date and this date will be replicated.",
+        description="The date until which you'd like to replicate data for AdCreatives and AdInsights APIs, in the format YYYY-MM-DDT00:00:00Z. All data generated between start_date and this date will be replicated. Not setting this option will result in always syncing the latest data. ",
         pattern="^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
         examples=["2017-01-26T00:00:00Z"],
     )

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams.py
@@ -161,9 +161,10 @@ class FBMarketingStream(Stream, ABC):
 class FBMarketingIncrementalStream(FBMarketingStream, ABC):
     cursor_field = "updated_time"
 
-    def __init__(self, start_date: datetime, **kwargs):
+    def __init__(self, start_date: datetime, end_date: datetime, **kwargs):
         super().__init__(**kwargs)
         self._start_date = pendulum.instance(start_date)
+        self._end_date = pendulum.instance(end_date)
 
     def get_updated_state(self, current_stream_state: MutableMapping[str, Any], latest_record: Mapping[str, Any]):
         """Update stream state from latest record"""
@@ -445,7 +446,7 @@ class AdsInsights(FBMarketingIncrementalStream):
             start_date = pendulum.parse(state_value) - self.lookback_window
         else:
             start_date = self._start_date
-        end_date = pendulum.now()
+        end_date = self._end_date
         start_date = max(end_date - self.INSIGHTS_RETENTION_PERIOD, start_date)
 
         for since in pendulum.period(start_date, end_date).range("days", self._days_per_job):

--- a/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_client.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_client.py
@@ -111,7 +111,7 @@ class TestBackoff:
         requests_mock.register_uri("GET", FacebookSession.GRAPH + f"/{FB_API_VERSION}/1/", [{"status_code": 200}])
         requests_mock.register_uri("GET", FacebookSession.GRAPH + f"/{FB_API_VERSION}/2/", [{"status_code": 200}])
 
-        stream = Campaigns(api=api, start_date=datetime.now(), include_deleted=False)
+        stream = Campaigns(api=api, start_date=datetime.now(), end_date=datetime.now(), include_deleted=False)
         try:
             records = list(stream.read_records(sync_mode=SyncMode.full_refresh, stream_state={}))
             assert records
@@ -172,5 +172,5 @@ class TestBackoff:
         requests_mock.register_uri("GET", FacebookSession.GRAPH + f"/{FB_API_VERSION}/act_{account_id}/campaigns", responses)
 
         with pytest.raises(FacebookRequestError):
-            stream = Campaigns(api=api, start_date=datetime.now(), include_deleted=False)
+            stream = Campaigns(api=api, start_date=datetime.now(), end_date=datetime.now(), include_deleted=False)
             list(stream.read_records(sync_mode=SyncMode.full_refresh, stream_state={}))


### PR DESCRIPTION
## What
Added optional `end_date` configuration to source-facebook-marketing connector, which will make an exemplary `config.json` look as follows:
```json
{
  "start_date": "2021-09-01T00:00:00Z",
  "end_date": "2021-09-15T00:00:00Z",
  "account_id": "<account-id>",
  "access_token": "<access-token>"
}
```
If `end_date` is not set in the `config.yml`, it defaults to the previous current date (now). This PR resolves #6046.

## How
The facebook marketing API supports the passing of an end date for data fetching. The connector implementation had it set to the current date (now). Changed implementation in source.

## Recommended reading order
1. `source_facebook_marketing/source.py`
2. `source_facebook_marketing/stream.py`

## Pre-merge Checklist

<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</p>
</details>
