### PR TITLE
Added temporal build script

### DIFF
--- a/airbyte-temporal/.gitignore
+++ b/airbyte-temporal/.gitignore
@@ -1,0 +1,2 @@
+scripts/*.tar.gz
+scripts/temporal-*

--- a/airbyte-temporal/scripts/build-temporal.sh
+++ b/airbyte-temporal/scripts/build-temporal.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -x
+
+TEMPORAL_VERSION=1.13.0
+
+curl -OL https://github.com/temporalio/temporal/archive/refs/tags/v"$TEMPORAL_VERSION".tar.gz
+tar -xvf v"$TEMPORAL_VERSION".tar.gz
+cd temporal-"$TEMPORAL_VERSION" && docker build . -t temporalio/auto-setup:"$TEMPORAL_VERSION" --build-arg TARGET=auto-setup
+rm -rf ../temporal-"$TEMPORAL_VERSION" ../v"$TEMPORAL_VERSION".tar.gz

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -37,17 +37,20 @@ SUB_BUILD=PLATFORM ./gradlew build
 If you're using Mac M1 \(Apple Silicon\) machines, it is possible to compile Airbyte by setting
 some additional environment variables:
 
+Build temporal (This is required until official images are available Refer: https://github.com/temporalio/temporal/issues/1305)
+```bash
+cd airbyte-temporal/scripts
+./build-temporal.sh
+```
+
 ```bash
 export DOCKER_BUILD_PLATFORM=linux/arm64
 export DOCKER_BUILD_ARCH=arm64
 export ALPINE_IMAGE=arm64v8/alpine:3.14
 export POSTGRES_IMAGE=arm64v8/postgres:13-alpine
 export JDK_VERSION=17
-export NODE_VERSION=16.11.1
 SUB_BUILD=PLATFORM ./gradlew build
 ```
-
-Please note that though the `JDK_VERSION` variable is set to `17`, you should still run the command with JDK 14 locally. Otherwise, `testconatiners` will run into a JNA related issue.
 
 There are some known issues (Temporal failing during runs, and some connectors not working). See the [GitHub issue](https://github.com/airbytehq/airbyte/issues/2017) for more information.
 


### PR DESCRIPTION
## What
Workaround for (#2017) to build temporal on Mac M1 (until official builds are ready)

## How
Added custom build script

## Recommended reading order
1. `airbyte-temporal/scripts/build-temporal.sh`
