### PR TITLE
prefer AirbyteVersion over String

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/version/AirbyteVersion.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/version/AirbyteVersion.java
@@ -43,7 +43,7 @@ public class AirbyteVersion {
     this.patch = patch;
   }
 
-  public String getVersion() {
+  public String serialize() {
     return version;
   }
 
@@ -75,6 +75,27 @@ public class AirbyteVersion {
   }
 
   /**
+   * @return true if this is greater than other. otherwise false.
+   */
+  public boolean greaterThan(final AirbyteVersion other) {
+    return patchVersionCompareTo(other) > 0;
+  }
+
+  /**
+   * @return true if this is greater than or equal toother. otherwise false.
+   */
+  public boolean greaterThanOrEqualTo(final AirbyteVersion other) {
+    return patchVersionCompareTo(other) >= 0;
+  }
+
+  /**
+   * @return true if this is less than other. otherwise false.
+   */
+  public boolean lessThan(final AirbyteVersion other) {
+    return patchVersionCompareTo(other) < 0;
+  }
+
+  /**
    * Compares two Airbyte Version to check if they are equivalent (including patch version).
    */
   public int patchVersionCompareTo(final AirbyteVersion another) {
@@ -92,6 +113,10 @@ public class AirbyteVersion {
     return compareVersion(patch, another.patch);
   }
 
+  public boolean isDev() {
+    return version.equals(DEV_VERSION);
+  }
+
   /**
    * Version string needs to be converted to integer for comparison, because string comparison does
    * not handle version string with different digits correctly. For example:
@@ -101,25 +126,21 @@ public class AirbyteVersion {
     return Integer.compare(Integer.parseInt(v1), Integer.parseInt(v2));
   }
 
-  public static void assertIsCompatible(final String version1, final String version2) throws IllegalStateException {
+  public static void assertIsCompatible(final AirbyteVersion version1, final AirbyteVersion version2) throws IllegalStateException {
     if (!isCompatible(version1, version2)) {
       throw new IllegalStateException(getErrorMessage(version1, version2));
     }
   }
 
-  public static String getErrorMessage(final String version1, final String version2) {
-    final String cleanVersion1 = version1.replace("\n", "").strip();
-    final String cleanVersion2 = version2.replace("\n", "").strip();
+  public static String getErrorMessage(final AirbyteVersion version1, final AirbyteVersion version2) {
     return String.format(
         "Version mismatch between %s and %s.\n" +
             "Please upgrade or reset your Airbyte Database, see more at https://docs.airbyte.io/operator-guides/upgrading-airbyte",
-        cleanVersion1, cleanVersion2);
+        version1.serialize(), version2.serialize());
   }
 
-  public static boolean isCompatible(final String v1, final String v2) {
-    final AirbyteVersion version1 = new AirbyteVersion(v1);
-    final AirbyteVersion version2 = new AirbyteVersion(v2);
-    return version1.compatibleVersionCompareTo(version2) == 0;
+  public static boolean isCompatible(final AirbyteVersion v1, final AirbyteVersion v2) {
+    return v1.compatibleVersionCompareTo(v2) == 0;
   }
 
   @Override
@@ -137,7 +158,7 @@ public class AirbyteVersion {
         + "."
         + airbyteVersion.getMinorVersion()
         + ".0-"
-        + airbyteVersion.getVersion().replace("\n", "").strip().split("-")[1];
+        + airbyteVersion.serialize().replace("\n", "").strip().split("-")[1];
     return new AirbyteVersion(versionWithoutPatch);
   }
 

--- a/airbyte-commons/src/test/java/io/airbyte/commons/version/AirbyteVersionTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/version/AirbyteVersionTest.java
@@ -5,12 +5,13 @@
 package io.airbyte.commons.version;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-public class TestAirbyteVersion {
+public class AirbyteVersionTest {
 
   @Test
   public void testParseVersion() {
@@ -54,6 +55,32 @@ public class TestAirbyteVersion {
   }
 
   @Test
+  public void testGreaterThan() {
+    assertFalse(new AirbyteVersion("6.7.8-omega").greaterThan(new AirbyteVersion("6.7.8-gamma")));
+    assertFalse(new AirbyteVersion("6.7.8-alpha").greaterThan(new AirbyteVersion("6.7.9-alpha")));
+    assertFalse(new AirbyteVersion("6.7.8-alpha").greaterThan(new AirbyteVersion("6.7.11-alpha")));
+    assertTrue(new AirbyteVersion("6.8.0-alpha").greaterThan(new AirbyteVersion("6.7.8-alpha")));
+    assertTrue(new AirbyteVersion("6.11.0-alpha").greaterThan(new AirbyteVersion("6.7.8-alpha")));
+    assertFalse(new AirbyteVersion("3.8.0-alpha").greaterThan(new AirbyteVersion("6.7.8-alpha")));
+    assertFalse(new AirbyteVersion("3.8.0-alpha").greaterThan(new AirbyteVersion("11.7.8-alpha")));
+    assertFalse(new AirbyteVersion("1.2.3-prod").greaterThan(new AirbyteVersion("dev")));
+    assertFalse(new AirbyteVersion("dev").greaterThan(new AirbyteVersion("1.2.3-prod")));
+  }
+
+  @Test
+  public void testLessThan() {
+    assertFalse(new AirbyteVersion("6.7.8-omega").lessThan(new AirbyteVersion("6.7.8-gamma")));
+    assertTrue(new AirbyteVersion("6.7.8-alpha").lessThan(new AirbyteVersion("6.7.9-alpha")));
+    assertTrue(new AirbyteVersion("6.7.8-alpha").lessThan(new AirbyteVersion("6.7.11-alpha")));
+    assertFalse(new AirbyteVersion("6.8.0-alpha").lessThan(new AirbyteVersion("6.7.8-alpha")));
+    assertFalse(new AirbyteVersion("6.11.0-alpha").lessThan(new AirbyteVersion("6.7.8-alpha")));
+    assertTrue(new AirbyteVersion("3.8.0-alpha").lessThan(new AirbyteVersion("6.7.8-alpha")));
+    assertTrue(new AirbyteVersion("3.8.0-alpha").lessThan(new AirbyteVersion("11.7.8-alpha")));
+    assertFalse(new AirbyteVersion("1.2.3-prod").lessThan(new AirbyteVersion("dev")));
+    assertFalse(new AirbyteVersion("dev").lessThan(new AirbyteVersion("1.2.3-prod")));
+  }
+
+  @Test
   public void testInvalidVersions() {
     assertThrows(NullPointerException.class, () -> new AirbyteVersion(null));
     assertThrows(IllegalArgumentException.class, () -> new AirbyteVersion("0.6"));
@@ -61,8 +88,8 @@ public class TestAirbyteVersion {
 
   @Test
   public void testCheckVersion() {
-    AirbyteVersion.assertIsCompatible("3.2.1", "3.2.1");
-    assertThrows(IllegalStateException.class, () -> AirbyteVersion.assertIsCompatible("1.2.3", "3.2.1"));
+    AirbyteVersion.assertIsCompatible(new AirbyteVersion("3.2.1"), new AirbyteVersion("3.2.1"));
+    assertThrows(IllegalStateException.class, () -> AirbyteVersion.assertIsCompatible(new AirbyteVersion("1.2.3"), new AirbyteVersion("3.2.1")));
   }
 
 }

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/development/MigrationDevHelper.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/development/MigrationDevHelper.java
@@ -216,7 +216,7 @@ public class MigrationDevHelper {
     System.out.println("lastMigrationId: " + lastMigrationId);
     final String nextMigrationId = String.format("%03d", Integer.parseInt(lastMigrationId) + 1);
     System.out.println("nextMigrationId: " + nextMigrationId);
-    return MigrationVersion.fromVersion(String.format("%s_%s", migrationAirbyteVersion.getVersion(), nextMigrationId));
+    return MigrationVersion.fromVersion(String.format("%s_%s", migrationAirbyteVersion.serialize(), nextMigrationId));
   }
 
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/development/MigrationDevHelperTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/development/MigrationDevHelperTest.java
@@ -23,7 +23,7 @@ class MigrationDevHelperTest {
   public void testGetAirbyteVersion() {
     final MigrationVersion migrationVersion = MigrationVersion.fromVersion("0.11.3.010");
     final AirbyteVersion airbyteVersion = MigrationDevHelper.getAirbyteVersion(migrationVersion);
-    assertEquals("0.11.3", airbyteVersion.getVersion());
+    assertEquals("0.11.3", airbyteVersion.serialize());
   }
 
   @Test

--- a/airbyte-migration/src/main/java/io/airbyte/migrate/MigrationRunner.java
+++ b/airbyte-migration/src/main/java/io/airbyte/migrate/MigrationRunner.java
@@ -29,8 +29,9 @@ public class MigrationRunner {
 
   public static void run(MigrateConfig migrateConfig) throws IOException {
     final Path workspaceRoot = Files.createTempDirectory(Path.of("/tmp"), "airbyte_migrate");
-    migrateConfig = new MigrateConfig(migrateConfig.getInputPath(), migrateConfig.getOutputPath(),
-        AirbyteVersion.versionWithoutPatch(migrateConfig.getTargetVersion()).getVersion());
+    migrateConfig = new MigrateConfig(migrateConfig.getInputPath(),
+        migrateConfig.getOutputPath(),
+        AirbyteVersion.versionWithoutPatch(migrateConfig.getTargetVersion()).serialize());
 
     if (migrateConfig.getInputPath().toString().endsWith(".gz")) {
       LOGGER.info("Unpacking tarball");

--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
@@ -220,7 +220,9 @@ public class SchedulerApp {
         configs.getWorkspaceRetentionConfig(),
         workspaceRoot,
         jobPersistence);
-    AirbyteVersion.assertIsCompatible(configs.getAirbyteVersion(), jobPersistence.getVersion().orElseThrow());
+    AirbyteVersion.assertIsCompatible(
+        new AirbyteVersion(configs.getAirbyteVersion()),
+        jobPersistence.getVersion().map(AirbyteVersion::new).orElseThrow());
 
     TrackingClientSingleton.initialize(
         configs.getTrackingStrategy(),

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImporter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImporter.java
@@ -120,7 +120,7 @@ public class ConfigDumpImporter {
     }
   }
 
-  public void importDataWithSeed(final String targetVersion, final File archive, final ConfigPersistence seedPersistence)
+  public void importDataWithSeed(final AirbyteVersion targetVersion, final File archive, final ConfigPersistence seedPersistence)
       throws IOException, JsonValidationException {
     final Path sourceRoot = Files.createTempDirectory(Path.of("/tmp"), "airbyte_archive");
     try {
@@ -145,7 +145,7 @@ public class ConfigDumpImporter {
 
       // 5. Set DB version
       LOGGER.info("Setting the DB Airbyte version to : " + targetVersion);
-      jobPersistence.setVersion(targetVersion);
+      jobPersistence.setVersion(targetVersion.serialize());
 
       // 6. check db version
       checkDBVersion(targetVersion);
@@ -158,10 +158,12 @@ public class ConfigDumpImporter {
     configRepository.listStandardWorkspaces(true).forEach(workspace -> TrackingClientSingleton.get().identify(workspace.getWorkspaceId()));
   }
 
-  private void checkImport(final String targetVersion, final Path tempFolder) throws IOException {
+  private void checkImport(final AirbyteVersion targetVersion, final Path tempFolder) throws IOException {
     final Path versionFile = tempFolder.resolve(VERSION_FILE_NAME);
-    final String importVersion = Files.readString(versionFile, Charset.defaultCharset())
-        .replace("\n", "").strip();
+    final AirbyteVersion importVersion = new AirbyteVersion(Files
+        .readString(versionFile, Charset.defaultCharset())
+        .replace("\n", "")
+        .strip());
     LOGGER.info(String.format("Checking Airbyte Version to import %s", importVersion));
     if (!AirbyteVersion.isCompatible(targetVersion, importVersion)) {
       throw new IOException(String
@@ -232,7 +234,7 @@ public class ConfigDumpImporter {
   }
 
   // Postgres Portion
-  public void importDatabaseFromArchive(final Path storageRoot, final String airbyteVersion) throws IOException {
+  public void importDatabaseFromArchive(final Path storageRoot, final AirbyteVersion airbyteVersion) throws IOException {
     try {
       final Map<JobsDatabaseSchema, Stream<JsonNode>> data = new HashMap<>();
       for (final JobsDatabaseSchema tableType : JobsDatabaseSchema.values()) {
@@ -245,7 +247,7 @@ public class ConfigDumpImporter {
 
         data.put(tableType, tableStream);
       }
-      jobPersistence.importDatabase(airbyteVersion, data);
+      jobPersistence.importDatabase(airbyteVersion.serialize(), data);
       LOGGER.info("Successful upgrade of airbyte postgres database from archive");
     } catch (final Exception e) {
       LOGGER.warn("Postgres database version upgrade failed, reverting to state previous to migration.");
@@ -309,10 +311,10 @@ public class ConfigDumpImporter {
     }
   }
 
-  private void checkDBVersion(final String airbyteVersion) throws IOException {
-    final Optional<String> airbyteDatabaseVersion = jobPersistence.getVersion();
+  private void checkDBVersion(final AirbyteVersion airbyteVersion) throws IOException {
+    final Optional<AirbyteVersion> airbyteDatabaseVersion = jobPersistence.getVersion().map(AirbyteVersion::new);
     airbyteDatabaseVersion
-        .ifPresent(dbversion -> AirbyteVersion.assertIsCompatible(airbyteVersion, dbversion));
+        .ifPresent(dbVersion -> AirbyteVersion.assertIsCompatible(airbyteVersion, dbVersion));
   }
 
   public UploadRead uploadArchiveResource(final File archive) {
@@ -341,7 +343,7 @@ public class ConfigDumpImporter {
     FileUtils.deleteQuietly(archive);
   }
 
-  public void importIntoWorkspace(final String targetVersion, final UUID workspaceId, final File archive)
+  public void importIntoWorkspace(final AirbyteVersion targetVersion, final UUID workspaceId, final File archive)
       throws IOException, JsonValidationException, ConfigNotFoundException {
     final Path sourceRoot = Files.createTempDirectory(Path.of("/tmp"), "airbyte_archive");
     try {

--- a/airbyte-server/src/main/java/io/airbyte/server/RunMigration.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/RunMigration.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.server;
 
+import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.migrate.MigrateConfig;
@@ -24,7 +25,7 @@ import org.slf4j.LoggerFactory;
 public class RunMigration implements Runnable, AutoCloseable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RunMigration.class);
-  private final String targetVersion;
+  private final AirbyteVersion targetVersion;
   private final ConfigPersistence seedPersistence;
   private final ConfigDumpExporter configDumpExporter;
   private final ConfigDumpImporter configDumpImporter;
@@ -32,7 +33,7 @@ public class RunMigration implements Runnable, AutoCloseable {
 
   public RunMigration(final JobPersistence jobPersistence,
                       final ConfigRepository configRepository,
-                      final String targetVersion,
+                      final AirbyteVersion targetVersion,
                       final ConfigPersistence seedPersistence,
                       final SpecFetcher specFetcher) {
     this.targetVersion = targetVersion;
@@ -55,7 +56,7 @@ public class RunMigration implements Runnable, AutoCloseable {
       filesToBeCleanedUp.add(tempFolder.toFile());
 
       // Run Migration
-      final MigrateConfig migrateConfig = new MigrateConfig(exportData.toPath(), output.toPath(), targetVersion);
+      final MigrateConfig migrateConfig = new MigrateConfig(exportData.toPath(), output.toPath(), targetVersion.serialize());
       MigrationRunner.run(migrateConfig);
 
       // Import data

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -81,6 +81,7 @@ import io.airbyte.api.model.WorkspaceRead;
 import io.airbyte.api.model.WorkspaceReadList;
 import io.airbyte.api.model.WorkspaceUpdate;
 import io.airbyte.commons.io.FileTtlManager;
+import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.Configs;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigPersistence;
@@ -192,7 +193,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
     webBackendDestinationsHandler = new WebBackendDestinationsHandler(destinationHandler, configRepository, trackingClient);
     healthCheckHandler = new HealthCheckHandler(configRepository);
     archiveHandler = new ArchiveHandler(
-        configs.getAirbyteVersion(),
+        new AirbyteVersion(configs.getAirbyteVersion()),
         configRepository,
         jobPersistence,
         seed,

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
@@ -10,6 +10,7 @@ import io.airbyte.api.model.ImportRequestBody;
 import io.airbyte.api.model.UploadRead;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.io.FileTtlManager;
+import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
@@ -30,13 +31,13 @@ public class ArchiveHandler {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArchiveHandler.class);
 
-  private final String version;
+  private final AirbyteVersion version;
   private final ConfigDumpExporter configDumpExporter;
   private final ConfigDumpImporter configDumpImporter;
   private final ConfigPersistence seed;
   private final FileTtlManager fileTtlManager;
 
-  public ArchiveHandler(final String version,
+  public ArchiveHandler(final AirbyteVersion version,
                         final ConfigRepository configRepository,
                         final JobPersistence jobPersistence,
                         final ConfigPersistence seed,
@@ -52,7 +53,7 @@ public class ArchiveHandler {
         seed);
   }
 
-  public ArchiveHandler(final String version,
+  public ArchiveHandler(final AirbyteVersion version,
                         final FileTtlManager fileTtlManager,
                         final ConfigDumpExporter configDumpExporter,
                         final ConfigDumpImporter configDumpImporter,

--- a/airbyte-server/src/main/java/io/airbyte/server/version_mismatch/VersionMismatchServer.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/version_mismatch/VersionMismatchServer.java
@@ -28,11 +28,11 @@ import org.slf4j.LoggerFactory;
 public class VersionMismatchServer implements ServerRunnable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(VersionMismatchServer.class);
-  private final String version1;
-  private final String version2;
+  private final AirbyteVersion version1;
+  private final AirbyteVersion version2;
   private final int port;
 
-  public VersionMismatchServer(final String version1, final String version2, final int port) {
+  public VersionMismatchServer(final AirbyteVersion version1, final AirbyteVersion version2, final int port) {
     this.version1 = version1;
     this.version2 = version2;
     this.port = port;

--- a/airbyte-server/src/test/java/io/airbyte/server/ConfigDumpImporterTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/ConfigDumpImporterTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardDestinationDefinition;
@@ -43,31 +44,26 @@ import org.junit.jupiter.api.Test;
 
 class ConfigDumpImporterTest {
 
-  public static final String TEST_VERSION = "0.0.1-test-version";
+  public static final AirbyteVersion TEST_VERSION = new AirbyteVersion("0.0.1-test-version");
 
   private ConfigRepository configRepository;
-  private JobPersistence jobPersistence;
-  private WorkspaceHelper workspaceHelper;
   private ConfigDumpImporter configDumpImporter;
   private ConfigDumpExporter configDumpExporter;
 
   private UUID workspaceId;
-  private StandardSourceDefinition standardSourceDefinition;
   private SourceConnection sourceConnection;
-  private StandardDestinationDefinition standardDestinationDefinition;
   private DestinationConnection destinationConnection;
   private StandardSyncOperation operation;
   private StandardSync connection;
   private ConnectorSpecification emptyConnectorSpec;
-  private SpecFetcher specFetcher;
 
   @BeforeEach
   public void setup() throws IOException, JsonValidationException, ConfigNotFoundException {
     configRepository = mock(ConfigRepository.class);
-    jobPersistence = mock(JobPersistence.class);
-    workspaceHelper = mock(WorkspaceHelper.class);
+    final JobPersistence jobPersistence = mock(JobPersistence.class);
+    final WorkspaceHelper workspaceHelper = mock(WorkspaceHelper.class);
 
-    specFetcher = mock(SpecFetcher.class);
+    final SpecFetcher specFetcher = mock(SpecFetcher.class);
     emptyConnectorSpec = mock(ConnectorSpecification.class);
     when(emptyConnectorSpec.getConnectionSpecification()).thenReturn(Jsons.emptyObject());
     when(specFetcher.getSpec(any(StandardSourceDefinition.class))).thenReturn(emptyConnectorSpec);
@@ -78,9 +74,9 @@ class ConfigDumpImporterTest {
     configDumpExporter = new ConfigDumpExporter(configRepository, jobPersistence, workspaceHelper);
 
     workspaceId = UUID.randomUUID();
-    when(jobPersistence.getVersion()).thenReturn(Optional.of(TEST_VERSION));
+    when(jobPersistence.getVersion()).thenReturn(Optional.of(TEST_VERSION.serialize()));
 
-    standardSourceDefinition = new StandardSourceDefinition()
+    final StandardSourceDefinition standardSourceDefinition = new StandardSourceDefinition()
         .withSourceDefinitionId(UUID.randomUUID())
         .withName("test-standard-source")
         .withDockerRepository("test")
@@ -102,7 +98,7 @@ class ConfigDumpImporterTest {
     when(configRepository.getSourceConnection(any()))
         .thenReturn(sourceConnection);
 
-    standardDestinationDefinition = new StandardDestinationDefinition()
+    final StandardDestinationDefinition standardDestinationDefinition = new StandardDestinationDefinition()
         .withDestinationDefinitionId(UUID.randomUUID())
         .withName("test-standard-destination")
         .withDockerRepository("test")

--- a/airbyte-server/src/test/java/io/airbyte/server/apis/ConfigurationApiTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/apis/ConfigurationApiTest.java
@@ -25,6 +25,7 @@ public class ConfigurationApiTest {
   @Test
   void testImportDefinitions() {
     final Configs configs = mock(Configs.class);
+    when(configs.getAirbyteVersion()).thenReturn("0.1.0-alpha");
     when(configs.getWebappUrl()).thenReturn("http://localhost");
 
     final ConfigurationApi configurationApi = new ConfigurationApi(

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -20,6 +20,7 @@ import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.io.FileTtlManager;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.string.Strings;
+import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
@@ -65,7 +66,7 @@ public class ArchiveHandlerTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArchiveHandlerTest.class);
 
-  private static final String VERSION = "0.6.8";
+  private static final AirbyteVersion VERSION = new AirbyteVersion("0.6.8");
   private static PostgreSQLContainer<?> container;
 
   private Database jobDatabase;
@@ -113,7 +114,7 @@ public class ArchiveHandlerTest {
     configPersistence.loadData(seedPersistence);
     configRepository = new ConfigRepository(configPersistence, new NoOpSecretsHydrator(), Optional.empty(), Optional.empty());
 
-    jobPersistence.setVersion(VERSION);
+    jobPersistence.setVersion(VERSION.serialize());
 
     final SpecFetcher specFetcher = mock(SpecFetcher.class);
     final ConnectorSpecification emptyConnectorSpec = mock(ConnectorSpecification.class);

--- a/airbyte-server/src/test/java/io/airbyte/server/migration/DatabaseArchiver.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/migration/DatabaseArchiver.java
@@ -9,7 +9,6 @@ import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.lang.CloseableConsumer;
 import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.commons.stream.MoreStreams;
-import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.commons.yaml.Yamls;
 import io.airbyte.db.instance.jobs.JobsDatabaseSchema;
 import io.airbyte.scheduler.persistence.JobPersistence;
@@ -23,7 +22,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,11 +79,6 @@ public class DatabaseArchiver {
     return storageRoot
         .resolve(DB_FOLDER_NAME)
         .resolve(String.format("%s.yaml", tableName.toUpperCase()));
-  }
-
-  public void checkVersion(final String airbyteVersion) throws IOException {
-    final Optional<String> airbyteDatabaseVersion = persistence.getVersion();
-    airbyteDatabaseVersion.ifPresent(dbversion -> AirbyteVersion.assertIsCompatible(airbyteVersion, dbversion));
   }
 
   /**

--- a/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
@@ -16,8 +16,8 @@ import static org.mockito.Mockito.when;
 import com.google.common.io.Resources;
 import io.airbyte.commons.io.Archives;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.config.Configs;
 import io.airbyte.commons.version.AirbyteVersion;
+import io.airbyte.config.Configs;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.OperatorNormalization.Option;
 import io.airbyte.config.SourceConnection;
@@ -353,14 +353,8 @@ public class RunMigrationTest {
     configRepository.setSpecFetcher(s -> MOCK_CONNECTOR_SPEC);
     try (final RunMigration runMigration = new RunMigration(
         jobPersistence,
-<<<<<<< HEAD
         configRepository,
-        TARGET_VERSION,
-=======
-        new ConfigRepository(FileSystemConfigPersistence.createWithValidation(configRoot), new NoOpSecretsHydrator(), Optional.of(secretPersistence),
-            Optional.of(secretPersistence)),
         new AirbyteVersion(TARGET_VERSION),
->>>>>>> 4475ecd0b (prefer AirbyteVersion over string)
         YamlSeedConfigPersistence.getDefault(),
         mock(SpecFetcher.class))) {
       runMigration.run();

--- a/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/migration/RunMigrationTest.java
@@ -17,6 +17,7 @@ import com.google.common.io.Resources;
 import io.airbyte.commons.io.Archives;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.Configs;
+import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.OperatorNormalization.Option;
 import io.airbyte.config.SourceConnection;
@@ -352,8 +353,14 @@ public class RunMigrationTest {
     configRepository.setSpecFetcher(s -> MOCK_CONNECTOR_SPEC);
     try (final RunMigration runMigration = new RunMigration(
         jobPersistence,
+<<<<<<< HEAD
         configRepository,
         TARGET_VERSION,
+=======
+        new ConfigRepository(FileSystemConfigPersistence.createWithValidation(configRoot), new NoOpSecretsHydrator(), Optional.of(secretPersistence),
+            Optional.of(secretPersistence)),
+        new AirbyteVersion(TARGET_VERSION),
+>>>>>>> 4475ecd0b (prefer AirbyteVersion over string)
         YamlSeedConfigPersistence.getDefault(),
         mock(SpecFetcher.class))) {
       runMigration.run();

--- a/airbyte-server/src/test/java/io/airbyte/server/version_mismatch/VersionMismatchServerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/version_mismatch/VersionMismatchServerTest.java
@@ -21,8 +21,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 public class VersionMismatchServerTest {
 
-  private static final AirbyteVersion VERSION1 = new AirbyteVersion("v1");
-  private static final AirbyteVersion VERSION2 = new AirbyteVersion("v2");
+  private static final AirbyteVersion VERSION1 = new AirbyteVersion("0.1.0-alpha");
+  private static final AirbyteVersion VERSION2 = new AirbyteVersion("0.2.0-alpha");
 
   private static URI rootUri;
   private static Server server;

--- a/airbyte-server/src/test/java/io/airbyte/server/version_mismatch/VersionMismatchServerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/version_mismatch/VersionMismatchServerTest.java
@@ -7,6 +7,7 @@ package io.airbyte.server.version_mismatch;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.net.HttpHeaders;
+import io.airbyte.commons.version.AirbyteVersion;
 import java.net.HttpURLConnection;
 import java.net.ServerSocket;
 import java.net.URI;
@@ -20,8 +21,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 public class VersionMismatchServerTest {
 
-  private static final String VERSION1 = "v1";
-  private static final String VERSION2 = "v2";
+  private static final AirbyteVersion VERSION1 = new AirbyteVersion("v1");
+  private static final AirbyteVersion VERSION2 = new AirbyteVersion("v2");
 
   private static URI rootUri;
   private static Server server;

--- a/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
+++ b/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
@@ -109,7 +109,7 @@ public class MigrationAcceptanceTest {
   }
 
   private String targetVersionWithoutPatch(final String targetVersion) {
-    return AirbyteVersion.versionWithoutPatch(targetVersion).getVersion();
+    return AirbyteVersion.versionWithoutPatch(targetVersion).serialize();
   }
 
   @SuppressWarnings("UnstableApiUsage")


### PR DESCRIPTION
## What
* We have an abstraction called `AirbyteVersion` to make it easy to interact with versions and perform various operations on them. Throughout the codebase though, we tend pass the version around as a `String`. We need to lean into this abstraction. It gives us type safety guarantees. It also allows us to push noisy serialization issues out to the edge of our system. With the string, there were a lot of odd checks to make sure it was not empty and such deep in our internals. 
* Going forward we should be pretty vigilant about passing `AirbyteVersion` instead of `String`.

## How
* Search and destroy. Find `String` usages, replace with `AirbyteVersion`
* I skipped the `airbyte-migrations` submodule as that was going to be a _real_ pain, and we plan to remove it soon anyway.