### PR TITLE
Add the `needs-triage` label to new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a bug to help us improve
 title: ''
-labels: type/bug
+labels: type/bug, needs-triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for Airbyte
 title: ''
-labels: type/enhancement
+labels: type/enhancement, needs-triage
 assignees: ''
 
 ---


### PR DESCRIPTION
We're starting to partition issues based on whether they are connectors/platform/normalization etc.. issues. This label will help us find issues which have not yet been triaged. 