### PR TITLE
Do not run excluded tags in integration tests

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
@@ -25,7 +25,11 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
             testClassesDirs += project.sourceSets.integrationTestJava.output.classesDirs
             classpath += project.sourceSets.integrationTestJava.runtimeClasspath
 
-            useJUnitPlatform()
+            useJUnitPlatform {
+                // todo (cgardens) - figure out how to de-dupe this exclusion with the one in build.gradle.
+                excludeTags 'log4j2-config', 'logger-client', 'cloud-storage'
+            }
+
             testLogging() {
                 events "passed", "failed"
                 exceptionFormat "full"


### PR DESCRIPTION
## What
* The build was failing ([example](https://github.com/airbytehq/airbyte/runs/4488863219?check_suite_focus=true)), because 2 newly added tests (`S3DocumentStoreClientTest` and `GcsDocumentStoreClientTest`) that was supposed to be run only as part of `tools/bin/cloud_storage_logging_test.sh` were getting run when `airbyte-workers:integrationTest` was run. This was happening because `airbyte-integration-test-java.gradle` overrides the exclude tags set in `build.gradle`. This did _not_ affect the other tests run in this script, because the gradle sub modules that those tests were in did _not_ have integration tests. `airbyte-workers` does have integration tests so it was affected.

## How
explicitly add the exclusions in `airbyte-integration-test-java.gradle`. this isn't very pretty, but i couldn't find a more elegant way of doing it, so going with this for now to fix the build.