### PR TITLE
Format code

### DIFF
--- a/airbyte-integrations/connectors/destination-kvdb/destination_kvdb/writer.py
+++ b/airbyte-integrations/connectors/destination-kvdb/destination_kvdb/writer.py
@@ -25,7 +25,7 @@ class KvDbWriter:
         self.client = client
 
     def delete_stream_entries(self, stream_name: str):
-        """ Deletes all the records belonging to the input stream """
+        """Deletes all the records belonging to the input stream"""
         keys_to_delete = []
         for key in self.client.list_keys(prefix=f"{stream_name}__ab__"):
             keys_to_delete.append(key)

--- a/airbyte-integrations/connectors/source-amazon-ads/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/auth.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/auth.py
@@ -41,7 +41,7 @@ class AWSSignature(AuthBase):
 
     @staticmethod
     def _sign_msg(key: bytes, msg: str) -> bytes:
-        """ Sign message using key """
+        """Sign message using key"""
         return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
 
     def _get_authorization_header(self, prepared_request: requests.PreparedRequest) -> str:

--- a/airbyte-integrations/connectors/source-amazon-sqs/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-amazon-sqs/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-amplitude/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-amplitude/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-apify-dataset/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-apify-dataset/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-appsflyer/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-appsflyer/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-asana/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-asana/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-aws-cloudtrail/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-aws-cloudtrail/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-azure-table/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-azure-table/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-bamboo-hr/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-bamboo-hr/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-bigcommerce/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-bigcommerce/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-bing-ads/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-bing-ads/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-cart/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-cart/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-chargebee/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-chargebee/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-close-com/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-close-com/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachJdbcSourceOperations.java
+++ b/airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachJdbcSourceOperations.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.source.cockroachdb;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -64,4 +68,5 @@ public class CockroachJdbcSourceOperations extends JdbcSourceOperations {
       node.put(columnName, (Double) null);
     }
   }
+
 }

--- a/airbyte-integrations/connectors/source-cockroachdb/src/test-integration/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-cockroachdb/src/test-integration/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSourceDatatypeTest.java
@@ -313,7 +313,7 @@ public class CockroachDbSourceDatatypeTest extends AbstractSourceDatabaseTypeTes
             .addNullExpectedValue()
             .build());
 
