### PR TITLE
Source Trello: enable specifying board ids in configuration

### DIFF
--- a/airbyte-integrations/connectors/source-trello/source_trello/source.py
+++ b/airbyte-integrations/connectors/source-trello/source_trello/source.py
@@ -207,12 +207,12 @@ class SourceTrello(AbstractSource):
             authenticator = self._get_authenticator(config)
 
             session = requests.get(url, headers=authenticator.get_auth_header())
+            session.raise_for_status()
             available_boards = {row.get('id') for row in session.json()}
             for board_id in config.get("board_ids", []):
                 if board_id not in available_boards:
                     raise Exception(f"board_id {board_id} not found")
 
-            session.raise_for_status()
 
             return True, None
         except requests.exceptions.RequestException as e:

--- a/airbyte-integrations/connectors/source-trello/source_trello/source.py
+++ b/airbyte-integrations/connectors/source-trello/source_trello/source.py
@@ -202,11 +202,16 @@ class SourceTrello(AbstractSource):
         """
 
         try:
-            url = f"{TrelloStream.url_base}members/me"
+            url = f"{TrelloStream.url_base}members/me/boards"
 
             authenticator = self._get_authenticator(config)
 
             session = requests.get(url, headers=authenticator.get_auth_header())
+            available_boards = {row.get('id') for row in session.json()}
+            for board_id in config.get("board_ids", []):
+                if board_id not in available_boards:
+                    raise Exception(f"board_id {board_id} not found")
+
             session.raise_for_status()
 
             return True, None

--- a/airbyte-integrations/connectors/source-trello/source_trello/source.py
+++ b/airbyte-integrations/connectors/source-trello/source_trello/source.py
@@ -55,8 +55,7 @@ class ChildStreamMixin:
     parent_stream_class: Optional[TrelloStream] = None
 
     def stream_slices(self, sync_mode, **kwargs) -> Iterable[Optional[Mapping[str, any]]]:
-        config = self.config
-        board_ids = config.get("board_ids", [])
+        board_ids = self.config.get("board_ids", [])
         if len(board_ids) > 0:
             for id in board_ids:
                 yield {"id": id}

--- a/airbyte-integrations/connectors/source-trello/source_trello/source.py
+++ b/airbyte-integrations/connectors/source-trello/source_trello/source.py
@@ -208,11 +208,10 @@ class SourceTrello(AbstractSource):
 
             session = requests.get(url, headers=authenticator.get_auth_header())
             session.raise_for_status()
-            available_boards = {row.get('id') for row in session.json()}
+            available_boards = {row.get("id") for row in session.json()}
             for board_id in config.get("board_ids", []):
                 if board_id not in available_boards:
                     raise Exception(f"board_id {board_id} not found")
-
 
             return True, None
         except requests.exceptions.RequestException as e:

--- a/airbyte-integrations/connectors/source-trello/source_trello/source.py
+++ b/airbyte-integrations/connectors/source-trello/source_trello/source.py
@@ -55,6 +55,13 @@ class ChildStreamMixin:
     parent_stream_class: Optional[TrelloStream] = None
 
     def stream_slices(self, sync_mode, **kwargs) -> Iterable[Optional[Mapping[str, any]]]:
+        config = self.config
+        board_ids = config.get("board_ids", [])
+        if len(board_ids) > 0:
+            for id in board_ids:
+                yield {"id": id}
+            # early exit because we don't need to fetch all boards we specifically told us not to
+            return
         for item in self.parent_stream_class(config=self.config).read_records(sync_mode=sync_mode):
             yield {"id": item["id"]}
 
@@ -209,5 +216,4 @@ class SourceTrello(AbstractSource):
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         config["authenticator"] = self._get_authenticator(config)
-
         return [Actions(config), Boards(config), Cards(config), Checklists(config), Lists(config), Users(config)]

--- a/airbyte-integrations/connectors/source-trello/source_trello/spec.json
+++ b/airbyte-integrations/connectors/source-trello/source_trello/spec.json
@@ -30,7 +30,7 @@
         "type": "array",
         "items":{
           "type": "string",
-          "pattern": "^[a-zA-Z0-9,]*$"
+          "pattern": "^[0-9a-fA-F]{24}$"
         },
         "title": "Trello board IDs",
         "description": "IDs of the boards from which you'd like to replicate data. If left empty, data from all boards to which you have access will be replicated."

--- a/airbyte-integrations/connectors/source-trello/source_trello/spec.json
+++ b/airbyte-integrations/connectors/source-trello/source_trello/spec.json
@@ -25,6 +25,15 @@
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$",
         "description": "UTC date and time in the format 2017-01-25T00:00:00Z. Any data before this date will not be replicated.",
         "examples": ["2021-03-01T00:00:00.000Z"]
+      },
+      "board_ids": {
+        "type": "array",
+        "items":{
+          "type": "string"
+        },
+        "title": "Trello board IDs",
+        "pattern": "^[a-zA-Z0-9,]*$",
+        "description": "IDs of the boards from which you'd like to replicate data. If left empty, data from all boards to which you have access will be replicated."
       }
     }
   },

--- a/airbyte-integrations/connectors/source-trello/source_trello/spec.json
+++ b/airbyte-integrations/connectors/source-trello/source_trello/spec.json
@@ -29,10 +29,10 @@
       "board_ids": {
         "type": "array",
         "items":{
-          "type": "string"
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9,]*$"
         },
         "title": "Trello board IDs",
-        "pattern": "^[a-zA-Z0-9,]*$",
         "description": "IDs of the boards from which you'd like to replicate data. If left empty, data from all boards to which you have access will be replicated."
       }
     }


### PR DESCRIPTION
## What
* Added configuration for allowing the user to specify board ids in configuration
## How
If the user has specified board ids in UI, the source connector will not fetch board data again and again for every source.

## Recommended reading order
1. `x.java`
2. `y.python`



#### Community member or Airbyter
   
- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
</p>
</details>


<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>
</details>

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
