### PR TITLE
CDK: fix logging configuration inside source and streams

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         args: ["--tmpl=LICENSE_SHORT", "--ext=py", "-f"]
 
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 21.10b0
     hooks:
       - id: black
         args: ["--line-length=140"]

--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.34
+Fix logging inside source and streams
+
 ## 0.1.33
  Resolve $ref fields for discover json schema.
 

--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -22,7 +22,7 @@ logger = init_logger("airbyte")
 class AirbyteEntrypoint(object):
     def __init__(self, source: Source):
         self.source = source
-        self.logger = logging.getLogger(f"source.{getattr(source, 'name', '')}")
+        self.logger = logging.getLogger(f"airbyte.{getattr(source, 'name', '')}")
 
     def parse_args(self, args: List[str]) -> argparse.Namespace:
         # set up parent parsers

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.33",
+    version="0.1.34",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -64,7 +64,7 @@ class AirbytePythonPlugin implements Plugin<Project> {
             scope = 'VIRTUALENV'
             installVirtualenv = true
             pip 'flake8:3.8.4'
-            pip 'black:20.8b1'
+            pip 'black:21.10b0'
             pip 'mypy:0.812'
             pip 'isort:5.6.4'
             pip 'pytest:6.1.2'


### PR DESCRIPTION
## What
After we migrated to python native logging we introduced the issue with configuration. The logger instance that we pass to the source and streams wasn't configured as airbyte logger with proper logging level (i.e. TRACE), but rather default level (WARNING).

## How
Inherit source logger from the root `airbyte` logger

## Recommended reading order
1. `x.java`
2. `y.python`

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> New Connector </strong></summary>
<p>
   