### PR TITLE
suggestion: save state from temporal temporal

### DIFF
--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigPersistence2.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigPersistence2.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.persistence;
+
+import static io.airbyte.db.instance.configs.jooq.Tables.SYNC_STATE;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.State;
+import io.airbyte.db.Database;
+import io.airbyte.db.ExceptionWrappingDatabase;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+import org.jooq.JSONB;
+import org.jooq.Record1;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConfigPersistence2 {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConfigPersistence2.class);
+
+  private final ExceptionWrappingDatabase configDatabase;
+  private final Supplier<Instant> timeSupplier;
+
+  public ConfigPersistence2(final Database configDatabase) {
+    this(configDatabase, Instant::now);
+  }
+
+  @VisibleForTesting
+  ConfigPersistence2(final Database configDatabase, final Supplier<Instant> timeSupplier) {
+    this.configDatabase = new ExceptionWrappingDatabase(configDatabase);
+
+    this.timeSupplier = timeSupplier;
+  }
+
+  public Optional<State> getCurrentState(final UUID connectionId) throws IOException {
+    return configDatabase.query(ctx -> {
+      final Record1<JSONB> record = ctx.select(SYNC_STATE.STATE)
+          .from(SYNC_STATE)
+          .where(SYNC_STATE.SYNC_ID.eq(connectionId))
+          .fetchAny();
+      if (record == null) {
+        return Optional.empty();
+      }
+
+      return Optional.of(Jsons.deserialize(record.value1().data(), State.class));
+    });
+  }
+
+  public void updateSyncState(final UUID connectionId, final State state) throws IOException {
+    final OffsetDateTime now = OffsetDateTime.ofInstant(timeSupplier.get(), ZoneOffset.UTC);
+
+    configDatabase.transaction(
+        ctx -> {
+          final boolean hasExistingRecord = ctx.fetchExists(SYNC_STATE, SYNC_STATE.SYNC_ID.eq(connectionId));
+          if (hasExistingRecord) {
+            LOGGER.info("Updating connection {} state", connectionId);
+            return ctx.update(SYNC_STATE)
+                .set(SYNC_STATE.STATE, JSONB.valueOf(Jsons.serialize(state)))
+                .set(SYNC_STATE.UPDATED_AT, now)
+                .where(SYNC_STATE.SYNC_ID.eq(connectionId))
+                .execute();
+          } else {
+            LOGGER.info("Inserting new state for connection {}", connectionId);
+            return ctx.insertInto(SYNC_STATE)
+                .set(SYNC_STATE.SYNC_ID, connectionId)
+                .set(SYNC_STATE.STATE, JSONB.valueOf(Jsons.serialize(state)))
+                .set(SYNC_STATE.CREATED_AT, now)
+                .set(SYNC_STATE.UPDATED_AT, now)
+                .execute();
+          }
+        });
+  }
+
+}

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigPersistence2Test.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigPersistence2Test.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.persistence;
+
+class ConfigPersistence2Test {}

--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/JobScheduler.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/JobScheduler.java
@@ -9,6 +9,7 @@ import io.airbyte.analytics.TrackingClient;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSync.Status;
 import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigPersistence2;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.scheduler.models.Job;
 import io.airbyte.scheduler.persistence.DefaultJobCreator;
