### PR TITLE
🎉 Source GitLab: allow all domains to be used as `api_url`

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/5e6175e5-68e1-4c17-bff9-56103bbb0d80.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/5e6175e5-68e1-4c17-bff9-56103bbb0d80.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "5e6175e5-68e1-4c17-bff9-56103bbb0d80",
   "name": "Gitlab",
   "dockerRepository": "airbyte/source-gitlab",
-  "dockerImageTag": "0.1.1",
+  "dockerImageTag": "0.1.2",
   "documentationUrl": "https://docs.airbyte.io/integrations/sources/gitlab"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -296,7 +296,7 @@
 - sourceDefinitionId: 5e6175e5-68e1-4c17-bff9-56103bbb0d80
   name: Gitlab
   dockerRepository: airbyte/source-gitlab
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   documentationUrl: https://docs.airbyte.io/integrations/sources/gitlab
   sourceType: api
 - sourceDefinitionId: ed9dfefa-1bbc-419d-8c5e-4d78f0ef6734

--- a/airbyte-integrations/connectors/source-gitlab/Dockerfile
+++ b/airbyte-integrations/connectors/source-gitlab/Dockerfile
@@ -13,5 +13,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/source-gitlab

--- a/airbyte-integrations/connectors/source-gitlab/source_gitlab/spec.json
+++ b/airbyte-integrations/connectors/source-gitlab/source_gitlab/spec.json
@@ -10,8 +10,7 @@
       "api_url": {
         "type": "string",
         "examples": ["gitlab.com"],
-        "description": "Please enter your basic URL from Gitlab instance",
-        "pattern": "^gitlab[a-zA-Z0-9._-]*\\.com$"
+        "description": "Please enter your basic URL from Gitlab instance"
       },
       "private_token": {
         "type": "string",

--- a/docs/integrations/sources/gitlab.md
+++ b/docs/integrations/sources/gitlab.md
@@ -61,7 +61,7 @@ GitLab source is working with GitLab API v4. It can also work with self-hosted G
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| 0.1.2 | 2021-10-?? | [7108](https://github.com/airbytehq/airbyte/pull/7108) | Allow all domains to be used as `api_url` |
+| 0.1.2 | 2021-10-18 | [7108](https://github.com/airbytehq/airbyte/pull/7108) | Allow all domains to be used as `api_url` |
 | 0.1.1 | 2021-10-12 | [6932](https://github.com/airbytehq/airbyte/pull/6932) | Fix pattern field in spec file, remove unused fields from config files, use cache from CDK |
 | 0.1.0 | 2021-07-06 | [4174](https://github.com/airbytehq/airbyte/pull/4174) | Initial Release |
 

--- a/docs/integrations/sources/gitlab.md
+++ b/docs/integrations/sources/gitlab.md
@@ -53,10 +53,15 @@ Log into Gitlab and then generate a [personal access token](https://docs.gitlab.
 
 Your token should have the `read_api` scope, that Grants read access to the API, including all groups and projects, the container registry, and the package registry.
 
+## Additional information
+
+GitLab source is working with GitLab API v4. It can also work with self-hosted GitLab API v4.
+
 ## Changelog
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.2 | 2021-10-?? | [7108](https://github.com/airbytehq/airbyte/pull/7108) | Allow all domains to be used as `api_url` |
 | 0.1.1 | 2021-10-12 | [6932](https://github.com/airbytehq/airbyte/pull/6932) | Fix pattern field in spec file, remove unused fields from config files, use cache from CDK |
 | 0.1.0 | 2021-07-06 | [4174](https://github.com/airbytehq/airbyte/pull/4174) | Initial Release |
 


### PR DESCRIPTION
## What
Closes #3265.

## Pre-merge Checklist
   
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [x] Code reviews completed
- [x] Documentation updated 
    - [x] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [x] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
