### PR TITLE
fix: overflow-y for SyncCatalogField

### DIFF
--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/SyncCatalogField.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/SyncCatalogField.tsx
@@ -20,7 +20,7 @@ const TreeViewContainer = styled.div`
   margin-bottom: 29px;
   border-radius: 4px;
   max-height: 600px;
-  overflow-y: overlay;
+  overflow-y: auto;
 `;
 
 const SchemaHeader = styled(Header)`


### PR DESCRIPTION
## What
`overflow-y: overlay` is changed to `:auto` due to `overlay` not supported by Firefox