### PR TITLE
Fix exception on API calls

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImporter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImporter.java
@@ -89,14 +89,13 @@ public class ConfigDumpImporter {
   private static final String CONFIG_FOLDER_NAME = "airbyte_config";
   private static final String DB_FOLDER_NAME = "airbyte_db";
   private static final String VERSION_FILE_NAME = "VERSION";
-  private static final String TMP_AIRBYTE_STAGED_RESOURCES = "/tmp/airbyte_staged_resources";
+  private static final Path TMP_AIRBYTE_STAGED_RESOURCES = Path.of("/tmp/airbyte_staged_resources");
 
   private final ConfigRepository configRepository;
   private final WorkspaceHelper workspaceHelper;
   private final SpecFetcher specFetcher;
   private final JsonSchemaValidator jsonSchemaValidator;
   private final JobPersistence jobPersistence;
-  private final Path stagedResourceRoot;
 
   public ConfigDumpImporter(ConfigRepository configRepository,
                             JobPersistence jobPersistence,
@@ -116,13 +115,22 @@ public class ConfigDumpImporter {
     this.configRepository = configRepository;
     this.workspaceHelper = workspaceHelper;
     this.specFetcher = specFetcher;
+  }
+
+  /**
+   * Re-initialize the staged resource folder that contains uploaded artifacts when importing
+   * workspaces. This is because they need to be done in two steps (two API endpoints), upload
+   * resource first then import. When server starts, we flush the content of this folder, deleting
+   * previously staged resources that were not imported yet.
+   */
+  public static void initStagedResourceFolder() {
     try {
-      this.stagedResourceRoot = Path.of(TMP_AIRBYTE_STAGED_RESOURCES);
-      if (stagedResourceRoot.toFile().exists()) {
-        FileUtils.forceDelete(stagedResourceRoot.toFile());
+      File stagedResourceRoot = TMP_AIRBYTE_STAGED_RESOURCES.toFile();
+      if (stagedResourceRoot.exists()) {
+        FileUtils.forceDelete(stagedResourceRoot);
       }
-      FileUtils.forceMkdir(stagedResourceRoot.toFile());
-      FileUtils.forceDeleteOnExit(stagedResourceRoot.toFile());
+      FileUtils.forceMkdir(stagedResourceRoot);
+      FileUtils.forceDeleteOnExit(stagedResourceRoot);
     } catch (IOException e) {
       throw new RuntimeException("Failed to create staging resource folder", e);
     }
@@ -325,7 +333,7 @@ public class ConfigDumpImporter {
   public UploadRead uploadArchiveResource(File archive) {
     try {
       final UUID resourceId = UUID.randomUUID();
-      FileUtils.moveFile(archive, stagedResourceRoot.resolve(resourceId.toString()).toFile());
+      FileUtils.moveFile(archive, TMP_AIRBYTE_STAGED_RESOURCES.resolve(resourceId.toString()).toFile());
       return new UploadRead()
           .status(UploadRead.StatusEnum.SUCCEEDED)
           .resourceId(resourceId);
@@ -336,7 +344,7 @@ public class ConfigDumpImporter {
   }
 
   public File getArchiveResource(UUID resourceId) {
-    final File archive = stagedResourceRoot.resolve(resourceId.toString()).toFile();
+    final File archive = TMP_AIRBYTE_STAGED_RESOURCES.resolve(resourceId.toString()).toFile();
     if (!archive.exists()) {
       throw new IdNotFoundKnownException("Archive Resource not found", resourceId.toString());
     }

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -174,6 +174,9 @@ public class ServerApp implements ServerRunnable {
 
     LogClientSingleton.setWorkspaceMdc(LogClientSingleton.getServerLogsRoot(configs));
 
+    LOGGER.info("Creating Staged Resource folder...");
+    ConfigDumpImporter.initStagedResourceFolder();
+
     LOGGER.info("Creating config repository...");
     final Database configDatabase = new ConfigsDatabaseInstance(
         configs.getConfigDatabaseUser(),


### PR DESCRIPTION
## What
ConfigDumpImporter needs a temporary folder to store staged archives files before actually importing them.
This folder was being flushed every time an API call was made instead of only once at startup.

Closes https://github.com/airbytehq/airbyte/issues/5872

## How
Initialize at ServerApp start.