### PR TITLE
Stop using gentle close with heartbeat

### DIFF
--- a/airbyte-integrations/connectors/destination-e2e-test/src/main/java/io/airbyte/integrations/destination/e2e_test/FailAfterNDestination.java
+++ b/airbyte-integrations/connectors/destination-e2e-test/src/main/java/io/airbyte/integrations/destination/e2e_test/FailAfterNDestination.java
@@ -1,0 +1,69 @@
+package io.airbyte.integrations.destination.e2e_test;
+
+import static java.lang.Thread.sleep;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.integrations.BaseConnector;
+import io.airbyte.integrations.base.AirbyteMessageConsumer;
+import io.airbyte.integrations.base.Destination;
+import io.airbyte.protocol.models.AirbyteConnectionStatus;
+import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
+import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteMessage.Type;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FailAfterNDestination extends BaseConnector implements Destination {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(FailAfterNDestination.class);
+
+  @Override
+  public AirbyteConnectionStatus check(final JsonNode config) {
+    return new AirbyteConnectionStatus().withStatus(Status.SUCCEEDED);
+  }
+
+  @Override
+  public AirbyteMessageConsumer getConsumer(final JsonNode config,
+      final ConfiguredAirbyteCatalog catalog,
+      final Consumer<AirbyteMessage> outputRecordCollector) {
+    return new FailAfterNConsumer(config.get("num_messages").asLong(), outputRecordCollector);
+  }
+
+  public static class FailAfterNConsumer implements AirbyteMessageConsumer {
+
+    private final Consumer<AirbyteMessage> outputRecordCollector;
+    private final long numMessagesAfterWhichToFail;
+    private long numMessagesSoFar;
+
+    public FailAfterNConsumer(final long numMessagesAfterWhichToFail, final Consumer<AirbyteMessage> outputRecordCollector) {
+      this.numMessagesAfterWhichToFail = numMessagesAfterWhichToFail;
+      this.outputRecordCollector = outputRecordCollector;
+      this.numMessagesSoFar = 0;
+    }
+
+    @Override
+    public void start() {}
+
+    @Override
+    public void accept(final AirbyteMessage message) throws Exception {
+      LOGGER.info("received record: {}", message);
+      numMessagesSoFar += 1;
+      LOGGER.info("received {} messages so far", numMessagesSoFar);
+
+      if (numMessagesSoFar > numMessagesAfterWhichToFail) {
+        throw new IllegalStateException("Forcing a fail after processing " + numMessagesAfterWhichToFail + " messages.");
+      }
+
+      if (message.getType() == Type.STATE) {
+        LOGGER.info("emitting state: {}", message);
+        outputRecordCollector.accept(message);
+      }
+    }
+
+    @Override
+    public void close() {}
+
+  }
+}

--- a/airbyte-integrations/connectors/destination-e2e-test/src/main/java/io/airbyte/integrations/destination/e2e_test/TestingDestinations.java
+++ b/airbyte-integrations/connectors/destination-e2e-test/src/main/java/io/airbyte/integrations/destination/e2e_test/TestingDestinations.java
@@ -27,7 +27,8 @@ public class TestingDestinations extends BaseConnector implements Destination {
   public enum TestDestinationType {
     LOGGING,
     THROTTLED,
-    SILENT
+    SILENT,
+    FAILING
   }
 
   public TestingDestinations() {
@@ -35,6 +36,7 @@ public class TestingDestinations extends BaseConnector implements Destination {
         .put(TestDestinationType.LOGGING, new LoggingDestination())
         .put(TestDestinationType.THROTTLED, new ThrottledDestination())
         .put(TestDestinationType.SILENT, new SilentDestination())
+        .put(TestDestinationType.FAILING, new FailAfterNDestination())
         .build());
   }
 

--- a/airbyte-integrations/connectors/destination-e2e-test/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-e2e-test/src/main/resources/spec.json
@@ -48,6 +48,22 @@
             "type": "integer"
           }
         }
+      },
+      {
+        "title": "Failing",
+        "required": ["type", "num_messages"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "FAILING",
+            "default": "FAILING"
+          },
+          "num_messages": {
+            "description": "Number of messages after which to fail.",
+            "type": "integer"
+          }
+        }
       }
     ]
   }

