### PR TITLE
prevent gitbook from running all of our builds twice

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '0 */1 * * *'
   push:
+    branches-ignore:
+      - 'gitbook/v1'
 
 jobs:
   ## Gradle Build (Connectors Base)


### PR DESCRIPTION
Something changed with Gitbook where now it's showing all of the builds as running for each of its doc branch updates. This should prevent it from running on both. 