### PR TITLE
🐛 Helm chart: Using helper to get postgres credentials

### DIFF
--- a/charts/airbyte/templates/scheduler/deployment.yaml
+++ b/charts/airbyte/templates/scheduler/deployment.yaml
@@ -49,11 +49,19 @@ spec:
             configMapKeyRef:
               name: airbyte-env
               key: DATABASE_PORT
+        {{- if .Values.postgresql.enabled }}
         - name: DATABASE_PASSWORD
           valueFrom:
             configMapKeyRef:
               name: airbyte-env
               key: DATABASE_PASSWORD
+        {{- else }}
+        - name: DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "airbyte.postgresql.secretName" . }}
+              key: {{ include "airbyte.database.existingsecret.key" . }}
+        {{- end }}
         - name: DATABASE_URL
           valueFrom:
             configMapKeyRef:

--- a/charts/airbyte/templates/server/deployment.yaml
+++ b/charts/airbyte/templates/server/deployment.yaml
@@ -53,8 +53,8 @@ spec:
         - name: DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.externalDatabase.existingSecret }}
-              key: {{ .Values.externalDatabase.existingSecretPasswordKey }}
+              name: {{ include "airbyte.postgresql.secretName" . }}
+              key: {{ include "airbyte.database.existingsecret.key" . }}
         {{- end }}
         - name: DATABASE_URL
           valueFrom:

--- a/charts/airbyte/templates/temporal/deployment.yaml
+++ b/charts/airbyte/templates/temporal/deployment.yaml
@@ -34,11 +34,19 @@ spec:
           value: {{ include "airbyte.database.port" . | quote }}
         - name: POSTGRES_USER
           value: {{ include "airbyte.database.user" . }}
+        {{- if .Values.postgresql.enabled }}
+        - name: POSTGRES_PWD
+          valueFrom:
+            configMapKeyRef:
+              name: airbyte-env
+              key: DATABASE_PASSWORD
+        {{- else }}
         - name: POSTGRES_PWD
           valueFrom:
             secretKeyRef:
               name: {{ include "airbyte.postgresql.secretName" . }}
               key: {{ include "airbyte.database.existingsecret.key" . }}
+        {{- end }}
         - name: POSTGRES_SEEDS
           value: {{ include "airbyte.database.host" . }}
         - name: DYNAMIC_CONFIG_FILE_PATH
@@ -51,6 +59,9 @@ spec:
         volumeMounts:
         - name: airbyte-temporal-dynamicconfig
           mountPath: "/etc/temporal/config/dynamicconfig/"
+        {{- if .Values.server.resources }}
+        resources: {{- toYaml .Values.temporal.resources | nindent 10 }}
+        {{- end }}
       volumes:
       - name: airbyte-temporal-dynamicconfig
         configMap:

--- a/charts/airbyte/templates/worker/deployment.yaml
+++ b/charts/airbyte/templates/worker/deployment.yaml
@@ -51,11 +51,19 @@ spec:
             configMapKeyRef:
               name: airbyte-env
               key: DATABASE_PORT
+        {{- if .Values.postgresql.enabled }}
         - name: DATABASE_PASSWORD
           valueFrom:
             configMapKeyRef:
               name: airbyte-env
               key: DATABASE_PASSWORD
+        {{- else }}
+        - name: DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "airbyte.postgresql.secretName" . }}
+              key: {{ include "airbyte.database.existingsecret.key" . }}
+        {{- end }}
         - name: DATABASE_URL
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
## What
For several helm chart components the db secret was collected in various ways and some components were not able to connect to the db because it was not consistent.

## How
DB secret is fetched in all affected components from the configmap if the postgres helm chart is used otherwise from a secret which is identified by the named template.
