### PR TITLE
allow retrieving deleted sources and destinations

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
@@ -16,7 +16,6 @@ import io.airbyte.api.model.DestinationSearch;
 import io.airbyte.api.model.DestinationUpdate;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -150,13 +149,6 @@ public class DestinationHandler {
 
   public DestinationRead getDestination(final DestinationIdRequestBody destinationIdRequestBody)
       throws JsonValidationException, IOException, ConfigNotFoundException {
-    final UUID destinationId = destinationIdRequestBody.getDestinationId();
-    final DestinationConnection dci = configRepository.getDestinationConnection(destinationId);
-
-    if (dci.getTombstone()) {
-      throw new ConfigNotFoundException(ConfigSchema.DESTINATION_CONNECTION, destinationId.toString());
-    }
-
     return buildDestinationRead(destinationIdRequestBody.getDestinationId());
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -14,7 +14,6 @@ import io.airbyte.api.model.SourceReadList;
 import io.airbyte.api.model.SourceSearch;
 import io.airbyte.api.model.SourceUpdate;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
-import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -111,14 +110,7 @@ public class SourceHandler {
 
   public SourceRead getSource(final SourceIdRequestBody sourceIdRequestBody)
       throws JsonValidationException, IOException, ConfigNotFoundException {
-    final UUID sourceId = sourceIdRequestBody.getSourceId();
-    final SourceConnection sourceConnection = configRepository.getSourceConnection(sourceId);
-
-    if (sourceConnection.getTombstone()) {
-      throw new ConfigNotFoundException(ConfigSchema.SOURCE_CONNECTION, sourceId.toString());
-    }
-
-    return buildSourceRead(sourceId);
+    return buildSourceRead(sourceIdRequestBody.getSourceId());
   }
 
   public SourceReadList listSourcesForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody)

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
@@ -5,7 +5,6 @@
 package io.airbyte.server.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -196,18 +195,6 @@ class DestinationHandlerTest {
     assertEquals(expectedDestinationRead, actualDestinationRead);
     verify(secretsProcessor)
         .maskSecrets(destinationConnection.getConfiguration(), destinationDefinitionSpecificationRead.getConnectionSpecification());
-  }
-
-  @Test
-  void testGetDeletedDestination() throws JsonValidationException, ConfigNotFoundException, IOException {
-    final UUID destinationId = destinationConnection.getDestinationId();
-    final DestinationIdRequestBody destinationIdRequestBody = new DestinationIdRequestBody().destinationId(destinationId);
-    final DestinationConnection deleted = DestinationHelpers.generateDestination(destinationId, true);
-
-    when(configRepository.getDestinationConnection(destinationId))
-        .thenReturn(deleted);
-
-    assertThrows(ConfigNotFoundException.class, () -> destinationHandler.getDestination(destinationIdRequestBody));
   }
 
   @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
@@ -13,8 +13,6 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
-import io.airbyte.api.model.ConnectionRead;
-import io.airbyte.api.model.ConnectionReadList;
 import io.airbyte.api.model.DestinationCreate;
 import io.airbyte.api.model.DestinationDefinitionIdRequestBody;
 import io.airbyte.api.model.DestinationDefinitionSpecificationRead;
@@ -28,19 +26,16 @@ import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSync;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.server.converters.ConfigurationUpdate;
-import io.airbyte.server.helpers.ConnectionHelpers;
 import io.airbyte.server.helpers.ConnectorSpecificationHelpers;
 import io.airbyte.server.helpers.DestinationHelpers;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -134,35 +129,6 @@ class DestinationHandlerTest {
     verify(configRepository).writeDestinationConnection(destinationConnection, connectorSpecification);
     verify(secretsProcessor)
         .maskSecrets(destinationConnection.getConfiguration(), destinationDefinitionSpecificationRead.getConnectionSpecification());
-  }
-
-  @Test
-  void testDeleteDestination() throws JsonValidationException, ConfigNotFoundException, IOException {
-    final JsonNode newConfiguration = destinationConnection.getConfiguration();
-    ((ObjectNode) newConfiguration).put("apiKey", "987-xyz");
-
-    final DestinationConnection expectedDestinationConnection = Jsons.clone(destinationConnection).withTombstone(true);
-    final DestinationIdRequestBody destinationId = new DestinationIdRequestBody().destinationId(destinationConnection.getDestinationId());
-    final StandardSync standardSync = ConnectionHelpers.generateSyncWithDestinationId(destinationConnection.getDestinationId());
-    final ConnectionRead connectionRead = ConnectionHelpers.generateExpectedConnectionRead(standardSync);
-    final ConnectionReadList connectionReadList = new ConnectionReadList().connections(Collections.singletonList(connectionRead));
-    final WorkspaceIdRequestBody workspaceIdRequestBody = new WorkspaceIdRequestBody().workspaceId(destinationConnection.getWorkspaceId());
-
-    when(configRepository.getDestinationConnectionWithSecrets(destinationConnection.getDestinationId()))
-        .thenReturn(destinationConnection)
-        .thenReturn(expectedDestinationConnection);
-    when(configRepository.getDestinationConnection(destinationConnection.getDestinationId()))
-        .thenReturn(destinationConnection)
-        .thenReturn(expectedDestinationConnection);
-    when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getDestinationDefinitionId()))
-        .thenReturn(standardDestinationDefinition);
-    when(connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody)).thenReturn(connectionReadList);
-
-    destinationHandler.deleteDestination(destinationId);
-
-    verify(configRepository).writeDestinationConnection(expectedDestinationConnection, connectorSpecification);
-    verify(connectionsHandler).listConnectionsForWorkspace(workspaceIdRequestBody);
-    verify(connectionsHandler).deleteConnection(connectionRead);
   }
 
   @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
@@ -5,7 +5,6 @@
 package io.airbyte.server.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -176,18 +175,6 @@ class SourceHandlerTest {
 
     assertEquals(expectedSourceRead, actualSourceRead);
     verify(secretsProcessor).maskSecrets(sourceConnection.getConfiguration(), sourceDefinitionSpecificationRead.getConnectionSpecification());
-  }
-
-  @Test
-  void testGetDeletedSource() throws JsonValidationException, ConfigNotFoundException, IOException {
-    final UUID sourceId = sourceConnection.getSourceId();
-    final SourceIdRequestBody sourceIdRequestBody = new SourceIdRequestBody().sourceId(sourceId);
-    final SourceConnection deleted = SourceHelpers.generateSource(sourceId, true);
-
-    when(configRepository.getSourceConnection(sourceId))
-        .thenReturn(deleted);
-
-    assertThrows(ConfigNotFoundException.class, () -> sourceHandler.getSource(sourceIdRequestBody));
   }
 
   @Test


### PR DESCRIPTION
The current behavior is unintuitive. There's no reason a tombstoned value shouldn't be retrievable by the API.

Removed the test cases instead of changing the test cases since it's no longer a special case.

I believe this change will fix at least most of https://github.com/airbytehq/oncall/issues/41

