### PR TITLE
airbyte-8585 Template for bug-fix PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug-fix_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug-fix_template.md
@@ -1,0 +1,23 @@
+# Bug-fix Request
+
+Fixes #*(issue number)*
+
+---
+
+## Reason
+*describe here what is the root cause of the issue*
+
+## Confirmation
+ - [ ] **Was reproduced locally**
+
+*if this PR is a guess at a solution, put here your thoughts with explanations, else remove this*
+
+
+## How does the code change in the PR fix the issue?
+*describe here*
+
+---
+
+### Recommended reading order
+1. `x.java`
+2. `y.python`


### PR DESCRIPTION
Prepared the template itself.
Requires an additional tool to work with, as it to complicated to choose PR template manually.

## What
Partly solves #8585 

## How
The template is created, but only one possibility to use different templates for PRs is to make manual queries with parameters in URL. It could become easier later in case of creating a helper as a part of general CLI tool.
Anyway, the template itself could be useful now for ones who would copy&paste its content duirng making their PRs. So it should be stored.
