### PR TITLE
Add info about skipped failed tests in /test command message

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -115,6 +115,7 @@ jobs:
           body: |
             > :white_check_mark: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
             ${{env.PYTHON_UNITTEST_COVERAGE_REPORT}}
+            ${{env.PYTHON_SHORT_TEST_SUMMARY_INFO}}
       - name: Add Failure Comment
         if: github.event.inputs.comment-id && failure()
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -115,7 +115,7 @@ jobs:
           body: |
             > :white_check_mark: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
             ${{env.PYTHON_UNITTEST_COVERAGE_REPORT}}
-            ${{env.PYTHON_SHORT_TEST_SUMMARY_INFO}}
+            > ${{env.PYTHON_SHORT_TEST_SUMMARY_INFO}}
       - name: Add Failure Comment
         if: github.event.inputs.comment-id && failure()
         uses: peter-evans/create-or-update-comment@v1
@@ -124,6 +124,7 @@ jobs:
           body: |
             > :x: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
             > :bug: ${{env.GRADLE_SCAN_LINK}}
+            > ${{env.PYTHON_SHORT_TEST_SUMMARY_INFO}}
   # In case of self-hosted EC2 errors, remove this block.
   stop-test-runner:
     name: Stop Build EC2 Runner

--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -22,7 +22,7 @@ Add ignored fields for full refresh test (unit tests)
 Add ignored fields for full refresh test
 
 ## 0.1.25
-Fix incorrect nested strucutres compare.
+Fix incorrect nested structures compare.
 
 ## 0.1.24
 Improve message about errors in the stream's schema: https://github.com/airbytehq/airbyte/pull/6934
@@ -43,7 +43,7 @@ Add oauth init flow parameter verification for spec.
 Assert a non-empty overlap between the fields present in the record and the declared json schema.
 
 ## 0.1.18
-Fix checking date-time format againt nullable field.
+Fix checking date-time format against nullable field.
 
 ## 0.1.17
 Fix serialize function for acceptance-tests: https://github.com/airbytehq/airbyte/pull/5738

--- a/airbyte-integrations/connectors/source-stripe/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-stripe/acceptance-test-config.yml
@@ -12,29 +12,29 @@ tests:
   discovery:
     - config_path: "secrets/config.json"
     - config_path: "secrets/connected_account_config.json"
-  basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/full_refresh_configured_catalog.json"
-    # TEST 1 - Reading catalog without invoice_line_items
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
-      timeout_seconds: 3600
-#    # TEST 2 - Reading data from account that has no records for stream Disputes
-    - config_path: "secrets/connected_account_config.json"
-      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"
-      timeout_seconds: 3600
-  incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
-      future_state_path: "integration_tests/abnormal_state.json"
-    - config_path: "secrets/connected_account_config.json"
-      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"
-      future_state_path: "integration_tests/abnormal_state.json"
-  full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
-      timeout_seconds: 3600
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/full_refresh_configured_catalog.json"
-    - config_path: "secrets/connected_account_config.json"
-      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"
+#  basic_read:
+#    - config_path: "secrets/config.json"
+#      configured_catalog_path: "integration_tests/full_refresh_configured_catalog.json"
+#    # TEST 1 - Reading catalog without invoice_line_items
+#    - config_path: "secrets/config.json"
+#      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
+#      timeout_seconds: 3600
+##    # TEST 2 - Reading data from account that has no records for stream Disputes
+#    - config_path: "secrets/connected_account_config.json"
+#      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"
+#      timeout_seconds: 3600
+#  incremental:
+#    - config_path: "secrets/config.json"
+#      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
+#      future_state_path: "integration_tests/abnormal_state.json"
+#    - config_path: "secrets/connected_account_config.json"
+#      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"
+#      future_state_path: "integration_tests/abnormal_state.json"
+#  full_refresh:
+#    - config_path: "secrets/config.json"
+#      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
+#      timeout_seconds: 3600
+#    - config_path: "secrets/config.json"
+#      configured_catalog_path: "integration_tests/full_refresh_configured_catalog.json"
+#    - config_path: "secrets/connected_account_config.json"
+#      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"

--- a/airbyte-integrations/connectors/source-stripe/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-stripe/acceptance-test-config.yml
@@ -9,8 +9,6 @@ tests:
       status: "succeed"
     - config_path: "integration_tests/invalid_config.json"
       status: "failed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "succeed"
   discovery:
     - config_path: "secrets/config.json"
     - config_path: "secrets/connected_account_config.json"

--- a/airbyte-integrations/connectors/source-stripe/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-stripe/acceptance-test-config.yml
@@ -9,6 +9,8 @@ tests:
       status: "succeed"
     - config_path: "integration_tests/invalid_config.json"
       status: "failed"
