### PR TITLE
remove duplicate source_definitions (OneSignal)

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -352,12 +352,6 @@
   dockerImageTag: 0.1.2
   documentationUrl: https://docs.airbyte.io/integrations/sources/okta
   sourceType: api
-- name: OneSignal
-  sourceDefinitionId: bb6afd81-87d5-47e3-97c4-e2c2901b1cf8
-  dockerRepository: airbyte/source-onesignal
-  dockerImageTag: 0.1.0
-  documentationUrl: https://docs.airbyte.io/integrations/sources/lever-onesignal
-  sourceType: api
 - name: Oracle DB
   sourceDefinitionId: b39a7370-74c3-45a6-ac3a-380d48520a83
   dockerRepository: airbyte/source-oracle


### PR DESCRIPTION
## What
in this [PR](https://github.com/airbytehq/airbyte/pull/6975/files#diff-3394238aa97d045886b68a0bb12a00a6cdea5680be6940e3c171d0018979ddf3R580) the source "OneSignal" was duplicated and it raises an exception on production

## How
I removed the duplicate source on the file