### PR TITLE
Make the jaffle shop example repository more clear in the transformation docs.

### DIFF
--- a/docs/operator-guides/transformation-and-normalization/transformations-with-airbyte.md
+++ b/docs/operator-guides/transformation-and-normalization/transformations-with-airbyte.md
@@ -18,7 +18,9 @@ After replication of data from a source connector \(Extract\) to a destination c
 
 ## Public Git repository
 
-In the connection settings page, I can add new Transformations steps to apply after [normalization](../../understanding-airbyte/basic-normalization.md). For example, I want to run my custom dbt project [jaffle\_shop](https://github.com/fishtown-analytics/jaffle_shop), whenever my sync is done replicating and normalizing my data.
+In the connection settings page, I can add new Transformations steps to apply after [normalization](../../understanding-airbyte/basic-normalization.md). For example, I want to run my custom dbt project jaffle_shop, whenever my sync is done replicating and normalizing my data.
+
+You can find the jaffle shop test repository by clicking [here](https://github.com/dbt-labs/jaffle_shop).
 
 ![](../../.gitbook/assets/custom-dbt-transformations-seed.png)
 


### PR DESCRIPTION
## Main Changes
We had some users not sure where to find an example dbt repository. This is due to the fact that GitBook links are no longer underlined or clearly colored, leading to them being missed.

I've tried to make this link very clear to make sure we get people landing on the page.