### PR TITLE
add delete source/destination def in ConfigRepository

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/set/MoreSets.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/set/MoreSets.java
@@ -6,17 +6,33 @@ package io.airbyte.commons.set;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
+import java.util.HashSet;
 import java.util.Set;
 
 public class MoreSets {
 
-  public static <T> void assertEqualsVerbose(Set<T> set1, Set<T> set2) {
+  public static <T> void assertEqualsVerbose(final Set<T> set1, final Set<T> set2) {
     Preconditions.checkNotNull(set1);
     Preconditions.checkNotNull(set2);
 
     Preconditions.checkArgument(set1.equals(set2), String.format(
         "Sets are not the same. Elements in set 1 and not in set 2: %s.  Elements in set 2 and not in set 1: %s",
         Sets.difference(set1, set2), Sets.difference(set2, set1)));
+  }
+
+  /**
+   * Remove subtract all of the records in one set from another.
+   *
+   * @param minuend - set being subtracted from
+   * @param subtrahend - set with values to subtract
+   * @param <T> - type of the set
+   * @return - difference -- original set (minuend) with all of the items that were present in the
+   *         subtrahend removed (if they were present).
+   */
+  public static <T> Set<T> subtract(final Set<T> minuend, final Set<T> subtrahend) {
+    final HashSet<T> difference = new HashSet<>(minuend);
+    difference.removeAll(subtrahend);
+    return difference;
   }
 
 }

--- a/airbyte-commons/src/main/java/io/airbyte/commons/set/MoreSets.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/set/MoreSets.java
@@ -6,7 +6,6 @@ package io.airbyte.commons.set;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
-import java.util.HashSet;
 import java.util.Set;
 
 public class MoreSets {
@@ -18,21 +17,6 @@ public class MoreSets {
     Preconditions.checkArgument(set1.equals(set2), String.format(
         "Sets are not the same. Elements in set 1 and not in set 2: %s.  Elements in set 2 and not in set 1: %s",
         Sets.difference(set1, set2), Sets.difference(set2, set1)));
-  }
-
-  /**
-   * Remove subtract all of the records in one set from another.
-   *
-   * @param minuend - set being subtracted from
-   * @param subtrahend - set with values to subtract
-   * @param <T> - type of the set
-   * @return - difference -- original set (minuend) with all of the items that were present in the
-   *         subtrahend removed (if they were present).
-   */
-  public static <T> Set<T> subtract(final Set<T> minuend, final Set<T> subtrahend) {
-    final HashSet<T> difference = new HashSet<>(minuend);
-    difference.removeAll(subtrahend);
-    return difference;
   }
 
 }

--- a/airbyte-commons/src/test/java/io/airbyte/commons/set/MoreSetsTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/set/MoreSetsTest.java
@@ -5,6 +5,7 @@
 package io.airbyte.commons.set;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
@@ -22,6 +23,14 @@ class MoreSetsTest {
     assertDoesNotThrow(() -> MoreSets.assertEqualsVerbose(set1, set1));
     assertDoesNotThrow(() -> MoreSets.assertEqualsVerbose(set1, set2));
     assertThrows(IllegalArgumentException.class, () -> MoreSets.assertEqualsVerbose(set1, set3));
+  }
+
+  @Test
+  void testSubtract() {
+    final Set<Integer> minuend = ImmutableSet.of(1, 2, 3);
+    final Set<Integer> subtrahend = ImmutableSet.of(1, 2, 4);
+    final Set<Integer> difference = ImmutableSet.of(3);
+    assertEquals(difference, MoreSets.subtract(minuend, subtrahend));
   }
 
 }

--- a/airbyte-commons/src/test/java/io/airbyte/commons/set/MoreSetsTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/set/MoreSetsTest.java
@@ -5,7 +5,6 @@
 package io.airbyte.commons.set;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
@@ -23,14 +22,6 @@ class MoreSetsTest {
     assertDoesNotThrow(() -> MoreSets.assertEqualsVerbose(set1, set1));
     assertDoesNotThrow(() -> MoreSets.assertEqualsVerbose(set1, set2));
     assertThrows(IllegalArgumentException.class, () -> MoreSets.assertEqualsVerbose(set1, set3));
-  }
-
-  @Test
-  void testSubtract() {
-    final Set<Integer> minuend = ImmutableSet.of(1, 2, 3);
-    final Set<Integer> subtrahend = ImmutableSet.of(1, 2, 4);
-    final Set<Integer> difference = ImmutableSet.of(3);
-    assertEquals(difference, MoreSets.subtract(minuend, subtrahend));
   }
 
 }

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -134,8 +134,7 @@ public class ConfigRepository {
     return persistence.listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class);
   }
 
-  public void writeStandardSourceDefinition(final StandardSourceDefinition sourceDefinition)
-      throws JsonValidationException, IOException {
+  public void writeStandardSourceDefinition(final StandardSourceDefinition sourceDefinition) throws JsonValidationException, IOException {
     persistence.writeConfig(
         ConfigSchema.STANDARD_SOURCE_DEFINITION,
         sourceDefinition.getSourceDefinitionId().toString(),

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -39,8 +39,12 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ConfigRepository {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConfigRepository.class);
 
   private static final UUID NO_WORKSPACE = UUID.fromString("00000000-0000-0000-0000-000000000000");
 
@@ -138,6 +142,14 @@ public class ConfigRepository {
         sourceDefinition);
   }
 
+  public void deleteStandardSourceDefinition(final UUID sourceDefId) throws IOException {
+    try {
+      persistence.deleteConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, sourceDefId.toString());
+    } catch (final ConfigNotFoundException e) {
+      LOGGER.info("Attempted to delete source definition with id: {}, but it does not exist", sourceDefId);
+    }
+  }
+
   public List<StandardSourceDefinition> listStandardSources() throws JsonValidationException, IOException {
     return persistence.listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class);
   }
@@ -180,6 +192,14 @@ public class ConfigRepository {
         ConfigSchema.STANDARD_DESTINATION_DEFINITION,
         destinationDefinition.getDestinationDefinitionId().toString(),
         destinationDefinition);
+  }
+
+  public void deleteStandardDestinationDefinition(final UUID destDefId) throws IOException {
+    try {
+      persistence.deleteConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destDefId.toString());
+    } catch (final ConfigNotFoundException e) {
+      LOGGER.info("Attempted to delete destination definition with id: {}, but it does not exist", destDefId);
+    }
   }
 
   public SourceConnection getSourceConnection(final UUID sourceId) throws JsonValidationException, ConfigNotFoundException, IOException {


### PR DESCRIPTION
relates to https://github.com/airbytehq/airbyte/issues/6628
this is the first PR of 2. second PR in cloud: https://github.com/airbytehq/airbyte-cloud/pull/325

## What
* We want to make it so cloud _only_ uses connectors that are present in its seed.
* This PR adds some database methods to make it possible to delete definitions (cloud will use these to delete definitions that should not exist).
* Also adds a set helper that will be used in cloud.
