### PR TITLE
Output run time per stream

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/utils/event_timing.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/event_timing.py
@@ -6,7 +6,8 @@ import datetime
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from base_python.logger import AirbyteLogger
+
+from airbyte_cdk.logger import AirbyteLogger
 
 logger = AirbyteLogger()
 

--- a/airbyte-cdk/python/unit_tests/test_counter.py
+++ b/airbyte-cdk/python/unit_tests/test_counter.py
@@ -1,9 +1,11 @@
 #
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
+
+
 from unittest import mock
 
-from base_python.cdk.utils.event_timing import create_timer
+from airbyte_cdk.utils.event_timing import create_timer
 
 
 def test_counter_init():
@@ -13,14 +15,14 @@ def test_counter_init():
 
 def test_counter_start_event():
     with create_timer("Counter") as timer:
-        with mock.patch("base_python.cdk.utils.event_timing.EventTimer.start_event") as mock_start_event:
+        with mock.patch("airbyte_cdk.utils.event_timing.EventTimer.start_event") as mock_start_event:
             timer.start_event("test_event")
             mock_start_event.assert_called_with("test_event")
 
 
 def test_counter_finish_event():
     with create_timer("Counter") as timer:
-        with mock.patch("base_python.cdk.utils.event_timing.EventTimer.finish_event") as mock_finish_event:
+        with mock.patch("airbyte_cdk.utils.event_timing.EventTimer.finish_event") as mock_finish_event:
             timer.finish_event("test_event")
             mock_finish_event.assert_called_with("test_event")
 
@@ -51,4 +53,3 @@ def test_double_finish_is_safely_ignored():
         timer.finish_event()
         timer.finish_event()
         assert timer.count == 1
-

--- a/airbyte-integrations/bases/base-python/base_python/cdk/abstract_source.py
+++ b/airbyte-integrations/bases/base-python/base_python/cdk/abstract_source.py
@@ -80,24 +80,23 @@ class AbstractSource(Source, ABC):
         # get the streams once in case the connector needs to make any queries to generate them
         stream_instances = {s.name: s for s in self.streams(config)}
         with create_timer(self.name) as timer:
-            try:
-                for configured_stream in catalog.streams:
-                    try:
-                        stream_instance = stream_instances[configured_stream.stream.name]
-                        timer.start_event(configured_stream.stream.name)
-                        yield from self._read_stream(
-                            logger=logger,
-                            stream_instance=stream_instance,
-                            configured_stream=configured_stream,
-                            connector_state=connector_state,
-                        )
-                        timer.end_event()
-                    except Exception as e:
-                        logger.exception(f"Encountered an exception while reading stream {self.name}")
-                        raise e
-            finally:
-                logger.info(f"Finished syncing {self.name}")
-                logger.info(timer.report())
+            for configured_stream in catalog.streams:
+                try:
+                    stream_instance = stream_instances[configured_stream.stream.name]
+                    timer.start_event(configured_stream.stream.name)
+                    yield from self._read_stream(
+                        logger=logger,
+                        stream_instance=stream_instance,
+                        configured_stream=configured_stream,
+                        connector_state=connector_state,
+                    )
+                    timer.end_event()
+                except Exception as e:
+                    logger.exception(f"Encountered an exception while reading stream {self.name}")
+                    raise e
+                finally:
+                    logger.info(f"Finished syncing {self.name}")
+                    logger.info(timer.report())
 
         logger.info(f"Finished syncing {self.name}")
 

--- a/airbyte-integrations/bases/base-python/base_python/cdk/abstract_source.py
+++ b/airbyte-integrations/bases/base-python/base_python/cdk/abstract_source.py
@@ -21,6 +21,7 @@ from airbyte_protocol import (
 )
 from airbyte_protocol import Type as MessageType
 from base_python.cdk.streams.core import Stream
+from base_python.cdk.utils.event_timing import EventTimer
 from base_python.integration import Source
 from base_python.logger import AirbyteLogger
 
@@ -78,15 +79,25 @@ class AbstractSource(Source, ABC):
         # TODO assert all streams exist in the connector
         # get the streams once in case the connector needs to make any queries to generate them
         stream_instances = {s.name: s for s in self.streams(config)}
-        for configured_stream in catalog.streams:
+        with EventTimer(self.name) as timer:
             try:
-                stream_instance = stream_instances[configured_stream.stream.name]
-                yield from self._read_stream(
-                    logger=logger, stream_instance=stream_instance, configured_stream=configured_stream, connector_state=connector_state
-                )
-            except Exception as e:
-                logger.exception(f"Encountered an exception while reading stream {self.name}")
-                raise e
+                for configured_stream in catalog.streams:
+                    try:
+                        stream_instance = stream_instances[configured_stream.stream.name]
+                        timer.start_event(configured_stream.stream.name)
+                        yield from self._read_stream(
+                            logger=logger,
+                            stream_instance=stream_instance,
+                            configured_stream=configured_stream,
+                            connector_state=connector_state,
+                        )
+                        timer.end_event()
+                    except Exception as e:
+                        logger.exception(f"Encountered an exception while reading stream {self.name}")
+                        raise e
+            finally:
+                logger.info(f"Finished syncing {self.name}")
+                logger.info(timer.report())
 
         logger.info(f"Finished syncing {self.name}")
 

