### PR TITLE
🐛 Source Mixpanel: Fix schemas and UI issues

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/12928b32-bf0a-4f1e-964f-07e12e37153a.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/12928b32-bf0a-4f1e-964f-07e12e37153a.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "12928b32-bf0a-4f1e-964f-07e12e37153a",
   "name": "Mixpanel",
   "dockerRepository": "airbyte/source-mixpanel",
-  "dockerImageTag": "0.1.5",
+  "dockerImageTag": "0.1.6",
   "documentationUrl": "https://docs.airbyte.io/integrations/sources/mixpanel",
   "icon": "mixpanel.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -352,7 +352,7 @@
 - name: Mixpanel
   sourceDefinitionId: 12928b32-bf0a-4f1e-964f-07e12e37153a
   dockerRepository: airbyte/source-mixpanel
-  dockerImageTag: 0.1.5
+  dockerImageTag: 0.1.6
   documentationUrl: https://docs.airbyte.io/integrations/sources/mixpanel
   icon: mixpanel.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -3675,7 +3675,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-mixpanel:0.1.5"
+- dockerImage: "airbyte/source-mixpanel:0.1.6"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/mixpanel"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-mixpanel/Dockerfile
+++ b/airbyte-integrations/connectors/source-mixpanel/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.5
+LABEL io.airbyte.version=0.1.6
 LABEL io.airbyte.name=airbyte/source-mixpanel

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/schemas/cohort_members.json
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/schemas/cohort_members.json
@@ -8,6 +8,46 @@
     },
     "distinct_id": {
       "type": ["null", "string"]
+    },
+    "browser": {
+      "type": ["null", "string"]
+    },
+    "browser_version": {
+      "type": ["null", "string"]
+    },
+    "city": {
+      "type": ["null", "string"]
+    },
+    "country_code": {
+      "type": ["null", "string"]
+    },
+    "region": {
+      "type": ["null", "string"]
+    },
+    "timezone": {
+      "type": ["null", "string"]
+    },
+    "last_seen": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "email": {
+      "type": ["null", "string"]
+    },
+    "name": {
+      "type": ["null", "string"]
+    },
+    "first_name": {
+      "type": ["null", "string"]
+    },
+    "last_name": {
+      "type": ["null", "string"]
+    },
+    "id": {
+      "type": ["null", "string"]
+    },
+    "unblocked": {
+      "type": ["null", "string"]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/schemas/export.json
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/schemas/export.json
@@ -14,17 +14,10 @@
       "format": "date-time"
     },
     "labels": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        {
-          "type": "null"
+      "type": ["null", "array"],
+      "items": {
+            "type": ["null", "string"]
         }
-      ]
     },
     "sampling_factor": {
       "type": ["null", "integer"]

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/schemas/funnels.json
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/schemas/funnels.json
@@ -18,113 +18,106 @@
       "format": "date-time"
     },
     "steps": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "count": {
+            "type": ["null", "integer"]
+          },
+          "avg_time": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-20
+          },
+          "avg_time_from_start": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-20
+          },
+          "goal": {
+            "type": ["null", "string"]
+          },
+          "overall_conv_ratio": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-20
+          },
+          "step_conv_ratio": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-20
+          },
+          "event": {
+            "type": ["null", "string"]
+          },
+          "session_event": {
+            "type": ["null", "string"]
+          },
+          "step_label": {
+            "type": ["null", "string"]
+          },
+          "selector": {
+            "type": ["null", "string"]
+          },
+          "selector_params": {
             "type": ["null", "object"],
             "additionalProperties": true,
             "properties": {
-              "count": {
-                "type": ["null", "integer"]
-              },
-              "avg_time": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-20
-              },
-              "avg_time_from_start": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-20
-              },
-              "goal": {
-                "type": ["null", "string"]
-              },
-              "overall_conv_ratio": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-20
-              },
-              "step_conv_ratio": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-20
-              },
-              "event": {
-                "type": ["null", "string"]
-              },
-              "session_event": {
-                "type": ["null", "string"]
-              },
               "step_label": {
                 "type": ["null", "string"]
+              }
+            }
+          },
+          "time_buckets_from_start": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+              "lower": {
+                "type": ["null", "integer"]
               },
-              "selector": {
-                "type": ["null", "string"]
+              "higher": {
+                "type": ["null", "integer"]
               },
-              "selector_params": {
-                "type": ["null", "object"],
-                "additionalProperties": true,
-                "properties": {
-                  "step_label": {
-                    "type": ["null", "string"]
+              "buckets": {
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  },
+                  {
+                    "type": "null"
                   }
-                }
+                ]
+              }
+            }
+          },
+          "time_buckets_from_prev": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+              "lower": {
+                "type": ["null", "integer"]
               },
