### PR TITLE
implement NoOpMigration for 0.30.0-alpha

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -534,6 +534,7 @@
   dockerRepository: airbyte/source-amazon-ads
   dockerImageTag: 0.1.1
   documentationUrl: https://docs.airbyte.io/integrations/sources/amazon-ads
+  sourceType: api
 - sourceDefinitionId: 137ece28-5434-455c-8f34-69dc3782f451
   name: LinkedIn Ads
   dockerRepository: airbyte/source-linkedin-ads

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/Migrations.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/Migrations.java
@@ -39,6 +39,7 @@ public class Migrations {
   private static final Migration MIGRATION_V_0_27_0 = new MigrationV0_27_0(MIGRATION_V_0_26_0);
   public static final Migration MIGRATION_V_0_28_0 = new MigrationV0_28_0(MIGRATION_V_0_27_0);
   public static final Migration MIGRATION_V_0_29_0 = new MigrationV0_29_0(MIGRATION_V_0_28_0);
+  public static final Migration MIGRATION_V_0_30_0 = new NoOpMigration(MIGRATION_V_0_29_0, "0.30.0-alpha");
 
   // all migrations must be added to the list in the order that they should be applied.
   public static final List<Migration> MIGRATIONS = ImmutableList.of(
@@ -58,6 +59,7 @@ public class Migrations {
       MIGRATION_V_0_26_0,
       MIGRATION_V_0_27_0,
       MIGRATION_V_0_28_0,
-      MIGRATION_V_0_29_0);
+      MIGRATION_V_0_29_0,
+      MIGRATION_V_0_30_0);
 
 }

--- a/airbyte-migration/src/test/java/io/airbyte/migrate/MigrationCurrentSchemaTest.java
+++ b/airbyte-migration/src/test/java/io/airbyte/migrate/MigrationCurrentSchemaTest.java
@@ -13,7 +13,7 @@ public class MigrationCurrentSchemaTest {
   @Test
   public void testLastMigration() {
     final Migration lastMigration = Migrations.MIGRATIONS.get(Migrations.MIGRATIONS.size() - 1);
-    assertEquals(Migrations.MIGRATION_V_0_29_0.getVersion(), lastMigration.getVersion(),
+    assertEquals(Migrations.MIGRATION_V_0_30_0.getVersion(), lastMigration.getVersion(),
         "The file-based migration is deprecated. Please do not write a new migration this way. Use Flyway instead.");
   }
 


### PR DESCRIPTION
We tried to release version 0.30.0-alpha of Airbyte without any Migration for version 0.30.0-alpha but the deployment started failing. This is because we rely on Automatic migration to make the database version with the new version value [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java#L219) 
But the fact that we didnt introduce any migration, the automatic migration failed saying no migration found for version 0.30.0-alpha. 

Because of that the db version was not updated with the new incoming version and as a result the check `AirbyteVersion.isCompatible(airbyteVersion, airbyteDatabaseVersion.get())` [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java#L225) failed and the server didnt start up.

In order to solve it we introduced a NoOpMigration and tested it locally and it worked