### PR TITLE
Implement password reset with firebase

### DIFF
--- a/airbyte-webapp/src/packages/cloud/lib/auth/GoogleAuthService.ts
+++ b/airbyte-webapp/src/packages/cloud/lib/auth/GoogleAuthService.ts
@@ -8,6 +8,9 @@ import {
   confirmPasswordReset,
   applyActionCode,
   sendEmailVerification,
+  EmailAuthProvider,
+  reauthenticateWithCredential,
+  updatePassword,
 } from "firebase/auth";
 
 import { FieldError } from "packages/cloud/lib/errors/FieldError";
@@ -20,6 +23,13 @@ interface AuthService {
   signOut(): Promise<any>;
 
   signUp(email: string, password: string): Promise<UserCredential>;
+
+  reauthenticate(
+    email: string,
+    passwordPassword: string
+  ): Promise<UserCredential>;
+
+  updatePassword(newPassword: string): Promise<void>;
 
   resetPassword(email: string): Promise<void>;
 
@@ -73,6 +83,26 @@ export class GoogleAuthService implements AuthService {
         throw err;
       }
     );
+  }
+
+  async reauthenticate(
+    email: string,
+    password: string
+  ): Promise<UserCredential> {
+    if (this.auth.currentUser === null) {
+      throw new Error("You must log in first to reauthenticate!");
+    }
+    const credential = EmailAuthProvider.credential(email, password);
+    return reauthenticateWithCredential(this.auth.currentUser, credential);
+  }
+
+  async updatePassword(newPassword: string): Promise<void> {
+    if (this.auth.currentUser === null) {
+      throw new Error("You must log in first to update password!");
+    }
+    return updatePassword(this.auth.currentUser, newPassword).catch((err) => {
+      throw err;
+    });
   }
 
   async resetPassword(email: string): Promise<void> {

--- a/airbyte-webapp/src/packages/cloud/locales/en.json
+++ b/airbyte-webapp/src/packages/cloud/locales/en.json
@@ -81,6 +81,6 @@
   "firebase.auth.success": "A new confirmation email has been sent to you",
   "firebase.auth.error.invalidPassword": "Incorrect password",
   "firebase.auth.error.networkRequestFailed": "There appears to be a network issue. Please try again later.",
-  "firebase.auth.error.tooManyRequests": "You have retried too many times or too quickly. Please wait 10 minutes before you try again.",
+  "firebase.auth.error.tooManyRequests": "Too many retires. Please wait 10 minutes before trying again.",
   "firebase.auth.error.default": "Confirmation email cannot be sent. Please try again later."
 }

--- a/airbyte-webapp/src/packages/cloud/locales/en.json
+++ b/airbyte-webapp/src/packages/cloud/locales/en.json
@@ -44,9 +44,15 @@
   "settings.accountSettings.lastName": "Last name",
   "settings.accountSettings.lastName.placeholder": "Smith",
   "settings.accountSettings.email": "Email",
-  "settings.accountSettings.password": "Password",
   "settings.accountSettings.currentPassword": "Current password",
-  "settings.accountSettings.repeatPassword": "Repeat password",
+  "settings.accountSettings.currentPassword.placeholder": "Current password",
+  "settings.accountSettings.newPassword": "New password",
+  "settings.accountSettings.newPasswordConfirmation": "Password confirmation",
+  "settings.accountSettings.updatePassword": "Update",
+  "settings.accountSettings.error.newPasswordMismatch": "New password and confirmation do not match",
+  "settings.accountSettings.error.newPasswordSameAsCurrent": "New password is the same as the current one",
+  "settings.accountSettings.updatePasswordError": "Password update failed: ",
+  "settings.accountSettings.updatePasswordSuccess": "Your password has been updated!",
   "settings.userSettings": "User settings",
   "settings.workspaceSettings": "Workspace settings",
   "settings.generalSettings": "General Settings",
@@ -73,7 +79,8 @@
   "workspaces.viewAllWorkspaces": "View all workspaces",
 
   "firebase.auth.success": "A new confirmation email has been sent to you",
+  "firebase.auth.error.invalidPassword": "Incorrect password",
   "firebase.auth.error.networkRequestFailed": "There appears to be a network issue. Please try again later.",
-  "firebase.auth.error.tooManyRequests": "You have requested too many confirmation links. Please check your inbox first, or wait 10 minutes before you try again.",
+  "firebase.auth.error.tooManyRequests": "You have retried too many times or too quickly. Please wait 10 minutes before you try again.",
   "firebase.auth.error.default": "Confirmation email cannot be sent. Please try again later."
 }

