### PR TITLE
add docs on how to set up ide to automatically add final

### DIFF
--- a/docs/contributing-to-airbyte/code-style.md
+++ b/docs/contributing-to-airbyte/code-style.md
@@ -17,4 +17,18 @@ Install it in IntelliJ:
 3. Select `GoogleStyle` in the dropdown
 4. Change default `Hard wrap at` in `Wrapping and Braces` tab to **150**.
 5. We prefer `import foo.bar.ClassName` over `import foo.bar.*`. Even in cases where we import multiple classes from the same package. This can be set by going to `Preferences > Code Style > Java > Imports` and changing `Class count to use import with '*'` to 9999 and \`Names count to use static import with '\*' to 9999.
-6. You're done!
+6. We add the `final` keyword wherever possible. It's a drag to have to do it manually, however, so we set up the IDE to do it for us. You can either set this as the default for your IDE or you can set it just for the Airbyte project(s) that you are using.
+   1. Turn on the inspection. Go into project settings...
+      1. Editor > Inspections > Search "Field may be 'final'" > check the box
+      2. Editor > Inspections > Search "local variable or parameter may be final" > check the box
+      3. Apply the changes.
+   2. Turn on the auto add final. Go into project settings...
+      1. Plugins - install Save Actions if not already installed.
+      2. Go to Save Actions
+         1. Activate save actions on save > check the box
+         2. Active save actions on shortcut > check the box
+         3. Activate save actions on batch > check the box
+         4. Add final modifier to field > check the box
+         5. Add final modifier to local variable or parameter > check the box
+         6. Apply the changes.
+7. You're done!

--- a/docs/contributing-to-airbyte/code-style.md
+++ b/docs/contributing-to-airbyte/code-style.md
@@ -19,12 +19,12 @@ Install it in IntelliJ:
 5. We prefer `import foo.bar.ClassName` over `import foo.bar.*`. Even in cases where we import multiple classes from the same package. This can be set by going to `Preferences > Code Style > Java > Imports` and changing `Class count to use import with '*'` to 9999 and \`Names count to use static import with '\*' to 9999.
 6. We add the `final` keyword wherever possible. It's a drag to have to do it manually, however, so we set up the IDE to do it for us. You can either set this as the default for your IDE or you can set it just for the Airbyte project(s) that you are using.
    1. Turn on the inspection. Go into project settings...
-      1. Editor > Inspections > Search "Field may be 'final'" > check the box
+      1. Editor > Inspections > Search (with the quotation marks included) "Field may be 'final'" > check the box
       2. Editor > Inspections > Search "local variable or parameter may be final" > check the box
       3. Apply the changes.
    2. Turn on the auto add final. Go into project settings...
       1. Plugins - install Save Actions if not already installed.
-      2. Go to Save Actions
+      2. Go to Save Actions (NOT Tools > Actions on Save -- that is a different tool)
          1. Activate save actions on save > check the box
          2. Active save actions on shortcut > check the box
          3. Activate save actions on batch > check the box


### PR DESCRIPTION
## What
* We would like add the final keyword where possible but we don't want to have developers fiddling around adding it themselves. This PR documents how to setup intellij to do it all for us.

## Pre-Merge Checklist
- [x] - find a guinea pig to give feedback on the clarity of instructions
- [ ] - once approved, ask everyone on the team to update their ide
- [x] - once approved, do a separate PR that adds all of the `final` keywords (https://github.com/airbytehq/airbyte/pull/7084)