+    - config_path: "integration_tests/invalid_config.json"
+      status: "succeed"
   discovery:
     - config_path: "secrets/config.json"
     - config_path: "secrets/connected_account_config.json"

--- a/airbyte-integrations/connectors/source-stripe/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-stripe/acceptance-test-config.yml
@@ -12,29 +12,29 @@ tests:
   discovery:
     - config_path: "secrets/config.json"
     - config_path: "secrets/connected_account_config.json"
-#  basic_read:
-#    - config_path: "secrets/config.json"
-#      configured_catalog_path: "integration_tests/full_refresh_configured_catalog.json"
-#    # TEST 1 - Reading catalog without invoice_line_items
-#    - config_path: "secrets/config.json"
-#      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
-#      timeout_seconds: 3600
-##    # TEST 2 - Reading data from account that has no records for stream Disputes
-#    - config_path: "secrets/connected_account_config.json"
-#      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"
-#      timeout_seconds: 3600
-#  incremental:
-#    - config_path: "secrets/config.json"
-#      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
-#      future_state_path: "integration_tests/abnormal_state.json"
-#    - config_path: "secrets/connected_account_config.json"
-#      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"
-#      future_state_path: "integration_tests/abnormal_state.json"
-#  full_refresh:
-#    - config_path: "secrets/config.json"
-#      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
-#      timeout_seconds: 3600
-#    - config_path: "secrets/config.json"
-#      configured_catalog_path: "integration_tests/full_refresh_configured_catalog.json"
-#    - config_path: "secrets/connected_account_config.json"
-#      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"
+  basic_read:
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/full_refresh_configured_catalog.json"
+    # TEST 1 - Reading catalog without invoice_line_items
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
+      timeout_seconds: 3600
+    # TEST 2 - Reading data from account that has no records for stream Disputes
+    - config_path: "secrets/connected_account_config.json"
+      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"
+      timeout_seconds: 3600
+  incremental:
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
+      future_state_path: "integration_tests/abnormal_state.json"
+    - config_path: "secrets/connected_account_config.json"
+      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"
+      future_state_path: "integration_tests/abnormal_state.json"
+  full_refresh:
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
+      timeout_seconds: 3600
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/full_refresh_configured_catalog.json"
+    - config_path: "secrets/connected_account_config.json"
+      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"

--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -55,8 +55,37 @@ test $run_status == "0" || {
    # Save gradle scan link to github GRADLE_SCAN_LINK variable for next job.
    # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
    echo "GRADLE_SCAN_LINK=$link" >> $GITHUB_ENV
+
+   skipped_failed_info=`sed -n '/^=* short test summary info =*/,/^=* [0-9]/p' build.out`
+   if ! test -z "$skipped_failed_info"
+      then
+         echo "PYTHON_SHORT_TEST_SUMMARY_INFO<<EOF" >> $GITHUB_ENV
+         echo "Python short test summary info:" >> $GITHUB_ENV
+         echo '```' >> $GITHUB_ENV
+         echo "$skipped_failed_info" >> $GITHUB_ENV
+         echo '```' >> $GITHUB_ENV
+         echo "EOF" >> $GITHUB_ENV
+   else
+      echo "PYTHON_SHORT_TEST_SUMMARY_INFO=No skipped/failed tests"
+   fi
+
    exit $run_status
 }
+
+skipped_failed_info=`sed -n '/^=* short test summary info =*/,/^=* [0-9]/p' build.out`
+
+if ! test -z "$skipped_failed_info"
+then
+   echo "PYTHON_SHORT_TEST_SUMMARY_INFO<<EOF" >> $GITHUB_ENV
+   echo "Python short test summary info:" >> $GITHUB_ENV
+   echo '```' >> $GITHUB_ENV
+   echo "$skipped_failed_info" >> $GITHUB_ENV
+   echo '```' >> $GITHUB_ENV
+   echo "EOF" >> $GITHUB_ENV
+else
+   echo "PYTHON_SHORT_TEST_SUMMARY_INFO=No skipped/failed tests"
+fi
+
 
 # Build successed
 coverage_report=`sed -n '/^[ \t]*-\+ coverage: /,/TOTAL   /p' build.out`


### PR DESCRIPTION
## What
Closes #7947.

## How
Update `ci_integration_test.sh` script to extract `short test summary info` and show it in `/test` message.
Link to failed message is [here](https://github.com/airbytehq/airbyte/pull/8654#issuecomment-990827604).
Link to success message is [here](https://github.com/airbytehq/airbyte/pull/8654#issuecomment-990845881).


I changed `airbyte-integrations/connectors/source-stripe/acceptance-test-config.yml` only for tests. I'll remove these changes before merging this PR.