### PR TITLE
chore(workflow): added github community issue/pr label bot

### DIFF
--- a/.github/workflows/github-community-label-bot.yaml
+++ b/.github/workflows/github-community-label-bot.yaml
@@ -1,0 +1,14 @@
+name: CI
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: harshithmullapudi/label-actions@f8ad41cf4765a89e7f094157597f5301570b9365
+        with:
+          github-token: ${{ secrets.LABEL_BOT_TOKEN }}


### PR DESCRIPTION
## What
Workflow to label github issues/pr as community

## How
Workflow gets initiated when new pr/issue is created and does the label using author_association
