### PR TITLE
Clarify Connector Spec Caching in Developing Locally.

### DIFF
--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -137,7 +137,10 @@ npm start
 
 ### Connector Specification Caching
 
-The Configuration API caches connector specifications. This is done to avoid needing to run docker everytime one is needed in the UI. Without this caching, the UI crawls. If you update the specification of a connector and you need to clear this cache so the API / UI pick up the change. You have two options: 1. Go to the Admin page in the UI and update the version of the connector. Updating to the same version will for the cache to clear for that connector. 1. Restart the server
+The Configuration API caches connector specifications. This is done to avoid needing to run Docker everytime one is needed in the UI. Without this caching, the UI crawls. If you update the specification of a connector and need to clear this cache so the API / UI picks up the change, you have two options: 
+
+1. Go to the Admin page in the UI and update the version of the connector. Updating to any version, including the one you're already on, will trigger clearing the cache. 
+2. Restart the server by running the following commands:
 
 ```bash
 VERSION=dev docker-compose down -v


### PR DESCRIPTION
## Main Changes
The section about connector spec caching was very unclear, so I'm making some wording updates to it. 