### PR TITLE
Build on MacOS M1 (Apple Silicon)

### DIFF
--- a/airbyte-config/persistence/build.gradle
+++ b/airbyte-config/persistence/build.gradle
@@ -14,6 +14,6 @@ dependencies {
     implementation project(':airbyte-config:init')
     implementation project(':airbyte-json-validation')
     implementation 'com.google.cloud:google-cloud-secretmanager:1.7.2'
-    testImplementation "org.testcontainers:postgresql:1.15.1"
+    testImplementation "org.testcontainers:postgresql:1.15.3"
     integrationTestJavaImplementation project(':airbyte-config:persistence')
 }

--- a/airbyte-db/jooq/build.gradle
+++ b/airbyte-db/jooq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     // jOOQ code generation
     implementation 'org.jooq:jooq-codegen:3.13.4'
-    implementation "org.testcontainers:postgresql:1.15.1"
+    implementation "org.testcontainers:postgresql:1.15.3"
     // The jOOQ code generator only has access to classes added to the jooqGenerator configuration
     jooqGenerator project(':airbyte-db:lib')
 }

--- a/airbyte-db/lib/build.gradle
+++ b/airbyte-db/lib/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation project(':airbyte-protocol:models')
     implementation project(':airbyte-json-validation')
     implementation "org.flywaydb:flyway-core:7.14.0"
-    implementation "org.testcontainers:postgresql:1.15.1"
+    implementation "org.testcontainers:postgresql:1.15.3"
 
     testImplementation project(':airbyte-test-utils')
     testImplementation 'org.apache.commons:commons-lang3:3.11'

--- a/airbyte-e2e-testing/build.gradle
+++ b/airbyte-e2e-testing/build.gradle
@@ -3,9 +3,11 @@ plugins {
     id "com.github.node-gradle.node" version "2.2.4"
 }
 
+def nodeVersion = System.getenv('NODE_VERSION') ?: '14.11.0'
+
 node {
     download = true
-    version = "14.11.0"
+    version = nodeVersion
 }
 
 

--- a/airbyte-integrations/bases/base-java/Dockerfile
+++ b/airbyte-integrations/bases/base-java/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:14.0.2-slim
+ARG JDK_VERSION=14.0.2
+FROM openjdk:${JDK_VERSION}-slim
 COPY --from=airbyte/integration-base:dev /airbyte /airbyte
 
 WORKDIR /airbyte

