### PR TITLE
autoboot IntercomProvider

### DIFF
--- a/airbyte-webapp/src/packages/cloud/App.tsx
+++ b/airbyte-webapp/src/packages/cloud/App.tsx
@@ -65,7 +65,7 @@ const App: React.FC = () => {
                   <FeatureService features={Features}>
                     <AppServicesProvider>
                       <AuthenticationProvider>
-                        <IntercomProvider appId={INTERCOM_APP_ID}>
+                        <IntercomProvider appId={INTERCOM_APP_ID} autoBoot>
                           <AnalyticsInitializer>
                             <Routing />
                           </AnalyticsInitializer>


### PR DESCRIPTION
The window doesn't show for intercom if it isn't booted. Since we always want the intercom bubble on all pages we can `autoBoot`. 

See https://github.com/devrnt/react-use-intercom and https://devrnt.github.io/react-use-intercom/#/useIntercom for more information.