-              "time_buckets_from_start": {
-                "type": ["null", "object"],
-                "additionalProperties": false,
-                "properties": {
-                  "lower": {
-                    "type": ["null", "integer"]
-                  },
-                  "higher": {
-                    "type": ["null", "integer"]
-                  },
-                  "buckets": {
-                    "anyOf": [
-                      {
-                        "type": "array",
-                        "items": {
-                          "type": "integer"
-                        }
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  }
-                }
+              "higher": {
+                "type": ["null", "integer"]
               },
-              "time_buckets_from_prev": {
-                "type": ["null", "object"],
-                "additionalProperties": false,
-                "properties": {
-                  "lower": {
-                    "type": ["null", "integer"]
+              "buckets": {
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
                   },
-                  "higher": {
-                    "type": ["null", "integer"]
-                  },
-                  "buckets": {
-                    "anyOf": [
-                      {
-                        "type": "array",
-                        "items": {
-                          "type": "integer"
-                        }
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                  {
+                    "type": "null"
                   }
-                }
+                ]
               }
             }
           }
-        },
-        {
-          "type": "null"
         }
-      ]
+      }
     },
     "analysis": {
       "type": ["null", "object"],

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/schemas/funnels.json
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/schemas/funnels.json
@@ -77,17 +77,10 @@
                 "type": ["null", "integer"]
               },
               "buckets": {
-                "anyOf": [
-                  {
-                    "type": "array",
-                    "items": {
-                      "type": "integer"
-                    }
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "type": ["null", "array"],
+                "items": {
+                  "type": "integer"
+                }
               }
             }
           },
@@ -102,17 +95,10 @@
                 "type": ["null", "integer"]
               },
               "buckets": {
-                "anyOf": [
-                  {
-                    "type": "array",
-                    "items": {
-                      "type": "integer"
-                    }
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "type": ["null", "array"],
+                "items": {
+                  "type": "integer"
+                }
               }
             }
           }

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
@@ -16,6 +16,7 @@ import requests
 from airbyte_cdk.logger import AirbyteLogger
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources import AbstractSource
+from airbyte_cdk.sources.utils.transform import TransformConfig, Transformer
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http import HttpStream
 from airbyte_cdk.sources.streams.http.auth import HttpAuthenticator, TokenAuthenticator
@@ -400,6 +401,9 @@ class Engage(MixpanelStream):
     primary_key = "distinct_id"
     page_size = 1000  # min 100
     _total = None
+
+    # enable automatic object mutation to align with desired schema before outputting to the destination
+    transformer = Transformer(TransformConfig.DefaultSchemaNormalization)
 
     def path(self, **kwargs) -> str:
         return "engage"

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
@@ -16,7 +16,7 @@ import requests
 from airbyte_cdk.logger import AirbyteLogger
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources import AbstractSource
-from airbyte_cdk.sources.utils.transform import TransformConfig, Transformer
+from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http import HttpStream
 from airbyte_cdk.sources.streams.http.auth import HttpAuthenticator, TokenAuthenticator
@@ -403,7 +403,7 @@ class Engage(MixpanelStream):
     _total = None
 
     # enable automatic object mutation to align with desired schema before outputting to the destination
