### PR TITLE
Fix migration validation issue

### DIFF
--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/jobs/migrations/V0_29_15_001__Add_temporalWorkflowId_col_to_Attempts.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/jobs/migrations/V0_29_15_001__Add_temporalWorkflowId_col_to_Attempts.java
@@ -38,7 +38,8 @@ public class V0_29_15_001__Add_temporalWorkflowId_col_to_Attempts extends BaseJa
     // As database schema changes, the generated jOOQ code can be deprecated. So
     // old migration may not compile if there is any generated code.
     DSLContext ctx = DSL.using(context.getConnection());
-    ctx.alterTable("attempts").addColumn(DSL.field("temporal_workflow_id", SQLDataType.VARCHAR(256).nullable(true)))
+    ctx.alterTable("attempts")
+        .addColumnIfNotExists(DSL.field("temporal_workflow_id", SQLDataType.VARCHAR(256).nullable(true)))
         .execute();
   }
 

--- a/airbyte-db/lib/src/main/resources/jobs_database/Attempts.yaml
+++ b/airbyte-db/lib/src/main/resources/jobs_database/Attempts.yaml
@@ -11,7 +11,7 @@ required:
   - status
   - created_at
   - updated_at
-additionalProperties: false
+additionalProperties: true
 properties:
   id:
     type: number

--- a/airbyte-db/lib/src/main/resources/jobs_database/Attempts.yaml
+++ b/airbyte-db/lib/src/main/resources/jobs_database/Attempts.yaml
@@ -11,7 +11,7 @@ required:
   - status
   - created_at
   - updated_at
-additionalProperties: true
+additionalProperties: false
 properties:
   id:
     type: number
@@ -25,8 +25,6 @@ properties:
     type: ["null", object]
   status:
     type: string
-  temporal_workflow_id:
-    type: ["null", string]
   created_at:
     # todo should be datetime.
     type: string

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_14_0/airbyte_db/Attempts.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_14_0/airbyte_db/Attempts.yaml
@@ -11,7 +11,7 @@ required:
   - status
   - created_at
   - updated_at
-additionalProperties: false
+additionalProperties: true
 properties:
   id:
     type: number

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_14_0/airbyte_db/Attempts.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_14_0/airbyte_db/Attempts.yaml
@@ -11,7 +11,7 @@ required:
   - status
   - created_at
   - updated_at
-additionalProperties: true
+additionalProperties: false
 properties:
   id:
     type: number


### PR DESCRIPTION
- The `temporal_workflow_id` added in the Flyway migration (#5850) is not visible to the file-based migration system. So the migration will fail whenever a user tries to upgrades the server from an old version.
- This is a temporary fix to mark the `Attempts` schema forward compatible so that the migration can run.
- We are actually working on deprecating the file-based migration system. Once it is done, we can revert this change.
