### PR TITLE
Ignore python test coverage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,21 @@ __pycache__
 .ipynb_checkpoints
 .pytest_
 
+# Python unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
 # dbt
 profiles.yml
 


### PR DESCRIPTION
PR #6045 added python coverage reports. We should ignore these report files.

The list is copied from https://github.com/github/gitignore/blob/master/Python.gitignore.
