### PR TITLE
added __init__.py file to utils

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.39
+Add `__init__.py` to mark the directory `airbyte_cdk/utils` as a package.
+
 ## 0.1.38
 Improve URL-creation in CDK. Changed to using `urllib.parse.urljoin()`.
 

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.38",
+    version="0.1.39",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## What
`airbyte_cdk/utils` is not recognized as a python package. It prevents to import from that.
## How
add `__init__.py` to mark the directory as a package

## Recommended reading order
1. `airbyte_cdk/utils/__init__.py`
