### PR TITLE
Update log message for empty env variable

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -424,7 +424,7 @@ public class EnvConfigs implements Configs {
     if (value != null && !value.isEmpty()) {
       return parser.apply(value);
     } else {
-      LOGGER.info("Default null or empty environment variable {} to '{}'", key, isSecret ? "*****" : defaultValue);
+      LOGGER.info("Using default value for environment variable {}: '{}'", key, isSecret ? "*****" : defaultValue);
       return defaultValue;
     }
   }

--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -424,7 +424,7 @@ public class EnvConfigs implements Configs {
     if (value != null && !value.isEmpty()) {
       return parser.apply(value);
     } else {
-      LOGGER.info("{} not found or empty, defaulting to {}", key, isSecret ? "*****" : defaultValue);
+      LOGGER.info("Default null or empty environment variable {} to '{}'", key, isSecret ? "*****" : defaultValue);
       return defaultValue;
     }
   }


### PR DESCRIPTION
The original message that a variable is "not found" can be worrisome. Example: [slack thread](https://airbytehq.slack.com/archives/C01MFR03D5W/p1631732592355900). It is replaced with a hopefully less alerting tone.
