### PR TITLE
Add back the migration acceptance test

### DIFF
--- a/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
+++ b/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
@@ -61,7 +61,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,11 +77,7 @@ public class MigrationAcceptanceTest {
   // assume env file is one directory level up from airbyte-tests.
   private final static File ENV_FILE = Path.of(System.getProperty("user.dir")).getParent().resolve(".env").toFile();
 
-  /**
-   * This test is deprecated because it no longer works after the introduce of the Flyway migration.
-   */
   @Test
-  @Disabled
   public void testAutomaticMigration() throws Exception {
     // default to version in env file but can override it.
     final String targetVersion;


### PR DESCRIPTION
This PR reverts #5988.

To prevent issues like #6151, we need this acceptance test as long as the file-based migration system still exists in our codebase.

The acceptance test works now, since production has been fixed in #6154.
