### PR TITLE
remove job submitter from scheduleJobsPool

### DIFF
--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
@@ -129,7 +129,6 @@ public class SchedulerApp {
           MDC.setContextMap(mdc);
           jobRetrier.run();
           jobScheduler.run();
-          jobSubmitter.run();
         },
         0L,
         SCHEDULING_DELAY.toSeconds(),


### PR DESCRIPTION
We run jobSubmitter in executeJobsPool. There is no need to run it in scheduleJobsPool. Tested this via deploying custom scheduler image in cloud 