### PR TITLE
Add accept-terms property to databricks spec

### DIFF
--- a/airbyte-integrations/connectors/destination-databricks/Dockerfile
+++ b/airbyte-integrations/connectors/destination-databricks/Dockerfile
@@ -7,5 +7,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/destination-databricks

--- a/airbyte-integrations/connectors/destination-databricks/sample_secrets/config.json
+++ b/airbyte-integrations/connectors/destination-databricks/sample_secrets/config.json
@@ -1,4 +1,5 @@
 {
+  "accept_terms": true,
   "databricks_server_hostname": "required",
   "databricks_http_path": "required",
   "databricks_port": "443",

--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksDestinationConfig.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksDestinationConfig.java
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination.databricks;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
 import io.airbyte.integrations.destination.s3.S3DestinationConfig;
 import io.airbyte.integrations.destination.s3.parquet.S3ParquetFormatConfig;
 
@@ -43,6 +44,10 @@ public class DatabricksDestinationConfig {
   }
 
   public static DatabricksDestinationConfig get(JsonNode config) {
+    Preconditions.checkArgument(
+        config.has("accept_terms") && config.get("accept_terms").asBoolean(),
+        "You must agree to the Databricks JDBC Terms & Conditions to use this connector");
+
     return new DatabricksDestinationConfig(
         config.get("databricks_server_hostname").asText(),
         config.get("databricks_http_path").asText(),

--- a/airbyte-integrations/connectors/destination-databricks/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/resources/spec.json
@@ -9,6 +9,7 @@
     "title": "Databricks Destination Spec",
     "type": "object",
     "required": [
+      "accept_terms",
       "databricks_server_hostname",
       "databricks_http_path",
       "databricks_personal_access_token",
@@ -16,6 +17,12 @@
     ],
     "additionalProperties": false,
     "properties": {
+      "accept_terms": {
+        "title": "Agree to the Databricks JDBC Driver Terms & Conditions",
+        "type": "boolean",
+        "description": "You must agree to the Databricks JDBC Driver <a href=\"https://databricks.com/jdbc-odbc-driver-license\">Terms & Conditions</a> to use this connector.",
+        "default": false
+      },
       "databricks_server_hostname": {
         "title": "Databricks Cluster Server Hostname",
         "type": "string",

--- a/airbyte-integrations/connectors/destination-databricks/src/test/java/io/airbyte/integrations/destination/databricks/DatabricksDestinationConfigTest.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/test/java/io/airbyte/integrations/destination/databricks/DatabricksDestinationConfigTest.java
@@ -5,6 +5,7 @@
 package io.airbyte.integrations.destination.databricks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -30,6 +31,12 @@ class DatabricksDestinationConfigTest {
         .put("databricks_personal_access_token", "pak")
         .set("data_source", dataSourceConfig);
 
+    assertThrows(IllegalArgumentException.class, () -> DatabricksDestinationConfig.get(databricksConfig));
+
+    databricksConfig.put("accept_terms", false);
+    assertThrows(IllegalArgumentException.class, () -> DatabricksDestinationConfig.get(databricksConfig));
+
+    databricksConfig.put("accept_terms", true);
     DatabricksDestinationConfig config1 = DatabricksDestinationConfig.get(databricksConfig);
     assertEquals(DatabricksDestinationConfig.DEFAULT_DATABRICKS_PORT, config1.getDatabricksPort());
     assertEquals(DatabricksDestinationConfig.DEFAULT_DATABASE_SCHEMA, config1.getDatabaseSchema());

--- a/docs/integrations/destinations/databricks.md
+++ b/docs/integrations/destinations/databricks.md
@@ -103,5 +103,5 @@ Learn how source data is converted to Parquet and the current limitations [here]
 
 | Version | Date | Pull Request | Subject |
 | :--- | :---  | :--- | :--- |
-| 0.1.1 | 2021-10-05 | [#](https://github.com/airbytehq/airbyte/pull/) | Require users to accept Databricks JDBC Driver [Terms & Conditions](https://databricks.com/jdbc-odbc-driver-license). |
+| 0.1.1 | 2021-10-05 | [#6792](https://github.com/airbytehq/airbyte/pull/6792) | Require users to accept Databricks JDBC Driver [Terms & Conditions](https://databricks.com/jdbc-odbc-driver-license). |
 | 0.1.0 | 2021-09-14 | [#5998](https://github.com/airbytehq/airbyte/pull/5998) | Initial private release. |

--- a/docs/integrations/destinations/databricks.md
+++ b/docs/integrations/destinations/databricks.md
@@ -103,4 +103,5 @@ Learn how source data is converted to Parquet and the current limitations [here]
 
 | Version | Date | Pull Request | Subject |
 | :--- | :---  | :--- | :--- |
+| 0.1.1 | 2021-10-05 | [#](https://github.com/airbytehq/airbyte/pull/) | Require users to accept Databricks JDBC Driver [Terms & Conditions](https://databricks.com/jdbc-odbc-driver-license). |
 | 0.1.0 | 2021-09-14 | [#5998](https://github.com/airbytehq/airbyte/pull/5998) | Initial private release. |


### PR DESCRIPTION
## What
- Add a new property to ask users to accept the Databricks JDBC Driver terms and conditions.
- Users already accepted these terms when they sign up. But we add it here for extra legal safety.

## TODO
- [x] Update configs in Github secrets and Lastpass.

## Screenshot

<img width="826" alt="Screen Shot 2021-10-05 at 11 44 59" src="https://user-images.githubusercontent.com/1933157/136087209-aed16550-eb62-4d25-8c86-f3231cbdfede.png">

## Open questions
- [x] We should check if there are existing cloud users for this connector. Otherwise, we cannot make this new property a required field.
- [ ] Is it alright to default this property to `false`? I imagine people will forget to check this, and have a failed run because of it.
