### PR TITLE
Fix airbyte-cli build on Mac M1

### DIFF
--- a/airbyte-cli/Dockerfile
+++ b/airbyte-cli/Dockerfile
@@ -2,9 +2,10 @@ ARG ALPINE_IMAGE=alpine:3.4
 FROM ${ALPINE_IMAGE}
 
 RUN apk --no-cache add curl tar \
-    && curl -OL https://github.com/danielgtaylor/restish/releases/download/v0.9.0/restish-0.9.0-linux-`uname -m`.tar.gz \
-    && tar -C /usr/local/bin -xzf restish-0.9.0-linux-`uname -m`.tar.gz \
-    && rm -rf restish-0.9.0-linux-`uname -m`.tar.gz
+    && if [[ `uname -m` == "aarch64" ]] ; then ARCH=arm64  ; else ARCH=`uname -m` ; fi \
+    && curl -OL https://github.com/danielgtaylor/restish/releases/download/v0.9.0/restish-0.9.0-linux-${ARCH}.tar.gz \
+    && tar -C /usr/local/bin -xzf restish-0.9.0-linux-${ARCH}.tar.gz \
+    && rm -rf restish-0.9.0-linux-${ARCH}.tar.gz
 
 ENTRYPOINT ["restish"]
 


### PR DESCRIPTION
## What
Fix build

## How
Correct the restish binary download URL

## Recommended reading order
1. `Dockerfile`
