### PR TITLE
🐛 Helm chart: Allow writing logs to S3 easily

### DIFF
--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -24,16 +24,16 @@ version: 0.3.0
 appVersion: "0.33.5-alpha"
 
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  tags:
-    - bitnami-common
-  version: 1.x.x
-- condition: postgresql.enabled
-  name: postgresql
-  version: 10.x.x
-  repository: https://charts.bitnami.com/bitnami
-- condition: minio.enabled
-  name: minio
-  version: 7.x.x
-  repository: https://charts.bitnami.com/bitnami
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
+  - condition: postgresql.enabled
+    name: postgresql
+    version: 10.x.x
+    repository: https://charts.bitnami.com/bitnami
+  - condition: minio.enabled
+    name: minio
+    version: 7.x.x
+    repository: https://charts.bitnami.com/bitnami

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -39,7 +39,6 @@
 | `webapp.tolerations`         | Tolerations for webapp pod assignment.                           | `[]`             |
 | `webapp.ingress.enabled`     | Set to true to enable ingress record generation                  | `false`          |
 | `webapp.ingress.className`   | Specifies ingressClassName for clusters >= 1.18+                 | `""`             |
-| `webapp.ingress.hosts`       | Ingress Hosts configuration                                      | `[]`             |
 | `webapp.ingress.annotations` | Ingress annotations done as key:value pairs                      | `{}`             |
 | `webapp.ingress.hosts`       | The list of hostnames to be covered with this ingress record.    | `[]`             |
 | `webapp.ingress.tls`         | Custom ingress TLS configuration                                 | `[]`             |
@@ -176,14 +175,18 @@
 | `externalDatabase.port`                      | Database port number                                                                      | `5432`       |
 
 
-### Minio parameters
+### Logs parameters
 
-| Name                       | Description                                      | Value       |
-| -------------------------- | ------------------------------------------------ | ----------- |
-| `minio.enabled`            | Switch to enable or disable the Minio helm chart | `true`      |
-| `minio.accessKey.password` | Minio Access Key                                 | `minio`     |
-| `minio.secretKey.password` | Minio Secret Key                                 | `minio123`  |
-| `externalMinio.host`       | Minio Host                                       | `localhost` |
-| `externalMinio.port`       | Minio Port                                       | `9000`      |
+| Name                         | Description                                            | Value              |
+| ---------------------------- | ------------------------------------------------------ | ------------------ |
+| `logs.accessKey.password`    | Logs Access Key                                        | `minio`            |
+| `logs.secretKey.password`    | Logs Secret Key                                        | `minio123`         |
+| `logs.minio.enabled`         | Switch to enable or disable the Minio helm chart       | `true`             |
+| `logs.externalMinio.enabled` | Switch to enable or disable an external Minio instance | `false`            |
+| `logs.externalMinio.host`    | External Minio Host                                    | `localhost`        |
+| `logs.externalMinio.port`    | External Minio Port                                    | `9000`             |
+| `logs.s3.enabled`            | Switch to enable or disable custom S3 Log location     | `false`            |
+| `logs.s3.bucket`             | Bucket name where logs should be stored                | `airbyte-dev-logs` |
+| `logs.s3.bucketRegion`       | Region of the bucket (must be empty if using minio)    | `""`               |
 
 

--- a/charts/airbyte/templates/_helpers.tpl
+++ b/charts/airbyte/templates/_helpers.tpl
@@ -151,28 +151,25 @@ Create a default fully qualified minio name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "airbyte.minio.fullname" -}}
-{{- $name := default "minio" .Values.minio.nameOverride -}}
+{{- $name := default "minio" .Values.logs.minio.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Add environment variables to configure minio
 */}}
-{{- define "airbyte.minio.host" -}}
-{{- ternary (include "airbyte.minio.fullname" .) .Values.externalMinio.host .Values.minio.enabled -}}
-{{- end -}}
-
-{{/*
-Add environment variables to configure minio
-*/}}
-{{- define "airbyte.minio.port" -}}
-{{- ternary "9000" .Values.externalMinio.port .Values.minio.enabled -}}
-{{- end -}}
-
 {{- define "airbyte.minio.endpoint" -}}
