### PR TITLE
Remove platform option to fix build temporarily

### DIFF
--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -2,7 +2,6 @@ version: "3.7"
 
 services:
   init:
-    platform: linux/amd64
     image: airbyte/init:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -10,7 +9,6 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   db:
-    platform: linux/amd64
     image: airbyte/db:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -18,7 +16,6 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   scheduler:
-    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/scheduler:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -28,7 +25,6 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   worker:
-    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/worker:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -39,7 +35,6 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   server:
-    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/server:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -49,7 +44,6 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   webapp:
-    platform: linux/amd64
     image: airbyte/webapp:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -57,7 +51,6 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   migration:
-    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/migration:${VERSION}
     build:
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary

- The master build is broken from merging PR #7104.
  - Everything works locally. Not sure why it does not in github action.
  - Maybe related to https://github.com/docker/compose/pull/5985.
- This PR temporarily removes the offending option to fix the master build.
- Will fix it in a follow up PR.

## Logs
Sample github action run:
https://github.com/airbytehq/airbyte/runs/3943186008

Logs:
```
The Compose file './docker-compose.build.yaml' is invalid because:

Unsupported config option for services.db: 'platform'
> Task :composeBuild FAILED
Unsupported config option for services.init: 'platform'
Unsupported config option for services.migration: 'platform'
Unsupported config option for services.scheduler: 'platform'
Unsupported config option for services.server: 'platform'
Unsupported config option for services.webapp: 'platform'
Unsupported config option for services.worker: 'platform'
```

It's interesting that there is no complaint for `services.db`, which also specifies the `platform` option.
