### PR TITLE
Destination Redshift: (Performance) Add parallel loading to Redshift via manifest file

### DIFF
--- a/airbyte-integrations/connectors/destination-jdbc/Dockerfile
+++ b/airbyte-integrations/connectors/destination-jdbc/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.3.5
+LABEL io.airbyte.version=0.3.6
 LABEL io.airbyte.name=airbyte/destination-jdbc

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3StreamCopier.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3StreamCopier.java
@@ -48,21 +48,21 @@ public abstract class S3StreamCopier implements StreamCopier {
   // WARNING: Too large a part size can cause potential OOM errors.
   public static final int DEFAULT_PART_SIZE_MB = 10;
 
-  private final AmazonS3 s3Client;
-  private final S3Config s3Config;
-  private final String tmpTableName;
+  protected final AmazonS3 s3Client;
+  protected final S3Config s3Config;
+  protected final String tmpTableName;
   private final DestinationSyncMode destSyncMode;
-  private final String schemaName;
-  private final String streamName;
-  private final JdbcDatabase db;
+  protected final String schemaName;
+  protected final String streamName;
+  protected final JdbcDatabase db;
   private final ExtendedNameTransformer nameTransformer;
   private final SqlOperations sqlOperations;
-  private final Set<String> s3StagingFiles = new HashSet<>();
+  protected final Set<String> s3StagingFiles = new HashSet<>();
   private final Map<String, StreamTransferManager> multipartUploadManagers = new HashMap<>();
   private final Map<String, MultiPartOutputStream> outputStreams = new HashMap<>();
   private final Map<String, CSVPrinter> csvPrinters = new HashMap<>();
   private final String s3FileName;
-  private final String stagingFolder;
+  protected final String stagingFolder;
 
   public S3StreamCopier(String stagingFolder,
                         DestinationSyncMode destSyncMode,
@@ -198,7 +198,7 @@ public abstract class S3StreamCopier implements StreamCopier {
     LOGGER.info("{} tmp table in destination cleaned.", tmpTableName);
   }
 
-  private static String getFullS3Path(String s3BucketName, String s3StagingFile) {
+  protected static String getFullS3Path(String s3BucketName, String s3StagingFile) {
     return String.join("/", "s3:/", s3BucketName, s3StagingFile);
   }
 

--- a/airbyte-integrations/connectors/destination-redshift/Dockerfile
+++ b/airbyte-integrations/connectors/destination-redshift/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.3.14
+LABEL io.airbyte.version=0.3.15
 LABEL io.airbyte.name=airbyte/destination-redshift

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftCopyS3Destination.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftCopyS3Destination.java
@@ -21,13 +21,13 @@ import java.util.function.Consumer;
 /**
  * A more efficient Redshift Destination than the sql-based {@link RedshiftDestination}. Instead of
  * inserting data as batched SQL INSERTs, we follow Redshift best practices and, 1) Stream the data
- * to S3. One compressed file is created per table. 2) Copy the S3 file to Redshift. See
+ * to S3, creating multiple compressed files per stream. 2) Create a manifest file to load the data
+ * files in parallel. See:
  * https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-use-copy.html for more info.
  *
- * Although Redshift recommends splitting the file for more efficient copying, this introduces
- * complexity around file partitioning that should be handled by a file destination connector. The
- * single file approach is orders of magnitude faster than batch inserting and 'good-enough' for
- * now.
+ * Creating multiple files per stream currently has the naive approach of one file per batch on a
+ * stream up to the max limit of (26 * 26 * 26) 17576 files.  Each batch is randomly prefixed by
+ * 3 Alpha characters and on a collision the batch is appended to the existing file.
  */
 public class RedshiftCopyS3Destination extends CopyDestination {
 

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftStreamCopier.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftStreamCopier.java
@@ -5,16 +5,27 @@
 package io.airbyte.integrations.destination.redshift;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.commons.string.Strings;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.destination.ExtendedNameTransformer;
 import io.airbyte.integrations.destination.jdbc.SqlOperations;
 import io.airbyte.integrations.destination.jdbc.copy.s3.S3Config;
 import io.airbyte.integrations.destination.jdbc.copy.s3.S3StreamCopier;
+import io.airbyte.integrations.destination.redshift.manifest.Entry;
+import io.airbyte.integrations.destination.redshift.manifest.Manifest;
 import io.airbyte.protocol.models.DestinationSyncMode;
-import java.sql.SQLException;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RedshiftStreamCopier extends S3StreamCopier {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RedshiftStreamCopier.class);
+
+  private final ObjectMapper objectMapper;
 
   public RedshiftStreamCopier(String stagingFolder,
                               DestinationSyncMode destSyncMode,
@@ -27,24 +38,55 @@ public class RedshiftStreamCopier extends S3StreamCopier {
                               SqlOperations sqlOperations) {
     super(stagingFolder, destSyncMode, schema, streamName, Strings.addRandomSuffix("", "", 3) + "_" + streamName, client, db, s3Config,
         nameTransformer, sqlOperations);
+    objectMapper = new ObjectMapper();
   }
 
   @Override
-  public void copyS3CsvFileIntoTable(JdbcDatabase database, String s3FileLocation, String schema, String tableName, S3Config s3Config)
-      throws SQLException {
+  public void copyStagingFileToTemporaryTable() throws Exception {
+    final var manifestFullS3Path = createManifest();
+
+    LOGGER.info("Starting copy to tmp table: {} in destination for stream: {}, schema: {}, .", tmpTableName, streamName, schemaName);
     final var copyQuery = String.format(
         "COPY %s.%s FROM '%s'\n"
             + "CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'\n"
             + "CSV REGION '%s' TIMEFORMAT 'auto'\n"
             + "STATUPDATE OFF;\n",
-        schema,
-        tableName,
-        s3FileLocation,
+        schemaName,
+        tmpTableName,
+        manifestFullS3Path,
         s3Config.getAccessKeyId(),
         s3Config.getSecretAccessKey(),
         s3Config.getRegion());
 
-    database.execute(copyQuery);
+    db.execute(copyQuery);
+    LOGGER.info("Copy to tmp table {} in destination for stream {} complete.", tmpTableName, streamName);
+  }
+
+  @Override
+  public void copyS3CsvFileIntoTable(JdbcDatabase database, String s3FileLocation, String schema, String tableName, S3Config s3Config) {
+    throw new RuntimeException("Redshift Stream Copier should not be copying individual files without use of a manifest");
+  }
+
+  /**
+   * Creates a manifest file and uploads the file to s3. Note: Using a manifest to COPY a set of s3
+   * files into Redshift, is accordance AWS Redshift best practices.
+   *
+   * @return the full s3 path of the newly created manifest file
+   */
+  public String createManifest() {
+    final var manifestFilePath =
+        String.join("/", stagingFolder, schemaName, String.format("%s.manifest", UUID.randomUUID()));
+
+    final var s3FilesFullPath = s3StagingFiles.stream()
+        .map(filePath -> new Entry(getFullS3Path(s3Config.getBucketName(), filePath)))
+        .collect(Collectors.toList());
+
+    final var manifest = new Manifest(s3FilesFullPath);
+
+    final String manifestContents = Exceptions.toRuntime(() -> objectMapper.writeValueAsString(manifest));
+    s3Client.putObject(s3Config.getBucketName(), manifestFilePath, manifestContents);
+
+    return getFullS3Path(s3Config.getBucketName(), manifestFilePath);
   }
 
 }

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftStreamCopier.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftStreamCopier.java
@@ -72,9 +72,7 @@ public class RedshiftStreamCopier extends S3StreamCopier {
 
   /**
    * Creates the contents of a manifest file given the `s3StagingFiles`. There must be at least one
-   * entry in a manifest file otherwise it is not valid, thus this method will return Empty when a
-   * proper manifest file cannot be constructed. and uploads the file to s3. Note: Using a manifest to
-   * COPY a set of s3 files into Redshift, which is in accordance AWS Redshift best practices.
+   * entry in a manifest file otherwise it is not considered valid for the COPY command.
    *
    * @return null if no stagingFiles exist otherwise the manifest body String
    */
@@ -107,7 +105,7 @@ public class RedshiftStreamCopier extends S3StreamCopier {
   }
 
   /**
-   * Run Redshift Copy command with the given manifest file
+   * Run Redshift COPY command with the given manifest file
    *
    * @param manifestPath the path in S3 to the manifest file
    */

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftStreamCopier.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftStreamCopier.java
@@ -50,7 +50,8 @@ public class RedshiftStreamCopier extends S3StreamCopier {
         "COPY %s.%s FROM '%s'\n"
             + "CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'\n"
             + "CSV REGION '%s' TIMEFORMAT 'auto'\n"
-            + "STATUPDATE OFF;\n",
+            + "STATUPDATE OFF\n"
+            + "MANIFEST;",
         schemaName,
         tmpTableName,
         manifestFullS3Path,
@@ -69,7 +70,7 @@ public class RedshiftStreamCopier extends S3StreamCopier {
 
   /**
    * Creates a manifest file and uploads the file to s3. Note: Using a manifest to COPY a set of s3
-   * files into Redshift, is accordance AWS Redshift best practices.
+   * files into Redshift, which is in accordance AWS Redshift best practices.
    *
    * @return the full s3 path of the newly created manifest file
    */

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/manifest/Entry.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/manifest/Entry.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift.manifest;
+
+public class Entry {
+
+  public final String url;
+  public final Boolean mandatory;
+
+  public Entry(String url, Boolean mandatory) {
+    this.url = url;
+    this.mandatory = mandatory;
+  }
+
+  public Entry(String url) {
+    this(url, true);
+  }
+
+}

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/manifest/Manifest.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/manifest/Manifest.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift.manifest;
+
+import java.util.List;
+
+public class Manifest {
+
+  public final List<Entry> entries;
+
+  public Manifest(List<Entry> entries) {
+    this.entries = entries;
+  }
+
+}


### PR DESCRIPTION
## What
Issue: [4871](https://github.com/airbytehq/airbyte/issues/4871#issuecomment-929646893)
Add Parallelization for copying multiple files in Redshift.

## How
- Leverage the existing [change](https://github.com/airbytehq/airbyte/pull/5783) bucketing batches into different files in s3 
- Writing code to build a manifest of all the files to load to S3.
- Change copy command to use manifest to load data in parallel

## Recommended reading order
1. `RedshiftStreamCopier.java`
2. `Manifest.java`
3. `Entry.java`
4. `S3StreamCopier.java`

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> New Connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector added to connector index like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
   
</p>
</details>


<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</p>
</details>

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