--- a/airbyte-integrations/bases/base-java/build.gradle
+++ b/airbyte-integrations/bases/base-java/build.gradle
@@ -14,8 +14,8 @@ dependencies {
 
     implementation project(':airbyte-protocol:models')
     implementation project(":airbyte-json-validation")
-    implementation "org.testcontainers:testcontainers:1.15.1"
-    implementation "org.testcontainers:jdbc:1.15.1"
+    implementation "org.testcontainers:testcontainers:1.15.3"
+    implementation "org.testcontainers:jdbc:1.15.3"
 
     implementation files(project(':airbyte-integrations:bases:base').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/bases/base-standard-source-test-file/Dockerfile
+++ b/airbyte-integrations/bases/base-standard-source-test-file/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:14.0.2-slim
+ARG JDK_VERSION=14.0.2
+FROM openjdk:${JDK_VERSION}-slim
 
 # Install Docker to launch worker images. Eventually should be replaced with Docker-java.
 # See https://gitter.im/docker-java/docker-java?at=5f3eb87ba8c1780176603f4e for more information on why we are not currently using Docker-java

--- a/airbyte-integrations/bases/standard-source-test/Dockerfile
+++ b/airbyte-integrations/bases/standard-source-test/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:14.0.2-slim
+ARG JDK_VERSION=14.0.2
+FROM openjdk:${JDK_VERSION}-slim
 
 # Install Docker to launch worker images. Eventually should be replaced with Docker-java.
 # See https://gitter.im/docker-java/docker-java?at=5f3eb87ba8c1780176603f4e for more information on why we are not currently using Docker-java

--- a/airbyte-integrations/connector-templates/generator/build.gradle
+++ b/airbyte-integrations/connector-templates/generator/build.gradle
@@ -3,9 +3,11 @@ plugins {
     id "com.github.node-gradle.node" version "2.2.4"
 }
 
+def nodeVersion = System.getenv('NODE_VERSION') ?: '14.11.0'
+
 node {
     download = true
-    version = "14.11.0"
+    version = nodeVersion
 }
 
 assemble.dependsOn(npmInstall)

--- a/airbyte-integrations/connectors/destination-e2e-test/build.gradle
+++ b/airbyte-integrations/connectors/destination-e2e-test/build.gradle
@@ -16,11 +16,11 @@ dependencies {
 
     testImplementation project(':airbyte-test-utils')
 
-    testImplementation "org.testcontainers:postgresql:1.15.1"
+    testImplementation "org.testcontainers:postgresql:1.15.3"
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
 
-    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.1"
+    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.3"
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)

--- a/airbyte-integrations/connectors/destination-jdbc/build.gradle
+++ b/airbyte-integrations/connectors/destination-jdbc/build.gradle
@@ -17,10 +17,10 @@ dependencies {
     implementation 'com.github.alexmojaki:s3-stream-upload:2.2.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
-    testImplementation "org.testcontainers:postgresql:1.15.1"
+    testImplementation "org.testcontainers:postgresql:1.15.3"
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
-    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.1"
+    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.3"
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)

--- a/airbyte-integrations/connectors/destination-meilisearch/build.gradle
+++ b/airbyte-integrations/connectors/destination-meilisearch/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-meilisearch')
 
-    integrationTestJavaImplementation "org.testcontainers:testcontainers:1.15.1"
+    integrationTestJavaImplementation "org.testcontainers:testcontainers:1.15.3"
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/destination-mysql-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-mysql-strict-encrypt/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-mysql')
-    integrationTestJavaImplementation "org.testcontainers:mysql:1.15.1"
+    integrationTestJavaImplementation "org.testcontainers:mysql:1.15.3"
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)

--- a/airbyte-integrations/connectors/destination-mysql/build.gradle
+++ b/airbyte-integrations/connectors/destination-mysql/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-mysql')
-    integrationTestJavaImplementation "org.testcontainers:mysql:1.15.1"
+    integrationTestJavaImplementation "org.testcontainers:mysql:1.15.3"
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
 
-    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.1"
+    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.3"
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)

--- a/airbyte-integrations/connectors/destination-postgres/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres/build.gradle
@@ -17,12 +17,12 @@ dependencies {
 
     testImplementation project(':airbyte-test-utils')
 
-    testImplementation "org.testcontainers:postgresql:1.15.1"
+    testImplementation "org.testcontainers:postgresql:1.15.3"
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-postgres')
 
-    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.1"
+    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.3"
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)

--- a/airbyte-integrations/connectors/source-e2e-test/build.gradle
+++ b/airbyte-integrations/connectors/source-e2e-test/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testImplementation project(":airbyte-json-validation")
     testImplementation project(':airbyte-test-utils')
 
-    testImplementation 'org.testcontainers:postgresql:1.15.1'
+    testImplementation 'org.testcontainers:postgresql:1.15.3'
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
 

