### PR TITLE
require terms of service to be selected

### DIFF
--- a/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/SignupPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/SignupPage.tsx
@@ -27,7 +27,7 @@ const SignupPageValidationSchema = yup.object().shape({
   password: yup.string().required("form.empty.error"),
   name: yup.string().required("form.empty.error"),
   company: yup.string().required("form.empty.error"),
-  security: yup.boolean().required("form.empty.error"),
+  security: yup.boolean().oneOf([true], "form.empty.error"),
 });
 
 const SignupPage: React.FC = () => {


### PR DESCRIPTION
resolves https://github.com/airbytehq/airbyte/issues/6651

I believe `yup` requires the boolean to be sent, even if it's false. This requires the value to be `true` explicitly.