### PR TITLE
SAT: Add `-r fEsx` flag to SAT Dockerfile

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.32
+Add info about skipped failed tests in /test command message on GitHub: [#8691](https://github.com/airbytehq/airbyte/pull/8691)
+
 ## 0.1.31
 Take ConfiguredAirbyteCatalog from discover command by default
 

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -9,7 +9,7 @@ COPY setup.py ./
 COPY pytest.ini ./
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.31
+LABEL io.airbyte.version=0.1.32
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
-ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin"]
+ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]


### PR DESCRIPTION
## What
Partially closes #7947.

## How
Add a necessary `-r fEsx` flag to SAT Dockerfile.
From pytest help:
<img width="1223" alt="image" src="https://user-images.githubusercontent.com/19872253/145411102-2d36477d-39f5-4457-94f5-99726f0739e6.png">

It adds following block of info:
<img width="1239" alt="image" src="https://user-images.githubusercontent.com/19872253/145540726-0f095ba5-7c03-4806-8be2-d05842ae17d2.png">