--- a/airbyte-integrations/connectors/source-jdbc/build.gradle
+++ b/airbyte-integrations/connectors/source-jdbc/build.gradle
@@ -28,10 +28,10 @@ dependencies {
     testImplementation project(':airbyte-test-utils')
 
     testImplementation "org.postgresql:postgresql:42.2.18"
-    testImplementation "org.testcontainers:postgresql:1.15.1"
+    testImplementation "org.testcontainers:postgresql:1.15.3"
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
-    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.1"
+    integrationTestJavaImplementation "org.testcontainers:postgresql:1.15.3"
 
     testFixturesImplementation "org.hamcrest:hamcrest-all:1.3"
     testFixturesImplementation project(':airbyte-protocol:models')

--- a/airbyte-integrations/connectors/source-mssql-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql-strict-encrypt/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation "org.testcontainers:mssqlserver:1.15.1"
+    testImplementation "org.testcontainers:mssqlserver:1.15.3"
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-mssql-strict-encrypt')

--- a/airbyte-integrations/connectors/source-mssql/build.gradle
+++ b/airbyte-integrations/connectors/source-mssql/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation "org.testcontainers:mssqlserver:1.15.1"
+    testImplementation "org.testcontainers:mssqlserver:1.15.3"
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-mssql')

--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
     testImplementation project(':airbyte-test-utils')
 
-    testImplementation 'org.testcontainers:mysql:1.15.1'
+    testImplementation 'org.testcontainers:mysql:1.15.3'
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
 

--- a/airbyte-integrations/connectors/source-mysql/build.gradle
+++ b/airbyte-integrations/connectors/source-mysql/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     testImplementation testFixtures(project(':airbyte-integrations:bases:debezium'))
     testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation 'org.testcontainers:mysql:1.15.1'
+    testImplementation 'org.testcontainers:mysql:1.15.3'
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-mysql')

--- a/airbyte-integrations/connectors/source-oracle-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-oracle-strict-encrypt/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     testImplementation project(':airbyte-test-utils')
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation 'org.testcontainers:oracle-xe:1.15.2'
+    testImplementation 'org.testcontainers:oracle-xe:1.15.3'
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
 

--- a/airbyte-integrations/connectors/source-oracle/build.gradle
+++ b/airbyte-integrations/connectors/source-oracle/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     testImplementation project(':airbyte-test-utils')
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation 'org.testcontainers:oracle-xe:1.15.2'
+    testImplementation 'org.testcontainers:oracle-xe:1.15.3'
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
 

--- a/airbyte-integrations/connectors/source-postgres-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres-strict-encrypt/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
     testImplementation project(':airbyte-test-utils')
 
-    testImplementation 'org.testcontainers:postgresql:1.15.1'
+    testImplementation 'org.testcontainers:postgresql:1.15.3'
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
 

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testImplementation project(":airbyte-json-validation")
     testImplementation project(':airbyte-test-utils')
 
-    testImplementation 'org.testcontainers:postgresql:1.15.1'
+    testImplementation 'org.testcontainers:postgresql:1.15.3'
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
 

--- a/airbyte-integrations/connectors/source-relational-db/build.gradle
+++ b/airbyte-integrations/connectors/source-relational-db/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     testImplementation project(':airbyte-test-utils')
 
     testImplementation "org.postgresql:postgresql:42.2.18"
-    testImplementation "org.testcontainers:postgresql:1.15.1"
+    testImplementation "org.testcontainers:postgresql:1.15.3"
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }

--- a/airbyte-migration/Dockerfile
+++ b/airbyte-migration/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:14.0.2-slim AS migrate
+ARG JDK_VERSION=14.0.2
+FROM openjdk:${JDK_VERSION}-slim AS migrate
 
 ENV APPLICATION airbyte-migration
 

--- a/airbyte-scheduler/app/Dockerfile
+++ b/airbyte-scheduler/app/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:14.0.2-slim AS scheduler
+ARG JDK_VERSION=14.0.2
+FROM openjdk:${JDK_VERSION}-slim AS scheduler
 
 ENV APPLICATION airbyte-scheduler
 

--- a/airbyte-scheduler/app/build.gradle
+++ b/airbyte-scheduler/app/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation project(':airbyte-scheduler:persistence')
     implementation project(':airbyte-workers')
 
