### PR TITLE
remove python from platform build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -183,15 +183,6 @@ jobs:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
 
-      - name: Pip Caching
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/pip
-          key: ${{ secrets.CACHE_VERSION }}-pip-${{ runner.os }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ secrets.CACHE_VERSION }}-pip-${{ runner.os }}-
-
       - name: Npm Caching
         uses: actions/cache@v2
         with:
@@ -218,13 +209,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.7'
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
-
-      - name: Install Pyenv
-        run: python3 -m pip install virtualenv==16.7.9 --user
 
       - name: Set up CI Gradle Properties
         run: |

--- a/settings.gradle
+++ b/settings.gradle
@@ -58,8 +58,6 @@ if(!System.getenv().containsKey("SUB_BUILD") || System.getenv().get("SUB_BUILD")
     include ':airbyte-tests'
     include ':airbyte-webapp'
     include ':airbyte-secrets-migration'
-
-    include ':tools:code-generator'
 }
 
 // connectors base


### PR DESCRIPTION
## What
* since normalization is no longer in the platform build (after this pr: https://github.com/airbytehq/airbyte/pull/7068) we should no longer need to install python and penv.