### PR TITLE
Add kubernetes labels to PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,3 +36,9 @@ CDK:
 normalization:
   - airbyte-integrations/bases/base-normalization/*
   - airbyte-integrations/bases/base-normalization/**/*
+
+kubernetes:
+  - kube/*
+  - kube/**/*
+  - charts/*
+  - charts/**/*


### PR DESCRIPTION
## What

This PR makes it easier to see which PRs deal with kubernetes manifests.

## How

It adds labeling rules to the existing labeler workflow and uses the same label `kubernetes` that is used for issues.