### PR TITLE
Zoura oAuth support 

### DIFF
--- a/airbyte-integrations/connectors/source-zuora/Dockerfile
+++ b/airbyte-integrations/connectors/source-zuora/Dockerfile
@@ -33,5 +33,5 @@ COPY source_zuora ./source_zuora
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.3
+LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/source-zuora

--- a/airbyte-integrations/connectors/source-zuora/source_zuora/spec.json
+++ b/airbyte-integrations/connectors/source-zuora/source_zuora/spec.json
@@ -62,5 +62,13 @@
         "airbyte_secret": true
       }
     }
+  },
+  "authSpecification": {
+    "auth_type": "oauth2.0",
+    "oauth2Specification": {
+      "rootObject": [],
+      "oauthFlowInitParameters": [["client_id"], ["client_secret"]],
+      "oauthFlowOutputParameters": []
+    }
   }
 }

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/OAuthImplementationFactory.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/OAuthImplementationFactory.java
@@ -11,6 +11,7 @@ import io.airbyte.oauth.flows.FacebookMarketingOAuthFlow;
 import io.airbyte.oauth.flows.GithubOAuthFlow;
 import io.airbyte.oauth.flows.SalesforceOAuthFlow;
 import io.airbyte.oauth.flows.TrelloOAuthFlow;
+import io.airbyte.oauth.flows.ZuoraOAuthFlow;
 import io.airbyte.oauth.flows.google.GoogleAdsOAuthFlow;
 import io.airbyte.oauth.flows.google.GoogleAnalyticsOAuthFlow;
 import io.airbyte.oauth.flows.google.GoogleSearchConsoleOAuthFlow;
@@ -33,6 +34,7 @@ public class OAuthImplementationFactory {
         .put("airbyte/source-google-sheets", new GoogleSheetsOAuthFlow(configRepository))
         .put("airbyte/source-salesforce", new SalesforceOAuthFlow(configRepository))
         .put("airbyte/source-trello", new TrelloOAuthFlow(configRepository))
+        .put("airbyte/source-zuora", new ZuoraOAuthFlow())
         .build();
   }
 

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/flows/ZuoraOAuthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/flows/ZuoraOAuthFlow.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.oauth.flows;
+
+import io.airbyte.oauth.OAuthFlowImplementation;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.oauth.BaseOAuthFlow;
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Following docs from
+ * https://www.zuora.com/developer/api-reference/#section/Authentication/OAuth-v2.0
+ * Zoura oAuth supports only client_credentials grant type therefore no getting
+ * code/refresh_token stage needed. Only purpose of Zuora oAuth flow is to
+ * store and inject client_id/secret_id parameters so connector could do
+ * authentication on its own.
+ */
+public class ZuoraOAuthFlow implements OAuthFlowImplementation {
+
+  public String getSourceConsentUrl(UUID workspaceId, UUID sourceDefinitionId, String redirectUrl) throws IOException, ConfigNotFoundException {
+     return "";
+  }
+
+  public String getDestinationConsentUrl(UUID workspaceId, UUID destinationDefinitionId, String redirectUrl) throws IOException, ConfigNotFoundException {
+     return "";
+  }
+
+  public Map<String, Object> completeSourceOAuth(
+                                                 final UUID workspaceId,
+                                                 final UUID sourceDefinitionId,
+                                                 final Map<String, Object> queryParams,
+                                                 final String redirectUrl)
+      throws IOException, ConfigNotFoundException {
+    return Map.of();
+  }
+
+  public Map<String, Object> completeDestinationOAuth(final UUID workspaceId,
+                                                      final UUID destinationDefinitionId,
+                                                      final Map<String, Object> queryParams,
+                                                      final String redirectUrl)
+      throws IOException, ConfigNotFoundException {
+    return Map.of();
+  }
+
+}

--- a/airbyte-oauth/src/test/java/io/airbyte/oauth/flows/ZuoraOAuthFlowTest.java
+++ b/airbyte-oauth/src/test/java/io/airbyte/oauth/flows/ZuoraOAuthFlowTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.oauth.flows;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.SourceOAuthParameter;
+import io.airbyte.config.DestinationOAuthParameter;
+import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.validation.json.JsonValidationException;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ZuoraOAuthFlowTest {
+
+  private UUID workspaceId;
+  private UUID definitionId;
+  private ZuoraOAuthFlow zuoraoAuthFlow;
+
+  @BeforeEach
+  public void setup() throws IOException, JsonValidationException {
+    workspaceId = UUID.randomUUID();
+    definitionId = UUID.randomUUID();
+    zuoraoAuthFlow = new ZuoraOAuthFlow();
+
+  }
+
+  @Test
+  public void testGetConcentUrl() throws IOException, InterruptedException, ConfigNotFoundException {
+    String concentUrl =
+        zuoraoAuthFlow.getSourceConsentUrl(workspaceId, definitionId, "");
+    assertEquals(concentUrl, "");
+    concentUrl =
+        zuoraoAuthFlow.getDestinationConsentUrl(workspaceId, definitionId, "");
+    assertEquals(concentUrl, "");
+  }
+
+
+  @Test
+  public void testCompleteOAuth() throws IOException, JsonValidationException, InterruptedException, ConfigNotFoundException {
+
+    final Map<String, Object> queryParams = Map.of("code", "test_code");
+    Map<String, Object> actualQueryParams =
+        zuoraoAuthFlow.completeSourceOAuth(workspaceId, definitionId, queryParams, "");
+    assertTrue(actualQueryParams.equals(Map.of()));
+
+    actualQueryParams =
+        zuoraoAuthFlow.completeDestinationOAuth(workspaceId, definitionId, queryParams, "");
+    assertTrue(actualQueryParams.equals(Map.of()));
+  }
+
+}

--- a/docs/integrations/sources/zuora.md
+++ b/docs/integrations/sources/zuora.md
@@ -149,6 +149,7 @@ Usually, the very first sync operation for all of the objects inside Zuora accou
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.4 | 2021-10-26 | [7384](https://github.com/airbytehq/airbyte/pull/7384) | Add oAuth flow support |
 | 0.1.3 | 2021-10-16 | [7053](https://github.com/airbytehq/airbyte/pull/7093) | Added support of `Unlimited` option for `Data Query` |
 | 0.1.2 | 2021-10-11 | [6960](https://github.com/airbytehq/airbyte/pull/6960) | Change minimum value for `Window_in_days` to 1, instead of 30 |
 | 0.1.1 | 2021-10-01 | [6575](https://github.com/airbytehq/airbyte/pull/6575) | Added OAuth support for Airbyte Cloud |


### PR DESCRIPTION
Resolves #7112

Zuora supports only oAuth  client_credentials grant type. That means we have nothing to do on backend, only inject client_id/client_secret parameters wnen doing check_connection/read operations.

But still there is Authorization button on UI that doing nothing, I can see couple of solutions on this:
- Do not show Authorization button if there is oauthFlowOutputParameters is empty;
- Use Authorization button to check if provided credentials are correct. In this cause we need 
     a) mechanism to pass oAuth input parameters (as for #6971 issues) because Zuora authorization endpoint is  dependant on "tenant_endpoint" parameter
     b) Additional UI flow for those cases.