### PR TITLE
make the seed for YamlSeedConfigPersistence configurable

### DIFF
--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/YamlSeedConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/YamlSeedConfigPersistence.java
@@ -54,34 +54,22 @@ public class YamlSeedConfigPersistence implements ConfigPersistence {
       ConfigSchema.STANDARD_SOURCE_DEFINITION, SeedType.STANDARD_SOURCE_DEFINITION,
       ConfigSchema.STANDARD_DESTINATION_DEFINITION, SeedType.STANDARD_DESTINATION_DEFINITION);
 
-  private static final Object lock = new Object();
-  private static YamlSeedConfigPersistence INSTANCE;
-
   // A mapping from seed config type to config UUID to config.
   private final ImmutableMap<SeedType, Map<String, JsonNode>> allSeedConfigs;
+
+  public static YamlSeedConfigPersistence getDefault() throws IOException {
+    return new YamlSeedConfigPersistence(DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
+  }
+
+  public static YamlSeedConfigPersistence get(final Class<?> seedDefinitionsResourceClass) throws IOException {
+    return new YamlSeedConfigPersistence(seedDefinitionsResourceClass);
+  }
 
   private YamlSeedConfigPersistence(final Class<?> seedDefinitionsResourceClass) throws IOException {
     this.allSeedConfigs = ImmutableMap.<SeedType, Map<String, JsonNode>>builder()
         .put(SeedType.STANDARD_SOURCE_DEFINITION, getConfigs(seedDefinitionsResourceClass, SeedType.STANDARD_SOURCE_DEFINITION))
         .put(SeedType.STANDARD_DESTINATION_DEFINITION, getConfigs(seedDefinitionsResourceClass, SeedType.STANDARD_DESTINATION_DEFINITION))
         .build();
-  }
-
-  public static void initialize(final Class<?> seedDefinitionsResourceClass) {
-    try {
-      INSTANCE = new YamlSeedConfigPersistence(seedDefinitionsResourceClass);
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  public static YamlSeedConfigPersistence get() {
-    synchronized (lock) {
-      if (INSTANCE == null) {
-        throw new IllegalStateException("YamlSeedConfigPersistence has not been initialized");
-      }
-      return INSTANCE;
-    }
   }
 
   @SuppressWarnings("UnstableApiUsage")

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/YamlSeedConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/YamlSeedConfigPersistence.java
@@ -48,36 +48,45 @@ import java.util.stream.Stream;
  */
 public class YamlSeedConfigPersistence implements ConfigPersistence {
 
+  public static Class<?> DEFAULT_SEED_DEFINITION_RESOURCE_CLASS = SeedType.class;
+
   private static final Map<AirbyteConfig, SeedType> CONFIG_SCHEMA_MAP = Map.of(
       ConfigSchema.STANDARD_SOURCE_DEFINITION, SeedType.STANDARD_SOURCE_DEFINITION,
       ConfigSchema.STANDARD_DESTINATION_DEFINITION, SeedType.STANDARD_DESTINATION_DEFINITION);
 
-  private static final YamlSeedConfigPersistence INSTANCE;
-  static {
-    try {
-      INSTANCE = new YamlSeedConfigPersistence();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
+  private static final Object lock = new Object();
+  private static YamlSeedConfigPersistence INSTANCE;
 
   // A mapping from seed config type to config UUID to config.
   private final ImmutableMap<SeedType, Map<String, JsonNode>> allSeedConfigs;
 
-  private YamlSeedConfigPersistence() throws IOException {
+  private YamlSeedConfigPersistence(final Class<?> seedDefinitionsResourceClass) throws IOException {
     this.allSeedConfigs = ImmutableMap.<SeedType, Map<String, JsonNode>>builder()
-        .put(SeedType.STANDARD_SOURCE_DEFINITION, getConfigs(SeedType.STANDARD_SOURCE_DEFINITION))
-        .put(SeedType.STANDARD_DESTINATION_DEFINITION, getConfigs(SeedType.STANDARD_DESTINATION_DEFINITION))
+        .put(SeedType.STANDARD_SOURCE_DEFINITION, getConfigs(seedDefinitionsResourceClass, SeedType.STANDARD_SOURCE_DEFINITION))
+        .put(SeedType.STANDARD_DESTINATION_DEFINITION, getConfigs(seedDefinitionsResourceClass, SeedType.STANDARD_DESTINATION_DEFINITION))
         .build();
   }
 
+  public static void initialize(final Class<?> seedDefinitionsResourceClass) {
+    try {
+      INSTANCE = new YamlSeedConfigPersistence(seedDefinitionsResourceClass);
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   public static YamlSeedConfigPersistence get() {
-    return INSTANCE;
+    synchronized (lock) {
+      if (INSTANCE == null) {
+        throw new IllegalStateException("YamlSeedConfigPersistence has not been initialized");
+      }
+      return INSTANCE;
+    }
   }
 
   @SuppressWarnings("UnstableApiUsage")
-  private static Map<String, JsonNode> getConfigs(SeedType seedType) throws IOException {
-    final URL url = Resources.getResource(SeedType.class, seedType.getResourcePath());
+  private static Map<String, JsonNode> getConfigs(final Class<?> seedDefinitionsResourceClass, final SeedType seedType) throws IOException {
+    final URL url = Resources.getResource(seedDefinitionsResourceClass, seedType.getResourcePath());
     final String yamlString = Resources.toString(url, StandardCharsets.UTF_8);
     final JsonNode configList = Yamls.deserialize(yamlString);
     return MoreIterators.toList(configList.elements()).stream().collect(Collectors.toMap(
@@ -86,7 +95,7 @@ public class YamlSeedConfigPersistence implements ConfigPersistence {
   }
 
   @Override
-  public <T> T getConfig(AirbyteConfig configType, String configId, Class<T> clazz)
+  public <T> T getConfig(final AirbyteConfig configType, final String configId, final Class<T> clazz)
       throws ConfigNotFoundException, JsonValidationException, IOException {
     final Map<String, JsonNode> configs = allSeedConfigs.get(CONFIG_SCHEMA_MAP.get(configType));
     if (configs == null) {
@@ -100,7 +109,7 @@ public class YamlSeedConfigPersistence implements ConfigPersistence {
   }
 
   @Override
-  public <T> List<T> listConfigs(AirbyteConfig configType, Class<T> clazz) {
+  public <T> List<T> listConfigs(final AirbyteConfig configType, final Class<T> clazz) {
     final Map<String, JsonNode> configs = allSeedConfigs.get(CONFIG_SCHEMA_MAP.get(configType));
     if (configs == null) {
       throw new UnsupportedOperationException("There is no seed for " + configType.name());
@@ -109,17 +118,17 @@ public class YamlSeedConfigPersistence implements ConfigPersistence {
   }
 
   @Override
-  public <T> void writeConfig(AirbyteConfig configType, String configId, T config) {
+  public <T> void writeConfig(final AirbyteConfig configType, final String configId, final T config) {
     throw new UnsupportedOperationException("The seed config persistence is read only.");
   }
 
   @Override
-  public void deleteConfig(AirbyteConfig configType, String configId) {
+  public void deleteConfig(final AirbyteConfig configType, final String configId) {
     throw new UnsupportedOperationException("The seed config persistence is read only.");
   }
 
   @Override
-  public void replaceAllConfigs(Map<AirbyteConfig, Stream<?>> configs, boolean dryRun) {
+  public void replaceAllConfigs(final Map<AirbyteConfig, Stream<?>> configs, final boolean dryRun) {
     throw new UnsupportedOperationException("The seed config persistence is read only.");
   }
 
@@ -131,7 +140,7 @@ public class YamlSeedConfigPersistence implements ConfigPersistence {
   }
 
   @Override
-  public void loadData(ConfigPersistence seedPersistence) throws IOException {
+  public void loadData(final ConfigPersistence seedPersistence) throws IOException {
     throw new UnsupportedOperationException("The seed config persistence is read only.");
   }
 

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
@@ -56,6 +56,7 @@ public abstract class BaseDatabaseConfigPersistenceTest {
 
   @BeforeAll
   public static void dbSetup() {
+    YamlSeedConfigPersistence.initialize(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
     container = new PostgreSQLContainer<>("postgres:13-alpine")
         .withDatabaseName("airbyte")
         .withUsername("docker")
@@ -75,7 +76,8 @@ public abstract class BaseDatabaseConfigPersistenceTest {
 
   static {
     try {
-      ConfigPersistence seedPersistence = YamlSeedConfigPersistence.get();
+      YamlSeedConfigPersistence.initialize(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
+      final ConfigPersistence seedPersistence = YamlSeedConfigPersistence.get();
       SOURCE_GITHUB = seedPersistence
           .getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, "ef69ef6e-aa7f-4af1-a01d-ef775033524e", StandardSourceDefinition.class);
       SOURCE_POSTGRES = seedPersistence
@@ -84,24 +86,26 @@ public abstract class BaseDatabaseConfigPersistenceTest {
           .getConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, "424892c4-daac-4491-b35d-c6688ba547ba", StandardDestinationDefinition.class);
       DESTINATION_S3 = seedPersistence
           .getConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, "4816b78f-1489-44c1-9060-4b19d5fa9362", StandardDestinationDefinition.class);
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new RuntimeException(e);
     }
   }
 
-  protected static void writeSource(ConfigPersistence configPersistence, StandardSourceDefinition source) throws Exception {
+  protected static void writeSource(final ConfigPersistence configPersistence, final StandardSourceDefinition source) throws Exception {
     configPersistence.writeConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, source.getSourceDefinitionId().toString(), source);
   }
 
-  protected static void writeDestination(ConfigPersistence configPersistence, StandardDestinationDefinition destination) throws Exception {
+  protected static void writeDestination(final ConfigPersistence configPersistence, final StandardDestinationDefinition destination)
+      throws Exception {
     configPersistence.writeConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destination.getDestinationDefinitionId().toString(), destination);
   }
 
-  protected static void deleteDestination(ConfigPersistence configPersistence, StandardDestinationDefinition destination) throws Exception {
+  protected static void deleteDestination(final ConfigPersistence configPersistence, final StandardDestinationDefinition destination)
+      throws Exception {
     configPersistence.deleteConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destination.getDestinationDefinitionId().toString());
   }
 
-  protected Map<String, Set<JsonNode>> getMapWithSet(Map<String, Stream<JsonNode>> input) {
+  protected Map<String, Set<JsonNode>> getMapWithSet(final Map<String, Stream<JsonNode>> input) {
     return input.entrySet().stream().collect(Collectors.toMap(
         Entry::getKey,
         e -> e.getValue().collect(Collectors.toSet())));
@@ -109,22 +113,22 @@ public abstract class BaseDatabaseConfigPersistenceTest {
 
   // assertEquals cannot correctly check the equality of two maps with stream values,
   // so streams are converted to sets before being compared.
-  protected void assertSameConfigDump(Map<String, Stream<JsonNode>> expected, Map<String, Stream<JsonNode>> actual) {
+  protected void assertSameConfigDump(final Map<String, Stream<JsonNode>> expected, final Map<String, Stream<JsonNode>> actual) {
     assertEquals(getMapWithSet(expected), getMapWithSet(actual));
   }
 
-  protected void assertRecordCount(int expectedCount) throws Exception {
-    Result<Record1<Integer>> recordCount = database.query(ctx -> ctx.select(count(asterisk())).from(table("airbyte_configs")).fetch());
+  protected void assertRecordCount(final int expectedCount) throws Exception {
+    final Result<Record1<Integer>> recordCount = database.query(ctx -> ctx.select(count(asterisk())).from(table("airbyte_configs")).fetch());
     assertEquals(expectedCount, recordCount.get(0).value1());
   }
 
-  protected void assertHasSource(StandardSourceDefinition source) throws Exception {
+  protected void assertHasSource(final StandardSourceDefinition source) throws Exception {
     assertEquals(source, configPersistence
         .getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, source.getSourceDefinitionId().toString(),
             StandardSourceDefinition.class));
   }
 
-  protected void assertHasDestination(StandardDestinationDefinition destination) throws Exception {
+  protected void assertHasDestination(final StandardDestinationDefinition destination) throws Exception {
     assertEquals(destination, configPersistence
         .getConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destination.getDestinationDefinitionId().toString(),
             StandardDestinationDefinition.class));

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
@@ -56,7 +56,6 @@ public abstract class BaseDatabaseConfigPersistenceTest {
 
   @BeforeAll
   public static void dbSetup() {
-    YamlSeedConfigPersistence.initialize(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
     container = new PostgreSQLContainer<>("postgres:13-alpine")
         .withDatabaseName("airbyte")
         .withUsername("docker")

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
@@ -76,8 +76,7 @@ public abstract class BaseDatabaseConfigPersistenceTest {
 
   static {
     try {
-      YamlSeedConfigPersistence.initialize(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
-      final ConfigPersistence seedPersistence = YamlSeedConfigPersistence.get();
+      final ConfigPersistence seedPersistence = YamlSeedConfigPersistence.getDefault();
       SOURCE_GITHUB = seedPersistence
           .getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, "ef69ef6e-aa7f-4af1-a01d-ef775033524e", StandardSourceDefinition.class);
       SOURCE_POSTGRES = seedPersistence

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceLoadDataTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceLoadDataTest.java
@@ -61,6 +61,7 @@ public class DatabaseConfigPersistenceLoadDataTest extends BaseDatabaseConfigPer
 
   @BeforeAll
   public static void setup() throws Exception {
+    YamlSeedConfigPersistence.initialize(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
     database = new ConfigsDatabaseInstance(container.getUsername(), container.getPassword(), container.getJdbcUrl()).getAndInitialize();
     configPersistence = spy(new DatabaseConfigPersistence(database));
     database.query(ctx -> ctx.execute("TRUNCATE TABLE airbyte_configs"));
@@ -100,23 +101,23 @@ public class DatabaseConfigPersistenceLoadDataTest extends BaseDatabaseConfigPer
   @DisplayName("When a connector is in use, its definition should not be updated")
   public void testNoUpdateForUsedConnector() throws Exception {
     // the seed has a newer version of s3 destination and github source
-    StandardDestinationDefinition destinationS3V2 = YamlSeedConfigPersistence.get()
+    final StandardDestinationDefinition destinationS3V2 = YamlSeedConfigPersistence.get()
         .getConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, "4816b78f-1489-44c1-9060-4b19d5fa9362", StandardDestinationDefinition.class)
         .withDockerImageTag("10000.1.0");
     when(seedPersistence.listConfigs(ConfigSchema.STANDARD_DESTINATION_DEFINITION, StandardDestinationDefinition.class))
         .thenReturn(Collections.singletonList(destinationS3V2));
-    StandardSourceDefinition sourceGithubV2 = YamlSeedConfigPersistence.get()
+    final StandardSourceDefinition sourceGithubV2 = YamlSeedConfigPersistence.get()
         .getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, "ef69ef6e-aa7f-4af1-a01d-ef775033524e", StandardSourceDefinition.class)
         .withDockerImageTag("10000.15.3");
     when(seedPersistence.listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class))
         .thenReturn(Collections.singletonList(sourceGithubV2));
 
     // create connections to mark the source and destination as in use
-    DestinationConnection s3Connection = new DestinationConnection()
+    final DestinationConnection s3Connection = new DestinationConnection()
         .withDestinationId(UUID.randomUUID())
         .withDestinationDefinitionId(destinationS3V2.getDestinationDefinitionId());
     configPersistence.writeConfig(ConfigSchema.DESTINATION_CONNECTION, s3Connection.getDestinationId().toString(), s3Connection);
-    SourceConnection githubConnection = new SourceConnection()
+    final SourceConnection githubConnection = new SourceConnection()
         .withSourceId(UUID.randomUUID())
         .withSourceDefinitionId(sourceGithubV2.getSourceDefinitionId());
     configPersistence.writeConfig(ConfigSchema.SOURCE_CONNECTION, githubConnection.getSourceId().toString(), githubConnection);
@@ -132,7 +133,7 @@ public class DatabaseConfigPersistenceLoadDataTest extends BaseDatabaseConfigPer
   @DisplayName("When a connector is not in use, its definition should be updated")
   public void testUpdateForUnusedConnector() throws Exception {
     // the seed has a newer version of snowflake destination
-    StandardDestinationDefinition snowflakeV2 = YamlSeedConfigPersistence.get()
+    final StandardDestinationDefinition snowflakeV2 = YamlSeedConfigPersistence.get()
         .getConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, "424892c4-daac-4491-b35d-c6688ba547ba", StandardDestinationDefinition.class)
         .withDockerImageTag("10000.2.0");
     when(seedPersistence.listConfigs(ConfigSchema.STANDARD_DESTINATION_DEFINITION, StandardDestinationDefinition.class))

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceLoadDataTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceLoadDataTest.java
@@ -61,7 +61,6 @@ public class DatabaseConfigPersistenceLoadDataTest extends BaseDatabaseConfigPer
 
   @BeforeAll
   public static void setup() throws Exception {
-    YamlSeedConfigPersistence.initialize(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
     database = new ConfigsDatabaseInstance(container.getUsername(), container.getPassword(), container.getJdbcUrl()).getAndInitialize();
     configPersistence = spy(new DatabaseConfigPersistence(database));
     database.query(ctx -> ctx.execute("TRUNCATE TABLE airbyte_configs"));
@@ -101,12 +100,12 @@ public class DatabaseConfigPersistenceLoadDataTest extends BaseDatabaseConfigPer
   @DisplayName("When a connector is in use, its definition should not be updated")
   public void testNoUpdateForUsedConnector() throws Exception {
     // the seed has a newer version of s3 destination and github source
-    final StandardDestinationDefinition destinationS3V2 = YamlSeedConfigPersistence.get()
+    final StandardDestinationDefinition destinationS3V2 = YamlSeedConfigPersistence.getDefault()
         .getConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, "4816b78f-1489-44c1-9060-4b19d5fa9362", StandardDestinationDefinition.class)
         .withDockerImageTag("10000.1.0");
     when(seedPersistence.listConfigs(ConfigSchema.STANDARD_DESTINATION_DEFINITION, StandardDestinationDefinition.class))
         .thenReturn(Collections.singletonList(destinationS3V2));
-    final StandardSourceDefinition sourceGithubV2 = YamlSeedConfigPersistence.get()
+    final StandardSourceDefinition sourceGithubV2 = YamlSeedConfigPersistence.getDefault()
         .getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, "ef69ef6e-aa7f-4af1-a01d-ef775033524e", StandardSourceDefinition.class)
         .withDockerImageTag("10000.15.3");
     when(seedPersistence.listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class))
@@ -133,7 +132,7 @@ public class DatabaseConfigPersistenceLoadDataTest extends BaseDatabaseConfigPer
   @DisplayName("When a connector is not in use, its definition should be updated")
   public void testUpdateForUnusedConnector() throws Exception {
     // the seed has a newer version of snowflake destination
-    final StandardDestinationDefinition snowflakeV2 = YamlSeedConfigPersistence.get()
+    final StandardDestinationDefinition snowflakeV2 = YamlSeedConfigPersistence.getDefault()
         .getConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, "424892c4-daac-4491-b35d-c6688ba547ba", StandardDestinationDefinition.class)
         .withDockerImageTag("10000.2.0");
     when(seedPersistence.listConfigs(ConfigSchema.STANDARD_DESTINATION_DEFINITION, StandardDestinationDefinition.class))

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
@@ -122,8 +122,8 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
     writeSource(configPersistence, SOURCE_GITHUB);
     writeSource(configPersistence, SOURCE_POSTGRES);
     writeDestination(configPersistence, DESTINATION_S3);
-    Map<String, Stream<JsonNode>> actual = configPersistence.dumpConfigs();
-    Map<String, Stream<JsonNode>> expected = Map.of(
+    final Map<String, Stream<JsonNode>> actual = configPersistence.dumpConfigs();
+    final Map<String, Stream<JsonNode>> expected = Map.of(
         ConfigSchema.STANDARD_SOURCE_DEFINITION.name(), Stream.of(Jsons.jsonNode(SOURCE_GITHUB), Jsons.jsonNode(SOURCE_POSTGRES)),
         ConfigSchema.STANDARD_DESTINATION_DEFINITION.name(), Stream.of(Jsons.jsonNode(DESTINATION_S3)));
     assertSameConfigDump(expected, actual);
@@ -131,20 +131,20 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
 
   @Test
   public void testGetConnectorRepositoryToInfoMap() throws Exception {
-    String connectorRepository = "airbyte/duplicated-connector";
-    String oldVersion = "0.1.10";
-    String newVersion = "0.2.0";
-    StandardSourceDefinition source1 = new StandardSourceDefinition()
+    final String connectorRepository = "airbyte/duplicated-connector";
+    final String oldVersion = "0.1.10";
+    final String newVersion = "0.2.0";
+    final StandardSourceDefinition source1 = new StandardSourceDefinition()
         .withSourceDefinitionId(UUID.randomUUID())
         .withDockerRepository(connectorRepository)
         .withDockerImageTag(oldVersion);
-    StandardSourceDefinition source2 = new StandardSourceDefinition()
+    final StandardSourceDefinition source2 = new StandardSourceDefinition()
         .withSourceDefinitionId(UUID.randomUUID())
         .withDockerRepository(connectorRepository)
         .withDockerImageTag(newVersion);
     writeSource(configPersistence, source1);
     writeSource(configPersistence, source2);
-    Map<String, ConnectorInfo> result = database.query(ctx -> configPersistence.getConnectorRepositoryToInfoMap(ctx));
+    final Map<String, ConnectorInfo> result = database.query(ctx -> configPersistence.getConnectorRepositoryToInfoMap(ctx));
     // when there are duplicated connector definitions, the one with the latest version should be
     // retrieved
     assertEquals(newVersion, result.get(connectorRepository).dockerImageTag);
@@ -152,12 +152,12 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
 
   @Test
   public void testInsertConfigRecord() throws Exception {
-    OffsetDateTime timestamp = OffsetDateTime.now();
-    UUID definitionId = UUID.randomUUID();
-    String connectorRepository = "airbyte/test-connector";
+    final OffsetDateTime timestamp = OffsetDateTime.now();
+    final UUID definitionId = UUID.randomUUID();
+    final String connectorRepository = "airbyte/test-connector";
 
     // when the record does not exist, it is inserted
-    StandardSourceDefinition source1 = new StandardSourceDefinition()
+    final StandardSourceDefinition source1 = new StandardSourceDefinition()
         .withSourceDefinitionId(definitionId)
         .withDockerRepository(connectorRepository)
         .withDockerImageTag("0.1.2");
@@ -175,7 +175,7 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
     assertHasSource(SOURCE_GITHUB);
 
     // when the record already exists, it is ignored
-    StandardSourceDefinition source2 = new StandardSourceDefinition()
+    final StandardSourceDefinition source2 = new StandardSourceDefinition()
         .withSourceDefinitionId(definitionId)
         .withDockerRepository(connectorRepository)
         .withDockerImageTag("0.1.5");
@@ -193,11 +193,11 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
 
   @Test
   public void testUpdateConfigRecord() throws Exception {
-    OffsetDateTime timestamp = OffsetDateTime.now();
-    UUID definitionId = UUID.randomUUID();
-    String connectorRepository = "airbyte/test-connector";
+    final OffsetDateTime timestamp = OffsetDateTime.now();
+    final UUID definitionId = UUID.randomUUID();
+    final String connectorRepository = "airbyte/test-connector";
 
-    StandardSourceDefinition oldSource = new StandardSourceDefinition()
+    final StandardSourceDefinition oldSource = new StandardSourceDefinition()
         .withSourceDefinitionId(definitionId)
         .withDockerRepository(connectorRepository)
         .withDockerImageTag("0.3.5");
@@ -208,7 +208,7 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
     assertHasSource(oldSource);
     assertHasSource(SOURCE_GITHUB);
 
-    StandardSourceDefinition newSource = new StandardSourceDefinition()
+    final StandardSourceDefinition newSource = new StandardSourceDefinition()
         .withSourceDefinitionId(definitionId)
         .withDockerRepository(connectorRepository)
         .withDockerImageTag("0.3.5");
@@ -231,8 +231,8 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
 
   @Test
   public void testGetNewFields() {
-    JsonNode o1 = Jsons.deserialize("{ \"field1\": 1, \"field2\": 2 }");
-    JsonNode o2 = Jsons.deserialize("{ \"field1\": 1, \"field3\": 3 }");
+    final JsonNode o1 = Jsons.deserialize("{ \"field1\": 1, \"field2\": 2 }");
+    final JsonNode o2 = Jsons.deserialize("{ \"field1\": 1, \"field3\": 3 }");
     assertEquals(Collections.emptySet(), DatabaseConfigPersistence.getNewFields(o1, o1));
     assertEquals(Collections.singleton("field3"), DatabaseConfigPersistence.getNewFields(o1, o2));
     assertEquals(Collections.singleton("field2"), DatabaseConfigPersistence.getNewFields(o2, o1));
@@ -240,13 +240,13 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
 
   @Test
   public void testGetDefinitionWithNewFields() {
-    JsonNode current = Jsons.deserialize("{ \"field1\": 1, \"field2\": 2 }");
-    JsonNode latest = Jsons.deserialize("{ \"field1\": 1, \"field3\": 3, \"field4\": 4 }");
-    Set<String> newFields = Set.of("field3");
+    final JsonNode current = Jsons.deserialize("{ \"field1\": 1, \"field2\": 2 }");
+    final JsonNode latest = Jsons.deserialize("{ \"field1\": 1, \"field3\": 3, \"field4\": 4 }");
+    final Set<String> newFields = Set.of("field3");
 
     assertEquals(current, DatabaseConfigPersistence.getDefinitionWithNewFields(current, latest, Collections.emptySet()));
 
-    JsonNode currentWithNewFields = Jsons.deserialize("{ \"field1\": 1, \"field2\": 2, \"field3\": 3 }");
+    final JsonNode currentWithNewFields = Jsons.deserialize("{ \"field1\": 1, \"field2\": 2, \"field3\": 3 }");
     assertEquals(currentWithNewFields, DatabaseConfigPersistence.getDefinitionWithNewFields(current, latest, newFields));
   }
 

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceUpdateConnectorDefinitionsTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceUpdateConnectorDefinitionsTest.java
@@ -83,8 +83,8 @@ public class DatabaseConfigPersistenceUpdateConnectorDefinitionsTest extends Bas
   @Test
   @DisplayName("When an old connector is in use, if it has all fields, do not update it")
   public void testOldConnectorInUseWithAllFields() throws Exception {
-    StandardSourceDefinition currentSource = getSource().withDockerImageTag("0.0.0");
-    StandardSourceDefinition latestSource = getSource().withDockerImageTag("0.1000.0");
+    final StandardSourceDefinition currentSource = getSource().withDockerImageTag("0.0.0");
+    final StandardSourceDefinition latestSource = getSource().withDockerImageTag("0.1000.0");
 
     assertUpdateConnectorDefinition(
         Collections.singletonList(currentSource),
@@ -96,9 +96,9 @@ public class DatabaseConfigPersistenceUpdateConnectorDefinitionsTest extends Bas
   @Test
   @DisplayName("When a old connector is in use, add missing fields, do not update its version")
   public void testOldConnectorInUseWithMissingFields() throws Exception {
-    StandardSourceDefinition currentSource = getSource().withDockerImageTag("0.0.0").withDocumentationUrl(null).withSourceType(null);
-    StandardSourceDefinition latestSource = getSource().withDockerImageTag("0.1000.0");
-    StandardSourceDefinition currentSourceWithNewFields = getSource().withDockerImageTag("0.0.0");
+    final StandardSourceDefinition currentSource = getSource().withDockerImageTag("0.0.0").withDocumentationUrl(null).withSourceType(null);
+    final StandardSourceDefinition latestSource = getSource().withDockerImageTag("0.1000.0");
+    final StandardSourceDefinition currentSourceWithNewFields = getSource().withDockerImageTag("0.0.0");
 
     assertUpdateConnectorDefinition(
         Collections.singletonList(currentSource),
@@ -110,8 +110,8 @@ public class DatabaseConfigPersistenceUpdateConnectorDefinitionsTest extends Bas
   @Test
   @DisplayName("When an unused connector has a new version, update it")
   public void testUnusedConnectorWithOldVersion() throws Exception {
-    StandardSourceDefinition currentSource = getSource().withDockerImageTag("0.0.0");
-    StandardSourceDefinition latestSource = getSource().withDockerImageTag("0.1000.0");
+    final StandardSourceDefinition currentSource = getSource().withDockerImageTag("0.0.0");
+    final StandardSourceDefinition latestSource = getSource().withDockerImageTag("0.1000.0");
 
     assertUpdateConnectorDefinition(
         Collections.singletonList(currentSource),
@@ -123,9 +123,9 @@ public class DatabaseConfigPersistenceUpdateConnectorDefinitionsTest extends Bas
   @Test
   @DisplayName("When an unused connector has missing fields, add the missing fields, do not update its version")
   public void testUnusedConnectorWithMissingFields() throws Exception {
-    StandardSourceDefinition currentSource = getSource().withDockerImageTag("0.1000.0").withDocumentationUrl(null).withSourceType(null);
-    StandardSourceDefinition latestSource = getSource().withDockerImageTag("0.99.0");
-    StandardSourceDefinition currentSourceWithNewFields = getSource().withDockerImageTag("0.1000.0");
+    final StandardSourceDefinition currentSource = getSource().withDockerImageTag("0.1000.0").withDocumentationUrl(null).withSourceType(null);
+    final StandardSourceDefinition latestSource = getSource().withDockerImageTag("0.99.0");
+    final StandardSourceDefinition currentSourceWithNewFields = getSource().withDockerImageTag("0.1000.0");
 
     assertUpdateConnectorDefinition(
         Collections.singletonList(currentSource),
@@ -145,23 +145,23 @@ public class DatabaseConfigPersistenceUpdateConnectorDefinitionsTest extends Bas
    * @param currentSources all sources currently exist in the database
    * @param currentSourcesInUse a subset of currentSources; sources currently used in data syncing
    */
-  private void assertUpdateConnectorDefinition(List<StandardSourceDefinition> currentSources,
-                                               List<StandardSourceDefinition> currentSourcesInUse,
-                                               List<StandardSourceDefinition> latestSources,
-                                               List<StandardSourceDefinition> expectedUpdatedSources)
+  private void assertUpdateConnectorDefinition(final List<StandardSourceDefinition> currentSources,
+                                               final List<StandardSourceDefinition> currentSourcesInUse,
+                                               final List<StandardSourceDefinition> latestSources,
+                                               final List<StandardSourceDefinition> expectedUpdatedSources)
       throws Exception {
-    for (StandardSourceDefinition source : currentSources) {
+    for (final StandardSourceDefinition source : currentSources) {
       writeSource(configPersistence, source);
     }
 
-    for (StandardSourceDefinition source : currentSourcesInUse) {
+    for (final StandardSourceDefinition source : currentSourcesInUse) {
       assertTrue(currentSources.contains(source), "currentSourcesInUse must exist in currentSources");
     }
 
-    Set<String> sourceRepositoriesInUse = currentSourcesInUse.stream()
+    final Set<String> sourceRepositoriesInUse = currentSourcesInUse.stream()
         .map(StandardSourceDefinition::getDockerRepository)
         .collect(Collectors.toSet());
-    Map<String, ConnectorInfo> currentSourceRepositoryToInfo = currentSources.stream()
+    final Map<String, ConnectorInfo> currentSourceRepositoryToInfo = currentSources.stream()
         .collect(Collectors.toMap(
             StandardSourceDefinition::getDockerRepository,
             s -> new ConnectorInfo(s.getSourceDefinitionId().toString(), Jsons.jsonNode(s))));
@@ -175,14 +175,14 @@ public class DatabaseConfigPersistenceUpdateConnectorDefinitionsTest extends Bas
             latestSources,
             sourceRepositoriesInUse,
             currentSourceRepositoryToInfo);
-      } catch (IOException e) {
+      } catch (final IOException e) {
         throw new SQLException(e);
       }
       return null;
     });
 
     assertRecordCount(expectedUpdatedSources.size());
-    for (StandardSourceDefinition source : expectedUpdatedSources) {
+    for (final StandardSourceDefinition source : expectedUpdatedSources) {
       assertHasSource(source);
     }
   }

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/YamlSeedConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/YamlSeedConfigPersistenceTest.java
@@ -46,8 +46,7 @@ public class YamlSeedConfigPersistenceTest {
 
   @BeforeAll
   static void setup() {
-    YamlSeedConfigPersistence.initialize(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
-    PERSISTENCE = YamlSeedConfigPersistence.get();
+    PERSISTENCE = YamlSeedConfigPersistence.getDefault();
   }
 
   @Test

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/YamlSeedConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/YamlSeedConfigPersistenceTest.java
@@ -37,11 +37,18 @@ import io.airbyte.config.StandardWorkspace;
 import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class YamlSeedConfigPersistenceTest {
 
-  private static final YamlSeedConfigPersistence PERSISTENCE = YamlSeedConfigPersistence.get();
+  private static YamlSeedConfigPersistence PERSISTENCE;
+
+  @BeforeAll
+  static void setup() {
+    YamlSeedConfigPersistence.initialize(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
+    PERSISTENCE = YamlSeedConfigPersistence.get();
+  }
 
   @Test
   public void testGetConfig() throws Exception {
@@ -75,7 +82,7 @@ public class YamlSeedConfigPersistenceTest {
 
   @Test
   public void testDumpConfigs() {
-    Map<String, Stream<JsonNode>> allSeedConfigs = PERSISTENCE.dumpConfigs();
+    final Map<String, Stream<JsonNode>> allSeedConfigs = PERSISTENCE.dumpConfigs();
     assertEquals(2, allSeedConfigs.size());
     assertTrue(allSeedConfigs.get(ConfigSchema.STANDARD_SOURCE_DEFINITION.name()).findAny().isPresent());
     assertTrue(allSeedConfigs.get(ConfigSchema.STANDARD_DESTINATION_DEFINITION.name()).findAny().isPresent());

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigurationApiFactory.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigurationApiFactory.java
@@ -26,6 +26,7 @@ package io.airbyte.server;
 
 import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.config.Configs;
+import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.db.Database;
 import io.airbyte.scheduler.client.CachingSynchronousSchedulerClient;
@@ -42,6 +43,7 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
   private static WorkflowServiceStubs temporalService;
   private static ConfigRepository configRepository;
   private static JobPersistence jobPersistence;
+  private static ConfigPersistence seed;
   private static SchedulerJobClient schedulerJobClient;
   private static CachingSynchronousSchedulerClient synchronousSchedulerClient;
   private static Configs configs;
@@ -50,50 +52,39 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
   private static Database configsDatabase;
   private static Database jobsDatabase;
 
-  public static void setConfigRepository(final ConfigRepository configRepository) {
+  public static void setValues(
+                               final WorkflowServiceStubs temporalService,
+                               final ConfigRepository configRepository,
+                               final JobPersistence jobPersistence,
+                               final ConfigPersistence seed,
+                               final SchedulerJobClient schedulerJobClient,
+                               final CachingSynchronousSchedulerClient synchronousSchedulerClient,
+                               final Configs configs,
+                               final FileTtlManager archiveTtlManager,
+                               final Map<String, String> mdc,
+                               final Database configsDatabase,
+                               final Database jobsDatabase) {
     ConfigurationApiFactory.configRepository = configRepository;
-  }
-
-  public static void setJobPersistence(final JobPersistence jobPersistence) {
     ConfigurationApiFactory.jobPersistence = jobPersistence;
-  }
-
-  public static void setSchedulerJobClient(final SchedulerJobClient schedulerJobClient) {
+    ConfigurationApiFactory.seed = seed;
     ConfigurationApiFactory.schedulerJobClient = schedulerJobClient;
-  }
-
-  public static void setSynchronousSchedulerClient(final CachingSynchronousSchedulerClient synchronousSchedulerClient) {
     ConfigurationApiFactory.synchronousSchedulerClient = synchronousSchedulerClient;
-  }
-
-  public static void setConfigs(Configs configs) {
     ConfigurationApiFactory.configs = configs;
-  }
-
-  public static void setArchiveTtlManager(final FileTtlManager archiveTtlManager) {
     ConfigurationApiFactory.archiveTtlManager = archiveTtlManager;
-  }
-
-  public static void setMdc(Map<String, String> mdc) {
     ConfigurationApiFactory.mdc = mdc;
-  }
-
-  public static void setTemporalService(final WorkflowServiceStubs temporalService) {
     ConfigurationApiFactory.temporalService = temporalService;
-  }
-
-  public static void setDatabases(final Database configsDatabase, final Database jobsDatabase) {
     ConfigurationApiFactory.configsDatabase = configsDatabase;
     ConfigurationApiFactory.jobsDatabase = jobsDatabase;
   }
 
   @Override
   public ConfigurationApi provide() {
-    MDC.setContextMap(mdc);
+    MDC.setContextMap(ConfigurationApiFactory.mdc);
 
     return new ConfigurationApi(
         ConfigurationApiFactory.configRepository,
         ConfigurationApiFactory.jobPersistence,
+        ConfigurationApiFactory.seed,
         ConfigurationApiFactory.schedulerJobClient,
         ConfigurationApiFactory.synchronousSchedulerClient,
         ConfigurationApiFactory.configs,
@@ -104,7 +95,7 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
   }
 
   @Override
-  public void dispose(ConfigurationApi service) {
+  public void dispose(final ConfigurationApi service) {
     /* noop */
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -33,6 +33,7 @@ import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.EnvConfigs;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.helpers.LogClientSingleton;
+import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.DatabaseConfigPersistence;
 import io.airbyte.config.persistence.YamlSeedConfigPersistence;
@@ -169,7 +170,7 @@ public class ServerApp implements ServerRunnable {
     TrackingClientSingleton.get().identify(workspaceId);
   }
 
-  public static ServerRunnable getServer(final ServerFactory apiFactory) throws Exception {
+  public static ServerRunnable getServer(final ServerFactory apiFactory, final ConfigPersistence seed) throws Exception {
     final Configs configs = new EnvConfigs();
 
     LogClientSingleton.setWorkspaceMdc(LogClientSingleton.getServerLogsRoot(configs));
@@ -230,7 +231,7 @@ public class ServerApp implements ServerRunnable {
       final boolean versionSupportsAutoMigrate =
           new AirbyteVersion(airbyteDatabaseVersion.get()).patchVersionCompareTo(KUBE_SUPPORT_FOR_AUTOMATIC_MIGRATION) >= 0;
       if (!isKubernetes || versionSupportsAutoMigrate) {
-        runAutomaticMigration(configRepository, jobPersistence, specFetcher, airbyteVersion, airbyteDatabaseVersion.get());
+        runAutomaticMigration(configRepository, jobPersistence, seed, specFetcher, airbyteVersion, airbyteDatabaseVersion.get());
         // After migration, upgrade the DB version
         airbyteDatabaseVersion = jobPersistence.getVersion();
       } else {
@@ -242,7 +243,7 @@ public class ServerApp implements ServerRunnable {
       LOGGER.info("Starting server...");
 
       runFlywayMigration(configs, configDatabase, jobDatabase);
-      configPersistence.loadData(YamlSeedConfigPersistence.get());
+      configPersistence.loadData(seed);
 
       return apiFactory.create(
           schedulerJobClient,
@@ -250,6 +251,7 @@ public class ServerApp implements ServerRunnable {
           temporalService,
           configRepository,
           jobPersistence,
+          seed,
           configDatabase,
           jobDatabase,
           configs);
@@ -260,7 +262,7 @@ public class ServerApp implements ServerRunnable {
   }
 
   public static void main(final String[] args) throws Exception {
-    getServer(new ServerFactory.Api()).start();
+    getServer(new ServerFactory.Api(), YamlSeedConfigPersistence.getDefault()).start();
   }
 
   /**
@@ -269,6 +271,7 @@ public class ServerApp implements ServerRunnable {
    */
   private static void runAutomaticMigration(final ConfigRepository configRepository,
                                             final JobPersistence jobPersistence,
+                                            final ConfigPersistence seed,
                                             final SpecFetcher specFetcher,
                                             final String airbyteVersion,
                                             final String airbyteDatabaseVersion) {
@@ -277,7 +280,7 @@ public class ServerApp implements ServerRunnable {
         jobPersistence,
         configRepository,
         airbyteVersion,
-        YamlSeedConfigPersistence.get(),
+        seed,
         specFetcher)) {
       runMigration.run();
     } catch (final Exception e) {

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerFactory.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerFactory.java
@@ -26,7 +26,9 @@ package io.airbyte.server;
 
 import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.config.Configs;
+import io.airbyte.config.init.SeedType;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.YamlSeedConfigPersistence;
 import io.airbyte.db.Database;
 import io.airbyte.scheduler.client.SchedulerJobClient;
 import io.airbyte.scheduler.client.SpecCachingSynchronousSchedulerClient;
@@ -51,14 +53,16 @@ public interface ServerFactory {
   class Api implements ServerFactory {
 
     @Override
-    public ServerRunnable create(SchedulerJobClient schedulerJobClient,
-                                 SpecCachingSynchronousSchedulerClient cachingSchedulerClient,
-                                 WorkflowServiceStubs temporalService,
-                                 ConfigRepository configRepository,
-                                 JobPersistence jobPersistence,
-                                 Database configsDatabase,
-                                 Database jobsDatabase,
-                                 Configs configs) {
+    public ServerRunnable create(final SchedulerJobClient schedulerJobClient,
+                                 final SpecCachingSynchronousSchedulerClient cachingSchedulerClient,
+                                 final WorkflowServiceStubs temporalService,
+                                 final ConfigRepository configRepository,
+                                 final JobPersistence jobPersistence,
+                                 final Database configsDatabase,
+                                 final Database jobsDatabase,
+                                 final Configs configs) {
+      YamlSeedConfigPersistence.initialize(SeedType.class);
+
       // set static values for factory
       ConfigurationApiFactory.setSchedulerJobClient(schedulerJobClient);
       ConfigurationApiFactory.setSynchronousSchedulerClient(cachingSchedulerClient);

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerFactory.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerFactory.java
@@ -26,9 +26,8 @@ package io.airbyte.server;
 
 import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.config.Configs;
-import io.airbyte.config.init.SeedType;
+import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.config.persistence.YamlSeedConfigPersistence;
 import io.airbyte.db.Database;
 import io.airbyte.scheduler.client.SchedulerJobClient;
 import io.airbyte.scheduler.client.SpecCachingSynchronousSchedulerClient;
@@ -46,6 +45,8 @@ public interface ServerFactory {
                         WorkflowServiceStubs temporalService,
                         ConfigRepository configRepository,
                         JobPersistence jobPersistence,
+                        ConfigPersistence seed,
+
                         Database configsDatabase,
                         Database jobsDatabase,
                         Configs configs);
@@ -58,21 +59,22 @@ public interface ServerFactory {
                                  final WorkflowServiceStubs temporalService,
                                  final ConfigRepository configRepository,
                                  final JobPersistence jobPersistence,
+                                 final ConfigPersistence seed,
                                  final Database configsDatabase,
                                  final Database jobsDatabase,
                                  final Configs configs) {
-      YamlSeedConfigPersistence.initialize(SeedType.class);
-
       // set static values for factory
-      ConfigurationApiFactory.setSchedulerJobClient(schedulerJobClient);
-      ConfigurationApiFactory.setSynchronousSchedulerClient(cachingSchedulerClient);
-      ConfigurationApiFactory.setTemporalService(temporalService);
-      ConfigurationApiFactory.setConfigRepository(configRepository);
-      ConfigurationApiFactory.setJobPersistence(jobPersistence);
-      ConfigurationApiFactory.setConfigs(configs);
-      ConfigurationApiFactory.setArchiveTtlManager(new FileTtlManager(10, TimeUnit.MINUTES, 10));
-      ConfigurationApiFactory.setMdc(MDC.getCopyOfContextMap());
-      ConfigurationApiFactory.setDatabases(configsDatabase, jobsDatabase);
+      ConfigurationApiFactory.setValues(
+          temporalService,
+          configRepository,
+          jobPersistence,
+          seed,
+          schedulerJobClient,
+          cachingSchedulerClient,
+          configs,
+          new FileTtlManager(10, TimeUnit.MINUTES, 10),
+          MDC.getCopyOfContextMap(),
+          configsDatabase, jobsDatabase);
 
       // server configurations
       final Set<Class<?>> componentClasses = Set.of(ConfigurationApi.class);

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -98,6 +98,7 @@ import io.airbyte.api.model.WorkspaceUpdate;
 import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.config.Configs;
 import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.db.Database;
 import io.airbyte.scheduler.client.CachingSynchronousSchedulerClient;
@@ -159,6 +160,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
 
   public ConfigurationApi(final ConfigRepository configRepository,
                           final JobPersistence jobPersistence,
+                          final ConfigPersistence seed,
                           final SchedulerJobClient schedulerJobClient,
                           final CachingSynchronousSchedulerClient synchronousSchedulerClient,
                           final Configs configs,
@@ -197,8 +199,14 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
     webBackendSourcesHandler = new WebBackendSourcesHandler(sourceHandler, configRepository);
     webBackendDestinationsHandler = new WebBackendDestinationsHandler(destinationHandler, configRepository);
     healthCheckHandler = new HealthCheckHandler(configRepository);
-    archiveHandler =
-        new ArchiveHandler(configs.getAirbyteVersion(), configRepository, jobPersistence, workspaceHelper, archiveTtlManager, specFetcher);
+    archiveHandler = new ArchiveHandler(
+        configs.getAirbyteVersion(),
+        configRepository,
+        jobPersistence,
+        seed,
+        workspaceHelper,
+        archiveTtlManager,
+        specFetcher);
     logsHandler = new LogsHandler();
     openApiConfigHandler = new OpenApiConfigHandler();
     dbMigrationHandler = new DbMigrationHandler(configsDatabase, jobsDatabase);
@@ -282,27 +290,27 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   // OAUTH
 
   @Override
-  public OAuthConsentRead getSourceOAuthConsent(SourceOauthConsentRequest sourceOauthConsentRequest) {
+  public OAuthConsentRead getSourceOAuthConsent(final SourceOauthConsentRequest sourceOauthConsentRequest) {
     return execute(() -> oAuthHandler.getSourceOAuthConsent(sourceOauthConsentRequest));
   }
 
   @Override
-  public Map<String, Object> completeSourceOAuth(CompleteSourceOauthRequest completeSourceOauthRequest) {
+  public Map<String, Object> completeSourceOAuth(final CompleteSourceOauthRequest completeSourceOauthRequest) {
     return execute(() -> oAuthHandler.completeSourceOAuth(completeSourceOauthRequest));
   }
 
   @Override
-  public OAuthConsentRead getDestinationOAuthConsent(DestinationOauthConsentRequest destinationOauthConsentRequest) {
+  public OAuthConsentRead getDestinationOAuthConsent(final DestinationOauthConsentRequest destinationOauthConsentRequest) {
     return execute(() -> oAuthHandler.getDestinationOAuthConsent(destinationOauthConsentRequest));
   }
 
   @Override
-  public Map<String, Object> completeDestinationOAuth(CompleteDestinationOAuthRequest requestBody) {
+  public Map<String, Object> completeDestinationOAuth(final CompleteDestinationOAuthRequest requestBody) {
     return execute(() -> oAuthHandler.completeDestinationOAuth(requestBody));
   }
 
   @Override
-  public void setInstancewideDestinationOauthParams(SetInstancewideDestinationOauthParamsRequestBody requestBody) {
+  public void setInstancewideDestinationOauthParams(final SetInstancewideDestinationOauthParamsRequestBody requestBody) {
     execute(() -> {
       oAuthHandler.setDestinationInstancewideOauthParams(requestBody);
       return null;
@@ -310,7 +318,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   }
 
   @Override
-  public void setInstancewideSourceOauthParams(SetInstancewideSourceOauthParamsRequestBody requestBody) {
+  public void setInstancewideSourceOauthParams(final SetInstancewideSourceOauthParamsRequestBody requestBody) {
     execute(() -> {
       oAuthHandler.setSourceInstancewideOauthParams(requestBody);
       return null;
@@ -365,12 +373,12 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   // DB MIGRATION
 
   @Override
-  public DbMigrationReadList listMigrations(DbMigrationRequestBody request) {
+  public DbMigrationReadList listMigrations(final DbMigrationRequestBody request) {
     return execute(() -> dbMigrationHandler.list(request));
   }
 
   @Override
-  public DbMigrationExecutionRead executeMigrations(DbMigrationRequestBody request) {
+  public DbMigrationExecutionRead executeMigrations(final DbMigrationRequestBody request) {
     return execute(() -> dbMigrationHandler.migrate(request));
   }
 
@@ -492,7 +500,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   // Operations
 
   @Override
-  public CheckOperationRead checkOperation(OperatorConfiguration operatorConfiguration) {
+  public CheckOperationRead checkOperation(final OperatorConfiguration operatorConfiguration) {
     return execute(() -> operationsHandler.checkOperation(operatorConfiguration));
   }
 
@@ -502,7 +510,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   }
 
   @Override
-  public void deleteOperation(OperationIdRequestBody operationIdRequestBody) {
+  public void deleteOperation(final OperationIdRequestBody operationIdRequestBody) {
     execute(() -> {
       operationsHandler.deleteOperation(operationIdRequestBody);
       return null;
@@ -510,17 +518,17 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   }
 
   @Override
-  public OperationReadList listOperationsForConnection(ConnectionIdRequestBody connectionIdRequestBody) {
+  public OperationReadList listOperationsForConnection(final ConnectionIdRequestBody connectionIdRequestBody) {
     return execute(() -> operationsHandler.listOperationsForConnection(connectionIdRequestBody));
   }
 
   @Override
-  public OperationRead getOperation(OperationIdRequestBody operationIdRequestBody) {
+  public OperationRead getOperation(final OperationIdRequestBody operationIdRequestBody) {
     return execute(() -> operationsHandler.getOperation(operationIdRequestBody));
   }
 
   @Override
-  public OperationRead updateOperation(OperationUpdate operationUpdate) {
+  public OperationRead updateOperation(final OperationUpdate operationUpdate) {
     return execute(() -> operationsHandler.updateOperation(operationUpdate));
   }
 
@@ -591,7 +599,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   }
 
   @Override
-  public WebBackendConnectionRead webBackendCreateConnection(WebBackendConnectionCreate webBackendConnectionCreate) {
+  public WebBackendConnectionRead webBackendCreateConnection(final WebBackendConnectionCreate webBackendConnectionCreate) {
     return execute(() -> webBackendConnectionsHandler.webBackendCreateConnection(webBackendConnectionCreate));
   }
 
@@ -623,30 +631,30 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   }
 
   @Override
-  public File exportWorkspace(WorkspaceIdRequestBody workspaceIdRequestBody) {
+  public File exportWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody) {
     return execute(() -> archiveHandler.exportWorkspace(workspaceIdRequestBody));
   }
 
   @Override
-  public UploadRead uploadArchiveResource(File archiveFile) {
+  public UploadRead uploadArchiveResource(final File archiveFile) {
     return execute(() -> archiveHandler.uploadArchiveResource(archiveFile));
   }
 
   @Override
-  public ImportRead importIntoWorkspace(ImportRequestBody importRequestBody) {
+  public ImportRead importIntoWorkspace(final ImportRequestBody importRequestBody) {
     return execute(() -> archiveHandler.importIntoWorkspace(importRequestBody));
   }
 
-  private <T> T execute(HandlerCall<T> call) {
+  private <T> T execute(final HandlerCall<T> call) {
     try {
       return call.call();
-    } catch (ConfigNotFoundException e) {
+    } catch (final ConfigNotFoundException e) {
       throw new IdNotFoundKnownException(String.format("Could not find configuration for %s: %s.", e.getType().toString(), e.getConfigId()),
           e.getConfigId(), e);
-    } catch (JsonValidationException e) {
+    } catch (final JsonValidationException e) {
       throw new BadObjectSchemaKnownException(
           String.format("The provided configuration does not fulfill the specification. Errors: %s", e.getMessage()), e);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
@@ -31,8 +31,8 @@ import io.airbyte.api.model.UploadRead;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.config.persistence.YamlSeedConfigPersistence;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.scheduler.persistence.WorkspaceHelper;
 import io.airbyte.server.ConfigDumpExporter;
@@ -53,11 +53,13 @@ public class ArchiveHandler {
   private final String version;
   private final ConfigDumpExporter configDumpExporter;
   private final ConfigDumpImporter configDumpImporter;
+  private final ConfigPersistence seed;
   private final FileTtlManager fileTtlManager;
 
   public ArchiveHandler(final String version,
                         final ConfigRepository configRepository,
                         final JobPersistence jobPersistence,
+                        final ConfigPersistence seed,
                         final WorkspaceHelper workspaceHelper,
                         final FileTtlManager fileTtlManager,
                         final SpecFetcher specFetcher) {
@@ -65,16 +67,19 @@ public class ArchiveHandler {
         version,
         fileTtlManager,
         new ConfigDumpExporter(configRepository, jobPersistence, workspaceHelper),
-        new ConfigDumpImporter(configRepository, jobPersistence, workspaceHelper, specFetcher));
+        new ConfigDumpImporter(configRepository, jobPersistence, workspaceHelper, specFetcher),
+        seed);
   }
 
   public ArchiveHandler(final String version,
                         final FileTtlManager fileTtlManager,
                         final ConfigDumpExporter configDumpExporter,
-                        final ConfigDumpImporter configDumpImporter) {
+                        final ConfigDumpImporter configDumpImporter,
+                        final ConfigPersistence seed) {
     this.version = version;
     this.configDumpExporter = configDumpExporter;
     this.configDumpImporter = configDumpImporter;
+    this.seed = seed;
     this.fileTtlManager = fileTtlManager;
   }
 
@@ -95,13 +100,13 @@ public class ArchiveHandler {
    * @param workspaceIdRequestBody which is the target workspace to export
    * @return that lightweight tarball file
    */
-  public File exportWorkspace(WorkspaceIdRequestBody workspaceIdRequestBody) {
+  public File exportWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody) {
     final File archive;
     try {
       archive = configDumpExporter.exportWorkspace(workspaceIdRequestBody.getWorkspaceId());
       fileTtlManager.register(archive.toPath());
       return archive;
-    } catch (JsonValidationException | IOException | ConfigNotFoundException e) {
+    } catch (final JsonValidationException | IOException | ConfigNotFoundException e) {
       throw new InternalServerKnownException(String.format("Failed to export Workspace configuration due to: %s", e.getMessage()));
     }
   }
@@ -112,15 +117,15 @@ public class ArchiveHandler {
    *
    * @return a status object describing if import was successful or not.
    */
-  public ImportRead importData(File archive) {
+  public ImportRead importData(final File archive) {
     try {
-      return importInternal(() -> configDumpImporter.importDataWithSeed(version, archive, YamlSeedConfigPersistence.get()));
+      return importInternal(() -> configDumpImporter.importDataWithSeed(version, archive, seed));
     } finally {
       FileUtils.deleteQuietly(archive);
     }
   }
 
-  public UploadRead uploadArchiveResource(File archive) {
+  public UploadRead uploadArchiveResource(final File archive) {
     return configDumpImporter.uploadArchiveResource(archive);
   }
 
@@ -132,7 +137,7 @@ public class ArchiveHandler {
    *
    * @return a status object describing if import was successful or not.
    */
-  public ImportRead importIntoWorkspace(ImportRequestBody importRequestBody) {
+  public ImportRead importIntoWorkspace(final ImportRequestBody importRequestBody) {
     final File archive = configDumpImporter.getArchiveResource(importRequestBody.getResourceId());
     try {
       return importInternal(
@@ -142,12 +147,12 @@ public class ArchiveHandler {
     }
   }
 
-  private ImportRead importInternal(importCall importCall) {
+  private ImportRead importInternal(final importCall importCall) {
     ImportRead result;
     try {
       importCall.importData();
       result = new ImportRead().status(StatusEnum.SUCCEEDED);
-    } catch (Exception e) {
+    } catch (final Exception e) {
       LOGGER.error("Import failed", e);
       result = new ImportRead().status(StatusEnum.FAILED).reason(e.getMessage());
     }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -100,12 +100,13 @@ public class ArchiveHandlerTest {
       super(1L, TimeUnit.MINUTES, 1L);
     }
 
-    public void register(Path path) {}
+    public void register(final Path path) {}
 
   }
 
   @BeforeAll
   public static void dbSetup() {
+    YamlSeedConfigPersistence.initialize(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
     container = new PostgreSQLContainer<>("postgres:13-alpine")
         .withDatabaseName("airbyte")
         .withUsername("docker")
@@ -166,21 +167,21 @@ public class ArchiveHandlerTest {
 
     // After importing the configs, the dump is restored.
     assertTrue(archive.exists());
-    ImportRead importResult = archiveHandler.importData(archive);
+    final ImportRead importResult = archiveHandler.importData(archive);
     assertFalse(archive.exists());
     assertEquals(StatusEnum.SUCCEEDED, importResult.getStatus());
     assertSameConfigDump(seedPersistence.dumpConfigs(), configRepository.dumpConfigs());
 
     // When a connector definition is in use, it will not be updated.
-    UUID sourceS3DefinitionId = UUID.fromString("69589781-7828-43c5-9f63-8925b1c1ccc2");
-    String sourceS3DefinitionVersion = "0.0.0";
-    StandardSourceDefinition sourceS3Definition = seedPersistence.getConfig(
+    final UUID sourceS3DefinitionId = UUID.fromString("69589781-7828-43c5-9f63-8925b1c1ccc2");
+    final String sourceS3DefinitionVersion = "0.0.0";
+    final StandardSourceDefinition sourceS3Definition = seedPersistence.getConfig(
         ConfigSchema.STANDARD_SOURCE_DEFINITION,
         sourceS3DefinitionId.toString(),
         StandardSourceDefinition.class)
         // This source definition is on an old version
         .withDockerImageTag(sourceS3DefinitionVersion);
-    SourceConnection sourceConnection = new SourceConnection()
+    final SourceConnection sourceConnection = new SourceConnection()
         .withSourceDefinitionId(sourceS3DefinitionId)
         .withSourceId(UUID.randomUUID())
         .withWorkspaceId(UUID.randomUUID())
@@ -198,7 +199,7 @@ public class ArchiveHandlerTest {
     archiveHandler.importData(archive);
 
     // The version has not changed.
-    StandardSourceDefinition actualS3Definition = configPersistence.getConfig(
+    final StandardSourceDefinition actualS3Definition = configPersistence.getConfig(
         ConfigSchema.STANDARD_SOURCE_DEFINITION,
         sourceS3DefinitionId.toString(),
         StandardSourceDefinition.class);
@@ -219,7 +220,7 @@ public class ArchiveHandlerTest {
 
     // Export the first workspace configs
     File archive = archiveHandler.exportWorkspace(new WorkspaceIdRequestBody().workspaceId(workspaceId));
-    File secondArchive = Files.createTempFile("tests", "archive").toFile();
+    final File secondArchive = Files.createTempFile("tests", "archive").toFile();
     FileUtils.copyFile(archive, secondArchive);
 
     // After deleting all the configs, the dump becomes empty.
@@ -251,9 +252,9 @@ public class ArchiveHandlerTest {
     setupWorkspaceData(secondWorkspaceId);
 
     // the archive is importing again in another workspace
-    UploadRead secondUploadRead = archiveHandler.uploadArchiveResource(secondArchive);
+    final UploadRead secondUploadRead = archiveHandler.uploadArchiveResource(secondArchive);
     assertEquals(UploadRead.StatusEnum.SUCCEEDED, secondUploadRead.getStatus());
-    ImportRead secondImportResult = archiveHandler.importIntoWorkspace(new ImportRequestBody()
+    final ImportRead secondImportResult = archiveHandler.importIntoWorkspace(new ImportRequestBody()
         .resourceId(secondUploadRead.getResourceId())
         .workspaceId(secondWorkspaceId));
     assertEquals(StatusEnum.SUCCEEDED, secondImportResult.getStatus());
@@ -272,7 +273,7 @@ public class ArchiveHandlerTest {
         .withTombstone(false)
         .withConfiguration(Jsons.emptyObject());
 
-    ConnectorSpecification emptyConnectorSpec = mock(ConnectorSpecification.class);
+    final ConnectorSpecification emptyConnectorSpec = mock(ConnectorSpecification.class);
     when(emptyConnectorSpec.getConnectionSpecification()).thenReturn(Jsons.emptyObject());
 
     configRepository.writeSourceConnection(sourceConnection, emptyConnectorSpec);
@@ -292,14 +293,14 @@ public class ArchiveHandlerTest {
     assertSameConfigDump(secondWorkspaceDump, configRepository.dumpConfigs());
   }
 
-  private void setupWorkspaceData(UUID workspaceId) throws IOException {
+  private void setupWorkspaceData(final UUID workspaceId) throws IOException {
     configPersistence.writeConfig(ConfigSchema.STANDARD_WORKSPACE, workspaceId.toString(), new StandardWorkspace()
         .withWorkspaceId(workspaceId)
         .withName("test-workspace")
         .withTombstone(false));
   }
 
-  private void setupTestData(UUID workspaceId) throws JsonValidationException, IOException {
+  private void setupTestData(final UUID workspaceId) throws JsonValidationException, IOException {
     // Fill up with some configurations
     setupWorkspaceData(workspaceId);
     final UUID sourceid = UUID.randomUUID();
@@ -320,16 +321,16 @@ public class ArchiveHandlerTest {
         .withTombstone(false));
   }
 
-  private void assertSameConfigDump(Map<String, Stream<JsonNode>> expected, Map<String, Stream<JsonNode>> actual) {
+  private void assertSameConfigDump(final Map<String, Stream<JsonNode>> expected, final Map<String, Stream<JsonNode>> actual) {
     assertEquals(expected.keySet(), actual.keySet(),
         String.format("The expected (%s) vs actual (%s) streams does not match", expected.size(), actual.size()));
-    for (String stream : expected.keySet()) {
+    for (final String stream : expected.keySet()) {
       LOGGER.info("Checking stream {}", stream);
       // assertEquals cannot correctly check the equality of two maps with stream values,
       // so streams are converted to sets before being compared.
       final Set<JsonNode> expectedRecords = expected.get(stream).collect(Collectors.toSet());
       final Set<JsonNode> actualRecords = actual.get(stream).collect(Collectors.toSet());
-      for (var expectedRecord : expectedRecords) {
+      for (final var expectedRecord : expectedRecords) {
         assertTrue(actualRecords.contains(expectedRecord),
             String.format("\n Expected record was not found:\n%s\n Actual records were:\n%s\n",
                 expectedRecord,

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -106,7 +106,6 @@ public class ArchiveHandlerTest {
 
   @BeforeAll
   public static void dbSetup() {
-    YamlSeedConfigPersistence.initialize(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
     container = new PostgreSQLContainer<>("postgres:13-alpine")
         .withDatabaseName("airbyte")
         .withUsername("docker")
@@ -124,7 +123,7 @@ public class ArchiveHandlerTest {
     database = new JobsDatabaseInstance(container.getUsername(), container.getPassword(), container.getJdbcUrl()).getAndInitialize();
     jobPersistence = new DefaultJobPersistence(database);
     database = new ConfigsDatabaseInstance(container.getUsername(), container.getPassword(), container.getJdbcUrl()).getAndInitialize();
-    seedPersistence = YamlSeedConfigPersistence.get();
+    seedPersistence = YamlSeedConfigPersistence.getDefault();
     configPersistence = new DatabaseConfigPersistence(database);
     configPersistence.replaceAllConfigs(Collections.emptyMap(), false);
     configPersistence.loadData(seedPersistence);
@@ -141,6 +140,7 @@ public class ArchiveHandlerTest {
         VERSION,
         configRepository,
         jobPersistence,
+        YamlSeedConfigPersistence.getDefault(),
         new WorkspaceHelper(configRepository, jobPersistence),
         new NoOpFileTtlManager(),
         specFetcher);

--- a/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
@@ -123,22 +123,22 @@ public class RunMigrationTest {
     }
   }
 
-  private void assertPreMigrationConfigs(Path configRoot, JobPersistence jobPersistence) throws Exception {
+  private void assertPreMigrationConfigs(final Path configRoot, final JobPersistence jobPersistence) throws Exception {
     assertDatabaseVersion(jobPersistence, INITIAL_VERSION);
-    ConfigRepository configRepository = new ConfigRepository(FileSystemConfigPersistence.createWithValidation(configRoot));
-    Map<String, StandardSourceDefinition> sourceDefinitionsBeforeMigration = configRepository.listStandardSources().stream()
+    final ConfigRepository configRepository = new ConfigRepository(FileSystemConfigPersistence.createWithValidation(configRoot));
+    final Map<String, StandardSourceDefinition> sourceDefinitionsBeforeMigration = configRepository.listStandardSources().stream()
         .collect(Collectors.toMap(c -> c.getSourceDefinitionId().toString(), c -> c));
     assertTrue(sourceDefinitionsBeforeMigration.containsKey(DEPRECATED_SOURCE_DEFINITION_NOT_BEING_USED));
     assertTrue(sourceDefinitionsBeforeMigration.containsKey(DEPRECATED_SOURCE_DEFINITION_BEING_USED));
   }
 
-  private void assertDatabaseVersion(JobPersistence jobPersistence, String version) throws IOException {
+  private void assertDatabaseVersion(final JobPersistence jobPersistence, final String version) throws IOException {
     final Optional<String> versionFromDb = jobPersistence.getVersion();
     assertTrue(versionFromDb.isPresent());
     assertEquals(versionFromDb.get(), version);
   }
 
-  private void assertPostMigrationConfigs(Path importRoot) throws Exception {
+  private void assertPostMigrationConfigs(final Path importRoot) throws Exception {
     final ConfigRepository configRepository = new ConfigRepository(FileSystemConfigPersistence.createWithValidation(importRoot));
     final UUID workspaceId = configRepository.listStandardWorkspaces(true).get(0).getWorkspaceId();
     // originally the default workspace started with a hardcoded id. the migration in version 0.29.0
@@ -154,7 +154,7 @@ public class RunMigrationTest {
     assertDestinationDefinitions(configRepository);
   }
 
-  private void assertSourceDefinitions(ConfigRepository configRepository) throws JsonValidationException, IOException {
+  private void assertSourceDefinitions(final ConfigRepository configRepository) throws JsonValidationException, IOException {
     final Map<String, StandardSourceDefinition> sourceDefinitions = configRepository.listStandardSources()
         .stream()
         .collect(Collectors.toMap(c -> c.getSourceDefinitionId().toString(), c -> c));
@@ -170,7 +170,7 @@ public class RunMigrationTest {
     assertEquals("MySQL", mysqlDefinition.getName());
 
     final StandardSourceDefinition postgresDefinition = sourceDefinitions.get("decd338e-5647-4c0b-adf4-da0e75f5a750");
-    String[] tagBrokenAsArray = postgresDefinition.getDockerImageTag().replace(".", ",").split(",");
+    final String[] tagBrokenAsArray = postgresDefinition.getDockerImageTag().replace(".", ",").split(",");
     assertEquals(3, tagBrokenAsArray.length);
     assertTrue(Integer.parseInt(tagBrokenAsArray[0]) >= 0);
     assertTrue(Integer.parseInt(tagBrokenAsArray[1]) >= 3);
@@ -178,7 +178,7 @@ public class RunMigrationTest {
     assertTrue(postgresDefinition.getName().contains("Postgres"));
   }
 
-  private void assertDestinationDefinitions(ConfigRepository configRepository) throws JsonValidationException, IOException {
+  private void assertDestinationDefinitions(final ConfigRepository configRepository) throws JsonValidationException, IOException {
     final Map<String, StandardDestinationDefinition> sourceDefinitions = configRepository.listStandardDestinationDefinitions()
         .stream()
         .collect(Collectors.toMap(c -> c.getDestinationDefinitionId().toString(), c -> c));
@@ -193,7 +193,7 @@ public class RunMigrationTest {
     assertEquals("0.2.0", localCsvDefinition.getDockerImageTag());
 
     final StandardDestinationDefinition snowflakeDefinition = sourceDefinitions.get("424892c4-daac-4491-b35d-c6688ba547ba");
-    String[] tagBrokenAsArray = snowflakeDefinition.getDockerImageTag().replace(".", ",").split(",");
+    final String[] tagBrokenAsArray = snowflakeDefinition.getDockerImageTag().replace(".", ",").split(",");
     assertEquals(3, tagBrokenAsArray.length);
     assertTrue(Integer.parseInt(tagBrokenAsArray[0]) >= 0);
     assertTrue(Integer.parseInt(tagBrokenAsArray[1]) >= 3);
@@ -201,12 +201,12 @@ public class RunMigrationTest {
     assertTrue(snowflakeDefinition.getName().contains("Snowflake"));
   }
 
-  private void assertStandardSyncs(ConfigRepository configRepository,
-                                   StandardSyncOperation standardSyncOperation)
+  private void assertStandardSyncs(final ConfigRepository configRepository,
+                                   final StandardSyncOperation standardSyncOperation)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final List<StandardSync> standardSyncs = configRepository.listStandardSyncs();
     assertEquals(standardSyncs.size(), 2);
-    for (StandardSync standardSync : standardSyncs) {
+    for (final StandardSync standardSync : standardSyncs) {
       if (standardSync.getConnectionId().toString().equals("a294256f-1abe-4837-925f-91602c7207b4")) {
         assertEquals(standardSync.getPrefix(), "");
         assertEquals(standardSync.getSourceId().toString(), "28ffee2b-372a-4f72-9b95-8ed56a8b99c5");
@@ -233,7 +233,7 @@ public class RunMigrationTest {
   }
 
   @NotNull
-  private StandardSyncOperation assertSyncOperations(ConfigRepository configRepository) throws IOException, JsonValidationException {
+  private StandardSyncOperation assertSyncOperations(final ConfigRepository configRepository) throws IOException, JsonValidationException {
     final List<StandardSyncOperation> standardSyncOperations = configRepository.listStandardSyncOperations();
     assertEquals(standardSyncOperations.size(), 1);
     final StandardSyncOperation standardSyncOperation = standardSyncOperations.get(0);
@@ -245,7 +245,7 @@ public class RunMigrationTest {
     return standardSyncOperation;
   }
 
-  private void assertSources(ConfigRepository configRepository, UUID workspaceId) throws JsonValidationException, IOException {
+  private void assertSources(final ConfigRepository configRepository, final UUID workspaceId) throws JsonValidationException, IOException {
     final Map<String, SourceConnection> sources = configRepository.listSourceConnection()
         .stream()
         .collect(Collectors.toMap(sourceConnection -> sourceConnection.getSourceId().toString(), sourceConnection -> sourceConnection));
@@ -264,7 +264,7 @@ public class RunMigrationTest {
 
   }
 
-  private void assertWorkspace(ConfigRepository configRepository, UUID workspaceId) throws JsonValidationException, IOException {
+  private void assertWorkspace(final ConfigRepository configRepository, final UUID workspaceId) throws JsonValidationException, IOException {
     final List<StandardWorkspace> standardWorkspaces = configRepository.listStandardWorkspaces(true);
     assertEquals(1, standardWorkspaces.size());
     final StandardWorkspace workspace = standardWorkspaces.get(0);
@@ -279,7 +279,7 @@ public class RunMigrationTest {
     assertEquals(false, workspace.getDisplaySetupWizard());
   }
 
-  private void assertDestinations(ConfigRepository configRepository, UUID workspaceId) throws JsonValidationException, IOException {
+  private void assertDestinations(final ConfigRepository configRepository, final UUID workspaceId) throws JsonValidationException, IOException {
     final List<DestinationConnection> destinationConnections = configRepository.listDestinationConnection();
     assertEquals(destinationConnections.size(), 2);
     for (final DestinationConnection destination : destinationConnections) {
@@ -305,12 +305,12 @@ public class RunMigrationTest {
     }
   }
 
-  private void runMigration(JobPersistence jobPersistence, Path configRoot) throws Exception {
+  private void runMigration(final JobPersistence jobPersistence, final Path configRoot) throws Exception {
     try (final RunMigration runMigration = new RunMigration(
         jobPersistence,
         new ConfigRepository(FileSystemConfigPersistence.createWithValidation(configRoot)),
         TARGET_VERSION,
-        YamlSeedConfigPersistence.get(),
+        YamlSeedConfigPersistence.getDefault(),
         mock(SpecFetcher.class) // this test was disabled/broken when this fetcher mock was added. apologies if you have to fix this
                                 // in the future.
     )) {
@@ -319,7 +319,7 @@ public class RunMigrationTest {
   }
 
   @SuppressWarnings("SameParameterValue")
-  private JobPersistence getJobPersistence(Database database, File file, String version) throws IOException {
+  private JobPersistence getJobPersistence(final Database database, final File file, final String version) throws IOException {
     final DefaultJobPersistence jobPersistence = new DefaultJobPersistence(database);
     final Path tempFolder = Files.createTempDirectory(Path.of("/tmp"), "db_init");
     resourceToBeCleanedUp.add(tempFolder.toFile());


### PR DESCRIPTION
Relates to https://github.com/airbytehq/airbyte/issues/6334
## What
* We want the cloud app to use a different seed than OSS. This change makes it so that it possible to customize where YamlSeedConfigPersistence pulls the seed from. My understanding is that changing this class to take in the correct seed should completely solve the issue of the cloud operating on a different index. I will still need to, as a one off, prune out the connectors in cloud that shouldn't be there.
* @tuliren curious if you think this is a good approach or given that it needs an argument now, I should move to dependency injection.

## Recommended reading order
1. `YamlSeedConfigPersistence.java`
