### PR TITLE
Instance-wide params should only be injected if a connector will be using oauth

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
@@ -141,6 +141,10 @@ public class Jsons {
     return node;
   }
 
+  public static void replaceNestedValue(final JsonNode json, final List<String> keys, final JsonNode replacement) {
+    replaceNested(json, keys, (node, finalKey) -> node.put(finalKey, replacement));
+  }
+
   public static void replaceNestedString(final JsonNode json, final List<String> keys, final String replacement) {
     replaceNested(json, keys, (node, finalKey) -> node.put(finalKey, replacement));
   }

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/BaseOAuthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/BaseOAuthFlow.java
@@ -61,7 +61,7 @@ public abstract class BaseOAuthFlow implements OAuthFlowImplementation {
       final Optional<DestinationOAuthParameter> param = MoreOAuthParameters.getDestinationOAuthParameter(
           configRepository.listDestinationOAuthParam().stream(), workspaceId, destinationDefinitionId);
       if (param.isPresent()) {
-        // TODO: if we write a flyway migration to flatten persisted configs in db, we don't need to flatten
+        // TODO: if we write a migration to flatten persisted configs in db, we don't need to flatten
         // here see https://github.com/airbytehq/airbyte/issues/7624
         return MoreOAuthParameters.flattenOAuthConfig(param.get().getConfiguration());
       } else {

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/BaseOAuthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/BaseOAuthFlow.java
@@ -142,6 +142,9 @@ public abstract class BaseOAuthFlow implements OAuthFlowImplementation {
         validator,
         oAuthConfigSpecification.getCompleteOauthServerOutputSpecification(),
         Jsons.keys(oAuthParamConfig),
+        // TODO secrets should be masked with the correct type
+        // https://github.com/airbytehq/airbyte/issues/5990
+        // In the short-term this is not world-ending as all secret fields are currently strings
         (resultMap, key) -> resultMap.put(key, MoreOAuthParameters.SECRET_MASK));
 
     return MoreMaps.merge(oAuthServerOutputs, oAuthOutputs);

--- a/airbyte-oauth/src/test/java/io/airbyte/oauth/MoreOAuthParametersTest.java
+++ b/airbyte-oauth/src/test/java/io/airbyte/oauth/MoreOAuthParametersTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
@@ -42,31 +41,8 @@ public class MoreOAuthParametersTest {
     assertThrows(IllegalStateException.class, () -> MoreOAuthParameters.flattenOAuthConfig(nestedConfig));
   }
 
-  private void maskAllValues(final ObjectNode node) {
-    for (final String key : Jsons.keys(node)) {
-      if (node.get(key).getNodeType() == JsonNodeType.OBJECT) {
-        maskAllValues((ObjectNode) node.get(key));
-      } else {
-        node.set(key, MoreOAuthParameters.getSecretMask());
-      }
-    }
-  }
-
   @Test
-  void testInjectUnnestedNode_Masked() {
-    final ObjectNode oauthParams = (ObjectNode) Jsons.jsonNode(generateOAuthParameters());
-    final ObjectNode maskedOauthParams = Jsons.clone(oauthParams);
-    maskAllValues(maskedOauthParams);
-    final ObjectNode actual = generateJsonConfig();
-    final ObjectNode expected = Jsons.clone(actual);
-    expected.setAll(maskedOauthParams);
-
-    MoreOAuthParameters.mergeJsons(actual, oauthParams, MoreOAuthParameters.getSecretMask());
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  void testInjectUnnestedNode_Unmasked() {
+  void testInjectUnnestedNode() {
     final ObjectNode oauthParams = (ObjectNode) Jsons.jsonNode(generateOAuthParameters());
 
     final ObjectNode actual = generateJsonConfig();
@@ -79,26 +55,8 @@ public class MoreOAuthParametersTest {
   }
 
   @Test
-  void testInjectNewNestedNode_Masked() {
-    final ObjectNode oauthParams = (ObjectNode) Jsons.jsonNode(generateOAuthParameters());
-    final ObjectNode maskedOauthParams = Jsons.clone(oauthParams);
-    maskAllValues(maskedOauthParams);
-    final ObjectNode nestedConfig = (ObjectNode) Jsons.jsonNode(ImmutableMap.builder()
-        .put("oauth_credentials", oauthParams)
-        .build());
-
-    // nested node does not exist in actual object
-    final ObjectNode actual = generateJsonConfig();
-    final ObjectNode expected = Jsons.clone(actual);
-    expected.putObject("oauth_credentials").setAll(maskedOauthParams);
-
-    MoreOAuthParameters.mergeJsons(actual, nestedConfig, MoreOAuthParameters.getSecretMask());
-    assertEquals(expected, actual);
-  }
-
-  @Test
   @DisplayName("A nested config should be inserted with the same nesting structure")
-  void testInjectNewNestedNode_Unmasked() {
+  void testInjectNewNestedNode() {
     final ObjectNode oauthParams = (ObjectNode) Jsons.jsonNode(generateOAuthParameters());
     final ObjectNode nestedConfig = (ObjectNode) Jsons.jsonNode(ImmutableMap.builder()
         .put("oauth_credentials", oauthParams)
@@ -116,7 +74,7 @@ public class MoreOAuthParametersTest {
 
   @Test
   @DisplayName("A nested node which partially exists in the main config should be merged into the main config, not overwrite the whole nested object")
-  void testInjectedPartiallyExistingNestedNode_Unmasked() {
+  void testInjectedPartiallyExistingNestedNode() {
     final ObjectNode oauthParams = (ObjectNode) Jsons.jsonNode(generateOAuthParameters());
     final ObjectNode nestedConfig = (ObjectNode) Jsons.jsonNode(ImmutableMap.builder()
         .put("oauth_credentials", oauthParams)

--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/JobScheduler.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/JobScheduler.java
@@ -56,7 +56,7 @@ public class JobScheduler implements Runnable {
         new DefaultSyncJobFactory(
             new DefaultJobCreator(jobPersistence, configRepository),
             configRepository,
-            new OAuthConfigSupplier(configRepository, false, trackingClient)));
+            new OAuthConfigSupplier(configRepository, trackingClient)));
   }
 
   @Override

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplier.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplier.java
@@ -4,10 +4,15 @@
 
 package io.airbyte.scheduler.persistence.job_factory;
 
+import static com.fasterxml.jackson.databind.node.JsonNodeType.ARRAY;
+import static com.fasterxml.jackson.databind.node.JsonNodeType.OBJECT;
+
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.analytics.TrackingClient;
+import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
@@ -18,17 +23,22 @@ import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.persistence.job_tracker.TrackingMetadata;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OAuthConfigSupplier {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(OAuthConfigSupplier.class);
+
+  public static final String PATH_IN_CONNECTOR_CONFIG = "path_in_connector_config";
   final private ConfigRepository configRepository;
-  private final boolean maskSecrets;
   private final TrackingClient trackingClient;
 
-  public OAuthConfigSupplier(final ConfigRepository configRepository, final boolean maskSecrets, final TrackingClient trackingClient) {
+  public OAuthConfigSupplier(final ConfigRepository configRepository, final TrackingClient trackingClient) {
     this.configRepository = configRepository;
-    this.maskSecrets = maskSecrets;
     this.trackingClient = trackingClient;
   }
 
@@ -39,23 +49,15 @@ public class OAuthConfigSupplier {
   public JsonNode injectSourceOAuthParameters(final UUID sourceDefinitionId, final UUID workspaceId, final JsonNode sourceConnectorConfig)
       throws IOException {
     try {
-      final ImmutableMap<String, Object> metadata = generateSourceMetadata(sourceDefinitionId);
-      // TODO there will be cases where we shouldn't write oauth params. See
-      // https://github.com/airbytehq/airbyte/issues/5989
+      final StandardSourceDefinition sourceDefinition = configRepository.getStandardSourceDefinition(sourceDefinitionId);
       MoreOAuthParameters.getSourceOAuthParameter(configRepository.listSourceOAuthParam().stream(), workspaceId, sourceDefinitionId)
-          .ifPresent(
-              sourceOAuthParameter -> {
-                if (maskSecrets) {
-                  // when maskSecrets = true, no real oauth injections is happening, only masked values
-                  MoreOAuthParameters.mergeJsons(
-                      (ObjectNode) sourceConnectorConfig,
-                      (ObjectNode) sourceOAuthParameter.getConfiguration(),
-                      MoreOAuthParameters.getSecretMask());
-                } else {
-                  MoreOAuthParameters.mergeJsons((ObjectNode) sourceConnectorConfig, (ObjectNode) sourceOAuthParameter.getConfiguration());
-                  Exceptions.swallow(() -> trackingClient.track(workspaceId, "OAuth Injection - Backend", metadata));
-                }
-              });
+          .ifPresent(sourceOAuthParameter -> {
+            if (injectOAuthParameters(sourceDefinition.getName(), sourceDefinition.getSpec(), sourceOAuthParameter.getConfiguration(),
+                sourceConnectorConfig)) {
+              final ImmutableMap<String, Object> metadata = TrackingMetadata.generateSourceDefinitionMetadata(sourceDefinition);
+              Exceptions.swallow(() -> trackingClient.track(workspaceId, "OAuth Injection - Backend", metadata));
+            }
+          });
       return sourceConnectorConfig;
     } catch (final JsonValidationException | ConfigNotFoundException e) {
       throw new IOException(e);
@@ -67,17 +69,12 @@ public class OAuthConfigSupplier {
                                                    final JsonNode destinationConnectorConfig)
       throws IOException {
     try {
-      final ImmutableMap<String, Object> metadata = generateDestinationMetadata(destinationDefinitionId);
+      final StandardDestinationDefinition destinationDefinition = configRepository.getStandardDestinationDefinition(destinationDefinitionId);
       MoreOAuthParameters.getDestinationOAuthParameter(configRepository.listDestinationOAuthParam().stream(), workspaceId, destinationDefinitionId)
           .ifPresent(destinationOAuthParameter -> {
-            if (maskSecrets) {
-              // when maskSecrets = true, no real oauth injections is happening, only masked values
-              MoreOAuthParameters.mergeJsons(
-                  (ObjectNode) destinationConnectorConfig,
-                  (ObjectNode) destinationOAuthParameter.getConfiguration(),
-                  MoreOAuthParameters.getSecretMask());
-            } else {
-              MoreOAuthParameters.mergeJsons((ObjectNode) destinationConnectorConfig, (ObjectNode) destinationOAuthParameter.getConfiguration());
+            if (injectOAuthParameters(destinationDefinition.getName(), destinationDefinition.getSpec(), destinationOAuthParameter.getConfiguration(),
+                destinationConnectorConfig)) {
+              final ImmutableMap<String, Object> metadata = TrackingMetadata.generateDestinationDefinitionMetadata(destinationDefinition);
               Exceptions.swallow(() -> trackingClient.track(workspaceId, "OAuth Injection - Backend", metadata));
             }
           });
@@ -87,16 +84,67 @@ public class OAuthConfigSupplier {
     }
   }
 
-  private ImmutableMap<String, Object> generateSourceMetadata(final UUID sourceDefinitionId)
-      throws JsonValidationException, ConfigNotFoundException, IOException {
-    final StandardSourceDefinition sourceDefinition = configRepository.getStandardSourceDefinition(sourceDefinitionId);
-    return TrackingMetadata.generateSourceDefinitionMetadata(sourceDefinition);
+  private static boolean injectOAuthParameters(final String connectorName,
+                                               final ConnectorSpecification spec,
+                                               final JsonNode oAuthParameters,
+                                               final JsonNode connectorConfig) {
+    if (hasOAuthConfigSpecification(spec)) {
+      if (!checkOAuthPredicate(spec.getAdvancedAuth().getPredicateKey(), spec.getAdvancedAuth().getPredicateValue(), connectorConfig)) {
+        return false;
+      }
+      final JsonNode outputSpec = spec.getAdvancedAuth().getOauthConfigSpecification().getCompleteOauthServerOutputSpecification();
+      boolean result = false;
+      for (final String key : Jsons.keys(outputSpec)) {
+        final JsonNode node = outputSpec.get(key);
+        if (node.getNodeType() == OBJECT) {
+          final JsonNode pathNode = node.get(PATH_IN_CONNECTOR_CONFIG);
+          if (pathNode != null && pathNode.getNodeType() == ARRAY) {
+            final List<String> propertyPath = new ArrayList<>();
+            final ArrayNode arrayNode = (ArrayNode) pathNode;
+            for (int i = 0; i < arrayNode.size(); ++i) {
+              propertyPath.add(arrayNode.get(i).asText());
+            }
+            if (propertyPath.size() > 0) {
+              Jsons.replaceNestedValue(connectorConfig, propertyPath, oAuthParameters.get(key));
+              result = true;
+            } else {
+              LOGGER.error(String.format("In %s's advanced_auth spec, completeOAuthServerOutputSpecification includes an invalid empty %s for %s",
+                  connectorName, PATH_IN_CONNECTOR_CONFIG, key));
+            }
+          } else {
+            LOGGER.error(
+                String.format("In %s's advanced_auth spec, completeOAuthServerOutputSpecification does not declare an Array<String> %s for %s",
+                    connectorName, PATH_IN_CONNECTOR_CONFIG, key));
+          }
+        } else {
+          LOGGER.error(String.format("In %s's advanced_auth spec, completeOAuthServerOutputSpecification does not declare an ObjectNode for %s",
+              connectorName, key));
+        }
+      }
+      return result;
+    } else {
+      MoreOAuthParameters.mergeJsons((ObjectNode) connectorConfig, (ObjectNode) oAuthParameters);
+      return true;
+    }
   }
 
-  private ImmutableMap<String, Object> generateDestinationMetadata(final UUID destinationDefinitionId)
-      throws JsonValidationException, ConfigNotFoundException, IOException {
-    final StandardDestinationDefinition destinationDefinition = configRepository.getStandardDestinationDefinition(destinationDefinitionId);
-    return TrackingMetadata.generateDestinationDefinitionMetadata(destinationDefinition);
+  private static boolean checkOAuthPredicate(final List<String> predicateKey, final String predicateValue, final JsonNode connectorConfig) {
+    if (!predicateKey.isEmpty()) {
+      JsonNode node = connectorConfig;
+      for (final String key : predicateKey) {
+        if (node.has(key)) {
+          node = node.get(key);
+        } else {
+          return false;
+        }
+      }
+      if (predicateValue != null && !predicateValue.isBlank()) {
+        return node.asText().equals(predicateValue);
+      } else {
+        return true;
+      }
+    }
+    return true;
   }
 
 }

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplier.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplier.java
@@ -92,6 +92,9 @@ public class OAuthConfigSupplier {
       if (!checkOAuthPredicate(spec.getAdvancedAuth().getPredicateKey(), spec.getAdvancedAuth().getPredicateValue(), connectorConfig)) {
         return false;
       }
+      // TODO: if we write a migration to flatten persisted configs in db, we don't need to flatten
+      // here see https://github.com/airbytehq/airbyte/issues/7624
+      final JsonNode flatOAuthParameters = MoreOAuthParameters.flattenOAuthConfig(oAuthParameters);
       final JsonNode outputSpec = spec.getAdvancedAuth().getOauthConfigSpecification().getCompleteOauthServerOutputSpecification();
       boolean result = false;
       for (final String key : Jsons.keys(outputSpec)) {
@@ -105,7 +108,7 @@ public class OAuthConfigSupplier {
               propertyPath.add(arrayNode.get(i).asText());
             }
             if (propertyPath.size() > 0) {
-              Jsons.replaceNestedValue(connectorConfig, propertyPath, oAuthParameters.get(key));
+              Jsons.replaceNestedValue(connectorConfig, propertyPath, flatOAuthParameters.get(key));
               result = true;
             } else {
               LOGGER.error(String.format("In %s's advanced_auth spec, completeOAuthServerOutputSpecification includes an invalid empty %s for %s",

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplierTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplierTest.java
@@ -291,7 +291,8 @@ public class OAuthConfigSupplierTest {
 
   @Test
   public void testOAuthFullInjectionBecauseNoOAuthSpecNestedParameters() throws JsonValidationException, IOException, ConfigNotFoundException {
-    // Until https://github.com/airbytehq/airbyte/issues/7624 is solved, we need to handle nested oauth parameters
+    // Until https://github.com/airbytehq/airbyte/issues/7624 is solved, we need to handle nested oauth
+    // parameters
     final JsonNode config = generateJsonConfig();
     final UUID workspaceId = UUID.randomUUID();
     final Map<String, Object> oauthParameters = generateNestedOAuthParameters();
@@ -320,7 +321,8 @@ public class OAuthConfigSupplierTest {
 
   @Test
   public void testOAuthInjectionNestedParameters() throws JsonValidationException, IOException {
-    // Until https://github.com/airbytehq/airbyte/issues/7624 is solved, we need to handle nested oauth parameters
+    // Until https://github.com/airbytehq/airbyte/issues/7624 is solved, we need to handle nested oauth
+    // parameters
     final JsonNode config = generateJsonConfig();
     final UUID workspaceId = UUID.randomUUID();
     final Map<String, Object> oauthParameters = generateNestedOAuthParameters();

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplierTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplierTest.java
@@ -35,6 +35,9 @@ import org.junit.jupiter.api.Test;
 
 public class OAuthConfigSupplierTest {
 
+  public static final String API_CLIENT = "api_client";
+  public static final String CREDENTIALS = "credentials";
+
   private ConfigRepository configRepository;
   private TrackingClient trackingClient;
   private OAuthConfigSupplier oAuthConfigSupplier;
@@ -53,13 +56,13 @@ public class OAuthConfigSupplierTest {
         .withSpec(new ConnectorSpecification()
             .withAdvancedAuth(new AdvancedAuth()
                 .withAuthFlowType(AuthFlowType.OAUTH_2_0)
-                .withPredicateKey(List.of("credentials", "auth_type"))
+                .withPredicateKey(List.of(CREDENTIALS, "auth_type"))
                 .withPredicateValue("oauth")
                 .withOauthConfigSpecification(new OAuthConfigSpecification()
                     .withCompleteOauthServerOutputSpecification(Jsons.jsonNode(Map.of(
-                        "api_client", Map.of(
+                        API_CLIENT, Map.of(
                             "type", "string",
-                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of("credentials", "api_client")))))))));
+                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of(CREDENTIALS, API_CLIENT)))))))));
   }
 
   @Test
@@ -84,9 +87,9 @@ public class OAuthConfigSupplierTest {
                 .withPredicateValue("oauth")
                 .withOauthConfigSpecification(new OAuthConfigSpecification()
                     .withCompleteOauthServerOutputSpecification(Jsons.jsonNode(Map.of(
-                        "api_client", Map.of(
+                        API_CLIENT, Map.of(
                             "type", "string",
-                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of("credentials", "api_client")))))))));
+                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of(CREDENTIALS, API_CLIENT)))))))));
     final JsonNode config = generateJsonConfig();
     final UUID workspaceId = UUID.randomUUID();
     final Map<String, String> oauthParameters = generateOAuthParameters();
@@ -115,13 +118,13 @@ public class OAuthConfigSupplierTest {
         .withSpec(new ConnectorSpecification()
             .withAdvancedAuth(new AdvancedAuth()
                 .withAuthFlowType(AuthFlowType.OAUTH_2_0)
-                .withPredicateKey(List.of("credentials", "auth_type"))
+                .withPredicateKey(List.of(CREDENTIALS, "auth_type"))
                 .withPredicateValue("wrong_auth_type")
                 .withOauthConfigSpecification(new OAuthConfigSpecification()
                     .withCompleteOauthServerOutputSpecification(Jsons.jsonNode(Map.of(
-                        "api_client", Map.of(
+                        API_CLIENT, Map.of(
                             "type", "string",
-                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of("credentials", "api_client")))))))));
+                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of(CREDENTIALS, API_CLIENT)))))))));
     final JsonNode config = generateJsonConfig();
     final UUID workspaceId = UUID.randomUUID();
     final Map<String, String> oauthParameters = generateOAuthParameters();
@@ -158,7 +161,7 @@ public class OAuthConfigSupplierTest {
             .withWorkspaceId(null)
             .withConfiguration(Jsons.jsonNode(generateOAuthParameters()))));
     final JsonNode actualConfig = oAuthConfigSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
-    final JsonNode expectedConfig = getExpectedNode(oauthParameters);
+    final JsonNode expectedConfig = getExpectedNode(oauthParameters.get(API_CLIENT));
     assertEquals(expectedConfig, actualConfig);
     assertTracking(workspaceId);
   }
@@ -174,9 +177,9 @@ public class OAuthConfigSupplierTest {
                 .withAuthFlowType(AuthFlowType.OAUTH_2_0)
                 .withOauthConfigSpecification(new OAuthConfigSpecification()
                     .withCompleteOauthServerOutputSpecification(Jsons.jsonNode(Map.of(
-                        "api_client", Map.of(
+                        API_CLIENT, Map.of(
                             "type", "string",
-                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of("credentials", "api_client")))))))));
+                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of(CREDENTIALS, API_CLIENT)))))))));
     final JsonNode config = generateJsonConfig();
     final UUID workspaceId = UUID.randomUUID();
     final Map<String, String> oauthParameters = generateOAuthParameters();
