### PR TITLE
add cli commons to factor out common parsing code

### DIFF
--- a/airbyte-commons-cli/build.gradle
+++ b/airbyte-commons-cli/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+    id "java-library"
+}
+
+dependencies {
+    implementation 'commons-cli:commons-cli:1.4'
+}

--- a/airbyte-commons-cli/readme.md
+++ b/airbyte-commons-cli/readme.md
@@ -1,0 +1,1 @@
+This module houses utility functions for the `commons-cli` library. It is separate from `commons`, because it depends on external library `commons-cli` which we do not want to introduce as a dependency to every module.

--- a/airbyte-commons-cli/src/main/java/io/airbyte/commons/cli/Clis.java
+++ b/airbyte-commons-cli/src/main/java/io/airbyte/commons/cli/Clis.java
@@ -30,7 +30,9 @@ public class Clis {
     try {
       return parser.parse(options, args);
     } catch (final ParseException e) {
-      helpFormatter.printHelp(commandLineSyntax, options);
+      if (commandLineSyntax != null && !commandLineSyntax.isEmpty()) {
+        helpFormatter.printHelp(commandLineSyntax, options);
+      }
       throw new IllegalArgumentException(e);
     }
   }
@@ -40,7 +42,7 @@ public class Clis {
   }
 
   public static CommandLine parse(final String[] args, final Options options, final CommandLineParser parser) {
-    return parse(args, options, parser, "");
+    return parse(args, options, parser, null);
   }
 
   public static CommandLine parse(final String[] args, final Options options) {

--- a/airbyte-commons-cli/src/main/java/io/airbyte/commons/cli/Clis.java
+++ b/airbyte-commons-cli/src/main/java/io/airbyte/commons/cli/Clis.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.cli;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+public class Clis {
+
+  /**
+   * Parse an options object
+   *
+   * @param args - command line args
+   * @param options - expected options
+   * @return object with parsed values.
+   */
+  public static CommandLine parse(final String[] args, final Options options, final CommandLineParser parser, final String commandLineSyntax) {
+    final HelpFormatter helpFormatter = new HelpFormatter();
+
+    try {
+      return parser.parse(options, args);
+    } catch (final ParseException e) {
+      helpFormatter.printHelp(commandLineSyntax, options);
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  public static CommandLine parse(final String[] args, final Options options, final String commandLineSyntax) {
+    return parse(args, options, new DefaultParser(), commandLineSyntax);
+  }
+
+  public static CommandLine parse(final String[] args, final Options options, final CommandLineParser parser) {
+    return parse(args, options, parser, "");
+  }
+
+  public static CommandLine parse(final String[] args, final Options options) {
+    return parse(args, options, new DefaultParser());
+  }
+
+  /**
+   * Provide a fluent interface for building an OptionsGroup.
+   *
+   * @param isRequired - is the option group required
+   * @param options - options in the option group
+   * @return the created option group.
+   */
+  public static OptionGroup createOptionGroup(final boolean isRequired, final Option... options) {
+    final OptionGroup optionGroup = new OptionGroup();
+    optionGroup.setRequired(isRequired);
+    for (final Option option : options) {
+      optionGroup.addOption(option);
+    }
+    return optionGroup;
+  }
+
+  public static CommandLineParser getRelaxedParser() {
+    return new RelaxedParser();
+  }
+
+  // https://stackoverflow.com/questions/33874902/apache-commons-cli-1-3-1-how-to-ignore-unknown-arguments
+  private static class RelaxedParser extends DefaultParser {
+
+    @Override
+    public CommandLine parse(final Options options, final String[] arguments) throws ParseException {
+      final List<String> knownArgs = new ArrayList<>();
+      for (int i = 0; i < arguments.length; i++) {
+        if (options.hasOption(arguments[i])) {
+          knownArgs.add(arguments[i]);
+          if (i + 1 < arguments.length && options.getOption(arguments[i]).hasArg()) {
+            knownArgs.add(arguments[i + 1]);
+          }
+        }
+      }
+      return super.parse(options, knownArgs.toArray(new String[0]));
+    }
+
+  }
+
+}

--- a/airbyte-commons-cli/src/test/java/io/airbyte/commons/cli/ClisTest.java
+++ b/airbyte-commons-cli/src/test/java/io/airbyte/commons/cli/ClisTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ClisTest {
+
+  @Test
+  void testGetTaggedImageName() {
+    final String repository = "airbyte/repo";
+    final String tag = "12.3";
+    assertEquals("airbyte/repo:12.3", Clis.getTaggedImageName(repository, tag));
+  }
+
+}

--- a/airbyte-commons-cli/src/test/java/io/airbyte/commons/cli/ClisTest.java
+++ b/airbyte-commons-cli/src/test/java/io/airbyte/commons/cli/ClisTest.java
@@ -5,16 +5,72 @@
 package io.airbyte.commons.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
+import org.apache.commons.cli.Options;
 import org.junit.jupiter.api.Test;
 
 class ClisTest {
 
   @Test
-  void testGetTaggedImageName() {
-    final String repository = "airbyte/repo";
-    final String tag = "12.3";
-    assertEquals("airbyte/repo:12.3", Clis.getTaggedImageName(repository, tag));
+  void testCreateOptionGroup() {
+    final Option optionA = new Option("a", "alpha");
+    final Option optionB = new Option("b", "beta");
+    final OptionGroup optionGroupExpected = new OptionGroup();
+    optionGroupExpected.addOption(optionA);
+    optionGroupExpected.addOption(optionB);
+
+    final OptionGroup optionGroupActual = Clis.createOptionGroup(
+        false,
+        optionA,
+        optionB);
+
+    // hack: OptionGroup does not define hashcode, so compare its string instead of the object itself.
+    assertEquals(optionGroupExpected.toString(), optionGroupActual.toString());
+  }
+
+  @Test
+  void testParse() {
+    final Option optionA = Option.builder("a").required(true).hasArg(true).build();
+    final Option optionB = Option.builder("b").required(true).hasArg(true).build();
+    final Options options = new Options().addOption(optionA).addOption(optionB);
+    final String[] args = {"-a", "alpha", "-b", "beta"};
+    final CommandLine parsed = Clis.parse(args, options, new DefaultParser());
+    assertEquals("alpha", parsed.getOptions()[0].getValue());
+    assertEquals("beta", parsed.getOptions()[1].getValue());
+  }
+
+  @Test
+  void testParseNonConforming() {
+    final Option optionA = Option.builder("a").required(true).hasArg(true).build();
+    final Option optionB = Option.builder("b").required(true).hasArg(true).build();
+    final Options options = new Options().addOption(optionA).addOption(optionB);
+    final String[] args = {"-a", "alpha", "-b", "beta", "-c", "charlie"};
+    assertThrows(IllegalArgumentException.class, () -> Clis.parse(args, options, new DefaultParser()));
+  }
+
+  @Test
+  void testParseNonConformingWithSyntax() {
+    final Option optionA = Option.builder("a").required(true).hasArg(true).build();
+    final Option optionB = Option.builder("b").required(true).hasArg(true).build();
+    final Options options = new Options().addOption(optionA).addOption(optionB);
+    final String[] args = {"-a", "alpha", "-b", "beta", "-c", "charlie"};
+    assertThrows(IllegalArgumentException.class, () -> Clis.parse(args, options, new DefaultParser(), "search"));
+  }
+
+  @Test
+  void testRelaxedParser() {
+    final Option optionA = Option.builder("a").required(true).hasArg(true).build();
+    final Option optionB = Option.builder("b").required(true).hasArg(true).build();
+    final Options options = new Options().addOption(optionA).addOption(optionB);
+    final String[] args = {"-a", "alpha", "-b", "beta", "-c", "charlie"};
+    final CommandLine parsed = Clis.parse(args, options, Clis.getRelaxedParser());
+    assertEquals("alpha", parsed.getOptions()[0].getValue());
+    assertEquals("beta", parsed.getOptions()[1].getValue());
   }
 
 }

--- a/airbyte-integrations/bases/base-java/build.gradle
+++ b/airbyte-integrations/bases/base-java/build.gradle
@@ -4,6 +4,10 @@ plugins {
 }
 
 dependencies {
+    implementation project(':airbyte-protocol:models')
+    implementation project(':airbyte-commons-cli')
+    implementation project(':airbyte-json-validation')
+
     implementation 'commons-cli:commons-cli:1.4'
     implementation 'org.apache.sshd:sshd-mina:2.7.0'
     // bouncycastle is pinned to version-match the transitive dependency from kubernetes client-java
@@ -12,8 +16,6 @@ dependencies {
     implementation 'org.bouncycastle:bcpkix-jdk15on:1.66'
     implementation 'org.bouncycastle:bctls-jdk15on:1.66'
 
-    implementation project(':airbyte-protocol:models')
-    implementation project(":airbyte-json-validation")
     implementation "org.testcontainers:testcontainers:1.15.3"
     implementation "org.testcontainers:jdbc:1.15.3"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,6 +28,7 @@ if(!System.getenv().containsKey("SUB_BUILD")) {
 include ':airbyte-api'
 include ':airbyte-commons'
 include ':airbyte-commons-docker'
+include ':airbyte-commons-cli'
 include ':airbyte-config:models' // reused by acceptance tests in connector base.
 include ':airbyte-db:lib' // reused by acceptance tests in connector base.
 include ':airbyte-json-validation'


### PR DESCRIPTION
## What
* With Cloud we are leaning towards writing more scripts in java. We currently use apache.commons.cli for this. While I recommend in this [issue](https://github.com/airbytehq/airbyte-internal-issues/issues/300) we move away from it (and use picocli instead), this PR adds a couple quick helpers to factor out common logic we use for parsing command line args with the current tool. It also helps concentrate all of the use of the cli tool, so it'll be easier to excise. 
* Once it is released, I'll switch cloud to depend on it.