### PR TITLE
Treat oauthFlowInitParameters just as hidden

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/useBuildForm.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/useBuildForm.tsx
@@ -33,7 +33,8 @@ function useBuildInitialSchema(
           (schema as any).is_auth = true;
           const schemaWithoutPaths = removeNestedPaths(
             schema,
-            spec.oauthFlowInitParameters ?? []
+            spec.oauthFlowInitParameters ?? [],
+            false
           );
 
           const schemaWithoutOutputPats = removeNestedPaths(


### PR DESCRIPTION

## What
Fixes #7864 

## How
Treats `oauthFlowInitParameters` as hidden instead of totally removing them from spec. 

Based on the reply from @ChristopheDuong https://github.com/airbytehq/airbyte/issues/7864#issuecomment-971909733 from now we could assume that `oauthFlowOutputParametersand` will always include `oauthFlowInitParameters`
