### PR TITLE
Restore platform option in m1-specific docker compose file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -254,7 +254,7 @@ task composeBuild {
     doFirst {
         exec {
             workingDir rootDir
-            commandLine 'docker-compose', '-f', 'docker-compose.build.yaml', 'build', '--parallel', '--quiet'
+            commandLine 'docker compose', '-f', 'docker-compose.build.yaml', 'build', '--parallel', '--quiet'
             environment 'VERSION', buildTag
             environment 'DOCKER_BUILD_PLATFORM', buildPlatform
             environment 'DOCKER_BUILD_ARCH', buildArch

--- a/build.gradle
+++ b/build.gradle
@@ -251,10 +251,11 @@ task composeBuild {
     def buildPlatform = System.getenv('DOCKER_BUILD_PLATFORM') ?: 'linux/amd64'
     def buildArch = System.getenv('DOCKER_BUILD_ARCH') ?: 'amd64'
     def jdkVersion = System.getenv('JDK_VERSION') ?: '14.0.2'
+    def dockerComposeFile = buildArch == 'arm64' ? 'docker-compose.build.m1.yaml' : 'docker-compose.build.yaml'
     doFirst {
         exec {
             workingDir rootDir
-            commandLine 'docker compose', '-f', 'docker-compose.build.yaml', 'build', '--parallel', '--quiet'
+            commandLine 'docker compose', '-f', dockerComposeFile, 'build', '--parallel', '--quiet'
             environment 'VERSION', buildTag
             environment 'DOCKER_BUILD_PLATFORM', buildPlatform
             environment 'DOCKER_BUILD_ARCH', buildArch

--- a/build.gradle
+++ b/build.gradle
@@ -251,7 +251,7 @@ task composeBuild {
     def buildPlatform = System.getenv('DOCKER_BUILD_PLATFORM') ?: 'linux/amd64'
     def buildArch = System.getenv('DOCKER_BUILD_ARCH') ?: 'amd64'
     def jdkVersion = System.getenv('JDK_VERSION') ?: '14.0.2'
-    def dockerComposeFile = buildArch == 'arm64' ? 'docker-compose.build.m1.yaml' : 'docker-compose.build.yaml'
+    def dockerComposeFile = buildArch == 'arm64' ? 'docker-compose.build-m1.yaml' : 'docker-compose.build.yaml'
     doFirst {
         exec {
             workingDir rootDir

--- a/build.gradle
+++ b/build.gradle
@@ -255,7 +255,7 @@ task composeBuild {
     doFirst {
         exec {
             workingDir rootDir
-            commandLine 'docker compose', '-f', dockerComposeFile, 'build', '--parallel', '--quiet'
+            commandLine 'docker-compose', '-f', dockerComposeFile, 'build', '--parallel', '--quiet'
             environment 'VERSION', buildTag
             environment 'DOCKER_BUILD_PLATFORM', buildPlatform
             environment 'DOCKER_BUILD_ARCH', buildArch

--- a/docker-compose.build-m1.yaml
+++ b/docker-compose.build-m1.yaml
@@ -1,7 +1,14 @@
+# This file is exactly the same as docker-compose.build.yaml, except
+# that it specifies the platform. This is a temporary solution for M1
+# Mac computers. Currently, our Github Action runner has an old version
+# of docker-compose, which does not support the platform option. Once
+# we upgrade the docker-compose in the runners, we should delete this file.
+
 version: "3.7"
 
 services:
   init:
+    platform: linux/amd64
     image: airbyte/init:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -9,6 +16,7 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   db:
+    platform: linux/amd64
     image: airbyte/db:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -16,6 +24,7 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   scheduler:
+    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/scheduler:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -25,6 +34,7 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   worker:
+    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/worker:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -35,6 +45,7 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   server:
+    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/server:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -44,6 +55,7 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   webapp:
+    platform: linux/amd64
     image: airbyte/webapp:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -51,6 +63,7 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   migration:
+    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/migration:${VERSION}
     build:
       dockerfile: Dockerfile

--- a/docker-compose.build-m1.yaml
+++ b/docker-compose.build-m1.yaml
@@ -1,7 +1,8 @@
 # This file is exactly the same as docker-compose.build.yaml, except
 # that it specifies the platform. This is a temporary solution for M1
-# Mac computers. Currently, our Github Action runner has an old version
-# of docker-compose, which does not support the platform option. Once
+# Mac computers. The platform option is required for M1 users to build
+# the project. However, currently, our Github Action runner has an old
+# version of docker-compose, which does not support this option. Once
 # we upgrade the docker-compose in the runners, we should delete this file.
 
 version: "3.7"

--- a/docker-compose.build-m1.yaml
+++ b/docker-compose.build-m1.yaml
@@ -4,6 +4,7 @@
 # the project. However, currently, our Github Action runner has an old
 # version of docker-compose, which does not support this option. Once
 # we upgrade the docker-compose in the runners, we should delete this file.
+# Issue: https://github.com/airbytehq/airbyte/issues/7191
 
 version: "3.7"
 

--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -2,6 +2,7 @@ version: "3.7"
 
 services:
   init:
+    platform: linux/amd64
     image: airbyte/init:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -9,6 +10,7 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   db:
+    platform: linux/amd64
     image: airbyte/db:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -16,6 +18,7 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   scheduler:
+    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/scheduler:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -25,6 +28,7 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   worker:
+    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/worker:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -35,6 +39,7 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   server:
+    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/server:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -44,6 +49,7 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   webapp:
+    platform: linux/amd64
     image: airbyte/webapp:${VERSION}
     build:
       dockerfile: Dockerfile
@@ -51,6 +57,7 @@ services:
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
   migration:
+    platform: ${DOCKER_BUILD_PLATFORM}
     image: airbyte/migration:${VERSION}
     build:
       dockerfile: Dockerfile


### PR DESCRIPTION
- This is a temporary solution for M1 Mac computers.
- The `platform` option is required for M1 users to build the project. However, currently, our Github Action runner has an old version of `docker-compose`, which does not support this option.
- So a M1 specific docker compose file has been added to solve this problem.
  - Github Action and non-M1 users will use the normal docker compose build file.
  - M1 users will use the M1 specific docker compose build file.
- Once we upgrade the docker-compose in the runners, we should delete this file.
- This is a follow up PR for #7104 and #7184.
- Follow up issue: https://github.com/airbytehq/airbyte/issues/7191
