### PR TITLE
🐛  Source BigQuery: handle empty or null data set id

### DIFF
--- a/airbyte-integrations/connectors/source-bigquery/src/main/java/io/airbyte/integrations/source/bigquery/BigQuerySource.java
+++ b/airbyte-integrations/connectors/source-bigquery/src/main/java/io/airbyte/integrations/source/bigquery/BigQuerySource.java
@@ -48,11 +48,13 @@ public class BigQuerySource extends AbstractRelationalDbSource<StandardSQLTypeNa
 
   @Override
   public JsonNode toDatabaseConfig(JsonNode config) {
-    return Jsons.jsonNode(ImmutableMap.builder()
+    var conf = ImmutableMap.builder()
         .put(CONFIG_PROJECT_ID, config.get(CONFIG_PROJECT_ID).asText())
-        .put(CONFIG_CREDS, config.get(CONFIG_CREDS).asText())
-        .put(CONFIG_DATASET_ID, config.get(CONFIG_DATASET_ID).asText())
-        .build());
+        .put(CONFIG_CREDS, config.get(CONFIG_CREDS).asText());
+    if (config.hasNonNull(CONFIG_DATASET_ID)) {
+      conf.put(CONFIG_DATASET_ID, config.get(CONFIG_DATASET_ID).asText());
+    }
+    return Jsons.jsonNode(conf.build());
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-bigquery/src/test/java/io/airbyte/integrations/source/bigquery/BigQuerySourceTest.java
+++ b/airbyte-integrations/connectors/source-bigquery/src/test/java/io/airbyte/integrations/source/bigquery/BigQuerySourceTest.java
@@ -5,6 +5,7 @@
 package io.airbyte.integrations.source.bigquery;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -20,6 +21,20 @@ class BigQuerySourceTest {
     JsonNode configJson = Jsons.deserialize(MoreResources.readResource("test_config_empty_datasetid.json"));
     JsonNode dbConfig = new BigQuerySource().toDatabaseConfig(configJson);
     assertTrue(dbConfig.get(BigQuerySource.CONFIG_DATASET_ID).isEmpty());
+  }
+
+  @Test
+  public void testMissingDatasetIdInConfig() throws IOException {
+    JsonNode configJson = Jsons.deserialize(MoreResources.readResource("test_config_missing_datasetid.json"));
+    JsonNode dbConfig = new BigQuerySource().toDatabaseConfig(configJson);
+    assertFalse(dbConfig.hasNonNull(BigQuerySource.CONFIG_DATASET_ID));
+  }
+
+  @Test
+  public void testNullDatasetIdInConfig() throws IOException {
+    JsonNode configJson = Jsons.deserialize(MoreResources.readResource("test_config_null_datasetid.json"));
+    JsonNode dbConfig = new BigQuerySource().toDatabaseConfig(configJson);
+    assertFalse(dbConfig.hasNonNull(BigQuerySource.CONFIG_DATASET_ID));
   }
 
   @Test

--- a/airbyte-integrations/connectors/source-bigquery/src/test/resources/test_config_missing_datasetid.json
+++ b/airbyte-integrations/connectors/source-bigquery/src/test/resources/test_config_missing_datasetid.json
@@ -1,0 +1,4 @@
+{
+  "project_id": "xxxx",
+  "credentials_json": "xxxx"
+}

--- a/airbyte-integrations/connectors/source-bigquery/src/test/resources/test_config_null_datasetid.json
+++ b/airbyte-integrations/connectors/source-bigquery/src/test/resources/test_config_null_datasetid.json
@@ -1,0 +1,5 @@
+{
+  "dataset_id": null,
+  "project_id": "xxxx",
+  "credentials_json": "xxxx"
+}


### PR DESCRIPTION
## What
* Dataset is optional in BigQuery source
* https://github.com/airbytehq/airbyte/pull/6051 fixed it, except one flow.
* Looks like when creating a new source, UI does not send `dataset_id` if its not given.
![Screenshot from 2021-09-28 19-10-12](https://user-images.githubusercontent.com/47996246/135191622-e8653388-6276-45db-b365-3bb613ef3006.png)
* Since it's optional, it makes sense to properly check and only set if non-null in `toDatabaseConfig`

## How
* Check optionally before adding it to config.

## Recommended reading order
1. `BigQuerySource.java`
2. `BigQuerySourceTest.java`

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> New Connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector added to connector index like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
   
</p>
</details>


<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</p>
</details>

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
