### PR TITLE
Bump Airbyte version from 0.30.1-alpha to 0.30.2-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.30.1-alpha
+current_version = 0.30.2-alpha
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.30.1-alpha
+VERSION=0.30.2-alpha
 
 # Airbyte Internal Job Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_USER=docker

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.30.1-alpha",
+  "version": "0.30.2-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.30.1-alpha",
+  "version": "0.30.2-alpha",
   "private": true,
   "scripts": {
     "start": "react-scripts start",

--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.2.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.30.1-alpha"
+appVersion: "0.30.2-alpha"
 
 dependencies:
 - name: common

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -29,7 +29,7 @@
 | `webapp.replicaCount`        | Number of webapp replicas                                        | `1`              |
 | `webapp.image.repository`    | The repository to use for the airbyte webapp image.              | `airbyte/webapp` |
 | `webapp.image.pullPolicy`    | the pull policy to use for the airbyte webapp image              | `IfNotPresent`   |
-| `webapp.image.tag`           | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.30.1-alpha`   |
+| `webapp.image.tag`           | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.30.2-alpha`   |
 | `webapp.podAnnotations`      | Add extra annotations to the scheduler pod                       | `{}`             |
 | `webapp.service.type`        | The service type to use for the webapp service                   | `ClusterIP`      |
 | `webapp.service.port`        | The service port to expose the webapp on                         | `80`             |
@@ -57,7 +57,7 @@
 | `scheduler.replicaCount`       | Number of scheduler replicas                                        | `1`                 |
 | `scheduler.image.repository`   | The repository to use for the airbyte scheduler image.              | `airbyte/scheduler` |
 | `scheduler.image.pullPolicy`   | the pull policy to use for the airbyte scheduler image              | `IfNotPresent`      |
-| `scheduler.image.tag`          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.30.1-alpha`      |
+| `scheduler.image.tag`          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.30.2-alpha`      |
 | `scheduler.podAnnotations`     | Add extra annotations to the scheduler pod                          | `{}`                |
 | `scheduler.resources.limits`   | The resources limits for the scheduler container                    | `{}`                |
 | `scheduler.resources.requests` | The requested resources for the scheduler container                 | `{}`                |
@@ -87,7 +87,7 @@
 | `server.replicaCount`                       | Number of server replicas                                        | `1`              |
 | `server.image.repository`                   | The repository to use for the airbyte server image.              | `airbyte/server` |
 | `server.image.pullPolicy`                   | the pull policy to use for the airbyte server image              | `IfNotPresent`   |
-| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.30.1-alpha`   |
+| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.30.2-alpha`   |
 | `server.podAnnotations`                     | Add extra annotations to the server pod                          | `{}`             |
 | `server.livenessProbe.enabled`              | Enable livenessProbe on the server                               | `true`           |
 | `server.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                          | `30`             |

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -44,7 +44,7 @@ webapp:
   image:
     repository: airbyte/webapp
     pullPolicy: IfNotPresent
-    tag: 0.30.1-alpha
+    tag: 0.30.2-alpha
 
   ## @param webapp.podAnnotations [object] Add extra annotations to the scheduler pod
   ##
@@ -141,7 +141,7 @@ scheduler:
   image:
     repository: airbyte/scheduler
     pullPolicy: IfNotPresent
-    tag: 0.30.1-alpha
+    tag: 0.30.2-alpha
 
   ## @param scheduler.podAnnotations [object] Add extra annotations to the scheduler pod
   ##
@@ -240,7 +240,7 @@ server:
   image:
     repository: airbyte/server
     pullPolicy: IfNotPresent
-    tag: 0.30.1-alpha
+    tag: 0.30.2-alpha
 
   ## @param server.podAnnotations [object] Add extra annotations to the server pod
   ##

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -81,7 +81,7 @@ If you are upgrading from  (i.e. your current version of Airbyte is) Airbyte ver
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.30.1-alpha --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.30.2-alpha --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/kube/overlays/stable-with-resource-limits/.env
+++ b/kube/overlays/stable-with-resource-limits/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.30.1-alpha
+AIRBYTE_VERSION=0.30.2-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.30.1-alpha
+    newTag: 0.30.2-alpha
   - name: airbyte/scheduler
-    newTag: 0.30.1-alpha
+    newTag: 0.30.2-alpha
   - name: airbyte/server
-    newTag: 0.30.1-alpha
+    newTag: 0.30.2-alpha
   - name: airbyte/webapp
-    newTag: 0.30.1-alpha
+    newTag: 0.30.2-alpha
   - name: airbyte/worker
-    newTag: 0.30.1-alpha
+    newTag: 0.30.2-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.30.1-alpha
+AIRBYTE_VERSION=0.30.2-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.30.1-alpha
+    newTag: 0.30.2-alpha
   - name: airbyte/scheduler
-    newTag: 0.30.1-alpha
+    newTag: 0.30.2-alpha
   - name: airbyte/server
-    newTag: 0.30.1-alpha
+    newTag: 0.30.2-alpha
   - name: airbyte/webapp
-    newTag: 0.30.1-alpha
+    newTag: 0.30.2-alpha
   - name: airbyte/worker
-    newTag: 0.30.1-alpha
+    newTag: 0.30.2-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 


### PR DESCRIPTION
Changelog:

d7ad61654 🐛 Fix migration failure by making notification forward compatible (#6559)

Steps After Merging PR:
1. Pull most recent version of master
2. Run ./tools/bin/tag_version.sh
3. Create a GitHub release with the changelog