### PR TITLE
🎉  Source GitHub: PullRequestStats and Reviews streams now respects start date property

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -184,7 +184,7 @@
 - name: GitHub
   sourceDefinitionId: ef69ef6e-aa7f-4af1-a01d-ef775033524e
   dockerRepository: airbyte/source-github
-  dockerImageTag: 0.2.5
+  dockerImageTag: 0.2.6
   documentationUrl: https://docs.airbyte.io/integrations/sources/github
   icon: github.svg
   sourceType: api

--- a/airbyte-integrations/connectors/source-github/Dockerfile
+++ b/airbyte-integrations/connectors/source-github/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.5
+LABEL io.airbyte.version=0.2.6
 LABEL io.airbyte.name=airbyte/source-github

--- a/airbyte-integrations/connectors/source-github/source_github/source.py
+++ b/airbyte-integrations/connectors/source-github/source_github/source.py
@@ -153,37 +153,39 @@ class SourceGithub(AbstractSource):
         repositories = repos + organization_repos
 
         organizations = list({org.split("/")[0] for org in repositories})
-        full_refresh_args = {"authenticator": authenticator, "repositories": repositories}
-        incremental_args = {**full_refresh_args, "start_date": config["start_date"]}
+
         organization_args = {"authenticator": authenticator, "organizations": organizations}
-        default_branches, branches_to_pull = self._get_branches_data(config.get("branch", ""), full_refresh_args)
+        repository_args = {"authenticator": authenticator, "repositories": repositories}
+        repository_from_date_args = {**repository_args, "start_date": config["start_date"]}
+
+        default_branches, branches_to_pull = self._get_branches_data(config.get("branch", ""), repository_args)
 
         return [
-            Assignees(**full_refresh_args),
-            Branches(**full_refresh_args),
-            Collaborators(**full_refresh_args),
-            Comments(**incremental_args),
-            CommitCommentReactions(**incremental_args),
-            CommitComments(**incremental_args),
-            Commits(**incremental_args, branches_to_pull=branches_to_pull, default_branches=default_branches),
-            Events(**incremental_args),
-            IssueCommentReactions(**incremental_args),
-            IssueEvents(**incremental_args),
-            IssueLabels(**full_refresh_args),
-            IssueMilestones(**incremental_args),
-            IssueReactions(**incremental_args),
-            Issues(**incremental_args),
+            Assignees(**repository_args),
+            Branches(**repository_args),
+            Collaborators(**repository_args),
+            Comments(**repository_from_date_args),
+            CommitCommentReactions(**repository_from_date_args),
+            CommitComments(**repository_from_date_args),
+            Commits(**repository_from_date_args, branches_to_pull=branches_to_pull, default_branches=default_branches),
+            Events(**repository_from_date_args),
+            IssueCommentReactions(**repository_from_date_args),
+            IssueEvents(**repository_from_date_args),
+            IssueLabels(**repository_args),
+            IssueMilestones(**repository_from_date_args),
+            IssueReactions(**repository_from_date_args),
+            Issues(**repository_from_date_args),
             Organizations(**organization_args),
-            Projects(**incremental_args),
-            PullRequestCommentReactions(**incremental_args),
-            PullRequestStats(**full_refresh_args),
-            PullRequests(**incremental_args),
-            Releases(**incremental_args),
+            Projects(**repository_from_date_args),
+            PullRequestCommentReactions(**repository_from_date_args),
+            PullRequestStats(PullRequests(**repository_from_date_args), **repository_args),
+            PullRequests(**repository_from_date_args),
+            Releases(**repository_from_date_args),
             Repositories(**organization_args),
-            ReviewComments(**incremental_args),
-            Reviews(**full_refresh_args),
-            Stargazers(**incremental_args),
-            Tags(**full_refresh_args),
+            ReviewComments(**repository_from_date_args),
+            Reviews(PullRequests(**repository_from_date_args), **repository_args),
+            Stargazers(**repository_from_date_args),
+            Tags(**repository_args),
             Teams(**organization_args),
             Users(**organization_args),
         ]

--- a/airbyte-integrations/connectors/source-github/source_github/source.py
+++ b/airbyte-integrations/connectors/source-github/source_github/source.py
@@ -156,35 +156,36 @@ class SourceGithub(AbstractSource):
 
         organization_args = {"authenticator": authenticator, "organizations": organizations}
         repository_args = {"authenticator": authenticator, "repositories": repositories}
