### PR TITLE
kube build fixes

### DIFF
--- a/.github/workflows/gke-kube-test-command.yml
+++ b/.github/workflows/gke-kube-test-command.yml
@@ -25,7 +25,7 @@ jobs:
           aws-region: us-east-2
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.2.1
+        uses: machulav/ec2-github-runner@v2.3.0
         with:
           mode: start
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
@@ -135,7 +135,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.2.1
+        uses: machulav/ec2-github-runner@v2.3.0
         with:
           mode: stop
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,7 +24,7 @@ jobs:
           aws-region: us-east-2
       - name: Start EC2 Runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.2.1
+        uses: machulav/ec2-github-runner@v2.3.0
         with:
           mode: start
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
@@ -154,7 +154,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.2.1
+        uses: machulav/ec2-github-runner@v2.3.0
         with:
           mode: stop
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
@@ -179,7 +179,7 @@ jobs:
           aws-region: us-east-2
       - name: Start EC2 Runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.2.1
+        uses: machulav/ec2-github-runner@v2.3.0
         with:
           mode: start
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
@@ -312,7 +312,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.2.1
+        uses: machulav/ec2-github-runner@v2.3.0
         with:
           mode: stop
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
@@ -338,7 +338,7 @@ jobs:
           aws-region: us-east-2
       - name: Start EC2 Runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.2.1
+        uses: machulav/ec2-github-runner@v2.3.0
         with:
           mode: start
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
@@ -404,7 +404,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.2.1
+        uses: machulav/ec2-github-runner@v2.3.0
         with:
           mode: stop
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
@@ -430,7 +430,7 @@ jobs:
           aws-region: us-east-2
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.2.1
+        uses: machulav/ec2-github-runner@v2.3.0
         with:
           mode: start
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
@@ -558,7 +558,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.2.1
+        uses: machulav/ec2-github-runner@v2.3.0
         with:
           mode: stop
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -509,6 +509,9 @@ jobs:
 
       - name: Describe kube nodes
         run: kubectl describe nodes
+        env:
+          USER: root
+          HOME: /home/runner
 
       - name: Build Platform Docker Images
         run: SUB_BUILD=PLATFORM ./gradlew composeBuild --scan

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -434,7 +434,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
-          ec2-image-id: ami-0717900bad4b648ca
+          ec2-image-id: ami-0d4083c04fde515c4
           ec2-instance-type: c5.2xlarge
           subnet-id: subnet-0469a9e68a379c1d3
           security-group-id: sg-0793f3c9413f21970
@@ -499,12 +499,16 @@ jobs:
       - name: KIND Kubernetes Cluster Setup
         uses: helm/kind-action@v1.2.0
         with:
+          node_image: kindest/node:v1.21.2
           config: /tmp/kind-config.yaml
         # In case of self-hosted EC2 errors, remove this env block.
         env:
           USER: root
           HOME: /home/runner
           CHANGE_MINIKUBE_NONE_USER: true
+
+      - name: Describe kube nodes
+        run: kubectl describe nodes
 
       - name: Build Platform Docker Images
         run: SUB_BUILD=PLATFORM ./gradlew composeBuild --scan

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1183,7 +1183,7 @@ public class AcceptanceTests {
       throws InterruptedException, ApiException {
     JobRead job = originalJob;
     int count = 0;
-    while (count < 200 && jobStatuses.contains(job.getStatus())) {
+    while (count < 400 && jobStatuses.contains(job.getStatus())) {
       sleep(1000);
       count++;
 

--- a/tools/bin/acceptance_test_kube.sh
+++ b/tools/bin/acceptance_test_kube.sh
@@ -9,11 +9,13 @@ assert_root
 # Since KIND does not have access to the local docker agent, manually load the minimum images required for the Kubernetes Acceptance Tests.
 # See https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster.
 echo "Loading images into KIND..."
-kind load docker-image airbyte/server:dev --name chart-testing
-kind load docker-image airbyte/scheduler:dev --name chart-testing
-kind load docker-image airbyte/webapp:dev --name chart-testing
-kind load docker-image airbyte/worker:dev --name chart-testing
-kind load docker-image airbyte/db:dev --name chart-testing
+kind load docker-image airbyte/server:dev --name chart-testing &
+kind load docker-image airbyte/scheduler:dev --name chart-testing &
+kind load docker-image airbyte/webapp:dev --name chart-testing &
+kind load docker-image airbyte/worker:dev --name chart-testing &
+kind load docker-image airbyte/db:dev --name chart-testing &
+kind load docker-image airbyte/normalization:dev --name chart-testing &
+wait
 
 echo "Starting app..."
 
@@ -46,9 +48,10 @@ sleep 120s
 server_logs () { echo "server logs:" && kubectl logs deployment.apps/airbyte-server; }
 scheduler_logs () { echo "scheduler logs:" && kubectl logs deployment.apps/airbyte-scheduler; }
 pod_sweeper_logs () { echo "pod sweeper logs:" && kubectl logs deployment.apps/airbyte-pod-sweeper; }
+worker_logs () { echo "worker logs:" && kubectl logs deployment.apps/airbyte-worker; }
 describe_pods () { echo "describe pods:" && kubectl describe pods; }
-print_all_logs () { server_logs; scheduler_logs; pod_sweeper_logs; describe_pods; }
-
+describe_nodes () { echo "describe nodes:" && kubectl describe nodes; }
+print_all_logs () { server_logs; scheduler_logs; worker_logs; pod_sweeper_logs; describe_nodes; describe_pods; }
 trap "echo 'kube logs:' && print_all_logs" EXIT
 
 kubectl port-forward svc/airbyte-server-svc 8001:8001 &


### PR DESCRIPTION
picks up some of the changes from https://github.com/airbytehq/airbyte/pull/7066
- uses 120gb disk ami (important)
- adds normalization image loading for dev image (important)
- increases wait time for processes in the acceptance test
- upgrades ec2-github-runner version
- adds logging around node status in case of failure
- speeds up image loading to KIND by parallelizing

This doesn't fix all of the transient issues but it goes from always not working to mostly working.