### PR TITLE
Direct to Discourse tagged list instead of specific issues on Trouble…

### DIFF
--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -23,9 +23,7 @@ There are two flavors of connectors for this destination:
 
 ## Troubleshooting
 
-#### Issue: `Dataset not found` after running sync. [\[Solution\]](https://discuss.airbyte.io/t/destination-bigquery-dataset-not-found/52)
-
-#### Issue: `Field _airbyte_emitted_at has changed type from TIMESTAMP to STRING` sync error. [\[Solution\]](https://discuss.airbyte.io/t/destination-bigquery-field-airbyte-emitted-at-has-changed-type-from-timestamp-to-string/60)
+Check out common troubleshooting issues for the BigQuery destination connector on our Discourse [here](https://discuss.airbyte.io/tags/c/connector/11/destination-bigquery).
 
 ## Output Schema for BigQuery
 

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -13,7 +13,7 @@ The Airbyte S3 destination allows you to sync data to AWS S3 or Minio S3. Each s
 
 ## Troubleshooting
 
-**Issue: `Failed to parse XML document with handler class` with failed sync. [\[Solution\]](https://discuss.airbyte.io/t/destination-s3-failed-to-upload-files/113/2)**
+Check out common troubleshooting issues for the S3 destination connector on our Discourse [here](https://discuss.airbyte.io/tags/c/connector/11/destination-s3).
 
 ## Configuration
 

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -11,7 +11,7 @@
 
 ## Troubleshooting 
 
-**Issue: `414 Client Error: Request-URI Too Large for url` failing sync. [\[Workaround\]](https://discuss.airbyte.io/t/source-hubspot-failed-sync-request-uri-too-large-for-contact-stream/59)**
+Check out common troubleshooting issues for the Hubspot connector on our Discourse [here](https://discuss.airbyte.io/tags/c/connector/11/source-hubspot). 
 
 ## Supported Tables
 

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -11,7 +11,7 @@
 
 ## Troubleshooting
 
-#### Issue: `Normalization failing, keyError updated` [\[Discussion.\]](https://discuss.airbyte.io/t/source-jira-failing-in-normalization-step-keyerror-updated/57)
+Check out common troubleshooting issues for the Jira connector on our Discourse [here](https://discuss.airbyte.io/tags/c/connector/11/source-jira).
 
 ## Supported Tables
 

--- a/docs/integrations/sources/mssql.md
+++ b/docs/integrations/sources/mssql.md
@@ -16,7 +16,7 @@ The MSSQL source does not alter the schema present in your database. Depending o
 
 ## Troubleshooting
 
-#### Issue: `Connector provides wrong values for some data types.` See [discussion](https://github.com/airbytehq/airbyte/issues/4270) on unexpected behaviour for certain datatypes.
+You may run into an issue where the connector provides wrong values for some data types. See [discussion](https://github.com/airbytehq/airbyte/issues/4270) on unexpected behaviour for certain datatypes.
 
 ## Getting Started (Airbyte Cloud)
 On Airbyte Cloud, only TLS connections to your MSSQL instance are supported in source configuration. Other than that, you can proceed with the open-source instructions below.


### PR DESCRIPTION
## Main Changes
Placing specific issues in Troubleshooting isn't scalable. Let's just link to all tagged issues in our Discourse.