### PR TITLE
fix first sync check NPE 

### DIFF
--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/JobSubmitter.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/JobSubmitter.java
@@ -144,7 +144,7 @@ public class JobSubmitter implements Runnable {
               final String connectionId = job.getScope();
               final StandardWorkspace workspace = configRepository.getStandardWorkspaceFromConnection(UUID.fromString(connectionId), false);
 
-              if (!workspace.getFirstCompletedSync()) {
+              if (workspace.getFirstCompletedSync() == null || !workspace.getFirstCompletedSync()) {
                 workspace.setFirstCompletedSync(true);
                 configRepository.writeStandardWorkspace(workspace);
               }


### PR DESCRIPTION
At the end of my successful sync with a workspace that was created before https://github.com/airbytehq/airbyte/pull/7832, I get:
```
java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "io.airbyte.config.StandardWorkspace.getFirstCompletedSync()" is null
	at io.airbyte.scheduler.app.JobSubmitter.lambda$submitJob$2(JobSubmitter.java:147) ~[io.airbyte.airbyte-scheduler-app-0.32.2-alpha.jar:?]
	at io.airbyte.commons.concurrency.LifecycledCallable.onSuccess(LifecycledCallable.java:99) [io.airbyte-airbyte-commons-0.32.2-alpha.jar:?]
	at io.airbyte.commons.concurrency.LifecycledCallable.call(LifecycledCallable.java:79) [io.airbyte-airbyte-commons-0.32.2-alpha.jar:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
```

This isn't _that_ terrible since it doesn't actually break the sync.