### PR TITLE
add temporal and db logs for kube test output

### DIFF
--- a/tools/bin/acceptance_test_kube.sh
+++ b/tools/bin/acceptance_test_kube.sh
@@ -49,9 +49,20 @@ server_logs () { echo "server logs:" && kubectl logs deployment.apps/airbyte-ser
 scheduler_logs () { echo "scheduler logs:" && kubectl logs deployment.apps/airbyte-scheduler; }
 pod_sweeper_logs () { echo "pod sweeper logs:" && kubectl logs deployment.apps/airbyte-pod-sweeper; }
 worker_logs () { echo "worker logs:" && kubectl logs deployment.apps/airbyte-worker; }
+db_logs () { echo "db logs:" && kubectl logs deployment.apps/airbyte-db; }
+temporal_logs () { echo "temporal logs:" && kubectl logs deployment.apps/airbyte-temporal; }
 describe_pods () { echo "describe pods:" && kubectl describe pods; }
 describe_nodes () { echo "describe nodes:" && kubectl describe nodes; }
-print_all_logs () { server_logs; scheduler_logs; worker_logs; pod_sweeper_logs; describe_nodes; describe_pods; }
+print_all_logs () {
+  server_logs;
+  scheduler_logs;
+  worker_logs;
+  db_logs;
+  temporal_logs;
+  pod_sweeper_logs;
+  describe_nodes;
+  describe_pods;
+}
 trap "echo 'kube logs:' && print_all_logs" EXIT
 
 kubectl port-forward svc/airbyte-server-svc 8001:8001 &


### PR DESCRIPTION
Some of the transient Kube failures are showing errors like `Connection refused: airbyte-temporal-svc/10.96.221.222:7233` and they're very hard to debug without access to logs. 

It feels bad to overload Github logs like this. It's already hard to parse the logs. If you have an alternative idea please let me know.