### PR TITLE
Add support for more dynamic variables in webapp

### DIFF
--- a/airbyte-webapp/src/config/configProviders.ts
+++ b/airbyte-webapp/src/config/configProviders.ts
@@ -20,6 +20,14 @@ const windowConfigProvider: ConfigProvider = async () => {
     apiUrl: window.API_URL,
     version: window.AIRBYTE_VERSION,
     isDemo: window.IS_DEMO === "true",
+    // cloud only start
+    firebase: {
+      apiKey: window.FIREBASE_API_KEY,
+      authDomain: window.FIREBASE_AUTH_DOMAIN,
+    },
+    cloudApiUrl: window.CLOUD_API_URL,
+    cloud: window.CLOUD === "true",
+    // cloud only end
   };
 };
 

--- a/airbyte-webapp/src/config/types.ts
+++ b/airbyte-webapp/src/config/types.ts
@@ -13,6 +13,10 @@ declare global {
     AIRBYTE_VERSION?: string;
     API_URL?: string;
     IS_DEMO?: string;
+    CLOUD?: string;
+    FIREBASE_API_KEY?: string;
+    FIREBASE_AUTH_DOMAIN?: string;
+    CLOUD_API_URL?: string;
 
     analytics: SegmentAnalytics;
     _API_URL: string;

--- a/airbyte-webapp/src/hooks/useFullStory.tsx
+++ b/airbyte-webapp/src/hooks/useFullStory.tsx
@@ -6,8 +6,12 @@ let inited = false;
 const useFullStory = (config: FullStory.SnippetOptions): boolean => {
   useEffect(() => {
     if (!inited) {
-      FullStory.init(config);
-      inited = true;
+      try {
+        FullStory.init(config);
+        inited = true;
+      } catch (e) {
+        console.error("Failed to init Full Story");
+      }
     }
   }, [config]);
 

--- a/airbyte-webapp/src/index.tsx
+++ b/airbyte-webapp/src/index.tsx
@@ -11,7 +11,11 @@ const App = lazy(() => import(`./App`));
 
 ReactDOM.render(
   <Suspense fallback={null}>
-    {process.env.REACT_APP_CLOUD ? <CloudApp /> : <App />}
+    {process.env.REACT_APP_CLOUD || window.CLOUD === "true" ? (
+      <CloudApp />
+    ) : (
+      <App />
+    )}
   </Suspense>,
   document.getElementById("root")
 );


### PR DESCRIPTION
## What
The webapp doesn't support accepting all env variables dynamically. This PR makes it so it can support more of them. This is good enough to get us to a place where we can massively simplify our build / deploy pipeline.

As a follow on task we should make it possible (and straight forward) to see all of the env variables required by the webapp and have any of them be assigned in this manner. One of the main blockers here is that the structure of the config object is that not all config providers can accept all variables.

This PR blocks the webapp deploy upgrade in cloud.
