### PR TITLE
Modify oauthSpecification to allow working with oneOfs

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1940,7 +1940,7 @@ components:
           type: string
           enum: ["oauth2.0"] # Future auth types should be added here
         oauth2Specification:
-          description: If the connector supports OAuth, this field should be non-null.
+          "$ref": "#/components/schemas/OAuth2Specification"
     OAuth2Specification:
       description: An object containing any metadata needed to describe this connector's Oauth flow
       type: object

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1940,22 +1940,50 @@ components:
           type: string
           enum: ["oauth2.0"] # Future auth types should be added here
         oauth2Specification:
-          "$ref": "#/components/schemas/OAuth2Specification"
+          description: If the connector supports OAuth, this field should be non-null.
     OAuth2Specification:
       description: An object containing any metadata needed to describe this connector's Oauth flow
       type: object
+      required:
+        - rootObject
+        - oauthFlowInitParameters
+        - oauthFlowOutputParameters
       properties:
-        oauthFlowInitParameters:
+        rootObject:
           description:
-            "Pointers to the fields in the ConnectorSpecification which are needed to obtain the initial refresh/access tokens for the OAuth flow.
-            Each inner array represents the path in the ConnectorSpecification of the referenced field.
-            For example.
-            Assume the ConnectorSpecification contains params 'app_secret', 'app_id' which are needed to get the initial refresh token.
-            If they are not nested in the config, then the array would look like this [['app_secret'], ['app_id']]
-            If they are nested inside, say, an object called 'auth_params' then this array would be [['auth_params', 'app_secret'], ['auth_params', 'app_id']]"
+            "A list of strings representing a pointer to the root object which contains any oauth parameters in the ConnectorSpecification.
+
+            Examples:
+
+            if oauth parameters were contained inside the top level, rootObject=[]
+            If they were nested inside another object {'credentials': {'app_id' etc...}, rootObject=['credentials']
+            If they were inside a oneOf {'switch': {oneOf: [{client_id...}, {non_oauth_param]}},  rootObject=['switch', 0]
+            "
           type: array
           items:
-            description: A list of strings which describes each parameter's path inside the ConnectionSpecification
+            type: string
+        oauthFlowInitParameters:
+          description:
+            "Pointers to the fields in the rootObject needed to obtain the initial refresh/access tokens for the OAuth flow.
+            Each inner array represents the path in the rootObject of the referenced field.
+            For example.
+            Assume the rootObject contains params 'app_secret', 'app_id' which are needed to get the initial refresh token.
+            If they are not nested in the rootObject, then the array would look like this [['app_secret'], ['app_id']]
+            If they are nested inside an object called 'auth_params' then this array would be [['auth_params', 'app_secret'], ['auth_params', 'app_id']]"
+          type: array
+          items:
+            description: A list of strings denoting a pointer into the rootObject for where to find this property
+            type: array
+            items:
+              type: string
+        oauthFlowOutputParameters:
+          description:
+            "Pointers to the fields in the rootObject which can be populated from successfully completing the oauth flow using the init parameters.
+            This is typically a refresh/access token.
+            Each inner array represents the path in the rootObject of the referenced field."
+          type: array
+          items:
+            description: A list of strings denoting a pointer into the rootObject for where to find this property
             type: array
             items:
               type: string

--- a/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
+++ b/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
@@ -104,9 +104,17 @@ class DestinationSyncMode(Enum):
 
 
 class OAuth2Specification(BaseModel):
-    oauthFlowInitParameters: Optional[List[List[str]]] = Field(
-        None,
-        description="Pointers to the fields in the ConnectorSpecification which are needed to obtain the initial refresh/access tokens for the OAuth flow. Each inner array represents the path in the ConnectorSpecification of the referenced field. For example. Assume the ConnectorSpecification contains params 'app_secret', 'app_id' which are needed to get the initial refresh token. If they are not nested in the config, then the array would look like this [['app_secret'], ['app_id']] If they are nested inside, say, an object called 'auth_params' then this array would be [['auth_params', 'app_secret'], ['auth_params', 'app_id']]",
+    rootObject: List[str] = Field(
+        ...,
+        description="A list of strings representing a pointer to the root object which contains any oauth parameters in the ConnectorSpecification.\nExamples:\nif oauth parameters were contained inside the top level, rootObject=[] If they were nested inside another object {'credentials': {'app_id' etc...}, rootObject=['credentials'] If they were inside a oneOf {'switch': {oneOf: [{client_id...}, {non_oauth_param]}},  rootObject=['switch', 0] ",
+    )
+    oauthFlowInitParameters: List[List[str]] = Field(
+        ...,
+        description="Pointers to the fields in the rootObject needed to obtain the initial refresh/access tokens for the OAuth flow. Each inner array represents the path in the rootObject of the referenced field. For example. Assume the rootObject contains params 'app_secret', 'app_id' which are needed to get the initial refresh token. If they are not nested in the rootObject, then the array would look like this [['app_secret'], ['app_id']] If they are nested inside an object called 'auth_params' then this array would be [['auth_params', 'app_secret'], ['auth_params', 'app_id']]",
+    )
+    oauthFlowOutputParameters: List[List[str]] = Field(
+        ...,
+        description="Pointers to the fields in the rootObject which can be populated from successfully completing the oauth flow using the init parameters. This is typically a refresh/access token. Each inner array represents the path in the rootObject of the referenced field.",
     )
 
 

--- a/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
+++ b/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
@@ -104,9 +104,17 @@ class DestinationSyncMode(Enum):
 
 
 class OAuth2Specification(BaseModel):
-    oauthFlowInitParameters: Optional[List[List[str]]] = Field(
-        None,
-        description="Pointers to the fields in the ConnectorSpecification which are needed to obtain the initial refresh/access tokens for the OAuth flow. Each inner array represents the path in the ConnectorSpecification of the referenced field. For example. Assume the ConnectorSpecification contains params 'app_secret', 'app_id' which are needed to get the initial refresh token. If they are not nested in the config, then the array would look like this [['app_secret'], ['app_id']] If they are nested inside, say, an object called 'auth_params' then this array would be [['auth_params', 'app_secret'], ['auth_params', 'app_id']]",
+    rootObject: List[str] = Field(
+        ...,
+        description="A list of strings representing a pointer to the root object which contains any oauth parameters in the ConnectorSpecification.\nExamples:\nif oauth parameters were contained inside the top level, rootObject=[] If they were nested inside another object {'credentials': {'app_id' etc...}, rootObject=['credentials'] If they were inside a oneOf {'switch': {oneOf: [{client_id...}, {non_oauth_param]}},  rootObject=['switch', 0] ",
+    )
+    oauthFlowInitParameters: List[List[str]] = Field(
+        ...,
+        description="Pointers to the fields in the rootObject needed to obtain the initial refresh/access tokens for the OAuth flow. Each inner array represents the path in the rootObject of the referenced field. For example. Assume the rootObject contains params 'app_secret', 'app_id' which are needed to get the initial refresh token. If they are not nested in the rootObject, then the array would look like this [['app_secret'], ['app_id']] If they are nested inside an object called 'auth_params' then this array would be [['auth_params', 'app_secret'], ['auth_params', 'app_id']]",
+    )
+    oauthFlowOutputParameters: List[List[str]] = Field(
+        ...,
+        description="Pointers to the fields in the rootObject which can be populated from successfully completing the oauth flow using the init parameters. This is typically a refresh/access token. Each inner array represents the path in the rootObject of the referenced field.",
     )
 
 

--- a/airbyte-integrations/connectors/source-scaffold-source-http/unit_tests/test_incremental_streams.py
+++ b/airbyte-integrations/connectors/source-scaffold-source-http/unit_tests/test_incremental_streams.py
@@ -22,9 +22,8 @@
 # SOFTWARE.
 #
 
-from pytest import fixture
-
 from airbyte_cdk.models import SyncMode
+from pytest import fixture
 from source_scaffold_source_http.source import IncrementalScaffoldSourceHttpStream
 
 

--- a/airbyte-integrations/connectors/source-scaffold-source-http/unit_tests/test_incremental_streams.py
+++ b/airbyte-integrations/connectors/source-scaffold-source-http/unit_tests/test_incremental_streams.py
@@ -22,8 +22,9 @@
 # SOFTWARE.
 #
 
-from airbyte_cdk.models import SyncMode
 from pytest import fixture
+
+from airbyte_cdk.models import SyncMode
 from source_scaffold_source_http.source import IncrementalScaffoldSourceHttpStream
 
 

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -211,18 +211,46 @@ definitions:
   OAuth2Specification:
     description: An object containing any metadata needed to describe this connector's Oauth flow
     type: object
+    required:
+      - rootObject
+      - oauthFlowInitParameters
+      - oauthFlowOutputParameters
     properties:
-      oauthFlowInitParameters:
+      rootObject:
         description:
-          "Pointers to the fields in the ConnectorSpecification which are needed to obtain the initial refresh/access tokens for the OAuth flow.
-          Each inner array represents the path in the ConnectorSpecification of the referenced field.
-          For example.
-          Assume the ConnectorSpecification contains params 'app_secret', 'app_id' which are needed to get the initial refresh token.
-          If they are not nested in the config, then the array would look like this [['app_secret'], ['app_id']]
-          If they are nested inside, say, an object called 'auth_params' then this array would be [['auth_params', 'app_secret'], ['auth_params', 'app_id']]"
+          "A list of strings representing a pointer to the root object which contains any oauth parameters in the ConnectorSpecification.
+
+          Examples:
+
+          if oauth parameters were contained inside the top level, rootObject=[]
+          If they were nested inside another object {'credentials': {'app_id' etc...}, rootObject=['credentials']
+          If they were inside a oneOf {'switch': {oneOf: [{client_id...}, {non_oauth_param]}},  rootObject=['switch', 0]
+          "
         type: array
         items:
-          description: A list of strings which describe the path inside a JSON object for finding the
+          type: string
+      oauthFlowInitParameters:
+        description:
+          "Pointers to the fields in the rootObject needed to obtain the initial refresh/access tokens for the OAuth flow.
+          Each inner array represents the path in the rootObject of the referenced field.
+          For example.
+          Assume the rootObject contains params 'app_secret', 'app_id' which are needed to get the initial refresh token.
+          If they are not nested in the rootObject, then the array would look like this [['app_secret'], ['app_id']]
+          If they are nested inside an object called 'auth_params' then this array would be [['auth_params', 'app_secret'], ['auth_params', 'app_id']]"
+        type: array
+        items:
+          description: A list of strings denoting a pointer into the rootObject for where to find this property
+          type: array
+          items:
+            type: string
+      oauthFlowOutputParameters:
+        description:
+          "Pointers to the fields in the rootObject which can be populated from successfully completing the oauth flow using the init parameters.
+          This is typically a refresh/access token.
+          Each inner array represents the path in the rootObject of the referenced field."
+        type: array
+        items:
+          description: A list of strings denoting a pointer into the rootObject for where to find this property
           type: array
           items:
             type: string

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/OauthModelConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/OauthModelConverter.java
@@ -27,6 +27,7 @@ package io.airbyte.server.converters;
 import io.airbyte.api.model.AuthSpecification;
 import io.airbyte.api.model.OAuth2Specification;
 import io.airbyte.protocol.models.ConnectorSpecification;
+
 import java.util.Optional;
 
 public class OauthModelConverter {
@@ -41,7 +42,10 @@ public class OauthModelConverter {
     if (incomingAuthSpec.getAuthType() == io.airbyte.protocol.models.AuthSpecification.AuthType.OAUTH_2_0) {
       authSpecification.authType(AuthSpecification.AuthTypeEnum.OAUTH2_0)
           .oauth2Specification(new OAuth2Specification()
-              .oauthFlowInitParameters(incomingAuthSpec.getOauth2Specification().getOauthFlowInitParameters()));
+              .rootObject(incomingAuthSpec.getOauth2Specification().getRootObject())
+              .oauthFlowInitParameters(incomingAuthSpec.getOauth2Specification().getOauthFlowInitParameters())
+              .oauthFlowOutputParameters(incomingAuthSpec.getOauth2Specification().getOauthFlowOutputParameters())
+          );
     }
 
     return Optional.ofNullable(authSpecification);

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/OauthModelConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/OauthModelConverter.java
@@ -27,7 +27,6 @@ package io.airbyte.server.converters;
 import io.airbyte.api.model.AuthSpecification;
 import io.airbyte.api.model.OAuth2Specification;
 import io.airbyte.protocol.models.ConnectorSpecification;
-
 import java.util.Optional;
 
 public class OauthModelConverter {
@@ -44,8 +43,7 @@ public class OauthModelConverter {
           .oauth2Specification(new OAuth2Specification()
               .rootObject(incomingAuthSpec.getOauth2Specification().getRootObject())
               .oauthFlowInitParameters(incomingAuthSpec.getOauth2Specification().getOauthFlowInitParameters())
-              .oauthFlowOutputParameters(incomingAuthSpec.getOauth2Specification().getOauthFlowOutputParameters())
-          );
+              .oauthFlowOutputParameters(incomingAuthSpec.getOauth2Specification().getOauthFlowOutputParameters()));
     }
 
     return Optional.ofNullable(authSpecification);

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/OauthModelConverterTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/OauthModelConverterTest.java
@@ -1,19 +1,40 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Airbyte
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.airbyte.server.converters;
 
-import io.airbyte.commons.json.Jsons;
+import static org.junit.jupiter.api.Assertions.*;
+
 import io.airbyte.protocol.models.AuthSpecification;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.protocol.models.OAuth2Specification;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class OauthModelConverterTest {
 
@@ -38,8 +59,7 @@ class OauthModelConverterTest {
         Arguments.of(
             List.of(List.of()),
             List.of(List.of()),
-            List.of("path"))
-    );
+            List.of("path")));
   }
 
   @ParameterizedTest
@@ -51,9 +71,7 @@ class OauthModelConverterTest {
             .withOauth2Specification(new OAuth2Specification()
                 .withOauthFlowInitParameters(initParams)
                 .withOauthFlowOutputParameters(outputParams)
-                .withRootObject(rootObject)
-            )
-    );
+                .withRootObject(rootObject)));
 
     io.airbyte.api.model.AuthSpecification expected = new io.airbyte.api.model.AuthSpecification()
         .authType(io.airbyte.api.model.AuthSpecification.AuthTypeEnum.OAUTH2_0)
@@ -61,11 +79,11 @@ class OauthModelConverterTest {
             new io.airbyte.api.model.OAuth2Specification()
                 .oauthFlowInitParameters(initParams)
                 .oauthFlowOutputParameters(outputParams)
-                .rootObject(rootObject)
-        );
+                .rootObject(rootObject));
 
     Optional<io.airbyte.api.model.AuthSpecification> authSpec = OauthModelConverter.getAuthSpec(input);
     assertTrue(authSpec.isPresent());
     assertEquals(expected, authSpec.get());
   }
+
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/OauthModelConverterTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/OauthModelConverterTest.java
@@ -1,0 +1,71 @@
+package io.airbyte.server.converters;
+
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.protocol.models.AuthSpecification;
+import io.airbyte.protocol.models.ConnectorSpecification;
+import io.airbyte.protocol.models.OAuth2Specification;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OauthModelConverterTest {
+
+  private static Stream<Arguments> testProvider() {
+    return Stream.of(
+        // all fields filled out with nesting
+        Arguments.of(
+            List.of(List.of("init1"), List.of("init2-1", "init2-2")),
+            List.of(List.of("output1"), List.of("output2-1", "output2-2")),
+            List.of("path")),
+        // init params only
+        Arguments.of(
+            List.of(List.of("init1"), List.of("init2-1", "init2-2")),
+            List.of(List.of()),
+            List.of()),
+        // output params only
+        Arguments.of(
+            List.of(List.of()),
+            List.of(List.of("output1"), List.of("output2-1", "output2-2")),
+            List.of()),
+        // rootObject only
+        Arguments.of(
+            List.of(List.of()),
+            List.of(List.of()),
+            List.of("path"))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("testProvider")
+  public void testIt(List<List<String>> initParams, List<List<String>> outputParams, List<String> rootObject) {
+    ConnectorSpecification input = new ConnectorSpecification().withAuthSpecification(
+        new AuthSpecification()
+            .withAuthType(AuthSpecification.AuthType.OAUTH_2_0)
+            .withOauth2Specification(new OAuth2Specification()
+                .withOauthFlowInitParameters(initParams)
+                .withOauthFlowOutputParameters(outputParams)
+                .withRootObject(rootObject)
+            )
+    );
+
+    io.airbyte.api.model.AuthSpecification expected = new io.airbyte.api.model.AuthSpecification()
+        .authType(io.airbyte.api.model.AuthSpecification.AuthTypeEnum.OAUTH2_0)
+        .oauth2Specification(
+            new io.airbyte.api.model.OAuth2Specification()
+                .oauthFlowInitParameters(initParams)
+                .oauthFlowOutputParameters(outputParams)
+                .rootObject(rootObject)
+        );
+
+    Optional<io.airbyte.api.model.AuthSpecification> authSpec = OauthModelConverter.getAuthSpec(input);
+    assertTrue(authSpec.isPresent());
+    assertEquals(expected, authSpec.get());
+  }
+}

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -2299,9 +2299,7 @@ font-style: italic;
   "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "authSpecification" : {
     "auth_type" : "oauth2.0",
-    "oauth2Specification" : {
-      "oauthFlowInitParameters" : [ [ "oauthFlowInitParameters", "oauthFlowInitParameters" ], [ "oauthFlowInitParameters", "oauthFlowInitParameters" ] ]
-    }
+    "oauth2Specification" : ""
   },
   "jobInfo" : {
     "createdAt" : 0,
@@ -4650,9 +4648,7 @@ font-style: italic;
   "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "authSpecification" : {
     "auth_type" : "oauth2.0",
-    "oauth2Specification" : {
-      "oauthFlowInitParameters" : [ [ "oauthFlowInitParameters", "oauthFlowInitParameters" ], [ "oauthFlowInitParameters", "oauthFlowInitParameters" ] ]
-    }
+    "oauth2Specification" : ""
   },
   "jobInfo" : {
     "createdAt" : 0,
@@ -6462,7 +6458,7 @@ font-style: italic;
       <div class="param">auth_type (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">oauth2.0</div>
-<div class="param">oauth2Specification (optional)</div><div class="param-desc"><span class="param-type"><a href="#OAuth2Specification">OAuth2Specification</a></span>  </div>
+<div class="param">oauth2Specification (optional)</div><div class="param-desc"><span class="param-type"><a href="#">oas_any_type_not_mapped</a></span> If the connector supports OAuth, this field should be non-null. </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -6967,7 +6963,11 @@ font-style: italic;
     <h3><a name="OAuth2Specification"><code>OAuth2Specification</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'>An object containing any metadata needed to describe this connector's Oauth flow</div>
     <div class="field-items">
-      <div class="param">oauthFlowInitParameters (optional)</div><div class="param-desc"><span class="param-type"><a href="#array">array[array[String]]</a></span> Pointers to the fields in the ConnectorSpecification which are needed to obtain the initial refresh/access tokens for the OAuth flow. Each inner array represents the path in the ConnectorSpecification of the referenced field. For example. Assume the ConnectorSpecification contains params 'app_secret', 'app_id' which are needed to get the initial refresh token. If they are not nested in the config, then the array would look like this [['app_secret'], ['app_id']] If they are nested inside, say, an object called 'auth_params' then this array would be [['auth_params', 'app_secret'], ['auth_params', 'app_id']] </div>
+      <div class="param">rootObject </div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> A list of strings representing a pointer to the root object which contains any oauth parameters in the ConnectorSpecification.
+Examples:
+if oauth parameters were contained inside the top level, rootObject=[] If they were nested inside another object {'credentials': {'app_id' etc...}, rootObject=['credentials'] If they were inside a oneOf {'switch': {oneOf: [{client_id...}, {non_oauth_param]}},  rootObject=['switch', 0] </div>
+<div class="param">oauthFlowInitParameters </div><div class="param-desc"><span class="param-type"><a href="#array">array[array[String]]</a></span> Pointers to the fields in the rootObject needed to obtain the initial refresh/access tokens for the OAuth flow. Each inner array represents the path in the rootObject of the referenced field. For example. Assume the rootObject contains params 'app_secret', 'app_id' which are needed to get the initial refresh token. If they are not nested in the rootObject, then the array would look like this [['app_secret'], ['app_id']] If they are nested inside an object called 'auth_params' then this array would be [['auth_params', 'app_secret'], ['auth_params', 'app_id']] </div>
+<div class="param">oauthFlowOutputParameters </div><div class="param-desc"><span class="param-type"><a href="#array">array[array[String]]</a></span> Pointers to the fields in the rootObject which can be populated from successfully completing the oauth flow using the init parameters. This is typically a refresh/access token. Each inner array represents the path in the rootObject of the referenced field. </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -2299,7 +2299,11 @@ font-style: italic;
   "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "authSpecification" : {
     "auth_type" : "oauth2.0",
-    "oauth2Specification" : ""
+    "oauth2Specification" : {
+      "oauthFlowOutputParameters" : [ [ "oauthFlowOutputParameters", "oauthFlowOutputParameters" ], [ "oauthFlowOutputParameters", "oauthFlowOutputParameters" ] ],
+      "rootObject" : [ "rootObject", "rootObject" ],
+      "oauthFlowInitParameters" : [ [ "oauthFlowInitParameters", "oauthFlowInitParameters" ], [ "oauthFlowInitParameters", "oauthFlowInitParameters" ] ]
+    }
   },
   "jobInfo" : {
     "createdAt" : 0,
@@ -4648,7 +4652,11 @@ font-style: italic;
   "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "authSpecification" : {
     "auth_type" : "oauth2.0",
-    "oauth2Specification" : ""
+    "oauth2Specification" : {
+      "oauthFlowOutputParameters" : [ [ "oauthFlowOutputParameters", "oauthFlowOutputParameters" ], [ "oauthFlowOutputParameters", "oauthFlowOutputParameters" ] ],
+      "rootObject" : [ "rootObject", "rootObject" ],
+      "oauthFlowInitParameters" : [ [ "oauthFlowInitParameters", "oauthFlowInitParameters" ], [ "oauthFlowInitParameters", "oauthFlowInitParameters" ] ]
+    }
   },
   "jobInfo" : {
     "createdAt" : 0,
@@ -6458,7 +6466,7 @@ font-style: italic;
       <div class="param">auth_type (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">oauth2.0</div>
-<div class="param">oauth2Specification (optional)</div><div class="param-desc"><span class="param-type"><a href="#">oas_any_type_not_mapped</a></span> If the connector supports OAuth, this field should be non-null. </div>
+<div class="param">oauth2Specification (optional)</div><div class="param-desc"><span class="param-type"><a href="#OAuth2Specification">OAuth2Specification</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What
While working on oauth UI/BE interface, we realized the current `authSpecification` block is insufficiently expressive to encode situations where the oauth credentials live inside a `oneOf` block. For example, if there is a `oneOf` block like the following:

```
credentials: {
oneOf: [
  {
     title: Webflow Oauth
     type: object
     properties:
       client_id:
       client_secret:
       refresh_token:
  },
  {
     title: API Key auth
    type: object
    properties: {
       apiKey
    }
  }
]
}
```

Then the current `authSpecification` primitive:

```
authSpecification:
  type: oauth2.0
  oauth2Specification:
     initParameters: [["credentials", "client_id"], ["credentials", "client_secret"]]
```

has some problems:
1. It's inaccurate in that a connector might support multiple auth formats (Oauth2, openID connect, API key, etc...)
2. it is incapable of expressing differences within a `oneOf` (or any combination keyword). For example, if there are _two_ slightly different oauth blocks inside a `oneOf` (e.g: if one can be obtained via the Oauth webflow and the other via an oauth playground that doesn't require a developer app) then there can be name collisions that make it impossible to know when the UI should display the "authorize" button or not.

This leaves us with a few options:
1. **Disable multiple auth options for a connector and if a connector uses oauth, make that the only auth method**. This sounds tempting but has some significant drawbacks. For many connectors for an OSS users, oauth2 is strictly worse than API key. This means we need to fork the connectors and have one used in cloud and one used in OSS. But while we were able to fork java connectors a little more easily such as in #6419, it's more difficult for a python connector in our current monorepo setup for the reasons outlined in #6455. I would have loved to just go with this limitation for now but unfortunately it is not workable within a reasonable timeline/contains delivery risks.
2. Handle the `oneOf` case now via one of the following options
    1. embed the auth specification into nodes in `connectionSpecification` directly e.g:
    ```
    "connectionSpecification": {
        "properties": {
          "credentials": {
            "title": "Authentication mechanism",
            "type": "object",
            "description": "Choose either OAuth2.0 flow or provide your own JWT credentials for service account",
            "oneOf": [
              {
                "type": "object",
                "title": "OAuth2.0 authorization",
                "auth": { <<<<<<<<<< THIS IS THE CUSTOM BLOCK
                   "type": "oauth2.0",
                   "initParams": [["client_id"], ["client_secret"]],
                   "outputParams": [["refresh_token"]]
                },
                "properties": {
                  "option_title": {
                    "type": "string",
                    "const": "Default OAuth2.0 authorization"
                  },
                  "client_id": { "type": "string" },
                  "client_secret": { "type": "string", "airbyte_secret": true },
                  "refresh_token": { "type": "string", "airbyte_secret": true }
                },
                "required": ["client_id", "client_secret", "refresh_token"],
                "additionalProperties": false
              },
              ...
            ]
          }
        }
   }
   ```
   2. handle the path in the top-level object by adding a property `rootObject` which tells us which object contains the oauth logic. This way, if the object is ever used inside a `oneOf` then a UI understands that when this object is selected, the "authorize" button should be shown.
   ```
    {
          "connectionSpecification": {
            "properties": {
              "credentials": {
                "title": "Authentication mechanism",
                "type": "object",
                "description": "Choose either OAuth2.0 flow or provide your own JWT credentials for service account",
                "oneOf": [
                  {
                    "type": "object",
                    "title": "OAuth2.0 authorization",
                    "properties": {
                      "option_title": {
                        "type": "string",
                        "const": "Default OAuth2.0 authorization"
                      },
                      "client_id": { "type": "string" },
                      "client_secret": { "type": "string", "airbyte_secret": true },
                      "refresh_token": { "type": "string", "airbyte_secret": true }
                    },
                    "required": ["client_id", "client_secret", "refresh_token"],
                    "additionalProperties": false
                  },
                  ...
                ]
              }
          },
          "authSpecification": {
            "auth_type": "oauth2.0",
            "oauth2Specification": {
              "rootObject": ["credentials", 0],
              "oauthFlowInitParameters": [["client_id"], ["client_secret"]]
              "oauthFlowOutputParameters": [["refresh_token"]]
            }
          }
        }
   ```

The tradeoffs between the approaches are:
* Approach 2.i (embed/in-line) makes it easier to express multiple possible auth flows. Let’s say you have oneof containing openID connect and oauth2.0. Then auth specification must also have a way of expressing this oneof. The most natural way of doing it is inline. Otherwise you have to follow all this pointer logic because it lives at the top level. drawbacks of that approach is it’s harder to validate and it mixes domain-specific logic inside the connector's spec
* Approach 2.ii (top-level) keeps the concerns very separated but is probably more difficult for a UI to consume. Plus, it 


I'm honestly not sure exactly what the right solution is. I like inlining for the reason mentioned above (more natural way to express things). But
at the same time, inlining doesn't actually give us multiple auth mechanisms (the assumptions baked in the API/UI are that there is only ever one oauth implementation) so it's probably not worth completely changing course to half-implement a feature. Since all of these are two way doors so I'm choosing something and we'll probably have to come back to adjust it in the future.

## How
This PR Takes approach 2.ii

## Recommended reading order
1. `config.yaml`/`airbyte_protocol.yaml` (they're the same change expressed in both the protocol and the API layer) 