-    testImplementation "org.testcontainers:postgresql:1.15.1"
+    testImplementation "org.testcontainers:postgresql:1.15.3"
 }
 
 application {

--- a/airbyte-scheduler/persistence/build.gradle
+++ b/airbyte-scheduler/persistence/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     implementation project(':airbyte-scheduler:models')
 
     testImplementation "org.flywaydb:flyway-core:7.14.0"
-    testImplementation "org.testcontainers:postgresql:1.15.1"
+    testImplementation "org.testcontainers:postgresql:1.15.3"
 }

--- a/airbyte-secrets-migration/Dockerfile
+++ b/airbyte-secrets-migration/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:14.0.2-slim
+ARG JDK_VERSION=14.0.2
+FROM openjdk:${JDK_VERSION}-slim
 
 ENV APPLICATION airbyte-secrets-migration
 WORKDIR /airbyte

--- a/airbyte-secrets-migration/build.gradle
+++ b/airbyte-secrets-migration/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation project(':airbyte-config:persistence')
     testImplementation project(':airbyte-json-validation')
     testImplementation 'org.apache.commons:commons-lang3:3.11'
-    testImplementation "org.testcontainers:postgresql:1.15.1"
+    testImplementation "org.testcontainers:postgresql:1.15.3"
     integrationTestJavaImplementation project(':airbyte-secrets-migration')
 }
 

--- a/airbyte-server/Dockerfile
+++ b/airbyte-server/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:14.0.2-slim AS server
+ARG JDK_VERSION=14.0.2
+FROM openjdk:${JDK_VERSION}-slim AS server
 
 EXPOSE 8000
 

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'application'
     id 'maven-publish'
