### PR TITLE
:fireworks:  Spec.json linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,17 @@ repos:
     hooks:
       - id: mypy
         args: ["--config-file=tools/python/.mypy.ini"]
+
+  - repo: local
+    hooks:
+    -   id: spec-linter
+        name: validate connectors spec files
+        language: system
+        entry: python tools/bin/spec_linter.py
+        files: ^.*/spec.json$
+        require_serial: true
+        exclude: |
+            (?x)^.*(
+                /connectors/destination-e2e-test|
+                /connectors/source-e2e-test
+            ).*$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,6 @@ repos:
         language: system
         entry: python tools/bin/spec_linter.py
         files: ^.*/spec.json$
-        require_serial: true
         exclude: |
             (?x)^.*(
                 /connectors/destination-e2e-test|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,13 +38,13 @@ repos:
 
   - repo: local
     hooks:
-    -   id: spec-linter
+      - id: spec-linter
         name: validate connectors spec files
         language: system
         entry: python tools/bin/spec_linter.py
         files: ^.*/spec.json$
         exclude: |
-            (?x)^.*(
-                /connectors/destination-e2e-test|
-                /connectors/source-e2e-test
-            ).*$
+          (?x)^.*(
+              /connectors/destination-e2e-test|
+              /connectors/source-e2e-test
+          ).*$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       - id: spec-linter
         name: validate connectors spec files
         language: system
-        entry: python tools/bin/spec_linter.py
+        entry: python tools/git_hooks/spec_linter.py
         files: ^.*/spec.json$
         exclude: |
           (?x)^.*(

--- a/tools/bin/spec_linter.py
+++ b/tools/bin/spec_linter.py
@@ -1,0 +1,49 @@
+import logging
+import sys
+import os
+import json
+
+# errors counter
+ERRORS = 0
+# required fields for each property field
+FIELDS_TO_CHECK = {"title", "description"}
+# configure logging format
+FORMAT = '%(message)s'
+logging.basicConfig(format=FORMAT)
+
+def parse_spec(spec_path: str):
+    global ERRORS
+    with open(spec_path) as json_file:
+        data = json.load(json_file)
+
+        try:
+            props = data['connectionSpecification']['properties']
+        except KeyError:
+            logging.error(f"\033[1m{spec_path}\033[0m: Couldn't find properties in connector spec.json")
+            ERRORS += 1
+            return
+
+        for field_name, property in props.items():
+            if not FIELDS_TO_CHECK.issubset(property):
+                logging.error(f"\033[1m{spec_path}\033[0m: Check failed for field \x1b[31;1m{field_name}\033[0m")
+                ERRORS += 1
+
+def validate_spec_field(spec_path, spec_object, field):
+    global ERRORS
+    for field_name, property in spec_object.items():
+        if not FIELDS_TO_CHECK.issubset(property):
+            logging.error(f"\033[1m{spec_path}\033[0m: Check failed for field \x1b[31;1m{field_name}\033[0m")
+            ERRORS += 1
+
+if __name__ == "__main__":
+    spec_files = sys.argv[1:]
+    print(f'Spec files found: {len(spec_files)}')
+
+    project_root_dir = os.path.abspath(os.curdir)
+    spec_files = [os.path.join(project_root_dir, f) for f in spec_files]
+    for file_path in spec_files:
+        parse_spec(file_path)
+
+    if ERRORS != 0:
+        exit(1)
+

--- a/tools/bin/spec_linter.py
+++ b/tools/bin/spec_linter.py
@@ -1,9 +1,26 @@
+"""
+This script is responsible for connectors spec.json file validation.
+
+Input:
+List of spec files
+
+Output:
+exit code 0 - check is success
+exit code 1 - check failed for at least one spec file
+
+How spec file validation works:
+1. read spec file and serialize it as python dict object
+2. get properties field from spec object
+3. check if all fields from FIELDS_TO_CHECK exist in each property
+4. if field has oneOf attribute - fetch all subobjects and for each of them goto 2. step
+"""
+
 import logging
 import sys
 import os
 import json
 from collections import defaultdict
-from typing import Any, List, Mapping, Union
+from typing import Any, List, Mapping
 
 # errors counter
 ERRORS = defaultdict(int)
@@ -13,47 +30,65 @@ FIELDS_TO_CHECK = {"title", "description"}
 logging.basicConfig(format="%(message)s")
 
 
-def parse_spec(spec_path: str):
+def read_spec_file(spec_path: str):
     with open(spec_path) as json_file:
         try:
-            properties = json.load(json_file)['connectionSpecification']['properties']
+            root_schema = json.load(json_file)['connectionSpecification']['properties']
         except KeyError:
             logging.error(f"\033[1m{spec_path}\033[0m: Couldn't find properties in connector spec.json")
             ERRORS[spec_path] += 1
             return
 
-    return validate_spec_field(spec_path, properties)
+    validate_schema(spec_path, root_schema)
 
 
-def validate_spec_field(
+def validate_schema(
     spec_path: str,
-    spec_object: Union[Mapping[str, Any], List],
+    schema: Mapping[str, Any],
     parent_fields: List[str] = None
 ):
     parent_fields = parent_fields if parent_fields else []
-    if isinstance(spec_object, dict):
-        for field_name, field_object in spec_object.items():
-            if not FIELDS_TO_CHECK.issubset(field_object):
-                full_field_name = get_full_field_name(field_name, parent_fields)
-                logging.error(f"\033[1m{spec_path}\033[0m: Check failed for field \x1b[31;1m{full_field_name}\033[0m")
-                ERRORS[spec_path] += 1
-                validate_spec_field()
-    elif isinstance(spec_object, list)
+    for field_name, field_schema in schema.items():
+        if not FIELDS_TO_CHECK.issubset(field_schema):
+            full_field_name = get_full_field_name(field_name, parent_fields)
+            logging.error(
+                f"\033[1m{spec_path}\033[0m: Check failed for field \x1b[31;1m{full_field_name}\033[0m"
+            )
+            ERRORS[spec_path] += 1
+
+        for index, oneof_schema in enumerate(fetch_oneof_schemas(field_schema)):
+            validate_schema(
+                spec_path,
+                oneof_schema['properties'],
+                parent_fields + [field_name, str(index)]
+            )
+
+
+def fetch_oneof_schemas(schema: Mapping[str, Any]) -> List[Mapping[str, Any]]:
+    """
+    Finds sub-objects in oneOf field
+    """
+    if schema.get("oneOf") and schema["type"] == "object":
+        return [spec for spec in schema["oneOf"] if spec.get('properties')]
+    return []
 
 
 def get_full_field_name(field_name: str, parent_fields: List[str] = None):
+    """
+    Returns full path to field.
+    e.g. root.middle.child, root.oneof.1.attr
+    """
     return '.'.join(parent_fields + [field_name]) if parent_fields else field_name
 
 
 if __name__ == "__main__":
-    # read list of spec.json files
     spec_files = sys.argv[1:]
-    print(f'Spec files found: {len(spec_files)}')
+    logging.warning(f'Spec files found: {len(spec_files)}')
 
     project_root_dir = os.path.abspath(os.curdir)
     spec_files = [os.path.join(project_root_dir, f) for f in spec_files]
     for file_path in spec_files:
-        parse_spec(file_path)
+        read_spec_file(file_path)
 
     if ERRORS:
         exit(1)

--- a/tools/bin/spec_linter.py
+++ b/tools/bin/spec_linter.py
@@ -12,12 +12,11 @@ How spec file validation works:
 1. read spec file and serialize it as python dict object
 2. get properties field from spec object
 3. check if all fields from FIELDS_TO_CHECK exist in each property
-4. if field has oneOf attribute - fetch all subobjects and for each of them goto 2. step
+4. if field has oneOf attribute - fetch all subobjects and for each of them goto step (2)
 """
 
 import logging
 import sys
-import os
 import json
 from collections import defaultdict
 from typing import Any, List, Mapping
@@ -33,7 +32,7 @@ logging.basicConfig(format="%(message)s")
 def read_spec_file(spec_path: str):
     with open(spec_path) as json_file:
         try:
-            root_schema = json.load(json_file)['connectionSpecification']['properties']
+            root_schema = json.load(json_file)["connectionSpecification"]["properties"]
         except KeyError:
             logging.error(f"\033[1m{spec_path}\033[0m: Couldn't find properties in connector spec.json")
             ERRORS[spec_path] += 1
@@ -45,23 +44,17 @@ def read_spec_file(spec_path: str):
 def validate_schema(
     spec_path: str,
     schema: Mapping[str, Any],
-    parent_fields: List[str] = None
+    parent_fields: List[str] = None,
 ):
     parent_fields = parent_fields if parent_fields else []
     for field_name, field_schema in schema.items():
         if not FIELDS_TO_CHECK.issubset(field_schema):
             full_field_name = get_full_field_name(field_name, parent_fields)
-            logging.error(
-                f"\033[1m{spec_path}\033[0m: Check failed for field \x1b[31;1m{full_field_name}\033[0m"
-            )
+            logging.error(f"\033[1m{spec_path}\033[0m: Check failed for field \x1b[31;1m{full_field_name}\033[0m")
             ERRORS[spec_path] += 1
 
         for index, oneof_schema in enumerate(fetch_oneof_schemas(field_schema)):
-            validate_schema(
-                spec_path,
-                oneof_schema['properties'],
-                parent_fields + [field_name, str(index)]
-            )
+            validate_schema(spec_path, oneof_schema["properties"], parent_fields + [field_name, str(index)])
 
 
 def fetch_oneof_schemas(schema: Mapping[str, Any]) -> List[Mapping[str, Any]]:
@@ -69,27 +62,23 @@ def fetch_oneof_schemas(schema: Mapping[str, Any]) -> List[Mapping[str, Any]]:
     Finds sub-objects in oneOf field
     """
     if schema.get("oneOf") and schema["type"] == "object":
-        return [spec for spec in schema["oneOf"] if spec.get('properties')]
+        return [spec for spec in schema["oneOf"] if spec.get("properties")]
     return []
 
 
 def get_full_field_name(field_name: str, parent_fields: List[str] = None):
     """
-    Returns full path to field.
+    Returns full path to a field.
     e.g. root.middle.child, root.oneof.1.attr
     """
-    return '.'.join(parent_fields + [field_name]) if parent_fields else field_name
+    return ".".join(parent_fields + [field_name]) if parent_fields else field_name
 
 
 if __name__ == "__main__":
     spec_files = sys.argv[1:]
-    logging.warning(f'Spec files found: {len(spec_files)}')
 
-    project_root_dir = os.path.abspath(os.curdir)
-    spec_files = [os.path.join(project_root_dir, f) for f in spec_files]
     for file_path in spec_files:
         read_spec_file(file_path)
 
     if ERRORS:
         exit(1)
-

--- a/tools/bin/spec_linter.py
+++ b/tools/bin/spec_linter.py
@@ -2,40 +2,51 @@ import logging
 import sys
 import os
 import json
+from collections import defaultdict
+from typing import Any, List, Mapping, Union
 
 # errors counter
-ERRORS = 0
-# required fields for each property field
+ERRORS = defaultdict(int)
+# required fields for each property field in spec
 FIELDS_TO_CHECK = {"title", "description"}
-# configure logging format
-FORMAT = '%(message)s'
-logging.basicConfig(format=FORMAT)
+# configure logging
+logging.basicConfig(format="%(message)s")
+
 
 def parse_spec(spec_path: str):
-    global ERRORS
     with open(spec_path) as json_file:
-        data = json.load(json_file)
-
         try:
-            props = data['connectionSpecification']['properties']
+            properties = json.load(json_file)['connectionSpecification']['properties']
         except KeyError:
             logging.error(f"\033[1m{spec_path}\033[0m: Couldn't find properties in connector spec.json")
-            ERRORS += 1
+            ERRORS[spec_path] += 1
             return
 
-        for field_name, property in props.items():
-            if not FIELDS_TO_CHECK.issubset(property):
-                logging.error(f"\033[1m{spec_path}\033[0m: Check failed for field \x1b[31;1m{field_name}\033[0m")
-                ERRORS += 1
+    return validate_spec_field(spec_path, properties)
 
-def validate_spec_field(spec_path, spec_object, field):
-    global ERRORS
-    for field_name, property in spec_object.items():
-        if not FIELDS_TO_CHECK.issubset(property):
-            logging.error(f"\033[1m{spec_path}\033[0m: Check failed for field \x1b[31;1m{field_name}\033[0m")
-            ERRORS += 1
+
+def validate_spec_field(
+    spec_path: str,
+    spec_object: Union[Mapping[str, Any], List],
+    parent_fields: List[str] = None
+):
+    parent_fields = parent_fields if parent_fields else []
+    if isinstance(spec_object, dict):
+        for field_name, field_object in spec_object.items():
+            if not FIELDS_TO_CHECK.issubset(field_object):
+                full_field_name = get_full_field_name(field_name, parent_fields)
+                logging.error(f"\033[1m{spec_path}\033[0m: Check failed for field \x1b[31;1m{full_field_name}\033[0m")
+                ERRORS[spec_path] += 1
+                validate_spec_field()
+    elif isinstance(spec_object, list)
+
+
+def get_full_field_name(field_name: str, parent_fields: List[str] = None):
+    return '.'.join(parent_fields + [field_name]) if parent_fields else field_name
+
 
 if __name__ == "__main__":
+    # read list of spec.json files
     spec_files = sys.argv[1:]
     print(f'Spec files found: {len(spec_files)}')
 
@@ -44,6 +55,6 @@ if __name__ == "__main__":
     for file_path in spec_files:
         parse_spec(file_path)
 
-    if ERRORS != 0:
+    if ERRORS:
         exit(1)
 

--- a/tools/git_hooks/README.md
+++ b/tools/git_hooks/README.md
@@ -1,0 +1,10 @@
+
+## Pre commit linter for spec.json files
+
+Run and apply to all files
+
+`pre-commit run spec-linter -a`
+
+Run unit tests
+
+`python -m pytest .`

--- a/tools/git_hooks/spec_linter.py
+++ b/tools/git_hooks/spec_linter.py
@@ -50,6 +50,10 @@ logging.basicConfig(format="%(message)s")
 
 
 def read_spec_file(spec_path: str) -> bool:
+    """
+    Parses spec file and applies validation rules.
+    Returns True if spec is valid else False
+    """
     errors: List[Tuple[str, Optional[str]]] = []
     with open(spec_path) as json_file:
         try:
@@ -83,11 +87,15 @@ def validate_schema(
     schema: Mapping[str, Any],
     parent_fields: Optional[List[str]] = None,
 ) -> List[Tuple[str, str]]:
+    """
+    Validates given spec dictionary object. Returns list of errors
+    """
     errors: List[Tuple[str, str]] = []
     parent_fields = parent_fields if parent_fields else []
     for field_name, field_schema in schema.items():
-        errors.extend(validate_field(field_name, field_schema, parent_fields))
-        if errors:
+        field_errors = validate_field(field_name, field_schema, parent_fields)
+        errors.extend(field_errors)
+        if field_errors:
             continue
 
         for index, oneof_schema in enumerate(fetch_oneof_schemas(field_schema)):
@@ -115,7 +123,7 @@ def validate_field(
     parent_fields: Optional[List[str]] = None,
 ) -> List[Tuple[str, str]]:
     """
-    Validates single field objects and return errors if thay are exist
+    Validates single field objects and return errors if they exist
     """
     errors: List[Tuple[str, str]] = []
     full_field_name = get_full_field_name(field_name, parent_fields)

--- a/tools/git_hooks/spec_linter.py
+++ b/tools/git_hooks/spec_linter.py
@@ -54,18 +54,17 @@ def read_spec_file(spec_path: str) -> bool:
     with open(spec_path) as json_file:
         try:
             root_schema = json.load(json_file)["connectionSpecification"]["properties"]
-        except KeyError:
+        except (KeyError, TypeError):
             errors.append("Couldn't find properties in connector spec.json")
         except json.JSONDecodeError:
             errors.append("Couldn't parse json file")
         else:
             errors.extend(validate_schema(spec_path, root_schema))
 
-    if errors:
-        for msg in errors:
-            logging.error(f"\033[1m{spec_path}\033[0m:{msg}")
-        return False
-    return True
+    for msg in errors:
+        logging.error(f"\033[1m{spec_path}\033[0m:{msg}")
+
+    return False if errors else True
 
 
 def validate_schema(
@@ -96,9 +95,7 @@ def fetch_oneof_schemas(schema: Mapping[str, Any]) -> List[Mapping[str, Any]]:
     """
     Finds subschemas in oneOf field
     """
-    if schema.get("oneOf"):
-        return [spec for spec in schema["oneOf"] if spec.get("properties")]
-    return []
+    return [spec for spec in schema.get("oneOf", []) if spec.get("properties")]
 
 
 def validate_field(
@@ -112,7 +109,7 @@ def validate_field(
     errors: List[str] = []
     full_field_name = get_full_field_name(field_name, parent_fields)
 
-    if not FIELDS_TO_CHECK.issubset(field_name):
+    if not FIELDS_TO_CHECK.issubset(schema.keys()):
         errors.append("Check failed for field")
 
     if schema.get("oneOf") and (schema["type"] != "object" or not isinstance(schema["oneOf"], list)):

--- a/tools/git_hooks/tests/test_spec_linter.py
+++ b/tools/git_hooks/tests/test_spec_linter.py
@@ -1,0 +1,122 @@
+#
+# MIT License
+#
+# Copyright (c) 2020 Airbyte
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+import json
+import unittest.mock as mock
+
+import spec_linter
+
+
+def test_get_full_field_name():
+    assert spec_linter.get_full_field_name("field") == "field"
+    assert spec_linter.get_full_field_name("field", ["root"]) == "root.field"
+    assert spec_linter.get_full_field_name("field", ["root", "fake_field", "0"]) == "root.fake_field.0.field"
+
+
+def test_fetch_oneof_schemas():
+    # case 1)
+    root_schema = {"oneOf": [{"properties": {1: 1}}, {"values": [1, 2, 3]}]}
+    schemas = spec_linter.fetch_oneof_schemas(root_schema)
+    assert len(schemas) == 1
+    assert schemas[0] == {"properties": {1: 1}}
+    # case 2)
+    root_schema = {"oneOf": [{"properties": {1: 1}}, {"properties": {2: 2}}]}
+    schemas = spec_linter.fetch_oneof_schemas(root_schema)
+    assert len(schemas) == 2
+    assert schemas[0] == {"properties": {1: 1}}
+    assert schemas[1] == {"properties": {2: 2}}
+
+
+def test_validate_field_no_title():
+    schema = {"type": "string", "description": "Format: YYYY-MM-DDTHH:mm:ss[Z]."}
+    errors = spec_linter.validate_field("field", schema, [])
+    assert len(errors) == 1
+    assert "Check failed for field" in errors[0]
+
+
+def test_validate_field_no_description():
+    schema = {"type": "string", "title": "Field", "examples": ["2020-01-01T00:00:00Z"]}
+    errors = spec_linter.validate_field("field", schema, [])
+    assert len(errors) == 1
+    assert "Check failed for field" in errors[0]
+
+
+def test_validate_field_oneof_failed():
+    schema = {
+        "type": "string",
+        "title": "Field",
+        "description": "Format: YYYY-MM-DDTHH:mm:ss[Z].",
+        "examples": ["2020-01-01T00:00:00Z"],
+        "oneOf": [1, 2, 3],
+    }
+    errors = spec_linter.validate_field("field", schema, [])
+    assert len(errors) == 1
+    assert "Incorrect oneOf schema in field" in errors[0]
+
+
+def test_validate_field_oneof_not_array():
+    schema = {
+        "type": "string",
+        "title": "Field",
+        "description": "Format: YYYY-MM-DDTHH:mm:ss[Z].",
+        "examples": ["2020-01-01T00:00:00Z"],
+        "oneOf": "invalid",
+    }
+    errors = spec_linter.validate_field("field", schema, [])
+    assert len(errors) == 1
+    assert "Incorrect oneOf schema in field" in errors[0]
+
+
+def test_read_spec_file():
+    # file is not json serializable
+    with mock.patch("builtins.open", mock.mock_open(read_data="test")):
+        assert not spec_linter.read_spec_file("path_1")
+    # property field is not exist
+    with mock.patch("builtins.open", mock.mock_open(read_data='{"connectionSpecification": "test"}')):
+        assert not spec_linter.read_spec_file("path_1")
+    # valid schema
+    valid_schema = {"connectionSpecification": {"properties": {}}}
+    with mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(valid_schema))):
+        assert spec_linter.read_spec_file("path_1")
+    # schema with invalid field
+    invalid_schema = {"connectionSpecification": {"properties": {"field": {"title": "Field", "type": "string"}}}}
+    with mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(invalid_schema))):
+        assert not spec_linter.read_spec_file("path_1")
+
+
+def test_validate_schema():
+    schema = {
+        "access_token": {"type": "string", "airbyte_secret": True, "description": "API Key."},
+        "store_name": {"type": "string", "description": "Store name."},
+        "start_date": {
+            "title": "Start Date",
+            "type": "string",
+            "description": "The date from which you'd like to replicate the data",
+            "examples": ["2021-01-01T00:00:00Z"],
+        },
+    }
+
+    errors = spec_linter.validate_schema("path", schema, ["root"])
+    assert len(errors) == 2
+    assert "Check failed for field" in errors[0] and "root.access_token" in errors[0]
+    assert "Check failed for field" in errors[1] and "root.store_name" in errors[1]


### PR DESCRIPTION
## What
Implemented linter script which parse spec file #5937 

Linter applies for commited files only, so already existing connectors should not be affected

## How to execute
1. `pip install pre-commit`
2. `pre-commit run spec-linter -a`

## How
1. read spec file and serialize it as python dict object
2. get properties field from spec object
3. check if all fields from `FIELDS_TO_CHECK` exist in each property
4. if field has oneOf attribute - fetch all subobjects and for each of them goto step (2)

## Recommended reading order
1. `.pre-commit-config.yaml`
2. `tools/bin/spec_linter.py`

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> New Connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector added to connector index like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
   
</p>
</details>


<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</p>
</details>

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
