### PR TITLE
fix dependabot problems

### DIFF
--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -86,6 +86,8 @@
         "prettier": "^2.2.1",
         "react-scripts": "4.0.2",
         "storybook-addon-styled-component-theme": "^2.0.0",
+        "tar": "^6.1.11",
+        "tmpl": "^1.0.5",
         "typescript": "4.2.4"
       }
     },
@@ -43255,9 +43257,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -43626,9 +43628,9 @@
       }
     },
     "node_modules/tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "node_modules/to-arraybuffer": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -89,6 +89,8 @@
     "prettier": "^2.2.1",
     "react-scripts": "4.0.2",
     "storybook-addon-styled-component-theme": "^2.0.0",
+    "tar": "^6.1.11",
+    "tmpl": "^1.0.5",
     "typescript": "4.2.4"
   },
   "husky": {


### PR DESCRIPTION
https://github.com/airbytehq/airbyte/pull/7655 and https://github.com/airbytehq/airbyte/pull/7654 were causing some problems because new builds would overwrite the `package-lock.json` file. Setting these as a dev dep seems to fix the issue.