### PR TITLE
fix ssl flag used for postgres source in acceptance tests

### DIFF
--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1102,6 +1102,7 @@ public class AcceptanceTests {
     dbConfig.put("port", psql.getFirstMappedPort());
     dbConfig.put("database", psql.getDatabaseName());
     dbConfig.put("username", psql.getUsername());
+    dbConfig.put("ssl", false);
 
     if (withSchema) {
       dbConfig.put("schema", "public");

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/GKEPostgresConfig.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/GKEPostgresConfig.java
@@ -34,6 +34,7 @@ public class GKEPostgresConfig {
     dbConfig.put("port", PORT);
     dbConfig.put("database", DB);
     dbConfig.put("username", USERNAME);
+    dbConfig.put("ssl", false);
 
     if (withSchema) {
       dbConfig.put("schema", "public");

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/GKEPostgresConfig.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/GKEPostgresConfig.java
@@ -34,7 +34,6 @@ public class GKEPostgresConfig {
     dbConfig.put("port", PORT);
     dbConfig.put("database", DB);
     dbConfig.put("username", USERNAME);
-    dbConfig.put("ssl", false);
 
     if (withSchema) {
       dbConfig.put("schema", "public");


### PR DESCRIPTION
At some point the default for the SSL flag was switched. This wasn't added to the `source_definitions.yaml` file until today by https://github.com/airbytehq/airbyte/pull/7339/files#diff-3394238aa97d045886b68a0bb12a00a6cdea5680be6940e3c171d0018979ddf3R408 which failed the build. This was soon masked by other unrelated build issues, but we're fixing this now. 