### PR TITLE
DAT destination acceptance tests & custom dbt transformations

### DIFF
--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -714,15 +714,17 @@ public abstract class DestinationAcceptanceTest {
 
   @Test
   public void testCustomDbtTransformations() throws Exception {
-    if (!normalizationFromSpec() || !dbtFromSpec()) {
-      // we require normalization implementation for this destination, because we make sure to install
-      // required dbt dependency in the normalization docker image in order to run this test successfully
-      // (we don't actually rely on normalization running anything here though)
+    if (!dbtFromSpec()) {
       return;
     }
 
     final JsonNode config = getConfig();
 
+    // This may throw IllegalStateException "Requesting normalization, but it is not included in the normalization mappings"
+    // We indeed require normalization implementation of the 'transform_config' function for this destination,
+    // because we make sure to install required dbt dependency in the normalization docker image in order to run
+    // this test successfully and that we are able to convert a destination 'config.json' into a dbt 'profiles.yml'
+    // (we don't actually rely on normalization running anything else here though)
     final DbtTransformationRunner runner = new DbtTransformationRunner(processFactory, NormalizationRunnerFactory.create(
         getImageName(),
         processFactory));

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -720,10 +720,14 @@ public abstract class DestinationAcceptanceTest {
 
     final JsonNode config = getConfig();
 
-    // This may throw IllegalStateException "Requesting normalization, but it is not included in the normalization mappings"
-    // We indeed require normalization implementation of the 'transform_config' function for this destination,
-    // because we make sure to install required dbt dependency in the normalization docker image in order to run
-    // this test successfully and that we are able to convert a destination 'config.json' into a dbt 'profiles.yml'
+    // This may throw IllegalStateException "Requesting normalization, but it is not included in the
+    // normalization mappings"
+    // We indeed require normalization implementation of the 'transform_config' function for this
+    // destination,
+    // because we make sure to install required dbt dependency in the normalization docker image in
+    // order to run
+    // this test successfully and that we are able to convert a destination 'config.json' into a dbt
+    // 'profiles.yml'
     // (we don't actually rely on normalization running anything else here though)
     final DbtTransformationRunner runner = new DbtTransformationRunner(processFactory, NormalizationRunnerFactory.create(
         getImageName(),

--- a/airbyte-integrations/connectors/source-youtube-analytics/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-youtube-analytics/integration_tests/configured_catalog.json
@@ -4,10 +4,7 @@
       "stream": {
         "name": "channel_annotations_a1",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -16,10 +13,7 @@
       "stream": {
         "name": "channel_basic_a2",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -28,10 +22,7 @@
       "stream": {
         "name": "channel_cards_a1",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -40,10 +31,7 @@
       "stream": {
         "name": "channel_combined_a2",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -52,10 +40,7 @@
       "stream": {
         "name": "channel_demographics_a1",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -64,10 +49,7 @@
       "stream": {
         "name": "channel_device_os_a2",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -76,10 +58,7 @@
       "stream": {
         "name": "channel_end_screens_a1",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -88,10 +67,7 @@
       "stream": {
         "name": "channel_playback_location_a2",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -100,10 +76,7 @@
       "stream": {
         "name": "channel_province_a2",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -112,10 +85,7 @@
       "stream": {
         "name": "channel_sharing_service_a1",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -124,10 +94,7 @@
       "stream": {
         "name": "channel_subtitles_a2",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -136,10 +103,7 @@
       "stream": {
         "name": "channel_traffic_source_a2",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -148,10 +112,7 @@
       "stream": {
         "name": "playlist_basic_a1",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -160,10 +121,7 @@
       "stream": {
         "name": "playlist_combined_a1",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -172,10 +130,7 @@
       "stream": {
         "name": "playlist_device_os_a1",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -184,10 +139,7 @@
       "stream": {
         "name": "playlist_playback_location_a1",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -196,10 +148,7 @@
       "stream": {
         "name": "playlist_province_a1",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -208,10 +157,7 @@
       "stream": {
         "name": "playlist_traffic_source_a1",
         "json_schema": {},
-        "supported_sync_modes": [
-          "full_refresh",
-          "incremental"
-        ]
+        "supported_sync_modes": ["full_refresh", "incremental"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"

--- a/airbyte-integrations/connectors/source-youtube-analytics/integration_tests/invalid_config.json
+++ b/airbyte-integrations/connectors/source-youtube-analytics/integration_tests/invalid_config.json
@@ -1,7 +1,7 @@
 {
-    "credentials": {
-        "client_id": "client_id",
-        "client_secret": "client_secret",
-        "refresh_token": "refresh_token"
-    }
+  "credentials": {
+    "client_id": "client_id",
+    "client_secret": "client_secret",
+    "refresh_token": "refresh_token"
+  }
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
@@ -18,6 +18,8 @@ public class NormalizationRunnerFactory {
   static final Map<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>> NORMALIZATION_MAPPING =
       ImmutableMap.<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>>builder()
           .put("airbyte/destination-bigquery", ImmutablePair.of(BASE_NORMALIZATION_IMAGE_NAME, DefaultNormalizationRunner.DestinationType.BIGQUERY))
+          .put("airbyte/destination-bigquery-denormalized",
+              ImmutablePair.of(BASE_NORMALIZATION_IMAGE_NAME, DefaultNormalizationRunner.DestinationType.BIGQUERY))
           .put("airbyte/destination-mssql", ImmutablePair.of("airbyte/normalization-mssql", DestinationType.MSSQL))
           .put("airbyte/destination-mssql-strict-encrypt", ImmutablePair.of("airbyte/normalization-mssql", DestinationType.MSSQL))
           .put("airbyte/destination-mysql", ImmutablePair.of("airbyte/normalization-mysql", DestinationType.MYSQL))


### PR DESCRIPTION
## What
A destination that supports custom DBT transformations doesn't necessarily need to fully support normalization
(only transform_config part)

For example, BigQuery denormalized does not need normalization, but it should still be possible to run extra custom dbt transformations afterward (to do your BI transformations for example).

## How
Remove the check in the destination tests

## Context
See https://airbytehq.slack.com/archives/C01MFR03D5W/p1636199699220900

## Recommended reading order
1. `x.java`
2. `y.python`
