### PR TITLE
Update platform containers to use non-root users

### DIFF
--- a/airbyte-scheduler/app/Dockerfile
+++ b/airbyte-scheduler/app/Dockerfile
@@ -3,9 +3,15 @@ FROM openjdk:${JDK_VERSION}-slim AS scheduler
 
 ENV APPLICATION airbyte-scheduler
 
+RUN groupadd --gid 1000 airbyte && \
+    useradd --uid 1000 --gid airbyte airbyte
+
 WORKDIR /app
 
 ADD bin/${APPLICATION}-0.30.39-alpha.tar /app
+
+# Set user to Airbyte, use numeric value for k8s runAsNonRoot PodSecurityPolicy
+USER 1000:1000
 
 # wait for upstream dependencies to become available before starting server
 ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.39-alpha/bin/${APPLICATION}"]

--- a/airbyte-server/Dockerfile
+++ b/airbyte-server/Dockerfile
@@ -5,9 +5,15 @@ EXPOSE 8000
 
 ENV APPLICATION airbyte-server
 
+RUN groupadd --gid 1000 airbyte && \
+    useradd --uid 1000 --gid airbyte airbyte
+
 WORKDIR /app
 
 ADD bin/${APPLICATION}-0.30.39-alpha.tar /app
+
+# Set user to Airbyte, use numeric value for k8s runAsNonRoot PodSecurityPolicy
+USER 1000:1000
 
 # wait for upstream dependencies to become available before starting server
 ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.39-alpha/bin/${APPLICATION}"]

--- a/airbyte-webapp/Dockerfile
+++ b/airbyte-webapp/Dockerfile
@@ -1,6 +1,6 @@
-FROM nginx:1.19-alpine as webapp
+FROM nginxinc/nginx-unprivileged:1.19-alpine as webapp
 
-EXPOSE 80
+EXPOSE 8080
 
 COPY bin/docs docs/
 COPY bin/build /usr/share/nginx/html

