### PR TITLE
remove py from fe e2e test build

### DIFF
--- a/.github/workflows/gke-kube-test-command.yml
+++ b/.github/workflows/gke-kube-test-command.yml
@@ -52,13 +52,6 @@ jobs:
         with:
           node-version: '14.7'
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
-
-      - name: Install Pyenv
-        run: python3 -m pip install virtualenv==16.7.9 --user
-
       - name: Fix EC-2 Runner
         run: |
           mkdir -p /home/runner

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -200,7 +200,7 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
             **/.venv
-          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/package-lock.json') }}
 
       - uses: actions/setup-java@v1
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -193,14 +193,14 @@ jobs:
             ${{ secrets.CACHE_VERSION }}-npm-${{ runner.os }}-
 
       # this intentionally does not use restore-keys so we don't mess with gradle caching
-      - name: Gradle and Python Caching
+      - name: Gradle Caching
         uses: actions/cache@v2
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
             **/.venv
-          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/requirements.txt') }}
 
       - uses: actions/setup-java@v1
         with:
@@ -326,13 +326,6 @@ jobs:
         with:
           node-version: '14.7'
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
-
-      - name: Install Pyenv
-        run: python3 -m pip install virtualenv==16.7.9 --user
-
       - name: Install Cypress Test Dependencies
         run: sudo apt-get update && sudo apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
@@ -413,13 +406,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.7'
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
-
-      - name: Install Pyenv
-        run: python3 -m pip install virtualenv==16.7.9 --user
 
       - name: Fix EC-2 Runner
         run: |


### PR DESCRIPTION
## What
Noticed in this PR: https://github.com/airbytehq/airbyte/pull/7219 that the build was failing because python didn't install properly when setting up the FE E2E Tests. Those tests son't need python anyway, so... bye bye. Knocked it out a couple other places where I thought it was no longer needed.
