### PR TITLE
Remove status link from oss version

### DIFF
--- a/airbyte-webapp/src/views/layout/SideBar/SideBar.tsx
+++ b/airbyte-webapp/src/views/layout/SideBar/SideBar.tsx
@@ -156,7 +156,6 @@ const SideBar: React.FC = () => {
             options={[
               { value: "docs" },
               { value: "slack" },
-              { value: "status" },
               { value: "recipes" },
             ]}
           >


### PR DESCRIPTION
## What
Small qfix to remove status link from Resources section in oss
## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`