--- a/airbyte-integrations/connectors/source-e2e-test/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-e2e-test/src/main/resources/spec.json
@@ -24,7 +24,7 @@
       },
       {
         "title": "Infinite Feed",
-        "required": ["type", "max_records"],
+        "required": ["type", "max_records", "message_interval"],
         "additionalProperties": false,
         "properties": {
           "type": {
@@ -35,6 +35,11 @@
           "max_records": {
             "title": "Max Records",
             "description": "Number of records to emit. If not set, defaults to infinity.",
+            "type": "integer"
+          },
+          "message_interval": {
+            "title": "Message Interval",
+            "description": "Interval between messages in ms.",
             "type": "integer"
           }
         }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -59,7 +59,7 @@ public class WorkerUtils {
     }
 
     if (process.isAlive()) {
-      forceShutdown(process, Duration.of(1, ChronoUnit.MINUTES));
+      closeProcess(process, Duration.of(1, ChronoUnit.MINUTES));
     }
   }
 
@@ -90,7 +90,7 @@ public class WorkerUtils {
         gracefulShutdownDuration,
         checkHeartbeatDuration,
         forcedShutdownDuration,
-        WorkerUtils::forceShutdown);
+        WorkerUtils::closeProcess);
   }
 
   @VisibleForTesting
@@ -134,28 +134,15 @@ public class WorkerUtils {
     }
   }
 
-  @VisibleForTesting
-  static void forceShutdown(final Process process, final Duration lastChanceDuration) {
-    LOGGER.warn("Process is taking too long to finish. Killing it");
-    process.destroy();
-    try {
-      process.waitFor(lastChanceDuration.toMillis(), TimeUnit.MILLISECONDS);
-    } catch (final InterruptedException e) {
-      LOGGER.error("Exception while while killing the process", e);
-    }
-    if (process.isAlive()) {
-      LOGGER.error("Couldn't kill the process. You might have a zombie process.");
-    }
-  }
-
-  public static void closeProcess(final Process process, final int duration, final TimeUnit timeUnit) {
+  public static void closeProcess(final Process process, final Duration lastChanceDuration) {
     if (process == null) {
       return;
     }
     try {
       process.destroy();
-      process.waitFor(duration, timeUnit);
+      process.waitFor(lastChanceDuration.toMillis(), TimeUnit.MILLISECONDS);
       if (process.isAlive()) {
+        LOGGER.warn("Process is still alive after calling destroy. Attempting to destroy forcibly...");
         process.destroyForcibly();
       }
     } catch (final InterruptedException e) {
@@ -172,7 +159,7 @@ public class WorkerUtils {
   }
 
   public static void cancelProcess(final Process process) {
-    closeProcess(process, 10, TimeUnit.SECONDS);
+    closeProcess(process, Duration.of(10, ChronoUnit.SECONDS));
   }
 
   /**

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -107,7 +107,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
     }
 
     LOGGER.debug("Closing destination process");
-    WorkerUtils.gentleClose(destinationProcess, 10, TimeUnit.HOURS);
+    WorkerUtils.gentleClose(destinationProcess, 1, TimeUnit.MINUTES);
     if (destinationProcess.isAlive() || destinationProcess.exitValue() != 0) {
       final String message =
           destinationProcess.isAlive() ? "Destination has not terminated " : "Destination process exit with code " + destinationProcess.exitValue();


### PR DESCRIPTION
Resolves https://github.com/airbytehq/oncall/issues/15 

Currently, when a destination fails it causes `close()` to be called on the source and destination. However, the current implementation of this waits until the source process finishes its heartbeats, and then has an extremely long wait time (10 hours) before actually destroying the process, which makes the sync appear to hang during this time.

This PR solves the issue by removing the heartbeat check (this wasn't really useful anyway, as heartbeats were only listened to once the process was trying to be closed due to a finished job or error), and lowering the wait time to close the process from 10 hours to 1 minute.

I have tested this out locally using the e2e connectors that this PR adds, and it causes the source process to correctly be promptly closed once after the destination process fails.

Planning to add an acceptance test for this case in a separate PR, as the test will likely take multiple minutes to run and we therefore might not want to add it until we have proper asynchronous testing in place.