### PR TITLE
temporarily re-add webapp papercups/openreplay vars

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -167,6 +167,8 @@ services:
       - FULLSTORY=${FULLSTORY:-}
       - TRACKING_STRATEGY=${TRACKING_STRATEGY}
       - INTERNAL_API_HOST=${INTERNAL_API_HOST}
+      - OPENREPLAY=${OPENREPLAY:-}
+      - PAPERCUPS_STORYTIME=${PAPERCUPS_STORYTIME:-}
   airbyte-temporal:
     image: temporalio/auto-setup:1.7.0
     logging: *default-logging


### PR DESCRIPTION
The .env file is used for new deployments on the current released version of OSS Airbyte. I forgot that we needed to coordinate a release of Airbyte to remove these values on master. I'm just re-adding the values for now and doing a release immediately after. Then we can remove them again.