### PR TITLE
Improve URL creation in the CDK

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
@@ -6,6 +6,7 @@
 import os
 from abc import ABC, abstractmethod
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Union
+from urllib.parse import urljoin
 
 import requests
 import vcr
@@ -239,7 +240,7 @@ class HttpStream(Stream, ABC):
     def _create_prepared_request(
         self, path: str, headers: Mapping = None, params: Mapping = None, json: Any = None, data: Any = None
     ) -> requests.PreparedRequest:
-        args = {"method": self.http_method, "url": self.url_base + path, "headers": headers, "params": params}
+        args = {"method": self.http_method, "url": urljoin(self.url_base, path), "headers": headers, "params": params}
         if self.http_method.upper() in BODY_REQUEST_METHODS:
             if json and data:
                 raise RequestBodyException(

--- a/airbyte-integrations/connectors/source-amplitude/source_amplitude/api.py
+++ b/airbyte-integrations/connectors/source-amplitude/source_amplitude/api.py
@@ -20,7 +20,7 @@ from airbyte_cdk.sources.streams.http import HttpStream
 
 class AmplitudeStream(HttpStream, ABC):
 
-    url_base = "https://amplitude.com/api"
+    url_base = "https://amplitude.com/api/"
     api_version = 2
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
@@ -31,7 +31,7 @@ class AmplitudeStream(HttpStream, ABC):
         yield from respose_data.get(self.name, [])
 
     def path(self, **kwargs) -> str:
-        return f"/{self.api_version}/{self.name}"
+        return f"{self.api_version}/{self.name}"
 
 
 class Cohorts(AmplitudeStream):
@@ -160,7 +160,7 @@ class Events(IncrementalAmplitudeStream):
     def path(
         self, stream_state: Mapping[str, Any] = None, stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
     ) -> str:
-        return f"/{self.api_version}/export"
+        return f"{self.api_version}/export"
 
 
 class ActiveUsers(IncrementalAmplitudeStream):
@@ -177,7 +177,7 @@ class ActiveUsers(IncrementalAmplitudeStream):
                 yield {"date": date, "statistics": dict(zip(response_data["seriesLabels"], series[i]))}
 
     def path(self, **kwargs) -> str:
-        return f"/{self.api_version}/users"
+        return f"{self.api_version}/users"
 
 
 class AverageSessionLength(IncrementalAmplitudeStream):
@@ -196,4 +196,4 @@ class AverageSessionLength(IncrementalAmplitudeStream):
                 yield {"date": date, "length": series[i]}
 
     def path(self, **kwargs) -> str:
-        return f"/{self.api_version}/sessions/average"
+        return f"{self.api_version}/sessions/average"

--- a/airbyte-integrations/connectors/source-google-search-console/source_google_search_console/streams.py
+++ b/airbyte-integrations/connectors/source-google-search-console/source_google_search_console/streams.py
@@ -12,7 +12,7 @@ from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.streams.http import HttpStream
 from airbyte_cdk.sources.streams.http.auth import HttpAuthenticator
 
-BASE_URL = "https://www.googleapis.com/webmasters/v3"
+BASE_URL = "https://www.googleapis.com/webmasters/v3/"
 ROW_LIMIT = 25000
 
 
@@ -67,7 +67,7 @@ class Sites(GoogleSearchConsole):
         stream_slice: Mapping[str, Any] = None,
         next_page_token: Mapping[str, Any] = None,
     ) -> str:
-        return f"/sites/{stream_slice.get('site_url')}"
+        return f"sites/{stream_slice.get('site_url')}"
 
 
 class Sitemaps(GoogleSearchConsole):
@@ -83,7 +83,7 @@ class Sitemaps(GoogleSearchConsole):
         stream_slice: Mapping[str, Any] = None,
         next_page_token: Mapping[str, Any] = None,
     ) -> str:
-        return f"/sites/{stream_slice.get('site_url')}/sitemaps"
+        return f"sites/{stream_slice.get('site_url')}/sitemaps"
 
 
 class SearchAnalytics(GoogleSearchConsole, ABC):
