### PR TITLE
add oauth to connector base dependencies

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -76,6 +76,8 @@ if(!System.getenv().containsKey("SUB_BUILD") || System.getenv().get("SUB_BUILD")
     include ':airbyte-integrations:bases:debezium'
     include ':tools:code-generator'
 
+    include ':airbyte-oauth'
+
     // Needed by normalization integration tests
     include ':airbyte-integrations:connectors:destination-bigquery'
     include ':airbyte-integrations:connectors:destination-jdbc'


### PR DESCRIPTION
## What
connectors base build is breaking because `airbyte-oauth` is not included in its dependencies