### PR TITLE
refactor confusing method names

### DIFF
--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -135,10 +135,7 @@ public class ConfigRepository {
   }
 
   public void writeStandardSourceDefinition(final StandardSourceDefinition sourceDefinition) throws JsonValidationException, IOException {
-    persistence.writeConfig(
-        ConfigSchema.STANDARD_SOURCE_DEFINITION,
-        sourceDefinition.getSourceDefinitionId().toString(),
-        sourceDefinition);
+    persistence.writeConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, sourceDefinition.getSourceDefinitionId().toString(), sourceDefinition);
   }
 
   public void deleteStandardSourceDefinition(final UUID sourceDefId) throws IOException {
@@ -147,14 +144,6 @@ public class ConfigRepository {
     } catch (final ConfigNotFoundException e) {
       LOGGER.info("Attempted to delete source definition with id: {}, but it does not exist", sourceDefId);
     }
-  }
-
-  public List<StandardSourceDefinition> listStandardSources() throws JsonValidationException, IOException {
-    return persistence.listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class);
-  }
-
-  public void writeStandardSource(final StandardSourceDefinition source) throws JsonValidationException, IOException {
-    persistence.writeConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, source.getSourceDefinitionId().toString(), source);
   }
 
   public StandardDestinationDefinition getStandardDestinationDefinition(final UUID destinationDefinitionId)

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/WorkspaceHelperTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/WorkspaceHelperTest.java
@@ -116,7 +116,7 @@ class WorkspaceHelperTest {
 
   @Test
   public void testSource() throws IOException, JsonValidationException {
-    configRepository.writeStandardSource(SOURCE_DEF);
+    configRepository.writeStandardSourceDefinition(SOURCE_DEF);
     configRepository.writeSourceConnection(SOURCE, emptyConnectorSpec);
 
     final UUID retrievedWorkspace = workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(SOURCE_ID);
@@ -144,7 +144,7 @@ class WorkspaceHelperTest {
 
   @Test
   public void testConnection() throws IOException, JsonValidationException {
-    configRepository.writeStandardSource(SOURCE_DEF);
+    configRepository.writeStandardSourceDefinition(SOURCE_DEF);
     configRepository.writeSourceConnection(SOURCE, emptyConnectorSpec);
     configRepository.writeStandardDestinationDefinition(DEST_DEF);
     configRepository.writeDestinationConnection(DEST, emptyConnectorSpec);
@@ -184,7 +184,7 @@ class WorkspaceHelperTest {
 
   @Test
   public void testConnectionAndJobs() throws IOException, JsonValidationException {
-    configRepository.writeStandardSource(SOURCE_DEF);
+    configRepository.writeStandardSourceDefinition(SOURCE_DEF);
     configRepository.writeSourceConnection(SOURCE, emptyConnectorSpec);
     configRepository.writeStandardDestinationDefinition(DEST_DEF);
     configRepository.writeDestinationConnection(DEST, emptyConnectorSpec);

--- a/airbyte-server/src/test/java/io/airbyte/server/ConfigDumpImporterTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/ConfigDumpImporterTest.java
@@ -92,7 +92,7 @@ class ConfigDumpImporterTest {
         .withName("test-source")
         .withTombstone(false)
         .withWorkspaceId(workspaceId);
-    when(configRepository.listStandardSources())
+    when(configRepository.listStandardSourceDefinitions())
         .thenReturn(List.of(standardSourceDefinition));
     when(configRepository.getStandardSourceDefinition(standardSourceDefinition.getSourceDefinitionId()))
         .thenReturn(standardSourceDefinition);
@@ -229,31 +229,31 @@ class ConfigDumpImporterTest {
 
   @Test
   public void testReplaceDeploymentMetadata() throws Exception {
-    UUID oldDeploymentUuid = UUID.randomUUID();
-    UUID newDeploymentUuid = UUID.randomUUID();
+    final UUID oldDeploymentUuid = UUID.randomUUID();
+    final UUID newDeploymentUuid = UUID.randomUUID();
 
-    JsonNode airbyteVersion = Jsons.deserialize("{\"key\":\"airbyte_version\",\"value\":\"dev\"}");
-    JsonNode serverUuid = Jsons.deserialize("{\"key\":\"server_uuid\",\"value\":\"e895a584-7dbf-48ce-ace6-0bc9ea570c34\"}");
-    JsonNode date = Jsons.deserialize("{\"key\":\"date\",\"value\":\"1956-08-17\"}");
-    JsonNode oldDeploymentId = Jsons.deserialize(
+    final JsonNode airbyteVersion = Jsons.deserialize("{\"key\":\"airbyte_version\",\"value\":\"dev\"}");
+    final JsonNode serverUuid = Jsons.deserialize("{\"key\":\"server_uuid\",\"value\":\"e895a584-7dbf-48ce-ace6-0bc9ea570c34\"}");
+    final JsonNode date = Jsons.deserialize("{\"key\":\"date\",\"value\":\"1956-08-17\"}");
+    final JsonNode oldDeploymentId = Jsons.deserialize(
         String.format("{\"key\":\"%s\",\"value\":\"%s\"}", DefaultJobPersistence.DEPLOYMENT_ID_KEY, oldDeploymentUuid));
-    JsonNode newDeploymentId = Jsons.deserialize(
+    final JsonNode newDeploymentId = Jsons.deserialize(
         String.format("{\"key\":\"%s\",\"value\":\"%s\"}", DefaultJobPersistence.DEPLOYMENT_ID_KEY, newDeploymentUuid));
 
-    JobPersistence jobPersistence = mock(JobPersistence.class);
+    final JobPersistence jobPersistence = mock(JobPersistence.class);
 
     // when new deployment id does not exist, the old deployment id is removed
     when(jobPersistence.getDeployment()).thenReturn(Optional.empty());
-    Stream<JsonNode> inputStream1 = Stream.of(airbyteVersion, serverUuid, date, oldDeploymentId);
-    Stream<JsonNode> outputStream1 = ConfigDumpImporter.replaceDeploymentMetadata(jobPersistence, inputStream1);
-    Stream<JsonNode> expectedStream1 = Stream.of(airbyteVersion, serverUuid, date);
+    final Stream<JsonNode> inputStream1 = Stream.of(airbyteVersion, serverUuid, date, oldDeploymentId);
+    final Stream<JsonNode> outputStream1 = ConfigDumpImporter.replaceDeploymentMetadata(jobPersistence, inputStream1);
+    final Stream<JsonNode> expectedStream1 = Stream.of(airbyteVersion, serverUuid, date);
     assertEquals(expectedStream1.collect(Collectors.toList()), outputStream1.collect(Collectors.toList()));
 
     // when new deployment id exists, the old deployment id is replaced with the new one
     when(jobPersistence.getDeployment()).thenReturn(Optional.of(newDeploymentUuid));
-    Stream<JsonNode> inputStream2 = Stream.of(airbyteVersion, serverUuid, date, oldDeploymentId);
-    Stream<JsonNode> outputStream2 = ConfigDumpImporter.replaceDeploymentMetadata(jobPersistence, inputStream2);
-    Stream<JsonNode> expectedStream2 = Stream.of(airbyteVersion, serverUuid, date, newDeploymentId);
+    final Stream<JsonNode> inputStream2 = Stream.of(airbyteVersion, serverUuid, date, oldDeploymentId);
+    final Stream<JsonNode> outputStream2 = ConfigDumpImporter.replaceDeploymentMetadata(jobPersistence, inputStream2);
+    final Stream<JsonNode> expectedStream2 = Stream.of(airbyteVersion, serverUuid, date, newDeploymentId);
     assertEquals(expectedStream2.collect(Collectors.toList()), outputStream2.collect(Collectors.toList()));
   }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -289,7 +289,7 @@ public class ArchiveHandlerTest {
     configPersistence.writeConfig(ConfigSchema.SOURCE_CONNECTION, sourceid.toString(), new SourceConnection()
         .withSourceId(sourceid)
         .withWorkspaceId(workspaceId)
-        .withSourceDefinitionId(configRepository.listStandardSources().get(0).getSourceDefinitionId())
+        .withSourceDefinitionId(configRepository.listStandardSourceDefinitions().get(0).getSourceDefinitionId())
         .withName("test-source")
         .withConfiguration(Jsons.emptyObject())
         .withTombstone(false));

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -77,9 +77,9 @@ class SourceDefinitionsHandlerTest {
   void testListSourceDefinitions() throws JsonValidationException, IOException, URISyntaxException {
     final StandardSourceDefinition source2 = generateSource();
 
-    when(configRepository.listStandardSources()).thenReturn(Lists.newArrayList(source, source2));
+    when(configRepository.listStandardSourceDefinitions()).thenReturn(Lists.newArrayList(source, source2));
 
-    SourceDefinitionRead expectedSourceDefinitionRead1 = new SourceDefinitionRead()
+    final SourceDefinitionRead expectedSourceDefinitionRead1 = new SourceDefinitionRead()
         .sourceDefinitionId(source.getSourceDefinitionId())
         .name(source.getName())
         .dockerRepository(source.getDockerRepository())
@@ -87,7 +87,7 @@ class SourceDefinitionsHandlerTest {
         .documentationUrl(new URI(source.getDocumentationUrl()))
         .icon(SourceDefinitionsHandler.loadIcon(source.getIcon()));
 
-    SourceDefinitionRead expectedSourceDefinitionRead2 = new SourceDefinitionRead()
+    final SourceDefinitionRead expectedSourceDefinitionRead2 = new SourceDefinitionRead()
         .sourceDefinitionId(source2.getSourceDefinitionId())
         .name(source2.getName())
         .dockerRepository(source.getDockerRepository())
@@ -107,7 +107,7 @@ class SourceDefinitionsHandlerTest {
     when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId()))
         .thenReturn(source);
 
-    SourceDefinitionRead expectedSourceDefinitionRead = new SourceDefinitionRead()
+    final SourceDefinitionRead expectedSourceDefinitionRead = new SourceDefinitionRead()
         .sourceDefinitionId(source.getSourceDefinitionId())
         .name(source.getName())
         .dockerRepository(source.getDockerRepository())

--- a/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
@@ -113,7 +113,7 @@ public class RunMigrationTest {
     final ConfigRepository configRepository =
         new ConfigRepository(FileSystemConfigPersistence.createWithValidation(configRoot), new NoOpSecretsHydrator(), Optional.of(secretPersistence),
             Optional.of(secretPersistence));
-    final Map<String, StandardSourceDefinition> sourceDefinitionsBeforeMigration = configRepository.listStandardSources().stream()
+    final Map<String, StandardSourceDefinition> sourceDefinitionsBeforeMigration = configRepository.listStandardSourceDefinitions().stream()
         .collect(Collectors.toMap(c -> c.getSourceDefinitionId().toString(), c -> c));
     assertTrue(sourceDefinitionsBeforeMigration.containsKey(DEPRECATED_SOURCE_DEFINITION_NOT_BEING_USED));
     assertTrue(sourceDefinitionsBeforeMigration.containsKey(DEPRECATED_SOURCE_DEFINITION_BEING_USED));
@@ -144,7 +144,7 @@ public class RunMigrationTest {
   }
 
   private void assertSourceDefinitions(final ConfigRepository configRepository) throws JsonValidationException, IOException {
-    final Map<String, StandardSourceDefinition> sourceDefinitions = configRepository.listStandardSources()
+    final Map<String, StandardSourceDefinition> sourceDefinitions = configRepository.listStandardSourceDefinitions()
         .stream()
         .collect(Collectors.toMap(c -> c.getSourceDefinitionId().toString(), c -> c));
     assertTrue(sourceDefinitions.size() >= 59);


### PR DESCRIPTION
We have some methods that refer to StandardSources but really are dealing with StandardSource_Definitions_. This PR fixes it. @ChristopheDuong thanks for pointing it out.