### PR TITLE
fetch specs from definitions directly

### DIFF
--- a/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/BucketSpecCacheSchedulerClient.java
+++ b/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/BucketSpecCacheSchedulerClient.java
@@ -23,9 +23,7 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,16 +81,7 @@ public class BucketSpecCacheSchedulerClient implements SynchronousSchedulerClien
 
     if (cachedSpecOptional.isPresent()) {
       LOGGER.debug("Spec bucket cache: Cache hit.");
-      final long now = Instant.now().toEpochMilli();
-      final SynchronousJobMetadata mockMetadata = new SynchronousJobMetadata(
-          UUID.randomUUID(),
-          ConfigType.GET_SPEC,
-          null,
-          now,
-          now,
-          true,
-          null);
-      return new SynchronousResponse<>(cachedSpecOptional.get(), mockMetadata);
+      return new SynchronousResponse<>(cachedSpecOptional.get(), SynchronousJobMetadata.mock(ConfigType.GET_SPEC));
     } else {
       LOGGER.debug("Spec bucket cache: Cache miss.");
       return client.createGetSpecJob(dockerImage);

--- a/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/SynchronousJobMetadata.java
+++ b/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/SynchronousJobMetadata.java
@@ -130,4 +130,5 @@ public class SynchronousJobMetadata {
         succeeded,
         logPath);
   }
+
 }

--- a/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/SynchronousJobMetadata.java
+++ b/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/SynchronousJobMetadata.java
@@ -7,6 +7,7 @@ package io.airbyte.scheduler.client;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.workers.temporal.JobMetadata;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -114,4 +115,20 @@ public class SynchronousJobMetadata {
         '}';
   }
 
+  public static SynchronousJobMetadata mock(final ConfigType configType) {
+    final long now = Instant.now().toEpochMilli();
+    final UUID configId = null;
+    final boolean succeeded = true;
+    final Path logPath = null;
+
+    return new SynchronousJobMetadata(
+        UUID.randomUUID(),
+        configType,
+        configId,
+        now,
+        now,
+        succeeded,
+        logPath
+    );
+  }
 }

--- a/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/SynchronousJobMetadata.java
+++ b/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/SynchronousJobMetadata.java
@@ -128,7 +128,6 @@ public class SynchronousJobMetadata {
         now,
         now,
         succeeded,
-        logPath
-    );
+        logPath);
   }
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -70,8 +70,9 @@ public class ServerApp implements ServerRunnable {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerApp.class);
   private static final int PORT = 8001;
   /**
-   * We can't support automatic migration for kube before this version because we had a bug in kube which would cause airbyte db to erase state upon
-   * termination, as a result the automatic migration wouldn't run
+   * We can't support automatic migration for kube before this version because we had a bug in kube
+   * which would cause airbyte db to erase state upon termination, as a result the automatic migration
+   * wouldn't run
    */
   private static final AirbyteVersion KUBE_SUPPORT_FOR_AUTOMATIC_MIGRATION = new AirbyteVersion("0.26.5-alpha");
   private final String airbyteVersion;