-        repository_from_date_args = {**repository_args, "start_date": config["start_date"]}
+        repository_args_with_start_date = {**repository_args, "start_date": config["start_date"]}
 
         default_branches, branches_to_pull = self._get_branches_data(config.get("branch", ""), repository_args)
+        pull_requests_stream = PullRequests(**repository_args_with_start_date)
 
         return [
             Assignees(**repository_args),
             Branches(**repository_args),
             Collaborators(**repository_args),
-            Comments(**repository_from_date_args),
-            CommitCommentReactions(**repository_from_date_args),
-            CommitComments(**repository_from_date_args),
-            Commits(**repository_from_date_args, branches_to_pull=branches_to_pull, default_branches=default_branches),
-            Events(**repository_from_date_args),
-            IssueCommentReactions(**repository_from_date_args),
-            IssueEvents(**repository_from_date_args),
+            Comments(**repository_args_with_start_date),
+            CommitCommentReactions(**repository_args_with_start_date),
+            CommitComments(**repository_args_with_start_date),
+            Commits(**repository_args_with_start_date, branches_to_pull=branches_to_pull, default_branches=default_branches),
+            Events(**repository_args_with_start_date),
+            IssueCommentReactions(**repository_args_with_start_date),
+            IssueEvents(**repository_args_with_start_date),
             IssueLabels(**repository_args),
-            IssueMilestones(**repository_from_date_args),
-            IssueReactions(**repository_from_date_args),
-            Issues(**repository_from_date_args),
+            IssueMilestones(**repository_args_with_start_date),
+            IssueReactions(**repository_args_with_start_date),
+            Issues(**repository_args_with_start_date),
             Organizations(**organization_args),
-            Projects(**repository_from_date_args),
-            PullRequestCommentReactions(**repository_from_date_args),
-            PullRequestStats(PullRequests(**repository_from_date_args), **repository_args),
-            PullRequests(**repository_from_date_args),
-            Releases(**repository_from_date_args),
+            Projects(**repository_args_with_start_date),
+            PullRequestCommentReactions(**repository_args_with_start_date),
+            PullRequestStats(parent=pull_requests_stream, **repository_args),
+            PullRequests(**repository_args_with_start_date),
+            Releases(**repository_args_with_start_date),
             Repositories(**organization_args),
-            ReviewComments(**repository_from_date_args),
-            Reviews(PullRequests(**repository_from_date_args), **repository_args),
-            Stargazers(**repository_from_date_args),
+            ReviewComments(**repository_args_with_start_date),
+            Reviews(parent=pull_requests_stream, **repository_args),
+            Stargazers(**repository_args_with_start_date),
             Tags(**repository_args),
             Teams(**organization_args),
             Users(**organization_args),

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -92,6 +92,7 @@ Your token should have at least the `repo` scope. Depending on which streams you
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.2.6 | 2021-11-24 | [8030](https://github.com/airbytehq/airbyte/pull/8030) | Support start date property for PullRequestStats and Reviews streams |
 | 0.2.5 | 2021-11-21 | [8170](https://github.com/airbytehq/airbyte/pull/8170) | Fix slow check connection for organizations with a lot of repos |
 | 0.2.4 | 2021-11-11 | [7856](https://github.com/airbytehq/airbyte/pull/7856) | Resolve $ref fields in some stream schemas |
 | 0.2.3 | 2021-10-06 | [6833](https://github.com/airbytehq/airbyte/pull/6833) | Fix config backward compatability |


### PR DESCRIPTION
## What
Closes #7866 

## How
`PullRequestStats` and `Reviews` streams are now defined as `PullRequest` substreams, by inheriting from `HttpSubStream` via `PullRequestSubstream` classes.

This ensures that the `start_date` property, part of the configuration of the `PullRequest` stream, is considered. Consequently, the `start_date` also applies to the substreams, since their `stream_slices` are derived from their parent stream.

## Recommended reading order
1. `streams.py`
2. `source.py`

## 🚨 User Impact 🚨
If `start_date` is defined, `PullRequestStats` and `Reviews` streams only refresh from that date, instead of refreshing all before.

## Pre-merge Checklist

<p>
   
#### Community member or Airbyter
   
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>