### PR TITLE
Bump Airbyte version from 0.30.36-alpha to 0.30.37-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.30.36-alpha
+current_version = 0.30.37-alpha
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VERSION=0.30.36-alpha
+VERSION=0.30.37-alpha
 
 # Airbyte Internal Job Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_USER=docker

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -2354,12 +2354,12 @@
     supportsDBT: false
     supported_destination_sync_modes:
     - "append"
-- dockerImage: "airbyte/source-hubspot:0.1.23"
+- dockerImage: "airbyte/source-hubspot:0.1.24"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/hubspot"
     connectionSpecification:
       $schema: "http://json-schema.org/draft-07/schema#"
-      title: "Hubspot Source Spec"
+      title: "HubSpot Source Spec"
       type: "object"
       required:
       - "start_date"
@@ -2380,7 +2380,7 @@
           type: "object"
           oneOf:
           - type: "object"
-            title: "Authenticate via Hubspot (Oauth)"
+            title: "Authenticate via HubSpot (Oauth)"
             required:
             - "client_id"
             - "client_secret"
@@ -2398,14 +2398,14 @@
                 order: 0
               client_id:
                 title: "Client ID"
-                description: "Hubspot client_id. See our <a href=\"https://docs.airbyte.io/integrations/sources/hubspot\"\
+                description: "HubSpot client_id. See our <a href=\"https://docs.airbyte.io/integrations/sources/hubspot\"\
                   >docs</a> if you need help finding this id."
                 type: "string"
                 examples:
                 - "123456789000"
               client_secret:
                 title: "Client Secret"
-                description: "Hubspot client_secret. See our <a href=\"https://docs.airbyte.io/integrations/sources/hubspot\"\
+                description: "HubSpot client_secret. See our <a href=\"https://docs.airbyte.io/integrations/sources/hubspot\"\
                   >docs</a> if you need help finding this secret."
                 type: "string"
                 examples:
@@ -2413,7 +2413,7 @@
                 airbyte_secret: true
               refresh_token:
                 title: "Refresh token"
-                description: "Hubspot refresh_token. See our <a href=\"https://docs.airbyte.io/integrations/sources/hubspot\"\
+                description: "HubSpot refresh_token. See our <a href=\"https://docs.airbyte.io/integrations/sources/hubspot\"\
                   >docs</a> if you need help generating the token."
                 type: "string"
                 examples:
@@ -2436,7 +2436,7 @@
                 order: 0
               api_key:
                 title: "API key"
-                description: "Hubspot API Key. See our <a href=\"https://docs.airbyte.io/integrations/sources/hubspot\"\
+                description: "HubSpot API Key. See our <a href=\"https://docs.airbyte.io/integrations/sources/hubspot\"\
                   >docs</a> if you need help finding this key."
                 type: "string"
                 airbyte_secret: true
@@ -2454,7 +2454,7 @@
         - - "client_secret"
         oauthFlowOutputParameters:
         - - "refresh_token"
-- dockerImage: "airbyte/source-db2:0.1.1"
+- dockerImage: "airbyte/source-db2:0.1.2"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/db2"
     connectionSpecification:
@@ -2467,11 +2467,13 @@
       - "db"
       - "username"
       - "password"
+      - "encryption"
       additionalProperties: false
       properties:
         host:
           description: "Host of the Db2."
           type: "string"
+          order: 0
         port:
           description: "Port of the database."
           type: "integer"
@@ -2480,18 +2482,66 @@
           default: 8123
           examples:
           - "8123"
+          order: 1
         db:
           description: "Name of the database."
           type: "string"
           examples:
           - "default"
+          order: 2
         username:
           description: "Username to use to access the database."
           type: "string"
+          order: 3
         password:
           description: "Password associated with the username."
           type: "string"
           airbyte_secret: true
+          order: 4
+        encryption:
+          title: "Encryption"
+          type: "object"
+          description: "Encryption method to use when communicating with the database"
+          order: 5
+          oneOf:
+          - title: "Unencrypted"
+            additionalProperties: false
+            description: "Data transfer will not be encrypted."
+            required:
+            - "encryption_method"
+            properties:
+              encryption_method:
+                type: "string"
+                const: "unencrypted"
+                enum:
+                - "unencrypted"
+                default: "unencrypted"
+          - title: "TLS Encrypted (verify certificate)"
+            additionalProperties: false
+            description: "Verify and use the cert provided by the server."
+            required:
+            - "encryption_method"
+            - "ssl_certificate"
+            properties:
+              encryption_method:
+                type: "string"
+                const: "encrypted_verify_certificate"
+                enum:
+                - "encrypted_verify_certificate"
+                default: "encrypted_verify_certificate"
+              ssl_certificate:
+                title: "SSL PEM file"
+                description: "Privacy Enhanced Mail (PEM) files are concatenated certificate\
+                  \ containers frequently used in certificate installations"
+                type: "string"
+                airbyte_secret: true
+                multiline: true
+              key_store_password:
+                title: "Key Store Password. This field is optional. If you do not\
+                  \ fill in this field, the password will be randomly generated."
+                description: "Key Store Password"
+                type: "string"
+                airbyte_secret: true
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []

--- a/airbyte-migration/Dockerfile
+++ b/airbyte-migration/Dockerfile
@@ -6,7 +6,7 @@ ENV APPLICATION airbyte-migration
 WORKDIR /app
 
 # Move and run scheduler
-COPY bin/${APPLICATION}-0.30.36-alpha.tar ${APPLICATION}.tar
+COPY bin/${APPLICATION}-0.30.37-alpha.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 

--- a/airbyte-scheduler/app/Dockerfile
+++ b/airbyte-scheduler/app/Dockerfile
@@ -5,7 +5,7 @@ ENV APPLICATION airbyte-scheduler
 
 WORKDIR /app
 
-ADD bin/${APPLICATION}-0.30.36-alpha.tar /app
+ADD bin/${APPLICATION}-0.30.37-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.36-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.37-alpha/bin/${APPLICATION}"]

--- a/airbyte-server/Dockerfile
+++ b/airbyte-server/Dockerfile
@@ -7,7 +7,7 @@ ENV APPLICATION airbyte-server
 
 WORKDIR /app
 
-ADD bin/${APPLICATION}-0.30.36-alpha.tar /app
+ADD bin/${APPLICATION}-0.30.37-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.36-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.37-alpha/bin/${APPLICATION}"]

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.30.36-alpha",
+  "version": "0.30.37-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "airbyte-webapp",
-      "version": "0.30.36-alpha",
+      "version": "0.30.37-alpha",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-brands-svg-icons": "^5.15.4",

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.30.36-alpha",
+  "version": "0.30.37-alpha",
   "private": true,
   "scripts": {
     "start": "react-scripts start",

--- a/airbyte-workers/Dockerfile
+++ b/airbyte-workers/Dockerfile
@@ -23,7 +23,7 @@ ENV APPLICATION airbyte-workers
 WORKDIR /app
 
 # Move worker app
-ADD bin/${APPLICATION}-0.30.36-alpha.tar /app
+ADD bin/${APPLICATION}-0.30.37-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.36-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.37-alpha/bin/${APPLICATION}"]

--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.3.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.30.36-alpha"
+appVersion: "0.30.37-alpha"
 
 dependencies:
 - name: common

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -29,7 +29,7 @@
 | `webapp.replicaCount`        | Number of webapp replicas                                        | `1`              |
 | `webapp.image.repository`    | The repository to use for the airbyte webapp image.              | `airbyte/webapp` |
 | `webapp.image.pullPolicy`    | the pull policy to use for the airbyte webapp image              | `IfNotPresent`   |
-| `webapp.image.tag`           | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.30.36-alpha`  |
+| `webapp.image.tag`           | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.30.37-alpha`  |
 | `webapp.podAnnotations`      | Add extra annotations to the webapp pod(s)                       | `{}`             |
 | `webapp.service.type`        | The service type to use for the webapp service                   | `ClusterIP`      |
 | `webapp.service.port`        | The service port to expose the webapp on                         | `80`             |
@@ -56,7 +56,7 @@
 | `scheduler.replicaCount`       | Number of scheduler replicas                                        | `1`                 |
 | `scheduler.image.repository`   | The repository to use for the airbyte scheduler image.              | `airbyte/scheduler` |
 | `scheduler.image.pullPolicy`   | the pull policy to use for the airbyte scheduler image              | `IfNotPresent`      |
-| `scheduler.image.tag`          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.30.36-alpha`     |
+| `scheduler.image.tag`          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.30.37-alpha`     |
 | `scheduler.podAnnotations`     | Add extra annotations to the scheduler pod                          | `{}`                |
 | `scheduler.resources.limits`   | The resources limits for the scheduler container                    | `{}`                |
 | `scheduler.resources.requests` | The requested resources for the scheduler container                 | `{}`                |
@@ -87,7 +87,7 @@
 | `server.replicaCount`                       | Number of server replicas                                        | `1`              |
 | `server.image.repository`                   | The repository to use for the airbyte server image.              | `airbyte/server` |
 | `server.image.pullPolicy`                   | the pull policy to use for the airbyte server image              | `IfNotPresent`   |
-| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.30.36-alpha`  |
+| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.30.37-alpha`  |
 | `server.podAnnotations`                     | Add extra annotations to the server pod                          | `{}`             |
 | `server.livenessProbe.enabled`              | Enable livenessProbe on the server                               | `true`           |
 | `server.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                          | `30`             |
@@ -121,7 +121,7 @@
 | `worker.replicaCount`                       | Number of worker replicas                                        | `1`              |
 | `worker.image.repository`                   | The repository to use for the airbyte worker image.              | `airbyte/worker` |
 | `worker.image.pullPolicy`                   | the pull policy to use for the airbyte worker image              | `IfNotPresent`   |
-| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.30.36-alpha`  |
+| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.30.37-alpha`  |
 | `worker.podAnnotations`                     | Add extra annotations to the worker pod(s)                       | `{}`             |
 | `worker.livenessProbe.enabled`              | Enable livenessProbe on the worker                               | `true`           |
 | `worker.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                          | `30`             |

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -44,7 +44,7 @@ webapp:
   image:
     repository: airbyte/webapp
     pullPolicy: IfNotPresent
-    tag: 0.30.36-alpha
+    tag: 0.30.37-alpha
 
   ## @param webapp.podAnnotations [object] Add extra annotations to the webapp pod(s)
   ##
@@ -141,7 +141,7 @@ scheduler:
   image:
     repository: airbyte/scheduler
     pullPolicy: IfNotPresent
-    tag: 0.30.36-alpha
+    tag: 0.30.37-alpha
 
   ## @param scheduler.podAnnotations [object] Add extra annotations to the scheduler pod
   ##
@@ -248,7 +248,7 @@ server:
   image:
     repository: airbyte/server
     pullPolicy: IfNotPresent
-    tag: 0.30.36-alpha
+    tag: 0.30.37-alpha
 
   ## @param server.podAnnotations [object] Add extra annotations to the server pod
   ##
@@ -360,7 +360,7 @@ worker:
   image:
     repository: airbyte/worker
     pullPolicy: IfNotPresent
-    tag: 0.30.36-alpha
+    tag: 0.30.37-alpha
 
   ## @param worker.podAnnotations [object] Add extra annotations to the worker pod(s)
   ##

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -82,7 +82,7 @@ If you are upgrading from \(i.e. your current version of Airbyte is\) Airbyte ve
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.30.36-alpha --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.30.37-alpha --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/kube/overlays/stable-with-resource-limits/.env
+++ b/kube/overlays/stable-with-resource-limits/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.30.36-alpha
+AIRBYTE_VERSION=0.30.37-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.30.36-alpha
+    newTag: 0.30.37-alpha
   - name: airbyte/scheduler
-    newTag: 0.30.36-alpha
+    newTag: 0.30.37-alpha
   - name: airbyte/server
-    newTag: 0.30.36-alpha
+    newTag: 0.30.37-alpha
   - name: airbyte/webapp
-    newTag: 0.30.36-alpha
+    newTag: 0.30.37-alpha
   - name: airbyte/worker
-    newTag: 0.30.36-alpha
+    newTag: 0.30.37-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.30.36-alpha
+AIRBYTE_VERSION=0.30.37-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -8,15 +8,15 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.30.36-alpha
+    newTag: 0.30.37-alpha
   - name: airbyte/scheduler
-    newTag: 0.30.36-alpha
+    newTag: 0.30.37-alpha
   - name: airbyte/server
-    newTag: 0.30.36-alpha
+    newTag: 0.30.37-alpha
   - name: airbyte/webapp
-    newTag: 0.30.36-alpha
+    newTag: 0.30.37-alpha
   - name: airbyte/worker
-    newTag: 0.30.36-alpha
+    newTag: 0.30.37-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 


### PR DESCRIPTION
Changelog:

62992bff8 Fix BufferedStreamConsumer tests (#7773)
c3c3e318c :tada: intercom added oauth support (#7060)
aa112388f Reduce CLI docker image size (#7695)
1b38fc7b7 bugfix 'Hubspot' -> 'HubSpot' (#7683)
fdda80c5a :tada: Source DB2: added ssl support (#7355)
25c89a59a Source Facebook Marketing: Fix fail when async job takes too long (#7744)
6b0e9da4b 📚 Fix typo in the cdk documentation (#7784)
21d6dd93e Aesthetic clean-up / format OAuth code (#7782)
3d4f730a9 🐛 Source Salesforce: Fix types for anyType fields (#7778)
48d825046 🐛 Destination BigQuery-Denormalized: Fix JSON with $ref Definition keys (#7736)
2d2965b87 🎉 New Source: Pinterest (#7493)
84a532894 Jamakase/refactor initial load (#7713)
16b626cc9 Resolve discover catalog ref fields (#7734)

Steps After Merging PR:
1. Pull most recent version of master
2. Run ./tools/bin/tag_version.sh
3. Create a GitHub release with the changelog