### PR TITLE
show google sheets in UI again

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -90,7 +90,6 @@ const ConnectorServiceTypeControl: React.FC<{
       ? [
           "200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b", // Snapchat
           "2470e835-feaf-4db6-96f3-70fd645acc77", // Salesforce Singer
-          "71607ba1-c0ac-4799-8049-7f4b90dd50f7", // Google Sheets
           "9da77001-af33-4bcd-be46-6252bf9342b9", // Shopify
         ]
       : [];


### PR DESCRIPTION
## What
Google sheets has been on the disallow list for cloud because OAuth isn't set up. I'm adding the cloud OAuth support now so want to show Sheets connector in UI again.

## How
See the original _hack_ comment in the changed file for explanation of this disallow list.