### PR TITLE
🐛 Source Mixpanel: fix for `discovery` command takes a very long time

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/12928b32-bf0a-4f1e-964f-07e12e37153a.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/12928b32-bf0a-4f1e-964f-07e12e37153a.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "12928b32-bf0a-4f1e-964f-07e12e37153a",
   "name": "Mixpanel",
   "dockerRepository": "airbyte/source-mixpanel",
-  "dockerImageTag": "0.1.6",
+  "dockerImageTag": "0.1.7",
   "documentationUrl": "https://docs.airbyte.io/integrations/sources/mixpanel",
   "icon": "mixpanel.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -393,7 +393,7 @@
 - name: Mixpanel
   sourceDefinitionId: 12928b32-bf0a-4f1e-964f-07e12e37153a
   dockerRepository: airbyte/source-mixpanel
-  dockerImageTag: 0.1.6
+  dockerImageTag: 0.1.7
   documentationUrl: https://docs.airbyte.io/integrations/sources/mixpanel
   icon: mixpanel.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -3720,7 +3720,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-mixpanel:0.1.6"
+- dockerImage: "airbyte/source-mixpanel:0.1.7"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/mixpanel"
     connectionSpecification:
@@ -3732,24 +3732,20 @@
       additionalProperties: true
       properties:
         api_secret:
+          title: "API Secret"
           type: "string"
           description: "Mixpanel API Secret. See the <a href=\"https://docs.airbyte.io/integrations/sources/mixpanel\"\
             >docs</a> for more information on how to obtain this key."
           airbyte_secret: true
         attribution_window:
+          title: "Attribution Window"
           type: "integer"
           description: "Latency minimum number of days to look-back to account for\
             \ delays in attributing accurate results. Default attribution window is\
             \ 5 days."
           default: 5
-        date_window_size:
-          type: "integer"
-          description: "Number of days for date window looping through transactional\
-            \ endpoints with from_date and to_date. Default date_window_size is 30\
-            \ days. Clients with large volumes of events may want to decrease this\
-            \ to 14, 7, or even down to 1-2 days."
-          default: 30
         project_timezone:
+          title: "Project Timezone"
           type: "string"
           description: "Time zone in which integer date times are stored. The project\
             \ timezone may be found in the project settings in the Mixpanel console."
@@ -3758,12 +3754,14 @@
           - "US/Pacific"
           - "UTC"
         select_properties_by_default:
+          title: "Select Properties By Default"
           type: "boolean"
-          description: "Setting this config parameter to true ensures that new properties\
+          description: "Setting this config parameter to TRUE ensures that new properties\
             \ on events and engage records are captured. Otherwise new properties\
             \ will be ignored"
           default: true
         start_date:
+          title: "Start Date"
           type: "string"
           description: "The default value to use if no bookmark exists for an endpoint.\
             \ If this option is not set, the connector will replicate data from up\
@@ -3772,6 +3770,8 @@
           - "2021-11-16"
           pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$"
         region:
+          title: "Region"
+          description: "The region of mixpanel domain instance either US or EU."
           type: "string"
           enum:
           - "US"

--- a/airbyte-integrations/connectors/source-mixpanel/Dockerfile
+++ b/airbyte-integrations/connectors/source-mixpanel/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.6
+LABEL io.airbyte.version=0.1.7
 LABEL io.airbyte.name=airbyte/source-mixpanel

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
@@ -94,8 +94,9 @@ class MixpanelStream(HttpStream, ABC):
         # parse the whole response
         yield from self.process_response(response, **kwargs)
 
-        # wait for X seconds to match API limitations
-        time.sleep(3600 / self.reqs_per_hour_limit)
+        if self.reqs_per_hour_limit > 0:
+            # wait for X seconds to match API limitations
+            time.sleep(3600 / self.reqs_per_hour_limit)
 
     def get_stream_params(self) -> Mapping[str, Any]:
         """
@@ -355,12 +356,14 @@ class Funnels(DateSlicesMixin, IncrementalMixpanelStream):
 class EngageSchema(MixpanelStream):
     """
     Engage helper stream for dynamic schema extraction.
-    :: reqs_per_hour_limit: int - property is set to the value of 1 million, to get the sleep time close to the zero, while generating dynamic schema.
+    :: reqs_per_hour_limit: int - property is set to the value of 1 million, 
+       to get the sleep time close to the zero, while generating dynamic schema.
+       When `reqs_per_hour_limit = 0` - it means we skip this limits.
     """
 
     primary_key: str = None
     data_field: str = "results"
-    reqs_per_hour_limit: int = 1000000  # see the docstring
+    reqs_per_hour_limit: int = 0  # see the docstring
 
     def path(self, **kwargs) -> str:
         return "engage/properties"
@@ -630,12 +633,14 @@ class Revenue(DateSlicesMixin, IncrementalMixpanelStream):
 class ExportSchema(MixpanelStream):
     """
     Export helper stream for dynamic schema extraction.
