### PR TITLE
[WIP] Start supporting S3 logs for docker-based deployments

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/helpers/LogClientSingleton.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/helpers/LogClientSingleton.java
@@ -164,7 +164,8 @@ public class LogClientSingleton {
   }
 
   private static boolean shouldUseLocalLogs(Configs configs) {
-    return configs.getWorkerEnvironment().equals(WorkerEnvironment.DOCKER);
+    return configs.getWorkerEnvironment().equals(WorkerEnvironment.DOCKER)
+        && CloudLogs.hasEmptyConfigs(new LogConfigDelegator(configs));
   }
 
   private static void createCloudClientIfNull(LogConfigs configs) {

--- a/airbyte-config/models/src/main/java/io/airbyte/config/helpers/LogConfigDelegator.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/helpers/LogConfigDelegator.java
@@ -25,6 +25,7 @@
 package io.airbyte.config.helpers;
 
 import io.airbyte.config.Configs;
+import java.util.Optional;
 
 /**
  * Implements {@link LogConfigs} by delegating to a {@link Configs} implementation. Because the
@@ -39,39 +40,43 @@ public class LogConfigDelegator implements LogConfigs {
     delegate = configs;
   }
 
+  private String orEmptyString(String s) {
+    return Optional.ofNullable(s).orElse("");
+  }
+
   @Override
   public String getS3LogBucket() {
-    return delegate.getS3LogBucket();
+    return orEmptyString(delegate.getS3LogBucket());
   }
 
   @Override
   public String getS3LogBucketRegion() {
-    return delegate.getS3LogBucketRegion();
+    return orEmptyString(delegate.getS3LogBucketRegion());
   }
 
   @Override
   public String getAwsAccessKey() {
-    return delegate.getAwsAccessKey();
+    return orEmptyString(delegate.getAwsAccessKey());
   }
 
   @Override
   public String getAwsSecretAccessKey() {
-    return delegate.getAwsSecretAccessKey();
+    return orEmptyString(delegate.getAwsSecretAccessKey());
   }
 
   @Override
   public String getS3MinioEndpoint() {
-    return delegate.getS3MinioEndpoint();
+    return orEmptyString(delegate.getS3MinioEndpoint());
   }
 
   @Override
   public String getGcpStorageBucket() {
-    return delegate.getGcpStorageBucket();
+    return orEmptyString(delegate.getGcpStorageBucket());
   }
 
   @Override
   public String getGoogleApplicationCredentials() {
-    return delegate.getGoogleApplicationCredentials();
+    return orEmptyString(delegate.getGoogleApplicationCredentials());
   }
 
 }


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/issues/6361

I first updated the LogClientSingleton to check for any cloud-based logging configurations. Test suite from `gradle build` passed, but when I tried running a deployment locally, I kept getting an error `Only one of Region or EndpointConfiguration may be set` from the aws-sdk. I had to explicitly set `s3ServiceEndpoint` to an empty string in the Airbyte log4j2.xml to fix this error, otherwise it would be read as the literal string `${env:S3_MINIO_ENDPOINT}`. I don't know why this behavior happens.

Then, when I tried setting up a source, the `check connection` test would fail with this stacktrace: 
```
airbyte-worker      | java.util.concurrent.ExecutionException: io.airbyte.workers.WorkerException: Error while getting checking connection.
airbyte-worker      |   at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395) ~[?:?]
airbyte-worker      |   at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2063) ~[?:?]
airbyte-worker      |   at io.airbyte.workers.temporal.TemporalAttemptExecution.get(TemporalAttemptExecution.java:133) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   at io.airbyte.workers.temporal.CheckConnectionWorkflow$CheckConnectionActivityImpl.run(CheckConnectionWorkflow.java:107) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
airbyte-worker      |   at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
airbyte-worker      |   at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
airbyte-worker      |   at java.lang.reflect.Method.invoke(Method.java:564) ~[?:?]
airbyte-worker      |   at io.temporal.internal.sync.POJOActivityTaskHandler$POJOActivityInboundCallsInterceptor.execute(POJOActivityTaskHandler.java:277) ~[temporal-sdk-1.0.4.jar:?]
airbyte-worker      |   at io.temporal.internal.sync.POJOActivityTaskHandler$POJOActivityImplementation.execute(POJOActivityTaskHandler.java:216) ~[temporal-sdk-1.0.4.jar:?]
airbyte-worker      |   at io.temporal.internal.sync.POJOActivityTaskHandler.handle(POJOActivityTaskHandler.java:181) ~[temporal-sdk-1.0.4.jar:?]
airbyte-worker      |   at io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handle(ActivityWorker.java:192) ~[temporal-sdk-1.0.4.jar:?]
airbyte-worker      |   at io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handle(ActivityWorker.java:154) ~[temporal-sdk-1.0.4.jar:?]
airbyte-worker      |   at io.temporal.internal.worker.PollTaskExecutor.lambda$process$0(PollTaskExecutor.java:73) ~[temporal-sdk-1.0.4.jar:?]
airbyte-worker      |   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) [?:?]
airbyte-worker      |   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) [?:?]
airbyte-worker      |   at java.lang.Thread.run(Thread.java:832) [?:?]
airbyte-worker      | Caused by: io.airbyte.workers.WorkerException: Error while getting checking connection.
airbyte-worker      |   at io.airbyte.workers.DefaultCheckConnectionWorker.run(DefaultCheckConnectionWorker.java:100) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   at io.airbyte.workers.DefaultCheckConnectionWorker.run(DefaultCheckConnectionWorker.java:47) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getWorkerThread$1(TemporalAttemptExecution.java:165) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   ... 1 more
airbyte-worker      | Caused by: io.airbyte.workers.WorkerException: /tmp/workspace/239848a2-5dc6-4de1-ade4-52000ed5b74c/0
airbyte-worker      |   at io.airbyte.workers.process.DockerProcessFactory.create(DockerProcessFactory.java:150) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   at io.airbyte.workers.process.AirbyteIntegrationLauncher.check(AirbyteIntegrationLauncher.java:86) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   at io.airbyte.workers.DefaultCheckConnectionWorker.run(DefaultCheckConnectionWorker.java:69) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   at io.airbyte.workers.DefaultCheckConnectionWorker.run(DefaultCheckConnectionWorker.java:47) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getWorkerThread$1(TemporalAttemptExecution.java:165) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   ... 1 more
airbyte-worker      | Caused by: java.nio.file.NoSuchFileException: /tmp/workspace/239848a2-5dc6-4de1-ade4-52000ed5b74c/0
airbyte-worker      |   at sun.nio.fs.UnixException.translateToIOException(UnixException.java:92) ~[?:?]
airbyte-worker      |   at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111) ~[?:?]
airbyte-worker      |   at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116) ~[?:?]
airbyte-worker      |   at sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:389) ~[?:?]
airbyte-worker      |   at java.nio.file.Files.createDirectory(Files.java:694) ~[?:?]
airbyte-worker      |   at io.airbyte.workers.process.DockerProcessFactory.create(DockerProcessFactory.java:100) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   at io.airbyte.workers.process.AirbyteIntegrationLauncher.check(AirbyteIntegrationLauncher.java:86) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   at io.airbyte.workers.DefaultCheckConnectionWorker.run(DefaultCheckConnectionWorker.java:69) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   at io.airbyte.workers.DefaultCheckConnectionWorker.run(DefaultCheckConnectionWorker.java:47) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getWorkerThread$1(TemporalAttemptExecution.java:165) ~[io.airbyte-airbyte-workers-0.29.21-alpha.jar:?]
airbyte-worker      |   ... 1 more
```
I am not sure why this happens. Any guidance would be appreciated.

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> New Connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector added to connector index like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
   
</p>
</details>


<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</p>
</details>

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