@@ -192,7 +195,7 @@ public class OAuthConfigSupplierTest {
             .withWorkspaceId(null)
             .withConfiguration(Jsons.jsonNode(generateOAuthParameters()))));
     final JsonNode actualConfig = oAuthConfigSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
-    final JsonNode expectedConfig = getExpectedNode(oauthParameters);
+    final JsonNode expectedConfig = getExpectedNode(oauthParameters.get(API_CLIENT));
     assertEquals(expectedConfig, actualConfig);
     assertTracking(workspaceId);
   }
@@ -206,13 +209,13 @@ public class OAuthConfigSupplierTest {
         .withSpec(new ConnectorSpecification()
             .withAdvancedAuth(new AdvancedAuth()
                 .withAuthFlowType(AuthFlowType.OAUTH_2_0)
-                .withPredicateKey(List.of("credentials", "auth_type"))
+                .withPredicateKey(List.of(CREDENTIALS, "auth_type"))
                 .withPredicateValue("")
                 .withOauthConfigSpecification(new OAuthConfigSpecification()
                     .withCompleteOauthServerOutputSpecification(Jsons.jsonNode(Map.of(
-                        "api_client", Map.of(
+                        API_CLIENT, Map.of(
                             "type", "string",
-                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of("credentials", "api_client")))))))));
+                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of(CREDENTIALS, API_CLIENT)))))))));
     final JsonNode config = generateJsonConfig();
     final UUID workspaceId = UUID.randomUUID();
     final Map<String, String> oauthParameters = generateOAuthParameters();
