### PR TITLE
🍾  Free the Health Check.

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1557,6 +1557,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/HealthCheckRead"
+      # This route is unsecured for external monitoring.
+      security: []
   /v1/logs/get:
     post:
       tags:


### PR DESCRIPTION
## What
We do not need authentication on the health check route since this is meant for monitoring.

## How
Disable this by specifying an empty security block in the route.
   
   

