### PR TITLE
Helm chart worker

### DIFF
--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -120,7 +120,7 @@
 | `worker.replicaCount`                       | Number of worker replicas                                        | `1`              |
 | `worker.image.repository`                   | The repository to use for the airbyte worker image.              | `airbyte/worker` |
 | `worker.image.pullPolicy`                   | the pull policy to use for the airbyte worker image              | `IfNotPresent`   |
-| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.30.1-alpha`   |
+| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.30.3-alpha`   |
 | `worker.podAnnotations`                     | Add extra annotations to the worker pod(s)                       | `{}`             |
 | `worker.livenessProbe.enabled`              | Enable livenessProbe on the worker                               | `true`           |
 | `worker.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                          | `30`             |

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -115,19 +115,31 @@
 
 ### Worker Parameters
 
-| Name                        | Description                                                      | Value            |
-| --------------------------- | ---------------------------------------------------------------- | ---------------- |
-| `worker.replicaCount`       | Number of worker replicas                                        | `1`              |
-| `worker.image.repository`   | The repository to use for the airbyte worker image.              | `airbyte/worker` |
-| `worker.image.pullPolicy`   | the pull policy to use for the airbyte worker image              | `IfNotPresent`   |
-| `worker.image.tag`          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.30.1-alpha`   |
-| `worker.podAnnotations`     | Add extra annotations to the worker pod(s)                       | `{}`             |
-| `worker.resources.limits`   | The resources limits for the worker container                    | `{}`             |
-| `worker.resources.requests` | The requested resources for the worker container                 | `{}`             |
-| `worker.nodeSelector`       | Node labels for pod assignment                                   | `{}`             |
-| `worker.tolerations`        | Tolerations for worker pod assignment.                           | `[]`             |
-| `worker.log.level`          | The log level to log at.                                         | `INFO`           |
-| `worker.extraEnv`           | Additional env vars for worker pod(s).                           | `[]`             |
+| Name                                        | Description                                                      | Value            |
+| ------------------------------------------- | ---------------------------------------------------------------- | ---------------- |
+| `worker.replicaCount`                       | Number of worker replicas                                        | `1`              |
+| `worker.image.repository`                   | The repository to use for the airbyte worker image.              | `airbyte/worker` |
+| `worker.image.pullPolicy`                   | the pull policy to use for the airbyte worker image              | `IfNotPresent`   |
+| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.30.1-alpha`   |
+| `worker.podAnnotations`                     | Add extra annotations to the worker pod(s)                       | `{}`             |
+| `worker.livenessProbe.enabled`              | Enable livenessProbe on the worker                               | `true`           |
+| `worker.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                          | `30`             |
+| `worker.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                 | `10`             |
+| `worker.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                | `1`              |
+| `worker.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                              | `3`              |
+| `worker.livenessProbe.successThreshold`     | Success threshold for livenessProbe                              | `1`              |
+| `worker.readinessProbe.enabled`             | Enable readinessProbe on the worker                              | `true`           |
+| `worker.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                         | `10`             |
+| `worker.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                | `10`             |
+| `worker.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                               | `1`              |
+| `worker.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                             | `3`              |
+| `worker.readinessProbe.successThreshold`    | Success threshold for readinessProbe                             | `1`              |
+| `worker.resources.limits`                   | The resources limits for the worker container                    | `{}`             |
+| `worker.resources.requests`                 | The requested resources for the worker container                 | `{}`             |
+| `worker.nodeSelector`                       | Node labels for pod assignment                                   | `{}`             |
+| `worker.tolerations`                        | Tolerations for worker pod assignment.                           | `[]`             |
+| `worker.log.level`                          | The log level to log at.                                         | `INFO`           |
+| `worker.extraEnv`                           | Additional env vars for worker pod(s).                           | `[]`             |
 
 
 ### Temporal parameters

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -30,7 +30,7 @@
 | `webapp.image.repository`    | The repository to use for the airbyte webapp image.              | `airbyte/webapp` |
 | `webapp.image.pullPolicy`    | the pull policy to use for the airbyte webapp image              | `IfNotPresent`   |
 | `webapp.image.tag`           | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.30.3-alpha`   |
