### PR TITLE
Add section about user impact to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,6 @@ Expand the relevant checklist and delete the others.
 
 <details><summary> <strong> New Connector </strong></summary>
 <p>
-      
 #### Community member or Airbyter
    
 - [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 2. `y.python`
 
 ## 🚨 User Impact 🚨
-Are there any breaking changes? 
+Are there any breaking changes? If yes, please make sure to include it here and in any changelogs with the 🚨🚨 emoji
 What is the end result perceived by the user?
 
 ## Pre-merge Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,12 +9,16 @@
 1. `x.java`
 2. `y.python`
 
+## 🚨 User Impact 🚨
+Are there any breaking changes? 
+What is the end result perceived by the user?
+
 ## Pre-merge Checklist
 Expand the relevant checklist and delete the others. 
 
 <details><summary> <strong> New Connector </strong></summary>
 <p>
-   
+      
 #### Community member or Airbyter
    
 - [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,7 @@ Expand the relevant checklist and delete the others.
 
 <details><summary> <strong> New Connector </strong></summary>
 <p>
+
 #### Community member or Airbyter
    
 - [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))


### PR DESCRIPTION
## What
Add a section to the PR template which prompts the developer to think about the user impact of their change

the goal of this is to get the developer to think about the end impact this particular PR they are raising will have on the user especially if it contains a breaking change. If there is a breaking change, then we want to make sure it is:

1. very thoroughly considered
2. is communicated to users clearly perhaps via something like airbytehq/airbyte-internal-issues#331

this way, if there are any breaking issues or action required from the user, or just anything they really need to be aware of, this section will bring that to the forefront