### PR TITLE
Skip updating spec cache when publishing normalization docker image

### DIFF
--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -90,7 +90,7 @@ cmd_publish() {
   docker push "$versioned_image"
   docker push "$latest_image"
 
-  if [[ "true" == "${publish_spec_to_cache}" ]]; then
+  if [[ "true" == "${publish_spec_to_cache}" && "airbyte/normalization" != "${image_name}" ]]; then
     echo "Publishing and writing to spec cache."
 
     # publish spec to cache. do so, by running get spec locally and then pushing it to gcs.


### PR DESCRIPTION
## What
When publishing docker images via `/publish connectors=` command, it fails because normalization does not have a "spec"

see https://github.com/airbytehq/airbyte/pull/6396#issuecomment-925740525

## How
*Describe the solution*
Skip updating spec in case of normalization