### PR TITLE
upgrade temporal sdk to 1.6.0

### DIFF
--- a/airbyte-scheduler/app/build.gradle
+++ b/airbyte-scheduler/app/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation 'io.kubernetes:client-java-api:10.0.0'
     implementation 'io.kubernetes:client-java:10.0.0'
     implementation 'io.kubernetes:client-java-extended:10.0.0'
-    implementation 'io.temporal:temporal-sdk:1.0.4'
+    implementation 'io.temporal:temporal-sdk:1.6.0'
 
     implementation project(':airbyte-analytics')
     implementation project(':airbyte-api')

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -44,7 +44,7 @@ publishing {
 }
 
 dependencies {
-    implementation 'io.temporal:temporal-sdk:1.0.4'
+    implementation 'io.temporal:temporal-sdk:1.6.0'
 
     implementation 'org.apache.cxf:cxf-core:3.4.2'
 

--- a/airbyte-workers/build.gradle
+++ b/airbyte-workers/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:2.13.0'
     testImplementation 'org.postgresql:postgresql:42.2.18'
     testImplementation "org.flywaydb:flyway-core:7.14.0"
+    testImplementation 'io.temporal:temporal-testing:1.6.0'
     testImplementation 'org.testcontainers:testcontainers:1.15.3'
     testImplementation 'org.testcontainers:postgresql:1.15.3'
 

--- a/airbyte-workers/build.gradle
+++ b/airbyte-workers/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'io.kubernetes:client-java-api:10.0.0'
     implementation 'io.kubernetes:client-java:10.0.0'
     implementation 'io.kubernetes:client-java-extended:10.0.0'
-    implementation 'io.temporal:temporal-sdk:1.0.4'
+    implementation 'io.temporal:temporal-sdk:1.6.0'
     implementation 'org.apache.ant:ant:1.10.10'
     implementation 'org.apache.commons:commons-lang3:3.11'
     implementation 'org.apache.commons:commons-text:1.9'

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalAttemptExecutionTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalAttemptExecutionTest.java
@@ -17,7 +17,7 @@ import io.airbyte.config.Configs;
 import io.airbyte.db.instance.test.TestDatabaseProviders;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.Worker;
-import io.temporal.internal.common.CheckedExceptionWrapper;
+import io.temporal.serviceclient.CheckedExceptionWrapper;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;


### PR DESCRIPTION
Harsha posted about the release on Slack.

Looks like there are a variety of stability improvements over the past few versions. Also some `DEADLINE_EXCEEDED` retry improvements!