### PR TITLE
exclude archive from link checker

### DIFF
--- a/.github/workflows/doc-link-check.json
+++ b/.github/workflows/doc-link-check.json
@@ -44,6 +44,10 @@
     {
       "reason": "Test only scaffold connector",
       "pattern": "destinations/scaffold-"
+    },
+    {
+      "reason": "Archived articles aren't actively maintained.",
+      "pattern": "archive/"
     }
   ],
   "retryOn429": false,


### PR DESCRIPTION
Master is failing with a bunch of links in the archive. We don't actually want to test these.