### PR TITLE
upgrade fabric8 kube client from 5.5.0 -> 5.9.0

### DIFF
--- a/airbyte-scheduler/app/build.gradle
+++ b/airbyte-scheduler/app/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'io.fabric8:kubernetes-client:5.5.0'
+    implementation 'io.fabric8:kubernetes-client:5.9.0'
     implementation 'io.kubernetes:client-java-api:10.0.0'
     implementation 'io.kubernetes:client-java:10.0.0'
     implementation 'io.kubernetes:client-java-extended:10.0.0'


### PR DESCRIPTION
When looking into https://github.com/airbytehq/airbyte/issues/6882, I looked at the change log for the fabric8 kube client and saw a bunch of small changes around informers. Thought it'd be worth upgrading even if the changes don't necessarily address the underlying problem for that issue.