-| `webapp.podAnnotations`      | Add extra annotations to the scheduler pod                       | `{}`             |
+| `webapp.podAnnotations`      | Add extra annotations to the webapp pod(s)                       | `{}`             |
 | `webapp.service.type`        | The service type to use for the webapp service                   | `ClusterIP`      |
 | `webapp.service.port`        | The service port to expose the webapp on                         | `80`             |
 | `webapp.resources.limits`    | The resources limits for the Web container                       | `{}`             |
@@ -111,6 +111,23 @@
 | `server.nodeSelector`                       | Node labels for pod assignment                                   | `{}`             |
 | `server.tolerations`                        | Tolerations for server pod assignment.                           | `[]`             |
 | `server.log.level`                          | The log level to log at                                          | `INFO`           |
+
+
+### Worker Parameters
+
+| Name                        | Description                                                      | Value            |
+| --------------------------- | ---------------------------------------------------------------- | ---------------- |
+| `worker.replicaCount`       | Number of worker replicas                                        | `1`              |
+| `worker.image.repository`   | The repository to use for the airbyte worker image.              | `airbyte/worker` |
+| `worker.image.pullPolicy`   | the pull policy to use for the airbyte worker image              | `IfNotPresent`   |
+| `worker.image.tag`          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.30.1-alpha`   |
+| `worker.podAnnotations`     | Add extra annotations to the worker pod(s)                       | `{}`             |
+| `worker.resources.limits`   | The resources limits for the worker container                    | `{}`             |
+| `worker.resources.requests` | The requested resources for the worker container                 | `{}`             |
+| `worker.nodeSelector`       | Node labels for pod assignment                                   | `{}`             |
+| `worker.tolerations`        | Tolerations for worker pod assignment.                           | `[]`             |
+| `worker.log.level`          | The log level to log at.                                         | `INFO`           |
+| `worker.extraEnv`           | Additional env vars for worker pod(s).                           | `[]`             |
 
 
 ### Temporal parameters

--- a/charts/airbyte/templates/_helpers.tpl
+++ b/charts/airbyte/templates/_helpers.tpl
@@ -202,3 +202,10 @@ Returns the Airbyte podSweeper Image
 {{- define "airbyte.podSweeperImage" -}}
 {{- include "common.images.image" (dict "imageRoot" .Values.podSweeper.image "global" .Values.global) -}}
 {{- end -}}
+
+{{/*
+Returns the Temporal Image. TODO: This will probably be replaced if we move to using temporal as a dependency, like minio and postgres.
+*/}}
+{{- define "airbyte.temporalImage" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.temporal.image "global" .Values.global) -}}
+{{- end -}}

--- a/charts/airbyte/templates/_helpers.tpl
+++ b/charts/airbyte/templates/_helpers.tpl
@@ -204,6 +204,13 @@ Returns the Airbyte podSweeper Image
 {{- end -}}
 
 {{/*
+Returns the Airbyte worker Image
+*/}}
+{{- define "airbyte.workerImage" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.worker.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
 Returns the Temporal Image. TODO: This will probably be replaced if we move to using temporal as a dependency, like minio and postgres.
 */}}
 {{- define "airbyte.temporalImage" -}}

--- a/charts/airbyte/templates/temporal/deployment.yaml
+++ b/charts/airbyte/templates/temporal/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       {{- end }}
       containers:
       - name: airbyte-temporal
-        image: "{{ .Values.temporal.image.repository}}:{{ .Values.temporal.image.tag }}"
+        image: {{ include "airbyte.temporalImage" . }}
         imagePullPolicy: {{ .Values.temporal.image.pullPolicy }}
         env:
         - name: AUTO_SETUP

--- a/charts/airbyte/templates/worker/deployment.yaml
+++ b/charts/airbyte/templates/worker/deployment.yaml
@@ -1,33 +1,35 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "airbyte.fullname" . }}-scheduler
+  name: {{ include "airbyte.fullname" . }}-worker
   labels:
     {{- include "airbyte.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.scheduler.replicaCount }}
+  replicas: {{ .Values.worker.replicaCount }}
   selector:
     matchLabels:
-      airbyte: scheduler
+      airbyte: worker
   template:
     metadata:
       labels:
-        airbyte: scheduler
-      {{- if .Values.scheduler.podAnnotations }}
+        airbyte: worker
+      {{- if .Values.worker.podAnnotations }}
       annotations:
-        {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.podAnnotations "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.worker.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.scheduler.nodeSelector }}
-      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.nodeSelector "context" $) | nindent 8 }}
+      serviceAccountName: {{ include "airbyte.serviceAccountName" . }}
+      automountServiceAccountToken: true
+      {{- if .Values.worker.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.worker.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.scheduler.tolerations }}
-      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.tolerations "context" $) | nindent 8 }}
+      {{- if .Values.worker.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.worker.tolerations "context" $) | nindent 8 }}
       {{- end }}
       containers:
-      - name: airbyte-scheduler-container
-        image: {{ include "airbyte.schedulerImage" . }}
-        imagePullPolicy: "{{ .Values.scheduler.image.pullPolicy }}"
+      - name: airbyte-worker-container
+        image: {{ include "airbyte.workerImage" . }}
+        imagePullPolicy: "{{ .Values.worker.image.pullPolicy }}"
         env:
         - name: AIRBYTE_VERSION
           value: {{ .Chart.AppVersion }}
@@ -99,7 +101,7 @@ spec:
               name: airbyte-env
               key: TEMPORAL_WORKER_PORTS
         - name: LOG_LEVEL
-          value: "{{ .Values.scheduler.log.level }}"
+          value: "{{ .Values.worker.log.level }}"
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -168,8 +170,43 @@ spec:
             configMapKeyRef:
               name: airbyte-env
               key: INTERNAL_API_HOST
-        {{- if .Values.scheduler.resources }}
-        resources: {{- toYaml .Values.scheduler.resources | nindent 10 }}
+        {{- if .Values.worker.extraEnv }}
+        {{ .Values.worker.extraEnv | toYaml | nindent 8 }}
+        {{- end }}
+        ports:
+        - containerPort: 9000 # for heartbeat server
+        - containerPort: 9001 # start temporal worker port pool
+        - containerPort: 9002
+        - containerPort: 9003
+        - containerPort: 9004
+        - containerPort: 9005
+        - containerPort: 9006
+        - containerPort: 9007
+        - containerPort: 9008
+        - containerPort: 9009
+        - containerPort: 9010
+        - containerPort: 9011
+        - containerPort: 9012
+        - containerPort: 9013
+        - containerPort: 9014
+        - containerPort: 9015
+        - containerPort: 9016
+        - containerPort: 9017
+        - containerPort: 9018
+        - containerPort: 9019
+        - containerPort: 9020
+        - containerPort: 9021
+        - containerPort: 9022
+        - containerPort: 9023
+        - containerPort: 9024
+        - containerPort: 9025
+        - containerPort: 9026
+        - containerPort: 9027
+        - containerPort: 9028
+        - containerPort: 9029
+        - containerPort: 9030 # end temporal worker port pool
+        {{- if .Values.worker.resources }}
+        resources: {{- toYaml .Values.worker.resources | nindent 10 }}
         {{- end }}
         volumeMounts:
         - name: gcs-log-creds-volume

--- a/charts/airbyte/templates/worker/deployment.yaml
+++ b/charts/airbyte/templates/worker/deployment.yaml
@@ -173,8 +173,31 @@ spec:
         {{- if .Values.worker.extraEnv }}
         {{ .Values.worker.extraEnv | toYaml | nindent 8 }}
         {{- end }}
+        {{- if .Values.worker.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /
+            port: heartbeat
+          initialDelaySeconds: {{ .Values.worker.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.worker.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.worker.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.worker.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.worker.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.worker.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: heartbeat
+          initialDelaySeconds: {{ .Values.worker.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.worker.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.worker.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.worker.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.worker.readinessProbe.failureThreshold }}
+        {{- end }}
         ports:
-        - containerPort: 9000 # for heartbeat server
+        - name: heartbeat
+          containerPort: 9000 # for heartbeat server
         - containerPort: 9001 # start temporal worker port pool
         - containerPort: 9002
         - containerPort: 9003

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -350,6 +350,38 @@ worker:
   ##
   podAnnotations: {}
 
+  ## Configure extra options for the worker containers' liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ## @param worker.livenessProbe.enabled Enable livenessProbe on the worker
+  ## @param worker.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param worker.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param worker.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param worker.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param worker.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+
+  ## @param worker.readinessProbe.enabled Enable readinessProbe on the worker
+  ## @param worker.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param worker.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param worker.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param worker.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param worker.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+
   ## worker resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ## We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -46,7 +46,7 @@ webapp:
     pullPolicy: IfNotPresent
     tag: 0.30.3-alpha
 
-  ## @param webapp.podAnnotations [object] Add extra annotations to the scheduler pod
+  ## @param webapp.podAnnotations [object] Add extra annotations to the webapp pod(s)
   ##
   podAnnotations: {}
 
@@ -331,6 +331,66 @@ server:
   ## @param server.log.level The log level to log at
   log:
     level: "INFO"
+
+## @section Worker Parameters
+
+worker:
+  ## @param worker.replicaCount Number of worker replicas
+  replicaCount: 1
+
+  ## @param worker.image.repository The repository to use for the airbyte worker image.
+  ## @param worker.image.pullPolicy the pull policy to use for the airbyte worker image
+  ## @param worker.image.tag The airbyte worker image tag. Defaults to the chart's AppVersion
+  image:
+    repository: airbyte/worker
+    pullPolicy: IfNotPresent
+    tag: 0.30.1-alpha
+
+  ## @param worker.podAnnotations [object] Add extra annotations to the worker pod(s)
+  ##
+  podAnnotations: {}
+
+  ## worker resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param worker.resources.limits [object] The resources limits for the worker container
+  ## @param worker.resources.requests [object] The requested resources for the worker container
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 200m
+    ##    memory: 1Gi
+    limits: {}
+    ## Examples:
+    ## requests:
+    ##    memory: 256Mi
+    ##    cpu: 250m
+    requests: {}
+
+  ## @param worker.nodeSelector [object] Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## @param worker.tolerations [array] Tolerations for worker pod assignment.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## @param worker.log.level The log level to log at.
+  log:
+    level: "INFO"
+
+  ## @param worker.extraEnv [array] Additional env vars for worker pod(s).
+  ## Example:
+  ##
+  ## extraEnv:
+  ## - name: WORKER_POD_TOLERATIONS
+  ##   value: "key=airbyte-server,operator=Equals,value=true,effect=NoSchedule"
+  extraEnv: []
 
 ## @section Temporal parameters
 ## TODO: Move to consuming temporal from a dedicated helm chart

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -344,7 +344,7 @@ worker:
   image:
     repository: airbyte/worker
     pullPolicy: IfNotPresent
-    tag: 0.30.1-alpha
+    tag: 0.30.3-alpha
 
   ## @param worker.podAnnotations [object] Add extra annotations to the worker pod(s)
   ##


### PR DESCRIPTION
## What

Fixes #6416 by adding the worker pods that have been split out from the scheduler.

I also wasn't sure if it was valid to use port 9000 on the worker pods as a liveness and readiness probe, but @davinchia said to roll with it for now. When using the `--wait` flag with helm, its nice to have these as it will wait for the pods to be ready. Also, if for whatever reason, the pod stops responding then kubernetes will restart it.

