### PR TITLE
Revert "Revert "Update platform containers to use non-root users""

### DIFF
--- a/airbyte-scheduler/app/Dockerfile
+++ b/airbyte-scheduler/app/Dockerfile
@@ -3,9 +3,15 @@ FROM openjdk:${JDK_VERSION}-slim AS scheduler
 
 ENV APPLICATION airbyte-scheduler
 
+RUN groupadd --gid 1000 airbyte && \
+    useradd --uid 1000 --gid airbyte airbyte
+
 WORKDIR /app
 
 ADD bin/${APPLICATION}-0.33.5-alpha.tar /app
+
+# Set user to Airbyte, use numeric value for k8s runAsNonRoot PodSecurityPolicy
+USER 1000:1000
 
 # wait for upstream dependencies to become available before starting server
 ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.33.5-alpha/bin/${APPLICATION}"]

--- a/airbyte-server/Dockerfile
+++ b/airbyte-server/Dockerfile
@@ -5,9 +5,15 @@ EXPOSE 8000
 
 ENV APPLICATION airbyte-server
 
+RUN groupadd --gid 1000 airbyte && \
+    useradd --uid 1000 --gid airbyte airbyte
+
 WORKDIR /app
 
 ADD bin/${APPLICATION}-0.33.5-alpha.tar /app
+
+# Set user to Airbyte, use numeric value for k8s runAsNonRoot PodSecurityPolicy
+USER 1000:1000
 
 # wait for upstream dependencies to become available before starting server
 ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.33.5-alpha/bin/${APPLICATION}"]

--- a/airbyte-webapp/Dockerfile
+++ b/airbyte-webapp/Dockerfile
@@ -1,6 +1,6 @@
-FROM nginx:1.19-alpine as webapp
+FROM nginxinc/nginx-unprivileged:1.19-alpine as webapp
 
-EXPOSE 80
+EXPOSE 8080
 
 COPY bin/build /usr/share/nginx/html
 COPY bin/docs /usr/share/nginx/html/docs

