### PR TITLE
fix container specific logging

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/logging/MdcScope.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/logging/MdcScope.java
@@ -28,7 +28,7 @@ import org.slf4j.MDC;
  */
 public class MdcScope implements AutoCloseable {
 
-  public final static MdcScope DEFAULT = new Builder().build();
+  public final static MdcScope.Builder DEFAULT_BUILDER = new Builder();
 
   private final Map<String, String> originalContextMap;
 

--- a/airbyte-commons/src/main/resources/log4j2.xml
+++ b/airbyte-commons/src/main/resources/log4j2.xml
@@ -7,7 +7,7 @@
         <!-- The following patter log the application name in the beginning of the line, then a regular log line after a - separator. If the application name is not present in the context, the separator is removed -->
         <Property name="docker-worker-file-pattern">%replace{%X{log_source} - }{^ - }{}%d{yyyy-MM-dd HH:mm:ss}{GMT+0} %p (%X{job_root}) %C{1}(%M):%L - %replace{%m}{apikey=[\w\-]*}{apikey=*****}%n</Property>
         <!-- Remove paths from logs on Cloud as users aren't able to access file paths and these end up being noise. -->
-        <Property name="cloud-worker-file-pattern">%d{yyyy-MM-dd HH:mm:ss} %-5p %replace{%m}{apikey=[\w\-]*}{apikey=*****}%n</Property>
+        <Property name="cloud-worker-file-pattern">%replace{%X{log_source} - }{^ - }{}%d{yyyy-MM-dd HH:mm:ss}{GMT+0} %p %C{1}(%M):%L - %replace{%m}{apikey=[\w\-]*}{apikey=*****}%n</Property>
 
         <!-- Always log INFO by default. -->
         <Property name="log-level">$${env:LOG_LEVEL:-INFO}</Property>

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DbtTransformationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DbtTransformationRunner.java
@@ -31,10 +31,9 @@ public class DbtTransformationRunner implements AutoCloseable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DbtTransformationRunner.class);
   private static final String DBT_ENTRYPOINT_SH = "entrypoint.sh";
-  private static final MdcScope CONTAINER_LOG_MDC = new Builder()
+  private static final MdcScope.Builder CONTAINER_LOG_MDC_BUILDER = new Builder()
       .setLogPrefix("dbt")
-      .setPrefixColor(Color.CYAN)
-      .build();
+      .setPrefixColor(Color.CYAN);
 
   private final ProcessFactory processFactory;
   private final NormalizationRunner normalizationRunner;
@@ -93,9 +92,8 @@ public class DbtTransformationRunner implements AutoCloseable {
           processFactory.create(jobId, attempt, jobRoot, dbtConfig.getDockerImage(), false, files, "/bin/bash", resourceRequirements,
               Map.of(KubeProcessFactory.JOB_TYPE, KubeProcessFactory.SYNC_JOB, KubeProcessFactory.SYNC_STEP, KubeProcessFactory.CUSTOM_STEP),
               dbtArguments);
-
-      LineGobbler.gobble(process.getInputStream(), LOGGER::info, CONTAINER_LOG_MDC);
-      LineGobbler.gobble(process.getErrorStream(), LOGGER::error, CONTAINER_LOG_MDC);
+      LineGobbler.gobble(process.getInputStream(), LOGGER::info, CONTAINER_LOG_MDC_BUILDER);
+      LineGobbler.gobble(process.getErrorStream(), LOGGER::error, CONTAINER_LOG_MDC_BUILDER);
 
       WorkerUtils.wait(process);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
@@ -30,10 +30,9 @@ import org.slf4j.LoggerFactory;
 public class DefaultNormalizationRunner implements NormalizationRunner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNormalizationRunner.class);
-  private static final MdcScope CONTAINER_LOG_MDC = new Builder()
+  private static final MdcScope.Builder CONTAINER_LOG_MDC_BUILDER = new Builder()
       .setLogPrefix("normalization")
-      .setPrefixColor(Color.GREEN)
-      .build();
+      .setPrefixColor(Color.GREEN);
 
   private final DestinationType destinationType;
   private final ProcessFactory processFactory;