-    //  Time (04:05:06) would be represented like "1970-01-01T04:05:06Z"
+    // Time (04:05:06) would be represented like "1970-01-01T04:05:06Z"
     addDataTypeTestData(
         TestDataHolder.builder()
             .sourceType("timetz")

--- a/airbyte-integrations/connectors/source-commercetools/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-commercetools/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-confluence/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-confluence/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-db2-strict-encrypt/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/Db2StrictEncryptSourceCertificateAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-db2-strict-encrypt/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/Db2StrictEncryptSourceCertificateAcceptanceTest.java
@@ -164,8 +164,10 @@ public class Db2StrictEncryptSourceCertificateAcceptanceTest extends SourceAccep
   /* Helpers */
 
   private String getCertificate() throws IOException, InterruptedException {
-    // To enable SSL connection on the server, we need to generate self-signed certificates for the server and add them to the configuration.
-    // Then you need to enable SSL connection and specify on which port it will work. These changes will take effect after restart.
+    // To enable SSL connection on the server, we need to generate self-signed certificates for the
+    // server and add them to the configuration.
+    // Then you need to enable SSL connection and specify on which port it will work. These changes will
+    // take effect after restart.
     // The certificate for generating a user certificate has the extension *.arm.
     db.execInContainer("su", "-", "db2inst1", "-c", "gsk8capicmd_64 -keydb -create -db \"server.kdb\" -pw \"" + TEST_KEY_STORE_PASS + "\" -stash");
     db.execInContainer("su", "-", "db2inst1", "-c", "gsk8capicmd_64 -cert -create -db \"server.kdb\" -pw \"" + TEST_KEY_STORE_PASS

--- a/airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2Source.java
+++ b/airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2Source.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.jdbc.Db2JdbcStreamingQueryConfiguration;
-import io.airbyte.db.jdbc.JdbcSourceOperations;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;

--- a/airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2SourceOperations.java
+++ b/airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2SourceOperations.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.jdbc.JdbcSourceOperations;
-import java.sql.JDBCType;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;

--- a/airbyte-integrations/connectors/source-delighted/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-delighted/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-drift/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-drift/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-drift/source_drift/client/common.py
+++ b/airbyte-integrations/connectors/source-drift/source_drift/client/common.py
@@ -74,7 +74,7 @@ def next_url_paginator(request, start_index: int = None, per_page: int = 100, pa
 
 
 def exception_from_code(code: int, message: str) -> Exception:
-    """ Map response code to exception class"""
+    """Map response code to exception class"""
     mapping = {
         400: ValidationError,
         401: AuthError,
@@ -91,7 +91,7 @@ def exception_from_code(code: int, message: str) -> Exception:
 
 
 def _parsed_response(func):
-    """ Decorator to check response status and parse its body"""
+    """Decorator to check response status and parse its body"""
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
+
 import logging
 from datetime import datetime
 from typing import Any, List, Mapping, MutableMapping, Optional, Tuple, Type

--- a/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_async_job.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_async_job.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
+
 import time
 
 import pendulum

--- a/airbyte-integrations/connectors/source-file-secure/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-file-secure/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-freshsales/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-freshsales/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-freshsales/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/source-freshsales/integration_tests/integration_test.py
@@ -4,5 +4,5 @@
 
 
 def test_dummy_test():
-    """ this is the dummy test to pass integration tests step """
+    """this is the dummy test to pass integration tests step"""
     pass

--- a/airbyte-integrations/connectors/source-freshservice/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-freshservice/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-gitlab/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-gitlab/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-google-ads/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-google-ads/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-google-directory/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-google-directory/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-google-sheets/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-google-sheets/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-greenhouse/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-greenhouse/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-harvest/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-harvest/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/api.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/api.py
@@ -153,7 +153,7 @@ class API:
             message = response.json().get("message")
 
         if response.status_code == HTTPStatus.FORBIDDEN:
-            """ Once hit the forbidden endpoint, we return the error message from response. """
+            """Once hit the forbidden endpoint, we return the error message from response."""
             pass
         elif response.status_code in (HTTPStatus.UNAUTHORIZED, CLOUDFLARE_ORIGIN_DNS_ERROR):
             raise HubspotInvalidAuth(message, response=response)

--- a/airbyte-integrations/connectors/source-jira/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-jira/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-klaviyo/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-klaviyo/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-klaviyo/integration_tests/dummy_test.py
+++ b/airbyte-integrations/connectors/source-klaviyo/integration_tests/dummy_test.py
@@ -4,5 +4,5 @@
 
 
 def test_dummy():
-    """ This is just to fix customIntegration task in Gradle. It fails when pytest unable to find tests."""
+    """This is just to fix customIntegration task in Gradle. It fails when pytest unable to find tests."""
     assert True

--- a/airbyte-integrations/connectors/source-kustomer-singer/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-kustomer-singer/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-lemlist/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-lemlist/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-lever-hiring/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-lever-hiring/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-linkedin-ads/source_linkedin_ads/source.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/source_linkedin_ads/source.py
@@ -33,11 +33,11 @@ class LinkedinAdsStream(HttpStream, ABC):
 
     @property
     def accounts(self):
-        """ Property to return the list of the user Account Ids from input """
+        """Property to return the list of the user Account Ids from input"""
         return ",".join(map(str, self.config.get("account_ids")))
 
     def path(self, **kwargs) -> str:
-        """ Returns the API endpoint path for stream, from `endpoint` class attribute. """
+        """Returns the API endpoint path for stream, from `endpoint` class attribute."""
         return self.endpoint
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
@@ -112,11 +112,11 @@ class IncrementalLinkedinAdsStream(LinkedinAdsStream):
 
     @abstractproperty
     def parent_stream(self) -> object:
-        """ Defines the parrent stream for slicing, the class object should be provided. """
+        """Defines the parrent stream for slicing, the class object should be provided."""
 
     @property
     def state_checkpoint_interval(self) -> Optional[int]:
-        """ Define the checkpoint from the records output size. """
+        """Define the checkpoint from the records output size."""
         return super().records_limit
 
     def get_updated_state(self, current_stream_state: MutableMapping[str, Any], latest_record: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -146,7 +146,7 @@ class LinkedInAdsStreamSlicing(IncrementalLinkedinAdsStream):
         return params
 
     def filter_records_newer_than_state(self, stream_state: Mapping[str, Any] = None, records_slice: Mapping[str, Any] = None) -> Iterable:
-        """ For the streams that provide the cursor_field `lastModified`, we filter out the old records. """
+        """For the streams that provide the cursor_field `lastModified`, we filter out the old records."""
         if stream_state:
             for record in records_slice:
                 if record[self.cursor_field] >= stream_state.get(self.cursor_field):
@@ -248,7 +248,7 @@ class LinkedInAdsAnalyticsStream(IncrementalLinkedinAdsStream):
 
     @property
     def base_analytics_params(self) -> MutableMapping[str, Any]:
-        """ Define the base parameters for analytics streams """
+        """Define the base parameters for analytics streams"""
         return {"q": "analytics", "pivot": self.pivot_by, "timeGranularity": "DAILY"}
 
     def request_params(self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, Any] = None, **kwargs) -> MutableMapping[str, Any]:

--- a/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/analytics_tests/test_merge_chunks.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/analytics_tests/test_merge_chunks.py
@@ -9,5 +9,5 @@ TEST_MERGE_BY_KEY = "end_date"
 
 
 def test_merge_chunks():
-    """ `merge_chunks` is the generator object, to get the output the list() function is applied """
+    """`merge_chunks` is the generator object, to get the output the list() function is applied"""
     assert list(merge_chunks(test_input_result_record_chunks, TEST_MERGE_BY_KEY)) == test_output_merged_chunks

--- a/airbyte-integrations/connectors/source-looker/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-looker/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-marketo/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-marketo/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-mixpanel/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-mixpanel/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-monday/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-monday/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-onesignal/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-onesignal/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-paypal-transaction/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-paypal-transaction/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-paystack/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-paystack/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-pipedrive/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-pipedrive/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-posthog/integration_tests/dummy_test.py
+++ b/airbyte-integrations/connectors/source-posthog/integration_tests/dummy_test.py
@@ -4,5 +4,5 @@
 
 
 def test_dummy():
-    """ This is just to fix customIntegration task in Gradle. It fails when pytest unable to find tests."""
+    """This is just to fix customIntegration task in Gradle. It fails when pytest unable to find tests."""
     assert True

--- a/airbyte-integrations/connectors/source-quickbooks-singer/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-quickbooks-singer/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-recharge/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-recharge/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-retently/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-retently/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-s3/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-s3/integration_tests/acceptance.py
@@ -15,7 +15,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield
 
 

--- a/airbyte-integrations/connectors/source-s3/integration_tests/integration_test_abstract.py
+++ b/airbyte-integrations/connectors/source-s3/integration_tests/integration_test_abstract.py
@@ -22,7 +22,7 @@ JSONTYPE_TO_PYTHONTYPE = {"string": str, "number": float, "integer": int, "objec
 
 
 class AbstractTestIncrementalFileStream(ABC):
-    """ Prefix this class with Abstract so the tests don't run here but only in the children """
+    """Prefix this class with Abstract so the tests don't run here but only in the children"""
 
     @pytest.fixture(scope="session")
     def cloud_bucket_prefix(self) -> str:

--- a/airbyte-integrations/connectors/source-s3/source_s3/source_files_abstract/formats/csv_parser.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/source_files_abstract/formats/csv_parser.py
@@ -14,7 +14,7 @@ from .abstract_file_parser import AbstractFileParser
 
 
 def multiprocess_queuer(func, queue: mp.Queue, *args, **kwargs):
-    """ this is our multiprocesser helper function, lives at top-level to be Windows-compatible """
+    """this is our multiprocesser helper function, lives at top-level to be Windows-compatible"""
     queue.put(dill.loads(func)(*args, **kwargs))
 
 

--- a/airbyte-integrations/connectors/source-s3/source_s3/source_files_abstract/spec.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/source_files_abstract/spec.py
@@ -90,7 +90,7 @@ class SourceFilesAbstractSpec(BaseModel):
 
     @classmethod
     def schema(cls) -> dict:
-        """ we're overriding the schema classmethod to enable some post-processing """
+        """we're overriding the schema classmethod to enable some post-processing"""
         schema = super().schema()
         cls.check_provider_added(schema)
         schema = cls.change_format_to_oneOf(schema)

--- a/airbyte-integrations/connectors/source-s3/source_s3/source_files_abstract/stream.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/source_files_abstract/stream.py
@@ -377,7 +377,7 @@ class IncrementalFileStream(FileStream, ABC):
         return self.ab_last_mod_col
 
     def _get_datetime_from_stream_state(self, stream_state: Mapping[str, Any] = None) -> datetime:
-        """ if no state, we default to 1970-01-01 in order to pick up all files present. """
+        """if no state, we default to 1970-01-01 in order to pick up all files present."""
         if stream_state is not None and self.cursor_field in stream_state.keys():
             return datetime.strptime(stream_state[self.cursor_field], self.datetime_format_string)
         else:

--- a/airbyte-integrations/connectors/source-s3/unit_tests/abstract_test_parser.py
+++ b/airbyte-integrations/connectors/source-s3/unit_tests/abstract_test_parser.py
@@ -11,7 +11,7 @@ from smart_open import open as smart_open
 
 
 class AbstractTestParser(ABC):
-    """ Prefix this class with Abstract so the tests don't run here but only in the children """
+    """Prefix this class with Abstract so the tests don't run here but only in the children"""
 
     logger = AirbyteLogger()
 

--- a/airbyte-integrations/connectors/source-salesloft/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-salesloft/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-scaffold-source-http/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-scaffold-source-http/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-scaffold-source-python/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-scaffold-source-python/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-sentry/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-sentry/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-shopify/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-shopify/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-shopify/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/source-shopify/integration_tests/integration_test.py
@@ -4,5 +4,5 @@
 
 
 def test_dummy_test():
-    """ this is the dummy test to pass integration tests step """
+    """this is the dummy test to pass integration tests step"""
     pass

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/auth.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/auth.py
@@ -9,7 +9,7 @@ from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthentic
 
 
 class NotImplementedAuth(Exception):
-    """ Not implemented Auth option error"""
+    """Not implemented Auth option error"""
 
     logger = AirbyteLogger()
 

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/source.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/source.py
@@ -173,7 +173,7 @@ class ChildSubstream(IncrementalShopifyStream):
         stream_slice: Optional[Mapping[str, Any]] = None,
         **kwargs,
     ) -> Iterable[Mapping[str, Any]]:
-        """ Reading child streams records for each `id` """
+        """Reading child streams records for each `id`"""
 
         self.logger.info(f"Reading {self.name} for {self.slice_key}: {stream_slice.get(self.slice_key)}")
         records = super().read_records(stream_slice=stream_slice, **kwargs)

--- a/airbyte-integrations/connectors/source-shortio/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-shortio/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-snapchat-marketing/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-snapchat-marketing/source_snapchat_marketing/source.py
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/source_snapchat_marketing/source.py
@@ -37,7 +37,7 @@ default_stream_slices_return_value = [None]
 
 
 class SnapchatMarketingException(Exception):
-    """ Just for formatting the exception as SnapchatMarketing"""
+    """Just for formatting the exception as SnapchatMarketing"""
 
 
 def get_depend_on_ids(depends_on_stream, depends_on_stream_config: Mapping, slice_key_name: str) -> List:
@@ -117,7 +117,7 @@ class SnapchatMarketingStream(HttpStream, ABC):
 
     @property
     def response_root_name(self):
-        """ Using the class name in lower to set the root node for response parsing """
+        """Using the class name in lower to set the root node for response parsing"""
         return self.name
 
     @property
@@ -259,14 +259,14 @@ class IncrementalSnapchatMarketingStream(SnapchatMarketingStream, ABC):
 
 
 class Organizations(SnapchatMarketingStream):
-    """ Docs: https://marketingapi.snapchat.com/docs/#organizations """
+    """Docs: https://marketingapi.snapchat.com/docs/#organizations"""
 
     def path(self, **kwargs) -> str:
         return "me/organizations"
 
 
 class Adaccounts(IncrementalSnapchatMarketingStream):
-    """ Docs: https://marketingapi.snapchat.com/docs/#get-all-ad-accounts """
+    """Docs: https://marketingapi.snapchat.com/docs/#get-all-ad-accounts"""
 
     depends_on_stream = Organizations
     slice_key_name = "organization_id"
@@ -276,13 +276,13 @@ class Adaccounts(IncrementalSnapchatMarketingStream):
 
 
 class Creatives(IncrementalSnapchatMarketingStream):
-    """ Docs: https://marketingapi.snapchat.com/docs/#get-all-creatives """
+    """Docs: https://marketingapi.snapchat.com/docs/#get-all-creatives"""
 
     depends_on_stream = Adaccounts
 
 
 class Media(IncrementalSnapchatMarketingStream):
-    """ Docs: https://marketingapi.snapchat.com/docs/#get-all-media """
+    """Docs: https://marketingapi.snapchat.com/docs/#get-all-media"""
 
     depends_on_stream = Adaccounts
 
@@ -292,25 +292,25 @@ class Media(IncrementalSnapchatMarketingStream):
 
 
 class Campaigns(IncrementalSnapchatMarketingStream):
-    """ Docs: https://marketingapi.snapchat.com/docs/#get-all-campaigns """
+    """Docs: https://marketingapi.snapchat.com/docs/#get-all-campaigns"""
 
     depends_on_stream = Adaccounts
 
 
 class Ads(IncrementalSnapchatMarketingStream):
-    """ Docs: https://marketingapi.snapchat.com/docs/#get-all-ads-under-an-ad-account """
+    """Docs: https://marketingapi.snapchat.com/docs/#get-all-ads-under-an-ad-account"""
 
     depends_on_stream = Adaccounts
 
 
 class Adsquads(IncrementalSnapchatMarketingStream):
-    """ Docs: https://marketingapi.snapchat.com/docs/#get-all-ad-squads-under-an-ad-account """
+    """Docs: https://marketingapi.snapchat.com/docs/#get-all-ad-squads-under-an-ad-account"""
 
     depends_on_stream = Adaccounts
 
 
 class Segments(IncrementalSnapchatMarketingStream):
-    """ Docs: https://marketingapi.snapchat.com/docs/#get-all-audience-segments """
+    """Docs: https://marketingapi.snapchat.com/docs/#get-all-audience-segments"""
 
     depends_on_stream = Adaccounts
 

--- a/airbyte-integrations/connectors/source-snapchat-marketing/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/unit_tests/unit_test.py
@@ -32,7 +32,7 @@ expected_adaccount_ids = [
 
 
 def test_get_depend_on_ids_none():
-    """ Testing the stream that has non parent dependency (like Organizations has no dependency) """
+    """Testing the stream that has non parent dependency (like Organizations has no dependency)"""
     # sync_mode: SyncMode, cursor_field: List[str] = None, stream_state: Mapping[str, Any] = None
     depends_on_stream = None
     slice_key_name = None
@@ -41,7 +41,7 @@ def test_get_depend_on_ids_none():
 
 
 def test_get_depend_on_ids_1():
-    """ Testing the stream that has 1 level parent dependency (like Adaccounts has dependency on Organizations) """
+    """Testing the stream that has 1 level parent dependency (like Adaccounts has dependency on Organizations)"""
     # sync_mode: SyncMode, cursor_field: List[str] = None, stream_state: Mapping[str, Any] = None
     depends_on_stream = Organizations
     slice_key_name = "organization_id"

--- a/airbyte-integrations/connectors/source-square/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-square/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-square/source_square/source.py
+++ b/airbyte-integrations/connectors/source-square/source_square/source.py
@@ -17,7 +17,7 @@ from source_square.utils import separate_items_by_count
 
 
 class SquareException(Exception):
-    """ Just for formatting the exception as Square"""
+    """Just for formatting the exception as Square"""
 
     def __init__(self, status_code, errors):
         self.status_code = status_code
@@ -211,7 +211,7 @@ class ModifierList(IncrementalSquareCatalogObjectsStream):
 
 
 class Refunds(IncrementalSquareStream):
-    """ Docs: https://developer.squareup.com/reference/square_2021-06-16/refunds-api/list-payment-refunds """
+    """Docs: https://developer.squareup.com/reference/square_2021-06-16/refunds-api/list-payment-refunds"""
 
     data_field = "refunds"
 
@@ -226,7 +226,7 @@ class Refunds(IncrementalSquareStream):
 
 
 class Payments(IncrementalSquareStream):
-    """ Docs: https://developer.squareup.com/reference/square_2021-06-16/payments-api/list-payments """
+    """Docs: https://developer.squareup.com/reference/square_2021-06-16/payments-api/list-payments"""
 
     data_field = "payments"
 
@@ -241,7 +241,7 @@ class Payments(IncrementalSquareStream):
 
 
 class Locations(SquareStream):
-    """ Docs: https://developer.squareup.com/explorer/square/locations-api/list-locations """
+    """Docs: https://developer.squareup.com/explorer/square/locations-api/list-locations"""
 
     data_field = "locations"
 
@@ -250,7 +250,7 @@ class Locations(SquareStream):
 
 
 class Shifts(SquareStreamPageJsonAndLimit):
-    """ Docs: https://developer.squareup.com/reference/square/labor-api/search-shifts """
+    """Docs: https://developer.squareup.com/reference/square/labor-api/search-shifts"""
 
     data_field = "shifts"
     http_method = "POST"
@@ -261,7 +261,7 @@ class Shifts(SquareStreamPageJsonAndLimit):
 
 
 class TeamMembers(SquareStreamPageJsonAndLimit):
-    """ Docs: https://developer.squareup.com/reference/square/team-api/search-team-members """
+    """Docs: https://developer.squareup.com/reference/square/team-api/search-team-members"""
 
     data_field = "team_members"
     http_method = "POST"
@@ -271,7 +271,7 @@ class TeamMembers(SquareStreamPageJsonAndLimit):
 
 
 class TeamMemberWages(SquareStreamPageParam):
-    """ Docs: https://developer.squareup.com/reference/square_2021-06-16/labor-api/list-team-member-wages """
+    """Docs: https://developer.squareup.com/reference/square_2021-06-16/labor-api/list-team-member-wages"""
 
     data_field = "team_member_wages"
     items_per_page_limit = 200
@@ -296,7 +296,7 @@ class TeamMemberWages(SquareStreamPageParam):
 
 
 class Customers(SquareStreamPageParam):
-    """ Docs: https://developer.squareup.com/reference/square_2021-06-16/customers-api/list-customers """
+    """Docs: https://developer.squareup.com/reference/square_2021-06-16/customers-api/list-customers"""
 
     data_field = "customers"
 
@@ -313,7 +313,7 @@ class Customers(SquareStreamPageParam):
 
 
 class Orders(SquareStreamPageJson):
-    """ Docs: https://developer.squareup.com/reference/square/orders-api/search-orders """
+    """Docs: https://developer.squareup.com/reference/square/orders-api/search-orders"""
 
     data_field = "orders"
     http_method = "POST"

--- a/airbyte-integrations/connectors/source-strava/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-strava/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-surveymonkey/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-surveymonkey/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-tempo/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-tempo/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/spec.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/spec.py
@@ -72,7 +72,7 @@ class SourceTiktokMarketingSpec(BaseModel):
 
     @classmethod
     def schema(cls) -> dict:
-        """ we're overriding the schema classmethod to enable some post-processing """
+        """we're overriding the schema classmethod to enable some post-processing"""
         schema = super().schema()
         schema = cls.change_format_to_oneOf(schema, "environment")
         return cls.resolve_refs(schema)

--- a/airbyte-integrations/connectors/source-twilio/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-twilio/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-typeform/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-typeform/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-us-census/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-us-census/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-woocommerce/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-woocommerce/integration_tests/acceptance.py
@@ -10,7 +10,7 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
     # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-zendesk-sunshine/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-zendesk-sunshine/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-zendesk-support/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/integration_tests/acceptance.py
@@ -10,5 +10,5 @@ pytest_plugins = ("source_acceptance_test.plugin",)
 
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
-    """ This fixture is a placeholder for external resources that acceptance test might require."""
+    """This fixture is a placeholder for external resources that acceptance test might require."""
     yield

--- a/airbyte-integrations/connectors/source-zendesk-support/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/integration_tests/integration_test.py
@@ -43,11 +43,11 @@ class TestIntegrationZendeskSupport:
                 break
 
     def test_export_with_unixtime(self):
-        """ Tickets stream has 'generated_timestamp' as cursor_field and it is unixtime format'' """
+        """Tickets stream has 'generated_timestamp' as cursor_field and it is unixtime format''"""
         self._test_export_stream(Tickets)
 
     def test_export_with_str_datetime(self):
-        """ Other export streams has 'updated_at' as cursor_field and it is datetime  string format """
+        """Other export streams has 'updated_at' as cursor_field and it is datetime  string format"""
         self._test_export_stream(Users)
 
     def _test_insertion(self, stream_cls: type, index: int = None):

--- a/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/streams.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/streams.py
@@ -26,7 +26,7 @@ class SourceZendeskException(Exception):
 
 
 class SourceZendeskSupportStream(HttpStream, ABC):
-    """"Basic Zendesk class"""
+    """ "Basic Zendesk class"""
 
     primary_key = "id"
 
@@ -321,7 +321,7 @@ class IncrementalUnsortedPageStream(IncrementalUnsortedStream, ABC):
 
 
 class FullRefreshStream(IncrementalUnsortedPageStream, ABC):
-    """"Stream for endpoints where there are not any created_at or updated_at fields"""
+    """ "Stream for endpoints where there are not any created_at or updated_at fields"""
 
     # reset to default value
     cursor_field = SourceZendeskSupportStream.cursor_field

--- a/airbyte-integrations/connectors/source-zendesk-talk/source_zendesk_talk/source.py
+++ b/airbyte-integrations/connectors/source-zendesk-talk/source_zendesk_talk/source.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
+
 from datetime import datetime
 from typing import Any, List, Mapping, Tuple
 

--- a/airbyte-integrations/connectors/source-zendesk-talk/source_zendesk_talk/streams.py
+++ b/airbyte-integrations/connectors/source-zendesk-talk/source_zendesk_talk/streams.py
@@ -19,18 +19,18 @@ class ZendeskTalkStream(HttpStream, ABC):
     primary_key = "id"
 
     def __init__(self, subdomain: str, **kwargs):
-        """ Constructor, accepts subdomain to calculate correct url"""
+        """Constructor, accepts subdomain to calculate correct url"""
         super().__init__(**kwargs)
         self._subdomain = subdomain
 
     @property
     @abstractmethod
     def data_field(self) -> str:
-        """ Specifies root object name in a stream response"""
+        """Specifies root object name in a stream response"""
 
     @property
     def url_base(self) -> str:
-        """ API base url based on configured subdomain"""
+        """API base url based on configured subdomain"""
         return f"https://{self._subdomain}.zendesk.com/api/v2/channels/voice"
 
     def backoff_time(self, response: requests.Response) -> Optional[float]:
@@ -75,7 +75,7 @@ class ZendeskTalkStream(HttpStream, ABC):
         return dict(next_page_token or {})
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
-        """ Simply parse json and iterates over root object"""
+        """Simply parse json and iterates over root object"""
         response_json = response.json()
         if self.data_field:
             response_json = response_json[self.data_field]
@@ -110,7 +110,7 @@ class ZendeskTalkIncrementalStream(ZendeskTalkStream, ABC):
         return {self.cursor_field: new_cursor_value}
 
     def request_params(self, stream_state=None, **kwargs):
-        """ Add incremental parameters"""
+        """Add incremental parameters"""
         params = super().request_params(stream_state=stream_state, **kwargs)
 
         if self.filter_param not in params:
@@ -220,7 +220,7 @@ class IVRMenus(IVRs):
     name = "ivr_menus"
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
-        """ Simply parse json and iterates over root object"""
+        """Simply parse json and iterates over root object"""
         ivrs = super().parse_response(response=response, **kwargs)
         for ivr in ivrs:
             for menu in ivr["menus"]:
@@ -235,7 +235,7 @@ class IVRRoutes(IVRs):
     name = "ivr_routes"
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
-        """ Simply parse json and iterates over root object"""
+        """Simply parse json and iterates over root object"""
         ivrs = super().parse_response(response=response, **kwargs)
         for ivr in ivrs:
             for menu in ivr["menus"]:
@@ -310,4 +310,3 @@ class CallLegs(ZendeskTalkIncrementalStream):
 
     def path(self, **kwargs) -> str:
         return "/stats/incremental/legs"
-

--- a/airbyte-integrations/connectors/source-zuora/source_zuora/source.py
+++ b/airbyte-integrations/connectors/source-zuora/source_zuora/source.py
@@ -58,11 +58,11 @@ class ZuoraStream(HttpStream, ABC):
             raise QueryWindowError(value)
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
-        """ Abstractmethod HTTPStream CDK dependency """
+        """Abstractmethod HTTPStream CDK dependency"""
         return None
 
     def request_params(self, stream_state: Mapping[str, Any], **kwargs) -> MutableMapping[str, Any]:
-        """ Abstractmethod HTTPStream CDK dependency """
+        """Abstractmethod HTTPStream CDK dependency"""
         return {}
 
     def base_query_params(self) -> MutableMapping[str, Any]:
@@ -82,7 +82,7 @@ class ZuoraBase(ZuoraStream):
     """
 
     def path(self, **kwargs) -> str:
-        """ Abstractmethod HTTPStream CDK dependency """
+        """Abstractmethod HTTPStream CDK dependency"""
         return ""
 
     def request_kwargs(self, stream_slice: Mapping[str, Any] = None, **kwargs) -> Mapping[str, Any]:
@@ -483,11 +483,11 @@ class ZuoraGetJobResult(HttpStream):
         return self.url
 
     def path(self, **kwargs) -> str:
-        """ Abstractmethod HTTPStream CDK dependency """
+        """Abstractmethod HTTPStream CDK dependency"""
         return ""
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
-        """ Abstractmethod HTTPStream CDK dependency """
+        """Abstractmethod HTTPStream CDK dependency"""
         return None
 
     def parse_response(self, response: requests.Response, **kwargs) -> str:

--- a/airbyte-integrations/connectors/source-zuora/source_zuora/zuora_endpoint.py
+++ b/airbyte-integrations/connectors/source-zuora/source_zuora/zuora_endpoint.py
@@ -22,5 +22,5 @@ ZUORA_TENANT_ENDPOINT_MAP: Dict = {
 
 
 def get_url_base(tenant_endpoint: str) -> str:
-    """ Define the URL Base from user's input with respect to the ZUORA_TENANT_ENDPOINT_MAP """
+    """Define the URL Base from user's input with respect to the ZUORA_TENANT_ENDPOINT_MAP"""
     return ZUORA_TENANT_ENDPOINT_MAP.get(tenant_endpoint)

--- a/airbyte-integrations/connectors/source-zuora/source_zuora/zuora_errors.py
+++ b/airbyte-integrations/connectors/source-zuora/source_zuora/zuora_errors.py
@@ -11,7 +11,7 @@ from airbyte_cdk.logger import AirbyteLogger
 
 
 class Error(Exception):
-    """ Base Error class for other exceptions """
+    """Base Error class for other exceptions"""
 
     # Define the instance of the Native Airbyte Logger
     logger = AirbyteLogger()
@@ -26,7 +26,7 @@ class QueryWindowError(Error):
 
 
 class ZOQLQueryError(Error):
-    """ Base class for  ZOQL EXPORT query errors """
+    """Base class for  ZOQL EXPORT query errors"""
 
     def __init__(self, response: requests.Response = None):
         if response:
@@ -39,7 +39,7 @@ class ZOQLQueryError(Error):
 
 
 class ZOQLQueryFailed(ZOQLQueryError):
-    """ Failed to execute query on the server side """
+    """Failed to execute query on the server side"""
 
 
 class ZOQLQueryFieldCannotResolveCursor(Error):

--- a/airbyte-integrations/connectors/source-zuora/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-zuora/unit_tests/unit_test.py
@@ -4,5 +4,5 @@
 
 
 def test_example():
-    """ Example of unit test """
+    """Example of unit test"""
     pass


### PR DESCRIPTION
## What
running `./gradlew format`

## How
Since https://github.com/airbytehq/airbyte/pull/7808/ changed version of python linter Black, it seems the trailing whitespace are not formatted as before, this PR makes all python follow the new scheme