--- a/airbyte-webapp/nginx/default.conf.template
+++ b/airbyte-webapp/nginx/default.conf.template
@@ -3,8 +3,8 @@ upstream api-server {
 }
 
 server {
-    listen       80;
-    listen  [::]:80;
+    listen       8080;
+    listen  [::]:8080;
     server_name  localhost;
 
     #charset koi8-r;

--- a/airbyte-workers/Dockerfile
+++ b/airbyte-workers/Dockerfile
@@ -3,6 +3,9 @@ FROM openjdk:${JDK_VERSION}-slim AS worker
 
 ARG DOCKER_BUILD_ARCH=amd64
 
+RUN groupadd --gid 1000 airbyte && \
+    useradd --uid 1000 --gid airbyte airbyte
+
 # Install Docker to launch worker images. Eventually should be replaced with Docker-java.
 # See https://gitter.im/docker-java/docker-java?at=5f3eb87ba8c1780176603f4e for more information on why we are not currently using Docker-java
 RUN apt-get update && apt-get install -y \
@@ -24,6 +27,9 @@ WORKDIR /app
 
 # Move worker app
 ADD bin/${APPLICATION}-0.33.5-alpha.tar /app
+
+# Set user to Airbyte, use numeric value for k8s runAsNonRoot PodSecurityPolicy
+USER 1000:1000
 
 # wait for upstream dependencies to become available before starting server
 ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.33.5-alpha/bin/${APPLICATION}"]

--- a/charts/airbyte/templates/webapp/deployment.yaml
+++ b/charts/airbyte/templates/webapp/deployment.yaml
@@ -65,7 +65,7 @@ spec:
         {{- end }}
         ports:
         - name: http
-          containerPort: 80
+          containerPort: 8080
           protocol: TCP
         {{- if .Values.webapp.resources }}
         resources: {{- toYaml .Values.webapp.resources | nindent 10 }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -164,7 +164,7 @@ services:
     container_name: airbyte-webapp
     restart: unless-stopped
     ports:
-      - 8000:80
+      - 8000:8080
     environment:
       - AIRBYTE_ROLE=${AIRBYTE_ROLE:-}
       - AIRBYTE_VERSION=${VERSION}

--- a/docs/contributing-to-airbyte/developing-on-kubernetes.md
+++ b/docs/contributing-to-airbyte/developing-on-kubernetes.md
@@ -14,7 +14,7 @@ If you're developing locally using Minikube/Docker Desktop/Kind, you can iterate
 ./gradlew build # build dev images
 kubectl delete -k kube/overlays/dev # optional (allows you to recreate resources from scratch)
 kubectl apply -k kube/overlays/dev # applies manifests
-kubectl port-forward svc/airbyte-webapp-svc 8000:80 # port forward the api/ui
+kubectl port-forward svc/airbyte-webapp-svc 8000:8080 # port forward the api/ui
 ```
 
 ## Iteration Cycle \(on GKE\)

--- a/docs/deploying-airbyte/on-kubernetes.md
+++ b/docs/deploying-airbyte/on-kubernetes.md
@@ -132,7 +132,7 @@ kubectl apply -k kube/overlays/stable
 
 After 2-5 minutes, `kubectl get pods | grep airbyte` should show `Running` as the status for all the core Airbyte pods. This may take longer on Kubernetes clusters with slow internet connections.
 
-Run `kubectl port-forward svc/airbyte-webapp-svc 8000:80` to allow access to the UI/API.
+Run `kubectl port-forward svc/airbyte-webapp-svc 8000:8080` to allow access to the UI/API.
 
 Now visit [http://localhost:8000](http://localhost:8000) in your browser and start moving some data!
 

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -77,7 +77,7 @@ If you are upgrading from \(i.e. your current version of Airbyte is\) Airbyte ve
 
    After 2-5 minutes, `kubectl get pods | grep airbyte` should show `Running` as the status for all the core Airbyte pods. This may take longer on Kubernetes clusters with slow internet connections.
 
-   Run `kubectl port-forward svc/airbyte-webapp-svc 8000:80` to allow access to the UI/API.
+   Run `kubectl port-forward svc/airbyte-webapp-svc 8000:8080` to allow access to the UI/API.
 
 ## Upgrading on K8s \(0.26.4-alpha and below\)
 

--- a/kube/overlays/dev-integration-test/.env
+++ b/kube/overlays/dev-integration-test/.env
@@ -27,7 +27,7 @@ SUBMITTER_NUM_THREADS=10
 
 # Miscellaneous
 TRACKING_STRATEGY=logging
-WEBAPP_URL=airbyte-webapp-svc:80
+WEBAPP_URL=airbyte-webapp-svc:8080
 API_URL=/api/v1/
 INTERNAL_API_HOST=airbyte-server-svc:8001
 

--- a/kube/overlays/dev/.env
+++ b/kube/overlays/dev/.env
@@ -29,7 +29,7 @@ SUBMITTER_NUM_THREADS=10
 
 # Miscellaneous
 TRACKING_STRATEGY=logging
-WEBAPP_URL=airbyte-webapp-svc:80
+WEBAPP_URL=airbyte-webapp-svc:8080
 API_URL=/api/v1/
 INTERNAL_API_HOST=airbyte-server-svc:8001
 

--- a/kube/overlays/stable-with-resource-limits/.env
+++ b/kube/overlays/stable-with-resource-limits/.env
@@ -29,7 +29,7 @@ SUBMITTER_NUM_THREADS=10
 
 # Miscellaneous
 TRACKING_STRATEGY=segment
-WEBAPP_URL=airbyte-webapp-svc:80
+WEBAPP_URL=airbyte-webapp-svc:8080
 API_URL=/api/v1/
 INTERNAL_API_HOST=airbyte-server-svc:8001
 

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -29,7 +29,7 @@ SUBMITTER_NUM_THREADS=10
 
 # Miscellaneous
 TRACKING_STRATEGY=segment
-WEBAPP_URL=airbyte-webapp-svc:80
+WEBAPP_URL=airbyte-webapp-svc:8080
 API_URL=/api/v1/
 INTERNAL_API_HOST=airbyte-server-svc:8001
 

--- a/kube/resources/webapp.yaml
+++ b/kube/resources/webapp.yaml
@@ -6,7 +6,9 @@ spec:
   type: NodePort
   ports:
     - port: 80
+      targetPort: http
       protocol: TCP
+      name: http
   selector:
     airbyte: webapp
 ---
@@ -59,4 +61,6 @@ spec:
                   name: airbyte-env
                   key: INTERNAL_API_HOST
           ports:
-            - containerPort: 80
+            - name: http
+              containerPort: 8080
+              protocol: TCP


### PR DESCRIPTION
Reverts airbytehq/airbyte#8611

Puts back in the original PR. We can iterate on fixing the tests in this PR. 

To merge, we need to perform a release immediately after. Otherwise the docker-compose.yaml file will be out of sync with the current version specified, and new users won't be able to onboard. 