### PR TITLE
add docker-compose debug extension

### DIFF
--- a/docker-compose.debug.yaml
+++ b/docker-compose.debug.yaml
@@ -1,0 +1,23 @@
+# Adds ports to the db and access to the temporal UI for debugging purposes.
+# Expected to be used like this:
+# VERSION=dev docker-compose -f docker-compose.yaml -f docker-compose.debug.yaml up
+version: "3.7"
+x-logging: &default-logging
+  options:
+    max-size: "100m"
+    max-file: "5"
+  driver: json-file
+services:
+  db:
+    ports:
+      - 5432:5432
+  airbyte-temporal-ui:
+    image: temporalio/web:latest
+    logging: *default-logging
+    container_name: airbyte-temporal-ui
+    restart: unless-stopped
+    environment:
+      - TEMPORAL_GRPC_ENDPOINT=airbyte-temporal:7233
+      - TEMPORAL_PERMIT_WRITE_API=true
+    ports:
+      - 8088:8088

--- a/docker-compose.debug.yaml
+++ b/docker-compose.debug.yaml
@@ -10,7 +10,7 @@ x-logging: &default-logging
 services:
   db:
     ports:
-      - 5432:5432
+      - 8011:5432
   airbyte-temporal-ui:
     image: temporalio/web:latest
     logging: *default-logging
@@ -20,4 +20,4 @@ services:
       - TEMPORAL_GRPC_ENDPOINT=airbyte-temporal:7233
       - TEMPORAL_PERMIT_WRITE_API=true
     ports:
-      - 8088:8088
+      - 8012:8088


### PR DESCRIPTION
After looking up how to run the temporal ui 10x and manually adding the db port 100x, I thought it'd be useful to have a debugging docker-compose file that would allow extending our main docker-compose file for debugging.