@@ -47,6 +48,7 @@ public class JobScheduler implements Runnable {
   }
 
   public JobScheduler(final JobPersistence jobPersistence,
+                      final ConfigPersistence2 configPersistence2,
                       final ConfigRepository configRepository,
                       final TrackingClient trackingClient) {
     this(
@@ -54,7 +56,7 @@ public class JobScheduler implements Runnable {
         configRepository,
         new ScheduleJobPredicate(Instant::now),
         new DefaultSyncJobFactory(
-            new DefaultJobCreator(jobPersistence),
+            new DefaultJobCreator(jobPersistence, configPersistence2),
             configRepository,
             new OAuthConfigSupplier(configRepository, false, trackingClient)));
   }

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
@@ -12,6 +12,7 @@ import io.airbyte.config.JobSyncConfig;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOperation;
+import io.airbyte.config.persistence.ConfigPersistence2;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.DestinationSyncMode;
 import io.airbyte.protocol.models.SyncMode;
@@ -22,9 +23,11 @@ import java.util.Optional;
 public class DefaultJobCreator implements JobCreator {
 
   private final JobPersistence jobPersistence;
+  private final ConfigPersistence2 configPersistence2;
 
-  public DefaultJobCreator(final JobPersistence jobPersistence) {
+  public DefaultJobCreator(final JobPersistence jobPersistence, final ConfigPersistence2 configPersistence2) {
     this.jobPersistence = jobPersistence;
+    this.configPersistence2 = configPersistence2;
   }
 
   @Override
@@ -49,7 +52,7 @@ public class DefaultJobCreator implements JobCreator {
         .withState(null)
         .withResourceRequirements(standardSync.getResourceRequirements());
 
-    jobPersistence.getCurrentState(standardSync.getConnectionId()).ifPresent(jobSyncConfig::withState);
+    configPersistence2.getCurrentState(standardSync.getConnectionId()).ifPresent(jobSyncConfig::withState);
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(ConfigType.SYNC)

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobPersistence.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobPersistence.java
@@ -7,7 +7,6 @@ package io.airbyte.scheduler.persistence;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.config.JobConfig;
 import io.airbyte.config.JobConfig.ConfigType;
-import io.airbyte.config.State;
 import io.airbyte.db.instance.jobs.JobsDatabaseSchema;
 import io.airbyte.scheduler.models.Job;
 import io.airbyte.scheduler.models.JobStatus;
@@ -146,19 +145,6 @@ public interface JobPersistence {
   List<Job> listJobsWithStatus(JobConfig.ConfigType configType, JobStatus status) throws IOException;
 
   Optional<Job> getLastReplicationJob(UUID connectionId) throws IOException;
-
-  /**
-   * if a job does not succeed, we assume that it synced nothing. that is the most conservative
-   * assumption we can make. as long as all destinations write the final data output in a
-   * transactional way, this will be true. if this changes, then we may end up writing duplicate data
-   * with our incremental append only. this is preferable to failing to send data at all. our
-   * incremental append only most closely resembles a deliver at least once strategy anyway.
-   *
-   * @param connectionId - id of the connection whose state we want to fetch.
-   * @return the current state, if any of, the connection
-   * @throws IOException exception due to interaction with persistence
-   */
-  Optional<State> getCurrentState(UUID connectionId) throws IOException;
 
   Optional<Job> getNextJob() throws IOException;
 

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigurationApiFactory.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigurationApiFactory.java
@@ -8,6 +8,7 @@ import io.airbyte.analytics.TrackingClient;
 import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.config.Configs;
 import io.airbyte.config.persistence.ConfigPersistence;
+import io.airbyte.config.persistence.ConfigPersistence2;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.db.Database;
 import io.airbyte.scheduler.client.CachingSynchronousSchedulerClient;
@@ -23,6 +24,7 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
 
   private static WorkflowServiceStubs temporalService;
   private static ConfigRepository configRepository;
+  private static ConfigPersistence2 configPersistence2;
   private static JobPersistence jobPersistence;
   private static ConfigPersistence seed;
   private static SchedulerJobClient schedulerJobClient;
@@ -37,6 +39,7 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
   public static void setValues(
                                final WorkflowServiceStubs temporalService,
                                final ConfigRepository configRepository,
+                               final ConfigPersistence2 configPersistence2,
                                final JobPersistence jobPersistence,
                                final ConfigPersistence seed,
                                final SchedulerJobClient schedulerJobClient,
@@ -48,6 +51,7 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
                                final Database jobsDatabase,
                                final TrackingClient trackingClient) {
     ConfigurationApiFactory.configRepository = configRepository;
+    ConfigurationApiFactory.configPersistence2 = configPersistence2;
     ConfigurationApiFactory.jobPersistence = jobPersistence;
     ConfigurationApiFactory.seed = seed;
     ConfigurationApiFactory.schedulerJobClient = schedulerJobClient;
@@ -67,6 +71,7 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
 
     return new ConfigurationApi(
         ConfigurationApiFactory.configRepository,
+        ConfigurationApiFactory.configPersistence2,
         ConfigurationApiFactory.jobPersistence,
         ConfigurationApiFactory.seed,
         ConfigurationApiFactory.schedulerJobClient,

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -16,6 +16,7 @@ import io.airbyte.config.EnvConfigs;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.helpers.LogClientSingleton;
 import io.airbyte.config.persistence.ConfigPersistence;
+import io.airbyte.config.persistence.ConfigPersistence2;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.DatabaseConfigPersistence;
 import io.airbyte.config.persistence.YamlSeedConfigPersistence;
@@ -176,6 +177,7 @@ public class ServerApp implements ServerRunnable {
 
     final ConfigRepository configRepository =
         new ConfigRepository(configPersistence.withValidation(), secretsHydrator, secretPersistence, ephemeralSecretPersistence);
+    final ConfigPersistence2 configPersistence2 = new ConfigPersistence2(configDatabase);
 
     LOGGER.info("Creating Scheduler persistence...");
     final Database jobDatabase = new JobsDatabaseInstance(
@@ -183,7 +185,7 @@ public class ServerApp implements ServerRunnable {
         configs.getDatabasePassword(),
         configs.getDatabaseUrl())
             .getAndInitialize();
-    final JobPersistence jobPersistence = new DefaultJobPersistence(jobDatabase, configDatabase);
+    final JobPersistence jobPersistence = new DefaultJobPersistence(jobDatabase);
 
     createDeploymentIfNoneExists(jobPersistence);
 
@@ -209,7 +211,8 @@ public class ServerApp implements ServerRunnable {
     final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService(configs.getTemporalHost());
     final TemporalClient temporalClient = TemporalClient.production(configs.getTemporalHost(), configs.getWorkspaceRoot());
     final OAuthConfigSupplier oAuthConfigSupplier = new OAuthConfigSupplier(configRepository, false, trackingClient);
-    final SchedulerJobClient schedulerJobClient = new DefaultSchedulerJobClient(jobPersistence, new DefaultJobCreator(jobPersistence));
+    final SchedulerJobClient schedulerJobClient =
+        new DefaultSchedulerJobClient(jobPersistence, new DefaultJobCreator(jobPersistence, configPersistence2));
     final DefaultSynchronousSchedulerClient syncSchedulerClient =
         new DefaultSynchronousSchedulerClient(temporalClient, jobTracker, oAuthConfigSupplier);
     final SynchronousSchedulerClient bucketSpecCacheSchedulerClient =
@@ -245,6 +248,7 @@ public class ServerApp implements ServerRunnable {
           cachingSchedulerClient,
           temporalService,
           configRepository,
+          configPersistence2,
           jobPersistence,
           seed,
           configDatabase,

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerFactory.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerFactory.java
@@ -8,6 +8,7 @@ import io.airbyte.analytics.TrackingClient;
 import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.config.Configs;
 import io.airbyte.config.persistence.ConfigPersistence;
+import io.airbyte.config.persistence.ConfigPersistence2;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.db.Database;
 import io.airbyte.scheduler.client.SchedulerJobClient;
@@ -25,6 +26,7 @@ public interface ServerFactory {
                         SpecCachingSynchronousSchedulerClient cachingSchedulerClient,
                         WorkflowServiceStubs temporalService,
                         ConfigRepository configRepository,
+                        ConfigPersistence2 configPersistence2,
                         JobPersistence jobPersistence,
                         ConfigPersistence seed,
                         Database configsDatabase,
@@ -39,6 +41,7 @@ public interface ServerFactory {
                                  final SpecCachingSynchronousSchedulerClient cachingSchedulerClient,
                                  final WorkflowServiceStubs temporalService,
                                  final ConfigRepository configRepository,
+                                 final ConfigPersistence2 configPersistence2,
                                  final JobPersistence jobPersistence,
                                  final ConfigPersistence seed,
                                  final Database configsDatabase,
@@ -49,6 +52,7 @@ public interface ServerFactory {
       ConfigurationApiFactory.setValues(
           temporalService,
           configRepository,
+          configPersistence2,
           jobPersistence,
           seed,
           schedulerJobClient,

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -84,6 +84,7 @@ import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.config.Configs;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigPersistence;
+import io.airbyte.config.persistence.ConfigPersistence2;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.db.Database;
 import io.airbyte.scheduler.client.CachingSynchronousSchedulerClient;
@@ -145,6 +146,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   private final Configs configs;
 
   public ConfigurationApi(final ConfigRepository configRepository,
+                          final ConfigPersistence2 configPersistence2,
                           final JobPersistence jobPersistence,
                           final ConfigPersistence seed,
                           final SchedulerJobClient schedulerJobClient,
@@ -164,6 +166,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
         trackingClient);
     schedulerHandler = new SchedulerHandler(
         configRepository,
+        configPersistence2,
         schedulerJobClient,
         synchronousSchedulerClient,
         jobPersistence,

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -37,6 +37,7 @@ import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.State;
 import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigPersistence2;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.ConnectorSpecification;
@@ -68,7 +69,6 @@ import org.slf4j.LoggerFactory;
 public class SchedulerHandler {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerHandler.class);
-  private static final UUID NO_WORKSPACE = UUID.fromString("00000000-0000-0000-0000-000000000000");
 
   private final ConfigRepository configRepository;
   private final SchedulerJobClient schedulerJobClient;
@@ -80,8 +80,10 @@ public class SchedulerHandler {
   private final JobNotifier jobNotifier;
   private final WorkflowServiceStubs temporalService;
   private final OAuthConfigSupplier oAuthConfigSupplier;
+  private final ConfigPersistence2 configPersistence2;
 
   public SchedulerHandler(final ConfigRepository configRepository,
+                          final ConfigPersistence2 configPersistence2,
                           final SchedulerJobClient schedulerJobClient,
                           final SynchronousSchedulerClient synchronousSchedulerClient,
                           final JobPersistence jobPersistence,
@@ -90,6 +92,7 @@ public class SchedulerHandler {
                           final OAuthConfigSupplier oAuthConfigSupplier) {
     this(
         configRepository,
+        configPersistence2,
         schedulerJobClient,
         synchronousSchedulerClient,
         new ConfigurationUpdate(configRepository, new SpecFetcher(synchronousSchedulerClient)),
@@ -103,6 +106,7 @@ public class SchedulerHandler {
 
   @VisibleForTesting
   SchedulerHandler(final ConfigRepository configRepository,
+                   final ConfigPersistence2 configPersistence2,
                    final SchedulerJobClient schedulerJobClient,
                    final SynchronousSchedulerClient synchronousSchedulerClient,
                    final ConfigurationUpdate configurationUpdate,
@@ -113,6 +117,7 @@ public class SchedulerHandler {
                    final WorkflowServiceStubs temporalService,
                    final OAuthConfigSupplier oAuthConfigSupplier) {
     this.configRepository = configRepository;
+    this.configPersistence2 = configPersistence2;
     this.schedulerJobClient = schedulerJobClient;
     this.synchronousSchedulerClient = synchronousSchedulerClient;
     this.configurationUpdate = configurationUpdate;
@@ -354,7 +359,7 @@ public class SchedulerHandler {
   }
 
   public ConnectionState getState(final ConnectionIdRequestBody connectionIdRequestBody) throws IOException {
-    final Optional<State> currentState = jobPersistence.getCurrentState(connectionIdRequestBody.getConnectionId());
+    final Optional<State> currentState = configPersistence2.getCurrentState(connectionIdRequestBody.getConnectionId());
     LOGGER.info("currentState server: {}", currentState);
 
     final ConnectionState connectionState = new ConnectionState()
@@ -365,6 +370,7 @@ public class SchedulerHandler {
     return connectionState;
   }
 
+  // todo (cgardens) - this method needs a test.
   public JobInfoRead cancelJob(final JobIdRequestBody jobIdRequestBody) throws IOException {
     final long jobId = jobIdRequestBody.getId();
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -105,7 +105,7 @@ public class ArchiveHandlerTest {
   public void setup() throws Exception {
     jobDatabase = new JobsDatabaseInstance(container.getUsername(), container.getPassword(), container.getJdbcUrl()).getAndInitialize();
     configDatabase = new ConfigsDatabaseInstance(container.getUsername(), container.getPassword(), container.getJdbcUrl()).getAndInitialize();
-    jobPersistence = new DefaultJobPersistence(jobDatabase, configDatabase);
+    jobPersistence = new DefaultJobPersistence(jobDatabase);
     seedPersistence = YamlSeedConfigPersistence.getDefault();
     configPersistence = new DatabaseConfigPersistence(jobDatabase);
     configPersistence.replaceAllConfigs(Collections.emptyMap(), false);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
@@ -49,6 +49,7 @@ import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncOperation.OperatorType;
 import io.airbyte.config.State;
 import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigPersistence2;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.CatalogHelpers;
@@ -117,6 +118,7 @@ class SchedulerHandlerTest {
 
   private SchedulerHandler schedulerHandler;
   private ConfigRepository configRepository;
+  private ConfigPersistence2 configPersistence2;
   private Job completedJob;
   private SchedulerJobClient schedulerJobClient;
   private SynchronousSchedulerClient synchronousSchedulerClient;
@@ -140,11 +142,13 @@ class SchedulerHandlerTest {
     schedulerJobClient = spy(SchedulerJobClient.class);
     synchronousSchedulerClient = mock(SynchronousSchedulerClient.class);
     configRepository = mock(ConfigRepository.class);
+    configPersistence2 = mock(ConfigPersistence2.class);
     jobPersistence = mock(JobPersistence.class);
     final JobNotifier jobNotifier = mock(JobNotifier.class);
 
     schedulerHandler = new SchedulerHandler(
         configRepository,
+        configPersistence2,
         schedulerJobClient,
         synchronousSchedulerClient,
         configurationUpdate,
@@ -557,7 +561,7 @@ class SchedulerHandlerTest {
   void testGetCurrentState() throws IOException {
     final UUID connectionId = UUID.randomUUID();
     final State state = new State().withState(Jsons.jsonNode(ImmutableMap.of("checkpoint", 1)));
-    when(jobPersistence.getCurrentState(connectionId)).thenReturn(Optional.of(state));
+    when(configPersistence2.getCurrentState(connectionId)).thenReturn(Optional.of(state));
 
     final ConnectionState connectionState = schedulerHandler.getState(new ConnectionIdRequestBody().connectionId(connectionId));
     assertEquals(new ConnectionState().connectionId(connectionId).state(state.getState()), connectionState);
@@ -566,7 +570,7 @@ class SchedulerHandlerTest {
   @Test
   void testGetCurrentStateEmpty() throws IOException {
     final UUID connectionId = UUID.randomUUID();
-    when(jobPersistence.getCurrentState(connectionId)).thenReturn(Optional.empty());
+    when(configPersistence2.getCurrentState(connectionId)).thenReturn(Optional.empty());
 
     final ConnectionState connectionState = schedulerHandler.getState(new ConnectionIdRequestBody().connectionId(connectionId));
     assertEquals(new ConnectionState().connectionId(connectionId), connectionState);

--- a/airbyte-server/src/test/java/io/airbyte/server/migration/DatabaseArchiverTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/migration/DatabaseArchiverTest.java
@@ -43,7 +43,7 @@ public class DatabaseArchiverTest {
 
     jobDatabase = new JobsDatabaseInstance(container.getUsername(), container.getPassword(), container.getJdbcUrl()).getAndInitialize();
     configDatabase = new ConfigsDatabaseInstance(container.getUsername(), container.getPassword(), container.getJdbcUrl()).getAndInitialize();
-    final JobPersistence persistence = new DefaultJobPersistence(jobDatabase, configDatabase);
+    final JobPersistence persistence = new DefaultJobPersistence(jobDatabase);
     databaseArchiver = new DatabaseArchiver(persistence);
   }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
@@ -363,7 +363,7 @@ public class RunMigrationTest {
 
   @SuppressWarnings("SameParameterValue")
   private JobPersistence getJobPersistence(final File file, final String version) throws IOException {
-    final DefaultJobPersistence jobPersistence = new DefaultJobPersistence(jobDatabase, configDatabase);
+    final DefaultJobPersistence jobPersistence = new DefaultJobPersistence(jobDatabase);
     final Path tempFolder = Files.createTempDirectory(Path.of("/tmp"), "db_init");
     resourceToBeCleanedUp.add(tempFolder.toFile());
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/SyncWorkflow.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/SyncWorkflow.java
@@ -20,6 +20,8 @@ import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncOperation.OperatorType;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.StandardSyncSummary;
+import io.airbyte.config.State;
+import io.airbyte.config.persistence.ConfigPersistence2;
 import io.airbyte.config.persistence.split_secrets.SecretsHydrator;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
@@ -43,11 +45,14 @@ import io.temporal.activity.ActivityCancellationType;
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
 import io.temporal.activity.ActivityOptions;
+import io.temporal.common.RetryOptions;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
 import io.temporal.workflow.WorkflowMethod;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.UUID;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +64,8 @@ public interface SyncWorkflow {
   StandardSyncOutput run(JobRunConfig jobRunConfig,
                          IntegrationLauncherConfig sourceLauncherConfig,
                          IntegrationLauncherConfig destinationLauncherConfig,
-                         StandardSyncInput syncInput);
+                         StandardSyncInput syncInput,
+                         UUID connectionId);
 
   class WorkflowImpl implements SyncWorkflow {
 
@@ -73,15 +79,23 @@ public interface SyncWorkflow {
         .setRetryOptions(TemporalUtils.NO_RETRY)
         .build();
 
+    private static final ActivityOptions persistOptions = options.toBuilder()
+        .setRetryOptions(RetryOptions.newBuilder()
+            .setMaximumAttempts(10)
+            .build())
+        .build();
+
     private final ReplicationActivity replicationActivity = Workflow.newActivityStub(ReplicationActivity.class, options);
     private final NormalizationActivity normalizationActivity = Workflow.newActivityStub(NormalizationActivity.class, options);
     private final DbtTransformationActivity dbtTransformationActivity = Workflow.newActivityStub(DbtTransformationActivity.class, options);
+    private final PersistStateActivity persistActivity = Workflow.newActivityStub(PersistStateActivity.class, persistOptions);
 
     @Override
     public StandardSyncOutput run(final JobRunConfig jobRunConfig,
                                   final IntegrationLauncherConfig sourceLauncherConfig,
                                   final IntegrationLauncherConfig destinationLauncherConfig,
-                                  final StandardSyncInput syncInput) {
+                                  final StandardSyncInput syncInput,
+                                  final UUID connectionId) {
       final StandardSyncOutput run = replicationActivity.replicate(jobRunConfig, sourceLauncherConfig, destinationLauncherConfig, syncInput);
 
       if (syncInput.getOperationSequence() != null && !syncInput.getOperationSequence().isEmpty()) {
@@ -104,6 +118,7 @@ public interface SyncWorkflow {
             LOGGER.error(message);
             throw new IllegalArgumentException(message);
           }
+          persistActivity.persist(connectionId, run);
         }
       }
 
@@ -255,14 +270,12 @@ public interface SyncWorkflow {
     private final Path workspaceRoot;
     private final AirbyteConfigValidator validator;
     private final WorkerEnvironment workerEnvironment;
-    private final String airbyteVersion;
 
     public NormalizationActivityImpl(final ProcessFactory processFactory,
                                      final SecretsHydrator secretsHydrator,
                                      final Path workspaceRoot,
-                                     final WorkerEnvironment workerEnvironment,
-                                     final String airbyteVersion) {
-      this(processFactory, secretsHydrator, workspaceRoot, new AirbyteConfigValidator(), workerEnvironment, airbyteVersion);
+                                     final WorkerEnvironment workerEnvironment) {
+      this(processFactory, secretsHydrator, workspaceRoot, new AirbyteConfigValidator(), workerEnvironment);
     }
 
     @VisibleForTesting
@@ -270,14 +283,12 @@ public interface SyncWorkflow {
                               final SecretsHydrator secretsHydrator,
                               final Path workspaceRoot,
                               final AirbyteConfigValidator validator,
-                              final WorkerEnvironment workerEnvironment,
-                              final String airbyteVersion) {
+                              final WorkerEnvironment workerEnvironment) {
       this.processFactory = processFactory;
       this.secretsHydrator = secretsHydrator;
       this.workspaceRoot = workspaceRoot;
       this.validator = validator;
       this.workerEnvironment = workerEnvironment;
-      this.airbyteVersion = airbyteVersion;
     }
 
     @Override
@@ -335,27 +346,23 @@ public interface SyncWorkflow {
     private final SecretsHydrator secretsHydrator;
     private final Path workspaceRoot;
     private final AirbyteConfigValidator validator;
-    private final String airbyteVersion;
 
     public DbtTransformationActivityImpl(
                                          final ProcessFactory processFactory,
                                          final SecretsHydrator secretsHydrator,
-                                         final Path workspaceRoot,
-                                         final String airbyteVersion) {
-      this(processFactory, secretsHydrator, workspaceRoot, new AirbyteConfigValidator(), airbyteVersion);
+                                         final Path workspaceRoot) {
+      this(processFactory, secretsHydrator, workspaceRoot, new AirbyteConfigValidator());
     }
 
     @VisibleForTesting
     DbtTransformationActivityImpl(final ProcessFactory processFactory,
                                   final SecretsHydrator secretsHydrator,
                                   final Path workspaceRoot,
-                                  final AirbyteConfigValidator validator,
-                                  final String airbyteVersion) {
+                                  final AirbyteConfigValidator validator) {
       this.processFactory = processFactory;
       this.secretsHydrator = secretsHydrator;
       this.workspaceRoot = workspaceRoot;
       this.validator = validator;
-      this.airbyteVersion = airbyteVersion;
     }
 
     @Override
@@ -393,6 +400,42 @@ public interface SyncWorkflow {
               processFactory, NormalizationRunnerFactory.create(
                   destinationLauncherConfig.getDockerImage(),
                   processFactory)));
+    }
+
+  }
+
+  @ActivityInterface
+  interface PersistStateActivity {
+
+    @ActivityMethod
+    boolean persist(final UUID connectionId, final StandardSyncOutput syncOutput);
+
+  }
+
+  class PersistStateActivityImpl implements PersistStateActivity {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PersistStateActivityImpl.class);
+    private final Path workspaceRoot;
+    private final ConfigPersistence2 configPersistence2;
+
+    public PersistStateActivityImpl(final Path workspaceRoot, final ConfigPersistence2 configPersistence2) {
+      this.workspaceRoot = workspaceRoot;
+      this.configPersistence2 = configPersistence2;
+    }
+
+    @Override
+    public boolean persist(final UUID connectionId, final StandardSyncOutput syncOutput) {
+      final State state = syncOutput.getState();
+      if (state != null) {
+        try {
+          configPersistence2.updateSyncState(connectionId, state);
+        } catch (final IOException e) {
+          throw new RuntimeException(e);
+        }
+        return true;
+      } else {
+        return false;
+      }
     }
 
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
@@ -137,7 +137,7 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
           configs.getConfigDatabasePassword(),
           configs.getConfigDatabaseUrl())
               .getInitialized();
-      final JobPersistence jobPersistence = new DefaultJobPersistence(jobDatabase, configDatabase);
+      final JobPersistence jobPersistence = new DefaultJobPersistence(jobDatabase);
       final String workflowId = workflowIdProvider.get();
       jobPersistence.setAttemptTemporalWorkflowId(Long.parseLong(jobRunConfig.getJobId()), jobRunConfig.getAttemptId().intValue(), workflowId);
     }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -78,7 +78,7 @@ public class TemporalClient {
         () -> getWorkflowStub(DiscoverCatalogWorkflow.class, TemporalJobType.DISCOVER_SCHEMA).run(jobRunConfig, launcherConfig, input));
   }
 
-  public TemporalResponse<StandardSyncOutput> submitSync(final long jobId, final int attempt, final JobSyncConfig config) {
+  public TemporalResponse<StandardSyncOutput> submitSync(final long jobId, final int attempt, final JobSyncConfig config, final UUID connectionId) {
     final JobRunConfig jobRunConfig = TemporalUtils.createJobRunConfig(jobId, attempt);
 
     final IntegrationLauncherConfig sourceLauncherConfig = new IntegrationLauncherConfig()
@@ -107,7 +107,8 @@ public class TemporalClient {
             jobRunConfig,
             sourceLauncherConfig,
             destinationLauncherConfig,
-            input));
+            input,
+            connectionId));
   }
 
   private <T> T getWorkflowStub(final Class<T> workflowClass, final TemporalJobType jobType) {


### PR DESCRIPTION
Branching off this PR and thinking about a different approach: https://github.com/airbytehq/airbyte/pull/7219

Main things I'm trying to focus on:
1. save the state from temporal instead the job submitter. more robust to transient db failures because we can retry inside temporal (but we can't in the job submitter)
2. do _not_ add config database as a dependency in the `DefaultJobPersistence`. I think it's important to keep these databases separate in the code.
3. Handling making non-document-database-style queries in the configs database. There are two choices here, and I'm pretty ambivalent between them. See options below.

## Option 1: Separate Abstraction for "complex" queries in the configs db.
In this PR, I added a new persistence abstraction for the config db, called `ConfigPersistence2` (just ignore the bad naming for now, if we go in this direction we can fix it). The new abstraction is akin to what we do for the `JobsPersistence`, it takes in the database and then all the queries we write against that db can go in there. If we go with this approach we will have 3 abstractions. 
    * `ConfigPersistence` - document-database-style interface over the config database.
    * `ConfigRepository` - syntactic sugar over `ConfigPersistence`
    * `ConfigPersistence2` - all _non_ document-database-style queries.
    * as we normalize the config database schema, ConfigPersistence2 will get bigger and `ConfigPersistence` will get deemphasized. 

## Option 2: treat sync state like we do other objects in the configs db
we just add the sync state "table" the `airbyte_configs` table and have it look the same as all of the other configs. Then we worry about normalizing it later when we do it for the rest of the configs.

If we think Option2 is the right thing for now, that's fine with me too. Option 1 leaves us in a halfsey state and if we are not going to normalize the schemas soon, then that's probably a bad thing.