### PR TITLE
Enable freshdesk in cloud

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -94,7 +94,6 @@ const ConnectorServiceTypeControl: React.FC<{
           "71607ba1-c0ac-4799-8049-7f4b90dd50f7", // Google Sheets
           "9da77001-af33-4bcd-be46-6252bf9342b9", // Shopify
           "d8313939-3782-41b0-be29-b3ca20d8dd3a", // Intercom
-          "ec4b9503-13cb-48ab-a4ab-6ade4be46567", // Freshdesk
         ]
       : [];
   const sortedDropDownData = useMemo(


### PR DESCRIPTION
We had a false alarm that freshdesk needs oauth and disabled it. However, it doesn't per https://github.com/airbytehq/airbyte/issues/6262 so I am re-enabling it for cloud.

See https://github.com/airbytehq/airbyte/pull/6750/files for the origin of the denylist being modified