@@ -79,8 +80,8 @@ public class ServerApp implements ServerRunnable {
   private final Set<Object> customComponents;
 
   public ServerApp(final String airbyteVersion,
-      final Set<Class<?>> customComponentClasses,
-      final Set<Object> customComponents) {
+                   final Set<Class<?>> customComponentClasses,
+                   final Set<Object> customComponents) {
     this.airbyteVersion = airbyteVersion;
     this.customComponentClasses = customComponentClasses;
     this.customComponents = customComponents;
@@ -166,7 +167,7 @@ public class ServerApp implements ServerRunnable {
         configs.getConfigDatabaseUser(),
         configs.getConfigDatabasePassword(),
         configs.getConfigDatabaseUrl())
-        .getAndInitialize();
+            .getAndInitialize();
     final DatabaseConfigPersistence configPersistence = new DatabaseConfigPersistence(configDatabase);
     configPersistence.migrateFileConfigs(configs);
 
@@ -182,7 +183,7 @@ public class ServerApp implements ServerRunnable {
         configs.getDatabaseUser(),
         configs.getDatabasePassword(),
         configs.getDatabaseUrl())
-        .getAndInitialize();
+            .getAndInitialize();
     final JobPersistence jobPersistence = new DefaultJobPersistence(jobDatabase);
 
     createDeploymentIfNoneExists(jobPersistence);
@@ -262,14 +263,15 @@ public class ServerApp implements ServerRunnable {
   }
 
   /**
-   * Ideally when automatic migration runs, we should make sure that we acquire a lock on database and no other operation is allowed
+   * Ideally when automatic migration runs, we should make sure that we acquire a lock on database and
+   * no other operation is allowed
    */
   private static void runAutomaticMigration(final ConfigRepository configRepository,
-      final JobPersistence jobPersistence,
-      final ConfigPersistence seed,
-      final SpecFetcher specFetcher,
-      final String airbyteVersion,
-      final String airbyteDatabaseVersion) {
+                                            final JobPersistence jobPersistence,
+                                            final ConfigPersistence seed,
+                                            final SpecFetcher specFetcher,
+                                            final String airbyteVersion,
+                                            final String airbyteDatabaseVersion) {
     LOGGER.info("Running Automatic Migration from version : " + airbyteDatabaseVersion + " to version : " + airbyteVersion);
     try (final RunMigration runMigration = new RunMigration(
         jobPersistence,

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -70,9 +70,8 @@ public class ServerApp implements ServerRunnable {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerApp.class);
   private static final int PORT = 8001;
   /**
-   * We can't support automatic migration for kube before this version because we had a bug in kube
-   * which would cause airbyte db to erase state upon termination, as a result the automatic migration
-   * wouldn't run
+   * We can't support automatic migration for kube before this version because we had a bug in kube which would cause airbyte db to erase state upon
+   * termination, as a result the automatic migration wouldn't run
    */
   private static final AirbyteVersion KUBE_SUPPORT_FOR_AUTOMATIC_MIGRATION = new AirbyteVersion("0.26.5-alpha");
   private final String airbyteVersion;
@@ -80,8 +79,8 @@ public class ServerApp implements ServerRunnable {
   private final Set<Object> customComponents;
 
   public ServerApp(final String airbyteVersion,
-                   final Set<Class<?>> customComponentClasses,
-                   final Set<Object> customComponents) {
+      final Set<Class<?>> customComponentClasses,
+      final Set<Object> customComponents) {
     this.airbyteVersion = airbyteVersion;
     this.customComponentClasses = customComponentClasses;
     this.customComponents = customComponents;
@@ -167,7 +166,7 @@ public class ServerApp implements ServerRunnable {
         configs.getConfigDatabaseUser(),
         configs.getConfigDatabasePassword(),
         configs.getConfigDatabaseUrl())
-            .getAndInitialize();
+        .getAndInitialize();
     final DatabaseConfigPersistence configPersistence = new DatabaseConfigPersistence(configDatabase);
     configPersistence.migrateFileConfigs(configs);
 
@@ -183,7 +182,7 @@ public class ServerApp implements ServerRunnable {
         configs.getDatabaseUser(),
         configs.getDatabasePassword(),
         configs.getDatabaseUrl())
-            .getAndInitialize();
+        .getAndInitialize();
     final JobPersistence jobPersistence = new DefaultJobPersistence(jobDatabase);
 
     createDeploymentIfNoneExists(jobPersistence);
@@ -219,7 +218,7 @@ public class ServerApp implements ServerRunnable {
     final SpecFetcher specFetcher = new SpecFetcher(cachingSchedulerClient);
 
     // required before migration
-    configRepository.setSpecFetcher(dockerImage -> Exceptions.toRuntime(() -> specFetcher.execute(dockerImage)));
+    configRepository.setSpecFetcher(dockerImage -> Exceptions.toRuntime(() -> specFetcher.getSpec(dockerImage)));
 
     Optional<String> airbyteDatabaseVersion = jobPersistence.getVersion();
     if (airbyteDatabaseVersion.isPresent() && isDatabaseVersionBehindAppVersion(airbyteVersion, airbyteDatabaseVersion.get())) {
@@ -263,15 +262,14 @@ public class ServerApp implements ServerRunnable {
   }
 
   /**
-   * Ideally when automatic migration runs, we should make sure that we acquire a lock on database and
-   * no other operation is allowed
+   * Ideally when automatic migration runs, we should make sure that we acquire a lock on database and no other operation is allowed
    */
   private static void runAutomaticMigration(final ConfigRepository configRepository,
-                                            final JobPersistence jobPersistence,
-                                            final ConfigPersistence seed,
-                                            final SpecFetcher specFetcher,
-                                            final String airbyteVersion,
-                                            final String airbyteDatabaseVersion) {
+      final JobPersistence jobPersistence,
+      final ConfigPersistence seed,
+      final SpecFetcher specFetcher,
+      final String airbyteVersion,
+      final String airbyteDatabaseVersion) {
     LOGGER.info("Running Automatic Migration from version : " + airbyteDatabaseVersion + " to version : " + airbyteVersion);
     try (final RunMigration runMigration = new RunMigration(
         jobPersistence,

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -218,7 +218,7 @@ public class ServerApp implements ServerRunnable {
     final SpecFetcher specFetcher = new SpecFetcher(cachingSchedulerClient);
 
     // required before migration
-    // TODO: remove this specFetcherFn logic once specs are a required field of the source/dest definitions
+    // TODO: remove this specFetcherFn logic once file migrations are deprecated
     configRepository.setSpecFetcher(dockerImage -> Exceptions.toRuntime(() -> specFetcher.getSpec(dockerImage)));
 
     Optional<String> airbyteDatabaseVersion = jobPersistence.getVersion();

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -70,8 +70,9 @@ public class ServerApp implements ServerRunnable {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerApp.class);
   private static final int PORT = 8001;
   /**
-   * We can't support automatic migration for kube before this version because we had a bug in kube which would cause airbyte db to erase state upon
-   * termination, as a result the automatic migration wouldn't run
+   * We can't support automatic migration for kube before this version because we had a bug in kube
+   * which would cause airbyte db to erase state upon termination, as a result the automatic migration
+   * wouldn't run
    */
   private static final AirbyteVersion KUBE_SUPPORT_FOR_AUTOMATIC_MIGRATION = new AirbyteVersion("0.26.5-alpha");
   private final String airbyteVersion;
@@ -166,7 +167,7 @@ public class ServerApp implements ServerRunnable {
         configs.getConfigDatabaseUser(),
         configs.getConfigDatabasePassword(),
         configs.getConfigDatabaseUrl())
-        .getAndInitialize();
+            .getAndInitialize();
     final DatabaseConfigPersistence configPersistence = new DatabaseConfigPersistence(configDatabase);
     configPersistence.migrateFileConfigs(configs);
 
@@ -182,7 +183,7 @@ public class ServerApp implements ServerRunnable {
         configs.getDatabaseUser(),
         configs.getDatabasePassword(),
         configs.getDatabaseUrl())
-        .getAndInitialize();
+            .getAndInitialize();
     final JobPersistence jobPersistence = new DefaultJobPersistence(jobDatabase);
 
     createDeploymentIfNoneExists(jobPersistence);
@@ -263,7 +264,8 @@ public class ServerApp implements ServerRunnable {
   }
 
   /**
-   * Ideally when automatic migration runs, we should make sure that we acquire a lock on database and no other operation is allowed
+   * Ideally when automatic migration runs, we should make sure that we acquire a lock on database and
+   * no other operation is allowed
    */
   private static void runAutomaticMigration(final ConfigRepository configRepository,
                                             final JobPersistence jobPersistence,

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -70,9 +70,8 @@ public class ServerApp implements ServerRunnable {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerApp.class);
   private static final int PORT = 8001;
   /**
-   * We can't support automatic migration for kube before this version because we had a bug in kube
-   * which would cause airbyte db to erase state upon termination, as a result the automatic migration
-   * wouldn't run
+   * We can't support automatic migration for kube before this version because we had a bug in kube which would cause airbyte db to erase state upon
+   * termination, as a result the automatic migration wouldn't run
    */
   private static final AirbyteVersion KUBE_SUPPORT_FOR_AUTOMATIC_MIGRATION = new AirbyteVersion("0.26.5-alpha");
   private final String airbyteVersion;
@@ -167,7 +166,7 @@ public class ServerApp implements ServerRunnable {
         configs.getConfigDatabaseUser(),
         configs.getConfigDatabasePassword(),
         configs.getConfigDatabaseUrl())
-            .getAndInitialize();
+        .getAndInitialize();
     final DatabaseConfigPersistence configPersistence = new DatabaseConfigPersistence(configDatabase);
     configPersistence.migrateFileConfigs(configs);
 
@@ -183,7 +182,7 @@ public class ServerApp implements ServerRunnable {
         configs.getDatabaseUser(),
         configs.getDatabasePassword(),
         configs.getDatabaseUrl())
-            .getAndInitialize();
+        .getAndInitialize();
     final JobPersistence jobPersistence = new DefaultJobPersistence(jobDatabase);
 
     createDeploymentIfNoneExists(jobPersistence);
@@ -219,6 +218,7 @@ public class ServerApp implements ServerRunnable {
     final SpecFetcher specFetcher = new SpecFetcher(cachingSchedulerClient);
 
     // required before migration
+    // TODO: remove this specFetcherFn logic once specs are a required field of the source/dest definitions
     configRepository.setSpecFetcher(dockerImage -> Exceptions.toRuntime(() -> specFetcher.getSpec(dockerImage)));
 
     Optional<String> airbyteDatabaseVersion = jobPersistence.getVersion();
@@ -263,8 +263,7 @@ public class ServerApp implements ServerRunnable {
   }
 
   /**
-   * Ideally when automatic migration runs, we should make sure that we acquire a lock on database and
-   * no other operation is allowed
+   * Ideally when automatic migration runs, we should make sure that we acquire a lock on database and no other operation is allowed
    */
   private static void runAutomaticMigration(final ConfigRepository configRepository,
                                             final JobPersistence jobPersistence,

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/ConfigurationUpdate.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/ConfigurationUpdate.java
@@ -41,7 +41,7 @@ public class ConfigurationUpdate {
     persistedSource.setName(sourceName);
     // get spec
     final StandardSourceDefinition sourceDefinition = configRepository.getStandardSourceDefinition(persistedSource.getSourceDefinitionId());
-    final ConnectorSpecification spec = specFetcher.execute(sourceDefinition);
+    final ConnectorSpecification spec = specFetcher.getSpec(sourceDefinition);
     // copy any necessary secrets from the current source to the incoming updated source
     final JsonNode updatedConfiguration = secretsProcessor.copySecrets(
         persistedSource.getConfiguration(),
@@ -59,7 +59,7 @@ public class ConfigurationUpdate {
     // get spec
     final StandardDestinationDefinition destinationDefinition = configRepository
         .getStandardDestinationDefinition(persistedDestination.getDestinationDefinitionId());
-    final ConnectorSpecification spec = specFetcher.execute(destinationDefinition);
+    final ConnectorSpecification spec = specFetcher.getSpec(destinationDefinition);
     // copy any necessary secrets from the current destination to the incoming updated destination
     final JsonNode updatedConfiguration = secretsProcessor.copySecrets(
         persistedDestination.getConfiguration(),

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/ConfigurationUpdate.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/ConfigurationUpdate.java
@@ -5,7 +5,6 @@
 package io.airbyte.server.converters;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
@@ -42,8 +41,7 @@ public class ConfigurationUpdate {
     persistedSource.setName(sourceName);
     // get spec
     final StandardSourceDefinition sourceDefinition = configRepository.getStandardSourceDefinition(persistedSource.getSourceDefinitionId());
-    final String imageName = DockerUtils.getTaggedImageName(sourceDefinition.getDockerRepository(), sourceDefinition.getDockerImageTag());
-    final ConnectorSpecification spec = specFetcher.execute(imageName);
+    final ConnectorSpecification spec = specFetcher.execute(sourceDefinition);
     // copy any necessary secrets from the current source to the incoming updated source
     final JsonNode updatedConfiguration = secretsProcessor.copySecrets(
         persistedSource.getConfiguration(),
@@ -61,8 +59,7 @@ public class ConfigurationUpdate {
     // get spec
     final StandardDestinationDefinition destinationDefinition = configRepository
         .getStandardDestinationDefinition(persistedDestination.getDestinationDefinitionId());
-    final String imageName = DockerUtils.getTaggedImageName(destinationDefinition.getDockerRepository(), destinationDefinition.getDockerImageTag());
-    final ConnectorSpecification spec = specFetcher.execute(imageName);
+    final ConnectorSpecification spec = specFetcher.execute(destinationDefinition);
     // copy any necessary secrets from the current destination to the incoming updated destination
     final JsonNode updatedConfiguration = secretsProcessor.copySecrets(
         persistedDestination.getConfiguration(),

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
@@ -80,8 +80,7 @@ public class SpecFetcher {
         now,
         now,
         true,
-        null
-    );
+        null);
   }
 
   private static ConnectorSpecification getSpecFromJob(final SynchronousResponse<ConnectorSpecification> response) {

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
@@ -6,14 +6,22 @@ package io.airbyte.server.converters;
 
 import com.google.common.base.Preconditions;
 import io.airbyte.commons.docker.DockerUtils;
+import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.protocol.models.ConnectorSpecification;
+import io.airbyte.scheduler.client.SynchronousJobMetadata;
 import io.airbyte.scheduler.client.SynchronousResponse;
 import io.airbyte.scheduler.client.SynchronousSchedulerClient;
 import java.io.IOException;
+import java.time.Instant;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SpecFetcher {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SpecFetcher.class);
 
   private final SynchronousSchedulerClient schedulerJobClient;
 
@@ -21,30 +29,59 @@ public class SpecFetcher {
     this.schedulerJobClient = schedulerJobClient;
   }
 
-  public ConnectorSpecification execute(final String dockerImage) throws IOException {
+  public ConnectorSpecification getSpec(final String dockerImage) throws IOException {
     return getSpecFromJob(schedulerJobClient.createGetSpecJob(dockerImage));
   }
 
-  public ConnectorSpecification execute(final StandardSourceDefinition sourceDefinition) throws IOException {
-    final ConnectorSpecification spec = sourceDefinition.getSpec();
-
-    if (spec != null) {
-      return spec;
-    }
-
-    final String dockerImageName = DockerUtils.getTaggedImageName(sourceDefinition.getDockerRepository(), sourceDefinition.getDockerImageTag());
-    return getSpecFromJob(schedulerJobClient.createGetSpecJob(dockerImageName));
+  public ConnectorSpecification getSpec(final StandardSourceDefinition sourceDefinition) throws IOException {
+    return getSpecFromJob(getSpecJobResponse(sourceDefinition));
   }
 
-  public ConnectorSpecification execute(final StandardDestinationDefinition sourceDefinition) throws IOException {
+  public ConnectorSpecification getSpec(final StandardDestinationDefinition destinationDefinition) throws IOException {
+    return getSpecFromJob(getSpecJobResponse(destinationDefinition));
+  }
+
+  public SynchronousResponse<ConnectorSpecification> getSpecJobResponse(final StandardSourceDefinition sourceDefinition) throws IOException {
+    LOGGER.debug("Spec Fetcher: Getting spec for Source Definition.");
     final ConnectorSpecification spec = sourceDefinition.getSpec();
 
     if (spec != null) {
-      return spec;
+      LOGGER.debug("Spec Fetcher: Spec found in Source Definition.");
+      return new SynchronousResponse<>(spec, mockJobMetadata());
     }
 
+    LOGGER.debug("Spec Fetcher: Spec not found in Source Definition, fetching with scheduler job instead.");
     final String dockerImageName = DockerUtils.getTaggedImageName(sourceDefinition.getDockerRepository(), sourceDefinition.getDockerImageTag());
-    return getSpecFromJob(schedulerJobClient.createGetSpecJob(dockerImageName));
+    return schedulerJobClient.createGetSpecJob(dockerImageName);
+  }
+
+  public SynchronousResponse<ConnectorSpecification> getSpecJobResponse(final StandardDestinationDefinition destinationDefinition)
+      throws IOException {
+    LOGGER.debug("Spec Fetcher: Getting spec for Destination Definition.");
+    final ConnectorSpecification spec = destinationDefinition.getSpec();
+
+    if (spec != null) {
+      LOGGER.debug("Spec Fetcher: Spec found in Destination Definition.");
+      return new SynchronousResponse<>(spec, mockJobMetadata());
+    }
+
+    LOGGER.debug("Spec Fetcher: Spec not found in Destination Definition, fetching with scheduler job instead.");
+    final String dockerImageName = DockerUtils.getTaggedImageName(destinationDefinition.getDockerRepository(),
+        destinationDefinition.getDockerImageTag());
+    return schedulerJobClient.createGetSpecJob(dockerImageName);
+  }
+
+  private static SynchronousJobMetadata mockJobMetadata() {
+    final long now = Instant.now().toEpochMilli();
+    return new SynchronousJobMetadata(
+        UUID.randomUUID(),
+        ConfigType.GET_SPEC,
+        null,
+        now,
+        now,
+        true,
+        null
+    );
   }
 
   private static ConnectorSpecification getSpecFromJob(final SynchronousResponse<ConnectorSpecification> response) {

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
@@ -5,6 +5,9 @@
 package io.airbyte.server.converters;
 
 import com.google.common.base.Preconditions;
+import io.airbyte.commons.docker.DockerUtils;
+import io.airbyte.config.StandardDestinationDefinition;
+import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.client.SynchronousResponse;
 import io.airbyte.scheduler.client.SynchronousSchedulerClient;
@@ -20,6 +23,28 @@ public class SpecFetcher {
 
   public ConnectorSpecification execute(final String dockerImage) throws IOException {
     return getSpecFromJob(schedulerJobClient.createGetSpecJob(dockerImage));
+  }
+
+  public ConnectorSpecification execute(final StandardSourceDefinition sourceDefinition) throws IOException {
+    final ConnectorSpecification spec = sourceDefinition.getSpec();
+
+    if (spec != null) {
+      return spec;
+    }
+
+    final String dockerImageName = DockerUtils.getTaggedImageName(sourceDefinition.getDockerRepository(), sourceDefinition.getDockerImageTag());
+    return getSpecFromJob(schedulerJobClient.createGetSpecJob(dockerImageName));
+  }
+
+  public ConnectorSpecification execute(final StandardDestinationDefinition sourceDefinition) throws IOException {
+    final ConnectorSpecification spec = sourceDefinition.getSpec();
+
+    if (spec != null) {
+      return spec;
+    }
+
+    final String dockerImageName = DockerUtils.getTaggedImageName(sourceDefinition.getDockerRepository(), sourceDefinition.getDockerImageTag());
+    return getSpecFromJob(schedulerJobClient.createGetSpecJob(dockerImageName));
   }
 
   private static ConnectorSpecification getSpecFromJob(final SynchronousResponse<ConnectorSpecification> response) {

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
@@ -27,6 +27,8 @@ public class SpecFetcher {
     this.schedulerJobClient = schedulerJobClient;
   }
 
+  // TODO: remove this once file migrations are deprecated, as that is the only time this function is used
+  @Deprecated
   public ConnectorSpecification getSpec(final String dockerImage) throws IOException {
     return getSpecFromJob(schedulerJobClient.createGetSpecJob(dockerImage));
   }
@@ -73,7 +75,7 @@ public class SpecFetcher {
     return schedulerJobClient.createGetSpecJob(dockerImageName);
   }
 
-  private static ConnectorSpecification getSpecFromJob(final SynchronousResponse<ConnectorSpecification> response) {
+  public static ConnectorSpecification getSpecFromJob(final SynchronousResponse<ConnectorSpecification> response) {
     Preconditions.checkState(response.isSuccess(), "Get Spec job failed.");
     Preconditions.checkNotNull(response.getOutput(), "Get Spec job return null spec");
 

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
@@ -66,8 +66,9 @@ public class SpecFetcher {
     }
 
     LOGGER.debug("Spec Fetcher: Spec not found in Destination Definition, fetching with scheduler job instead.");
-    final String dockerImageName = DockerUtils.getTaggedImageName(destinationDefinition.getDockerRepository(),
-                                                                  destinationDefinition.getDockerImageTag());
+    final String dockerImageName = DockerUtils.getTaggedImageName(
+        destinationDefinition.getDockerRepository(),
+        destinationDefinition.getDockerImageTag());
     return schedulerJobClient.createGetSpecJob(dockerImageName);
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
@@ -14,8 +14,6 @@ import io.airbyte.scheduler.client.SynchronousJobMetadata;
 import io.airbyte.scheduler.client.SynchronousResponse;
 import io.airbyte.scheduler.client.SynchronousSchedulerClient;
 import java.io.IOException;
-import java.time.Instant;
-import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +45,7 @@ public class SpecFetcher {
 
     if (spec != null) {
       LOGGER.debug("Spec Fetcher: Spec found in Source Definition.");
-      return new SynchronousResponse<>(spec, mockJobMetadata());
+      return new SynchronousResponse<>(spec, SynchronousJobMetadata.mock(ConfigType.GET_SPEC));
     }
 
     LOGGER.debug("Spec Fetcher: Spec not found in Source Definition, fetching with scheduler job instead.");
@@ -62,25 +60,13 @@ public class SpecFetcher {
 
     if (spec != null) {
       LOGGER.debug("Spec Fetcher: Spec found in Destination Definition.");
-      return new SynchronousResponse<>(spec, mockJobMetadata());
+      return new SynchronousResponse<>(spec, SynchronousJobMetadata.mock(ConfigType.GET_SPEC));
     }
 
     LOGGER.debug("Spec Fetcher: Spec not found in Destination Definition, fetching with scheduler job instead.");
     final String dockerImageName = DockerUtils.getTaggedImageName(destinationDefinition.getDockerRepository(),
-        destinationDefinition.getDockerImageTag());
+                                                                  destinationDefinition.getDockerImageTag());
     return schedulerJobClient.createGetSpecJob(dockerImageName);
-  }
-
-  private static SynchronousJobMetadata mockJobMetadata() {
-    final long now = Instant.now().toEpochMilli();
-    return new SynchronousJobMetadata(
-        UUID.randomUUID(),
-        ConfigType.GET_SPEC,
-        null,
-        now,
-        now,
-        true,
-        null);
   }
 
   private static ConnectorSpecification getSpecFromJob(final SynchronousResponse<ConnectorSpecification> response) {

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
@@ -39,6 +39,7 @@ public class SpecFetcher {
     return getSpecFromJob(getSpecJobResponse(destinationDefinition));
   }
 
+  // TODO: remove this method once the spec is a required field on the StandardSourceDefinition struct
   public SynchronousResponse<ConnectorSpecification> getSpecJobResponse(final StandardSourceDefinition sourceDefinition) throws IOException {
     LOGGER.debug("Spec Fetcher: Getting spec for Source Definition.");
     final ConnectorSpecification spec = sourceDefinition.getSpec();
@@ -53,6 +54,7 @@ public class SpecFetcher {
     return schedulerJobClient.createGetSpecJob(dockerImageName);
   }
 
+  // TODO: remove this method once the spec is a required field on the StandardDestinationDefinition struct
   public SynchronousResponse<ConnectorSpecification> getSpecJobResponse(final StandardDestinationDefinition destinationDefinition)
       throws IOException {
     LOGGER.debug("Spec Fetcher: Getting spec for Destination Definition.");

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
@@ -27,7 +27,8 @@ public class SpecFetcher {
     this.schedulerJobClient = schedulerJobClient;
   }
 
-  // TODO: remove this once file migrations are deprecated, as that is the only time this function is used
+  // TODO: remove this once file migrations are deprecated, as that is the only time this function is
+  // used
   @Deprecated
   public ConnectorSpecification getSpec(final String dockerImage) throws IOException {
     return getSpecFromJob(schedulerJobClient.createGetSpecJob(dockerImage));

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/SpecFetcher.java
@@ -54,7 +54,8 @@ public class SpecFetcher {
     return schedulerJobClient.createGetSpecJob(dockerImageName);
   }
 
-  // TODO: remove this method once the spec is a required field on the StandardDestinationDefinition struct
+  // TODO: remove this method once the spec is a required field on the StandardDestinationDefinition
+  // struct
   public SynchronousResponse<ConnectorSpecification> getSpecJobResponse(final StandardDestinationDefinition destinationDefinition)
       throws IOException {
     LOGGER.debug("Spec Fetcher: Getting spec for Destination Definition.");

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
@@ -15,7 +15,6 @@ import io.airbyte.api.model.DestinationReadList;
 import io.airbyte.api.model.DestinationSearch;
 import io.airbyte.api.model.DestinationUpdate;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
-import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.DestinationConnection;
@@ -49,12 +48,12 @@ public class DestinationHandler {
 
   @VisibleForTesting
   DestinationHandler(final ConfigRepository configRepository,
-                     final JsonSchemaValidator integrationSchemaValidation,
-                     final SpecFetcher specFetcher,
-                     final ConnectionsHandler connectionsHandler,
-                     final Supplier<UUID> uuidGenerator,
-                     final JsonSecretsProcessor secretsProcessor,
-                     final ConfigurationUpdate configurationUpdate) {
+      final JsonSchemaValidator integrationSchemaValidation,
+      final SpecFetcher specFetcher,
+      final ConnectionsHandler connectionsHandler,
+      final Supplier<UUID> uuidGenerator,
+      final JsonSecretsProcessor secretsProcessor,
+      final ConfigurationUpdate configurationUpdate) {
     this.configRepository = configRepository;
     this.validator = integrationSchemaValidation;
     this.specFetcher = specFetcher;
@@ -65,9 +64,9 @@ public class DestinationHandler {
   }
 
   public DestinationHandler(final ConfigRepository configRepository,
-                            final JsonSchemaValidator integrationSchemaValidation,
-                            final SpecFetcher specFetcher,
-                            final ConnectionsHandler connectionsHandler) {
+      final JsonSchemaValidator integrationSchemaValidation,
+      final SpecFetcher specFetcher,
+      final ConnectionsHandler connectionsHandler) {
     this(
         configRepository,
         integrationSchemaValidation,
@@ -213,15 +212,15 @@ public class DestinationHandler {
 
   public static ConnectorSpecification getSpec(final SpecFetcher specFetcher, final StandardDestinationDefinition destinationDef)
       throws JsonValidationException, IOException, ConfigNotFoundException {
-    return specFetcher.execute(DockerUtils.getTaggedImageName(destinationDef.getDockerRepository(), destinationDef.getDockerImageTag()));
+    return specFetcher.execute(destinationDef);
   }
 
   private void persistDestinationConnection(final String name,
-                                            final UUID destinationDefinitionId,
-                                            final UUID workspaceId,
-                                            final UUID destinationId,
-                                            final JsonNode configurationJson,
-                                            final boolean tombstone)
+      final UUID destinationDefinitionId,
+      final UUID workspaceId,
+      final UUID destinationId,
+      final JsonNode configurationJson,
+      final boolean tombstone)
       throws JsonValidationException, IOException, ConfigNotFoundException {
     final DestinationConnection destinationConnection = new DestinationConnection()
         .withName(name)
@@ -251,7 +250,7 @@ public class DestinationHandler {
   }
 
   protected static DestinationRead toDestinationRead(final DestinationConnection destinationConnection,
-                                                     final StandardDestinationDefinition standardDestinationDefinition) {
+      final StandardDestinationDefinition standardDestinationDefinition) {
     return new DestinationRead()
         .destinationDefinitionId(standardDestinationDefinition.getDestinationDefinitionId())
         .destinationId(destinationConnection.getDestinationId())

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
@@ -48,12 +48,12 @@ public class DestinationHandler {
 
   @VisibleForTesting
   DestinationHandler(final ConfigRepository configRepository,
-      final JsonSchemaValidator integrationSchemaValidation,
-      final SpecFetcher specFetcher,
-      final ConnectionsHandler connectionsHandler,
-      final Supplier<UUID> uuidGenerator,
-      final JsonSecretsProcessor secretsProcessor,
-      final ConfigurationUpdate configurationUpdate) {
+                     final JsonSchemaValidator integrationSchemaValidation,
+                     final SpecFetcher specFetcher,
+                     final ConnectionsHandler connectionsHandler,
+                     final Supplier<UUID> uuidGenerator,
+                     final JsonSecretsProcessor secretsProcessor,
+                     final ConfigurationUpdate configurationUpdate) {
     this.configRepository = configRepository;
     this.validator = integrationSchemaValidation;
     this.specFetcher = specFetcher;
@@ -64,9 +64,9 @@ public class DestinationHandler {
   }
 
   public DestinationHandler(final ConfigRepository configRepository,
-      final JsonSchemaValidator integrationSchemaValidation,
-      final SpecFetcher specFetcher,
-      final ConnectionsHandler connectionsHandler) {
+                            final JsonSchemaValidator integrationSchemaValidation,
+                            final SpecFetcher specFetcher,
+                            final ConnectionsHandler connectionsHandler) {
     this(
         configRepository,
         integrationSchemaValidation,
@@ -216,11 +216,11 @@ public class DestinationHandler {
   }
 
   private void persistDestinationConnection(final String name,
-      final UUID destinationDefinitionId,
-      final UUID workspaceId,
-      final UUID destinationId,
-      final JsonNode configurationJson,
-      final boolean tombstone)
+                                            final UUID destinationDefinitionId,
+                                            final UUID workspaceId,
+                                            final UUID destinationId,
+                                            final JsonNode configurationJson,
+                                            final boolean tombstone)
       throws JsonValidationException, IOException, ConfigNotFoundException {
     final DestinationConnection destinationConnection = new DestinationConnection()
         .withName(name)
@@ -250,7 +250,7 @@ public class DestinationHandler {
   }
 
   protected static DestinationRead toDestinationRead(final DestinationConnection destinationConnection,
-      final StandardDestinationDefinition standardDestinationDefinition) {
+                                                     final StandardDestinationDefinition standardDestinationDefinition) {
     return new DestinationRead()
         .destinationDefinitionId(standardDestinationDefinition.getDestinationDefinitionId())
         .destinationId(destinationConnection.getDestinationId())

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
@@ -212,7 +212,7 @@ public class DestinationHandler {
 
   public static ConnectorSpecification getSpec(final SpecFetcher specFetcher, final StandardDestinationDefinition destinationDef)
       throws JsonValidationException, IOException, ConfigNotFoundException {
-    return specFetcher.execute(destinationDef);
+    return specFetcher.getSpec(destinationDef);
   }
 
   private void persistDestinationConnection(final String name,

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -258,8 +258,7 @@ public class SchedulerHandler {
     return specRead;
   }
 
-  public DestinationDefinitionSpecificationRead getDestinationSpecification(
-                                                                            final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody)
+  public DestinationDefinitionSpecificationRead getDestinationSpecification(final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final UUID destinationDefinitionId = destinationDefinitionIdRequestBody.getDestinationDefinitionId();
     final StandardDestinationDefinition destination = configRepository.getStandardDestinationDefinition(destinationDefinitionId);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -82,12 +82,12 @@ public class SchedulerHandler {
   private final OAuthConfigSupplier oAuthConfigSupplier;
 
   public SchedulerHandler(final ConfigRepository configRepository,
-      final SchedulerJobClient schedulerJobClient,
-      final SynchronousSchedulerClient synchronousSchedulerClient,
-      final JobPersistence jobPersistence,
-      final JobNotifier jobNotifier,
-      final WorkflowServiceStubs temporalService,
-      final OAuthConfigSupplier oAuthConfigSupplier) {
+                          final SchedulerJobClient schedulerJobClient,
+                          final SynchronousSchedulerClient synchronousSchedulerClient,
+                          final JobPersistence jobPersistence,
+                          final JobNotifier jobNotifier,
+                          final WorkflowServiceStubs temporalService,
+                          final OAuthConfigSupplier oAuthConfigSupplier) {
     this(
         configRepository,
         schedulerJobClient,
@@ -103,15 +103,15 @@ public class SchedulerHandler {
 
   @VisibleForTesting
   SchedulerHandler(final ConfigRepository configRepository,
-      final SchedulerJobClient schedulerJobClient,
-      final SynchronousSchedulerClient synchronousSchedulerClient,
-      final ConfigurationUpdate configurationUpdate,
-      final JsonSchemaValidator jsonSchemaValidator,
-      final SpecFetcher specFetcher,
-      final JobPersistence jobPersistence,
-      final JobNotifier jobNotifier,
-      final WorkflowServiceStubs temporalService,
-      final OAuthConfigSupplier oAuthConfigSupplier) {
+                   final SchedulerJobClient schedulerJobClient,
+                   final SynchronousSchedulerClient synchronousSchedulerClient,
+                   final ConfigurationUpdate configurationUpdate,
+                   final JsonSchemaValidator jsonSchemaValidator,
+                   final SpecFetcher specFetcher,
+                   final JobPersistence jobPersistence,
+                   final JobNotifier jobNotifier,
+                   final WorkflowServiceStubs temporalService,
+                   final OAuthConfigSupplier oAuthConfigSupplier) {
     this.configRepository = configRepository;
     this.schedulerJobClient = schedulerJobClient;
     this.synchronousSchedulerClient = synchronousSchedulerClient;
@@ -259,7 +259,7 @@ public class SchedulerHandler {
   }
 
   public DestinationDefinitionSpecificationRead getDestinationSpecification(
-      final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody)
+                                                                            final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final UUID destinationDefinitionId = destinationDefinitionIdRequestBody.getDestinationDefinitionId();
     final StandardDestinationDefinition destination = configRepository.getStandardDestinationDefinition(destinationDefinitionId);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -370,9 +370,9 @@ public class SchedulerHandler {
   }
 
   private void cancelTemporalWorkflowIfPresent(final long jobId) throws IOException {
-    final var latestAttemptId = jobPersistence.getJob(jobId).getAttempts().size() - 1; // attempts ids are monotonically increasing starting from 0
-    // and
-    // specific to a job id, allowing us to do this.
+    // attempts ids are monotonically increasing starting from
+    // 0 and specific to a job id, allowing us to do this.
+    final var latestAttemptId = jobPersistence.getJob(jobId).getAttempts().size() - 1;
     final var workflowId = jobPersistence.getAttemptTemporalWorkflowId(jobId, latestAttemptId);
 
     if (workflowId.isPresent()) {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -370,7 +370,8 @@ public class SchedulerHandler {
   }
 
   private void cancelTemporalWorkflowIfPresent(final long jobId) throws IOException {
-    // attempts ids are monotonically increasing starting from 0 and specific to a job id, allowing us to do this.
+    // attempts ids are monotonically increasing starting from 0 and specific to a job id, allowing us
+    // to do this.
     final var latestAttemptId = jobPersistence.getJob(jobId).getAttempts().size() - 1;
     final var workflowId = jobPersistence.getAttemptTemporalWorkflowId(jobId, latestAttemptId);
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -370,8 +370,7 @@ public class SchedulerHandler {
   }
 
   private void cancelTemporalWorkflowIfPresent(final long jobId) throws IOException {
-    // attempts ids are monotonically increasing starting from
-    // 0 and specific to a job id, allowing us to do this.
+    // attempts ids are monotonically increasing starting from 0 and specific to a job id, allowing us to do this.
     final var latestAttemptId = jobPersistence.getJob(jobId).getAttempts().size() - 1;
     final var workflowId = jobPersistence.getAttemptTemporalWorkflowId(jobId, latestAttemptId);
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -14,7 +14,6 @@ import io.airbyte.api.model.SourceReadList;
 import io.airbyte.api.model.SourceSearch;
 import io.airbyte.api.model.SourceUpdate;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
-import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSourceDefinition;
@@ -42,12 +41,12 @@ public class SourceHandler {
   private final JsonSecretsProcessor secretsProcessor;
 
   SourceHandler(final ConfigRepository configRepository,
-                final JsonSchemaValidator integrationSchemaValidation,
-                final SpecFetcher specFetcher,
-                final ConnectionsHandler connectionsHandler,
-                final Supplier<UUID> uuidGenerator,
-                final JsonSecretsProcessor secretsProcessor,
-                final ConfigurationUpdate configurationUpdate) {
+      final JsonSchemaValidator integrationSchemaValidation,
+      final SpecFetcher specFetcher,
+      final ConnectionsHandler connectionsHandler,
+      final Supplier<UUID> uuidGenerator,
+      final JsonSecretsProcessor secretsProcessor,
+      final ConfigurationUpdate configurationUpdate) {
     this.configRepository = configRepository;
     this.validator = integrationSchemaValidation;
     this.specFetcher = specFetcher;
@@ -58,9 +57,9 @@ public class SourceHandler {
   }
 
   public SourceHandler(final ConfigRepository configRepository,
-                       final JsonSchemaValidator integrationSchemaValidation,
-                       final SpecFetcher specFetcher,
-                       final ConnectionsHandler connectionsHandler) {
+      final JsonSchemaValidator integrationSchemaValidation,
+      final SpecFetcher specFetcher,
+      final ConnectionsHandler connectionsHandler) {
     this(
         configRepository,
         integrationSchemaValidation,
@@ -206,9 +205,7 @@ public class SourceHandler {
     // read configuration from db
     final StandardSourceDefinition sourceDef = configRepository
         .getSourceDefinitionFromSource(sourceId);
-    final String imageName = DockerUtils
-        .getTaggedImageName(sourceDef.getDockerRepository(), sourceDef.getDockerImageTag());
-    final ConnectorSpecification spec = specFetcher.execute(imageName);
+    final ConnectorSpecification spec = specFetcher.execute(sourceDef);
     return buildSourceRead(sourceId, spec);
   }
 
@@ -243,18 +240,16 @@ public class SourceHandler {
 
   public static ConnectorSpecification getSpecFromSourceDefinitionId(final SpecFetcher specFetcher, final StandardSourceDefinition sourceDefinition)
       throws IOException, ConfigNotFoundException {
-    final String imageName = DockerUtils
-        .getTaggedImageName(sourceDefinition.getDockerRepository(), sourceDefinition.getDockerImageTag());
-    return specFetcher.execute(imageName);
+    return specFetcher.execute(sourceDefinition);
   }
 
   private void persistSourceConnection(final String name,
-                                       final UUID sourceDefinitionId,
-                                       final UUID workspaceId,
-                                       final UUID sourceId,
-                                       final boolean tombstone,
-                                       final JsonNode configurationJson,
-                                       final ConnectorSpecification spec)
+      final UUID sourceDefinitionId,
+      final UUID workspaceId,
+      final UUID sourceId,
+      final boolean tombstone,
+      final JsonNode configurationJson,
+      final ConnectorSpecification spec)
       throws JsonValidationException, IOException {
     final SourceConnection sourceConnection = new SourceConnection()
         .withName(name)
@@ -268,7 +263,7 @@ public class SourceHandler {
   }
 
   protected static SourceRead toSourceRead(final SourceConnection sourceConnection,
-                                           final StandardSourceDefinition standardSourceDefinition) {
+      final StandardSourceDefinition standardSourceDefinition) {
     return new SourceRead()
         .sourceDefinitionId(standardSourceDefinition.getSourceDefinitionId())
         .sourceName(standardSourceDefinition.getName())

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -205,7 +205,7 @@ public class SourceHandler {
     // read configuration from db
     final StandardSourceDefinition sourceDef = configRepository
         .getSourceDefinitionFromSource(sourceId);
-    final ConnectorSpecification spec = specFetcher.execute(sourceDef);
+    final ConnectorSpecification spec = specFetcher.getSpec(sourceDef);
     return buildSourceRead(sourceId, spec);
   }
 
@@ -240,7 +240,7 @@ public class SourceHandler {
 
   public static ConnectorSpecification getSpecFromSourceDefinitionId(final SpecFetcher specFetcher, final StandardSourceDefinition sourceDefinition)
       throws IOException, ConfigNotFoundException {
-    return specFetcher.execute(sourceDefinition);
+    return specFetcher.getSpec(sourceDefinition);
   }
 
   private void persistSourceConnection(final String name,

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -41,12 +41,12 @@ public class SourceHandler {
   private final JsonSecretsProcessor secretsProcessor;
 
   SourceHandler(final ConfigRepository configRepository,
-      final JsonSchemaValidator integrationSchemaValidation,
-      final SpecFetcher specFetcher,
-      final ConnectionsHandler connectionsHandler,
-      final Supplier<UUID> uuidGenerator,
-      final JsonSecretsProcessor secretsProcessor,
-      final ConfigurationUpdate configurationUpdate) {
+                final JsonSchemaValidator integrationSchemaValidation,
+                final SpecFetcher specFetcher,
+                final ConnectionsHandler connectionsHandler,
+                final Supplier<UUID> uuidGenerator,
+                final JsonSecretsProcessor secretsProcessor,
+                final ConfigurationUpdate configurationUpdate) {
     this.configRepository = configRepository;
     this.validator = integrationSchemaValidation;
     this.specFetcher = specFetcher;
@@ -57,9 +57,9 @@ public class SourceHandler {
   }
 
   public SourceHandler(final ConfigRepository configRepository,
-      final JsonSchemaValidator integrationSchemaValidation,
-      final SpecFetcher specFetcher,
-      final ConnectionsHandler connectionsHandler) {
+                       final JsonSchemaValidator integrationSchemaValidation,
+                       final SpecFetcher specFetcher,
+                       final ConnectionsHandler connectionsHandler) {
     this(
         configRepository,
         integrationSchemaValidation,
@@ -244,12 +244,12 @@ public class SourceHandler {
   }
 
   private void persistSourceConnection(final String name,
-      final UUID sourceDefinitionId,
-      final UUID workspaceId,
-      final UUID sourceId,
-      final boolean tombstone,
-      final JsonNode configurationJson,
-      final ConnectorSpecification spec)
+                                       final UUID sourceDefinitionId,
+                                       final UUID workspaceId,
+                                       final UUID sourceId,
+                                       final boolean tombstone,
+                                       final JsonNode configurationJson,
+                                       final ConnectorSpecification spec)
       throws JsonValidationException, IOException {
     final SourceConnection sourceConnection = new SourceConnection()
         .withName(name)
@@ -263,7 +263,7 @@ public class SourceHandler {
   }
 
   protected static SourceRead toSourceRead(final SourceConnection sourceConnection,
-      final StandardSourceDefinition standardSourceDefinition) {
+                                           final StandardSourceDefinition standardSourceDefinition) {
     return new SourceRead()
         .sourceDefinitionId(standardSourceDefinition.getSourceDefinitionId())
         .sourceName(standardSourceDefinition.getName())

--- a/airbyte-server/src/main/java/io/airbyte/server/validators/DockerImageValidator.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/validators/DockerImageValidator.java
@@ -24,7 +24,8 @@ public class DockerImageValidator {
   }
 
   /**
-   * @throws BadObjectSchemaKnownException if it is unable to verify that the input image is a valid connector definition image.
+   * @throws BadObjectSchemaKnownException if it is unable to verify that the input image is a valid
+   *         connector definition image.
    */
   public void assertValidIntegrationImage(final String dockerRepository, final String imageTag) throws BadObjectSchemaKnownException {
     // Validates that the docker image exists and can generate a compatible spec by running a getSpec

--- a/airbyte-server/src/main/java/io/airbyte/server/validators/DockerImageValidator.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/validators/DockerImageValidator.java
@@ -24,15 +24,14 @@ public class DockerImageValidator {
   }
 
   /**
-   * @throws BadObjectSchemaKnownException if it is unable to verify that the input image is a valid
-   *         connector definition image.
+   * @throws BadObjectSchemaKnownException if it is unable to verify that the input image is a valid connector definition image.
    */
   public void assertValidIntegrationImage(final String dockerRepository, final String imageTag) throws BadObjectSchemaKnownException {
     // Validates that the docker image exists and can generate a compatible spec by running a getSpec
     // job on the provided image.
     final String imageName = DockerUtils.getTaggedImageName(dockerRepository, imageTag);
     try {
-      specFetcher.execute(imageName);
+      specFetcher.getSpec(imageName);
     } catch (final Exception e) {
       throw new BadObjectSchemaKnownException(
           String.format("Encountered an issue while validating input docker image (%s): %s", imageName, e.getMessage()));

--- a/airbyte-server/src/main/java/io/airbyte/server/validators/DockerImageValidator.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/validators/DockerImageValidator.java
@@ -4,35 +4,31 @@
 
 package io.airbyte.server.validators;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.commons.docker.DockerUtils;
+import io.airbyte.protocol.models.ConnectorSpecification;
+import io.airbyte.scheduler.client.SynchronousResponse;
 import io.airbyte.scheduler.client.SynchronousSchedulerClient;
 import io.airbyte.server.converters.SpecFetcher;
 import io.airbyte.server.errors.BadObjectSchemaKnownException;
 
 public class DockerImageValidator {
 
-  private final SpecFetcher specFetcher;
+  private final SynchronousSchedulerClient schedulerClient;
 
   public DockerImageValidator(final SynchronousSchedulerClient schedulerJobClient) {
-    this(new SpecFetcher(schedulerJobClient));
-  }
-
-  @VisibleForTesting
-  DockerImageValidator(final SpecFetcher specFetcher) {
-    this.specFetcher = specFetcher;
+    this.schedulerClient = schedulerJobClient;
   }
 
   /**
-   * @throws BadObjectSchemaKnownException if it is unable to verify that the input image is a valid
-   *         connector definition image.
+   * @throws BadObjectSchemaKnownException if it is unable to verify that the input image is a valid connector definition image.
    */
   public void assertValidIntegrationImage(final String dockerRepository, final String imageTag) throws BadObjectSchemaKnownException {
     // Validates that the docker image exists and can generate a compatible spec by running a getSpec
     // job on the provided image.
     final String imageName = DockerUtils.getTaggedImageName(dockerRepository, imageTag);
     try {
-      specFetcher.getSpec(imageName);
+      final SynchronousResponse<ConnectorSpecification> getSpecResponse = schedulerClient.createGetSpecJob(imageName);
+      SpecFetcher.getSpecFromJob(getSpecResponse);
     } catch (final Exception e) {
       throw new BadObjectSchemaKnownException(
           String.format("Encountered an issue while validating input docker image (%s): %s", imageName, e.getMessage()));

--- a/airbyte-server/src/main/java/io/airbyte/server/validators/DockerImageValidator.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/validators/DockerImageValidator.java
@@ -20,7 +20,8 @@ public class DockerImageValidator {
   }
 
   /**
-   * @throws BadObjectSchemaKnownException if it is unable to verify that the input image is a valid connector definition image.
+   * @throws BadObjectSchemaKnownException if it is unable to verify that the input image is a valid
+   *         connector definition image.
    */
   public void assertValidIntegrationImage(final String dockerRepository, final String imageTag) throws BadObjectSchemaKnownException {
     // Validates that the docker image exists and can generate a compatible spec by running a getSpec

--- a/airbyte-server/src/test/java/io/airbyte/server/ConfigDumpImporterTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/ConfigDumpImporterTest.java
@@ -70,7 +70,8 @@ class ConfigDumpImporterTest {
     specFetcher = mock(SpecFetcher.class);
     emptyConnectorSpec = mock(ConnectorSpecification.class);
     when(emptyConnectorSpec.getConnectionSpecification()).thenReturn(Jsons.emptyObject());
-    when(specFetcher.execute(any())).thenReturn(emptyConnectorSpec);
+    when(specFetcher.getSpec(any(StandardSourceDefinition.class))).thenReturn(emptyConnectorSpec);
+    when(specFetcher.getSpec(any(StandardDestinationDefinition.class))).thenReturn(emptyConnectorSpec);
 
     configDumpImporter =
         new ConfigDumpImporter(configRepository, jobPersistence, workspaceHelper, mock(JsonSchemaValidator.class), specFetcher, true);

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/ConfigurationUpdateTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/ConfigurationUpdateTest.java
@@ -88,7 +88,7 @@ class ConfigurationUpdateTest {
   void testSourceUpdate() throws JsonValidationException, IOException, ConfigNotFoundException {
     when(configRepository.getSourceConnectionWithSecrets(UUID1)).thenReturn(ORIGINAL_SOURCE_CONNECTION);
     when(configRepository.getStandardSourceDefinition(UUID2)).thenReturn(SOURCE_DEFINITION);
-    when(specFetcher.execute(IMAGE_NAME)).thenReturn(CONNECTOR_SPECIFICATION);
+    when(specFetcher.getSpec(SOURCE_DEFINITION)).thenReturn(CONNECTOR_SPECIFICATION);
     when(secretsProcessor.copySecrets(ORIGINAL_CONFIGURATION, NEW_CONFIGURATION, SPEC)).thenReturn(NEW_CONFIGURATION);
 
     final SourceConnection actual = configurationUpdate.source(UUID1, ORIGINAL_SOURCE_CONNECTION.getName(), NEW_CONFIGURATION);
@@ -100,7 +100,7 @@ class ConfigurationUpdateTest {
   void testDestinationUpdate() throws JsonValidationException, IOException, ConfigNotFoundException {
     when(configRepository.getDestinationConnectionWithSecrets(UUID1)).thenReturn(ORIGINAL_DESTINATION_CONNECTION);
     when(configRepository.getStandardDestinationDefinition(UUID2)).thenReturn(DESTINATION_DEFINITION);
-    when(specFetcher.execute(IMAGE_NAME)).thenReturn(CONNECTOR_SPECIFICATION);
+    when(specFetcher.getSpec(SOURCE_DEFINITION)).thenReturn(CONNECTOR_SPECIFICATION);
     when(secretsProcessor.copySecrets(ORIGINAL_CONFIGURATION, NEW_CONFIGURATION, SPEC)).thenReturn(NEW_CONFIGURATION);
 
     final DestinationConnection actual = configurationUpdate.destination(UUID1, ORIGINAL_DESTINATION_CONNECTION.getName(), NEW_CONFIGURATION);

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/ConfigurationUpdateTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/ConfigurationUpdateTest.java
@@ -100,7 +100,7 @@ class ConfigurationUpdateTest {
   void testDestinationUpdate() throws JsonValidationException, IOException, ConfigNotFoundException {
     when(configRepository.getDestinationConnectionWithSecrets(UUID1)).thenReturn(ORIGINAL_DESTINATION_CONNECTION);
     when(configRepository.getStandardDestinationDefinition(UUID2)).thenReturn(DESTINATION_DEFINITION);
-    when(specFetcher.getSpec(SOURCE_DEFINITION)).thenReturn(CONNECTOR_SPECIFICATION);
+    when(specFetcher.getSpec(DESTINATION_DEFINITION)).thenReturn(CONNECTOR_SPECIFICATION);
     when(secretsProcessor.copySecrets(ORIGINAL_CONFIGURATION, NEW_CONFIGURATION, SPEC)).thenReturn(NEW_CONFIGURATION);
 
     final DestinationConnection actual = configurationUpdate.destination(UUID1, ORIGINAL_DESTINATION_CONNECTION.getName(), NEW_CONFIGURATION);

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/SpecFetcherTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/SpecFetcherTest.java
@@ -122,4 +122,5 @@ class SpecFetcherTest {
     assertEquals(Optional.empty(), response.getMetadata().getConfigId());
     assertEquals(connectorSpecification, response.getOutput());
   }
+
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/SpecFetcherTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/SpecFetcherTest.java
@@ -11,20 +11,28 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.JobConfig.ConfigType;
+import io.airbyte.config.StandardDestinationDefinition;
+import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.client.SynchronousResponse;
 import io.airbyte.scheduler.client.SynchronousSchedulerClient;
 import java.io.IOException;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class SpecFetcherTest {
 
-  private static final String IMAGE_NAME = "foo:bar";
+  private static final String DOCKER_REPOSITORY = "foo";
+  private static final String DOCKER_IMAGE_TAG = "bar";
+  private static final String IMAGE_NAME = DOCKER_REPOSITORY + ":" + DOCKER_IMAGE_TAG;
 
   private SynchronousSchedulerClient schedulerJobClient;
   private SynchronousResponse<ConnectorSpecification> response;
   private ConnectorSpecification connectorSpecification;
+  private StandardSourceDefinition sourceDefinition;
+  private StandardDestinationDefinition destinationDefinition;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
@@ -32,25 +40,86 @@ class SpecFetcherTest {
     schedulerJobClient = mock(SynchronousSchedulerClient.class);
     response = mock(SynchronousResponse.class);
     connectorSpecification = new ConnectorSpecification().withConnectionSpecification(Jsons.jsonNode(ImmutableMap.of("foo", "bar")));
+    sourceDefinition = new StandardSourceDefinition().withDockerRepository(DOCKER_REPOSITORY).withDockerImageTag(DOCKER_IMAGE_TAG);
+    destinationDefinition = new StandardDestinationDefinition().withDockerRepository(DOCKER_REPOSITORY).withDockerImageTag(DOCKER_IMAGE_TAG);
   }
 
   @Test
-  void testFetch() throws IOException {
+  void testGetSpecFromDockerImageSuccess() throws IOException {
     when(schedulerJobClient.createGetSpecJob(IMAGE_NAME)).thenReturn(response);
     when(response.isSuccess()).thenReturn(true);
     when(response.getOutput()).thenReturn(connectorSpecification);
 
     final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
-    assertEquals(connectorSpecification, specFetcher.execute(IMAGE_NAME));
+    assertEquals(connectorSpecification, specFetcher.getSpec(IMAGE_NAME));
   }
 
   @Test
-  void testFetchEmpty() throws IOException {
+  void testGetSpecFromDockerImageFail() throws IOException {
     when(schedulerJobClient.createGetSpecJob(IMAGE_NAME)).thenReturn(response);
     when(response.isSuccess()).thenReturn(false);
 
     final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
-    assertThrows(IllegalStateException.class, () -> specFetcher.execute(IMAGE_NAME));
+    assertThrows(IllegalStateException.class, () -> specFetcher.getSpec(IMAGE_NAME));
   }
 
+  @Test
+  void testGetSpecFromSourceDefinitionNotNull() throws IOException {
+    sourceDefinition = sourceDefinition.withSpec(connectorSpecification);
+
+    final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
+    assertEquals(connectorSpecification, specFetcher.getSpec(sourceDefinition));
+  }
+
+  @Test
+  void testGetSpecFromSourceDefinitionNull() throws IOException {
+    when(schedulerJobClient.createGetSpecJob(IMAGE_NAME)).thenReturn(response);
+    when(response.isSuccess()).thenReturn(true);
+    when(response.getOutput()).thenReturn(connectorSpecification);
+
+    final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
+    assertEquals(connectorSpecification, specFetcher.getSpec(sourceDefinition));
+  }
+
+  @Test
+  void testGetSpecFromDestinationDefinitionNotNull() throws IOException {
+    destinationDefinition = destinationDefinition.withSpec(connectorSpecification);
+
+    final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
+    assertEquals(connectorSpecification, specFetcher.getSpec(destinationDefinition));
+  }
+
+  @Test
+  void testGetSpecFromDestinationDefinitionNull() throws IOException {
+    when(schedulerJobClient.createGetSpecJob(IMAGE_NAME)).thenReturn(response);
+    when(response.isSuccess()).thenReturn(true);
+    when(response.getOutput()).thenReturn(connectorSpecification);
+
+    final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
+    assertEquals(connectorSpecification, specFetcher.getSpec(destinationDefinition));
+  }
+
+  @Test
+  void testGetSpecJobResponseFromSourceReturnsMockedJobMetadata() throws IOException {
+    sourceDefinition = sourceDefinition.withSpec(connectorSpecification);
+
+    final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
+    final SynchronousResponse<ConnectorSpecification> response = specFetcher.getSpecJobResponse(sourceDefinition);
+
+    assertEquals(ConfigType.GET_SPEC, response.getMetadata().getConfigType());
+    assertEquals(Optional.empty(), response.getMetadata().getConfigId());
+    assertEquals(connectorSpecification, response.getOutput());
+  }
+
+  @Test
+  void testGetSpecJobResponseFromDestinationReturnsMockedJobMetadata() throws IOException {
+    destinationDefinition = destinationDefinition.withSpec(connectorSpecification);
+
+    final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
+    final SynchronousResponse<ConnectorSpecification> response = specFetcher.getSpecJobResponse(destinationDefinition);
+
+    assertEquals(ConfigType.GET_SPEC, response.getMetadata().getConfigType());
+    assertEquals(Optional.empty(), response.getMetadata().getConfigId());
+    assertEquals(connectorSpecification, response.getOutput());
+  }
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/SpecFetcherTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/SpecFetcherTest.java
@@ -65,10 +65,10 @@ class SpecFetcherTest {
 
   @Test
   void testGetSpecFromSourceDefinitionNotNull() throws IOException {
-    sourceDefinition = sourceDefinition.withSpec(connectorSpecification);
+    final StandardSourceDefinition sourceDefinitionWithSpec = Jsons.clone(sourceDefinition).withSpec(connectorSpecification);
 
     final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
-    assertEquals(connectorSpecification, specFetcher.getSpec(sourceDefinition));
+    assertEquals(connectorSpecification, specFetcher.getSpec(sourceDefinitionWithSpec));
   }
 
   @Test
@@ -83,10 +83,10 @@ class SpecFetcherTest {
 
   @Test
   void testGetSpecFromDestinationDefinitionNotNull() throws IOException {
-    destinationDefinition = destinationDefinition.withSpec(connectorSpecification);
+    final StandardDestinationDefinition destinationDefinitionWithSpec = Jsons.clone(destinationDefinition).withSpec(connectorSpecification);
 
     final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
-    assertEquals(connectorSpecification, specFetcher.getSpec(destinationDefinition));
+    assertEquals(connectorSpecification, specFetcher.getSpec(destinationDefinitionWithSpec));
   }
 
   @Test
@@ -101,10 +101,10 @@ class SpecFetcherTest {
 
   @Test
   void testGetSpecJobResponseFromSourceReturnsMockedJobMetadata() throws IOException {
-    sourceDefinition = sourceDefinition.withSpec(connectorSpecification);
+    final StandardSourceDefinition sourceDefinitionWithSpec = Jsons.clone(sourceDefinition).withSpec(connectorSpecification);
 
     final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
-    final SynchronousResponse<ConnectorSpecification> response = specFetcher.getSpecJobResponse(sourceDefinition);
+    final SynchronousResponse<ConnectorSpecification> response = specFetcher.getSpecJobResponse(sourceDefinitionWithSpec);
 
     assertEquals(ConfigType.GET_SPEC, response.getMetadata().getConfigType());
     assertEquals(Optional.empty(), response.getMetadata().getConfigId());
@@ -113,10 +113,10 @@ class SpecFetcherTest {
 
   @Test
   void testGetSpecJobResponseFromDestinationReturnsMockedJobMetadata() throws IOException {
-    destinationDefinition = destinationDefinition.withSpec(connectorSpecification);
+    final StandardDestinationDefinition destinationDefinitionWithSpec = Jsons.clone(destinationDefinition).withSpec(connectorSpecification);
 
     final SpecFetcher specFetcher = new SpecFetcher(schedulerJobClient);
-    final SynchronousResponse<ConnectorSpecification> response = specFetcher.getSpecJobResponse(destinationDefinition);
+    final SynchronousResponse<ConnectorSpecification> response = specFetcher.getSpecJobResponse(destinationDefinitionWithSpec);
 
     assertEquals(ConfigType.GET_SPEC, response.getMetadata().getConfigType());
     assertEquals(Optional.empty(), response.getMetadata().getConfigId());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -23,6 +23,7 @@ import io.airbyte.commons.string.Strings;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
+import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.persistence.ConfigPersistence;
@@ -82,7 +83,8 @@ public class ArchiveHandlerTest {
       super(1L, TimeUnit.MINUTES, 1L);
     }
 
-    public void register(final Path path) {}
+    public void register(final Path path) {
+    }
 
   }
 
@@ -116,7 +118,8 @@ public class ArchiveHandlerTest {
     final SpecFetcher specFetcher = mock(SpecFetcher.class);
     final ConnectorSpecification emptyConnectorSpec = mock(ConnectorSpecification.class);
     when(emptyConnectorSpec.getConnectionSpecification()).thenReturn(Jsons.emptyObject());
-    when(specFetcher.execute(any())).thenReturn(emptyConnectorSpec);
+    when(specFetcher.getSpec(any(StandardSourceDefinition.class))).thenReturn(emptyConnectorSpec);
+    when(specFetcher.getSpec(any(StandardDestinationDefinition.class))).thenReturn(emptyConnectorSpec);
 
     archiveHandler = new ArchiveHandler(
         VERSION,
@@ -159,9 +162,9 @@ public class ArchiveHandlerTest {
     final UUID sourceS3DefinitionId = UUID.fromString("69589781-7828-43c5-9f63-8925b1c1ccc2");
     final String sourceS3DefinitionVersion = "0.0.0";
     final StandardSourceDefinition sourceS3Definition = seedPersistence.getConfig(
-        ConfigSchema.STANDARD_SOURCE_DEFINITION,
-        sourceS3DefinitionId.toString(),
-        StandardSourceDefinition.class)
+            ConfigSchema.STANDARD_SOURCE_DEFINITION,
+            sourceS3DefinitionId.toString(),
+            StandardSourceDefinition.class)
         // This source definition is on an old version
         .withDockerImageTag(sourceS3DefinitionVersion);
     final SourceConnection sourceConnection = new SourceConnection()

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -83,8 +83,7 @@ public class ArchiveHandlerTest {
       super(1L, TimeUnit.MINUTES, 1L);
     }
 
-    public void register(final Path path) {
-    }
+    public void register(final Path path) {}
 
   }
 
@@ -162,9 +161,9 @@ public class ArchiveHandlerTest {
     final UUID sourceS3DefinitionId = UUID.fromString("69589781-7828-43c5-9f63-8925b1c1ccc2");
     final String sourceS3DefinitionVersion = "0.0.0";
     final StandardSourceDefinition sourceS3Definition = seedPersistence.getConfig(
-            ConfigSchema.STANDARD_SOURCE_DEFINITION,
-            sourceS3DefinitionId.toString(),
-            StandardSourceDefinition.class)
+        ConfigSchema.STANDARD_SOURCE_DEFINITION,
+        sourceS3DefinitionId.toString(),
+        StandardSourceDefinition.class)
         // This source definition is on an old version
         .withDockerImageTag(sourceS3DefinitionVersion);
     final SourceConnection sourceConnection = new SourceConnection()

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
@@ -187,7 +187,7 @@ class DestinationHandlerTest {
 
     when(secretsProcessor
         .copySecrets(destinationConnection.getConfiguration(), newConfiguration, destinationDefinitionSpecificationRead.getConnectionSpecification()))
-        .thenReturn(newConfiguration);
+            .thenReturn(newConfiguration);
     when(secretsProcessor.maskSecrets(newConfiguration, destinationDefinitionSpecificationRead.getConnectionSpecification()))
         .thenReturn(newConfiguration);
     when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getDestinationDefinitionId()))

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
@@ -110,7 +110,7 @@ class DestinationHandlerTest {
         .thenReturn(destinationConnection);
     when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getDestinationDefinitionId()))
         .thenReturn(standardDestinationDefinition);
-    when(specFetcher.execute(imageName)).thenReturn(connectorSpecification);
+    when(specFetcher.getSpec(standardDestinationDefinition)).thenReturn(connectorSpecification);
     when(secretsProcessor.maskSecrets(destinationConnection.getConfiguration(), destinationDefinitionSpecificationRead.getConnectionSpecification()))
         .thenReturn(destinationConnection.getConfiguration());
 
@@ -159,7 +159,7 @@ class DestinationHandlerTest {
         .thenReturn(expectedDestinationConnection);
     when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getDestinationDefinitionId()))
         .thenReturn(standardDestinationDefinition);
-    when(specFetcher.execute(imageName)).thenReturn(connectorSpecification);
+    when(specFetcher.getSpec(standardDestinationDefinition)).thenReturn(connectorSpecification);
     when(connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody)).thenReturn(connectionReadList);
 
     destinationHandler.deleteDestination(destinationId);
@@ -187,7 +187,7 @@ class DestinationHandlerTest {
 
     when(secretsProcessor
         .copySecrets(destinationConnection.getConfiguration(), newConfiguration, destinationDefinitionSpecificationRead.getConnectionSpecification()))
-            .thenReturn(newConfiguration);
+        .thenReturn(newConfiguration);
     when(secretsProcessor.maskSecrets(newConfiguration, destinationDefinitionSpecificationRead.getConnectionSpecification()))
         .thenReturn(newConfiguration);
     when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getDestinationDefinitionId()))
@@ -196,7 +196,7 @@ class DestinationHandlerTest {
         .thenReturn(standardDestinationDefinition);
     when(configRepository.getDestinationConnection(destinationConnection.getDestinationId()))
         .thenReturn(expectedDestinationConnection);
-    when(specFetcher.execute(imageName)).thenReturn(connectorSpecification);
+    when(specFetcher.getSpec(standardDestinationDefinition)).thenReturn(connectorSpecification);
     when(configurationUpdate.destination(destinationConnection.getDestinationId(), updatedDestName, newConfiguration))
         .thenReturn(expectedDestinationConnection);
 
@@ -229,7 +229,7 @@ class DestinationHandlerTest {
     when(configRepository.getDestinationConnection(destinationConnection.getDestinationId())).thenReturn(destinationConnection);
     when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getDestinationDefinitionId()))
         .thenReturn(standardDestinationDefinition);
-    when(specFetcher.execute(imageName)).thenReturn(connectorSpecification);
+    when(specFetcher.getSpec(standardDestinationDefinition)).thenReturn(connectorSpecification);
 
     final DestinationRead actualDestinationRead = destinationHandler.getDestination(destinationIdRequestBody);
 
@@ -263,7 +263,7 @@ class DestinationHandlerTest {
 
     when(configRepository.getDestinationConnection(destinationConnection.getDestinationId())).thenReturn(destinationConnection);
     when(configRepository.listDestinationConnection()).thenReturn(Lists.newArrayList(destinationConnection));
-    when(specFetcher.execute(imageName)).thenReturn(connectorSpecification);
+    when(specFetcher.getSpec(standardDestinationDefinition)).thenReturn(connectorSpecification);
     when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getDestinationDefinitionId()))
         .thenReturn(standardDestinationDefinition);
     when(secretsProcessor.maskSecrets(destinationConnection.getConfiguration(), destinationDefinitionSpecificationRead.getConnectionSpecification()))
@@ -288,7 +288,7 @@ class DestinationHandlerTest {
 
     when(configRepository.getDestinationConnection(destinationConnection.getDestinationId())).thenReturn(destinationConnection);
     when(configRepository.listDestinationConnection()).thenReturn(Lists.newArrayList(destinationConnection));
-    when(specFetcher.execute(imageName)).thenReturn(connectorSpecification);
+    when(specFetcher.getSpec(standardDestinationDefinition)).thenReturn(connectorSpecification);
     when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getDestinationDefinitionId()))
         .thenReturn(standardDestinationDefinition);
     when(secretsProcessor.maskSecrets(destinationConnection.getConfiguration(), destinationDefinitionSpecificationRead.getConnectionSpecification()))

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
@@ -209,14 +209,15 @@ class SchedulerHandlerTest {
         .name(source.getName())
         .sourceId(source.getSourceId())
         .connectionConfiguration(source.getConfiguration());
+    final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
+        .withDockerRepository(DESTINATION_DOCKER_REPO)
+        .withDockerImageTag(DESTINATION_DOCKER_TAG)
+        .withSourceDefinitionId(source.getSourceDefinitionId());
     when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId()))
-        .thenReturn(new StandardSourceDefinition()
-            .withDockerRepository(DESTINATION_DOCKER_REPO)
-            .withDockerImageTag(DESTINATION_DOCKER_TAG)
-            .withSourceDefinitionId(source.getSourceDefinitionId()));
+        .thenReturn(sourceDefinition);
     when(configRepository.getSourceConnection(source.getSourceId())).thenReturn(source);
     when(configurationUpdate.source(source.getSourceId(), source.getName(), sourceUpdate.getConnectionConfiguration())).thenReturn(source);
-    when(specFetcher.execute(DESTINATION_DOCKER_IMAGE)).thenReturn(CONNECTION_SPECIFICATION);
+    when(specFetcher.getSpec(sourceDefinition)).thenReturn(CONNECTION_SPECIFICATION);
     final SourceConnection submittedSource = new SourceConnection()
         .withSourceDefinitionId(source.getSourceDefinitionId())
         .withConfiguration(source.getConfiguration());
@@ -236,13 +237,14 @@ class SchedulerHandlerTest {
     final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody = new SourceDefinitionIdRequestBody().sourceDefinitionId(UUID.randomUUID());
 
     final SynchronousResponse<ConnectorSpecification> specResponse = (SynchronousResponse<ConnectorSpecification>) jobResponse;
+    final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
+        .withName("name")
+        .withDockerRepository(SOURCE_DOCKER_REPO)
+        .withDockerImageTag(SOURCE_DOCKER_TAG)
+        .withSourceDefinitionId(sourceDefinitionIdRequestBody.getSourceDefinitionId());
     when(configRepository.getStandardSourceDefinition(sourceDefinitionIdRequestBody.getSourceDefinitionId()))
-        .thenReturn(new StandardSourceDefinition()
-            .withName("name")
-            .withDockerRepository(SOURCE_DOCKER_REPO)
-            .withDockerImageTag(SOURCE_DOCKER_TAG)
-            .withSourceDefinitionId(sourceDefinitionIdRequestBody.getSourceDefinitionId()));
-    when(synchronousSchedulerClient.createGetSpecJob(SOURCE_DOCKER_IMAGE))
+        .thenReturn(sourceDefinition);
+    when(specFetcher.getSpecJobResponse(sourceDefinition))
         .thenReturn(specResponse);
     when(specResponse.getOutput()).thenReturn(CONNECTION_SPECIFICATION);
 
@@ -257,29 +259,20 @@ class SchedulerHandlerTest {
         new DestinationDefinitionIdRequestBody().destinationDefinitionId(UUID.randomUUID());
 
     final SynchronousResponse<ConnectorSpecification> specResponse = (SynchronousResponse<ConnectorSpecification>) this.jobResponse;
+    final StandardDestinationDefinition destinationDefinition = new StandardDestinationDefinition()
+        .withName("name")
+        .withDockerRepository(DESTINATION_DOCKER_REPO)
+        .withDockerImageTag(DESTINATION_DOCKER_TAG)
+        .withDestinationDefinitionId(destinationDefinitionIdRequestBody.getDestinationDefinitionId());
     when(configRepository.getStandardDestinationDefinition(destinationDefinitionIdRequestBody.getDestinationDefinitionId()))
-        .thenReturn(new StandardDestinationDefinition()
-            .withName("name")
-            .withDockerRepository(DESTINATION_DOCKER_REPO)
-            .withDockerImageTag(DESTINATION_DOCKER_TAG)
-            .withDestinationDefinitionId(destinationDefinitionIdRequestBody.getDestinationDefinitionId()));
-    when(synchronousSchedulerClient.createGetSpecJob(DESTINATION_DOCKER_IMAGE))
+        .thenReturn(destinationDefinition);
+    when(specFetcher.getSpecJobResponse(destinationDefinition))
         .thenReturn(specResponse);
     when(specResponse.getOutput()).thenReturn(CONNECTION_SPECIFICATION);
 
     schedulerHandler.getDestinationSpecification(destinationDefinitionIdRequestBody);
 
     verify(configRepository).getStandardDestinationDefinition(destinationDefinitionIdRequestBody.getDestinationDefinitionId());
-  }
-
-  @Test
-  public void testGetConnectorSpec() throws IOException {
-    final SynchronousResponse<ConnectorSpecification> specResponse = (SynchronousResponse<ConnectorSpecification>) jobResponse;
-    when(specResponse.getOutput()).thenReturn(CONNECTION_SPECIFICATION);
-    when(synchronousSchedulerClient.createGetSpecJob(SOURCE_DOCKER_IMAGE))
-        .thenReturn(specResponse);
-
-    assertEquals(CONNECTION_SPECIFICATION, schedulerHandler.getConnectorSpecification(SOURCE_DOCKER_IMAGE).getOutput());
   }
 
   @Test
@@ -335,15 +328,16 @@ class SchedulerHandlerTest {
         .name(destination.getName())
         .destinationId(destination.getDestinationId())
         .connectionConfiguration(destination.getConfiguration());
+    final StandardDestinationDefinition destinationDefinition = new StandardDestinationDefinition()
+        .withDockerRepository(DESTINATION_DOCKER_REPO)
+        .withDockerImageTag(DESTINATION_DOCKER_TAG)
+        .withDestinationDefinitionId(destination.getDestinationDefinitionId());
     when(configRepository.getStandardDestinationDefinition(destination.getDestinationDefinitionId()))
-        .thenReturn(new StandardDestinationDefinition()
-            .withDockerRepository(DESTINATION_DOCKER_REPO)
-            .withDockerImageTag(DESTINATION_DOCKER_TAG)
-            .withDestinationDefinitionId(destination.getDestinationDefinitionId()));
+        .thenReturn(destinationDefinition);
     when(configRepository.getDestinationConnection(destination.getDestinationId())).thenReturn(destination);
     when(configurationUpdate.destination(destination.getDestinationId(), destination.getName(), destinationUpdate.getConnectionConfiguration()))
         .thenReturn(destination);
-    when(specFetcher.execute(DESTINATION_DOCKER_IMAGE)).thenReturn(CONNECTION_SPECIFICATION);
+    when(specFetcher.getSpec(destinationDefinition)).thenReturn(CONNECTION_SPECIFICATION);
     final DestinationConnection submittedDestination = new DestinationConnection()
         .withDestinationDefinitionId(destination.getDestinationDefinitionId())
         .withConfiguration(destination.getConfiguration());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
@@ -105,7 +105,7 @@ class SourceHandlerTest {
 
     when(uuidGenerator.get()).thenReturn(sourceConnection.getSourceId());
     when(configRepository.getSourceConnection(sourceConnection.getSourceId())).thenReturn(sourceConnection);
-    when(specFetcher.execute(imageName)).thenReturn(connectorSpecification);
+    when(specFetcher.getSpec(standardSourceDefinition)).thenReturn(connectorSpecification);
     when(configRepository.getStandardSourceDefinition(sourceDefinitionSpecificationRead.getSourceDefinitionId()))
         .thenReturn(standardSourceDefinition);
     when(secretsProcessor.maskSecrets(sourceCreate.getConnectionConfiguration(), sourceDefinitionSpecificationRead.getConnectionSpecification()))
@@ -141,7 +141,7 @@ class SourceHandlerTest {
 
     when(secretsProcessor
         .copySecrets(sourceConnection.getConfiguration(), newConfiguration, sourceDefinitionSpecificationRead.getConnectionSpecification()))
-            .thenReturn(newConfiguration);
+        .thenReturn(newConfiguration);
     when(secretsProcessor.maskSecrets(newConfiguration, sourceDefinitionSpecificationRead.getConnectionSpecification())).thenReturn(newConfiguration);
     when(configRepository.getStandardSourceDefinition(sourceDefinitionSpecificationRead.getSourceDefinitionId()))
         .thenReturn(standardSourceDefinition);
@@ -150,7 +150,7 @@ class SourceHandlerTest {
     when(configRepository.getSourceConnection(sourceConnection.getSourceId()))
         .thenReturn(sourceConnection)
         .thenReturn(expectedSourceConnection);
-    when(specFetcher.execute(imageName)).thenReturn(connectorSpecification);
+    when(specFetcher.getSpec(standardSourceDefinition)).thenReturn(connectorSpecification);
     when(configurationUpdate.source(sourceConnection.getSourceId(), updatedSourceName, newConfiguration))
         .thenReturn(expectedSourceConnection);
 
@@ -174,7 +174,7 @@ class SourceHandlerTest {
     when(configRepository.getStandardSourceDefinition(sourceDefinitionSpecificationRead.getSourceDefinitionId()))
         .thenReturn(standardSourceDefinition);
     when(configRepository.getSourceDefinitionFromSource(sourceConnection.getSourceId())).thenReturn(standardSourceDefinition);
-    when(specFetcher.execute(imageName)).thenReturn(connectorSpecification);
+    when(specFetcher.getSpec(standardSourceDefinition)).thenReturn(connectorSpecification);
     when(secretsProcessor.maskSecrets(sourceConnection.getConfiguration(), sourceDefinitionSpecificationRead.getConnectionSpecification()))
         .thenReturn(sourceConnection.getConfiguration());
 
@@ -206,7 +206,7 @@ class SourceHandlerTest {
     when(configRepository.getStandardSourceDefinition(sourceDefinitionSpecificationRead.getSourceDefinitionId()))
         .thenReturn(standardSourceDefinition);
     when(configRepository.getSourceDefinitionFromSource(sourceConnection.getSourceId())).thenReturn(standardSourceDefinition);
-    when(specFetcher.execute(imageName)).thenReturn(connectorSpecification);
+    when(specFetcher.getSpec(standardSourceDefinition)).thenReturn(connectorSpecification);
     when(secretsProcessor.maskSecrets(sourceConnection.getConfiguration(), sourceDefinitionSpecificationRead.getConnectionSpecification()))
         .thenReturn(sourceConnection.getConfiguration());
 
@@ -225,7 +225,7 @@ class SourceHandlerTest {
     when(configRepository.getStandardSourceDefinition(sourceDefinitionSpecificationRead.getSourceDefinitionId()))
         .thenReturn(standardSourceDefinition);
     when(configRepository.getSourceDefinitionFromSource(sourceConnection.getSourceId())).thenReturn(standardSourceDefinition);
-    when(specFetcher.execute(imageName)).thenReturn(connectorSpecification);
+    when(specFetcher.getSpec(standardSourceDefinition)).thenReturn(connectorSpecification);
     when(secretsProcessor.maskSecrets(sourceConnection.getConfiguration(), sourceDefinitionSpecificationRead.getConnectionSpecification()))
         .thenReturn(sourceConnection.getConfiguration());
 
@@ -261,7 +261,7 @@ class SourceHandlerTest {
     when(configRepository.getStandardSourceDefinition(sourceDefinitionSpecificationRead.getSourceDefinitionId()))
         .thenReturn(standardSourceDefinition);
     when(configRepository.getSourceDefinitionFromSource(sourceConnection.getSourceId())).thenReturn(standardSourceDefinition);
-    when(specFetcher.execute(imageName)).thenReturn(connectorSpecification);
+    when(specFetcher.getSpec(standardSourceDefinition)).thenReturn(connectorSpecification);
     when(connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody)).thenReturn(connectionReadList);
     when(secretsProcessor.maskSecrets(sourceConnection.getConfiguration(), sourceDefinitionSpecificationRead.getConnectionSpecification()))
         .thenReturn(sourceConnection.getConfiguration());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
@@ -141,7 +141,7 @@ class SourceHandlerTest {
 
     when(secretsProcessor
         .copySecrets(sourceConnection.getConfiguration(), newConfiguration, sourceDefinitionSpecificationRead.getConnectionSpecification()))
-        .thenReturn(newConfiguration);
+            .thenReturn(newConfiguration);
     when(secretsProcessor.maskSecrets(newConfiguration, sourceDefinitionSpecificationRead.getConnectionSpecification())).thenReturn(newConfiguration);
     when(configRepository.getStandardSourceDefinition(sourceDefinitionSpecificationRead.getSourceDefinitionId()))
         .thenReturn(standardSourceDefinition);


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/airbyte/issues/7136, though a slightly different approach was taken than what was described in the issue, as explained below.

Refactors the SpecFetcher to take in Source and Destination Definitions and attempt to fetch the spec from those structs directly, before falling back to the scheduler job client.

## How 
Source and Destination definitions are almost always retrieved from the database before the spec fetcher is called, so this change takes advantage of that behavior by allowing those definitions to be passed into the spec fetcher, where it attempts to read the spec from them directly. 

Another advantage of this is that the logic for resolving the docker image name from a source/destination definition is now centralized in the spec fetcher and is only performed when the definition doesn't contain a spec, reducing some repeated code.

## Recommended reading order
1. `SpecFetcher.java`
2. Other non-test classes, which use the SpecFetcher
3. Test classes

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> New Connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector added to connector index like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
   
</p>
</details>


<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</p>
</details>

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
