### PR TITLE
🐛  Source Google Ads: Fix problem of valid custom queries failing.

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-ads/Dockerfile
@@ -13,5 +13,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.16
+LABEL io.airbyte.version=0.1.17
 LABEL io.airbyte.name=airbyte/source-google-ads

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -48,11 +48,12 @@ class SourceGoogleAds(AbstractSource):
                 q = q.get("query")
                 if CustomQuery.cursor_field in q:
                     raise Exception(f"Custom query should not contain {CustomQuery.cursor_field}")
-                req_q = CustomQuery.insert_segments_date_expr(q, "1980-01-01", "1980-01-01")
-                google_api.send_request(req_q)
+                #req_q = CustomQuery.insert_segments_date_expr(q, "1980-01-01", "1980-01-01")
+                #google_api.send_request(req_q)
+                google_api.send_request(q)
             return True, None
         except GoogleAdsException as error:
-            return False, f"Unable to connect to Google Ads API with the provided credentials - {repr(error.failure)}"
+            return False, f"Exception returned from Google Ads API - {repr(error.failure)}"
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         google_api = GoogleAds(credentials=self.get_credentials(config), customer_id=config["customer_id"])

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json
@@ -82,6 +82,12 @@
               "type": "string",
               "title": "Destination table name",
               "description": "The table name in your destination database for choosen query."
+            },
+            "segmentable": {
+              "type": "boolean",
+              "default": false,
+              "title": "Toggle on if query can be segmented by segments.date",
+              "description": "Queries that are valid when segmented by segments.date will be eligible for incremental syncs"
             }
           }
         }

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -95,6 +95,7 @@ This source is constrained by whatever API limits are set for the Google Ads tha
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| `0.1.17` | 2021-12-06 | []() | Fix failing custom queries |
 | `0.1.16` | 2021-11-22 | [8178](https://github.com/airbytehq/airbyte/pull/8178) | clarify setup fields |
 | `0.1.15` | 2021-10-07 | [6684](https://github.com/airbytehq/airbyte/pull/6684) | Add new stream `click_view` |
 | `0.1.14` | 2021-10-01 | [6565](https://github.com/airbytehq/airbyte/pull/6565) | Fix OAuth Spec File |

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -95,7 +95,7 @@ This source is constrained by whatever API limits are set for the Google Ads tha
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| `0.1.17` | 2021-12-06 | []() | Fix failing custom queries |
+| `0.1.17` | 2021-12-06 | [8567](https://github.com/airbytehq/airbyte/pull/8567) | Fix failing custom queries |
 | `0.1.16` | 2021-11-22 | [8178](https://github.com/airbytehq/airbyte/pull/8178) | clarify setup fields |
 | `0.1.15` | 2021-10-07 | [6684](https://github.com/airbytehq/airbyte/pull/6684) | Add new stream `click_view` |
 | `0.1.14` | 2021-10-01 | [6565](https://github.com/airbytehq/airbyte/pull/6565) | Fix OAuth Spec File |


### PR DESCRIPTION
## What

The Airbyte Source Connector for Google Ads was given the capability to handle custom queries to the API using Google's SQL-like query language (GAQL).  This was done in PR #5302.  When trying to use it, I discovered that the custom queries failed if I was querying a Google Ads object for which it is not possible to slice by the field `segments.date`.  That is because the (incrementally based) class that is handling the custom queries automatically appends a line with `segments.date` to all queries.  Example objects that cannot be queried with this connector are MediaFile and CampaignCriterion.  It is thus fairly easy for a user to write an otherwise valid GAQL query that will fail in the connector.

This PR would allow the Google Ads connector to include custom queries to objects that are not eligible to be segmented.  

## How
In the case of a custom query, the user is asked whether their query is eligible to be segmented by `segments.date` (via a boolean in the spec).  If it is not the case, then the original query is used rather than a sliced version (a full refresh version of the connector).  

## Recommended reading order
1. `spec.json`
2. `source.py`
3. `custom_query_stream.py`

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 



<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [x] Code reviews completed
- [x] Documentation updated 
    - [na] Connector's `README.md`
    - [na] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>
</details>

