### PR TITLE
Bump Airbyte version from 0.30.2-alpha to 0.30.3-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.30.2-alpha
+current_version = 0.30.3-alpha
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.30.2-alpha
+VERSION=0.30.3-alpha
 
 # Airbyte Internal Job Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_USER=docker

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.30.2-alpha",
+  "version": "0.30.3-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.30.2-alpha",
+  "version": "0.30.3-alpha",
   "private": true,
   "scripts": {
     "start": "react-scripts start",

--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.2.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.30.2-alpha"
+appVersion: "0.30.3-alpha"
 
 dependencies:
 - name: common

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -44,7 +44,7 @@ webapp:
   image:
     repository: airbyte/webapp
     pullPolicy: IfNotPresent
-    tag: 0.30.2-alpha
+    tag: 0.30.3-alpha
 
   ## @param webapp.podAnnotations [object] Add extra annotations to the scheduler pod
   ##
@@ -141,7 +141,7 @@ scheduler:
   image:
     repository: airbyte/scheduler
     pullPolicy: IfNotPresent
-    tag: 0.30.2-alpha
+    tag: 0.30.3-alpha
 
   ## @param scheduler.podAnnotations [object] Add extra annotations to the scheduler pod
   ##
@@ -240,7 +240,7 @@ server:
   image:
     repository: airbyte/server
     pullPolicy: IfNotPresent
-    tag: 0.30.2-alpha
+    tag: 0.30.3-alpha
 
   ## @param server.podAnnotations [object] Add extra annotations to the server pod
   ##

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -81,7 +81,7 @@ If you are upgrading from  (i.e. your current version of Airbyte is) Airbyte ver
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.30.2-alpha --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.30.3-alpha --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/kube/overlays/stable-with-resource-limits/.env
+++ b/kube/overlays/stable-with-resource-limits/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.30.2-alpha
+AIRBYTE_VERSION=0.30.3-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.30.2-alpha
+    newTag: 0.30.3-alpha
   - name: airbyte/scheduler
-    newTag: 0.30.2-alpha
+    newTag: 0.30.3-alpha
   - name: airbyte/server
-    newTag: 0.30.2-alpha
+    newTag: 0.30.3-alpha
   - name: airbyte/webapp
-    newTag: 0.30.2-alpha
+    newTag: 0.30.3-alpha
   - name: airbyte/worker
-    newTag: 0.30.2-alpha
+    newTag: 0.30.3-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.30.2-alpha
+AIRBYTE_VERSION=0.30.3-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.30.2-alpha
+    newTag: 0.30.3-alpha
   - name: airbyte/scheduler
-    newTag: 0.30.2-alpha
+    newTag: 0.30.3-alpha
   - name: airbyte/server
-    newTag: 0.30.2-alpha
+    newTag: 0.30.3-alpha
   - name: airbyte/webapp
-    newTag: 0.30.2-alpha
+    newTag: 0.30.3-alpha
   - name: airbyte/worker
-    newTag: 0.30.2-alpha
+    newTag: 0.30.3-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 


### PR DESCRIPTION
Changelog:

37542c0ba implement oauth in UI (#6385)
8ed5eea38 SAT: fix root object check for oauth init flow (#6569)
5afe181d2 Normalization: remove ssh errors if ssh is not being used (#6504)
5e750164a Publish SSL-only version of Postgres Destination (#6496)
7ec756fe1 :fireworks: Spec.json linter (#6366)

Steps After Merging PR:
1. Pull most recent version of master
2. Run ./tools/bin/tag_version.sh
3. Create a GitHub release with the changelog