### PR TITLE
[oc] log the job that is cancelled when pruning zombie jobs

### DIFF
--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
@@ -168,6 +168,12 @@ public class SchedulerApp {
   private void cleanupZombies(final JobPersistence jobPersistence, final JobNotifier jobNotifier) throws IOException {
     for (final Job zombieJob : jobPersistence.listJobsWithStatus(JobStatus.RUNNING)) {
       jobNotifier.failJob("zombie job was cancelled", zombieJob);
+      LOGGER.warn(
+          "zombie clean up - job was cancelled. job id: {}, type: {}, scope: {}",
+          zombieJob.getId(),
+          zombieJob.getConfigType(),
+          zombieJob.getScope());
+
       jobPersistence.cancelJob(zombieJob.getId());
     }
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CancellationHandler.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CancellationHandler.java
@@ -38,11 +38,12 @@ public interface CancellationHandler {
     @Override
     public void checkAndHandleCancellation(final Runnable onCancellationCallback) {
       try {
-        // Heartbeat is somewhat misleading here. What it does is check the current Temporal activity's
-        // context and
-        // throw an exception if the sync has been cancelled or timed out. The input to this heartbeat
-        // function
-        // is available as a field in thrown ActivityCompletionExceptions, which we aren't using for now.
+        /*
+         * Heartbeat is somewhat misleading here. What it does is check the current Temporal activity's
+         * context and throw an exception if the sync has been cancelled or timed out. The input to this
+         * heartbeat function is available as a field in thrown ActivityCompletionExceptions, which we
+         * aren't using for now.
+         */
         context.heartbeat(null);
       } catch (final ActivityCompletionException e) {
         onCancellationCallback.run();


### PR DESCRIPTION
relates to https://github.com/airbytehq/oncall/issues/44

## What
* My hypothesis is that these errant cancellations are because the scheduler is that these jobs get pruned when the scheduler restarts.

## How
* Log whenever the zombie job pruner cancels a job to verify this thesis.
