### PR TITLE
Update Mockito for running tests on Mac M1

### DIFF
--- a/airbyte-db/jooq/build.gradle
+++ b/airbyte-db/jooq/build.gradle
@@ -14,6 +14,9 @@ dependencies {
     // jOOQ code generation
     implementation 'org.jooq:jooq-codegen:3.13.4'
     implementation "org.testcontainers:postgresql:1.15.3"
+    implementation 'net.java.dev.jna:jna:5.8.0'
+    implementation 'net.java.dev.jna:jna-platform:5.8.0'
+
     // The jOOQ code generator only has access to classes added to the jooqGenerator configuration
     jooqGenerator project(':airbyte-db:lib')
 }

--- a/airbyte-db/jooq/build.gradle
+++ b/airbyte-db/jooq/build.gradle
@@ -14,6 +14,9 @@ dependencies {
     // jOOQ code generation
     implementation 'org.jooq:jooq-codegen:3.13.4'
     implementation "org.testcontainers:postgresql:1.15.3"
+    // These are required because gradle might be using lower version of Jna from other
+    // library transitive dependency. Can be removed if we can figure out which library is the cause.
+    // Refer: https://github.com/testcontainers/testcontainers-java/issues/3834#issuecomment-825409079
     implementation 'net.java.dev.jna:jna:5.8.0'
     implementation 'net.java.dev.jna:jna-platform:5.8.0'
 

--- a/airbyte-db/lib/build.gradle
+++ b/airbyte-db/lib/build.gradle
@@ -12,6 +12,9 @@ dependencies {
     implementation project(':airbyte-json-validation')
     implementation "org.flywaydb:flyway-core:7.14.0"
     implementation "org.testcontainers:postgresql:1.15.3"
+    // These are required because gradle might be using lower version of Jna from other
+    // library transitive dependency. Can be removed if we can figure out which library is the cause.
+    // Refer: https://github.com/testcontainers/testcontainers-java/issues/3834#issuecomment-825409079
     implementation 'net.java.dev.jna:jna:5.8.0'
     implementation 'net.java.dev.jna:jna-platform:5.8.0'
 

--- a/airbyte-db/lib/build.gradle
+++ b/airbyte-db/lib/build.gradle
@@ -12,6 +12,9 @@ dependencies {
     implementation project(':airbyte-json-validation')
     implementation "org.flywaydb:flyway-core:7.14.0"
     implementation "org.testcontainers:postgresql:1.15.3"
+    implementation 'net.java.dev.jna:jna:5.8.0'
+    implementation 'net.java.dev.jna:jna-platform:5.8.0'
+
 
     testImplementation project(':airbyte-test-utils')
     testImplementation 'org.apache.commons:commons-lang3:3.11'

--- a/build.gradle
+++ b/build.gradle
@@ -230,10 +230,10 @@ subprojects {
         implementation 'software.amazon.awssdk:s3:2.16.84'
 
 
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.1'
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
-        testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.1'
-        testImplementation 'org.mockito:mockito-junit-jupiter:3.9.0'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
+        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
+        testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
+        testImplementation 'org.mockito:mockito-junit-jupiter:3.12.4'
         testImplementation 'org.assertj:assertj-core:3.21.0'
     }
 


### PR DESCRIPTION
## What
*Describe what the change is solving*
Fix running tests on Mac M1 and further fixes #2017 

## How
Update Mockito verison

## Recommended reading order
build.gradle

## Pre-merge Checklist

TODO's

There are a couple of failing tests though

1) https://github.com/airbytehq/airbyte/blob/master/airbyte-commons/src/test/java/io/airbyte/commons/util/AutoCloseableIteratorsTest.java#L39

2) https://github.com/airbytehq/airbyte/blob/master/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java#L26 (Needs docker platform handling)