-{{- $host := (include "airbyte.minio.host" .) -}}
-{{- $port := (include "airbyte.minio.port" .) -}}
-{{- printf "http://%s:%s" $host $port -}}
+{{- if .Values.logs.minio.enabled -}}
+    {{- printf "http://%s:%s" (include "airbyte.minio.fullname" .) 9000 -}}
+{{- else if .Values.logs.externalMinio.enabled -}}
+    {{- printf "http://%s:%s" .Values.logs.externalMinio.host .Values.logs.externalMinio.port -}}
+{{- else -}}
+    {{- printf "" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "airbyte.s3PathStyleAccess" -}}
+{{- ternary "true" "" (or .Values.logs.minio.enabled .Values.logs.externalMinio.enabled) -}}
 {{- end -}}
 
 {{/*

--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -21,11 +21,11 @@ data:
   GOOGLE_APPLICATION_CREDENTIALS: ""
   INTERNAL_API_HOST: {{ include "common.names.fullname" . }}-server:{{ .Values.server.service.port }}
   IS_DEMO: {{ ternary "true" "false" .Values.webapp.isDemo | quote }}
-  LOCAL_ROOT: /tmp/airbyte_local
   JOB_POD_MAIN_CONTAINER_CPU_LIMIT: ""
   JOB_POD_MAIN_CONTAINER_CPU_REQUEST: ""
   JOB_POD_MAIN_CONTAINER_MEMORY_LIMIT: ""
   JOB_POD_MAIN_CONTAINER_MEMORY_REQUEST: ""
+  LOCAL_ROOT: /tmp/airbyte_local
   RUN_DATABASE_MIGRATION_ON_STARTUP: "true"
   S3_LOG_BUCKET: {{ .Values.logs.s3.bucket }}
   S3_LOG_BUCKET_REGION: {{ .Values.logs.s3.bucketRegion }}

--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -5,8 +5,8 @@ metadata:
 data:
   AIRBYTE_VERSION: {{ .Values.version | default .Chart.AppVersion }}
   API_URL: {{ .Values.webapp.api.url }}
-  AWS_ACCESS_KEY_ID: {{ .Values.minio.accessKey.password }}
-  AWS_SECRET_ACCESS_KEY: {{ .Values.minio.secretKey.password }}
+  AWS_ACCESS_KEY_ID: {{ .Values.logs.accessKey.password }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.logs.secretKey.password }}
   CONFIG_ROOT: /configs
   DATA_DOCKER_MOUNT: airbyte_data
   DATABASE_DB: {{ include "airbyte.database.name" . }}
@@ -27,10 +27,10 @@ data:
   JOB_POD_MAIN_CONTAINER_MEMORY_LIMIT: ""
   JOB_POD_MAIN_CONTAINER_MEMORY_REQUEST: ""
   RUN_DATABASE_MIGRATION_ON_STARTUP: "true"
-  S3_LOG_BUCKET: airbyte-dev-logs
-  S3_LOG_BUCKET_REGION: ""
-  S3_MINIO_ENDPOINT: {{ include "airbyte.minio.endpoint" . }}
-  S3_PATH_STYLE_ACCESS: "true"
+  S3_LOG_BUCKET: {{ .Values.logs.s3.bucket }}
+  S3_LOG_BUCKET_REGION: {{ .Values.logs.s3.bucketRegion }}
+  S3_MINIO_ENDPOINT: {{ include "airbyte.minio.endpoint" . | quote }}
+  S3_PATH_STYLE_ACCESS: {{ include "airbyte.s3PathStyleAccess" . | quote }}
   SUBMITTER_NUM_THREADS: "10"
   TEMPORAL_HOST: {{ include "common.names.fullname" . }}-temporal:{{ .Values.temporal.service.port }}
   TEMPORAL_WORKER_PORTS: 9001,9002,9003,9004,9005,9006,9007,9008,9009,9010,9011,9012,9013,9014,9015,9016,9017,9018,9019,9020,9021,9022,9023,9024,9025,9026,9027,9028,9029,9030,9031,9032,9033,9034,9035,9036,9037,9038,9039,9040

--- a/charts/airbyte/templates/scheduler/deployment.yaml
+++ b/charts/airbyte/templates/scheduler/deployment.yaml
@@ -151,9 +151,15 @@ spec:
               name: airbyte-env
               key: S3_LOG_BUCKET_REGION
         - name: AWS_ACCESS_KEY_ID
-          value: {{ .Values.minio.accessKey.password }}
+          valueFrom:
+            configMapKeyRef:
+              name: airbyte-env
+              key: AWS_ACCESS_KEY_ID
         - name: AWS_SECRET_ACCESS_KEY
-          value: {{ .Values.minio.secretKey.password }}
+          valueFrom:
+            configMapKeyRef:
+              name: airbyte-env
+              key: AWS_SECRET_ACCESS_KEY
         - name: S3_MINIO_ENDPOINT
           valueFrom:
             configMapKeyRef:

--- a/charts/airbyte/templates/server/deployment.yaml
+++ b/charts/airbyte/templates/server/deployment.yaml
@@ -92,7 +92,7 @@ spec:
               name: airbyte-env
               key: TEMPORAL_HOST
         - name: LOG_LEVEL
-          value: "{{ .Values.scheduler.log.level }}"
+          value: "{{ .Values.server.log.level }}"
         - name: JOB_POD_MAIN_CONTAINER_CPU_REQUEST
           valueFrom:
             configMapKeyRef:

--- a/charts/airbyte/templates/temporal/deployment.yaml
+++ b/charts/airbyte/templates/temporal/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         volumeMounts:
         - name: airbyte-temporal-dynamicconfig
           mountPath: "/etc/temporal/config/dynamicconfig/"
-        {{- if .Values.server.resources }}
+        {{- if .Values.temporal.resources }}
         resources: {{- toYaml .Values.temporal.resources | nindent 10 }}
         {{- end }}
       volumes:

--- a/charts/airbyte/templates/worker/deployment.yaml
+++ b/charts/airbyte/templates/worker/deployment.yaml
@@ -153,9 +153,15 @@ spec:
               name: airbyte-env
               key: S3_LOG_BUCKET_REGION
         - name: AWS_ACCESS_KEY_ID
-          value: {{ .Values.minio.accessKey.password }}
+          valueFrom:
+            configMapKeyRef:
+              name: airbyte-env
+              key: AWS_ACCESS_KEY_ID
         - name: AWS_SECRET_ACCESS_KEY
-          value: {{ .Values.minio.secretKey.password }}
+          valueFrom:
+            configMapKeyRef:
+              name: airbyte-env
+              key: AWS_SECRET_ACCESS_KEY
         - name: S3_MINIO_ENDPOINT
           valueFrom:
             configMapKeyRef:

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -534,8 +534,8 @@ logs:
     enabled: true
 
   ## @param logs.externalMinio.enabled Switch to enable or disable an external Minio instance
-  ## @param logs.externalMinio.host Minio Host
-  ## @param logs.externalMinio.port Minio Port
+  ## @param logs.externalMinio.host External Minio Host
+  ## @param logs.externalMinio.port External Minio Port
   externalMinio:
     enabled: false
     host: localhost

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -519,24 +519,32 @@ externalDatabase:
   database: db-airbyte
   port: 5432
 
-## @section Minio parameters
 
-## Minio chart configuration
-## ref: https://github.com/bitnami/charts/blob/master/bitnami/minio/values.yaml
-## @param minio.enabled Switch to enable or disable the Minio helm chart
-## @param minio.accessKey.password Minio Access Key
-## @param minio.secretKey.password Minio Secret Key
-minio:
-  enabled: true
+## @section Logs parameters
+logs:
+  ## @param logs.accessKey.password Logs Access Key
+  ## @param logs.secretKey.password Logs Secret Key
   accessKey:
     password: minio
   secretKey:
     password: minio123
 
-## External Minio configuration
-## All of these values are only used when minio.enabled is set to false
-## @param externalMinio.host Minio Host
-## @param externalMinio.port Minio Port
-externalMinio:
-  host: localhost
-  port: 9000
+  ## @param logs.minio.enabled Switch to enable or disable the Minio helm chart
+  minio:
+    enabled: true
+
+  ## @param logs.externalMinio.enabled Switch to enable or disable an external Minio instance
+  ## @param logs.externalMinio.host Minio Host
+  ## @param logs.externalMinio.port Minio Port
+  externalMinio:
+    enabled: false
+    host: localhost
+    port: 9000
+
+  ## @param logs.s3.enabled Switch to enable or disable custom S3 Log location
+  ## @param logs.s3.bucket Bucket name where logs should be stored
+  ## @param logs.s3.bucketRegion Region of the bucket (must be empty if using minio)
+  s3:
+    enabled: false
+    bucket: airbyte-dev-logs
+    bucketRegion: ""

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -31,7 +31,6 @@ serviceAccount:
 ## If changing the image tags below, you should probably also update this.
 version: ""
 
-
 ## @section Webapp Parameters
 
 webapp:
@@ -189,7 +188,6 @@ scheduler:
   ##   value: "key=sample-value"
   extraEnv: []
 
-
 ## @section Pod Sweeper parameters
 
 podSweeper:
@@ -234,7 +232,6 @@ podSweeper:
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-
 
 ## @section Server parameters
 
@@ -479,7 +476,6 @@ temporal:
   ##   value: "key=sample-value"
   extraEnv: []
 
-
 ## @section Airbyte Database parameters
 
 ## PostgreSQL chart configuration
@@ -499,7 +495,6 @@ postgresql:
   ##
   existingSecret: ""
 
-
 ## External PostgreSQL configuration
 ## All of these values are only used when postgresql.enabled is set to false
 ## @param externalDatabase.host Database host
@@ -518,7 +513,6 @@ externalDatabase:
   existingSecretPasswordKey: ""
   database: db-airbyte
   port: 5432
-
 
 ## @section Logs parameters
 logs:

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -90,7 +90,6 @@ webapp:
   ## ref: http://kubernetes.io/docs/user-guide/ingress/
   ## @param webapp.ingress.enabled Set to true to enable ingress record generation
   ## @param webapp.ingress.className Specifies ingressClassName for clusters >= 1.18+
-  ## @param webapp.ingress.hosts Ingress Hosts configuration
   ## @param webapp.ingress.annotations [object] Ingress annotations done as key:value pairs
   ## @param webapp.ingress.hosts The list of hostnames to be covered with this ingress record.
   ## @param webapp.ingress.tls [array] Custom ingress TLS configuration
@@ -98,13 +97,14 @@ webapp:
     enabled: false
     className: ""
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
-    hosts:
-    - host: chart-example.local
-      paths:
-      - path: /
-        pathType: ImplementationSpecific
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    hosts: []
+    # - host: chart-example.local
+    #   paths:
+    #   - path: /
+    #     pathType: ImplementationSpecific
+
     tls: []
     # - secretName: chart-example-tls
     #   hosts:


### PR DESCRIPTION
## What
The current helm chart is aimed to be used with Minio (chart or external) but not for S3 location.

## How
* add values for S3 env variables
* mutualize every logs-relative values in a `logs` section
* adapt the env configmap
* create or adapt helpers to manage every logging
* remove direct access to minio values in worker and scheduler deployments

### Also
* also fixed two non-relative values in temporal and server deployments

## 🚨 User Impact 🚨
People switching from the old chart to this version must adapt their values, especially `minio.*` and `externalMinio.*` that moved to `logs.minio.*` and `logs.externalMinio.*`
