### PR TITLE
🐛 Source Snowflake: Fixed parsing of extreme values for FLOAT and NUMBER data types

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2",
   "name": "Snowflake",
   "dockerRepository": "airbyte/source-snowflake",
-  "dockerImageTag": "0.1.1",
+  "dockerImageTag": "0.1.2",
   "documentationUrl": "https://docs.airbyte.io/integrations/sources/snowflake"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -392,7 +392,7 @@
 - sourceDefinitionId: e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2
   name: Snowflake
   dockerRepository: airbyte/source-snowflake
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   documentationUrl: https://docs.airbyte.io/integrations/sources/snowflake
   sourceType: database
 - sourceDefinitionId: 447e0381-3780-4b46-bb62-00a4e3c8b8e2

--- a/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceAcceptanceTest.java
@@ -909,10 +909,9 @@ public abstract class JdbcSourceAcceptanceTest {
   }
 
   private JsonNode convertIdBasedOnDatabase(final int idValue) {
-    if (getDriverClass().toLowerCase().contains("oracle")) {
+    final var driverClass = getDriverClass().toLowerCase();
+    if (driverClass.contains("oracle") || driverClass.contains("snowflake")) {
       return Jsons.jsonNode(BigDecimal.valueOf(idValue));
-    } else if (getDriverClass().toLowerCase().contains("snowflake")) {
-      return Jsons.jsonNode(Long.valueOf(idValue));
     } else {
       return Jsons.jsonNode(idValue);
     }

--- a/airbyte-integrations/connectors/source-snowflake/Dockerfile
+++ b/airbyte-integrations/connectors/source-snowflake/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/source-snowflake

--- a/airbyte-integrations/connectors/source-snowflake/src/main/java/io.airbyte.integrations.source.snowflake/SnowflakeSource.java
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/java/io.airbyte.integrations.source.snowflake/SnowflakeSource.java
@@ -7,6 +7,7 @@ package io.airbyte.integrations.source.snowflake;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.db.jdbc.JdbcSourceOperations;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
@@ -20,7 +21,7 @@ public class SnowflakeSource extends AbstractJdbcSource implements Source {
   public static final String DRIVER_CLASS = "net.snowflake.client.jdbc.SnowflakeDriver";
 
   public SnowflakeSource() {
-    super(DRIVER_CLASS, new SnowflakeJdbcStreamingQueryConfiguration());
+    super(DRIVER_CLASS, new SnowflakeJdbcStreamingQueryConfiguration(), new SnowflakeSourceOperations());
   }
 
   public static void main(final String[] args) throws Exception {
@@ -50,6 +51,11 @@ public class SnowflakeSource extends AbstractJdbcSource implements Source {
   public Set<String> getExcludedInternalNameSpaces() {
     return Set.of(
         "INFORMATION_SCHEMA");
+  }
+
+  @Override
+  protected JdbcSourceOperations getSourceOperations() {
+    return new SnowflakeSourceOperations();
   }
 
 }

--- a/airbyte-integrations/connectors/source-snowflake/src/main/java/io.airbyte.integrations.source.snowflake/SnowflakeSourceOperations.java
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/java/io.airbyte.integrations.source.snowflake/SnowflakeSourceOperations.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.snowflake;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.airbyte.db.jdbc.JdbcSourceOperations;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class SnowflakeSourceOperations extends JdbcSourceOperations {
+
+  @Override
+  protected void putDouble(final ObjectNode node, final String columnName, final ResultSet resultSet, final int index) {
+    try {
+      final double value = resultSet.getDouble(index);
+      node.put(columnName, value);
+    } catch (final SQLException e) {
+      node.put(columnName, (Double) null);
+    }
+  }
+
+  @Override
+  protected void putBigInt(final ObjectNode node, final String columnName, final ResultSet resultSet, int index) {
+    try {
+      final var value = resultSet.getBigDecimal(index);
+      node.put(columnName, value);
+    } catch (final SQLException e) {
+      node.put(columnName, (BigDecimal) null);
+    }
+  }
+
+}

--- a/airbyte-integrations/connectors/source-snowflake/src/main/java/io.airbyte.integrations.source.snowflake/SnowflakeSourceOperations.java
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/java/io.airbyte.integrations.source.snowflake/SnowflakeSourceOperations.java
@@ -7,7 +7,6 @@ package io.airbyte.integrations.source.snowflake;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.airbyte.db.jdbc.JdbcSourceOperations;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 

--- a/airbyte-integrations/connectors/source-snowflake/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SnowflakeJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-snowflake/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SnowflakeJdbcSourceAcceptanceTest.java
@@ -11,6 +11,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
 import io.airbyte.integrations.source.jdbc.test.JdbcSourceAcceptanceTest;
 import io.airbyte.integrations.source.snowflake.SnowflakeSource;
+import java.math.BigDecimal;
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -42,11 +43,11 @@ class SnowflakeJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest {
     COL_FIRST_NAME = "FIRST_NAME";
     COL_LAST_NAME = "LAST_NAME";
     COL_LAST_NAME_WITH_SPACE = "LAST NAME";
-    ID_VALUE_1 = 1L;
-    ID_VALUE_2 = 2L;
-    ID_VALUE_3 = 3L;
-    ID_VALUE_4 = 4L;
-    ID_VALUE_5 = 5L;
+    ID_VALUE_1 = new BigDecimal(1);
+    ID_VALUE_2 = new BigDecimal(2);
+    ID_VALUE_3 = new BigDecimal(3);
+    ID_VALUE_4 = new BigDecimal(4);
+    ID_VALUE_5 = new BigDecimal(5);
 
     super.setup();
   }

--- a/airbyte-integrations/connectors/source-snowflake/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SnowflakeSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-snowflake/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SnowflakeSourceAcceptanceTest.java
@@ -58,7 +58,7 @@ public class SnowflakeSourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected ConfiguredAirbyteCatalog getConfiguredCatalog() throws Exception {
+  protected ConfiguredAirbyteCatalog getConfiguredCatalog() {
     return new ConfiguredAirbyteCatalog().withStreams(Lists.newArrayList(
         new ConfiguredAirbyteStream()
             .withSyncMode(SyncMode.INCREMENTAL)
@@ -82,12 +82,12 @@ public class SnowflakeSourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected JsonNode getState() throws Exception {
+  protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }
 
   @Override
-  protected List<String> getRegexTests() throws Exception {
+  protected List<String> getRegexTests() {
     return Collections.emptyList();
   }
 

--- a/airbyte-integrations/connectors/source-snowflake/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SnowflakeSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-snowflake/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SnowflakeSourceDatatypeTest.java
@@ -31,7 +31,7 @@ public class SnowflakeSourceDatatypeTest extends AbstractSourceDatabaseTypeTest 
   }
 
   @Override
-  protected JsonNode getConfig() throws Exception {
+  protected JsonNode getConfig() {
     return config;
   }
 
@@ -86,15 +86,12 @@ public class SnowflakeSourceDatatypeTest extends AbstractSourceDatabaseTypeTest 
 
   @Override
   protected void initTests() {
-    // TODO https://github.com/airbytehq/airbyte/issues/4316
-    // should be tested with Snowflake extreme range -99999999999999999999999999999999999999 to
-    // +99999999999999999999999999999999999999 (inclusive)
     addDataTypeTestData(
         TestDataHolder.builder()
             .sourceType("NUMBER")
             .airbyteType(JsonSchemaPrimitive.NUMBER)
-            .addInsertValues("null", "9223372036854775807", "-9223372036854775808")
-            .addExpectedValues(null, "9223372036854775807", "-9223372036854775808")
+            .addInsertValues("null", "99999999999999999999999999999999999999", "-99999999999999999999999999999999999999","9223372036854775807", "-9223372036854775808")
+            .addExpectedValues(null, "99999999999999999999999999999999999999", "-99999999999999999999999999999999999999","9223372036854775807", "-9223372036854775808")
             .build());
     addDataTypeTestData(
         TestDataHolder.builder()
@@ -107,15 +104,15 @@ public class SnowflakeSourceDatatypeTest extends AbstractSourceDatabaseTypeTest 
         TestDataHolder.builder()
             .sourceType("NUMERIC")
             .airbyteType(JsonSchemaPrimitive.NUMBER)
-            .addInsertValues("null", "9223372036854775807", "-9223372036854775808")
-            .addExpectedValues(null, "9223372036854775807", "-9223372036854775808")
+            .addInsertValues("null", "99999999999999999999999999999999999999", "-99999999999999999999999999999999999999", "9223372036854775807", "-9223372036854775808")
+            .addExpectedValues(null, "99999999999999999999999999999999999999", "-99999999999999999999999999999999999999", "9223372036854775807", "-9223372036854775808")
             .build());
     addDataTypeTestData(
         TestDataHolder.builder()
             .sourceType("BIGINT")
             .airbyteType(JsonSchemaPrimitive.NUMBER)
-            .addInsertValues("null", "9223372036854775807", "-9223372036854775808")
-            .addExpectedValues(null, "9223372036854775807", "-9223372036854775808")
+            .addInsertValues("null", "99999999999999999999999999999999999999", "-99999999999999999999999999999999999999")
+            .addExpectedValues(null, "99999999999999999999999999999999999999", "-99999999999999999999999999999999999999")
             .build());
     addDataTypeTestData(
         TestDataHolder.builder()
@@ -174,13 +171,12 @@ public class SnowflakeSourceDatatypeTest extends AbstractSourceDatabaseTypeTest 
             .addInsertValues("10e-308", "10e+307")
             .addExpectedValues("1.0E-307", "1.0E308")
             .build());
-    // TODO should be fixed in scope of https://github.com/airbytehq/airbyte/issues/4316
     addDataTypeTestData(
         TestDataHolder.builder()
             .sourceType("FLOAT")
             .airbyteType(JsonSchemaPrimitive.NUMBER)
             .addInsertValues("'NaN'", "'inf'", "'-inf'")
-            .addExpectedValues(null, null, null)
+            .addExpectedValues("NaN", "Infinity", "-Infinity")
             .build());
 
     // Data Types for Text Strings

--- a/docs/integrations/sources/snowflake.md
+++ b/docs/integrations/sources/snowflake.md
@@ -75,5 +75,6 @@ Your database user should now be ready for use with Airbyte.
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.2 | 2021-10-21 | [](https://github.com/airbytehq/airbyte/pull/) | Fixed parsing of extreme values for FLOAT and NUMBER data types |
 | 0.1.1 | 2021-08-13 | [4699](https://github.com/airbytehq/airbyte/pull/4699) | Added json config validator |
 

--- a/docs/integrations/sources/snowflake.md
+++ b/docs/integrations/sources/snowflake.md
@@ -75,6 +75,6 @@ Your database user should now be ready for use with Airbyte.
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| 0.1.2 | 2021-10-21 | [](https://github.com/airbytehq/airbyte/pull/) | Fixed parsing of extreme values for FLOAT and NUMBER data types |
+| 0.1.2 | 2021-10-21 | [7257](https://github.com/airbytehq/airbyte/pull/7257) | Fixed parsing of extreme values for FLOAT and NUMBER data types |
 | 0.1.1 | 2021-08-13 | [4699](https://github.com/airbytehq/airbyte/pull/4699) | Added json config validator |
 


### PR DESCRIPTION
## What
Connector provides wrong values for a datatype: 
1. For all Data Types for Fixed-point Numbers in Snowflake the range of values is all integer values from -99999999999999999999999999999999999999 to +99999999999999999999999999999999999999 (inclusive), but returned NULL. The MIN and MAX values are Long extreme values.
2. FLOAT - NaN, inf, -inf values is returned as NULL, but should be mapped to Double NaN / POSITIVE_INFINITY / NEGATIVE_INFINITY

## How
Added SnowflakeSourceOperations class with two overrided methods: `putDouble` and `putBigInt`, which contain specific data type handling for Snowflake.

## Recommended reading order
1. `SnowflakeSourceOperations.java`
2. `SnowflakeSourceDatatypeTest.java`

## Pre-merge Checklist
<summary><strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [x] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [x] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [x] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [x] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [x] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</p>