### PR TITLE
remove selenium dependency from airbyte-oauth

### DIFF
--- a/airbyte-oauth/build.gradle
+++ b/airbyte-oauth/build.gradle
@@ -8,6 +8,4 @@ dependencies {
     implementation project(':airbyte-config:persistence')
     implementation project(':airbyte-json-validation')
     testImplementation project(':airbyte-oauth')
-
-    implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59'
 }


### PR DESCRIPTION
## What
The version of selenium being used introduces a dependency conflict for the module `byte-buddy` which is used by mockito. This causes some mocking tests to fail. Removing it here since selenium is not really needed. 

