### PR TITLE
Bump Airbyte version from 0.30.31-alpha to 0.30.32-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.30.31-alpha
+current_version = 0.30.32-alpha
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.30.31-alpha
+VERSION=0.30.32-alpha
 
 # Airbyte Internal Job Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_USER=docker

--- a/airbyte-scheduler/app/Dockerfile
+++ b/airbyte-scheduler/app/Dockerfile
@@ -5,7 +5,7 @@ ENV APPLICATION airbyte-scheduler
 
 WORKDIR /app
 
-ADD build/distributions/${APPLICATION}-0.30.31-alpha.tar /app
+ADD build/distributions/${APPLICATION}-0.30.32-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.31-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.32-alpha/bin/${APPLICATION}"]

--- a/airbyte-server/Dockerfile
+++ b/airbyte-server/Dockerfile
@@ -7,7 +7,7 @@ ENV APPLICATION airbyte-server
 
 WORKDIR /app
 
-ADD build/distributions/${APPLICATION}-0.30.31-alpha.tar /app
+ADD build/distributions/${APPLICATION}-0.30.32-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.31-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.32-alpha/bin/${APPLICATION}"]

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -250,12 +250,12 @@ public class ServerApp implements ServerRunnable {
 
       // todo (lmossman) - this will only exist temporarily to ensure all definitions contain specs. It
       // will be removed after the faux major version bump
-      migrateAllDefinitionsToContainSpec(
-          configRepository,
-          cachingSchedulerClient,
-          trackingClient,
-          configs.getWorkerEnvironment(),
-          configs.getLogConfigs());
+//      migrateAllDefinitionsToContainSpec(
+//          configRepository,
+//          cachingSchedulerClient,
+//          trackingClient,
+//          configs.getWorkerEnvironment(),
+//          configs.getLogConfigs());
 
       return apiFactory.create(
           schedulerJobClient,

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -250,12 +250,12 @@ public class ServerApp implements ServerRunnable {
 
       // todo (lmossman) - this will only exist temporarily to ensure all definitions contain specs. It
       // will be removed after the faux major version bump
-//      migrateAllDefinitionsToContainSpec(
-//          configRepository,
-//          cachingSchedulerClient,
-//          trackingClient,
-//          configs.getWorkerEnvironment(),
-//          configs.getLogConfigs());
+      // migrateAllDefinitionsToContainSpec(
+      // configRepository,
+      // cachingSchedulerClient,
+      // trackingClient,
+      // configs.getWorkerEnvironment(),
+      // configs.getLogConfigs());
 
       return apiFactory.create(
           schedulerJobClient,

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.30.31-alpha",
+  "version": "0.30.32-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.30.31-alpha",
+  "version": "0.30.32-alpha",
   "private": true,
   "scripts": {
     "start": "react-scripts start",

--- a/airbyte-workers/Dockerfile
+++ b/airbyte-workers/Dockerfile
@@ -23,7 +23,7 @@ ENV APPLICATION airbyte-workers
 WORKDIR /app
 
 # Move worker app
-ADD build/distributions/${APPLICATION}-0.30.31-alpha.tar /app
+ADD build/distributions/${APPLICATION}-0.30.32-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.31-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.32-alpha/bin/${APPLICATION}"]

--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.3.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.30.31-alpha"
+appVersion: "0.30.32-alpha"
 
 dependencies:
 - name: common

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -29,7 +29,7 @@
 | `webapp.replicaCount`        | Number of webapp replicas                                        | `1`              |
 | `webapp.image.repository`    | The repository to use for the airbyte webapp image.              | `airbyte/webapp` |
 | `webapp.image.pullPolicy`    | the pull policy to use for the airbyte webapp image              | `IfNotPresent`   |
-| `webapp.image.tag`           | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.30.31-alpha`  |
+| `webapp.image.tag`           | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.30.32-alpha`  |
 | `webapp.podAnnotations`      | Add extra annotations to the webapp pod(s)                       | `{}`             |
 | `webapp.service.type`        | The service type to use for the webapp service                   | `ClusterIP`      |
 | `webapp.service.port`        | The service port to expose the webapp on                         | `80`             |
@@ -56,7 +56,7 @@
 | `scheduler.replicaCount`       | Number of scheduler replicas                                        | `1`                 |
 | `scheduler.image.repository`   | The repository to use for the airbyte scheduler image.              | `airbyte/scheduler` |
 | `scheduler.image.pullPolicy`   | the pull policy to use for the airbyte scheduler image              | `IfNotPresent`      |
-| `scheduler.image.tag`          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.30.31-alpha`     |
+| `scheduler.image.tag`          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.30.32-alpha`     |
 | `scheduler.podAnnotations`     | Add extra annotations to the scheduler pod                          | `{}`                |
 | `scheduler.resources.limits`   | The resources limits for the scheduler container                    | `{}`                |
 | `scheduler.resources.requests` | The requested resources for the scheduler container                 | `{}`                |
@@ -87,7 +87,7 @@
 | `server.replicaCount`                       | Number of server replicas                                        | `1`              |
 | `server.image.repository`                   | The repository to use for the airbyte server image.              | `airbyte/server` |
 | `server.image.pullPolicy`                   | the pull policy to use for the airbyte server image              | `IfNotPresent`   |
-| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.30.31-alpha`  |
+| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.30.32-alpha`  |
 | `server.podAnnotations`                     | Add extra annotations to the server pod                          | `{}`             |
 | `server.livenessProbe.enabled`              | Enable livenessProbe on the server                               | `true`           |
 | `server.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                          | `30`             |
@@ -121,7 +121,7 @@
 | `worker.replicaCount`                       | Number of worker replicas                                        | `1`              |
 | `worker.image.repository`                   | The repository to use for the airbyte worker image.              | `airbyte/worker` |
 | `worker.image.pullPolicy`                   | the pull policy to use for the airbyte worker image              | `IfNotPresent`   |
-| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.30.31-alpha`  |
+| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.30.32-alpha`  |
 | `worker.podAnnotations`                     | Add extra annotations to the worker pod(s)                       | `{}`             |
 | `worker.livenessProbe.enabled`              | Enable livenessProbe on the worker                               | `true`           |
 | `worker.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                          | `30`             |

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -44,7 +44,7 @@ webapp:
   image:
     repository: airbyte/webapp
     pullPolicy: IfNotPresent
-    tag: 0.30.31-alpha
+    tag: 0.30.32-alpha
 
   ## @param webapp.podAnnotations [object] Add extra annotations to the webapp pod(s)
   ##
@@ -141,7 +141,7 @@ scheduler:
   image:
     repository: airbyte/scheduler
     pullPolicy: IfNotPresent
-    tag: 0.30.31-alpha
+    tag: 0.30.32-alpha
 
   ## @param scheduler.podAnnotations [object] Add extra annotations to the scheduler pod
   ##
@@ -248,7 +248,7 @@ server:
   image:
     repository: airbyte/server
     pullPolicy: IfNotPresent
-    tag: 0.30.31-alpha
+    tag: 0.30.32-alpha
 
   ## @param server.podAnnotations [object] Add extra annotations to the server pod
   ##
@@ -360,7 +360,7 @@ worker:
   image:
     repository: airbyte/worker
     pullPolicy: IfNotPresent
-    tag: 0.30.31-alpha
+    tag: 0.30.32-alpha
 
   ## @param worker.podAnnotations [object] Add extra annotations to the worker pod(s)
   ##

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -82,7 +82,7 @@ If you are upgrading from \(i.e. your current version of Airbyte is\) Airbyte ve
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.30.31-alpha --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.30.32-alpha --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/kube/overlays/stable-with-resource-limits/.env
+++ b/kube/overlays/stable-with-resource-limits/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.30.31-alpha
+AIRBYTE_VERSION=0.30.32-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.30.31-alpha
+    newTag: 0.30.32-alpha
   - name: airbyte/scheduler
-    newTag: 0.30.31-alpha
+    newTag: 0.30.32-alpha
   - name: airbyte/server
-    newTag: 0.30.31-alpha
+    newTag: 0.30.32-alpha
   - name: airbyte/webapp
-    newTag: 0.30.31-alpha
+    newTag: 0.30.32-alpha
   - name: airbyte/worker
-    newTag: 0.30.31-alpha
+    newTag: 0.30.32-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.30.31-alpha
+AIRBYTE_VERSION=0.30.32-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.30.31-alpha
+    newTag: 0.30.32-alpha
   - name: airbyte/scheduler
-    newTag: 0.30.31-alpha
+    newTag: 0.30.32-alpha
   - name: airbyte/server
-    newTag: 0.30.31-alpha
+    newTag: 0.30.32-alpha
   - name: airbyte/webapp
-    newTag: 0.30.31-alpha
+    newTag: 0.30.32-alpha
   - name: airbyte/worker
-    newTag: 0.30.31-alpha
+    newTag: 0.30.32-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 


### PR DESCRIPTION
Changelog:

76cb8448c format (#7699)
797d11a8d Revert "Bmoric/remove docker compose for build (#7500)" (#7698)
d84f33a62 Revert "have docker-compose.build.yaml to use new docker context (#7696)" (#7697)
b5af3f1d5 have docker-compose.build.yaml to use new docker context (#7696)
058c8f802 Backfill specs into definitions (#7616)
9791a14dd 🎉 Source Shopify: Add `FulfillmentOrders` and `Fulfillments` streams (#7107)
9bda6a7af 🐛 Bugfix: inject http client into server to prevent file churn (#7688)
45f6559c7 Fixed Mac M1 build (#7687)
16d9d15f5 🎉 New Destination: Pulsar (#7315)
2efef3c04 🐛 Source Salesforce: Fix getting `anyType` fields using BULK API (#7592)
9f750c2d0 Publish PR 7186: config files for destination cassandra (#7685)
f53fd5e66 🎉 New destination: Cassandra (#7186)
1f295f24e 🎉 Source Google Directory: support oauth
497858d6e Source Facebook Marketing: Bump docker version (#7682)
4e17fa21a Bmoric/remove docker compose for build (#7500)
23f3d3e59 Source Facebook Marketing: Fix number and integer fields in schemas (#7605)
c6edf1358 Eliziario/hubspot oauth (#7279)
7fd180446 Fix numerous create calls (#7659)
56db8065e 🐛 Source MSSQL: fix data type (smalldatetime, smallmoney) conversion from mssql source (#5609) (#7386)
af1c62f0c Publish new source Confluence #7241 (#7666)
4a99ac348 🎉 New Source: Confluence (#7241)
93afe184f Remove onboarding call reference. (#7665)

Steps After Merging PR:
1. Pull most recent version of master
2. Run ./tools/bin/tag_version.sh
3. Create a GitHub release with the changelog