### PR TITLE
Enforce building javadoc for platform only

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -226,7 +226,7 @@ jobs:
         run: git --no-pager diff && test -z "$(git --no-pager diff)"
 
       - name: Build
-        run: SUB_BUILD=PLATFORM ./gradlew build --scan
+        run: SUB_BUILD=PLATFORM ./gradlew build javadoc --scan
 
       - name: Ensure no file change
         run: git --no-pager diff && test -z "$(git --no-pager diff)"


### PR DESCRIPTION
## What
Enforces building javadoc during build, so that we keep our docs free of linting errors and can, in the future, more easily publish the javadoc.

## How
Adds javadoc to the gradle build command for platform.
