### PR TITLE
🎉 Source Tempo: add oauth support 

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d1aa448b-7c54-498e-ad95-263cbebcd2db.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/d1aa448b-7c54-498e-ad95-263cbebcd2db.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "d1aa448b-7c54-498e-ad95-263cbebcd2db",
   "name": "Tempo",
   "dockerRepository": "airbyte/source-tempo",
-  "dockerImageTag": "0.2.3",
+  "dockerImageTag": "0.2.4",
   "documentationUrl": "https://docs.airbyte.io/integrations/sources/tempo"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -308,7 +308,7 @@
 - sourceDefinitionId: d1aa448b-7c54-498e-ad95-263cbebcd2db
   name: Tempo
   dockerRepository: airbyte/source-tempo
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.2.4
   documentationUrl: https://docs.airbyte.io/integrations/sources/tempo
   sourceType: api
 - sourceDefinitionId: 4bfac00d-ce15-44ff-95b9-9e3c3e8fbd35

--- a/airbyte-integrations/connectors/source-tempo/Dockerfile
+++ b/airbyte-integrations/connectors/source-tempo/Dockerfile
@@ -14,5 +14,5 @@ RUN pip install .
 
 ENV AIRBYTE_ENTRYPOINT "/airbyte/base.sh"
 
-LABEL io.airbyte.version=0.2.3
+LABEL io.airbyte.version=0.2.4
 LABEL io.airbyte.name=airbyte/source-tempo

--- a/airbyte-integrations/connectors/source-tempo/setup.py
+++ b/airbyte-integrations/connectors/source-tempo/setup.py
@@ -5,12 +5,25 @@
 
 from setuptools import find_packages, setup
 
+MAIN_REQUIREMENTS = [
+    "airbyte-protocol",
+    "base-python",
+    "airbyte-cdk"
+]
+
+TEST_REQUIREMENTS = [
+    "pytest~=6.1"
+]
+
 setup(
     name="source_tempo",
     description="Source implementation for Tempo.",
     author="Thomas van Latum",
     author_email="thomas@gcompany.nl",
     packages=find_packages(),
-    install_requires=["airbyte-protocol", "base-python", "requests", "pytest==6.1.2"],
+    install_requires=MAIN_REQUIREMENTS,
     package_data={"": ["*.json", "schemas/*.json"]},
+    extras_require={
+        "tests": TEST_REQUIREMENTS,
+    },
 )

--- a/airbyte-integrations/connectors/source-tempo/source_tempo/spec.json
+++ b/airbyte-integrations/connectors/source-tempo/source_tempo/spec.json
@@ -4,13 +4,70 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Tempo Spec",
     "type": "object",
-    "required": ["api_token"],
+    "required": ["authorization"],
     "additionalProperties": false,
     "properties": {
-      "api_token": {
-        "type": "string",
-        "description": "Tempo API Token.",
-        "airbyte_secret": true
+      "authorization": {
+        "type": "object",
+        "title": "Authentication Type",
+        "oneOf": [
+          {
+            "title": "Authenticate via Oauth",
+            "type": "object",
+            "required": [
+              "auth_type",
+              "client_id",
+              "client_secret",
+              "refresh_token"
+            ],
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "Client",
+                "enum": ["Client"],
+                "default": "Client",
+                "order": 0
+              },
+              "client_id": {
+                "title": "Client ID",
+                "type": "string",
+                "description": "The Client ID of your developer application",
+                "airbyte_secret": true
+              },
+              "client_secret": {
+                "title": "Client Secret",
+                "type": "string",
+                "description": "The client secret of your developer application",
+                "airbyte_secret": true
+              },
+              "refresh_token": {
+                "title": "Refresh Token",
+                "type": "string",
+                "description": "A refresh token generated using the above client ID and secret",
+                "airbyte_secret": true
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "Authentication via API Token",
+            "required": ["auth_type",  "api_token"],
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "Token",
+                "enum": ["Token"],
+                "default": "Token",
+                "order": 0
+              },
+              "api_token": {
+                "type": "string",
+                "description": "Tempo API Token.",
+                "airbyte_secret": true
+              }
+            }
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
## What
Closes airbytehq/airbyte-internal-issues#261 

#### Community member or Airbyter
   
- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