--- a/airbyte-webapp/nginx/default.conf.template
+++ b/airbyte-webapp/nginx/default.conf.template
@@ -3,8 +3,8 @@ upstream api-server {
 }
 
 server {
-    listen       80;
-    listen  [::]:80;
+    listen       8080;
+    listen  [::]:8080;
     server_name  localhost;
 
     #charset koi8-r;

--- a/airbyte-workers/Dockerfile
+++ b/airbyte-workers/Dockerfile
@@ -3,6 +3,9 @@ FROM openjdk:${JDK_VERSION}-slim AS worker
 
 ARG DOCKER_BUILD_ARCH=amd64
 
+RUN groupadd --gid 1000 airbyte && \
+    useradd --uid 1000 --gid airbyte airbyte
+
 # Install Docker to launch worker images. Eventually should be replaced with Docker-java.
 # See https://gitter.im/docker-java/docker-java?at=5f3eb87ba8c1780176603f4e for more information on why we are not currently using Docker-java
 RUN apt-get update && apt-get install -y \
@@ -24,6 +27,9 @@ WORKDIR /app
 
 # Move worker app
 ADD bin/${APPLICATION}-0.30.39-alpha.tar /app
+
+# Set user to Airbyte, use numeric value for k8s runAsNonRoot PodSecurityPolicy
+USER 1000:1000
 
 # wait for upstream dependencies to become available before starting server
 ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.30.39-alpha/bin/${APPLICATION}"]

--- a/charts/airbyte/templates/webapp/deployment.yaml
+++ b/charts/airbyte/templates/webapp/deployment.yaml
@@ -65,7 +65,7 @@ spec:
         {{- end }}
         ports:
         - name: http
-          containerPort: 80
+          containerPort: 8080
           protocol: TCP
         {{- if .Values.webapp.resources }}
         resources: {{- toYaml .Values.webapp.resources | nindent 10 }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -164,7 +164,7 @@ services:
     container_name: airbyte-webapp
     restart: unless-stopped
     ports:
-      - 8000:80
+      - 8000:8080
     environment:
       - AIRBYTE_ROLE=${AIRBYTE_ROLE:-}
       - AIRBYTE_VERSION=${VERSION}

--- a/docs/contributing-to-airbyte/developing-on-kubernetes.md
+++ b/docs/contributing-to-airbyte/developing-on-kubernetes.md
@@ -14,7 +14,7 @@ If you're developing locally using Minikube/Docker Desktop/Kind, you can iterate
 ./gradlew build # build dev images
 kubectl delete -k kube/overlays/dev # optional (allows you to recreate resources from scratch)
 kubectl apply -k kube/overlays/dev # applies manifests
-kubectl port-forward svc/airbyte-webapp-svc 8000:80 # port forward the api/ui
+kubectl port-forward svc/airbyte-webapp-svc 8000:8080 # port forward the api/ui
 ```
 
 ## Iteration Cycle \(on GKE\)

--- a/docs/deploying-airbyte/on-kubernetes.md
+++ b/docs/deploying-airbyte/on-kubernetes.md
@@ -136,7 +136,7 @@ kubectl apply -k kube/overlays/stable
 
 After 2-5 minutes, `kubectl get pods | grep airbyte` should show `Running` as the status for all the core Airbyte pods. This may take longer on Kubernetes clusters with slow internet connections.
 
-Run `kubectl port-forward svc/airbyte-webapp-svc 8000:80` to allow access to the UI/API.
+Run `kubectl port-forward svc/airbyte-webapp-svc 8000:8080` to allow access to the UI/API.
 
 Now visit [http://localhost:8000](http://localhost:8000) in your browser and start moving some data!
 

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -60,7 +60,7 @@ If you are upgrading from \(i.e. your current version of Airbyte is\) Airbyte ve
 
    After 2-5 minutes, `kubectl get pods | grep airbyte` should show `Running` as the status for all the core Airbyte pods. This may take longer on Kubernetes clusters with slow internet connections.
 
-   Run `kubectl port-forward svc/airbyte-webapp-svc 8000:80` to allow access to the UI/API.
+   Run `kubectl port-forward svc/airbyte-webapp-svc 8000:8080` to allow access to the UI/API.
 
 ## Upgrading on K8s \(0.26.4-alpha and below\)
 

--- a/kube/overlays/dev-integration-test/.env
+++ b/kube/overlays/dev-integration-test/.env
@@ -27,7 +27,7 @@ SUBMITTER_NUM_THREADS=10
 
 # Miscellaneous
 TRACKING_STRATEGY=logging
-WEBAPP_URL=airbyte-webapp-svc:80
+WEBAPP_URL=airbyte-webapp-svc:8080
 API_URL=/api/v1/
 INTERNAL_API_HOST=airbyte-server-svc:8001
 

--- a/kube/overlays/dev/.env
+++ b/kube/overlays/dev/.env
@@ -29,7 +29,7 @@ SUBMITTER_NUM_THREADS=10
 
 # Miscellaneous
 TRACKING_STRATEGY=logging
-WEBAPP_URL=airbyte-webapp-svc:80
+WEBAPP_URL=airbyte-webapp-svc:8080
 API_URL=/api/v1/
 INTERNAL_API_HOST=airbyte-server-svc:8001
 

--- a/kube/overlays/stable-with-resource-limits/.env
+++ b/kube/overlays/stable-with-resource-limits/.env
@@ -29,7 +29,7 @@ SUBMITTER_NUM_THREADS=10
 
 # Miscellaneous
 TRACKING_STRATEGY=segment
-WEBAPP_URL=airbyte-webapp-svc:80
+WEBAPP_URL=airbyte-webapp-svc:8080
 API_URL=/api/v1/
 INTERNAL_API_HOST=airbyte-server-svc:8001
 

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -29,7 +29,7 @@ SUBMITTER_NUM_THREADS=10
 
 # Miscellaneous
 TRACKING_STRATEGY=segment
-WEBAPP_URL=airbyte-webapp-svc:80
+WEBAPP_URL=airbyte-webapp-svc:8080
 API_URL=/api/v1/
 INTERNAL_API_HOST=airbyte-server-svc:8001
 

--- a/kube/resources/webapp.yaml
+++ b/kube/resources/webapp.yaml
@@ -6,7 +6,9 @@ spec:
   type: NodePort
   ports:
     - port: 80
+      targetPort: http
       protocol: TCP
+      name: http
   selector:
     airbyte: webapp
 ---
@@ -59,4 +61,6 @@ spec:
                   name: airbyte-env
                   key: INTERNAL_API_HOST
           ports:
-            - containerPort: 80
+            - name: http
+              containerPort: 8080
+              protocol: TCP


### PR DESCRIPTION
## What
Currently all of the airbyte containers run as root users, this is not really needed, as well as an issue in locked-down kubernetes clusters (such as ours) where there is a restrictive PodSecurityPolicy with [runAsNonRoot](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups) set. 

While it is possible to create our own wrapper images that creates and uses their own non-root users, it would be nice to have this upstream as well. I only added this change now for the core platform containers. It would be nice to have for all sources/destinations as well, but that would be a bigger change, and I wanted to see if this is something you want first.

## How

For scheduler/worker/server, create a new user and switch to it in the Dockerfiles.

For the webapp, change base image to `nginxinc/nginx-unprivileged`, and use port 8080 instead of 80. 
There's a little bit of confusing config here, as port 8080 is used throughout the helm chart for the webapp, but it's served through 8000 in the docker-compose file, I kept the user facing behaviour the same for now.

## Recommended reading order
1. `Dockerfiles`

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> New Connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
</p>
</details>


<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>
</details>

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
