### PR TITLE
🐛Source Iterable: Fix date parsing

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -262,7 +262,7 @@
 - name: Iterable
   sourceDefinitionId: 2e875208-0c0b-4ee4-9e92-1cb3156ea799
   dockerRepository: airbyte/source-iterable
-  dockerImageTag: 0.1.10
+  dockerImageTag: 0.1.11
   documentationUrl: https://docs.airbyte.io/integrations/sources/iterable
   sourceType: api
 - name: Jira

--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.28
+Print stream name when incremental sync tests fail
+
 ## 0.1.27
 Add ignored fields for full refresh test (unit tests)
 

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -9,7 +9,7 @@ COPY setup.py ./
 COPY pytest.ini ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.27
+LABEL io.airbyte.version=0.1.28
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin"]

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_json_schema_helper.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_json_schema_helper.py
@@ -85,7 +85,7 @@ def test_simple_path(records, stream_mapping, simple_state):
     paths = {"my_stream": ["id"]}
 
     result = records_with_state(records=records, state=simple_state, stream_mapping=stream_mapping, state_cursor_paths=paths)
-    record_value, state_value = next(result)
+    record_value, state_value, stream_name = next(result)
 
     assert record_value == 1, "record value must be correctly found"
     assert state_value == 11, "state value must be correctly found"
@@ -96,7 +96,7 @@ def test_nested_path(records, stream_mapping, nested_state):
     paths = {"my_stream": ["some_account_id", "ts_updated"]}
 
     result = records_with_state(records=records, state=nested_state, stream_mapping=stream_mapping, state_cursor_paths=paths)
-    record_value, state_value = next(result)
+    record_value, state_value, stream_name = next(result)
 
     assert record_value == pendulum.datetime(2015, 5, 1), "record value must be correctly found"
     assert state_value == pendulum.datetime(2015, 1, 1, 22, 3, 11), "state value must be correctly found"
@@ -116,7 +116,7 @@ def test_absolute_path(records, stream_mapping, singer_state):
     paths = {"my_stream": ["bookmarks", "my_stream", "ts_created"]}
 
     result = records_with_state(records=records, state=singer_state, stream_mapping=stream_mapping, state_cursor_paths=paths)
-    record_value, state_value = next(result)
+    record_value, state_value, stream_name = next(result)
 
     assert record_value == pendulum.datetime(2015, 11, 1, 22, 3, 11), "record value must be correctly found"
     assert state_value == pendulum.datetime(2014, 1, 1, 22, 3, 11), "state value must be correctly found"

--- a/airbyte-integrations/connectors/source-iterable/Dockerfile
+++ b/airbyte-integrations/connectors/source-iterable/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.10
+LABEL io.airbyte.version=0.1.11
 LABEL io.airbyte.name=airbyte/source-iterable

--- a/airbyte-integrations/connectors/source-iterable/acceptance-test-docker.sh
+++ b/airbyte-integrations/connectors/source-iterable/acceptance-test-docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # Build latest connector image
-docker build . -t $(cat acceptance-test-config.yml | grep "connector_image" | head -n 1 | cut -d: -f2)
+docker build . -t $(cat acceptance-test-config.yml | grep "connector_image" | head -n 1 | cut -d: -f2):dev
 
 # Pull latest acctest image
 docker pull airbyte/source-acceptance-test:latest

--- a/airbyte-integrations/connectors/source-iterable/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-iterable/integration_tests/configured_catalog.json
@@ -170,6 +170,17 @@
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "templates",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["createdAt"]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/api.py
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/api.py
@@ -362,6 +362,7 @@ class Templates(IterableExportStream):
         records = response_json.get(self.data_field, [])
 
         for record in records:
+            record[self.cursor_field] = self._field_to_datetime(record[self.cursor_field])
             yield record
 
 

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/api.py
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/api.py
@@ -88,12 +88,8 @@ class IterableExportStream(IterableStream, ABC):
         """
         latest_benchmark = latest_record[self.cursor_field]
         if current_stream_state.get(self.cursor_field):
-            return {
-                self.cursor_field: max(
-                    latest_benchmark, self._field_to_datetime(current_stream_state[self.cursor_field])
-                ).to_datetime_string()
-            }
-        return {self.cursor_field: latest_benchmark.to_datetime_string()}
+            return {self.cursor_field: str(max(latest_benchmark, self._field_to_datetime(current_stream_state[self.cursor_field])))}
+        return {self.cursor_field: str(latest_benchmark)}
 
     def request_params(self, stream_state: Mapping[str, Any], **kwargs) -> MutableMapping[str, Any]:
 

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/templates.json
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/templates.json
@@ -4,7 +4,8 @@
       "type": ["null", "number"]
     },
     "createdAt": {
-      "type": ["null", "integer"]
+      "type": ["null", "string"],
+      "format": "date-time"
     },
     "updatedAt": {
       "type": ["null", "integer"]

--- a/docs/integrations/sources/iterable.md
+++ b/docs/integrations/sources/iterable.md
@@ -58,6 +58,7 @@ Please read [How to find your API key](https://support.iterable.com/hc/en-us/art
 
 | Version | Date | Pull Request | Subject |
 | :------ | :--------  | :-----       | :------ |
+| `0.1.11` | 2021-11-03 | [7619](https://github.com/airbytehq/airbyte/pull/7619) | Bugfix type error while incrementally loading the `Templates` stream |
 | `0.1.10` | 2021-11-03 | [7591](https://github.com/airbytehq/airbyte/pull/7591) | Optimize export streams memory consumption for large requests |
 | `0.1.9` | 2021-10-06 | [5915](https://github.com/airbytehq/airbyte/pull/5915) | Enable campaign_metrics stream |
 | `0.1.8` | 2021-09-20 | [5915](https://github.com/airbytehq/airbyte/pull/5915) | Add new streams: campaign_metrics, events |


### PR DESCRIPTION
## What
Fixes the following exception

```
2021-11-04 01:10:00 ERROR Encountered an exception while reading stream SourceIterable
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/airbyte_cdk/sources/abstract_source.py", line 106, in read
    internal_config=internal_config,
  File "/usr/local/lib/python3.7/site-packages/airbyte_cdk/sources/abstract_source.py", line 136, in _read_stream
    for record in record_iterator:
  File "/usr/local/lib/python3.7/site-packages/airbyte_cdk/sources/abstract_source.py", line 183, in _read_incremental
    stream_state = stream_instance.get_updated_state(stream_state, record_data)
  File "/airbyte/integration_code/source_iterable/api.py", line 96, in get_updated_state
    return {self.cursor_field: latest_benchmark.to_datetime_string()}
```

## How
Coerces integer date values into pendulum objects

## Pre-merge Checklist

   
#### Community member or Airbyter
   
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [x] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [x] Connector version bumped like described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

