### PR TITLE
Fix OAuth Summary strings

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1234,7 +1234,7 @@ paths:
     post:
       tags:
         - oauth
-      summary: Given a source def ID and optional workspaceID generate an access/refresh token etc.
+      summary: Given a source def ID generate an access/refresh token etc.
       operationId: completeSourceOAuth
       requestBody:
         content:
@@ -1280,7 +1280,7 @@ paths:
     post:
       tags:
         - oauth
-      summary:
+      summary: Given a destination def ID generate an access/refresh token etc.
       operationId: completeDestinationOAuth
       requestBody:
         content:

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -2767,7 +2767,7 @@ font-style: italic;
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
     <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/destination_oauths/complete_oauth</code></pre></div>
-    <div class="method-summary">null (<span class="nickname">completeDestinationOAuth</span>)</div>
+    <div class="method-summary">Given a destination def ID generate an access/refresh token etc. (<span class="nickname">completeDestinationOAuth</span>)</div>
     <div class="method-notes"></div>
 
 
@@ -2820,7 +2820,7 @@ font-style: italic;
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
     <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/source_oauths/complete_oauth</code></pre></div>
-    <div class="method-summary">Given a source def ID and optional workspaceID generate an access/refresh token etc. (<span class="nickname">completeSourceOAuth</span>)</div>
+    <div class="method-summary">Given a source def ID generate an access/refresh token etc. (<span class="nickname">completeSourceOAuth</span>)</div>
     <div class="method-notes"></div>
 
 


### PR DESCRIPTION
## What
Add a summary to all OAuth routes so conversions when deploying to ESP does not throw "null" errors
