### PR TITLE
Add ability to configure supporting worker job container images (curl, socat, busybox)

### DIFF
--- a/.env
+++ b/.env
@@ -43,6 +43,12 @@ HACK_LOCAL_ROOT_PARENT=/tmp
 # Maximum simultaneous jobs
 SUBMITTER_NUM_THREADS=10
 
+# Job container images
+# Usually you should not need to set these, they have defaults already set
+JOB_SOCAT_IMAGE=
+JOB_BUSYBOX_IMAGE=
+JOB_CURL_IMAGE=
+
 # Miscellaneous
 TRACKING_STRATEGY=segment
 WEBAPP_URL=http://localhost:8000/

--- a/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
@@ -75,6 +75,12 @@ public interface Configs {
 
   Map<String, String> getWorkerNodeSelectors();
 
+  String getJobSocatImage();
+
+  String getJobBusyboxImage();
+
+  String getJobCurlImage();
+
   MaxWorkersConfig getMaxWorkers();
 
   String getTemporalHost();

--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -54,6 +54,9 @@ public class EnvConfigs implements Configs {
   public static final String JOB_IMAGE_PULL_POLICY = "JOB_IMAGE_PULL_POLICY";
   public static final String WORKER_POD_TOLERATIONS = "WORKER_POD_TOLERATIONS";
   public static final String WORKER_POD_NODE_SELECTORS = "WORKER_POD_NODE_SELECTORS";
+  public static final String JOB_SOCAT_IMAGE = "JOB_SOCAT_IMAGE";
+  public static final String JOB_BUSYBOX_IMAGE = "JOB_BUSYBOX_IMAGE";
+  public static final String JOB_CURL_IMAGE = "JOB_CURL_IMAGE";
   public static final String MAX_SYNC_JOB_ATTEMPTS = "MAX_SYNC_JOB_ATTEMPTS";
   public static final String MAX_SYNC_TIMEOUT_DAYS = "MAX_SYNC_TIMEOUT_DAYS";
   private static final String MINIMUM_WORKSPACE_RETENTION_DAYS = "MINIMUM_WORKSPACE_RETENTION_DAYS";
@@ -83,6 +86,9 @@ public class EnvConfigs implements Configs {
   private static final String DEFAULT_JOB_IMAGE_PULL_POLICY = "IfNotPresent";
   private static final String SECRET_STORE_GCP_PROJECT_ID = "SECRET_STORE_GCP_PROJECT_ID";
   private static final String SECRET_STORE_GCP_CREDENTIALS = "SECRET_STORE_GCP_CREDENTIALS";
+  private static final String DEFAULT_JOB_SOCAT_IMAGE = "alpine/socat:1.7.4.1-r1";
+  private static final String DEFAULT_JOB_BUSYBOX_IMAGE = "busybox:1.28";
+  private static final String DEFAULT_JOB_CURL_IMAGE = "curlimages/curl:7.77.0";
   private static final long DEFAULT_MINIMUM_WORKSPACE_RETENTION_DAYS = 1;
   private static final long DEFAULT_MAXIMUM_WORKSPACE_RETENTION_DAYS = 60;
   private static final long DEFAULT_MAXIMUM_WORKSPACE_SIZE_MB = 5000;
@@ -345,6 +351,21 @@ public class EnvConfigs implements Configs {
         .filter(s -> !Strings.isNullOrEmpty(s) && s.contains("="))
         .map(s -> s.split("="))
         .collect(Collectors.toMap(s -> s[0], s -> s[1]));
+  }
+
+  @Override
+  public String getJobSocatImage() {
+    return getEnvOrDefault(JOB_SOCAT_IMAGE, DEFAULT_JOB_SOCAT_IMAGE);
+  }
+
+  @Override
+  public String getJobBusyboxImage() {
+    return getEnvOrDefault(JOB_BUSYBOX_IMAGE, DEFAULT_JOB_BUSYBOX_IMAGE);
+  }
+
+  @Override
+  public String getJobCurlImage() {
+    return getEnvOrDefault(JOB_CURL_IMAGE, DEFAULT_JOB_CURL_IMAGE);
   }
 
   @Override

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -37,6 +37,9 @@ public class WorkerUtils {
   public static final Map<String, String> DEFAULT_WORKER_POD_NODE_SELECTORS = CONFIGS.getWorkerNodeSelectors();
   public static final String DEFAULT_JOBS_IMAGE_PULL_SECRET = CONFIGS.getJobsImagePullSecret();
   public static final String DEFAULT_JOB_IMAGE_PULL_POLICY = CONFIGS.getJobImagePullPolicy();
+  public static final String JOB_SOCAT_IMAGE = CONFIGS.getJobSocatImage();
+  public static final String JOB_BUSYBOX_IMAGE = CONFIGS.getJobBusyboxImage();
+  public static final String JOB_CURL_IMAGE = CONFIGS.getJobCurlImage();
 
   public static void gentleClose(final Process process, final long timeout, final TimeUnit timeUnit) {
     if (process == null) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
@@ -134,6 +134,9 @@ public class KubeProcessFactory implements ProcessFactory {
           WorkerUtils.DEFAULT_WORKER_POD_TOLERATIONS,
           WorkerUtils.DEFAULT_WORKER_POD_NODE_SELECTORS,
           allLabels,
+          WorkerUtils.JOB_SOCAT_IMAGE,
+          WorkerUtils.JOB_BUSYBOX_IMAGE,
+          WorkerUtils.JOB_CURL_IMAGE,
           args);
     } catch (final Exception e) {
       throw new WorkerException(e.getMessage(), e);


### PR DESCRIPTION
## What
In locked-down kubernetes environments (such as ours), it is not uncommon to use private docker image registries or otherwise disable access to the outside world. This is not a problem for most of the container images used by airbyte, as they can be configured via helm chart or similar (or in the case of normalization, disabled).

However, the supporting containers for the job, busybox/curl/socat are currently hardcoded, making them hard to change :smiley: 

This also alleviates [#5736 ](https://github.com/airbytehq/airbyte/issues/5736) for us, as we can use non-root images and don't need to set a securityContext for the pods.

## How

This PR makes it possible to configure which images to for the busybox/curl/socat containers in a job run, via environment variables.

* I also added the settings to the `.env` file, mostly for documentation purposes
  * Are there any other places that should be updated?
* I didn't add the configuration variables to the helm chart. But could also do that here as we would need it regardless.
  * What key in values.yaml would be appropriate? `worker.job.image.curl`

## Recommended reading order

Pretty small PR, but if you want to go top-bottom:
1. `airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java`
2. `airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java`
3. `airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java`
4. `airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java`

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

Not a new connector or a change to one, so I don't think much of the below is applicable?

<details><summary> <strong> New Connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [x] Connector's `README.md` not a connector
    - [x] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)  not a connector
    - [x] `docs/SUMMARY.md` not a connector
    - [x] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)  not a connector
    - [x] `docs/integrations/README.md`  not a connector
    - [x] `airbyte-integrations/builds.md`  not a connector
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
</p>
</details>


<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>
</details>

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
