### PR TITLE
🐛 Source Google Search Console: set default end_date param value

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/eb4c9e00-db83-4d63-a386-39cfa91012a8.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/eb4c9e00-db83-4d63-a386-39cfa91012a8.json
@@ -2,6 +2,6 @@
   "sourceDefinitionId": "eb4c9e00-db83-4d63-a386-39cfa91012a8",
   "name": "Google Search Console",
   "dockerRepository": "airbyte/source-google-search-console",
-  "dockerImageTag": "0.1.7",
+  "dockerImageTag": "0.1.4",
   "documentationUrl": "https://docs.airbyte.io/integrations/sources/google-search-console"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/eb4c9e00-db83-4d63-a386-39cfa91012a8.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/eb4c9e00-db83-4d63-a386-39cfa91012a8.json
@@ -3,5 +3,6 @@
   "name": "Google Search Console",
   "dockerRepository": "airbyte/source-google-search-console",
   "dockerImageTag": "0.1.4",
-  "documentationUrl": "https://docs.airbyte.io/integrations/sources/google-search-console"
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/google-search-console",
+  "icon": "googlesearchconsole.svg"
 }

--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/eb4c9e00-db83-4d63-a386-39cfa91012a8.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/eb4c9e00-db83-4d63-a386-39cfa91012a8.json
@@ -2,7 +2,6 @@
   "sourceDefinitionId": "eb4c9e00-db83-4d63-a386-39cfa91012a8",
   "name": "Google Search Console",
   "dockerRepository": "airbyte/source-google-search-console",
-  "dockerImageTag": "0.1.4",
-  "documentationUrl": "https://docs.airbyte.io/integrations/sources/google-search-console",
-  "icon": "googlesearchconsole.svg"
+  "dockerImageTag": "0.1.7",
+  "documentationUrl": "https://docs.airbyte.io/integrations/sources/google-search-console"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -246,7 +246,7 @@
 - name: Google Search Console
   sourceDefinitionId: eb4c9e00-db83-4d63-a386-39cfa91012a8
   dockerRepository: airbyte/source-google-search-console
-  dockerImageTag: 0.1.6
+  dockerImageTag: 0.1.7
   documentationUrl: https://docs.airbyte.io/integrations/sources/google-search-console
   icon: googlesearchconsole.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -246,7 +246,7 @@
 - name: Google Search Console
   sourceDefinitionId: eb4c9e00-db83-4d63-a386-39cfa91012a8
   dockerRepository: airbyte/source-google-search-console
-  dockerImageTag: 0.1.7
+  dockerImageTag: 0.1.6
   documentationUrl: https://docs.airbyte.io/integrations/sources/google-search-console
   icon: googlesearchconsole.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -2216,7 +2216,7 @@
         - - "client_secret"
         oauthFlowOutputParameters:
         - - "refresh_token"
-- dockerImage: "airbyte/source-google-search-console:0.1.6"
+- dockerImage: "airbyte/source-google-search-console:0.1.7"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/google-search-console"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-google-search-console/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-search-console/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.6
+LABEL io.airbyte.version=0.1.7
 LABEL io.airbyte.name=airbyte/source-google-search-console

--- a/airbyte-integrations/connectors/source-google-search-console/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-google-search-console/acceptance-test-config.yml
@@ -16,11 +16,14 @@ tests:
   basic_read:
     - config_path: "secrets/config.json"
       configured_catalog_path: "integration_tests/configured_catalog.json"
+      timeout_seconds: 3600
       empty_streams: []
   full_refresh:
     - config_path: "secrets/config.json"
       configured_catalog_path: "integration_tests/catalog.json"
+      timeout_seconds: 3600
   incremental:
     - config_path: "secrets/config.json"
       configured_catalog_path: "integration_tests/configured_catalog.json"
       future_state_path: "integration_tests/abnormal_state.json"
+      timeout_seconds: 3600

--- a/airbyte-integrations/connectors/source-google-search-console/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-google-search-console/acceptance-test-config.yml
@@ -16,14 +16,11 @@ tests:
   basic_read:
     - config_path: "secrets/config.json"
       configured_catalog_path: "integration_tests/configured_catalog.json"
-      timeout_seconds: 3600
       empty_streams: []
   full_refresh:
     - config_path: "secrets/config.json"
       configured_catalog_path: "integration_tests/catalog.json"
-      timeout_seconds: 3600
   incremental:
     - config_path: "secrets/config.json"
       configured_catalog_path: "integration_tests/configured_catalog.json"
       future_state_path: "integration_tests/abnormal_state.json"
-      timeout_seconds: 3600

--- a/airbyte-integrations/connectors/source-google-search-console/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-google-search-console/acceptance-test-config.yml
@@ -22,5 +22,11 @@ tests:
       configured_catalog_path: "integration_tests/catalog.json"
   incremental:
     - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
+      configured_catalog_path: "integration_tests/configured_catalog_incremental.json"
       future_state_path: "integration_tests/abnormal_state.json"
+      cursor_paths:
+        search_analytics_by_country: [ "https://airbyte.io", "web", "date" ]
+        search_analytics_by_device: [ "https://airbyte.io", "web", "date" ]
+        search_analytics_by_page: [ "https://airbyte.io", "web", "date" ]
+        search_analytics_by_query: [ "https://airbyte.io", "web", "date" ]
+        search_analytics_all_fields: [ "https://airbyte.io", "web", "date" ]