--- a/airbyte-webapp/src/packages/cloud/locales/en.json
+++ b/airbyte-webapp/src/packages/cloud/locales/en.json
@@ -81,6 +81,6 @@
   "firebase.auth.success": "A new confirmation email has been sent to you",
   "firebase.auth.error.invalidPassword": "Incorrect password",
   "firebase.auth.error.networkRequestFailed": "There appears to be a network issue. Please try again later.",
-  "firebase.auth.error.tooManyRequests": "Too many retires. Please wait 10 minutes before trying again.",
+  "firebase.auth.error.tooManyRequests": "Too many retries. Please wait 10 minutes before trying again.",
   "firebase.auth.error.default": "Confirmation email cannot be sent. Please try again later."
 }

--- a/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
@@ -21,6 +21,11 @@ type AuthContextApi = {
   isLoading: boolean;
   login: (values: { email: string; password: string }) => Promise<User | null>;
   signUp: (form: { email: string; password: string }) => Promise<User | null>;
+  updatePassword: (
+    email: string,
+    currentPassword: string,
+    newPassword: string
+  ) => Promise<void>;
   requirePasswordReset: (email: string) => Promise<void>;
   confirmPasswordReset: (code: string, newPassword: string) => Promise<void>;
   sendEmailVerification: () => Promise<void>;
@@ -94,6 +99,16 @@ export const AuthenticationProvider: React.FC = ({ children }) => {
         await authService.signOut();
         loggedOut();
         await queryClient.invalidateQueries();
+      },
+      async updatePassword(
+        email: string,
+        currentPassword: string,
+        newPassword: string
+      ): Promise<void> {
+        // re-authentication may be needed before updating password
+        // https://firebase.google.com/docs/auth/web/manage-users#re-authenticate_a_user
+        await authService.reauthenticate(email, currentPassword);
+        return authService.updatePassword(newPassword);
       },
       async requirePasswordReset(email: string): Promise<void> {
         await authService.resetPassword(email);

--- a/airbyte-webapp/src/packages/cloud/views/users/AccountSettingsView/components/PasswordSection.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/users/AccountSettingsView/components/PasswordSection.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Field, FieldProps, Form, Formik } from "formik";
+import { AuthErrorCodes } from "firebase/auth";
 
 import {
   Content,
@@ -8,24 +9,103 @@ import {
 } from "pages/SettingsPage/pages/SettingsComponents";
 import { FieldItem } from "packages/cloud/views/auth/components/FormComponents";
 import { LabeledInput } from "components/LabeledInput";
+import { LoadingButton } from "components";
+import {
+  useAuthService,
+  useCurrentUser,
+} from "packages/cloud/services/auth/AuthService";
+import FeedbackBlock from "pages/SettingsPage/components/FeedbackBlock";
 
 export const PasswordSection: React.FC = () => {
   const formatMessage = useIntl().formatMessage;
+  const { updatePassword } = useAuthService();
+  const { email } = useCurrentUser();
+  const [successMessage, setSuccessMessage] = useState<string>("");
+  const [errorMessage, setErrorMessage] = useState<string>("");
 
   return (
     <SettingsCard>
       <Content>
         <Formik
           initialValues={{
-            currentPassword: "********",
-            repeatPassword: "",
-            password: "",
+            currentPassword: "",
+            newPassword: "",
+            passwordConfirmation: "",
           }}
-          onSubmit={() => {
-            throw new Error("Not implemented");
+          onSubmit={(values, { setSubmitting, setFieldValue }) => {
+            setSubmitting(true);
+
+            setSuccessMessage("");
+            setErrorMessage("");
+
+            if (values.newPassword !== values.passwordConfirmation) {
+              setErrorMessage(
+                formatMessage({
+                  id: "settings.accountSettings.error.newPasswordMismatch",
+                })
+              );
+              setSubmitting(false);
+              return;
+            }
+
+            if (values.currentPassword === values.newPassword) {
+              setErrorMessage(
+                formatMessage({
+                  id: "settings.accountSettings.error.newPasswordSameAsCurrent",
+                })
+              );
+              setSubmitting(false);
+              return;
+            }
+
+            updatePassword(email, values.currentPassword, values.newPassword)
+              .then(() => {
+                setSuccessMessage(
+                  formatMessage({
+                    id: "settings.accountSettings.updatePasswordSuccess",
+                  })
+                );
+                setFieldValue("currentPassword", "");
+                setFieldValue("newPassword", "");
+                setFieldValue("passwordConfirmation", "");
+              })
+              .catch((err) => {
+                switch (err.code) {
+                  case AuthErrorCodes.INVALID_PASSWORD:
+                    setErrorMessage(
+                      formatMessage({
+                        id: "firebase.auth.error.invalidPassword",
+                      })
+                    );
+                    break;
+                  case AuthErrorCodes.NETWORK_REQUEST_FAILED:
+                    setErrorMessage(
+                      formatMessage({
+                        id: "firebase.auth.error.networkRequestFailed",
+                      })
+                    );
+                    break;
+                  case AuthErrorCodes.TOO_MANY_ATTEMPTS_TRY_LATER:
+                    setErrorMessage(
+                      formatMessage({
+                        id: "firebase.auth.error.tooManyRequests",
+                      })
+                    );
+                    break;
+                  default:
+                    setErrorMessage(
+                      formatMessage({
+                        id: "settings.accountSettings.updatePasswordError",
+                      }) + JSON.stringify(err)
+                    );
+                }
+              })
+              .finally(() => {
+                setSubmitting(false);
+              });
           }}
         >
-          {() => (
+          {({ isSubmitting }) => (
             <Form>
               <FieldItem>
                 <Field name="currentPassword">
@@ -35,10 +115,8 @@ export const PasswordSection: React.FC = () => {
                       label={
                         <FormattedMessage id="settings.accountSettings.currentPassword" />
                       }
-                      disabled={true}
-                      placeholder={formatMessage({
-                        id: "login.password.placeholder",
-                      })}
+                      disabled={isSubmitting}
+                      required={true}
                       type="password"
                       error={!!meta.error && meta.touched}
                       message={
@@ -51,17 +129,15 @@ export const PasswordSection: React.FC = () => {
                 </Field>
               </FieldItem>
               <FieldItem>
-                <Field name="password">
+                <Field name="newPassword">
                   {({ field, meta }: FieldProps<string>) => (
                     <LabeledInput
                       {...field}
                       label={
-                        <FormattedMessage id="settings.accountSettings.password" />
+                        <FormattedMessage id="settings.accountSettings.newPassword" />
                       }
-                      disabled={true}
-                      placeholder={formatMessage({
-                        id: "login.password.placeholder",
-                      })}
+                      disabled={isSubmitting}
+                      required={true}
                       type="password"
                       error={!!meta.error && meta.touched}
                       message={
@@ -74,17 +150,15 @@ export const PasswordSection: React.FC = () => {
                 </Field>
               </FieldItem>
               <FieldItem>
-                <Field name="repeatPassword">
+                <Field name="passwordConfirmation">
                   {({ field, meta }: FieldProps<string>) => (
                     <LabeledInput
                       {...field}
                       label={
-                        <FormattedMessage id="settings.accountSettings.repeatPassword" />
+                        <FormattedMessage id="settings.accountSettings.newPasswordConfirmation" />
                       }
-                      disabled={true}
-                      placeholder={formatMessage({
-                        id: "login.password.placeholder",
-                      })}
+                      disabled={isSubmitting}
+                      required={true}
                       type="password"
                       error={!!meta.error && meta.touched}
                       message={
@@ -96,6 +170,14 @@ export const PasswordSection: React.FC = () => {
                   )}
                 </Field>
               </FieldItem>
+              <LoadingButton type="submit" isLoading={isSubmitting}>
+                <FormattedMessage id="settings.accountSettings.updatePassword" />
+              </LoadingButton>
+              <FeedbackBlock
+                errorMessage={errorMessage}
+                successMessage={successMessage}
+                isLoading={isSubmitting}
+              />
             </Form>
           )}
         </Formik>


### PR DESCRIPTION
## What
- Resolves #6335.

## How
- Use firebase API to first re-authenticate the user and then update the password.

## Screenshots

| Situation | Screenshot |
| --- | --- |
| Updating | <img width="561" alt="Screen Shot 2021-10-02 at 21 54 11" src="https://user-images.githubusercontent.com/1933157/135740727-9e855e70-5e83-4a13-a62a-8decde7d7ec9.png"> |
| Updated successfully |  <img width="550" alt="Screen Shot 2021-10-02 at 21 54 12" src="https://user-images.githubusercontent.com/1933157/135740741-0e304b33-1649-4ae6-a85e-45fec5a6e14e.png"> |
| New password is same as current |  <img width="546" alt="Screen Shot 2021-10-02 at 22 03 51" src="https://user-images.githubusercontent.com/1933157/135740747-5467c0c5-06bc-4c23-9be4-9526cc27798b.png"> |
| New password and confirmation does not match |<img width="546" alt="Screen Shot 2021-10-02 at 22 04 00" src="https://user-images.githubusercontent.com/1933157/135740748-3d5fb989-2344-4da2-9910-95c216bc562a.png"> |
| Incorrect password | <img width="547" alt="Screen Shot 2021-10-02 at 22 04 08" src="https://user-images.githubusercontent.com/1933157/135740749-f9ee4e13-1e6e-4b2a-b80f-b2e20d61fabf.png"> |
