### PR TITLE
Fix server errors

### DIFF
--- a/airbyte-e2e-testing/cypress.json
+++ b/airbyte-e2e-testing/cypress.json
@@ -1,6 +1,7 @@
 {
   "baseUrl": "http://localhost:3000",
   "testFiles": [
+    "base.spec.js",
     "onboarding.spec.js",
     "connection.spec.js",
     "destination.spec.js",

--- a/airbyte-e2e-testing/cypress/integration/base.spec.js
+++ b/airbyte-e2e-testing/cypress/integration/base.spec.js
@@ -1,0 +1,30 @@
+describe("Error handling view", () => {
+  it("Shows Version Mismatch page", () => {
+    cy.intercept("/api/v1/**", {
+      statusCode: 500,
+      body: {
+        error:
+          "Version mismatch between 0.0.1-ci and 0.0.2-ci.\nPlease upgrade or reset your Airbyte Database, see more at https://docs.airbyte.io/operator-guides/upgrading-airbyte",
+      },
+    });
+
+    cy.visit("/");
+
+    cy.get("div")
+      .contains("Version mismatch between 0.0.1-ci and 0.0.2-ci.")
+      .should("exist");
+  });
+
+  it("Shows Server Unavailable page", () => {
+    cy.intercept("/api/v1/**", {
+      statusCode: 502,
+      body: "Failed to fetch",
+    });
+
+    cy.visit("/");
+
+    cy.get("div")
+      .contains("Cannot reach server. The server may still be starting up.")
+      .should("exist");
+  });
+});

--- a/airbyte-e2e-testing/package.json
+++ b/airbyte-e2e-testing/package.json
@@ -4,7 +4,7 @@
   "description": "Airbyte e2e testing",
   "scripts": {
     "cypress:open": "cypress open",
-    "cypress:ci": "CYPRESS_BASE_URL=http://localhost:8000 cypress run"
+    "cypress:ci": "CYPRESS_BASE_URL=http://localhost:8000 cypress open"
   },
   "eslintConfig": {
     "env": {

--- a/airbyte-e2e-testing/package.json
+++ b/airbyte-e2e-testing/package.json
@@ -4,7 +4,7 @@
   "description": "Airbyte e2e testing",
   "scripts": {
     "cypress:open": "cypress open",
-    "cypress:ci": "CYPRESS_BASE_URL=http://localhost:8000 cypress open"
+    "cypress:ci": "CYPRESS_BASE_URL=http://localhost:8000 cypress run"
   },
   "eslintConfig": {
     "env": {

--- a/airbyte-webapp/src/App.tsx
+++ b/airbyte-webapp/src/App.tsx
@@ -80,12 +80,7 @@ const services = {
 
 const AppServices: React.FC = ({ children }) => (
   <ServicesProvider inject={services}>
-    <ConfigServiceProvider
-      defaultConfig={defaultConfig}
-      providers={configProviders}
-    >
-      <ServiceOverrides>{children}</ServiceOverrides>
-    </ConfigServiceProvider>
+    <ServiceOverrides>{children}</ServiceOverrides>
   </ServicesProvider>
 );
 
@@ -101,19 +96,24 @@ const App: React.FC = () => {
         <I18NProvider>
           <StoreProvider>
             <Suspense fallback={<LoadingPage />}>
-              <ApiErrorBoundary>
-                <FeatureService features={Features}>
-                  <NotificationService>
-                    <AppServices>
-                      <AnalyticsInitializer>
-                        <OnboardingServiceProvider>
-                          <Routing />
-                        </OnboardingServiceProvider>
-                      </AnalyticsInitializer>
-                    </AppServices>
-                  </NotificationService>
-                </FeatureService>
-              </ApiErrorBoundary>
+              <ConfigServiceProvider
+                defaultConfig={defaultConfig}
+                providers={configProviders}
+              >
+                <ApiErrorBoundary>
+                  <FeatureService features={Features}>
+                    <NotificationService>
+                      <AppServices>
+                        <AnalyticsInitializer>
+                          <OnboardingServiceProvider>
+                            <Routing />
+                          </OnboardingServiceProvider>
+                        </AnalyticsInitializer>
+                      </AppServices>
+                    </NotificationService>
+                  </FeatureService>
+                </ApiErrorBoundary>
+              </ConfigServiceProvider>
             </Suspense>
           </StoreProvider>
         </I18NProvider>

--- a/airbyte-webapp/src/config/ConfigServiceProvider.tsx
+++ b/airbyte-webapp/src/config/ConfigServiceProvider.tsx
@@ -15,7 +15,7 @@ const configContext = React.createContext<ConfigContext | null>(null);
 export function useConfig<T extends Config>(): T {
   const configService = useContext(configContext);
 
-  if (!configService) {
+  if (configService === null) {
     throw new Error("useConfig must be used within a ConfigProvider");
   }
 

--- a/airbyte-webapp/src/config/defaultConfig.ts
+++ b/airbyte-webapp/src/config/defaultConfig.ts
@@ -5,7 +5,7 @@ const defaultConfig: Config = {
   ui: uiConfig,
   segment: { enabled: true, token: "" },
   healthCheckInterval: 10000,
-  version: "",
+  version: "dev",
   apiUrl: `${window.location.protocol}//${window.location.hostname}:8001/api/v1/`,
   integrationUrl: "/docs",
   oauthRedirectUrl: `${window.location.protocol}//${window.location.host}`,

--- a/airbyte-webapp/src/packages/cloud/App.tsx
+++ b/airbyte-webapp/src/packages/cloud/App.tsx
@@ -18,6 +18,7 @@ import { Feature, FeatureItem, FeatureService } from "hooks/services/Feature";
 import { AuthenticationProvider } from "packages/cloud/services/auth/AuthService";
 import { AppServicesProvider } from "./services/AppServicesProvider";
 import { IntercomProvider } from "./services/IntercomProvider";
+import { ConfigProvider } from "./services/ConfigProvider";
 
 const messages = Object.assign({}, en, cloudLocales);
 
@@ -55,21 +56,23 @@ const App: React.FC = () => {
         <I18NProvider>
           <StoreProvider>
             <Suspense fallback={<LoadingPage />}>
-              <ApiErrorBoundary>
-                <NotificationServiceProvider>
-                  <FeatureService features={Features}>
-                    <AppServicesProvider>
-                      <AuthenticationProvider>
-                        <IntercomProvider>
-                          <AnalyticsInitializer>
-                            <Routing />
-                          </AnalyticsInitializer>
-                        </IntercomProvider>
-                      </AuthenticationProvider>
-                    </AppServicesProvider>
-                  </FeatureService>
-                </NotificationServiceProvider>
-              </ApiErrorBoundary>
+              <ConfigProvider>
+                <ApiErrorBoundary>
+                  <NotificationServiceProvider>
+                    <FeatureService features={Features}>
+                      <AppServicesProvider>
+                        <AuthenticationProvider>
+                          <IntercomProvider>
+                            <AnalyticsInitializer>
+                              <Routing />
+                            </AnalyticsInitializer>
+                          </IntercomProvider>
+                        </AuthenticationProvider>
+                      </AppServicesProvider>
+                    </FeatureService>
+                  </NotificationServiceProvider>
+                </ApiErrorBoundary>
+              </ConfigProvider>
             </Suspense>
           </StoreProvider>
         </I18NProvider>

--- a/airbyte-webapp/src/packages/cloud/services/AppServicesProvider.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/AppServicesProvider.tsx
@@ -9,7 +9,6 @@ import {
   useInjectServices,
 } from "core/servicesProvider";
 import { useApiServices } from "core/defaultServices";
-import { ConfigProvider } from "./ConfigProvider";
 import { FirebaseSdkProvider } from "./FirebaseSdkProvider";
 
 import { useWorkspaceService } from "./workspaces/WorkspacesService";
@@ -50,11 +49,9 @@ const AppServicesProvider: React.FC = ({ children }) => {
   );
   return (
     <ServicesProvider inject={services}>
-      <ConfigProvider>
-        <FirebaseSdkProvider>
-          <ServiceOverrides>{children}</ServiceOverrides>
-        </FirebaseSdkProvider>
-      </ConfigProvider>
+      <FirebaseSdkProvider>
+        <ServiceOverrides>{children}</ServiceOverrides>
+      </FirebaseSdkProvider>
     </ServicesProvider>
   );
 };


### PR DESCRIPTION
## What
Fixes `ConfigProvider` injection: now it is injected before `ErrorBoundary` so absent config won't through errors.
Add e2e tests for 500 and 502 errors from server.

Closes #7880 