@@ -102,7 +102,7 @@ class SearchAnalytics(GoogleSearchConsole, ABC):
         stream_slice: Mapping[str, Any] = None,
         next_page_token: Mapping[str, Any] = None,
     ) -> str:
-        return f"/sites/{stream_slice.get('site_url')}/searchAnalytics/query"
+        return f"sites/{stream_slice.get('site_url')}/searchAnalytics/query"
 
     @property
     def cursor_field(self) -> Union[str, List[str]]:

--- a/airbyte-integrations/connectors/source-marketo/source_marketo/source.py
+++ b/airbyte-integrations/connectors/source-marketo/source_marketo/source.py
@@ -30,7 +30,7 @@ class MarketoStream(HttpStream, ABC):
         self.config = config
         self.start_date = config["start_date"]
         self.window_in_days = config["window_in_days"]
-        self._url_base = config["domain_url"]
+        self._url_base = config["domain_url"].rstrip("/") + "/"
         self.stream_name = stream_name
         self.param = param
         self.export_id = export_id
@@ -40,7 +40,7 @@ class MarketoStream(HttpStream, ABC):
         return self._url_base
 
     def path(self, **kwargs) -> str:
-        return f"/rest/v1/{self.name}.json"
+        return f"rest/v1/{self.name}.json"
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         next_page = response.json().get("nextPageToken")
@@ -158,7 +158,7 @@ class MarketoExportBase(IncrementalMarketoStream):
         )
 
     def path(self, stream_slice: Mapping[str, Any] = None, **kwargs) -> str:
-        return f"/bulk/v1/{self.stream_name}/export/{stream_slice['id']}/file.json"
+        return f"bulk/v1/{self.stream_name}/export/{stream_slice['id']}/file.json"
 
     def stream_slices(self, sync_mode, stream_state: Mapping[str, Any] = None, **kwargs) -> Iterable[Optional[Mapping[str, any]]]:
         date_slices = super().stream_slices(sync_mode, stream_state, **kwargs)
@@ -252,7 +252,7 @@ class MarketoExportCreate(MarketoStream):
     http_method = "POST"
 
     def path(self, **kwargs) -> str:
-        return f"/bulk/v1/{self.stream_name}/export/create.json"
+        return f"bulk/v1/{self.stream_name}/export/create.json"
 
     def request_body_json(self, **kwargs) -> Optional[Mapping]:
         params = {"format": "CSV"}
@@ -280,7 +280,7 @@ class MarketoExportStart(MarketoStream):
     http_method = "POST"
 
     def path(self, **kwargs) -> str:
-        return f"/bulk/v1/{self.stream_name}/export/{self.export_id}/enqueue.json"
+        return f"bulk/v1/{self.stream_name}/export/{self.export_id}/enqueue.json"
 
 
 class MarketoExportStatus(MarketoStream):
@@ -290,7 +290,7 @@ class MarketoExportStatus(MarketoStream):
     """
 
     def path(self, **kwargs) -> str:
-        return f"/bulk/v1/{self.stream_name}/export/{self.export_id}/status.json"
+        return f"bulk/v1/{self.stream_name}/export/{self.export_id}/status.json"
 
     def parse_response(self, response: requests.Response, **kwargs) -> List[str]:
         return [response.json()[self.data_field][0]["status"]]
@@ -384,7 +384,7 @@ class ActivityTypes(MarketoStream):
     """
 
     def path(self, stream_slice: Mapping[str, Any] = None, **kwargs) -> str:
-        return "/rest/v1/activities/types.json"
+        return "rest/v1/activities/types.json"
 
 
 class Programs(IncrementalMarketoStream):
@@ -401,7 +401,7 @@ class Programs(IncrementalMarketoStream):
         self.offset = 0
 
     def path(self, **kwargs) -> str:
