### PR TITLE
Expose more configuration through values.yaml files

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -23,3 +23,7 @@ serialize =
 [bumpversion:file:kube/overlays/stable-with-resource-limits/.env]
 
 [bumpversion:file:kube/overlays/stable-with-resource-limits/kustomization.yaml]
+
+[bumpversion:file:charts/airbyte/Chart.yaml]
+
+[bumpversion:file:charts/airbyte/values.yaml]

--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.29.13-alpha"
+appVersion: "0.29.21-alpha"
 
 dependencies:
 - name: common

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -4,9 +4,10 @@
 
 ### Global Parameters
 
-| Name                  | Description                                  | Value |
-| --------------------- | -------------------------------------------- | ----- |
-| `global.storageClass` | Global StorageClass for Persistent Volume(s) | `""`  |
+| Name                   | Description                                  | Value |
+| ---------------------- | -------------------------------------------- | ----- |
+| `global.imageRegistry` | Global Docker image registry                 | `""`  |
+| `global.storageClass`  | Global StorageClass for Persistent Volume(s) | `""`  |
 
 
 ### Common Parameters
@@ -18,6 +19,7 @@
 | `serviceAccount.annotations` | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                          | `{}`            |
 | `serviceAccount.create`      | Specifies whether a ServiceAccount should be created                                                                | `true`          |
 | `serviceAccount.name`        | Name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `airbyte-admin` |
+| `version`                    | Sets the AIRBYTE_VERSION environment variable. Defaults to Chart.AppVersion.                                        | `""`            |
 
 
 ### Webapp Parameters
@@ -27,7 +29,7 @@
 | `webapp.replicaCount`        | Number of webapp replicas                                        | `1`              |
 | `webapp.image.repository`    | The repository to use for the airbyte webapp image.              | `airbyte/webapp` |
 | `webapp.image.pullPolicy`    | the pull policy to use for the airbyte webapp image              | `IfNotPresent`   |
-| `webapp.image.tag`           | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.29.13-alpha`  |
+| `webapp.image.tag`           | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.29.21-alpha`  |
 | `webapp.podAnnotations`      | Add extra annotations to the scheduler pod                       | `{}`             |
 | `webapp.service.type`        | The service type to use for the webapp service                   | `ClusterIP`      |
 | `webapp.service.port`        | The service port to expose the webapp on                         | `80`             |
@@ -41,6 +43,11 @@
 | `webapp.ingress.annotations` | Ingress annotations done as key:value pairs                      | `{}`             |
 | `webapp.ingress.hosts`       | The list of hostnames to be covered with this ingress record.    | `[]`             |
 | `webapp.ingress.tls`         | Custom ingress TLS configuration                                 | `[]`             |
+| `webapp.api.url`             | The webapp API url.                                              | `/api/v1/`       |
+| `webapp.isDemo`              | Set to true if this is a demo                                    | `false`          |
+| `webapp.fullstory.enabled`   | Whether or not to enable fullstory                               | `false`          |
+| `webapp.openreplay.enabled`  | Whether or not to enable openreplay                              | `false`          |
+| `webapp.storytime.enabled`   | Whether or not to enable Papercups storytime                     | `false`          |
 
 
 ### Scheduler Parameters
@@ -50,12 +57,13 @@
 | `scheduler.replicaCount`       | Number of scheduler replicas                                        | `1`                 |
 | `scheduler.image.repository`   | The repository to use for the airbyte scheduler image.              | `airbyte/scheduler` |
 | `scheduler.image.pullPolicy`   | the pull policy to use for the airbyte scheduler image              | `IfNotPresent`      |
-| `scheduler.image.tag`          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.29.13-alpha`     |
+| `scheduler.image.tag`          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.29.21-alpha`     |
 | `scheduler.podAnnotations`     | Add extra annotations to the scheduler pod                          | `{}`                |
 | `scheduler.resources.limits`   | The resources limits for the scheduler container                    | `{}`                |
 | `scheduler.resources.requests` | The requested resources for the scheduler container                 | `{}`                |
 | `scheduler.nodeSelector`       | Node labels for pod assignment                                      | `{}`                |
 | `scheduler.tolerations`        | Tolerations for scheduler pod assignment.                           | `[]`                |
+| `scheduler.log.level`          | The log level to log at.                                            | `INFO`              |
 
 
 ### Pod Sweeper parameters
@@ -79,7 +87,7 @@
 | `server.replicaCount`                       | Number of server replicas                                        | `1`              |
 | `server.image.repository`                   | The repository to use for the airbyte server image.              | `airbyte/server` |
 | `server.image.pullPolicy`                   | the pull policy to use for the airbyte server image              | `IfNotPresent`   |
-| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.29.13-alpha`  |
+| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.29.21-alpha`  |
 | `server.podAnnotations`                     | Add extra annotations to the server pod                          | `{}`             |
 | `server.livenessProbe.enabled`              | Enable livenessProbe on the server                               | `true`           |
 | `server.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                          | `30`             |
@@ -102,6 +110,7 @@
 | `server.persistence.storageClass`           | The storage class to use for the airbyte server pvc              | `""`             |
 | `server.nodeSelector`                       | Node labels for pod assignment                                   | `{}`             |
 | `server.tolerations`                        | Tolerations for server pod assignment.                           | `[]`             |
+| `server.log.level`                          | The log level to log at                                          | `INFO`           |
 
 
 ### Temporal parameters

--- a/charts/airbyte/templates/_helpers.tpl
+++ b/charts/airbyte/templates/_helpers.tpl
@@ -174,3 +174,31 @@ Add environment variables to configure minio
 {{- $port := (include "airbyte.minio.port" .) -}}
 {{- printf "http://%s:%s" $host $port -}}
 {{- end -}}
+
+{{/*
+Returns the Airbyte Scheduler Image
+*/}}
+{{- define "airbyte.schedulerImage" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.scheduler.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Returns the Airbyte Server Image
+*/}}
+{{- define "airbyte.serverImage" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.server.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Returns the Airbyte Webapp Image
+*/}}
+{{- define "airbyte.webappImage" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.webapp.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Returns the Airbyte podSweeper Image
+*/}}
+{{- define "airbyte.podSweeperImage" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.podSweeper.image "global" .Values.global) -}}
+{{- end -}}

--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -3,8 +3,8 @@ kind: ConfigMap
 metadata:
   name: airbyte-env
 data:
-  AIRBYTE_VERSION: {{ .Chart.AppVersion }}
-  API_URL: /api/v1/
+  AIRBYTE_VERSION: {{ .Values.version | default .Chart.AppVersion }}
+  API_URL: {{ .Values.webapp.api.url }}
   AWS_ACCESS_KEY_ID: {{ .Values.minio.accessKey.password }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.minio.secretKey.password }}
   CONFIG_ROOT: /configs
@@ -16,15 +16,14 @@ data:
   DATABASE_URL: {{ include "airbyte.database.url" . | quote }}
   DATABASE_USER: {{ include "airbyte.database.user" . }}
   DB_DOCKER_MOUNT: airbyte_db
-  FULLSTORY: enabled
+  FULLSTORY: {{ ternary "enabled" "disabled" .Values.webapp.fullstory.enabled }}
   GCP_STORAGE_BUCKET: ""
   GOOGLE_APPLICATION_CREDENTIALS: ""
   INTERNAL_API_HOST: {{ include "common.names.fullname" . }}-server:{{ .Values.server.service.port }}
-  IS_DEMO: "false"
+  IS_DEMO: {{ ternary "true" "false" .Values.webapp.isDemo | quote }}
   LOCAL_ROOT: /tmp/airbyte_local
-  LOG_LEVEL: INFO
-  OPENREPLAY: enabled
-  PAPERCUPS_STORYTIME: enabled
+  OPENREPLAY: {{ ternary "enabled" "disabled" .Values.webapp.openreplay.enabled }}
+  PAPERCUPS_STORYTIME: {{ ternary "enabled" "disabled" .Values.webapp.storytime.enabled }}
   RESOURCE_CPU_LIMIT: ""
   RESOURCE_CPU_REQUEST: ""
   RESOURCE_MEMORY_LIMIT: ""

--- a/charts/airbyte/templates/pod-sweeper/deployment.yaml
+++ b/charts/airbyte/templates/pod-sweeper/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       containers:
       - name: airbyte-pod-sweeper
-        image: "{{ .Values.podSweeper.image.repository }}:{{ .Values.podSweeper.image.tag}}"
+        image: {{ include "airbyte.podSweeperImage" . }}
         imagePullPolicy: "{{ .Values.podSweeper.image.pullPolicy }}"
         env:
         - name: KUBE_NAMESPACE

--- a/charts/airbyte/templates/scheduler/deployment.yaml
+++ b/charts/airbyte/templates/scheduler/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       containers:
       - name: airbyte-scheduler-container
-        image: "{{ .Values.scheduler.image.repository }}:{{ default .Chart.AppVersion .Values.scheduler.image.tag }}"
+        image: {{ include "airbyte.schedulerImage" . }}
         imagePullPolicy: "{{ .Values.scheduler.image.pullPolicy }}"
         env:
         - name: AIRBYTE_VERSION
@@ -101,10 +101,7 @@ spec:
               name: airbyte-env
               key: TEMPORAL_WORKER_PORTS
         - name: LOG_LEVEL
-          valueFrom:
-            configMapKeyRef:
-              name: airbyte-env
-              key: LOG_LEVEL
+          value: "{{ .Values.scheduler.log.level }}"
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/airbyte/templates/server/deployment.yaml
+++ b/charts/airbyte/templates/server/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       containers:
       - name: airbyte-server-container
-        image: "{{ .Values.server.image.repository }}:{{ default .Chart.AppVersion .Values.server.image.tag }}"
+        image: {{ include "airbyte.serverImage" . }}
         imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
         env:
         - name: AIRBYTE_VERSION
@@ -92,10 +92,7 @@ spec:
               name: airbyte-env
               key: TEMPORAL_HOST
         - name: LOG_LEVEL
-          valueFrom:
-            configMapKeyRef:
-              name: airbyte-env
-              key: LOG_LEVEL
+          value: "{{ .Values.scheduler.log.level }}"
         - name: RESOURCE_CPU_REQUEST
           valueFrom:
             configMapKeyRef:

--- a/charts/airbyte/templates/webapp/deployment.yaml
+++ b/charts/airbyte/templates/webapp/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       {{- end }}
       containers:
       - name: airbyte-webapp-container
-        image: "{{ .Values.webapp.image.repository }}:{{ default .Chart.AppVersion .Values.webapp.image.tag }}"
+        image: {{ include "airbyte.webappImage" . }}
         imagePullPolicy: "{{ .Values.webapp.image.pullPolicy }}"
         env:
         - name: AIRBYTE_VERSION

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -1,8 +1,10 @@
 ## @section Global Parameters
 
+## @param global.imageRegistry Global Docker image registry
 ## @param global.storageClass Global StorageClass for Persistent Volume(s)
 ##
 global:
+  imageRegistry: ""
   storageClass: ""
 
 ## @section Common Parameters
@@ -25,6 +27,11 @@ serviceAccount:
   annotations: {}
   name: airbyte-admin
 
+## @param version Sets the AIRBYTE_VERSION environment variable. Defaults to Chart.AppVersion.
+## If changing the image tags below, you should probably also update this.
+version: ""
+
+
 ## @section Webapp Parameters
 
 webapp:
@@ -37,7 +44,7 @@ webapp:
   image:
     repository: airbyte/webapp
     pullPolicy: IfNotPresent
-    tag: 0.29.13-alpha
+    tag: 0.29.21-alpha
 
   ## @param webapp.podAnnotations [object] Add extra annotations to the scheduler pod
   ##
@@ -103,6 +110,24 @@ webapp:
     #   hosts:
     #   - chart-example.local
 
+  ## @param webapp.api.url The webapp API url.
+  api:
+    url: /api/v1/
+
+  ## @param webapp.isDemo Set to true if this is a demo
+  isDemo: false
+
+  ## @param webapp.fullstory.enabled Whether or not to enable fullstory
+  fullstory:
+    enabled: false
+
+  ## @param webapp.openreplay.enabled Whether or not to enable openreplay
+  openreplay:
+    enabled: false
+
+  ## @param webapp.storytime.enabled Whether or not to enable Papercups storytime
+  storytime:
+    enabled: false
 
 ## @section Scheduler Parameters
 
@@ -116,7 +141,7 @@ scheduler:
   image:
     repository: airbyte/scheduler
     pullPolicy: IfNotPresent
-    tag: 0.29.13-alpha
+    tag: 0.29.21-alpha
 
   ## @param scheduler.podAnnotations [object] Add extra annotations to the scheduler pod
   ##
@@ -151,6 +176,10 @@ scheduler:
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
+
+  ## @param scheduler.log.level The log level to log at.
+  log:
+    level: "INFO"
 
 
 ## @section Pod Sweeper parameters
@@ -211,7 +240,7 @@ server:
   image:
     repository: airbyte/server
     pullPolicy: IfNotPresent
-    tag: 0.29.13-alpha
+    tag: 0.29.21-alpha
 
   ## @param server.podAnnotations [object] Add extra annotations to the server pod
   ##
@@ -298,6 +327,10 @@ server:
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
+
+  ## @param server.log.level The log level to log at
+  log:
+    level: "INFO"
 
 ## @section Temporal parameters
 ## TODO: Move to consuming temporal from a dedicated helm chart


### PR DESCRIPTION
## What

This bumps the helm chart version and allows for changing more configuration values by overwriting the values.yaml or supplying `--set`s when installing/upgrading.

## How

* Changed the template that generates the full image path to consider `global.imageRegistry`. This makes it easier to use a private image registry for all images.
* Exposed frontend configuration for fullstory, openreplay, storytime, and whether or not it is a demo.
* Allow for changing log level independently for scheduler and server.
* The helm chart can now be used to deploy different versions of Airbyte without having to bump the `.Chart.appVersion` and releasing a new version of the chart. To do this, you can override the values.yaml when installing with a partial like so:

```yaml
version: 0.29.22-alpha
webapp:
  image:
    tag: 0.29.22-alpha
server:
  image:
    tag: 0.29.22-alpha
scheduler:
  image:
    tag: 0.29.22-alpha
```

Its a little verbose, but it allows changing all values independently if testing different configurations is desired. 

