### PR TITLE
Add connector config to oauth api

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -1311,7 +1311,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CompleteOauthResponse"
+                $ref: "#/components/schemas/CompleteSourceOauthResponse"
         "404":
           $ref: "#/components/responses/NotFoundResponse"
         "422":
@@ -1357,7 +1357,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CompleteOauthResponse"
+                $ref: "#/components/schemas/CompleteDestinationOauthResponse"
         "404":
           $ref: "#/components/responses/NotFoundResponse"
         "422":
@@ -3241,6 +3241,8 @@ components:
         redirectUrl:
           description: The url to redirect to after getting the user consent
           type: string
+        connectionConfiguration:
+          $ref: "#/components/schemas/SourceConfiguration"
     DestinationOauthConsentRequest:
       type: object
       required:
@@ -3255,6 +3257,8 @@ components:
         redirectUrl:
           description: The url to redirect to after getting the user consent
           type: string
+        connectionConfiguration:
+          $ref: "#/components/schemas/DestinationConfiguration"
     OAuthConsentRead:
       type: object
       required:
@@ -3279,6 +3283,8 @@ components:
           description: The query parameters present in the redirect URL after a user granted consent e.g auth code
           type: object
           additionalProperties: true # Oauth parameters like code, state, etc.. will be different per API so we don't specify them in advance
+        connectionConfiguration:
+          $ref: "#/components/schemas/SourceConfiguration"
     CompleteDestinationOAuthRequest:
       type: object
       required:
@@ -3296,9 +3302,24 @@ components:
           description: The query parameters present in the redirect URL after a user granted consent e.g auth code
           type: object
           additionalProperties: true # Oauth parameters like code, state, etc.. will be different per API so we don't specify them in advance
-    CompleteOauthResponse:
+        connectionConfiguration:
+          $ref: "#/components/schemas/DestinationConfiguration"
+    CompleteSourceOauthResponse:
       type: object
-      additionalProperties: true # Oauth parameters like refresh/access token etc.. will be different per API so we don't specify them in advance
+      properties:
+        oauthOutput:
+          type: object
+          additionalProperties: true # Oauth parameters like refresh/access token etc.. will be different per API so we don't specify them in advance
+        connectionConfiguration:
+          $ref: "#/components/schemas/SourceConfiguration"
+    CompleteDestinationOauthResponse:
+      type: object
+      properties:
+        oauthOutput:
+          type: object
+          additionalProperties: true # Oauth parameters like refresh/access token etc.. will be different per API so we don't specify them in advance
+        connectionConfiguration:
+          $ref: "#/components/schemas/DestinationConfiguration"
     SetInstancewideSourceOauthParamsRequestBody:
       type: object
       required:

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -8,7 +8,9 @@ import io.airbyte.analytics.TrackingClient;
 import io.airbyte.api.model.CheckConnectionRead;
 import io.airbyte.api.model.CheckOperationRead;
 import io.airbyte.api.model.CompleteDestinationOAuthRequest;
+import io.airbyte.api.model.CompleteDestinationOauthResponse;
 import io.airbyte.api.model.CompleteSourceOauthRequest;
+import io.airbyte.api.model.CompleteSourceOauthResponse;
 import io.airbyte.api.model.ConnectionCreate;
 import io.airbyte.api.model.ConnectionIdRequestBody;
 import io.airbyte.api.model.ConnectionRead;
@@ -122,7 +124,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.nio.file.Path;
-import java.util.Map;
 
 @javax.ws.rs.Path("/v1")
 public class ConfigurationApi implements io.airbyte.api.V1Api {
@@ -300,7 +301,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   }
 
   @Override
-  public Map<String, Object> completeSourceOAuth(final CompleteSourceOauthRequest completeSourceOauthRequest) {
+  public CompleteSourceOauthResponse completeSourceOAuth(final CompleteSourceOauthRequest completeSourceOauthRequest) {
     return execute(() -> oAuthHandler.completeSourceOAuth(completeSourceOauthRequest));
   }
 
@@ -310,7 +311,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   }
 
   @Override
