### PR TITLE
upgrade jaxb and jackson versions

### DIFF
--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'commons-cli:commons-cli:1.4'
     implementation 'org.eclipse.jetty:jetty-server:9.4.31.v20200723'
     implementation 'org.eclipse.jetty:jetty-servlet:9.4.31.v20200723'
-    implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.3'
+    implementation 'org.glassfish.jaxb:jaxb-runtime:3.0.2'
     implementation 'org.glassfish.jersey.containers:jersey-container-servlet'
     implementation 'org.glassfish.jersey.inject:jersey-hk2'
     implementation 'org.glassfish.jersey.media:jersey-media-json-jackson'

--- a/build.gradle
+++ b/build.gradle
@@ -248,7 +248,7 @@ subprojects {
             implementation project(':airbyte-commons')
         }
 
-        implementation(platform("com.fasterxml.jackson:jackson-bom:2.10.4"))
+        implementation(platform("com.fasterxml.jackson:jackson-bom:2.13.0"))
         implementation(platform("org.glassfish.jersey:jersey-bom:2.31"))
 
 


### PR DESCRIPTION
This is necessary for https://github.com/airbytehq/airbyte/issues/6096 on cloud.