### PR TITLE
rename logger client tests to cloud storage tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -481,7 +481,7 @@ jobs:
           CI=true IS_MINIKUBE=true ./tools/bin/acceptance_test_kube.sh
 
       - name: Run Logging Tests
-        run: ./tools/bin/cloud_storage_logging_test.sh
+        run: ./tools/bin/cloud_storage_test.sh
         env:
           AWS_S3_INTEGRATION_TEST_CREDS: ${{ secrets.AWS_S3_INTEGRATION_TEST_CREDS }}
           GOOGLE_CLOUD_STORAGE_TEST_CREDS: ${{ secrets.GOOGLE_CLOUD_STORAGE_TEST_CREDS }}

--- a/airbyte-config/models/build.gradle
+++ b/airbyte-config/models/build.gradle
@@ -28,7 +28,7 @@ jsonSchema2Pojo {
 
 test {
     useJUnitPlatform {
-        excludeTags 'log4j2-config', 'logger-client'
+        excludeTags 'log4j2-config', 'cloud-storage-integration-test'
     }
     testLogging {
         events "passed", "skipped", "failed"
@@ -44,9 +44,9 @@ task log4j2IntegrationTest(type: Test) {
     }
 }
 
-task logClientsIntegrationTest(type: Test) {
+task cloudStorageIntegrationTest(type: Test) {
     useJUnitPlatform {
-        includeTags 'logger-client'
+        includeTags 'cloud-storage-integration-test'
     }
     testLogging {
         events "passed", "skipped", "failed"

--- a/airbyte-config/models/src/test/java/io/airbyte/config/helpers/GcsLogsTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/helpers/GcsLogsTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@Tag("logger-client")
+@Tag("cloud-storage-integration-test")
 public class GcsLogsTest {
 
   private static Storage getClientFactory() {

--- a/airbyte-config/models/src/test/java/io/airbyte/config/helpers/KubeLoggingConfigTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/helpers/KubeLoggingConfigTest.java
@@ -42,7 +42,7 @@ public class KubeLoggingConfigTest {
   /**
    * Because this test tests our env var set up is compatible with our Log4j2 configuration, we are
    * unable to perform injection, and instead rely on env vars set in
-   * ./tools/bin/cloud_storage_logging_test.sh.
+   * ./tools/bin/cloud_storage_test.sh.
    *
    * This test will fail if certain env vars aren't set.
    */

--- a/airbyte-config/models/src/test/java/io/airbyte/config/helpers/S3LogsTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/helpers/S3LogsTest.java
@@ -20,7 +20,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
-@Tag("logger-client")
+@Tag("cloud-storage-integration-test")
 public class S3LogsTest {
 
   private static final String REGION_STRING = "us-west-2";

--- a/airbyte-workers/src/test/java/io/airbyte/workers/storage/GcsCloudDocumentStoreClientTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/storage/GcsCloudDocumentStoreClientTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@Tag("logger-client")
+@Tag("cloud-storage-integration-test")
 class GcsCloudDocumentStoreClientTest {
 
   private static final String BUCKET_NAME = "airbyte-kube-integration-logging-test";

--- a/airbyte-workers/src/test/java/io/airbyte/workers/storage/S3CloudDocumentStoreClientTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/storage/S3CloudDocumentStoreClientTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
-@Tag("logger-client")
+@Tag("cloud-storage-integration-test")
 class S3CloudDocumentStoreClientTest {
 
   private static final String BUCKET_NAME = "airbyte-kube-integration-logging-test";

--- a/tools/bin/cloud_storage_test.sh
+++ b/tools/bin/cloud_storage_test.sh
@@ -17,7 +17,7 @@ export GCS_LOG_BUCKET=airbyte-kube-integration-logging-test
 
 # Run the logging test first since the same client is used in the log4j2 integration test.
 echo "Running log client tests.."
-SUB_BUILD=PLATFORM ./gradlew :airbyte-config:models:logClientsIntegrationTest  --scan
+SUB_BUILD=PLATFORM ./gradlew :airbyte-config:models:cloudStorageIntegrationTest  --scan
 
 # Reset existing configurations and run this for each possible configuration
 # These configurations mirror the configurations documented in https://docs.airbyte.io/deploying-airbyte/on-kubernetes#configure-logs.


### PR DESCRIPTION
relates to #7476

## What
* I'm reusing the test infra that we used for testing logger clients against cloud storage for the state storage project. This PR renames appropriate files, tags, etc to reflect this conceptual change.
