### PR TITLE
Detailed *not* to use username/pass here

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@ DATABASE_PASSWORD=docker
 DATABASE_HOST=db
 DATABASE_PORT=5432
 DATABASE_DB=airbyte
-# translate manually DATABASE_URL=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT/${DATABASE_DB}
+# translate manually DATABASE_URL=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT/${DATABASE_DB} (do not include the username or password here)
 DATABASE_URL=jdbc:postgresql://db:5432/airbyte
 
 # Airbyte Internal Config Database, default to reuse the Job Database when they are empty


### PR DESCRIPTION
## What
Constructing the `DATABASE_URL` was a sharp edge that tripped me up for a few hours when deploying to RDS. Coming from a world where you would provide a fully qualified `DATABASE_URL` (Rails, Phoenix Framework) I assumed I could do the same here.

The error message returned in the console was to do with a database connection but didn't mention anything further than that. I was stumped as I was able to successfully test the connection using `psql` but couldn't get AirByte to function until I realised I need to *omit* the username and password.

## How
As well as detailing how to construct the URL, I think it should explicitly mention keeping the username and password out of the URL.
