### PR TITLE
Fix docker-compose build of Airbyte

### DIFF
--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -19,8 +19,6 @@ services:
     image: airbyte/scheduler:${VERSION}
     build:
       dockerfile: Dockerfile
-      args:
-        JDK_VERSION: ${JDK_VERSION}
       context: airbyte-scheduler/app
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
@@ -28,9 +26,6 @@ services:
     image: airbyte/worker:${VERSION}
     build:
       dockerfile: Dockerfile
-      args:
-        ARCH: ${DOCKER_BUILD_ARCH}
-        JDK_VERSION: ${JDK_VERSION}
       context: airbyte-workers
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
@@ -38,8 +33,6 @@ services:
     image: airbyte/server:${VERSION}
     build:
       dockerfile: Dockerfile
-      args:
-        JDK_VERSION: ${JDK_VERSION}
       context: airbyte-server
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
@@ -54,8 +47,6 @@ services:
     image: airbyte/migration:${VERSION}
     build:
       dockerfile: Dockerfile
-      args:
-        JDK_VERSION: ${JDK_VERSION}
       context: airbyte-migration
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}


### PR DESCRIPTION
## What
I hit a [failure trying to release OSS airbyte](https://github.com/airbytehq/airbyte/runs/3967668219?check_suite_focus=true) which I'm pretty sure is a consequence of [this PR](https://github.com/airbytehq/airbyte/pull/7104), even after [this fix](https://github.com/airbytehq/airbyte/pull/7184).

## How
The new args (e.g. JDK_VERSION) added to docker-compose aren't being initialised first and end up as empty string making the docker build fail. By removing these, the builds use the default ARG in the dockerfile and all is good. I didn't edit the `docker-compose.build-m1.yaml` so applying unique values for args there should still work if it's necessary