@@ -228,7 +231,7 @@ public class OAuthConfigSupplierTest {
             .withWorkspaceId(null)
             .withConfiguration(Jsons.jsonNode(generateOAuthParameters()))));
     final JsonNode actualConfig = oAuthConfigSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
-    final JsonNode expectedConfig = getExpectedNode(oauthParameters);
+    final JsonNode expectedConfig = getExpectedNode(oauthParameters.get(API_CLIENT));
     assertEquals(expectedConfig, actualConfig);
     assertTracking(workspaceId);
   }
@@ -281,7 +284,59 @@ public class OAuthConfigSupplierTest {
             .withWorkspaceId(workspaceId)
             .withConfiguration(Jsons.jsonNode(oauthParameters))));
     final JsonNode actualConfig = oAuthConfigSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
-    final JsonNode expectedConfig = getExpectedNode(oauthParameters);
+    final JsonNode expectedConfig = getExpectedNode(oauthParameters.get(API_CLIENT));
+    assertEquals(expectedConfig, actualConfig);
+    assertTracking(workspaceId);
+  }
+
+  @Test
+  public void testOAuthFullInjectionBecauseNoOAuthSpecNestedParameters() throws JsonValidationException, IOException, ConfigNotFoundException {
+    // Until https://github.com/airbytehq/airbyte/issues/7624 is solved, we need to handle nested oauth parameters
+    final JsonNode config = generateJsonConfig();
+    final UUID workspaceId = UUID.randomUUID();
+    final Map<String, Object> oauthParameters = generateNestedOAuthParameters();
+    when(configRepository.getStandardSourceDefinition(any()))
+        .thenReturn(new StandardSourceDefinition()
+            .withSourceDefinitionId(sourceDefinitionId)
+            .withName("test")
+            .withDockerImageTag("dev")
+            .withSpec(null));
+    when(configRepository.listSourceOAuthParam()).thenReturn(List.of(
+        new SourceOAuthParameter()
+            .withOauthParameterId(UUID.randomUUID())
+            .withSourceDefinitionId(sourceDefinitionId)
+            .withWorkspaceId(null)
+            .withConfiguration(Jsons.jsonNode(oauthParameters))));
+    final JsonNode actualConfig = oAuthConfigSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
+    final JsonNode expectedConfig = Jsons.jsonNode(Map.of(
+        "fieldName", "fieldValue",
+        CREDENTIALS, Map.of(
+            "api_secret", "123",
+            "auth_type", "oauth",
+            API_CLIENT, ((Map<String, String>) oauthParameters.get(CREDENTIALS)).get(API_CLIENT))));
+    assertEquals(expectedConfig, actualConfig);
+    assertTracking(workspaceId);
+  }
+
+  @Test
+  public void testOAuthInjectionNestedParameters() throws JsonValidationException, IOException {
+    // Until https://github.com/airbytehq/airbyte/issues/7624 is solved, we need to handle nested oauth parameters
+    final JsonNode config = generateJsonConfig();
+    final UUID workspaceId = UUID.randomUUID();
+    final Map<String, Object> oauthParameters = generateNestedOAuthParameters();
+    when(configRepository.listSourceOAuthParam()).thenReturn(List.of(
+        new SourceOAuthParameter()
+            .withOauthParameterId(UUID.randomUUID())
+            .withSourceDefinitionId(sourceDefinitionId)
+            .withWorkspaceId(null)
+            .withConfiguration(Jsons.jsonNode(oauthParameters)),
+        new SourceOAuthParameter()
+            .withOauthParameterId(UUID.randomUUID())
+            .withSourceDefinitionId(UUID.randomUUID())
+            .withWorkspaceId(null)
+            .withConfiguration(Jsons.jsonNode(generateOAuthParameters()))));
+    final JsonNode actualConfig = oAuthConfigSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
+    final JsonNode expectedConfig = getExpectedNode((String) ((Map<String, Object>) oauthParameters.get(CREDENTIALS)).get(API_CLIENT));
     assertEquals(expectedConfig, actualConfig);
     assertTracking(workspaceId);
   }
