### PR TITLE
🐛 Airbyte CDK: fixing integration test failing

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.29
+Fix import logger error
+
 ## 0.1.28
 Added `check_config_against_spec` parameter to `Connector` abstract class 
 to allow skipping validating the input config against the spec for non-`check` calls

--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -5,6 +5,7 @@
 
 import argparse
 import importlib
+import logging
 import os.path
 import sys
 import tempfile
@@ -15,11 +16,13 @@ from airbyte_cdk.models import AirbyteMessage, Status, Type
 from airbyte_cdk.sources import Source
 from airbyte_cdk.sources.utils.schema_helpers import check_config_against_spec_or_exit, split_config
 
+logger = init_logger("airbyte")
+
 
 class AirbyteEntrypoint(object):
     def __init__(self, source: Source):
         self.source = source
-        self.logger = init_logger(getattr(source, "name", "source"))
+        self.logger = logging.getLogger(f"airbyte.source.{getattr(source, 'name', '')}")
 
     def parse_args(self, args: List[str]) -> argparse.Namespace:
         # set up parent parsers

--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -22,7 +22,7 @@ logger = init_logger("airbyte")
 class AirbyteEntrypoint(object):
     def __init__(self, source: Source):
         self.source = source
-        self.logger = logging.getLogger(f"airbyte.source.{getattr(source, 'name', '')}")
+        self.logger = logging.getLogger(f"source.{getattr(source, 'name', '')}")
 
     def parse_args(self, args: List[str]) -> argparse.Namespace:
         # set up parent parsers

--- a/airbyte-cdk/python/airbyte_cdk/logger.py
+++ b/airbyte-cdk/python/airbyte_cdk/logger.py
@@ -29,7 +29,7 @@ LOGGING_CONFIG = {
 }
 
 
-def init_logger(name: str):
+def init_logger(name: str = None):
     """Initial set up of logger"""
     logging.setLoggerClass(AirbyteNativeLogger)
     logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.28",
+    version="0.1.29",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-integrations/connectors/source-paypal-transaction/source_paypal_transaction/source.py
+++ b/airbyte-integrations/connectors/source-paypal-transaction/source_paypal_transaction/source.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
 
+import logging
 import time
 from abc import ABC
 from datetime import datetime, timedelta
@@ -69,7 +70,7 @@ class PaypalTransactionStream(HttpStream, ABC):
         minimum_allowed_start_date = now - timedelta(**self.start_date_min)
         if start_date < minimum_allowed_start_date:
             self.logger.log(
-                "WARN",
+                logging.WARN,
                 f'Stream {self.name}: start_date "{start_date.isoformat()}" is too old. '
                 + f'Reset start_date to the minimum_allowed_start_date "{minimum_allowed_start_date.isoformat()}"',
             )
@@ -78,7 +79,7 @@ class PaypalTransactionStream(HttpStream, ABC):
         self.maximum_allowed_start_date = min(now, self.end_date)
         if start_date > self.maximum_allowed_start_date:
             self.logger.log(
-                "WARN",
+                logging.WARN,
                 f'Stream {self.name}: start_date "{start_date.isoformat()}" is too recent. '
                 + f'Reset start_date to the maximum_allowed_start_date "{self.maximum_allowed_start_date.isoformat()}"',
             )

--- a/airbyte-integrations/connectors/source-s3/source_s3/source_files_abstract/stream.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/source_files_abstract/stream.py
@@ -61,7 +61,6 @@ class FileStream(Stream, ABC):
             self._schema = self._parse_user_input_schema(schema)
         self.master_schema = None
         self.storagefile_cache: Optional[List[Tuple[datetime, StorageFile]]] = None
-        self.logger = AirbyteLogger()
         self.logger.info(f"initialised stream with format: {format}")
 
     @staticmethod

--- a/airbyte-integrations/connectors/source-zuora/source_zuora/source.py
+++ b/airbyte-integrations/connectors/source-zuora/source_zuora/source.py
@@ -40,7 +40,6 @@ class ZuoraStream(HttpStream, ABC):
 
     def __init__(self, config: Dict):
         super().__init__(authenticator=config["authenticator"])
-        self.logger = AirbyteLogger()
         self._url_base = config["url_base"]
         self.start_date = config["start_date"]
         self.window_in_days = config["window_in_days"]


### PR DESCRIPTION
## What
After merging PR #6085 integration test for some sources start failing.

FAILED LAST BUILD ONLY - 10 connectors:
source-amazon-seller-partner ✅✅✅✅✅✅✅✅✅❌ https://github.com/airbytehq/airbyte/actions/runs/1337164004
source-facebook-marketing    ✅❌✅✅✅✅✅✅✅❌ https://github.com/airbytehq/airbyte/actions/runs/1337164262
source-instagram             ✅✅✅✅✅✅✅✅✅❌ https://github.com/airbytehq/airbyte/actions/runs/1337164801
source-mysql-strict-encrypt    ❌✅✅✅✅✅✅❌ https://github.com/airbytehq/airbyte/actions/runs/1337165289
source-paypal-transaction    ✅✅✅✅✅✅✅✅✅❌ https://github.com/airbytehq/airbyte/actions/runs/1337165354
source-postgres              ✅❌✅❌✅❌✅❌✅❌ https://github.com/airbytehq/airbyte/actions/runs/1337165418
source-redshift              ✅✅✅✅✅✅✅✅✅❌ https://github.com/airbytehq/airbyte/actions/runs/1337165509
source-s3                    ✅✅✅✅✅✅✅✅✅❌ https://github.com/airbytehq/airbyte/actions/runs/1337165522
source-snowflake             ✅✅✅✅✅✅✅✅✅❌ https://github.com/airbytehq/airbyte/actions/runs/1337165659
source-zuora                 ❌❌❌✅✅✅✅✅✅❌ https://github.com/airbytehq/airbyte/actions/runs/1337165913

## How

- fix import logger from airbyte_cdk.entrypoint
- source-paypal-transaction: change level from "WARN" to logging.WARN in self.logger.log
- source-s3: use native logger instead AirbyteLogger
- source-zuora: use native logger instead AirbyteLogger