### PR TITLE
🐛 Fix migration failure by making notification forward compatible

### DIFF
--- a/airbyte-config/models/src/main/resources/types/Notification.yaml
+++ b/airbyte-config/models/src/main/resources/types/Notification.yaml
@@ -6,7 +6,7 @@ description: Notification Settings
 type: object
 required:
   - notificationType
-additionalProperties: false
+additionalProperties: true
 properties:
   # Instead of this type field, we would prefer a json schema "oneOf" but unfortunately,
   # the jsonschema2pojo does not seem to support it yet: https://github.com/joelittlejohn/jsonschema2pojo/issues/392

--- a/airbyte-migration/src/main/resources/migrations/migrationV0_20_0/Notification.yaml
+++ b/airbyte-migration/src/main/resources/migrations/migrationV0_20_0/Notification.yaml
@@ -6,7 +6,7 @@ description: Notification Settings
 type: object
 required:
   - notificationType
-additionalProperties: false
+additionalProperties: true
 properties:
   # Instead of this type field, we would prefer a json schema "oneOf" but unfortunately,
   # the jsonschema2pojo does not seem to support it yet: https://github.com/joelittlejohn/jsonschema2pojo/issues/392


### PR DESCRIPTION
- The `sendOnSuccess` and `sendOnFailure` properties are introduced in Notification. But there is no file-based migration for them, because in the Flyway world, a change in the json blob does not need one.
- However, since there is a minor Airbyte release from 29 to 30, the file-based migration will run, which will do json schema validation.
  - Previously this is not a problem, because there was no minor release, only patch ones, since the introduce of Flyway.
- Anyone who has set `sendOnSuccess` and `sendOnFailure` will run into this problem when they upgrade to `0.30.1-alpha`.
- Until we can completely get rid of the file-based migration, whenever we add a new field, we need to make the schema forward compatible by flipping `additionalProperties` to `true`.
- Slack [thread](https://airbytehq.slack.com/archives/C0229LM09T4/p1632959498219900).
