### PR TITLE
fix off by one month

### DIFF
--- a/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/CreditsUsagePage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/CreditsUsagePage.tsx
@@ -24,10 +24,13 @@ const CreditsUsagePage: React.FC = () => {
   const chartData = useMemo(
     () =>
       data?.creditConsumptionByDay?.map(({ creditsConsumed, date }) => ({
-        name: formatDate(new Date(...date), {
-          month: "short",
-          day: "numeric",
-        }),
+        name: formatDate(
+          new Date(date[0], date[1] - 1 /* zero-indexed */, date[2]),
+          {
+            month: "short",
+            day: "numeric",
+          }
+        ),
         value: creditsConsumed,
       })),
     [data, formatDate]


### PR DESCRIPTION
The API is returning a value with 1-12 while the `Date` object is expecting 0-11.

Is this fine or is there a better way in mind?

Fixes problem in https://github.com/airbytehq/oncall/issues/42