### PR TITLE
Newline normalisation

### DIFF
--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/destination_name_transformer.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/destination_name_transformer.py
@@ -226,11 +226,13 @@ def transform_standard_naming(input_name: str) -> str:
     result = strip_accents(result)
     result = sub(r"\s+", "_", result)
     result = sub(r"[^a-zA-Z0-9_]", "_", result)
+    result = sub(r"\n", "_", result)
     return result
 
 
 def transform_json_naming(input_name: str) -> str:
     result = sub(r"['\"`]", "_", input_name)
+    result = sub(r"\n", "_", input_name)
     return result
 
 

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/destination_name_transformer.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/destination_name_transformer.py
@@ -232,7 +232,7 @@ def transform_standard_naming(input_name: str) -> str:
 
 def transform_json_naming(input_name: str) -> str:
     result = sub(r"['\"`]", "_", input_name)
-    result = sub(r"\n", "_", input_name)
+    result = sub(r"\n", "_", result)
     return result
 
 

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/destination_name_transformer.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/destination_name_transformer.py
@@ -226,7 +226,6 @@ def transform_standard_naming(input_name: str) -> str:
     result = strip_accents(result)
     result = sub(r"\s+", "_", result)
     result = sub(r"[^a-zA-Z0-9_]", "_", result)
-    result = sub(r"\n", "_", result)
     return result
 
 

--- a/airbyte-integrations/bases/base-normalization/unit_tests/test_destination_name_transformer.py
+++ b/airbyte-integrations/bases/base-normalization/unit_tests/test_destination_name_transformer.py
@@ -4,12 +4,14 @@
 
 
 import os
+from re import I
 
 import pytest
 from normalization.destination_type import DestinationType
 from normalization.transform_catalog.destination_name_transformer import (
     DestinationNameTransformer,
     strip_accents,
+    transform_json_naming,
     transform_standard_naming,
 )
 
@@ -96,6 +98,17 @@ def test_strip_accents(input_str: str, expected: str):
 )
 def test_transform_standard_naming(input_str: str, expected: str):
     assert transform_standard_naming(input_str) == expected
+
+
+@pytest.mark.parametrize(
+    "expected, input_str",
+    [
+        ("_identifier_name_", "'identifier_name'"),
+        ("_identifier_name_", "\nidentifier\nname\n"),
+    ],
+)
+def test_transform_json_naming(input_str: str, expected: str):
+    assert transform_json_naming(input_str) == expected
 
 
 @pytest.mark.parametrize(

--- a/airbyte-integrations/bases/base-normalization/unit_tests/test_destination_name_transformer.py
+++ b/airbyte-integrations/bases/base-normalization/unit_tests/test_destination_name_transformer.py
@@ -4,7 +4,6 @@
 
 
 import os
-from re import I
 
 import pytest
 from normalization.destination_type import DestinationType


### PR DESCRIPTION
## What
This fixes 'Unclosed string literals' when extracting a json scalar. Currently the normalised json path is not subbing \n, as such in calls like the following:

` json_extract = jinja_call(f"json_extract_array({json_column_name}, {json_path}, {normalized_json_path})")`

The generated dbt template will break line and generate an unclosed string literal error

## How
This solution "escapes" \n when normalising the json path
