### PR TITLE
fix buffered stream consumer tests

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/bytes/ByteUtils.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/bytes/ByteUtils.java
@@ -7,6 +7,7 @@ package io.airbyte.commons.bytes;
 public class ByteUtils {
 
   public static long getSizeInBytes(String s) {
+    // TODO use a smarter way of estimating byte size rather than always multiply by two
     return s.length() * 2; // by default UTF-8 encoding takes 2bytes per char
   }
 

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
@@ -146,7 +146,6 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
       // TODO use a more efficient way to compute bytes that doesn't require double serialization (records
       // are serialized again when writing to
       // the destination
-      // TODO use a smarter way of estimating byte size rather than always multiply by two
       long messageSizeInBytes = ByteUtils.getSizeInBytes(Jsons.serialize(recordMessage.getData()));
       if (bufferSizeInBytes + messageSizeInBytes >= maxQueueSizeInBytes) {
         flushQueueToDestination();

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumerTest.java
@@ -315,7 +315,7 @@ public class BufferedStreamConsumerTest {
     List<AirbyteMessage> output = Lists.newArrayList();
     long bytesCounter = 0;
     for (int i = 0;; i++) {
-      JsonNode payload = Jsons.jsonNode(ImmutableMap.of("id", RandomStringUtils.randomAscii(7), "name", "human " + i));
+      JsonNode payload = Jsons.jsonNode(ImmutableMap.of("id", RandomStringUtils.randomAscii(7), "name", "human " + String.format("%5d", i)));
       long sizeInBytes = ByteUtils.getSizeInBytes(Jsons.serialize(payload));
       bytesCounter += sizeInBytes;
       AirbyteMessage airbyteMessage = new AirbyteMessage()

--- a/airbyte-integrations/connector-templates/source-python-http-api/build.gradle.hbs
+++ b/airbyte-integrations/connector-templates/source-python-http-api/build.gradle.hbs
@@ -8,7 +8,3 @@ airbytePython {
     moduleDirectory 'source_{{snakeCase name}}'
 }
 
-dependencies {
-    implementation files(project(':airbyte-integrations:bases:source-acceptance-test').airbyteDocker.outputs)
-    implementation files(project(':airbyte-integrations:bases:base-python').airbyteDocker.outputs)
-}

--- a/airbyte-integrations/connector-templates/source-python-http-api/build.gradle.hbs
+++ b/airbyte-integrations/connector-templates/source-python-http-api/build.gradle.hbs
@@ -7,4 +7,3 @@ plugins {
 airbytePython {
     moduleDirectory 'source_{{snakeCase name}}'
 }
-

--- a/airbyte-integrations/connector-templates/source-python-http-api/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python-http-api/setup.py.hbs
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk",
+    "airbyte-cdk~=0.1",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connector-templates/source-python/build.gradle.hbs
+++ b/airbyte-integrations/connector-templates/source-python/build.gradle.hbs
@@ -7,8 +7,3 @@ plugins {
 airbytePython {
     moduleDirectory 'source_{{snakeCase name}}_singer'
 }
-
-dependencies {
-    implementation files(project(':airbyte-integrations:bases:source-acceptance-test').airbyteDocker.outputs)
-    implementation files(project(':airbyte-integrations:bases:base-python').airbyteDocker.outputs)
-}

--- a/airbyte-integrations/connector-templates/source-python/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/setup.py.hbs
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk",
+    "airbyte-cdk~=0.1",
 ]
 
 TEST_REQUIREMENTS = [


### PR DESCRIPTION
## What
The tests were failing because the byte size of the records being generated was inconsistent which caused the test to be flaky. Fixed it by padding stringified integers to a constant width. 