-        return f"/rest/asset/v1/{self.name}.json"
+        return f"rest/asset/v1/{self.name}.json"
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         data = response.json().get(self.data_field)

--- a/airbyte-integrations/connectors/source-okta/source_okta/source.py
+++ b/airbyte-integrations/connectors/source-okta/source_okta/source.py
@@ -21,7 +21,7 @@ class OktaStream(HttpStream, ABC):
     def __init__(self, url_base: str, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Inject custom url base to the stream
-        self._url_base = url_base
+        self._url_base = url_base.rstrip("/") + "/"
 
     @property
     def url_base(self) -> str:

--- a/airbyte-integrations/connectors/source-shortio/source_shortio/source.py
+++ b/airbyte-integrations/connectors/source-shortio/source_shortio/source.py
@@ -22,7 +22,7 @@ class BasicAuthenticator(TokenAuthenticator):
 
 class Links(HttpStream, ABC):
 
-    url_base = "https://api.short.io/api"
+    url_base = "https://api.short.io/api/"
     limit = 150
     primary_key = "id"
     before_id = None
@@ -60,7 +60,7 @@ class Links(HttpStream, ABC):
         next_page_token: Mapping[str, Any] = None,
     ) -> str:
         # Get all the links
-        return "/links"
+        return "links"
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
         """

--- a/airbyte-integrations/connectors/source-typeform/source_typeform/source.py
+++ b/airbyte-integrations/connectors/source-typeform/source_typeform/source.py
@@ -20,7 +20,7 @@ from pendulum.datetime import DateTime
 
 
 class TypeformStream(HttpStream, ABC):
-    url_base = "https://api.typeform.com"
+    url_base = "https://api.typeform.com/"
     # maximum number of entities in API response per single page
     limit: int = 200
     date_format: str = "YYYY-MM-DDTHH:mm:ss[Z]"
@@ -55,7 +55,7 @@ class TrimForms(TypeformStream):
         stream_slice: Mapping[str, Any] = None,
         next_page_token: Optional[Any] = None,
     ) -> str:
-        return "/forms"
+        return "forms"
 
     def next_page_token(self, response: requests.Response) -> Optional[Any]:
         page = self.get_current_page_token(response.url)
@@ -108,7 +108,7 @@ class Forms(TrimFormsMixin, TypeformStream):
         stream_slice: Mapping[str, Any] = None,
         next_page_token: Optional[Any] = None,
     ) -> str:
-        return f"/forms/{stream_slice['form_id']}"
+        return f"forms/{stream_slice['form_id']}"
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
         yield response.json()
@@ -149,7 +149,7 @@ class Responses(TrimFormsMixin, IncrementalTypeformStream):
     limit: int = 1000
 
     def path(self, stream_slice: Optional[Mapping[str, Any]] = None, **kwargs) -> str:
-        return f"/forms/{stream_slice['form_id']}/responses"
+        return f"forms/{stream_slice['form_id']}/responses"
 
     def get_form_id(self, record: Mapping[str, Any]) -> Optional[str]:
         """


### PR DESCRIPTION
Signed-off-by: Sergei Solonitcyn <sergei.solonitcyn@zazmic.com>

## What
Current realization of the CDK uses straight strings concatenation to create a full url from `url_base` and `/path`.
It works for the most of cases. But the reason why it is a common-known bad practice, is a lack of flexibility.

One case, which was the initial reson of this update, is a Mailgun source, where we get a full url for `next` and `previous` pages. Using current scheme we're forced to create ugly code trying to extract parts of the url and concatenate it with existing base url. Besides all, it's not guaranteed to get right url this way, as the source doesn't define it.

So, we should use best practice to create urls in a flexible and predictable way.

## How
Just replaced concatenation with `urllib.parse.urljoin` function.
Some of existing connectors used to rely on the old way of url creation. They also were updated according to the new one.

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py`
2. the rest

##  User Impact 
It isn't expected to have any user impact.
Only one dangerous is that some of existing conenctors could be left unattended during this change.
Automatic integration tests have to show if this is the case.