@@ -116,8 +115,8 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
       process = processFactory.create(jobId, attempt, jobRoot, normalizationImageName, false, files, null, resourceRequirements,
           Map.of(KubeProcessFactory.JOB_TYPE, KubeProcessFactory.SYNC_JOB, KubeProcessFactory.SYNC_STEP, KubeProcessFactory.NORMALISE_STEP), args);
 
-      LineGobbler.gobble(process.getInputStream(), LOGGER::info, CONTAINER_LOG_MDC);
-      LineGobbler.gobble(process.getErrorStream(), LOGGER::error, CONTAINER_LOG_MDC);
+      LineGobbler.gobble(process.getInputStream(), LOGGER::info, CONTAINER_LOG_MDC_BUILDER);
+      LineGobbler.gobble(process.getErrorStream(), LOGGER::error, CONTAINER_LOG_MDC_BUILDER);
 
       WorkerUtils.wait(process);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -33,10 +33,9 @@ import org.slf4j.LoggerFactory;
 public class DefaultAirbyteDestination implements AirbyteDestination {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAirbyteDestination.class);
-  private static final MdcScope CONTAINER_LOG_MDC = new Builder()
+  private static final MdcScope.Builder CONTAINER_LOG_MDC_BUILDER = new Builder()
       .setLogPrefix("destination")
-      .setPrefixColor(Color.MAGENTA)
-      .build();
+      .setPrefixColor(Color.MAGENTA);
 
   private final IntegrationLauncher integrationLauncher;
   private final AirbyteStreamFactory streamFactory;
@@ -48,7 +47,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
   private Iterator<AirbyteMessage> messageIterator = null;
 
   public DefaultAirbyteDestination(final IntegrationLauncher integrationLauncher) {
-    this(integrationLauncher, new DefaultAirbyteStreamFactory(CONTAINER_LOG_MDC));
+    this(integrationLauncher, new DefaultAirbyteStreamFactory(CONTAINER_LOG_MDC_BUILDER));
 
   }
 
@@ -70,7 +69,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
         WorkerConstants.DESTINATION_CATALOG_JSON_FILENAME,
         Jsons.serialize(destinationConfig.getCatalog()));
     // stdout logs are logged elsewhere since stdout also contains data
-    LineGobbler.gobble(destinationProcess.getErrorStream(), LOGGER::error, "airbyte-destination", CONTAINER_LOG_MDC);
+    LineGobbler.gobble(destinationProcess.getErrorStream(), LOGGER::error, "airbyte-destination", CONTAINER_LOG_MDC_BUILDER);
 
     writer = new BufferedWriter(new OutputStreamWriter(destinationProcess.getOutputStream(), Charsets.UTF_8));
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteStreamFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteStreamFactory.java
@@ -7,7 +7,6 @@ package io.airbyte.workers.protocols.airbyte;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.logging.MdcScope;
-import io.airbyte.commons.logging.MdcScope.Builder;
 import io.airbyte.protocol.models.AirbyteLogMessage;
 import io.airbyte.protocol.models.AirbyteMessage;
 import java.io.BufferedReader;
@@ -30,22 +29,22 @@ public class DefaultAirbyteStreamFactory implements AirbyteStreamFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAirbyteStreamFactory.class);
 
-  private final MdcScope containerLogMDC;
+  private final MdcScope.Builder containerLogMdcBuilder;
   private final AirbyteProtocolPredicate protocolValidator;
   private final Logger logger;
 
   public DefaultAirbyteStreamFactory() {
-    this(new Builder().build());
+    this(MdcScope.DEFAULT_BUILDER);
   }
 