-  public Map<String, Object> completeDestinationOAuth(final CompleteDestinationOAuthRequest requestBody) {
+  public CompleteDestinationOauthResponse completeDestinationOAuth(final CompleteDestinationOAuthRequest requestBody) {
     return execute(() -> oAuthHandler.completeDestinationOAuth(requestBody));
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/OAuthHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/OAuthHandler.java
@@ -7,7 +7,9 @@ package io.airbyte.server.handlers;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.analytics.TrackingClient;
 import io.airbyte.api.model.CompleteDestinationOAuthRequest;
+import io.airbyte.api.model.CompleteDestinationOauthResponse;
 import io.airbyte.api.model.CompleteSourceOauthRequest;
+import io.airbyte.api.model.CompleteSourceOauthResponse;
 import io.airbyte.api.model.DestinationOauthConsentRequest;
 import io.airbyte.api.model.OAuthConsentRead;
 import io.airbyte.api.model.SetInstancewideDestinationOauthParamsRequestBody;
@@ -26,7 +28,6 @@ import io.airbyte.scheduler.persistence.job_tracker.TrackingMetadata;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.net.http.HttpClient;
-import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,17 +84,18 @@ public class OAuthHandler {
     return result;
   }
 
-  public Map<String, Object> completeSourceOAuth(final CompleteSourceOauthRequest oauthSourceRequestBody)
+  public CompleteSourceOauthResponse completeSourceOAuth(final CompleteSourceOauthRequest oauthSourceRequestBody)
       throws JsonValidationException, ConfigNotFoundException, IOException {
     final StandardSourceDefinition sourceDefinition = configRepository.getStandardSourceDefinition(oauthSourceRequestBody.getSourceDefinitionId());
     final OAuthFlowImplementation oAuthFlowImplementation =
         oAuthImplementationFactory.create(sourceDefinition, oauthSourceRequestBody.getWorkspaceId());
     final ImmutableMap<String, Object> metadata = generateSourceMetadata(oauthSourceRequestBody.getSourceDefinitionId());
-    final Map<String, Object> result = oAuthFlowImplementation.completeSourceOAuth(
+    final CompleteSourceOauthResponse result = new CompleteSourceOauthResponse();
+    result.oauthOutput(oAuthFlowImplementation.completeSourceOAuth(
         oauthSourceRequestBody.getWorkspaceId(),
         oauthSourceRequestBody.getSourceDefinitionId(),
         oauthSourceRequestBody.getQueryParams(),
-        oauthSourceRequestBody.getRedirectUrl());
+        oauthSourceRequestBody.getRedirectUrl()));
     try {
       trackingClient.track(oauthSourceRequestBody.getWorkspaceId(), "Complete OAuth Flow - Backend", metadata);
     } catch (final Exception e) {
@@ -102,18 +104,19 @@ public class OAuthHandler {
     return result;
   }
 
-  public Map<String, Object> completeDestinationOAuth(final CompleteDestinationOAuthRequest oauthDestinationRequestBody)
+  public CompleteDestinationOauthResponse completeDestinationOAuth(final CompleteDestinationOAuthRequest oauthDestinationRequestBody)
       throws JsonValidationException, ConfigNotFoundException, IOException {
     final StandardDestinationDefinition destinationDefinition =
         configRepository.getStandardDestinationDefinition(oauthDestinationRequestBody.getDestinationDefinitionId());
     final OAuthFlowImplementation oAuthFlowImplementation =
         oAuthImplementationFactory.create(destinationDefinition, oauthDestinationRequestBody.getWorkspaceId());
     final ImmutableMap<String, Object> metadata = generateDestinationMetadata(oauthDestinationRequestBody.getDestinationDefinitionId());
-    final Map<String, Object> result = oAuthFlowImplementation.completeDestinationOAuth(
+    final CompleteDestinationOauthResponse result = new CompleteDestinationOauthResponse();
+    result.oauthOutput(oAuthFlowImplementation.completeDestinationOAuth(
         oauthDestinationRequestBody.getWorkspaceId(),
         oauthDestinationRequestBody.getDestinationDefinitionId(),
         oauthDestinationRequestBody.getQueryParams(),
-        oauthDestinationRequestBody.getRedirectUrl());
+        oauthDestinationRequestBody.getRedirectUrl()));
     try {
       trackingClient.track(oauthDestinationRequestBody.getWorkspaceId(), "Complete OAuth Flow - Backend", metadata);
     } catch (final Exception e) {

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -3032,12 +3032,22 @@ font-style: italic;
 
     <h3 class="field-label">Return type</h3>
     <div class="return-type">
+      <a href="#CompleteDestinationOauthResponse">CompleteDestinationOauthResponse</a>
       
-      map[String, Object]
     </div>
 
     <!--Todo: process Response Object and its headers, schema, examples -->
 
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "oauthOutput" : {
+    "key" : "{}"
+  },
+  "connectionConfiguration" : {
+    "user" : "charles"
+  }
+}</code></pre>
 
     <h3 class="field-label">Produces</h3>
     This API call produces the following media types according to the <span class="header">Accept</span> request header;
@@ -3049,7 +3059,7 @@ font-style: italic;
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">200</h4>
     Successful operation
-        <a href="#map[String, Object]">map[String, Object]</a>
+        <a href="#CompleteDestinationOauthResponse">CompleteDestinationOauthResponse</a>
     <h4 class="field-label">404</h4>
     Object with given id was not found.
         <a href="#NotFoundKnownExceptionInfo">NotFoundKnownExceptionInfo</a>
@@ -3085,12 +3095,22 @@ font-style: italic;
 
     <h3 class="field-label">Return type</h3>
     <div class="return-type">
+      <a href="#CompleteSourceOauthResponse">CompleteSourceOauthResponse</a>
       
-      map[String, Object]
     </div>
 
     <!--Todo: process Response Object and its headers, schema, examples -->
 
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "oauthOutput" : {
+    "key" : "{}"
+  },
+  "connectionConfiguration" : {
+    "user" : "charles"
+  }
+}</code></pre>
 
     <h3 class="field-label">Produces</h3>
     This API call produces the following media types according to the <span class="header">Accept</span> request header;
@@ -3102,7 +3122,7 @@ font-style: italic;
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">200</h4>
     Successful operation
-        <a href="#map[String, Object]">map[String, Object]</a>
+        <a href="#CompleteSourceOauthResponse">CompleteSourceOauthResponse</a>
     <h4 class="field-label">404</h4>
     Object with given id was not found.
         <a href="#NotFoundKnownExceptionInfo">NotFoundKnownExceptionInfo</a>
@@ -6594,7 +6614,9 @@ font-style: italic;
     <li><a href="#CheckConnectionRead"><code>CheckConnectionRead</code> - </a></li>
     <li><a href="#CheckOperationRead"><code>CheckOperationRead</code> - </a></li>
     <li><a href="#CompleteDestinationOAuthRequest"><code>CompleteDestinationOAuthRequest</code> - </a></li>
+    <li><a href="#CompleteDestinationOauthResponse"><code>CompleteDestinationOauthResponse</code> - </a></li>
     <li><a href="#CompleteSourceOauthRequest"><code>CompleteSourceOauthRequest</code> - </a></li>
+    <li><a href="#CompleteSourceOauthResponse"><code>CompleteSourceOauthResponse</code> - </a></li>
     <li><a href="#ConnectionCreate"><code>ConnectionCreate</code> - </a></li>
     <li><a href="#ConnectionIdRequestBody"><code>ConnectionIdRequestBody</code> - </a></li>
     <li><a href="#ConnectionRead"><code>ConnectionRead</code> - </a></li>
@@ -6802,6 +6824,15 @@ font-style: italic;
 <div class="param">workspaceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">redirectUrl (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> When completing OAuth flow to gain an access token, some API sometimes requires to verify that the app re-send the redirectUrl that was used when consent was given. </div>
 <div class="param">queryParams (optional)</div><div class="param-desc"><span class="param-type"><a href="#object">map[String, Object]</a></span> The query parameters present in the redirect URL after a user granted consent e.g auth code </div>
+<div class="param">connectionConfiguration (optional)</div><div class="param-desc"><span class="param-type"><a href="#DestinationConfiguration">DestinationConfiguration</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="CompleteDestinationOauthResponse"><code>CompleteDestinationOauthResponse</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">oauthOutput (optional)</div><div class="param-desc"><span class="param-type"><a href="#object">map[String, Object]</a></span>  </div>
+<div class="param">connectionConfiguration (optional)</div><div class="param-desc"><span class="param-type"><a href="#DestinationConfiguration">DestinationConfiguration</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -6812,6 +6843,15 @@ font-style: italic;
 <div class="param">workspaceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">redirectUrl (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> When completing OAuth flow to gain an access token, some API sometimes requires to verify that the app re-send the redirectUrl that was used when consent was given. </div>
 <div class="param">queryParams (optional)</div><div class="param-desc"><span class="param-type"><a href="#object">map[String, Object]</a></span> The query parameters present in the redirect URL after a user granted consent e.g auth code </div>
+<div class="param">connectionConfiguration (optional)</div><div class="param-desc"><span class="param-type"><a href="#SourceConfiguration">SourceConfiguration</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="CompleteSourceOauthResponse"><code>CompleteSourceOauthResponse</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">oauthOutput (optional)</div><div class="param-desc"><span class="param-type"><a href="#object">map[String, Object]</a></span>  </div>
+<div class="param">connectionConfiguration (optional)</div><div class="param-desc"><span class="param-type"><a href="#SourceConfiguration">SourceConfiguration</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -7058,6 +7098,7 @@ font-style: italic;
       <div class="param">destinationDefinitionId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">workspaceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">redirectUrl </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The url to redirect to after getting the user consent </div>
+<div class="param">connectionConfiguration (optional)</div><div class="param-desc"><span class="param-type"><a href="#DestinationConfiguration">DestinationConfiguration</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -7526,6 +7567,7 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
       <div class="param">sourceDefinitionId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">workspaceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">redirectUrl </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The url to redirect to after getting the user consent </div>
+<div class="param">connectionConfiguration (optional)</div><div class="param-desc"><span class="param-type"><a href="#SourceConfiguration">SourceConfiguration</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What
New OAuth flows will need values from the connector config in https://github.com/airbytehq/airbyte/issues/6971

## How
Alteernative to https://github.com/airbytehq/airbyte/pull/7798

This API changes adds an "optional" connector config parameter to the API endpoint:
- if config is provided, then we can follow the new oauth specification and implement https://github.com/airbytehq/airbyte/issues/7216 where values will be seeded into the connector config after completing the oauth flow. The API will return a valid connector config with oauth values already injected.
- if config is not provided, then previous behavior is kept

## Context

- When FE calls the completeOauth API endpoint, a partial connectionConfig (that the user is trying to create, as if it was the SourceCreate API but not exhaustive yet) can be passed. 
- If any fields is used as input fields to the oauth flow, the backend can refer to these values directly in the connectionConfig.
- once oauth flow is completed, the backend will copy the oauth outputs back inside the connector config where it needs to (in the rootObject) along with placeholder masked instance-wide params and return the modified connectionConfig. The merge of connectionConfig + oauth outputs is therefore not needed in the front end anymore.
- so after that call the FE can just forward the new connectionConfig to SourceCreate when clicking on "setup connection"