-    :: reqs_per_hour_limit: int - property is set to the value of 1 million, to get the sleep time close to the zero, while generating dynamic schema.
+    :: reqs_per_hour_limit: int - property is set to the value of 1 million, 
+       to get the sleep time close to the zero, while generating dynamic schema.
+       When `reqs_per_hour_limit = 0` - it means we skip this limits.
     """
 
     primary_key: str = None
     data_field: str = None
-    reqs_per_hour_limit: int = 1000000  # see the docstring
+    reqs_per_hour_limit: int = 0  # see the docstring
 
     def path(self, **kwargs) -> str:
         return "events/properties/top"

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
@@ -95,7 +95,8 @@ class MixpanelStream(HttpStream, ABC):
         yield from self.process_response(response, **kwargs)
 
         if self.reqs_per_hour_limit > 0:
-            # wait for X seconds to match API limitations
+            # we skip this block, if self.reqs_per_hour_limit = 0,
+            # in all other cases wait for X seconds to match API limitations
             time.sleep(3600 / self.reqs_per_hour_limit)
 
     def get_stream_params(self) -> Mapping[str, Any]:

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
@@ -8,7 +8,7 @@ import json
 import time
 from abc import ABC
 from datetime import date, datetime, timedelta
-from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Union
 from urllib.parse import parse_qs, urlparse
 
 import pendulum
@@ -16,10 +16,10 @@ import requests
 from airbyte_cdk.logger import AirbyteLogger
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources import AbstractSource
-from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http import HttpStream
 from airbyte_cdk.sources.streams.http.auth import HttpAuthenticator, TokenAuthenticator
+from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
 
 
 class MixpanelStream(HttpStream, ABC):
@@ -37,7 +37,7 @@ class MixpanelStream(HttpStream, ABC):
         return f"https://{prefix}mixpanel.com/api/2.0/"
 
     # https://help.mixpanel.com/hc/en-us/articles/115004602563-Rate-Limits-for-Export-API-Endpoints#api-export-endpoint-rate-limits
-    reqs_per_hour_limit = 400  # 1 req in 9 secs
+    reqs_per_hour_limit: int = 400  # 1 req in 9 secs
 
     def __init__(
         self,
@@ -139,8 +139,8 @@ class Cohorts(MixpanelStream):
 
     """
 
-    data_field = None
-    primary_key = "id"
+    data_field: str = None
+    primary_key: str = "id"
 
     def path(self, **kwargs) -> str:
         return "cohorts/list"
@@ -152,8 +152,8 @@ class FunnelsList(MixpanelStream):
     Endpoint: https://mixpanel.com/api/2.0/funnels/list
     """
 
-    primary_key = "funnel_id"
-    data_field = None
+    primary_key: str = "funnel_id"
+    data_field: str = None
 
     def path(self, **kwargs) -> str:
         return "funnels/list"
@@ -163,7 +163,7 @@ class DateSlicesMixin:
     def stream_slices(
         self, sync_mode, cursor_field: List[str] = None, stream_state: Mapping[str, Any] = None
     ) -> Iterable[Optional[Mapping[str, Any]]]:
-        date_slices = []
+        date_slices: list = []
 
         # use the latest date between self.start_date and stream_state
         start_date = self.start_date
@@ -207,10 +207,10 @@ class Funnels(DateSlicesMixin, IncrementalMixpanelStream):
     Endpoint: https://mixpanel.com/api/2.0/funnels
     """
 
-    primary_key = ["funnel_id", "date"]
-    data_field = "data"
-    cursor_field = "date"
-    min_date = "90"  # days
+    primary_key: List[str] = ["funnel_id", "date"]
+    data_field: str = "data"
+    cursor_field: str = "date"
+    min_date: str = "90"  # days
 
     def path(self, **kwargs) -> str:
         return "funnels"
