### PR TITLE
Use python:3.10-slim in code-generator

### DIFF
--- a/tools/code-generator/Dockerfile
+++ b/tools/code-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.10-slim
 RUN pip install datamodel-code-generator==0.10.1
 ENTRYPOINT ["datamodel-codegen"]
 

--- a/tools/code-generator/Dockerfile
+++ b/tools/code-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.8-slim
 RUN pip install datamodel-code-generator==0.10.1
 ENTRYPOINT ["datamodel-codegen"]
 


### PR DESCRIPTION
## What

Using `python:3.7-slim` makes the platfom build fail on Apple M1.

## How
The role of this image is to benefit from `datamodel-code-generator` CLI in a docker container. This python library is compatible with python 3.10 so I think we can upgrade to 3.10.
 
* Use `python:3.10-slim` image

