### PR TITLE
Check for defined instead of boolean check

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Property/Control.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Property/Control.tsx
@@ -4,6 +4,7 @@ import { FieldArray, useField } from "formik";
 import { DropDown, Input, Multiselect, TextArea, TagInput } from "components";
 import ConfirmationControl from "./ConfirmationControl";
 import { FormBaseItem } from "core/form/types";
+import { isDefined } from "utils/common";
 
 type IProps = {
   property: FormBaseItem;
@@ -105,7 +106,7 @@ const Control: React.FC<IProps> = ({
   } else if (property.isSecret) {
     const unfinishedSecret = unfinishedFlows[name];
     const isEditInProgress = !!unfinishedSecret;
-    const isFormInEditMode = !!meta.initialValue;
+    const isFormInEditMode = isDefined(meta.initialValue);
     return (
       <ConfirmationControl
         component={


### PR DESCRIPTION
## What
Closes #5231 

## How
Small improvement to check for null or undefined instead of _not_ check ( as it matches also 0 and `""` )