-  public DefaultAirbyteStreamFactory(final MdcScope containerLogMDC) {
-    this(new AirbyteProtocolPredicate(), LOGGER, containerLogMDC);
+  public DefaultAirbyteStreamFactory(final MdcScope.Builder containerLogMdcBuilder) {
+    this(new AirbyteProtocolPredicate(), LOGGER, containerLogMdcBuilder);
   }
 
-  DefaultAirbyteStreamFactory(final AirbyteProtocolPredicate protocolPredicate, final Logger logger, final MdcScope containerLogMDC) {
+  DefaultAirbyteStreamFactory(final AirbyteProtocolPredicate protocolPredicate, final Logger logger, final MdcScope.Builder containerLogMdcBuilder) {
     protocolValidator = protocolPredicate;
     this.logger = logger;
-    this.containerLogMDC = containerLogMDC;
+    this.containerLogMdcBuilder = containerLogMdcBuilder;
   }
 
   @Override
@@ -58,7 +57,7 @@ public class DefaultAirbyteStreamFactory implements AirbyteStreamFactory {
             // we log as info all the lines that are not valid json
             // some sources actually log their process on stdout, we
             // want to make sure this info is available in the logs.
-            try (containerLogMDC) {
+            try (final var mdcScope = containerLogMdcBuilder.build()) {
               logger.info(line);
             }
           }
@@ -83,7 +82,7 @@ public class DefaultAirbyteStreamFactory implements AirbyteStreamFactory {
         .filter(airbyteMessage -> {
           final boolean isLog = airbyteMessage.getType() == AirbyteMessage.Type.LOG;
           if (isLog) {
-            try (containerLogMDC) {
+            try (final var mdcScope = containerLogMdcBuilder.build()) {
               internalLog(airbyteMessage.getLog());
             }
           }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteStreamFactoryTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteStreamFactoryTest.java
@@ -121,7 +121,7 @@ class DefaultAirbyteStreamFactoryTest {
   private Stream<AirbyteMessage> stringToMessageStream(final String inputString) {
     final InputStream inputStream = new ByteArrayInputStream(inputString.getBytes());
     final BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
-    return new DefaultAirbyteStreamFactory(protocolPredicate, logger, new Builder().build()).create(bufferedReader);
+    return new DefaultAirbyteStreamFactory(protocolPredicate, logger, new Builder()).create(bufferedReader);
   }
 
 }


### PR DESCRIPTION
I wasn't rigorous when reviewing https://github.com/airbytehq/airbyte/pull/7268. The output looked roughly correct. Some lines had `source` labels, others had `destination` labels, but they didn't represent the full logs we were supposed to capture.


<details>
  <summary>Example this PR</summary>
  
```
2021-11-04 22:47:14 INFO () WorkerRun(call):49 - Executing worker wrapper. Airbyte version: dev
2021-11-04 22:47:15 INFO () TemporalAttemptExecution(get):116 - Executing worker wrapper. Airbyte version: dev
2021-11-04 22:47:15 WARN () Databases(createPostgresDatabaseWithRetry):41 - Waiting for database to become available...
2021-11-04 22:47:15 INFO () JobsDatabaseInstance(lambda$static$2):25 - Testing if jobs database is ready...
2021-11-04 22:47:15 INFO () Databases(createPostgresDatabaseWithRetry):58 - Database available!
2021-11-04 22:47:16 WARN () JsonMetaSchema(newValidator):338 - Unknown keyword example - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
2021-11-04 22:47:16 WARN () JsonMetaSchema(newValidator):338 - Unknown keyword existingJavaType - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
2021-11-04 22:47:16 INFO () DefaultReplicationWorker(run):82 - start sync worker. job id: 13 attempt id: 0
2021-11-04 22:47:16 INFO () DefaultReplicationWorker(run):91 - configured sync modes: {public._airbyte_raw_asdfads_airbyte_raw_pokemon=full_refresh - append, public._airbyte_raw_asasdfasdfsdasapokemon=full_refresh - append}
2021-11-04 22:47:16 INFO () DefaultAirbyteDestination(start):64 - Running destination...
2021-11-04 22:47:16 INFO () LineGobbler(voidCall):82 - Checking if airbyte/destination-local-json:0.2.8 exists...
2021-11-04 22:47:16 INFO () LineGobbler(voidCall):82 - airbyte/destination-local-json:0.2.8 was found locally.
2021-11-04 22:47:16 INFO () DockerProcessFactory(create):127 - Preparing command: docker run --rm --init -i -v airbyte_workspace:/data -v /tmp/airbyte_local:/local -w /data/13/0 --network host --log-driver none airbyte/destination-local-json:0.2.8 write --config destination_config.json --catalog destination_catalog.json
2021-11-04 22:47:16 INFO () LineGobbler(voidCall):82 - Checking if airbyte/source-postgres:0.3.13 exists...
2021-11-04 22:47:17 INFO () LineGobbler(voidCall):82 - airbyte/source-postgres:0.3.13 was found locally.
2021-11-04 22:47:17 INFO () DockerProcessFactory(create):127 - Preparing command: docker run --rm --init -i -v airbyte_workspace:/data -v /tmp/airbyte_local:/local -w /data/13/0 --network host --log-driver none airbyte/source-postgres:0.3.13 read --config source_config.json --catalog source_catalog.json
2021-11-04 22:47:17 INFO () DefaultReplicationWorker(lambda$getDestinationOutputRunnable$3):226 - Destination output thread started.
2021-11-04 22:47:17 INFO () DefaultReplicationWorker(run):119 - Waiting for source thread to join.
2021-11-04 22:47:17 INFO () DefaultReplicationWorker(lambda$getReplicationRunnable$2):190 - Replication thread started.
[34msource[0m - 2021-11-04 22:47:20 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:20 [32mINFO[m i.a.i.s.p.PostgresSource(main):262 - {} - starting source: class io.airbyte.integrations.source.postgres.PostgresSource
[35mdestination[0m - 2021-11-04 22:47:20 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:20 [32mINFO[m i.a.i.b.IntegrationRunner(run):96 - {} - Running integration: io.airbyte.integrations.destination.local_json.LocalJsonDestination
[35mdestination[0m - 2021-11-04 22:47:20 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:20 [32mINFO[m i.a.i.b.IntegrationCliParser(parseOptions):135 - {} - integration args: {catalog=destination_catalog.json, write=null, config=destination_config.json}
[35mdestination[0m - 2021-11-04 22:47:20 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:20 [32mINFO[m i.a.i.b.IntegrationRunner(run):100 - {} - Command: WRITE
[35mdestination[0m - 2021-11-04 22:47:20 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:20 [32mINFO[m i.a.i.b.IntegrationRunner(run):101 - {} - Integration config: IntegrationConfig{command=WRITE, configPath='destination_config.json', catalogPath='destination_catalog.json', statePath='null'}
[35mdestination[0m - 2021-11-04 22:47:20 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:20 [33mWARN[m c.n.s.JsonMetaSchema(newValidator):338 - {} - Unknown keyword examples - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
[34msource[0m - 2021-11-04 22:47:20 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:20 [32mINFO[m i.a.i.b.IntegrationRunner(run):76 - {} - Running integration: io.airbyte.integrations.base.ssh.SshWrappedSource
[34msource[0m - 2021-11-04 22:47:20 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:20 [32mINFO[m i.a.i.b.IntegrationCliParser(parseOptions):115 - {} - integration args: {read=null, catalog=source_catalog.json, config=source_config.json}
[34msource[0m - 2021-11-04 22:47:20 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:20 [32mINFO[m i.a.i.b.IntegrationRunner(run):80 - {} - Command: READ
[34msource[0m - 2021-11-04 22:47:20 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:20 [32mINFO[m i.a.i.b.IntegrationRunner(run):81 - {} - Integration config: IntegrationConfig{command=READ, configPath='source_config.json', catalogPath='source_catalog.json', statePath='null'}
[34msource[0m - 2021-11-04 22:47:21 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:21 [33mWARN[m c.n.s.JsonMetaSchema(newValidator):338 - {} - Unknown keyword order - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
[34msource[0m - 2021-11-04 22:47:21 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:21 [33mWARN[m c.n.s.JsonMetaSchema(newValidator):338 - {} - Unknown keyword examples - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
[34msource[0m - 2021-11-04 22:47:21 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:21 [33mWARN[m c.n.s.JsonMetaSchema(newValidator):338 - {} - Unknown keyword airbyte_secret - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
[34msource[0m - 2021-11-04 22:47:21 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:21 [33mWARN[m c.n.s.JsonMetaSchema(newValidator):338 - {} - Unknown keyword multiline - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
[35mdestination[0m - 2021-11-04 22:47:21 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:21 [32mINFO[m i.a.i.d.l.LocalJsonDestination$JsonConsumer(<init>):151 - {} - initializing consumer.
[34msource[0m - 2021-11-04 22:47:21 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:21 [32mINFO[m i.a.i.b.s.SshTunnel(getInstance):170 - {} - Starting connection with method: NO_TUNNEL
[34msource[0m - 2021-11-04 22:47:23 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:23 [32mINFO[m i.a.i.s.p.PostgresSource(isCdc):212 - {} - using CDC: false
[34msource[0m - 2021-11-04 22:47:23 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:23 [32mINFO[m i.a.i.s.j.AbstractJdbcSource(lambda$getCheckOperations$1):87 - {} - Attempting to get metadata from the database to see if we can connect.
[34msource[0m - 2021-11-04 22:47:23 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:23 [32mINFO[m i.a.i.s.r.CdcStateManager(<init>):26 - {} - Initialized CDC state with: null
[34msource[0m - 2021-11-04 22:47:23 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:23 [32mINFO[m i.a.i.s.r.StateManager(createCursorInfoForStream):118 - {} - No cursor field set in catalog but not present in state. Stream: AirbyteStreamNameNamespacePair{name='_airbyte_raw_asasdfasdfsdasapokemon', namespace='public'}, New Cursor Field: null. Resetting cursor value
[34msource[0m - 2021-11-04 22:47:23 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:23 [32mINFO[m i.a.i.s.r.StateManager(createCursorInfoForStream):118 - {} - No cursor field set in catalog but not present in state. Stream: AirbyteStreamNameNamespacePair{name='_airbyte_raw_asdfads_airbyte_raw_pokemon', namespace='public'}, New Cursor Field: null. Resetting cursor value
[34msource[0m - 2021-11-04 22:47:28 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:28 [32mINFO[m i.a.i.s.p.PostgresSource(isCdc):212 - {} - using CDC: false
[34msource[0m - 2021-11-04 22:47:28 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:28 [32mINFO[m i.a.i.s.r.AbstractRelationalDbSource(queryTableFullRefresh):35 - {} - Queueing query for table: _airbyte_raw_asasdfasdfsdasapokemon
[34msource[0m - 2021-11-04 22:47:28 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:28 [32mINFO[m i.a.i.s.r.AbstractRelationalDbSource(queryTableFullRefresh):35 - {} - Queueing query for table: _airbyte_raw_asdfads_airbyte_raw_pokemon
[34msource[0m - 2021-11-04 22:47:31 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:31 [32mINFO[m i.a.i.s.r.AbstractDbSource(lambda$read$2):121 - {} - Closing database connection pool.
[34msource[0m - 2021-11-04 22:47:31 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:31 [32mINFO[m i.a.i.s.r.AbstractDbSource(lambda$read$2):123 - {} - Closed database connection pool.
[34msource[0m - 2021-11-04 22:47:31 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:31 [32mINFO[m i.a.i.b.IntegrationRunner(run):133 - {} - Completed integration: io.airbyte.integrations.base.ssh.SshWrappedSource
[34msource[0m - 2021-11-04 22:47:31 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:31 [32mINFO[m i.a.i.s.p.PostgresSource(main):264 - {} - completed source: class io.airbyte.integrations.source.postgres.PostgresSource
2021-11-04 22:47:31 INFO () DefaultReplicationWorker(run):121 - Source thread complete.
2021-11-04 22:47:31 INFO () DefaultReplicationWorker(run):122 - Waiting for destination thread to join.
[35mdestination[0m - 2021-11-04 22:47:31 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:31 [32mINFO[m i.a.i.b.FailureTrackingAirbyteMessageConsumer(close):80 - {} - Airbyte message consumer: succeeded.
[35mdestination[0m - 2021-11-04 22:47:31 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:31 [32mINFO[m i.a.i.d.l.LocalJsonDestination$JsonConsumer(close):192 - {} - finalizing consumer.
[35mdestination[0m - 2021-11-04 22:47:31 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:31 [32mINFO[m i.a.i.d.l.LocalJsonDestination$JsonConsumer(close):208 - {} - File output: /local/afdsds/_airbyte_raw__airbyte_raw_asdfads_airbyte_raw_pokemon.jsonl
[35mdestination[0m - 2021-11-04 22:47:31 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:31 [32mINFO[m i.a.i.d.l.LocalJsonDestination$JsonConsumer(close):208 - {} - File output: /local/afdsds/_airbyte_raw__airbyte_raw_asasdfasdfsdasapokemon.jsonl
[35mdestination[0m - 2021-11-04 22:47:31 INFO () DefaultAirbyteStreamFactory(lambda$create$0):61 - 2021-11-04 22:47:31 [32mINFO[m i.a.i.b.IntegrationRunner(run):153 - {} - Completed integration: io.airbyte.integrations.destination.local_json.LocalJsonDestination
2021-11-04 22:47:31 INFO () DefaultReplicationWorker(run):124 - Destination thread complete.
2021-11-04 22:47:31 INFO () DefaultReplicationWorker(run):152 - sync summary: io.airbyte.config.ReplicationAttemptSummary@2c59d72a[status=completed,recordsSynced=4,bytesSynced=100944,startTime=1636066036442,endTime=1636066051420]
2021-11-04 22:47:31 INFO () DefaultReplicationWorker(run):161 - Source did not output any state messages
2021-11-04 22:47:31 WARN () DefaultReplicationWorker(run):172 - State capture: No state retained.
2021-11-04 22:47:31 INFO () TemporalAttemptExecution(get):137 - Stopping cancellation check scheduling...
2021-11-04 22:47:31 INFO () SyncWorkflow$ReplicationActivityImpl(replicate):233 - sync summary: io.airbyte.config.StandardSyncOutput@7a9b0b84[standardSyncSummary=io.airbyte.config.StandardSyncSummary@61d1981e[status=completed,recordsSynced=4,bytesSynced=100944,startTime=1636066036442,endTime=1636066051420],state=<null>,outputCatalog=io.airbyte.protocol.models.ConfiguredAirbyteCatalog@30785316[streams=[io.airbyte.protocol.models.ConfiguredAirbyteStream@6c8e9a9b[stream=io.airbyte.protocol.models.AirbyteStream@4eeb6ba5[name=_airbyte_raw_asasdfasdfsdasapokemon,jsonSchema={"type":"object","properties":{"_airbyte_data":{"type":"string"},"_airbyte_ab_id":{"type":"string"},"_airbyte_emitted_at":{"type":"string"}}},supportedSyncModes=[full_refresh, incremental],sourceDefinedCursor=<null>,defaultCursorField=[],sourceDefinedPrimaryKey=[[_airbyte_ab_id]],namespace=public,additionalProperties={}],syncMode=full_refresh,cursorField=[],destinationSyncMode=append,primaryKey=[[_airbyte_ab_id]],additionalProperties={}], io.airbyte.protocol.models.ConfiguredAirbyteStream@6f7fa0d6[stream=io.airbyte.protocol.models.AirbyteStream@30a16528[name=_airbyte_raw_asdfads_airbyte_raw_pokemon,jsonSchema={"type":"object","properties":{"_airbyte_data":{"type":"string"},"_airbyte_ab_id":{"type":"string"},"_airbyte_emitted_at":{"type":"string"}}},supportedSyncModes=[full_refresh, incremental],sourceDefinedCursor=<null>,defaultCursorField=[],sourceDefinedPrimaryKey=[[_airbyte_ab_id]],namespace=public,additionalProperties={}],syncMode=full_refresh,cursorField=[],destinationSyncMode=append,primaryKey=[[_airbyte_ab_id]],additionalProperties={}]],additionalProperties={}]]
```
</details>
