### PR TITLE
backfill specs into connector definitions.

### DIFF
--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigQueries.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigQueries.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.persistence;
+
+import io.airbyte.config.ConfigSchema;
+import io.airbyte.config.DestinationConnection;
+import io.airbyte.config.SourceConnection;
+import io.airbyte.config.StandardSync;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class ConfigQueries {
+
+  public static void deleteSourceDefinition(final ConfigPersistence configPersistence, final UUID sourceDefinitionId) throws Exception {
+    deleteConnectorDefinition(
+        configPersistence,
+        ConfigSchema.STANDARD_SOURCE_DEFINITION,
+        ConfigSchema.SOURCE_CONNECTION,
+        SourceConnection.class,
+        SourceConnection::getSourceDefinitionId,
+        sourceDefinitionId);
+  }
+
+  public static void deleteDestinationDefinition(final ConfigPersistence configPersistence, final UUID destinationDefinitionId) throws Exception {
+    deleteConnectorDefinition(
+        configPersistence,
+        ConfigSchema.STANDARD_DESTINATION_DEFINITION,
+        ConfigSchema.DESTINATION_CONNECTION,
+        DestinationConnection.class,
+        DestinationConnection::getDestinationDefinitionId,
+        destinationDefinitionId);
+  }
+
+  private static <T> void deleteConnectorDefinition(
+                                                    final ConfigPersistence configPersistence,
+                                                    final ConfigSchema definitionType,
+                                                    final ConfigSchema connectorType,
+                                                    final Class<T> connectorClass,
+                                                    final Function<T, UUID> connectorDefinitionIdGetter,
+                                                    final UUID definitionId)
+      throws Exception {
+    final Set<T> connectors = configPersistence.listConfigs(connectorType, connectorClass)
+        .stream()
+        .filter(connector -> connectorDefinitionIdGetter.apply(connector).equals(definitionId))
+        .collect(Collectors.toSet());
+    for (final T connector : connectors) {
+      final Set<StandardSync> syncs = configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC, StandardSync.class)
+          .stream()
+          .filter(sync -> sync.getDestinationId().equals(connectorDefinitionIdGetter.apply(connector)))
+          .collect(Collectors.toSet());
+
+      for (final StandardSync sync : syncs) {
+        configPersistence.deleteConfig(ConfigSchema.STANDARD_SYNC, sync.getConnectionId().toString());
+      }
+      configPersistence.deleteConfig(connectorType, connectorDefinitionIdGetter.apply(connector).toString());
+    }
+    configPersistence.deleteConfig(definitionType, definitionId.toString());
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -281,7 +281,7 @@ public class ServerApp implements ServerRunnable {
     for (final StandardSourceDefinition sourceDef : configRepository.listStandardSourceDefinitions()) {
       if (sourceDef.getSpec() == null) {
         final SynchronousResponse<ConnectorSpecification> getSpecJob = schedulerClient
-            .createGetSpecJob(sourceDef.getDockerRepository() + "" + sourceDef.getDockerImageTag());
+            .createGetSpecJob(sourceDef.getDockerRepository() + ":" + sourceDef.getDockerImageTag());
         if (getSpecJob.isSuccess()) {
           final StandardSourceDefinition updatedDef = Jsons.clone(sourceDef).withSpec(getSpecJob.getOutput());
           configRepository.writeStandardSourceDefinition(updatedDef);

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -236,14 +236,15 @@ public class ServerApp implements ServerRunnable {
         jobPersistence,
         configs);
 
-    // todo (cgardens) - this will exist in a single version of airbyte. to ensure all definitions
-    // contain specs.
-    migrateAllDefinitionsToContainSpec(configRepository, configPersistence, syncSchedulerClient);
-
     if (airbyteDatabaseVersion.isPresent() && AirbyteVersion.isCompatible(airbyteVersion, airbyteDatabaseVersion.get())) {
       LOGGER.info("Starting server...");
 
       runFlywayMigration(configs, configDatabase, jobDatabase);
+
+      // todo (cgardens) - this will exist in a single version of airbyte. to ensure all definitions
+      // contain specs.
+      migrateAllDefinitionsToContainSpec(configRepository, configPersistence, syncSchedulerClient);
+
       configPersistence.loadData(seed);
 
       return apiFactory.create(

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -294,7 +294,7 @@ public class ServerApp implements ServerRunnable {
     for (final StandardDestinationDefinition destDef : configRepository.listStandardDestinationDefinitions()) {
       if (destDef.getSpec() == null) {
         final SynchronousResponse<ConnectorSpecification> getSpecJob = schedulerClient
-            .createGetSpecJob(destDef.getDockerRepository() + "" + destDef.getDockerImageTag());
+            .createGetSpecJob(destDef.getDockerRepository() + ":" + destDef.getDockerImageTag());
         if (getSpecJob.isSuccess()) {
           final StandardDestinationDefinition updatedDef = Jsons.clone(destDef).withSpec(getSpecJob.getOutput());
           configRepository.writeStandardDestinationDefinition(updatedDef);

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -7,15 +7,19 @@ package io.airbyte.server;
 import io.airbyte.analytics.Deployment;
 import io.airbyte.analytics.TrackingClient;
 import io.airbyte.analytics.TrackingClientSingleton;
+import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.Configs;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.EnvConfigs;
+import io.airbyte.config.StandardDestinationDefinition;
+import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.helpers.LogClientSingleton;
 import io.airbyte.config.persistence.ConfigPersistence;
+import io.airbyte.config.persistence.ConfigQueries;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.DatabaseConfigPersistence;
 import io.airbyte.config.persistence.YamlSeedConfigPersistence;
@@ -27,11 +31,13 @@ import io.airbyte.db.instance.configs.ConfigsDatabaseInstance;
 import io.airbyte.db.instance.configs.ConfigsDatabaseMigrator;
 import io.airbyte.db.instance.jobs.JobsDatabaseInstance;
 import io.airbyte.db.instance.jobs.JobsDatabaseMigrator;
+import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.client.BucketSpecCacheSchedulerClient;
 import io.airbyte.scheduler.client.DefaultSchedulerJobClient;
 import io.airbyte.scheduler.client.DefaultSynchronousSchedulerClient;
 import io.airbyte.scheduler.client.SchedulerJobClient;
 import io.airbyte.scheduler.client.SpecCachingSynchronousSchedulerClient;
+import io.airbyte.scheduler.client.SynchronousResponse;
 import io.airbyte.scheduler.client.SynchronousSchedulerClient;
 import io.airbyte.scheduler.persistence.DefaultJobCreator;
 import io.airbyte.scheduler.persistence.DefaultJobPersistence;
@@ -230,6 +236,10 @@ public class ServerApp implements ServerRunnable {
         jobPersistence,
         configs);
 
+    // todo (cgardens) - this will exist in a single version of airbyte. to ensure all definitions
+    // contain specs.
+    migrateAllDefinitionsToContainSpec(configRepository, configPersistence, syncSchedulerClient);
+
     if (airbyteDatabaseVersion.isPresent() && AirbyteVersion.isCompatible(airbyteVersion, airbyteDatabaseVersion.get())) {
       LOGGER.info("Starting server...");
 
@@ -250,6 +260,47 @@ public class ServerApp implements ServerRunnable {
     } else {
       LOGGER.info("Start serving version mismatch errors. Automatic migration either failed or didn't run");
       return new VersionMismatchServer(airbyteVersion, airbyteDatabaseVersion.orElseThrow(), PORT);
+    }
+  }
+
+  /**
+   * Check that each spec in the database has a spec. If it doesn't, add it. If it can't be added,
+   * delete it and all connections and sources that depend on it. The goal is to end up in a working
+   * state.
+   *
+   * @param configRepository - access to the db
+   * @param configPersistence - lower level access to the db
+   * @param schedulerClient - scheduler client so that specs can be fetched as needed
+   * @throws Exception
+   */
+  private static void migrateAllDefinitionsToContainSpec(final ConfigRepository configRepository,
+                                                         final ConfigPersistence configPersistence,
+                                                         final SynchronousSchedulerClient schedulerClient)
+      throws Exception {
+    for (final StandardSourceDefinition sourceDef : configRepository.listStandardSourceDefinitions()) {
+      if (sourceDef.getSpec() == null) {
+        final SynchronousResponse<ConnectorSpecification> getSpecJob = schedulerClient
+            .createGetSpecJob(sourceDef.getDockerRepository() + "" + sourceDef.getDockerImageTag());
+        if (getSpecJob.isSuccess()) {
+          final StandardSourceDefinition updatedDef = Jsons.clone(sourceDef).withSpec(getSpecJob.getOutput());
+          configRepository.writeStandardSourceDefinition(updatedDef);
+        } else {
+          ConfigQueries.deleteSourceDefinition(configPersistence, sourceDef.getSourceDefinitionId());
+        }
+      }
+    }
+
+    for (final StandardDestinationDefinition destDef : configRepository.listStandardDestinationDefinitions()) {
+      if (destDef.getSpec() == null) {
+        final SynchronousResponse<ConnectorSpecification> getSpecJob = schedulerClient
+            .createGetSpecJob(destDef.getDockerRepository() + "" + destDef.getDockerImageTag());
+        if (getSpecJob.isSuccess()) {
+          final StandardDestinationDefinition updatedDef = Jsons.clone(destDef).withSpec(getSpecJob.getOutput());
+          configRepository.writeStandardDestinationDefinition(updatedDef);
+        } else {
+          ConfigQueries.deleteDestinationDefinition(configPersistence, destDef.getDestinationDefinitionId());
+        }
+      }
     }
   }
 
@@ -278,6 +329,7 @@ public class ServerApp implements ServerRunnable {
         LOGGER.info("Can not run automatic migration for Airbyte on KUBERNETES before version " + KUBE_SUPPORT_FOR_AUTOMATIC_MIGRATION.getVersion());
       }
     }
+
     return airbyteDatabaseVersion;
   }
 


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/7143
relates to relates to #6917

## What
* I was exploring what it is going to look like when do do our breaking migration and was curious if it would be easy to shoehorning guaranteeing that all definitions have a spec in there to avoid having to write a really awful flyway migration. I'm inclined to say this is worth it, because if we do it this way, we can then delete this awful code after the breaking migration.

If we do go this route, this PR should not be merged until the all code paths that create definitions in the db, always add a spec for new or updated definitions, _but_ the column cannot yet be required as this migration runs after the flyway migration, so the flyway migration will choke if spec isn't present. Then in the next version after this, we would make the column required.