-    transformer = Transformer(TransformConfig.DefaultSchemaNormalization)
+    transformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)
 
     def path(self, **kwargs) -> str:
         return "engage"

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
@@ -8,38 +8,39 @@
     "additionalProperties": true,
     "properties": {
       "api_secret": {
+        "title": "Api Secret",
         "type": "string",
         "description": "Mixpanel API Secret. See the <a href=\"https://docs.airbyte.io/integrations/sources/mixpanel\">docs</a> for more information on how to obtain this key.",
         "airbyte_secret": true
       },
       "attribution_window": {
+        "title": "Attribution Window",
         "type": "integer",
         "description": "Latency minimum number of days to look-back to account for delays in attributing accurate results. Default attribution window is 5 days.",
         "default": 5
       },
-      "date_window_size": {
-        "type": "integer",
-        "description": "Number of days for date window looping through transactional endpoints with from_date and to_date. Default date_window_size is 30 days. Clients with large volumes of events may want to decrease this to 14, 7, or even down to 1-2 days.",
-        "default": 30
-      },
       "project_timezone": {
+        "title": "Project Timezone",
         "type": "string",
         "description": "Time zone in which integer date times are stored. The project timezone may be found in the project settings in the Mixpanel console.",
         "default": "US/Pacific",
         "examples": ["US/Pacific", "UTC"]
       },
       "select_properties_by_default": {
+        "title": "Select Properties By Default",
         "type": "boolean",
         "description": "Setting this config parameter to true ensures that new properties on events and engage records are captured. Otherwise new properties will be ignored",
         "default": true
       },
       "start_date": {
+        "title": "Start Date",
         "type": "string",
         "description": "The default value to use if no bookmark exists for an endpoint. If this option is not set, the connector will replicate data from up to one year ago by default.",
         "examples": ["2021-11-16"],
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$"
       },
       "region": {
+        "title": "Region",
         "type": "string",
         "enum": ["US", "EU"],
         "default": "US"

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -59,7 +59,7 @@ Select the correct region \(EU or US\) for your Mixpanel project. See detail [he
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| `0.1.6` | 2021-11-25 | [0000](https://github.com/airbytehq/airbyte/issues/0000) | Deleted `date_window_size` and fix schemas date type issue |
+| `0.1.6` | 2021-11-25 | [8256](https://github.com/airbytehq/airbyte/issues/8256) | Deleted `date_window_size` and fix schemas date type issue |
 | `0.1.5` | 2021-11-10 | [7451](https://github.com/airbytehq/airbyte/issues/7451) | Support `start_date` older than 1 year |
 | `0.1.4` | 2021-11-08 | [7499](https://github.com/airbytehq/airbyte/pull/7499)   | Remove base-python dependencies |
 | `0.1.3` | 2021-10-30 | [7505](https://github.com/airbytehq/airbyte/issues/7505) | Guarantee that standard and custom mixpanel properties in the `Engage` stream are written as strings |

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -59,10 +59,11 @@ Select the correct region \(EU or US\) for your Mixpanel project. See detail [he
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| `0.1.6` | 2021-11-25 | [0000](https://github.com/airbytehq/airbyte/issues/0000) | Deleted `date_window_size` and fix schemas date type issue |
 | `0.1.5` | 2021-11-10 | [7451](https://github.com/airbytehq/airbyte/issues/7451) | Support `start_date` older than 1 year |
 | `0.1.4` | 2021-11-08 | [7499](https://github.com/airbytehq/airbyte/pull/7499)   | Remove base-python dependencies |
 | `0.1.3` | 2021-10-30 | [7505](https://github.com/airbytehq/airbyte/issues/7505) | Guarantee that standard and custom mixpanel properties in the `Engage` stream are written as strings |
 | `0.1.2` | 2021-11-02 | [7439](https://github.com/airbytehq/airbyte/issues/7439) | Added delay for all streams to match API limitation of requests rate |
 | `0.1.1` | 2021-09-16 | [6075](https://github.com/airbytehq/airbyte/issues/6075) | Added option to select project region |
-| `0.1.0` | 2021-07-06 | [3698](https://github.com/airbytehq/airbyte/issues/3698) | created CDK native mixpanel connector |
+| `0.1.0` | 2021-07-06 | [3698](https://github.com/airbytehq/airbyte/issues/3698) | Created CDK native mixpanel connector |
 


### PR DESCRIPTION
## What
#8062 - Source Mixpanel: failed during normalization

> Shortly about the problem.
Mixpanel 'engage' stream has a dynamic schema. There are some 'standard' fields but users can create custom fields as well.
I have tried to create such 'custom' fields but there is no way to specify the type for such custom fields. I tried to create fields with different values: ABC or 1. Such attrs are reported as a string for me. I was not able to find any way to change this.
The customer has a problem with the 'browser_version' field, which is a 'standard' field. It is reported as:
'number' - for customer
'string' - for our account.
The customer and I have similar values in this field, like "86.3.112.2", which is definitely a string.
So it is not clear what to do in this situation.

## How
- Normalization fix:
For `engage` stream already fixed bug here [PR](https://github.com/airbytehq/airbyte/pull/7505), need refresh schemas on the cloud. For `cohort_members` stream hard-code types for known 'standard' fields, but rely on API for other 'custom' fields. Also was enabled DefaultSchemaNormalization for `engage` and `cohort_members` streams.

- UI fix:
Fixed schema `anyOf` construction issue for `export` and `funnel` streams. Added titles and deleted `date_window_size` from `spec.json` according to UX handbook. 

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [x] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>
</details>