### PR TITLE
Bump Airbyte version from 0.29.22-alpha to 0.30.0-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.29.22-alpha
+current_version = 0.30.0-alpha
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.29.22-alpha
+VERSION=0.30.0-alpha
 
 # Airbyte Internal Job Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_USER=docker

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.29.22-alpha",
+  "version": "0.30.0-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.29.22-alpha",
+  "version": "0.30.0-alpha",
   "private": true,
   "scripts": {
     "start": "react-scripts start",

--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.2.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.29.22-alpha"
+appVersion: "0.30.0-alpha"
 
 dependencies:
 - name: common

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -44,7 +44,7 @@ webapp:
   image:
     repository: airbyte/webapp
     pullPolicy: IfNotPresent
-    tag: 0.29.22-alpha
+    tag: 0.30.0-alpha
 
   ## @param webapp.podAnnotations [object] Add extra annotations to the scheduler pod
   ##
@@ -141,7 +141,7 @@ scheduler:
   image:
     repository: airbyte/scheduler
     pullPolicy: IfNotPresent
-    tag: 0.29.22-alpha
+    tag: 0.30.0-alpha
 
   ## @param scheduler.podAnnotations [object] Add extra annotations to the scheduler pod
   ##
@@ -240,7 +240,7 @@ server:
   image:
     repository: airbyte/server
     pullPolicy: IfNotPresent
-    tag: 0.29.22-alpha
+    tag: 0.30.0-alpha
 
   ## @param server.podAnnotations [object] Add extra annotations to the server pod
   ##

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -81,7 +81,7 @@ If you are upgrading from  (i.e. your current version of Airbyte is) Airbyte ver
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.29.22-alpha --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.30.0-alpha --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/kube/overlays/stable-with-resource-limits/.env
+++ b/kube/overlays/stable-with-resource-limits/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.29.22-alpha
+AIRBYTE_VERSION=0.30.0-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.29.22-alpha
+    newTag: 0.30.0-alpha
   - name: airbyte/scheduler
-    newTag: 0.29.22-alpha
+    newTag: 0.30.0-alpha
   - name: airbyte/server
-    newTag: 0.29.22-alpha
+    newTag: 0.30.0-alpha
   - name: airbyte/webapp
-    newTag: 0.29.22-alpha
+    newTag: 0.30.0-alpha
   - name: airbyte/worker
-    newTag: 0.29.22-alpha
+    newTag: 0.30.0-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.29.22-alpha
+AIRBYTE_VERSION=0.30.0-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.29.22-alpha
+    newTag: 0.30.0-alpha
   - name: airbyte/scheduler
-    newTag: 0.29.22-alpha
+    newTag: 0.30.0-alpha
   - name: airbyte/server
-    newTag: 0.29.22-alpha
+    newTag: 0.30.0-alpha
   - name: airbyte/webapp
-    newTag: 0.29.22-alpha
+    newTag: 0.30.0-alpha
   - name: airbyte/worker
-    newTag: 0.29.22-alpha
+    newTag: 0.30.0-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 


### PR DESCRIPTION
Changelog:

a595c753e 🎉 Destination MSSQL: Added support for connection via SSH tunnels (#5… (#6503)
7d1a67f99 introduce method to query jobs database by end timestamp of attempts (#6505)
6b4c6a17f Fix "android_last_seen_at" data type (#6082)
10434372d Change license in connector generator base files (#6522)
c5e74cf33 Make spec storybook more prominent in docs
501d07f40 Facebook marketing source: fix field value type conversion
0105ca91b 🎉 BigQuery Denormalized Destination: Support for more bigquery types through the format annotation (#6145)
805fabb1f Fix list in quickstart guide. (#6520)
845f84b41 Marcos/test pr 5747 (#6516)
4631d8c92 Move long filename troubleshooting out of deploy guide (#6518)
6b19bf408 Add high level overview to normalization doc. (#6445)
911998baf Fix typo in CREATE PUBLICATION statement. (#6476)
d885d7758 mysql test int types (#2908)
a28b3f562 Bump Airbyte CDK version to 0.1.25 (#6511)
3c40e989e improvement: modifying the cli tool so that it can accept API_URL (#6507)
eb8be953e Update Google Search Console oauth specs (#6460)
c2561141f 🎉 Destination Oracle - Added support for connection via ssh tunnel (#6370)
8fa15713c 🎉 Destination MySQl - Added support for connection via ssh (aka bastion server) (#6317)
96aedd39e Stress Test Improvements (#6440)
33692375e 🎉 Add labels to Kube jobs. Allow injection of Kube Image Pull Secrets. (#6368)
802a8184c :bug: Python Alpine tempales: add build-base packages (#6457)
cbf268a5b add docker-compose debug extension (#6451)
f30869001 Exposing SSL-only version of Postgres Source (#6362)
d9adbd3c5 🎉 Source Stripe: use `start_date` parameter in incremental streams (#6466)
a9b1c6c04 Fix doc badges and structure (#6482)
3faaffdb2 Update Google Analytics Oauth Specs (#6459)
4ce6a0373 Update Google Ads oauth specs (#6458)
b563b1afa Fix exception in yaml persistence test (#6481)
2fe616655 Light cleanup to Quickstart deploy guide. (#6446)
f25542a14 🎉 Update license for Core (#6479)
1773e41e4 Shorten our headers + adds contributors file (#6478)
89dccf389 Modify oauthSpecification to allow working with oneOfs (#6456)
6767424b6 :tada: S3 source: add support for non-AWS S3 Storage (#6398)
f803481df 🐛 Source Chargebee: fix examples in spec file (#6454)
1c5ac5b5e :building_construction: Python CDK: add schema transformer class (#6139)
d386ed74f Update roadmap.md (#6452)
c85becc74 make the seed for YamlSeedConfigPersistence configurable (#6409)

Steps After Merging PR:
1. Pull most recent version of master
2. Run ./tools/bin/tag_version.sh
3. Create a GitHub release with the changelog