### PR TITLE
Filter out oauth connectors which are not ready from the UI

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -41,18 +41,41 @@ type MenuWithRequestButtonProps = MenuListComponentProps<IDataItem, false>;
 const ConnectorList: React.FC<MenuWithRequestButtonProps> = ({
   children,
   ...props
-}) => (
-  <>
-    <components.MenuList {...props}>{children}</components.MenuList>
-    <BottomElement>
-      <Block
-        onClick={props.selectProps.selectProps.onOpenRequestConnectorModal}
-      >
-        <FormattedMessage id="connector.requestConnectorBlock" />
-      </Block>
-    </BottomElement>
-  </>
-);
+}) => {
+    // TODO Begin hack
+    // During the Cloud private beta, we let users pick any connector in our catalog.
+    // Later on, we realized we shouldn't have allowed using connectors whose platforms required oauth
+    // But by that point, some users were already leveraging them, so removing them would crash the app for users
+    // instead we'll filter out those connectors from this drop down menu, and retain them in the backend
+    // This way, they will not be available for usage in new connections, but they will be available for users
+    // already leveraging them.
+    // TODO End hack
+    const blacklistedOauthConnectors = [
+        "200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b",
+        "2470e835-feaf-4db6-96f3-70fd645acc77",
+        "36c891d9-4bd9-43ac-bad2-10e12756272c",
+        "71607ba1-c0ac-4799-8049-7f4b90dd50f7",
+        "9da77001-af33-4bcd-be46-6252bf9342b9",
+        "d8313939-3782-41b0-be29-b3ca20d8dd3a",
+        "ec4b9503-13cb-48ab-a4ab-6ade4be46567"
+    ]
+    console.log(blacklistedOauthConnectors);
+    console.log(children);
+    return (
+        <>
+            <components.MenuList {...props}>{children}</components.MenuList>
+            <BottomElement>
+                <Block
+                    onClick={props.selectProps.selectProps.onOpenRequestConnectorModal}
+                >
+                    <FormattedMessage id="connector.requestConnectorBlock" />
+                </Block>
+            </BottomElement>
+        </>
+    );
+}
+
+
 
 const ConnectorServiceTypeControl: React.FC<{
   property: FormBaseItem;

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -42,26 +42,6 @@ const ConnectorList: React.FC<MenuWithRequestButtonProps> = ({
   children,
   ...props
 }) => {
-  // TODO Begin hack
-  // During the Cloud private beta, we let users pick any connector in our catalog.
-  // Later on, we realized we shouldn't have allowed using connectors whose platforms required oauth
-  // But by that point, some users were already leveraging them, so removing them would crash the app for users
-  // instead we'll filter out those connectors from this drop down menu, and retain them in the backend
-  // This way, they will not be available for usage in new connections, but they will be available for users
-  // already leveraging them.
-  // TODO End hack
-  const blacklistedOauthConnectors = [
-    "200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b",
-    "2470e835-feaf-4db6-96f3-70fd645acc77",
-    "36c891d9-4bd9-43ac-bad2-10e12756272c",
-    "71607ba1-c0ac-4799-8049-7f4b90dd50f7",
-    "9da77001-af33-4bcd-be46-6252bf9342b9",
-    "d8313939-3782-41b0-be29-b3ca20d8dd3a",
-    "ec4b9503-13cb-48ab-a4ab-6ade4be46567",
-  ];
-  console.log("HIIIIIIIIII");
-  console.log(blacklistedOauthConnectors);
-  console.log(children);
   return (
     <>
       <components.MenuList {...props}>{children}</components.MenuList>
@@ -98,9 +78,29 @@ const ConnectorServiceTypeControl: React.FC<{
   const formatMessage = useIntl().formatMessage;
   const [field, fieldMeta, { setValue }] = useField(property.path);
 
+  // TODO Begin hack
+  // During the Cloud private beta, we let users pick any connector in our catalog.
+  // Later on, we realized we shouldn't have allowed using connectors whose platforms required oauth
+  // But by that point, some users were already leveraging them, so removing them would crash the app for users
+  // instead we'll filter out those connectors from this drop down menu, and retain them in the backend
+  // This way, they will not be available for usage in new connections, but they will be available for users
+  // already leveraging them.
+  // TODO End hack
+  const blacklistedOauthConnectors = [
+    "200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b",
+    "2470e835-feaf-4db6-96f3-70fd645acc77",
+    "36c891d9-4bd9-43ac-bad2-10e12756272c",
+    "71607ba1-c0ac-4799-8049-7f4b90dd50f7",
+    "9da77001-af33-4bcd-be46-6252bf9342b9",
+    "d8313939-3782-41b0-be29-b3ca20d8dd3a",
+    "ec4b9503-13cb-48ab-a4ab-6ade4be46567",
+  ];
   const sortedDropDownData = useMemo(
     () =>
       availableServices
+        .filter((item) => {
+          return !blacklistedOauthConnectors.includes(Connector.id(item));
+        })
         .map((item) => ({
           label: item.name,
           value: Connector.id(item),

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -59,6 +59,7 @@ const ConnectorList: React.FC<MenuWithRequestButtonProps> = ({
         "d8313939-3782-41b0-be29-b3ca20d8dd3a",
         "ec4b9503-13cb-48ab-a4ab-6ade4be46567"
     ]
+    console.log("HIIIIIIIIII");
     console.log(blacklistedOauthConnectors);
     console.log(children);
     return (

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -86,15 +86,19 @@ const ConnectorServiceTypeControl: React.FC<{
   // This way, they will not be available for usage in new connections, but they will be available for users
   // already leveraging them.
   // TODO End hack
-  const blacklistedOauthConnectors = [
-    "200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b",
-    "2470e835-feaf-4db6-96f3-70fd645acc77",
-    "36c891d9-4bd9-43ac-bad2-10e12756272c",
-    "71607ba1-c0ac-4799-8049-7f4b90dd50f7",
-    "9da77001-af33-4bcd-be46-6252bf9342b9",
-    "d8313939-3782-41b0-be29-b3ca20d8dd3a",
-    "ec4b9503-13cb-48ab-a4ab-6ade4be46567",
-  ];
+  const blacklistedOauthConnectors =
+    // I would prefer to use windowConfigProvider.cloud but that function is async
+    window.CLOUD === "true"
+      ? [
+          "200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b", // Snapchat
+          "2470e835-feaf-4db6-96f3-70fd645acc77", // Salesforce Singer
+          "36c891d9-4bd9-43ac-bad2-10e12756272c", // Hubspot
+          "71607ba1-c0ac-4799-8049-7f4b90dd50f7", // Google Sheets
+          "9da77001-af33-4bcd-be46-6252bf9342b9", // Shopify
+          "d8313939-3782-41b0-be29-b3ca20d8dd3a", // Intercom
+          "ec4b9503-13cb-48ab-a4ab-6ade4be46567", // Freshdesk
+        ]
+      : [];
   const sortedDropDownData = useMemo(
     () =>
       availableServices

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -42,41 +42,39 @@ const ConnectorList: React.FC<MenuWithRequestButtonProps> = ({
   children,
   ...props
 }) => {
-    // TODO Begin hack
-    // During the Cloud private beta, we let users pick any connector in our catalog.
-    // Later on, we realized we shouldn't have allowed using connectors whose platforms required oauth
-    // But by that point, some users were already leveraging them, so removing them would crash the app for users
-    // instead we'll filter out those connectors from this drop down menu, and retain them in the backend
-    // This way, they will not be available for usage in new connections, but they will be available for users
-    // already leveraging them.
-    // TODO End hack
-    const blacklistedOauthConnectors = [
-        "200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b",
-        "2470e835-feaf-4db6-96f3-70fd645acc77",
-        "36c891d9-4bd9-43ac-bad2-10e12756272c",
-        "71607ba1-c0ac-4799-8049-7f4b90dd50f7",
-        "9da77001-af33-4bcd-be46-6252bf9342b9",
-        "d8313939-3782-41b0-be29-b3ca20d8dd3a",
-        "ec4b9503-13cb-48ab-a4ab-6ade4be46567"
-    ]
-    console.log("HIIIIIIIIII");
-    console.log(blacklistedOauthConnectors);
-    console.log(children);
-    return (
-        <>
-            <components.MenuList {...props}>{children}</components.MenuList>
-            <BottomElement>
-                <Block
-                    onClick={props.selectProps.selectProps.onOpenRequestConnectorModal}
-                >
-                    <FormattedMessage id="connector.requestConnectorBlock" />
-                </Block>
-            </BottomElement>
-        </>
-    );
-}
-
-
+  // TODO Begin hack
+  // During the Cloud private beta, we let users pick any connector in our catalog.
+  // Later on, we realized we shouldn't have allowed using connectors whose platforms required oauth
+  // But by that point, some users were already leveraging them, so removing them would crash the app for users
+  // instead we'll filter out those connectors from this drop down menu, and retain them in the backend
+  // This way, they will not be available for usage in new connections, but they will be available for users
+  // already leveraging them.
+  // TODO End hack
+  const blacklistedOauthConnectors = [
+    "200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b",
+    "2470e835-feaf-4db6-96f3-70fd645acc77",
+    "36c891d9-4bd9-43ac-bad2-10e12756272c",
+    "71607ba1-c0ac-4799-8049-7f4b90dd50f7",
+    "9da77001-af33-4bcd-be46-6252bf9342b9",
+    "d8313939-3782-41b0-be29-b3ca20d8dd3a",
+    "ec4b9503-13cb-48ab-a4ab-6ade4be46567",
+  ];
+  console.log("HIIIIIIIIII");
+  console.log(blacklistedOauthConnectors);
+  console.log(children);
+  return (
+    <>
+      <components.MenuList {...props}>{children}</components.MenuList>
+      <BottomElement>
+        <Block
+          onClick={props.selectProps.selectProps.onOpenRequestConnectorModal}
+        >
+          <FormattedMessage id="connector.requestConnectorBlock" />
+        </Block>
+      </BottomElement>
+    </>
+  );
+};
 
 const ConnectorServiceTypeControl: React.FC<{
   property: FormBaseItem;

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -41,20 +41,18 @@ type MenuWithRequestButtonProps = MenuListComponentProps<IDataItem, false>;
 const ConnectorList: React.FC<MenuWithRequestButtonProps> = ({
   children,
   ...props
-}) => {
-  return (
-    <>
-      <components.MenuList {...props}>{children}</components.MenuList>
-      <BottomElement>
-        <Block
-          onClick={props.selectProps.selectProps.onOpenRequestConnectorModal}
-        >
-          <FormattedMessage id="connector.requestConnectorBlock" />
-        </Block>
-      </BottomElement>
-    </>
-  );
-};
+}) => (
+  <>
+    <components.MenuList {...props}>{children}</components.MenuList>
+    <BottomElement>
+      <Block
+        onClick={props.selectProps.selectProps.onOpenRequestConnectorModal}
+      >
+        <FormattedMessage id="connector.requestConnectorBlock" />
+      </Block>
+    </BottomElement>
+  </>
+);
 
 const ConnectorServiceTypeControl: React.FC<{
   property: FormBaseItem;


### PR DESCRIPTION
## What
copying the key source code comment

```
 During the Cloud private beta, we let users pick any connector in our catalog.
  // Later on, we realized we shouldn't have allowed using connectors whose platforms required oauth
  // But by that point, some users were already leveraging them, so removing them would crash the app for users
  // instead we'll filter out those connectors from this drop down menu, and retain them in the backend
  // This way, they will not be available for usage in new connections, but they will be available for users
  // already leveraging them.
```

## How
Filter out bad connectors in the drop down list