@@ -252,10 +252,10 @@ class Funnels(DateSlicesMixin, IncrementalMixpanelStream):
         #    - int in funnel_slice
         #    - str in stream_state
         """
-        stream_state = stream_state or {}
+        stream_state: Dict = stream_state or {}
 
         # One stream slice is a combination of all funnel_slices and date_slices
-        stream_slices = []
+        stream_slices: List = []
         funnel_slices = self.funnel_slices(sync_mode)
         for funnel_slice in funnel_slices:
             # get single funnel state
@@ -353,10 +353,14 @@ class Funnels(DateSlicesMixin, IncrementalMixpanelStream):
 
 
 class EngageSchema(MixpanelStream):
-    """Engage helper stream for dynamic schema extraction"""
+    """
+    Engage helper stream for dynamic schema extraction.
+    :: reqs_per_hour_limit: int - property is set to the value of 1 million, to get the sleep time close to the zero, while generating dynamic schema.
+    """
 
-    primary_key = None
-    data_field = "results"
+    primary_key: str = None
+    data_field: str = "results"
+    reqs_per_hour_limit: int = 1000000  # see the docstring
 
     def path(self, **kwargs) -> str:
         return "engage/properties"
@@ -396,11 +400,11 @@ class Engage(MixpanelStream):
     Endpoint: https://mixpanel.com/api/2.0/engage
     """
 
-    http_method = "POST"
-    data_field = "results"
-    primary_key = "distinct_id"
-    page_size = 1000  # min 100
-    _total = None
+    http_method: str = "POST"
+    data_field: str = "results"
+    primary_key: str = "distinct_id"
+    page_size: int = 1000  # min 100
+    _total: Any = None
 
     # enable automatic object mutation to align with desired schema before outputting to the destination
     transformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)
@@ -569,8 +573,8 @@ class Annotations(DateSlicesMixin, MixpanelStream):
     That's why stream does not support incremental sync.
     """
 
-    data_field = "annotations"
-    primary_key = "id"
+    data_field: str = "annotations"
+    primary_key: str = "id"
 
     def path(self, **kwargs) -> str:
         return "annotations"
@@ -624,10 +628,14 @@ class Revenue(DateSlicesMixin, IncrementalMixpanelStream):
 
 
 class ExportSchema(MixpanelStream):
-    """Export helper stream for dynamic schema extraction"""
+    """
+    Export helper stream for dynamic schema extraction.
+    :: reqs_per_hour_limit: int - property is set to the value of 1 million, to get the sleep time close to the zero, while generating dynamic schema.
+    """
 
-    primary_key = None
-    data_field = None
+    primary_key: str = None
+    data_field: str = None
+    reqs_per_hour_limit: int = 1000000  # see the docstring
 
     def path(self, **kwargs) -> str:
         return "events/properties/top"
@@ -677,9 +685,9 @@ class Export(DateSlicesMixin, IncrementalMixpanelStream):
      3 queries per second and 60 queries per hour.
     """
 
-    primary_key = None
-    cursor_field = "time"
-    reqs_per_hour_limit = 60  # 1 query per minute
+    primary_key: str = None
+    cursor_field: str = "time"
+    reqs_per_hour_limit: str = 60  # 1 query per minute
 
     @property
     def url_base(self):

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
@@ -8,7 +8,7 @@
     "additionalProperties": true,
     "properties": {
       "api_secret": {
-        "title": "Api Secret",
+        "title": "API Secret",
         "type": "string",
         "description": "Mixpanel API Secret. See the <a href=\"https://docs.airbyte.io/integrations/sources/mixpanel\">docs</a> for more information on how to obtain this key.",
         "airbyte_secret": true
@@ -29,7 +29,7 @@
       "select_properties_by_default": {
         "title": "Select Properties By Default",
         "type": "boolean",
-        "description": "Setting this config parameter to true ensures that new properties on events and engage records are captured. Otherwise new properties will be ignored",
+        "description": "Setting this config parameter to TRUE ensures that new properties on events and engage records are captured. Otherwise new properties will be ignored",
         "default": true
       },
       "start_date": {
@@ -41,6 +41,7 @@
       },
       "region": {
         "title": "Region",
+        "description": "The region of mixpanel domain instance either US or EU.",
         "type": "string",
         "enum": ["US", "EU"],
         "default": "US"

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -59,6 +59,7 @@ Select the correct region \(EU or US\) for your Mixpanel project. See detail [he
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| `0.1.7` | 2021-12-01 | [8381](https://github.com/airbytehq/airbyte/pull/8381) | Increased performance for `discovery` stage during connector setup |
 | `0.1.6` | 2021-11-25 | [8256](https://github.com/airbytehq/airbyte/issues/8256) | Deleted `date_window_size` and fix schemas date type issue |
 | `0.1.5` | 2021-11-10 | [7451](https://github.com/airbytehq/airbyte/issues/7451) | Support `start_date` older than 1 year |
 | `0.1.4` | 2021-11-08 | [7499](https://github.com/airbytehq/airbyte/pull/7499)   | Remove base-python dependencies |


### PR DESCRIPTION
## What

From OnCall Repo:
#8321

## How
- changed the `reqs_per_hour_limit` value to `0` when we run the process of fetching dynamic properties from endpoint.
- edited the `parse_response` to handle these cases.

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter

- [X] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [X] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [X] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>
</details>