--- a/airbyte-integrations/connectors/source-google-search-console/integration_tests/configured_catalog_incremental.json
+++ b/airbyte-integrations/connectors/source-google-search-console/integration_tests/configured_catalog_incremental.json
@@ -1,0 +1,64 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "search_analytics_by_country",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["date"]
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["date"],
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "search_analytics_by_device",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["date"]
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["date"],
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "search_analytics_by_page",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["date"]
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["date"],
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "search_analytics_by_query",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["date"]
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["date"],
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "search_analytics_all_fields",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["date"]
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["date"],
+      "destination_sync_mode": "append"
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-google-search-console/source_google_search_console/source.py
+++ b/airbyte-integrations/connectors/source-google-search-console/source_google_search_console/source.py
@@ -71,9 +71,7 @@ class SourceGoogleSearchConsole(AbstractSource):
         stream_kwargs = {
             "site_urls": config.get("site_urls"),
             "start_date": config.get("start_date"),
-            # we should add few years, because end_date must be large than start_date, but for
-            # test with abnormal_state this condition will fail and test will fail
-            "end_date": config.get("end_date") or pendulum.now().add(years=2).to_date_string(),
+            "end_date": config.get("end_date") or pendulum.now().to_date_string(),
         }
 
         auth_type = authorization.get("auth_type")

--- a/airbyte-integrations/connectors/source-google-search-console/source_google_search_console/source.py
+++ b/airbyte-integrations/connectors/source-google-search-console/source_google_search_console/source.py
@@ -5,6 +5,7 @@
 import json
 from typing import Any, List, Mapping, Tuple
 
+import pendulum
 from airbyte_cdk.logger import AirbyteLogger
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources import AbstractSource
@@ -70,7 +71,9 @@ class SourceGoogleSearchConsole(AbstractSource):
         stream_kwargs = {
             "site_urls": config.get("site_urls"),
             "start_date": config.get("start_date"),
-            "end_date": config.get("end_date"),
+            # we should add few years, because end_date must be large than start_date, but for
+            # test with abnormal_state this condition will fail and test will fail
+            "end_date": config.get("end_date") or pendulum.now().add(years=2).to_date_string(),
         }
 
         auth_type = authorization.get("auth_type")

--- a/docs/integrations/sources/google-search-console.md
+++ b/docs/integrations/sources/google-search-console.md
@@ -96,7 +96,7 @@ You should now be ready to use the Google Workspace Admin Reports API connector 
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| `0.1.7` | 2021-10-27 | []() | Add default `end_date` param value |
+| `0.1.7` | 2021-10-27 | [7431](https://github.com/airbytehq/airbyte/pull/7431) | Add default `end_date` param value |
 | `0.1.6` | 2021-09-27 | [6460](https://github.com/airbytehq/airbyte/pull/6460) | Update OAuth Spec File |
 | `0.1.4` | 2021-09-23 | [6394](https://github.com/airbytehq/airbyte/pull/6394) | Update Doc link Spec File |
 | `0.1.3` | 2021-09-23 | [6405](https://github.com/airbytehq/airbyte/pull/6405) | Correct Spec File |

--- a/docs/integrations/sources/google-search-console.md
+++ b/docs/integrations/sources/google-search-console.md
@@ -96,7 +96,7 @@ You should now be ready to use the Google Workspace Admin Reports API connector 
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| `0.1.7` | 2021-10-27 | [7431](https://github.com/airbytehq/airbyte/pull/7431) | Add default `end_date` param value |
+| `0.1.7` | 2021-11-?? | [7431](https://github.com/airbytehq/airbyte/pull/7431) | Add default `end_date` param value |
 | `0.1.6` | 2021-09-27 | [6460](https://github.com/airbytehq/airbyte/pull/6460) | Update OAuth Spec File |
 | `0.1.4` | 2021-09-23 | [6394](https://github.com/airbytehq/airbyte/pull/6394) | Update Doc link Spec File |
 | `0.1.3` | 2021-09-23 | [6405](https://github.com/airbytehq/airbyte/pull/6405) | Correct Spec File |

--- a/docs/integrations/sources/google-search-console.md
+++ b/docs/integrations/sources/google-search-console.md
@@ -96,6 +96,7 @@ You should now be ready to use the Google Workspace Admin Reports API connector 
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| `0.1.7` | 2021-10-27 | []() | Add default `end_date` param value |
 | `0.1.6` | 2021-09-27 | [6460](https://github.com/airbytehq/airbyte/pull/6460) | Update OAuth Spec File |
 | `0.1.4` | 2021-09-23 | [6394](https://github.com/airbytehq/airbyte/pull/6394) | Update Doc link Spec File |
 | `0.1.3` | 2021-09-23 | [6405](https://github.com/airbytehq/airbyte/pull/6405) | Correct Spec File |

--- a/docs/integrations/sources/google-search-console.md
+++ b/docs/integrations/sources/google-search-console.md
@@ -96,7 +96,7 @@ You should now be ready to use the Google Workspace Admin Reports API connector 
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| `0.1.7` | 2021-11-?? | [7431](https://github.com/airbytehq/airbyte/pull/7431) | Add default `end_date` param value |
+| `0.1.7` | 2021-11-26 | [7431](https://github.com/airbytehq/airbyte/pull/7431) | Add default `end_date` param value |
 | `0.1.6` | 2021-09-27 | [6460](https://github.com/airbytehq/airbyte/pull/6460) | Update OAuth Spec File |
 | `0.1.4` | 2021-09-23 | [6394](https://github.com/airbytehq/airbyte/pull/6394) | Update Doc link Spec File |
 | `0.1.3` | 2021-09-23 | [6405](https://github.com/airbytehq/airbyte/pull/6405) | Correct Spec File |


### PR DESCRIPTION
## What
Fixes #6697 
The API endpoint requires two mandatory parameters: a start date and an end date. The end date is not a required field on our side, and if not specified, the end point will return an error. So, we use some date in the future

## How
Add default value for the `end_date` param

## Pre-merge Checklist
   
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [x] Code reviews completed
- [x] Documentation updated 
    - [x] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [x] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)


