### PR TITLE
stop trying to copy normalization image for kube tests

### DIFF
--- a/tools/bin/acceptance_test_kube.sh
+++ b/tools/bin/acceptance_test_kube.sh
@@ -14,7 +14,6 @@ kind load docker-image airbyte/scheduler:dev --name chart-testing &
 kind load docker-image airbyte/webapp:dev --name chart-testing &
 kind load docker-image airbyte/worker:dev --name chart-testing &
 kind load docker-image airbyte/db:dev --name chart-testing &
-kind load docker-image airbyte/normalization:dev --name chart-testing &
 wait
 
 echo "Starting app..."


### PR DESCRIPTION
We're seeing a `ERROR: image: "airbyte/normalization:dev" not present locally` in when setting up the acceptance tests (even though it isn't failing). Because we aren't building this image as part of the build it doesn't make sense to attempt to load it.