### PR TITLE
Add kafka source to source index

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -548,6 +548,12 @@
   documentationUrl: https://docs.airbyte.io/integrations/sources/mongodb-v2
   icon: mongodb.svg
   sourceType: database
+- sourceDefinitionId: d917a47b-8537-4d0d-8c10-36a9928d4265
+  name: Kafka
+  dockerRepository: airbyte/source-kafka
+  dockerImageTag: 0.1.0
+  documentationUrl: https://docs.airbyte.io/integrations/sources/kafka
+  sourceType: database
 - sourceDefinitionId: 3981c999-bd7d-4afc-849b-e53dea90c948
   name: Lever Hiring
   dockerRepository: airbyte/source-lever-hiring


### PR DESCRIPTION
- A follow up PR for #5906.
- Register the Kafka source in the source index.
- We temporarily categorize this connector as `database` for convenience. However, this may change in the future.