--- a/airbyte-integrations/bases/base-python/base_python/cdk/abstract_source.py
+++ b/airbyte-integrations/bases/base-python/base_python/cdk/abstract_source.py
@@ -21,7 +21,7 @@ from airbyte_protocol import (
 )
 from airbyte_protocol import Type as MessageType
 from base_python.cdk.streams.core import Stream
-from base_python.cdk.utils.event_timing import EventTimer
+from base_python.cdk.utils.event_timing import create_timer
 from base_python.integration import Source
 from base_python.logger import AirbyteLogger
 
@@ -79,7 +79,7 @@ class AbstractSource(Source, ABC):
         # TODO assert all streams exist in the connector
         # get the streams once in case the connector needs to make any queries to generate them
         stream_instances = {s.name: s for s in self.streams(config)}
-        with EventTimer(self.name) as timer:
+        with create_timer(self.name) as timer:
             try:
                 for configured_stream in catalog.streams:
                     try:

--- a/airbyte-integrations/bases/base-python/base_python/cdk/utils/event_timing.py
+++ b/airbyte-integrations/bases/base-python/base_python/cdk/utils/event_timing.py
@@ -1,0 +1,97 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+import datetime
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from threading import Lock, local
+
+from base_python.logger import AirbyteLogger
+
+logger = AirbyteLogger()
+
+
+class EventTimer:
+    """Simple nanosecond resolution event timer for debugging, initially intended to be used to record streams execution
+    time for a source.
+       As it is likely that streams could be read in parallel, we use a thread local storage to store the
+       stack of events and thus keep track of the current event.
+       Event nesting follows a LIFO pattern, so finish will apply to the last started event.
+    """
+
+    thread_local = local()
+
+    def __init__(self, name):
+        self.name = name
+        self.events = {}
+        self.count = 0
+        EventTimer.thread_local.stack = []
+        self.stack = EventTimer.thread_local.stack
+        self.lock = Lock()
+
+    def start_event(self, name):
+        """
+        Start a new event and push it to the stack.
+        """
+        self.lock.acquire()
+        self.events[name] = Event(name=name)
+        self.count += 1
+        self.lock.release()
+        self.stack.insert(0, self.events[name])
+
+    def finish_event(self):
+        """
+        Finish the current event and pop it from the stack.
+        """
+        self.lock.acquire()
+        if self.stack:
+            event = self.stack.pop(0)
+            event.finish()
+        else:
+            logger.warn(f"{self.name} finish_event called without start_event")
+        self.lock.release()
+
+    def report(self, order_by="name"):
+        """
+        :param order_by: 'name' or 'duration'
+        """
+        if order_by == "name":
+            events = sorted(self.events.values(), key=lambda event: event.name)
+        elif order_by == "duration":
+            events = sorted(self.events.values(), key=lambda event: event.duration)
+        self.lock.acquire()
+        text = f"{self.name} runtimes:\n"
+        text += "\n".join(str(event) for event in events)
+        self.lock.release()
+        return text
+
+
+@dataclass
+class Event:
+    name: str
+    start: float = field(default_factory=time.perf_counter_ns)
+    end: float = field(default=None)
+
+    @property
+    def duration(self) -> float:
+        """Returns the elapsed time in seconds or positive infinity if event was never finished"""
+        if self.end:
+            return (self.end - self.start) / 1e9
+        return float("+inf")
+
+    def __str__(self):
+        return f"{self.name} {datetime.timedelta(seconds=self.duration)}"
+
+    def finish(self):
+        self.end = time.perf_counter_ns()
+
+
+@contextmanager
+def create_timer(name):
+    """
+    Creates a new EventTimer as a context manager to improve code readability.
+    """
+    a_timer = EventTimer(name)
+    yield a_timer

--- a/airbyte-integrations/bases/base-python/base_python/cdk/utils/event_timing.py
+++ b/airbyte-integrations/bases/base-python/base_python/cdk/utils/event_timing.py
@@ -6,6 +6,7 @@ import datetime
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+
 from base_python.logger import AirbyteLogger
 
 logger = AirbyteLogger()

--- a/airbyte-integrations/bases/base-python/unit_tests/test_counter.py
+++ b/airbyte-integrations/bases/base-python/unit_tests/test_counter.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
+
 from unittest import mock
 
 from base_python.cdk.utils.event_timing import create_timer
@@ -51,4 +52,3 @@ def test_double_finish_is_safely_ignored():
         timer.finish_event()
         timer.finish_event()
         assert timer.count == 1
-


### PR DESCRIPTION
## What
Fixes #7965 
## How
An EventTimer class is introduced along with a context manager. Due to the possibility that streams could be run in parallell in the future, care has been taken to ensure EventTimer is thread safe


## Recommended reading order
1. `abstract_source.py`
2. `event_timing.py`

## 🚨 User Impact 🚨
Connectors need to rebuilt for change to be reflected 

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> New Connector </strong></summary>
<p>

#### Community member or Airbyter
   
- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [Y ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
</p>
</details>


<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>
</details>

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
