### PR TITLE
Source shopify: fix build

### DIFF
--- a/airbyte-integrations/connectors/source-shopify/Dockerfile
+++ b/airbyte-integrations/connectors/source-shopify/Dockerfile
@@ -5,7 +5,8 @@ FROM base as builder
 WORKDIR /airbyte/integration_code
 
 # upgrade pip to the latest version
-RUN apk --no-cache upgrade && pip install --upgrade pip
+RUN apk --no-cache upgrade && pip install --upgrade pip && apk --no-cache add tzdata build-base
+
 
 COPY setup.py ./
 # install necessary packages to a temporary folder 

--- a/airbyte-integrations/connectors/source-shopify/acceptance-test-docker.sh
+++ b/airbyte-integrations/connectors/source-shopify/acceptance-test-docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # Build latest connector image
-docker build . -t $(cat acceptance-test-config.yml | grep "connector_image" | head -n 1 | cut -d: -f2)
+docker build . -t $(cat acceptance-test-config.yml | grep "connector_image" | head -n 1 | cut -d: -f2):dev
 
 # Pull latest acctest image
 docker pull airbyte/source-acceptance-test:latest


### PR DESCRIPTION
## What
Recent builds [have been failing ](https://dnsgjos7lj2fu.cloudfront.net/tests/summary/source-shopify/) because buildtools wasn't installed. This PR adds them to the docker image. 

