### PR TITLE
fix normalization run length logging

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultNormalizationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultNormalizationWorker.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.lang.time.DurationFormatUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +63,8 @@ public class DefaultNormalizationWorker implements NormalizationWorker {
     }
 
     final Duration duration = Duration.ofMillis(System.currentTimeMillis() - startTime);
-    LOGGER.info("Normalization executed in {}.", duration.toMinutesPart());
+    final String durationDescription = DurationFormatUtils.formatDurationWords(duration.toMillis(), true, true);
+    LOGGER.info("Normalization executed in {}.", durationDescription);
 
     return null;
   }


### PR DESCRIPTION
I saw `Normalization executed in 0.` in all log cases. This was because the `toMinutesPart` implementation:
```
    public int toMinutesPart(){
        return (int) (toMinutes() % MINUTES_PER_HOUR);
    }
```

Anything less than 1 hr will be 0.

This other helper should output things like `2 days 1 hour 5 minutes 20 seconds`