@@ -290,7 +345,7 @@ public class OAuthConfigSupplierTest {
     return (ObjectNode) Jsons.jsonNode(
         Map.of(
             "fieldName", "fieldValue",
-            "credentials", Map.of(
+            CREDENTIALS, Map.of(
                 "api_secret", "123",
                 "auth_type", "oauth")));
   }
@@ -298,17 +353,21 @@ public class OAuthConfigSupplierTest {
   private static Map<String, String> generateOAuthParameters() {
     return Map.of(
         "api_secret", "mysecret",
-        "api_client", UUID.randomUUID().toString());
+        API_CLIENT, UUID.randomUUID().toString());
   }
 
-  private static JsonNode getExpectedNode(final Map<String, String> oauthParameters) {
+  private static Map<String, Object> generateNestedOAuthParameters() {
+    return Map.of(CREDENTIALS, generateOAuthParameters());
+  }
+
+  private static JsonNode getExpectedNode(final String apiClient) {
     return Jsons.jsonNode(
         Map.of(
             "fieldName", "fieldValue",
-            "credentials", Map.of(
+            CREDENTIALS, Map.of(
                 "api_secret", "123",
                 "auth_type", "oauth",
-                "api_client", oauthParameters.get("api_client"))));
+                API_CLIENT, apiClient)));
   }
 
   private void assertNoTracking() {

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplierTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplierTest.java
@@ -15,14 +15,16 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
 import io.airbyte.analytics.TrackingClient;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.SourceOAuthParameter;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.oauth.MoreOAuthParameters;
+import io.airbyte.protocol.models.AdvancedAuth;
+import io.airbyte.protocol.models.AdvancedAuth.AuthFlowType;
+import io.airbyte.protocol.models.ConnectorSpecification;
+import io.airbyte.protocol.models.OAuthConfigSpecification;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.List;
@@ -42,16 +44,26 @@ public class OAuthConfigSupplierTest {
   public void setup() throws JsonValidationException, ConfigNotFoundException, IOException {
     configRepository = mock(ConfigRepository.class);
     trackingClient = mock(TrackingClient.class);
-    oAuthConfigSupplier = new OAuthConfigSupplier(configRepository, false, trackingClient);
+    oAuthConfigSupplier = new OAuthConfigSupplier(configRepository, trackingClient);
     sourceDefinitionId = UUID.randomUUID();
     when(configRepository.getStandardSourceDefinition(any())).thenReturn(new StandardSourceDefinition()
         .withSourceDefinitionId(sourceDefinitionId)
         .withName("test")
-        .withDockerImageTag("dev"));
+        .withDockerImageTag("dev")
+        .withSpec(new ConnectorSpecification()
+            .withAdvancedAuth(new AdvancedAuth()
+                .withAuthFlowType(AuthFlowType.OAUTH_2_0)
+                .withPredicateKey(List.of("credentials", "auth_type"))
+                .withPredicateValue("oauth")
+                .withOauthConfigSpecification(new OAuthConfigSpecification()
+                    .withCompleteOauthServerOutputSpecification(Jsons.jsonNode(Map.of(
+                        "api_client", Map.of(
+                            "type", "string",
+                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of("credentials", "api_client")))))))));
   }
 
   @Test
-  public void testInjectEmptyOAuthParameters() throws IOException {
+  public void testNoOAuthInjectionBecauseEmptyParams() throws IOException {
     final JsonNode config = generateJsonConfig();
     final UUID workspaceId = UUID.randomUUID();
     final JsonNode actualConfig = oAuthConfigSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
@@ -60,10 +72,178 @@ public class OAuthConfigSupplierTest {
   }
 
   @Test
-  public void testInjectGlobalOAuthParameters() throws JsonValidationException, IOException {
+  public void testNoOAuthInjectionBecauseMissingPredicateKey() throws IOException, JsonValidationException, ConfigNotFoundException {
+    when(configRepository.getStandardSourceDefinition(any())).thenReturn(new StandardSourceDefinition()
+        .withSourceDefinitionId(sourceDefinitionId)
+        .withName("test")
+        .withDockerImageTag("dev")
+        .withSpec(new ConnectorSpecification()
+            .withAdvancedAuth(new AdvancedAuth()
+                .withAuthFlowType(AuthFlowType.OAUTH_2_0)
+                .withPredicateKey(List.of("some_random_fields", "auth_type"))
+                .withPredicateValue("oauth")
+                .withOauthConfigSpecification(new OAuthConfigSpecification()
+                    .withCompleteOauthServerOutputSpecification(Jsons.jsonNode(Map.of(
+                        "api_client", Map.of(
+                            "type", "string",
+                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of("credentials", "api_client")))))))));
     final JsonNode config = generateJsonConfig();
     final UUID workspaceId = UUID.randomUUID();
     final Map<String, String> oauthParameters = generateOAuthParameters();
+    when(configRepository.listSourceOAuthParam()).thenReturn(List.of(
+        new SourceOAuthParameter()
+            .withOauthParameterId(UUID.randomUUID())
+            .withSourceDefinitionId(sourceDefinitionId)
+            .withWorkspaceId(null)
+            .withConfiguration(Jsons.jsonNode(oauthParameters)),
+        new SourceOAuthParameter()
+            .withOauthParameterId(UUID.randomUUID())
+            .withSourceDefinitionId(UUID.randomUUID())
+            .withWorkspaceId(null)
+            .withConfiguration(Jsons.jsonNode(generateOAuthParameters()))));
+    final JsonNode actualConfig = oAuthConfigSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
+    assertEquals(config, actualConfig);
+    assertNoTracking();
+  }
+
+  @Test
+  public void testNoOAuthInjectionBecauseWrongPredicateValue() throws IOException, JsonValidationException, ConfigNotFoundException {
+    when(configRepository.getStandardSourceDefinition(any())).thenReturn(new StandardSourceDefinition()
+        .withSourceDefinitionId(sourceDefinitionId)
+        .withName("test")
+        .withDockerImageTag("dev")
+        .withSpec(new ConnectorSpecification()
+            .withAdvancedAuth(new AdvancedAuth()
+                .withAuthFlowType(AuthFlowType.OAUTH_2_0)
+                .withPredicateKey(List.of("credentials", "auth_type"))
+                .withPredicateValue("wrong_auth_type")
+                .withOauthConfigSpecification(new OAuthConfigSpecification()
+                    .withCompleteOauthServerOutputSpecification(Jsons.jsonNode(Map.of(
+                        "api_client", Map.of(
+                            "type", "string",
+                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of("credentials", "api_client")))))))));
+    final JsonNode config = generateJsonConfig();
+    final UUID workspaceId = UUID.randomUUID();
+    final Map<String, String> oauthParameters = generateOAuthParameters();
+    when(configRepository.listSourceOAuthParam()).thenReturn(List.of(
+        new SourceOAuthParameter()
+            .withOauthParameterId(UUID.randomUUID())
+            .withSourceDefinitionId(sourceDefinitionId)
+            .withWorkspaceId(null)
+            .withConfiguration(Jsons.jsonNode(oauthParameters)),
+        new SourceOAuthParameter()
+            .withOauthParameterId(UUID.randomUUID())
+            .withSourceDefinitionId(UUID.randomUUID())
+            .withWorkspaceId(null)
+            .withConfiguration(Jsons.jsonNode(generateOAuthParameters()))));
+    final JsonNode actualConfig = oAuthConfigSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
+    assertEquals(config, actualConfig);
+    assertNoTracking();
+  }
+
+  @Test
+  public void testOAuthInjection() throws JsonValidationException, IOException {
+    final JsonNode config = generateJsonConfig();
+    final UUID workspaceId = UUID.randomUUID();
+    final Map<String, String> oauthParameters = generateOAuthParameters();
+    when(configRepository.listSourceOAuthParam()).thenReturn(List.of(
+        new SourceOAuthParameter()
+            .withOauthParameterId(UUID.randomUUID())
+            .withSourceDefinitionId(sourceDefinitionId)
+            .withWorkspaceId(null)
+            .withConfiguration(Jsons.jsonNode(oauthParameters)),
+        new SourceOAuthParameter()
+            .withOauthParameterId(UUID.randomUUID())
+            .withSourceDefinitionId(UUID.randomUUID())
+            .withWorkspaceId(null)
+            .withConfiguration(Jsons.jsonNode(generateOAuthParameters()))));
+    final JsonNode actualConfig = oAuthConfigSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
+    final JsonNode expectedConfig = getExpectedNode(oauthParameters);
+    assertEquals(expectedConfig, actualConfig);
+    assertTracking(workspaceId);
+  }
+
+  @Test
+  public void testOAuthInjectionWithoutPredicate() throws JsonValidationException, IOException, ConfigNotFoundException {
+    when(configRepository.getStandardSourceDefinition(any())).thenReturn(new StandardSourceDefinition()
+        .withSourceDefinitionId(sourceDefinitionId)
+        .withName("test")
+        .withDockerImageTag("dev")
+        .withSpec(new ConnectorSpecification()
+            .withAdvancedAuth(new AdvancedAuth()
+                .withAuthFlowType(AuthFlowType.OAUTH_2_0)
+                .withOauthConfigSpecification(new OAuthConfigSpecification()
+                    .withCompleteOauthServerOutputSpecification(Jsons.jsonNode(Map.of(
+                        "api_client", Map.of(
+                            "type", "string",
+                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of("credentials", "api_client")))))))));
+    final JsonNode config = generateJsonConfig();
+    final UUID workspaceId = UUID.randomUUID();
+    final Map<String, String> oauthParameters = generateOAuthParameters();
+    when(configRepository.listSourceOAuthParam()).thenReturn(List.of(
+        new SourceOAuthParameter()
+            .withOauthParameterId(UUID.randomUUID())
+            .withSourceDefinitionId(sourceDefinitionId)
+            .withWorkspaceId(null)
+            .withConfiguration(Jsons.jsonNode(oauthParameters)),
+        new SourceOAuthParameter()
+            .withOauthParameterId(UUID.randomUUID())
+            .withSourceDefinitionId(UUID.randomUUID())
+            .withWorkspaceId(null)
+            .withConfiguration(Jsons.jsonNode(generateOAuthParameters()))));
+    final JsonNode actualConfig = oAuthConfigSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
+    final JsonNode expectedConfig = getExpectedNode(oauthParameters);
+    assertEquals(expectedConfig, actualConfig);
+    assertTracking(workspaceId);
+  }
+
+  @Test
+  public void testOAuthInjectionWithoutPredicateValue() throws JsonValidationException, IOException, ConfigNotFoundException {
+    when(configRepository.getStandardSourceDefinition(any())).thenReturn(new StandardSourceDefinition()
+        .withSourceDefinitionId(sourceDefinitionId)
+        .withName("test")
+        .withDockerImageTag("dev")
+        .withSpec(new ConnectorSpecification()
+            .withAdvancedAuth(new AdvancedAuth()
+                .withAuthFlowType(AuthFlowType.OAUTH_2_0)
+                .withPredicateKey(List.of("credentials", "auth_type"))
+                .withPredicateValue("")
+                .withOauthConfigSpecification(new OAuthConfigSpecification()
+                    .withCompleteOauthServerOutputSpecification(Jsons.jsonNode(Map.of(
+                        "api_client", Map.of(
+                            "type", "string",
+                            OAuthConfigSupplier.PATH_IN_CONNECTOR_CONFIG, List.of("credentials", "api_client")))))))));
+    final JsonNode config = generateJsonConfig();
+    final UUID workspaceId = UUID.randomUUID();
+    final Map<String, String> oauthParameters = generateOAuthParameters();
+    when(configRepository.listSourceOAuthParam()).thenReturn(List.of(
+        new SourceOAuthParameter()
+            .withOauthParameterId(UUID.randomUUID())
+            .withSourceDefinitionId(sourceDefinitionId)
+            .withWorkspaceId(null)
+            .withConfiguration(Jsons.jsonNode(oauthParameters)),
+        new SourceOAuthParameter()
+            .withOauthParameterId(UUID.randomUUID())
+            .withSourceDefinitionId(UUID.randomUUID())
+            .withWorkspaceId(null)
+            .withConfiguration(Jsons.jsonNode(generateOAuthParameters()))));
+    final JsonNode actualConfig = oAuthConfigSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
+    final JsonNode expectedConfig = getExpectedNode(oauthParameters);
+    assertEquals(expectedConfig, actualConfig);
+    assertTracking(workspaceId);
+  }
+
+  @Test
+  public void testOAuthFullInjectionBecauseNoOAuthSpec() throws JsonValidationException, IOException, ConfigNotFoundException {
+    final JsonNode config = generateJsonConfig();
+    final UUID workspaceId = UUID.randomUUID();
+    final Map<String, String> oauthParameters = generateOAuthParameters();
+    when(configRepository.getStandardSourceDefinition(any()))
+        .thenReturn(new StandardSourceDefinition()
+            .withSourceDefinitionId(sourceDefinitionId)
+            .withName("test")
+            .withDockerImageTag("dev")
+            .withSpec(null));
     when(configRepository.listSourceOAuthParam()).thenReturn(List.of(
         new SourceOAuthParameter()
             .withOauthParameterId(UUID.randomUUID())
@@ -81,86 +261,65 @@ public class OAuthConfigSupplierTest {
       expectedConfig.set(key, Jsons.jsonNode(oauthParameters.get(key)));
     }
     assertEquals(expectedConfig, actualConfig);
-    verify(trackingClient, times(1)).track(workspaceId, "OAuth Injection - Backend", Map.of(
-        "connector_source", "test",
-        "connector_source_definition_id", sourceDefinitionId,
-        "connector_source_version", "dev"));
+    assertTracking(workspaceId);
   }
 
   @Test
-  public void testInjectWorkspaceOAuthParameters() throws JsonValidationException, IOException {
-    final JsonNode config = generateJsonConfig();
-    final UUID workspaceId = UUID.randomUUID();
-    when(configRepository.listSourceOAuthParam()).thenReturn(List.of(
-        new SourceOAuthParameter()
-            .withOauthParameterId(UUID.randomUUID())
-            .withSourceDefinitionId(sourceDefinitionId)
-            .withWorkspaceId(null)
-            .withConfiguration(Jsons.jsonNode(generateOAuthParameters())),
-        new SourceOAuthParameter()
-            .withOauthParameterId(UUID.randomUUID())
-            .withSourceDefinitionId(sourceDefinitionId)
-            .withWorkspaceId(workspaceId)
-            .withConfiguration(Jsons.jsonNode(ImmutableMap.<String, Object>builder()
-                .put("api_secret", "my secret workspace")
-                .put("api_client", Map.of("anyOf", List.of(Map.of("id", "id"), Map.of("service", "account"))))
-                .build()))));
-    final JsonNode actualConfig = oAuthConfigSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
-    final ObjectNode expectedConfig = (ObjectNode) Jsons.clone(config);
-    expectedConfig.set("api_secret", Jsons.jsonNode("my secret workspace"));
-    expectedConfig.set("api_client", Jsons.jsonNode(Map.of("anyOf", List.of(
-        Map.of("id", "id"),
-        Map.of("service", "account")))));
-    assertEquals(expectedConfig, actualConfig);
-    verify(trackingClient, times(1)).track(workspaceId, "OAuth Injection - Backend", Map.of(
-        "connector_source", "test",
-        "connector_source_definition_id", sourceDefinitionId,
-        "connector_source_version", "dev"));
-  }
-
-  @Test
-  void testInjectMaskedOAuthParameters() throws JsonValidationException, IOException {
-    final OAuthConfigSupplier maskingSupplier = new OAuthConfigSupplier(configRepository, true, trackingClient);
-
+  public void testOAuthInjectionScopedToWorkspace() throws JsonValidationException, IOException {
     final JsonNode config = generateJsonConfig();
     final UUID workspaceId = UUID.randomUUID();
     final Map<String, String> oauthParameters = generateOAuthParameters();
     when(configRepository.listSourceOAuthParam()).thenReturn(List.of(
         new SourceOAuthParameter()
             .withOauthParameterId(UUID.randomUUID())
-            .withSourceDefinitionId(sourceDefinitionId)
-            .withWorkspaceId(null)
-            .withConfiguration(Jsons.jsonNode(oauthParameters)),
-        new SourceOAuthParameter()
-            .withOauthParameterId(UUID.randomUUID())
             .withSourceDefinitionId(UUID.randomUUID())
             .withWorkspaceId(null)
-            .withConfiguration(Jsons.jsonNode(generateOAuthParameters()))));
-    final JsonNode actualConfig = maskingSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
-    final ObjectNode expectedConfig = ((ObjectNode) Jsons.clone(config));
-    for (final String key : oauthParameters.keySet()) {
-      expectedConfig.set(key, MoreOAuthParameters.getSecretMask());
-    }
+            .withConfiguration(Jsons.jsonNode(generateOAuthParameters())),
+        new SourceOAuthParameter()
+            .withOauthParameterId(UUID.randomUUID())
+            .withSourceDefinitionId(sourceDefinitionId)
+            .withWorkspaceId(workspaceId)
+            .withConfiguration(Jsons.jsonNode(oauthParameters))));
+    final JsonNode actualConfig = oAuthConfigSupplier.injectSourceOAuthParameters(sourceDefinitionId, workspaceId, Jsons.clone(config));
+    final JsonNode expectedConfig = getExpectedNode(oauthParameters);
     assertEquals(expectedConfig, actualConfig);
-    assertNoTracking();
+    assertTracking(workspaceId);
   }
 
-  private ObjectNode generateJsonConfig() {
-    return (ObjectNode) Jsons.jsonNode(ImmutableMap.builder()
-        .put("apiSecret", "123")
-        .put("client", "testing")
-        .build());
+  private static ObjectNode generateJsonConfig() {
+    return (ObjectNode) Jsons.jsonNode(
+        Map.of(
+            "fieldName", "fieldValue",
+            "credentials", Map.of(
+                "api_secret", "123",
+                "auth_type", "oauth")));
   }
 
-  private Map<String, String> generateOAuthParameters() {
-    return ImmutableMap.<String, String>builder()
-        .put("api_secret", "mysecret")
-        .put("api_client", UUID.randomUUID().toString())
-        .build();
+  private static Map<String, String> generateOAuthParameters() {
+    return Map.of(
+        "api_secret", "mysecret",
+        "api_client", UUID.randomUUID().toString());
+  }
+
+  private static JsonNode getExpectedNode(final Map<String, String> oauthParameters) {
+    return Jsons.jsonNode(
+        Map.of(
+            "fieldName", "fieldValue",
+            "credentials", Map.of(
+                "api_secret", "123",
+                "auth_type", "oauth",
+                "api_client", oauthParameters.get("api_client"))));
   }
 
   private void assertNoTracking() {
     verify(trackingClient, times(0)).track(any(), anyString(), anyMap());
+  }
+
+  private void assertTracking(final UUID workspaceId) {
+    verify(trackingClient, times(1)).track(workspaceId, "OAuth Injection - Backend", Map.of(
+        "connector_source", "test",
+        "connector_source_definition_id", sourceDefinitionId,
+        "connector_source_version", "dev"));
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -213,7 +213,7 @@ public class ServerApp implements ServerRunnable {
     final JobTracker jobTracker = new JobTracker(configRepository, jobPersistence, trackingClient);
     final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService(configs.getTemporalHost());
     final TemporalClient temporalClient = TemporalClient.production(configs.getTemporalHost(), configs.getWorkspaceRoot());
-    final OAuthConfigSupplier oAuthConfigSupplier = new OAuthConfigSupplier(configRepository, false, trackingClient);
+    final OAuthConfigSupplier oAuthConfigSupplier = new OAuthConfigSupplier(configRepository, trackingClient);
     final SchedulerJobClient schedulerJobClient =
         new DefaultSchedulerJobClient(jobPersistence, new DefaultJobCreator(jobPersistence, configRepository));
     final DefaultSynchronousSchedulerClient syncSchedulerClient =

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -179,7 +179,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
         jobPersistence,
         jobNotifier,
         temporalService,
-        new OAuthConfigSupplier(configRepository, false, trackingClient), workerEnvironment, logConfigs);
+        new OAuthConfigSupplier(configRepository, trackingClient), workerEnvironment, logConfigs);
     final WorkspaceHelper workspaceHelper = new WorkspaceHelper(configRepository, jobPersistence);
     sourceDefinitionsHandler = new SourceDefinitionsHandler(configRepository, synchronousSchedulerClient);
     connectionsHandler = new ConnectionsHandler(configRepository, workspaceHelper, trackingClient);


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/5989

## How
- Since we removed the `webbackend/sources/create` endpoints for oauth and merge it into the `completeOAuth` ones in this [PR](https://github.com/airbytehq/airbyte/pull/7917#discussion_r748552447), we don't need to inject masked values into connector configs anymore. Therefore, the `OAuthConfigSupplier` is only used by the Scheduler at runtime to inject real OAuth credentials.
- The `OAuthConfigSupplier` injects values into the connector config by first checking oauth predicates from the `OAuthConfigSpecification` object attached to the connector's spec object. It also uses it to filter unwanted property outputs before merging them in the right location as specified by the field `path_in_connector_config`

## Recommended reading order
1. `airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplier.java`
2. the rest