-    id 'com.github.johnrengelman.shadow' version '6.1.0'
+    id 'com.github.johnrengelman.shadow' version '7.1.0'
 }
 
 shadowJar {
@@ -81,7 +81,7 @@ dependencies {
 
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.1'
 
-    testImplementation "org.testcontainers:postgresql:1.15.1"
+    testImplementation "org.testcontainers:postgresql:1.15.3"
 }
 
 // we want to be able to access the generated db files from config/init when we build the server docker image.

--- a/airbyte-test-utils/build.gradle
+++ b/airbyte-test-utils/build.gradle
@@ -5,6 +5,6 @@ plugins {
 dependencies {
     implementation project(':airbyte-db:lib')
 
-    implementation 'org.testcontainers:postgresql:1.15.1'
+    implementation 'org.testcontainers:postgresql:1.15.3'
     implementation "org.testcontainers:cockroachdb:1.15.3"
 }

--- a/airbyte-tests/build.gradle
+++ b/airbyte-tests/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     acceptanceTestsImplementation 'com.fasterxml.jackson.core:jackson-databind'
     acceptanceTestsImplementation 'io.github.cdimascio:java-dotenv:3.0.0'
     acceptanceTestsImplementation 'org.apache.commons:commons-csv:1.4'
-    acceptanceTestsImplementation 'org.testcontainers:postgresql:1.15.1'
+    acceptanceTestsImplementation 'org.testcontainers:postgresql:1.15.3'
     acceptanceTestsImplementation 'org.postgresql:postgresql:42.2.18'
 
     automaticMigrationAcceptanceTestImplementation project(':airbyte-api')

--- a/airbyte-webapp/build.gradle
+++ b/airbyte-webapp/build.gradle
@@ -3,9 +3,11 @@ plugins {
     id "com.github.node-gradle.node" version "3.1.1"
 }
 
+def nodeVersion = System.getenv('NODE_VERSION') ?: '14.11.0'
+
 node {
     download = true
-    version = "14.11.0"
+    version = nodeVersion
 }
 
 npm_run_build {

--- a/airbyte-workers/Dockerfile
+++ b/airbyte-workers/Dockerfile
@@ -1,4 +1,7 @@
-FROM openjdk:14.0.2-slim AS worker
+ARG JDK_VERSION=14.0.2
+FROM openjdk:${JDK_VERSION}-slim AS worker
+
+ARG ARCH=amd64
 
 # Install Docker to launch worker images. Eventually should be replaced with Docker-java.
 # See https://gitter.im/docker-java/docker-java?at=5f3eb87ba8c1780176603f4e for more information on why we are not currently using Docker-java
@@ -10,7 +13,7 @@ RUN apt-get update && apt-get install -y \
                           software-properties-common
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN add-apt-repository \
-       "deb [arch=amd64] https://download.docker.com/linux/debian \
+       "deb [arch=${ARCH}] https://download.docker.com/linux/debian \
        $(lsb_release -cs) \
        stable"
 RUN apt-get update && apt-get install -y docker-ce-cli jq
@@ -20,7 +23,7 @@ ENV APPLICATION airbyte-workers
 WORKDIR /app
 
 # Install kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.14/bin/linux/amd64/kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.14/bin/linux/${ARCH}/kubectl
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin
 

--- a/airbyte-workers/build.gradle
+++ b/airbyte-workers/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     testImplementation 'org.postgresql:postgresql:42.2.18'
     testImplementation "org.flywaydb:flyway-core:7.14.0"
     testImplementation 'org.testcontainers:testcontainers:1.15.3'
-    testImplementation 'org.testcontainers:postgresql:1.15.1'
+    testImplementation 'org.testcontainers:postgresql:1.15.3'
 
     testImplementation project(':airbyte-commons-docker')
 

--- a/build.gradle
+++ b/build.gradle
@@ -248,11 +248,17 @@ subprojects {
 
 task composeBuild {
     def buildTag = System.getenv('VERSION') ?: 'dev'
+    def buildPlatform = System.getenv('DOCKER_BUILD_PLATFORM') ?: 'linux/amd64'
+    def buildArch = System.getenv('DOCKER_BUILD_ARCH') ?: 'amd64'
+    def jdkVersion = System.getenv('JDK_VERSION') ?: '14.0.2'
     doFirst {
         exec {
             workingDir rootDir
             commandLine 'docker-compose', '-f', 'docker-compose.build.yaml', 'build', '--parallel', '--quiet'
             environment 'VERSION', buildTag
+            environment 'DOCKER_BUILD_PLATFORM', buildPlatform
+            environment 'DOCKER_BUILD_ARCH', buildArch
+            environment 'JDK_VERSION', jdkVersion
         }
     }
 }

--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -2,6 +2,7 @@ version: "3.7"
 
 services:
   init:
+    platform: linux/amd64
     image: airbyte/init:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -9,6 +10,7 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   db:
+    platform: linux/amd64
     image: airbyte/db:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -16,27 +18,38 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   scheduler:
+    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/scheduler:${VERSION}
     build:
       dockerfile: Dockerfile
+      args:
+        JDK_VERSION: ${JDK_VERSION}
       context: airbyte-scheduler/app
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   worker:
+    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/worker:${VERSION}
     build:
       dockerfile: Dockerfile
+      args:
+        ARCH: ${DOCKER_BUILD_ARCH}
+        JDK_VERSION: ${JDK_VERSION}
       context: airbyte-workers
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   server:
+    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/server:${VERSION}
     build:
       dockerfile: Dockerfile
+      args:
+        JDK_VERSION: ${JDK_VERSION}
       context: airbyte-server
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   webapp:
+    platform: linux/amd64
     image: airbyte/webapp:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -44,9 +57,12 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   migration:
+    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/migration:${VERSION}
     build:
       dockerfile: Dockerfile
+      args:
+        JDK_VERSION: ${JDK_VERSION}
       context: airbyte-migration
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -33,6 +33,15 @@ To compile and build just the platform \(not all the connectors\):
 SUB_BUILD=PLATFORM ./gradlew build
 ```
 
+On Mac M1\(Apple Silicon\) machines\
+```bash
+export DOCKER_BUILD_PLATFORM=linux/arm64
+export DOCKER_BUILD_ARCH=arm64
+export JDK_VERSION=17
+export NODE_VERSION=16.11.1
+SUB_BUILD=PLATFORM ./gradlew build
+```
+
 This will build all the code and run all the unit tests.
 
 `SUB_BUILD=PLATFORM ./gradlew build` creates all the necessary artifacts \(Webapp, Jars and Docker images\) so that you can run Airbyte locally. Since this builds everything, it can take some time.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,11 @@
 # NOTE: if you want to override this for your local machine, set overrides in ~/.gradle/gradle.properties
 
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx4g -Xss4m
+org.gradle.jvmargs=-Xmx4g -Xss4m --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 org.gradle.caching=true
 
 # Note, this might have issues on the normal Github runner.

--- a/tools/bin/build_image.sh
+++ b/tools/bin/build_image.sh
@@ -39,9 +39,10 @@ if [ "$FOLLOW_SYMLINKS" == "true" ]; then
   # to use as the build context
   tar cL "${exclusions[@]}" . | docker build - "${args[@]}"
 else
+  JDK_VERSION="${JDK_VERSION:-14.0.2}"
   if [[ -z "${DOCKER_BUILD_PLATFORM}" ]]; then
-    docker build . "${args[@]}"
+    docker build --build-arg JDK_VERSION="$JDK_VERSION" . "${args[@]}"
   else
-    docker build --platform="$DOCKER_BUILD_PLATFORM" . "${args[@]}"
+    docker build --build-arg JDK_VERSION="$JDK_VERSION" --platform="$DOCKER_BUILD_PLATFORM" . "${args[@]}"
   fi
 fi


### PR DESCRIPTION
## What
Experimental Build on macOS M1 (Apple silicon)

## How
Upgrade JDK version to 17 and parameterize through an environment variable
Upgrade Node version to 16 and parameterize through an environment variable
Parameterize the docker build platform

Example
```sh
export DOCKER_BUILD_PLATFORM=linux/arm64
export DOCKER_BUILD_ARCH=arm64
export JDK_VERSION=17
export NODE_VERSION=16.11.1
SUB_BUILD=PLATFORM ./gradlew build -x test
```


## Recommended reading order
1. `build.gradle`
2. `airbyte-workers/Dockerfile`

## Pre-merge Checklist
This is an experiment mainly to speed my dev cycle by solving https://github.com/airbytehq/airbyte/issues/2017.
Currently, I have to build on a separate Linux machine which is a frustratingly very slow dev loop.
Changes include fixes for the below issues.

- com.github.johnrengelman.shadow Gradle plugin should be upgraded to 7.1.0 Also watch https://github.com/johnrengelman/shadow/issues/713
- There is a weird issue with Gradle node plugin. Currently it does not allow customizing the node version platform. Only way to build on Mac M1 is to use Node 16.x which supports darwin/arm64 https://github.com/node-gradle/gradle-node-plugin/issues/154
- testcontainers should be upgraded to 1.15.3 or better 1.16.0 (which has good support for arm64). https://github.com/testcontainers/testcontainers-java/issues/3610
- JDK 17 which has native darwin/arm64 support. https://www.oracle.com/java/technologies/downloads/#jdk17-mac
- Set Gradle properties for Spotless plugin https://github.com/diffplug/spotless/issues/834

## TODO
- Make Airbyte worker pull connector docker images specific to platform (Currently docker pull prints a warning) https://docs.docker.com/engine/reference/commandline/pull/#options
- Make gradle pick correct JDK/JVM toolchain https://docs.gradle.org/current/userguide/toolchains.html#sec:vendors
- Temporal can be built for linux/arm64. In fact I added support for arm64 release binaries a while ago. But somehow docker images do not have linux/arm64 
https://github.com/temporalio/temporal/tree/master/docker/base-images
https://github.com/temporalio/temporal/releases/tag/v1.12.3

I am able to successfully run Airbyte on MacOS M1, created sample Connection, Destination, and Source.

<img width="1666" alt="Screen Shot 2021-10-18 at 12 35 53 AM" src="https://user-images.githubusercontent.com/2949492/137674670-c534dff1-c20a-4ad3-83c2-b17e51ec0c56.png">


