### PR TITLE
S3 configs should use record classes

### DIFF
--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksStreamCopier.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksStreamCopier.java
@@ -23,9 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This implementation is similar to
- * {@link io.airbyte.integrations.destination.jdbc.copy.s3.S3StreamCopier}. The difference is that
- * this implementation creates Parquet staging files, instead of CSV ones.
+ * This implementation is similar to {@link io.airbyte.integrations.destination.jdbc.copy.s3.S3StreamCopier}. The difference is that this
+ * implementation creates Parquet staging files, instead of CSV ones.
  * <p>
  * </p>
  * It does the following operations:
@@ -88,9 +87,9 @@ public class DatabricksStreamCopier implements StreamCopier {
     this.parquetWriter = (S3ParquetWriter) writerFactory.create(stagingS3Config, s3Client, configuredStream, uploadTime);
 
     this.tmpTableLocation = String.format("s3://%s/%s",
-        s3Config.getBucketName(), parquetWriter.getOutputPrefix());
+        s3Config.bucketName(), parquetWriter.getOutputPrefix());
     this.destTableLocation = String.format("s3://%s/%s/%s/%s",
-        s3Config.getBucketName(), s3Config.getBucketPath(), databricksConfig.getDatabaseSchema(), streamName);
+        s3Config.bucketName(), s3Config.bucketPath(), databricksConfig.getDatabaseSchema(), streamName);
 
     LOGGER.info("[Stream {}] Database schema: {}", streamName, schemaName);
     LOGGER.info("[Stream {}] Parquet schema: {}", streamName, parquetWriter.getSchema());
@@ -102,7 +101,7 @@ public class DatabricksStreamCopier implements StreamCopier {
 
   @Override
   public String prepareStagingFile() {
-    return String.join("/", s3Config.getBucketPath(), stagingFolder);
+    return String.join("/", s3Config.bucketPath(), stagingFolder);
   }
 
   @Override
@@ -188,22 +187,22 @@ public class DatabricksStreamCopier implements StreamCopier {
       sqlOperations.dropTableIfExists(database, schemaName, tmpTableName);
 
       LOGGER.info("[Stream {}] Deleting staging file: {}", streamName, parquetWriter.getOutputFilePath());
-      s3Client.deleteObject(s3Config.getBucketName(), parquetWriter.getOutputFilePath());
+      s3Client.deleteObject(s3Config.bucketName(), parquetWriter.getOutputFilePath());
     }
   }
 
   /**
-   * The staging data location is s3://<bucket-name>/<bucket-path>/<staging-folder>. This method
-   * creates an {@link S3DestinationConfig} whose bucket path is <bucket-path>/<staging-folder>.
+   * The staging data location is s3://<bucket-name>/<bucket-path>/<staging-folder>. This method creates an {@link S3DestinationConfig} whose bucket
+   * path is <bucket-path>/<staging-folder>.
    */
   static S3DestinationConfig getStagingS3DestinationConfig(final S3DestinationConfig config, final String stagingFolder) {
     return new S3DestinationConfig(
-        config.getEndpoint(),
-        config.getBucketName(),
-        String.join("/", config.getBucketPath(), stagingFolder),
-        config.getBucketRegion(),
-        config.getAccessKeyId(),
-        config.getSecretAccessKey(),
+        config.endpoint(),
+        config.bucketName(),
+        String.join("/", config.bucketPath(), stagingFolder),
+        config.bucketRegion(),
+        config.accessKeyId(),
+        config.secretAccessKey(),
         // use default parquet format config
         new S3ParquetFormatConfig(MAPPER.createObjectNode()));
   }

--- a/airbyte-integrations/connectors/destination-databricks/src/test-integration/java/io/airbyte/integrations/destination/databricks/DatabricksDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/test-integration/java/io/airbyte/integrations/destination/databricks/DatabricksDestinationAcceptanceTest.java
@@ -104,7 +104,7 @@ public class DatabricksDestinationAcceptanceTest extends DestinationAcceptanceTe
     this.configJson = configJson;
     this.databricksConfig = DatabricksDestinationConfig.get(configJson);
     this.s3Config = databricksConfig.getS3DestinationConfig();
-    LOGGER.info("Test full path: s3://{}/{}", s3Config.getBucketName(), s3Config.getBucketPath());
+    LOGGER.info("Test full path: s3://{}/{}", s3Config.bucketName(), s3Config.bucketPath());
 
     this.s3Client = s3Config.getS3Client();
   }
@@ -114,17 +114,17 @@ public class DatabricksDestinationAcceptanceTest extends DestinationAcceptanceTe
     // clean up s3
     final List<KeyVersion> keysToDelete = new LinkedList<>();
     final List<S3ObjectSummary> objects = s3Client
-        .listObjects(s3Config.getBucketName(), s3Config.getBucketPath())
+        .listObjects(s3Config.bucketName(), s3Config.bucketPath())
         .getObjectSummaries();
     for (final S3ObjectSummary object : objects) {
       keysToDelete.add(new KeyVersion(object.getKey()));
     }
 
     if (keysToDelete.size() > 0) {
-      LOGGER.info("Tearing down test bucket path: {}/{}", s3Config.getBucketName(),
-          s3Config.getBucketPath());
+      LOGGER.info("Tearing down test bucket path: {}/{}", s3Config.bucketName(),
+          s3Config.bucketPath());
       final DeleteObjectsResult result = s3Client
-          .deleteObjects(new DeleteObjectsRequest(s3Config.getBucketName()).withKeys(keysToDelete));
+          .deleteObjects(new DeleteObjectsRequest(s3Config.bucketName()).withKeys(keysToDelete));
       LOGGER.info("Deleted {} file(s).", result.getDeletedObjects().size());
     }
 

--- a/airbyte-integrations/connectors/destination-databricks/src/test/java/io/airbyte/integrations/destination/databricks/DatabricksStreamCopierTest.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/test/java/io/airbyte/integrations/destination/databricks/DatabricksStreamCopierTest.java
@@ -4,7 +4,7 @@
 
 package io.airbyte.integrations.destination.databricks;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.airbyte.integrations.destination.s3.S3DestinationConfig;
 import java.util.UUID;
@@ -18,7 +18,7 @@ class DatabricksStreamCopierTest {
     final S3DestinationConfig config = new S3DestinationConfig("", "", bucketPath, "", "", "", null);
     final String stagingFolder = UUID.randomUUID().toString();
     final S3DestinationConfig stagingConfig = DatabricksStreamCopier.getStagingS3DestinationConfig(config, stagingFolder);
-    assertEquals(String.format("%s/%s", bucketPath, stagingFolder), stagingConfig.getBucketPath());
+    assertEquals(String.format("%s/%s", bucketPath, stagingFolder), stagingConfig.bucketPath());
   }
 
 }

--- a/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/avro/GcsAvroWriter.java
+++ b/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/avro/GcsAvroWriter.java
@@ -54,7 +54,7 @@ public class GcsAvroWriter extends BaseGcsWriter implements S3Writer {
 
     this.avroRecordFactory = new AvroRecordFactory(schema, converter);
     this.uploadManager = S3StreamTransferManagerHelper.getDefault(
-        config.getBucketName(), objectKey, s3Client, config.getFormatConfig().getPartSize());
+        config.getBucketName(), objectKey, s3Client, config.getFormatConfig().partSize());
     // We only need one output stream as we only have one input stream. This is reasonably performant.
     this.outputStream = uploadManager.getMultiPartOutputStreams().get(0);
 
@@ -62,7 +62,7 @@ public class GcsAvroWriter extends BaseGcsWriter implements S3Writer {
     // The DataFileWriter always uses binary encoding.
     // If json encoding is needed in the future, use the GenericDatumWriter directly.
     this.dataFileWriter = new DataFileWriter<>(new GenericDatumWriter<Record>())
-        .setCodec(formatConfig.getCodecFactory())
+        .setCodec(formatConfig.codecFactory())
         .create(schema, outputStream);
   }
 

--- a/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/csv/GcsCsvWriter.java
+++ b/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/csv/GcsCsvWriter.java
@@ -55,7 +55,7 @@ public class GcsCsvWriter extends BaseGcsWriter implements S3Writer {
         objectKey);
 
     this.uploadManager = S3StreamTransferManagerHelper.getDefault(
-        config.getBucketName(), objectKey, s3Client, config.getFormatConfig().getPartSize());
+        config.getBucketName(), objectKey, s3Client, config.getFormatConfig().partSize());
     // We only need one output stream as we only have one input stream. This is reasonably performant.
     this.outputStream = uploadManager.getMultiPartOutputStreams().get(0);
     this.csvPrinter = new CSVPrinter(new PrintWriter(outputStream, true, StandardCharsets.UTF_8),

--- a/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/jsonl/GcsJsonlWriter.java
+++ b/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/jsonl/GcsJsonlWriter.java
@@ -48,7 +48,7 @@ public class GcsJsonlWriter extends BaseGcsWriter implements S3Writer {
     LOGGER.info("Full GCS path for stream '{}': {}/{}", stream.getName(), config.getBucketName(), objectKey);
 
     this.uploadManager = S3StreamTransferManagerHelper.getDefault(
-        config.getBucketName(), objectKey, s3Client, config.getFormatConfig().getPartSize());
+        config.getBucketName(), objectKey, s3Client, config.getFormatConfig().partSize());
 
     // We only need one output stream as we only have one input stream. This is reasonably performant.
     this.outputStream = uploadManager.getMultiPartOutputStreams().get(0);

--- a/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/parquet/GcsParquetWriter.java
+++ b/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/parquet/GcsParquetWriter.java
@@ -64,12 +64,12 @@ public class GcsParquetWriter extends BaseGcsWriter implements S3Writer {
     final Configuration hadoopConfig = getHadoopConfig(config);
     this.parquetWriter = AvroParquetWriter.<GenericData.Record>builder(HadoopOutputFile.fromPath(path, hadoopConfig))
         .withSchema(schema)
-        .withCompressionCodec(formatConfig.getCompressionCodec())
-        .withRowGroupSize(formatConfig.getBlockSize())
-        .withMaxPaddingSize(formatConfig.getMaxPaddingSize())
-        .withPageSize(formatConfig.getPageSize())
-        .withDictionaryPageSize(formatConfig.getDictionaryPageSize())
-        .withDictionaryEncoding(formatConfig.isDictionaryEncoding())
+        .withCompressionCodec(formatConfig.compressionCodec())
+        .withRowGroupSize(formatConfig.blockSize())
+        .withMaxPaddingSize(formatConfig.maxPaddingSize())
+        .withPageSize(formatConfig.pageSize())
+        .withDictionaryPageSize(formatConfig.dictionaryPageSize())
+        .withDictionaryEncoding(formatConfig.dictionaryEncoding())
         .build();
     this.avroRecordFactory = new AvroRecordFactory(schema, converter);
   }

--- a/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/writer/ProductionWriterFactory.java
+++ b/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/writer/ProductionWriterFactory.java
@@ -31,7 +31,7 @@ public class ProductionWriterFactory implements GcsWriterFactory {
                          final ConfiguredAirbyteStream configuredStream,
                          final Timestamp uploadTimestamp)
       throws Exception {
-    final S3Format format = config.getFormatConfig().getFormat();
+    final S3Format format = config.getFormatConfig().format();
 
     if (format == S3Format.AVRO || format == S3Format.PARQUET) {
       final AirbyteStream stream = configuredStream.getStream();

--- a/airbyte-integrations/connectors/destination-gcs/src/test/java/io/airbyte/integrations/destination/gcs/GcsDestinationConfigTest.java
+++ b/airbyte-integrations/connectors/destination-gcs/src/test/java/io/airbyte/integrations/destination/gcs/GcsDestinationConfigTest.java
@@ -39,7 +39,7 @@ class GcsDestinationConfigTest {
     assertTrue(formatConfig instanceof S3AvroFormatConfig);
 
     final S3AvroFormatConfig avroFormatConfig = (S3AvroFormatConfig) formatConfig;
-    assertEquals("deflate-5", avroFormatConfig.getCodecFactory().toString());
+    assertEquals("deflate-5", avroFormatConfig.codecFactory().toString());
   }
 
 }

--- a/airbyte-integrations/connectors/destination-gcs/src/test/java/io/airbyte/integrations/destination/gcs/avro/GcsAvroFormatConfigTest.java
+++ b/airbyte-integrations/connectors/destination-gcs/src/test/java/io/airbyte/integrations/destination/gcs/avro/GcsAvroFormatConfigTest.java
@@ -112,12 +112,12 @@ class GcsAvroFormatConfigTest {
     ConfigTestUtils.assertBaseConfig(gcsDestinationConfig);
 
     final S3FormatConfig formatConfig = gcsDestinationConfig.getFormatConfig();
-    assertEquals("AVRO", formatConfig.getFormat().name());
-    assertEquals(6, formatConfig.getPartSize());
+    assertEquals("AVRO", formatConfig.format().name());
+    assertEquals(6, formatConfig.partSize());
     // Assert that is set properly in config
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
         gcsDestinationConfig.getBucketName(), "objectKey", null,
-        gcsDestinationConfig.getFormatConfig().getPartSize());
+        gcsDestinationConfig.getFormatConfig().partSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 6, partSizeBytes);
@@ -136,7 +136,7 @@ class GcsAvroFormatConfigTest {
 
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
         gcsDestinationConfig.getBucketName(), "objectKey", null,
-        gcsDestinationConfig.getFormatConfig().getPartSize());
+        gcsDestinationConfig.getFormatConfig().partSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 5, partSizeBytes); // 5MB is a default value if nothing provided explicitly

--- a/airbyte-integrations/connectors/destination-gcs/src/test/java/io/airbyte/integrations/destination/gcs/csv/GcsCsvFormatConfigTest.java
+++ b/airbyte-integrations/connectors/destination-gcs/src/test/java/io/airbyte/integrations/destination/gcs/csv/GcsCsvFormatConfigTest.java
@@ -49,12 +49,12 @@ public class GcsCsvFormatConfigTest {
     ConfigTestUtils.assertBaseConfig(gcsDestinationConfig);
 
     final S3FormatConfig formatConfig = gcsDestinationConfig.getFormatConfig();
-    assertEquals("CSV", formatConfig.getFormat().name());
-    assertEquals(6, formatConfig.getPartSize());
+    assertEquals("CSV", formatConfig.format().name());
+    assertEquals(6, formatConfig.partSize());
     // Assert that is set properly in config
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
         gcsDestinationConfig.getBucketName(), "objectKey", null,
-        gcsDestinationConfig.getFormatConfig().getPartSize());
+        gcsDestinationConfig.getFormatConfig().partSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 6, partSizeBytes);
@@ -74,7 +74,7 @@ public class GcsCsvFormatConfigTest {
 
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
         gcsDestinationConfig.getBucketName(), "objectKey", null,
-        gcsDestinationConfig.getFormatConfig().getPartSize());
+        gcsDestinationConfig.getFormatConfig().partSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 5, partSizeBytes); // 5MB is a default value if nothing provided explicitly

--- a/airbyte-integrations/connectors/destination-gcs/src/test/java/io/airbyte/integrations/destination/gcs/jsonl/GcsJsonlFormatConfigTest.java
+++ b/airbyte-integrations/connectors/destination-gcs/src/test/java/io/airbyte/integrations/destination/gcs/jsonl/GcsJsonlFormatConfigTest.java
@@ -34,13 +34,13 @@ public class GcsJsonlFormatConfigTest {
     ConfigTestUtils.assertBaseConfig(gcsDestinationConfig);
 
     final S3FormatConfig formatConfig = gcsDestinationConfig.getFormatConfig();
-    assertEquals("JSONL", formatConfig.getFormat().name());
-    assertEquals(6, formatConfig.getPartSize());
+    assertEquals("JSONL", formatConfig.format().name());
+    assertEquals(6, formatConfig.partSize());
 
     // Assert that is set properly in config
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
         gcsDestinationConfig.getBucketName(), "objectKey", null,
-        gcsDestinationConfig.getFormatConfig().getPartSize());
+        gcsDestinationConfig.getFormatConfig().partSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 6, partSizeBytes);
@@ -59,7 +59,7 @@ public class GcsJsonlFormatConfigTest {
 
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
         gcsDestinationConfig.getBucketName(), "objectKey", null,
-        gcsDestinationConfig.getFormatConfig().getPartSize());
+        gcsDestinationConfig.getFormatConfig().partSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 5, partSizeBytes); // 5MB is a default value if nothing provided explicitly

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftStreamCopier.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/RedshiftStreamCopier.java
@@ -31,14 +31,14 @@ public class RedshiftStreamCopier extends S3StreamCopier {
   private String manifestFilePath = null;
 
   public RedshiftStreamCopier(final String stagingFolder,
-      final DestinationSyncMode destSyncMode,
-      final String schema,
-      final String streamName,
-      final AmazonS3 client,
-      final JdbcDatabase db,
-      final S3DestinationConfig s3Config,
-      final ExtendedNameTransformer nameTransformer,
-      final SqlOperations sqlOperations) {
+                              final DestinationSyncMode destSyncMode,
+                              final String schema,
+                              final String streamName,
+                              final AmazonS3 client,
+                              final JdbcDatabase db,
+                              final S3DestinationConfig s3Config,
+                              final ExtendedNameTransformer nameTransformer,
+                              final SqlOperations sqlOperations) {
     super(stagingFolder, destSyncMode, schema, streamName, Strings.addRandomSuffix("", "", FILE_PREFIX_LENGTH) + "_" + streamName,
         client, db, s3Config, nameTransformer, sqlOperations);
     objectMapper = new ObjectMapper();
@@ -69,16 +69,16 @@ public class RedshiftStreamCopier extends S3StreamCopier {
     super.removeFileAndDropTmpTable();
     if (manifestFilePath != null) {
       LOGGER.info("Begin cleaning s3 manifest file {}.", manifestFilePath);
-      if (s3Client.doesObjectExist(s3Config.getBucketName(), manifestFilePath)) {
-        s3Client.deleteObject(s3Config.getBucketName(), manifestFilePath);
+      if (s3Client.doesObjectExist(s3Config.bucketName(), manifestFilePath)) {
+        s3Client.deleteObject(s3Config.bucketName(), manifestFilePath);
       }
       LOGGER.info("S3 manifest file {} cleaned.", manifestFilePath);
     }
   }
 
   /**
-   * Creates the contents of a manifest file given the `s3StagingFiles`. There must be at least one
-   * entry in a manifest file otherwise it is not considered valid for the COPY command.
+   * Creates the contents of a manifest file given the `s3StagingFiles`. There must be at least one entry in a manifest file otherwise it is not
+   * considered valid for the COPY command.
    *
    * @return null if no stagingFiles exist otherwise the manifest body String
    */
@@ -88,7 +88,7 @@ public class RedshiftStreamCopier extends S3StreamCopier {
     }
 
     final var s3FileEntries = s3StagingFiles.stream()
-        .map(filePath -> new Entry(getFullS3Path(s3Config.getBucketName(), filePath)))
+        .map(filePath -> new Entry(getFullS3Path(s3Config.bucketName(), filePath)))
         .collect(Collectors.toList());
     final var manifest = new Manifest(s3FileEntries);
 
@@ -105,7 +105,7 @@ public class RedshiftStreamCopier extends S3StreamCopier {
     manifestFilePath =
         String.join("/", stagingFolder, schemaName, String.format("%s.manifest", UUID.randomUUID()));
 
-    s3Client.putObject(s3Config.getBucketName(), manifestFilePath, manifestContents);
+    s3Client.putObject(s3Config.bucketName(), manifestFilePath, manifestContents);
 
     return manifestFilePath;
   }
@@ -124,10 +124,10 @@ public class RedshiftStreamCopier extends S3StreamCopier {
             + "MANIFEST;",
         schemaName,
         tmpTableName,
-        getFullS3Path(s3Config.getBucketName(), manifestPath),
-        s3Config.getAccessKeyId(),
-        s3Config.getSecretAccessKey(),
-        s3Config.getBucketRegion());
+        getFullS3Path(s3Config.bucketName(), manifestPath),
+        s3Config.accessKeyId(),
+        s3Config.secretAccessKey(),
+        s3Config.bucketRegion());
 
     Exceptions.toRuntime(() -> db.execute(copyQuery));
   }

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3Destination.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3Destination.java
@@ -46,8 +46,8 @@ public class S3Destination extends BaseConnector implements Destination {
 
   @Override
   public AirbyteMessageConsumer getConsumer(final JsonNode config,
-      final ConfiguredAirbyteCatalog configuredCatalog,
-      final Consumer<AirbyteMessage> outputRecordCollector) {
+                                            final ConfiguredAirbyteCatalog configuredCatalog,
+                                            final Consumer<AirbyteMessage> outputRecordCollector) {
     final S3WriterFactory formatterFactory = new ProductionWriterFactory();
     return new S3Consumer(S3DestinationConfig.getS3DestinationConfig(config), configuredCatalog, formatterFactory, outputRecordCollector);
   }
@@ -67,7 +67,7 @@ public class S3Destination extends BaseConnector implements Destination {
   }
 
   private static void attemptWriteAndDeleteS3Object(final S3DestinationConfig s3Config, final String outputTableName, final AmazonS3 s3) {
-    final var s3Bucket = s3Config.getBucketName();
+    final var s3Bucket = s3Config.bucketName();
 
     s3.putObject(s3Bucket, outputTableName, "check-content");
     s3.deleteObject(s3Bucket, outputTableName);

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
@@ -12,26 +12,27 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.fasterxml.jackson.databind.JsonNode;
+import javax.annotation.Nullable;
 
 /**
  * An S3 configuration. Typical usage sets at most one of {@code bucketPath} (necessary for more delicate data syncing to S3) and {@code partSize}
  * (used by certain bulk-load database operations).
  */
-public class S3DestinationConfig {
+public record S3DestinationConfig(
+    String endpoint,
+    String bucketName,
+    String bucketPath,
+    String bucketRegion,
+    String accessKeyId,
+    String secretAccessKey,
+    Integer partSize,
+    S3FormatConfig formatConfig
+) {
 
   // The smallest part size is 5MB. An S3 upload can be maximally formed of 10,000 parts. This gives
   // us an upper limit of 10,000 * 10 / 1000 = 100 GB per table with a 10MB part size limit.
   // WARNING: Too large a part size can cause potential OOM errors.
   public static final int DEFAULT_PART_SIZE_MB = 10;
-
-  private final String endpoint;
-  private final String bucketName;
-  private final String bucketPath;
-  private final String bucketRegion;
-  private final String accessKeyId;
-  private final String secretAccessKey;
-  private final Integer partSize;
-  private final S3FormatConfig formatConfig;
 
   /**
    * The part size should not matter in any use case that depends on this constructor. So the default 10 MB is used.
@@ -39,31 +40,12 @@ public class S3DestinationConfig {
   public S3DestinationConfig(
       final String endpoint,
       final String bucketName,
-      final String bucketPath,
+      @Nullable final String bucketPath,
       final String bucketRegion,
       final String accessKeyId,
       final String secretAccessKey,
-      final S3FormatConfig formatConfig) {
+      @Nullable final S3FormatConfig formatConfig) {
     this(endpoint, bucketName, bucketPath, bucketRegion, accessKeyId, secretAccessKey, DEFAULT_PART_SIZE_MB, formatConfig);
-  }
-
-  public S3DestinationConfig(
-      final String endpoint,
-      final String bucketName,
-      final String bucketPath,
-      final String bucketRegion,
-      final String accessKeyId,
-      final String secretAccessKey,
-      final Integer partSize,
-      final S3FormatConfig formatConfig) {
-    this.endpoint = endpoint;
-    this.bucketName = bucketName;
-    this.bucketPath = bucketPath;
-    this.bucketRegion = bucketRegion;
-    this.accessKeyId = accessKeyId;
-    this.secretAccessKey = secretAccessKey;
-    this.formatConfig = formatConfig;
-    this.partSize = partSize;
   }
 
   public static S3DestinationConfig getS3DestinationConfig(final JsonNode config) {
@@ -90,38 +72,6 @@ public class S3DestinationConfig {
         partSize,
         format
     );
-  }
-
-  public String getEndpoint() {
-    return endpoint;
-  }
-
-  public String getBucketName() {
-    return bucketName;
-  }
-
-  public String getBucketPath() {
-    return bucketPath;
-  }
-
-  public String getBucketRegion() {
-    return bucketRegion;
-  }
-
-  public String getAccessKeyId() {
-    return accessKeyId;
-  }
-
-  public String getSecretAccessKey() {
-    return secretAccessKey;
-  }
-
-  public Integer getPartSize() {
-    return partSize;
-  }
-
-  public S3FormatConfig getFormatConfig() {
-    return formatConfig;
   }
 
   public AmazonS3 getS3Client() {

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3FormatConfig.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3FormatConfig.java
@@ -8,9 +8,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public interface S3FormatConfig {
 
-  S3Format getFormat();
+  S3Format format();
 
-  Long getPartSize();
+  Long partSize();
 
   static String withDefault(final JsonNode config, final String property, final String defaultValue) {
     final JsonNode value = config.get(property);

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/S3AvroFormatConfig.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/S3AvroFormatConfig.java
@@ -11,14 +11,13 @@ import io.airbyte.integrations.destination.s3.S3Format;
 import io.airbyte.integrations.destination.s3.S3FormatConfig;
 import org.apache.avro.file.CodecFactory;
 
-public class S3AvroFormatConfig implements S3FormatConfig {
-
-  private final CodecFactory codecFactory;
-  private final Long partSize;
+public record S3AvroFormatConfig(CodecFactory codecFactory, Long partSize) implements S3FormatConfig {
 
   public S3AvroFormatConfig(final JsonNode formatConfig) {
-    this.codecFactory = parseCodecConfig(formatConfig.get("compression_codec"));
-    this.partSize = formatConfig.get(PART_SIZE_MB_ARG_NAME) != null ? formatConfig.get(PART_SIZE_MB_ARG_NAME).asLong() : null;
+    this(
+        parseCodecConfig(formatConfig.get("compression_codec")),
+        formatConfig.get(PART_SIZE_MB_ARG_NAME) != null ? formatConfig.get(PART_SIZE_MB_ARG_NAME).asLong() : null
+    );
   }
 
   public static CodecFactory parseCodecConfig(final JsonNode compressionCodecConfig) {
@@ -82,16 +81,8 @@ public class S3AvroFormatConfig implements S3FormatConfig {
     return checksumConfig.asBoolean();
   }
 
-  public CodecFactory getCodecFactory() {
-    return codecFactory;
-  }
-
-  public Long getPartSize() {
-    return partSize;
-  }
-
   @Override
-  public S3Format getFormat() {
+  public S3Format format() {
     return S3Format.AVRO;
   }
 

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/S3AvroWriter.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/S3AvroWriter.java
@@ -52,7 +52,7 @@ public class S3AvroWriter extends BaseS3Writer implements S3Writer {
 
     this.avroRecordFactory = new AvroRecordFactory(schema, converter);
     this.uploadManager = S3StreamTransferManagerHelper.getDefault(
-        config.bucketName(), objectKey, s3Client, config.formatConfig().getPartSize());
+        config.bucketName(), objectKey, s3Client, config.formatConfig().partSize());
     // We only need one output stream as we only have one input stream. This is reasonably performant.
     this.outputStream = uploadManager.getMultiPartOutputStreams().get(0);
 
@@ -60,7 +60,7 @@ public class S3AvroWriter extends BaseS3Writer implements S3Writer {
     // The DataFileWriter always uses binary encoding.
     // If json encoding is needed in the future, use the GenericDatumWriter directly.
     this.dataFileWriter = new DataFileWriter<>(new GenericDatumWriter<Record>())
-        .setCodec(formatConfig.getCodecFactory())
+        .setCodec(formatConfig.codecFactory())
         .create(schema, outputStream);
   }
 

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/S3AvroWriter.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/S3AvroWriter.java
@@ -47,16 +47,16 @@ public class S3AvroWriter extends BaseS3Writer implements S3Writer {
     final String outputFilename = BaseS3Writer.getOutputFilename(uploadTimestamp, S3Format.AVRO);
     final String objectKey = String.join("/", outputPrefix, outputFilename);
 
-    LOGGER.info("Full S3 path for stream '{}': s3://{}/{}", stream.getName(), config.getBucketName(),
+    LOGGER.info("Full S3 path for stream '{}': s3://{}/{}", stream.getName(), config.bucketName(),
         objectKey);
 
     this.avroRecordFactory = new AvroRecordFactory(schema, converter);
     this.uploadManager = S3StreamTransferManagerHelper.getDefault(
-        config.getBucketName(), objectKey, s3Client, config.getFormatConfig().getPartSize());
+        config.bucketName(), objectKey, s3Client, config.formatConfig().getPartSize());
     // We only need one output stream as we only have one input stream. This is reasonably performant.
     this.outputStream = uploadManager.getMultiPartOutputStreams().get(0);
 
-    final S3AvroFormatConfig formatConfig = (S3AvroFormatConfig) config.getFormatConfig();
+    final S3AvroFormatConfig formatConfig = (S3AvroFormatConfig) config.formatConfig();
     // The DataFileWriter always uses binary encoding.
     // If json encoding is needed in the future, use the GenericDatumWriter directly.
     this.dataFileWriter = new DataFileWriter<>(new GenericDatumWriter<Record>())

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/CsvSheetGenerator.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/CsvSheetGenerator.java
@@ -11,8 +11,7 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * This class takes case of the generation of the CSV data sheet, including the header row and the
- * data row.
+ * This class takes case of the generation of the CSV data sheet, including the header row and the data row.
  */
 public interface CsvSheetGenerator {
 
@@ -23,13 +22,13 @@ public interface CsvSheetGenerator {
   final class Factory {
 
     public static CsvSheetGenerator create(final JsonNode jsonSchema, final S3CsvFormatConfig formatConfig) {
-      if (formatConfig.getFlattening() == Flattening.NO) {
+      if (formatConfig.flattening() == Flattening.NO) {
         return new NoFlatteningSheetGenerator();
-      } else if (formatConfig.getFlattening() == Flattening.ROOT_LEVEL) {
+      } else if (formatConfig.flattening() == Flattening.ROOT_LEVEL) {
         return new RootLevelFlatteningSheetGenerator(jsonSchema);
       } else {
         throw new IllegalArgumentException(
-            "Unexpected flattening config: " + formatConfig.getFlattening());
+            "Unexpected flattening config: " + formatConfig.flattening());
       }
     }
 

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/S3CsvFormatConfig.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/S3CsvFormatConfig.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.integrations.destination.s3.S3Format;
 import io.airbyte.integrations.destination.s3.S3FormatConfig;
 
-public class S3CsvFormatConfig implements S3FormatConfig {
+public record S3CsvFormatConfig(Flattening flattening, Long partSize) implements S3FormatConfig {
 
   public enum Flattening {
 
@@ -41,33 +41,15 @@ public class S3CsvFormatConfig implements S3FormatConfig {
 
   }
 
-  private final Flattening flattening;
-  private final Long partSize;
-
   public S3CsvFormatConfig(final JsonNode formatConfig) {
-    this.flattening = Flattening.fromValue(formatConfig.get("flattening").asText());
-    this.partSize = formatConfig.get(PART_SIZE_MB_ARG_NAME) != null ? formatConfig.get(PART_SIZE_MB_ARG_NAME).asLong() : null;
+    this(
+        Flattening.fromValue(formatConfig.get("flattening").asText()),
+        formatConfig.get(PART_SIZE_MB_ARG_NAME) != null ? formatConfig.get(PART_SIZE_MB_ARG_NAME).asLong() : null
+    );
   }
 
   @Override
-  public S3Format getFormat() {
+  public S3Format format() {
     return S3Format.CSV;
   }
-
-  public Flattening getFlattening() {
-    return flattening;
-  }
-
-  public Long getPartSize() {
-    return partSize;
-  }
-
-  @Override
-  public String toString() {
-    return "S3CsvFormatConfig{" +
-        "flattening=" + flattening +
-        ", partSize=" + partSize +
-        '}';
-  }
-
 }

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/S3CsvWriter.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/S3CsvWriter.java
@@ -41,18 +41,18 @@ public class S3CsvWriter extends BaseS3Writer implements S3Writer {
       throws IOException {
     super(config, s3Client, configuredStream);
 
-    final S3CsvFormatConfig formatConfig = (S3CsvFormatConfig) config.getFormatConfig();
+    final S3CsvFormatConfig formatConfig = (S3CsvFormatConfig) config.formatConfig();
     this.csvSheetGenerator = CsvSheetGenerator.Factory.create(configuredStream.getStream().getJsonSchema(),
         formatConfig);
 
     final String outputFilename = BaseS3Writer.getOutputFilename(uploadTimestamp, S3Format.CSV);
     final String objectKey = String.join("/", outputPrefix, outputFilename);
 
-    LOGGER.info("Full S3 path for stream '{}': s3://{}/{}", stream.getName(), config.getBucketName(),
+    LOGGER.info("Full S3 path for stream '{}': s3://{}/{}", stream.getName(), config.bucketName(),
         objectKey);
 
     this.uploadManager = S3StreamTransferManagerHelper.getDefault(
-        config.getBucketName(), objectKey, s3Client, config.getFormatConfig().getPartSize());
+        config.bucketName(), objectKey, s3Client, config.formatConfig().getPartSize());
     // We only need one output stream as we only have one input stream. This is reasonably performant.
     this.outputStream = uploadManager.getMultiPartOutputStreams().get(0);
     this.csvPrinter = new CSVPrinter(new PrintWriter(outputStream, true, StandardCharsets.UTF_8),

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/S3CsvWriter.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/S3CsvWriter.java
@@ -52,7 +52,7 @@ public class S3CsvWriter extends BaseS3Writer implements S3Writer {
         objectKey);
 
     this.uploadManager = S3StreamTransferManagerHelper.getDefault(
-        config.bucketName(), objectKey, s3Client, config.formatConfig().getPartSize());
+        config.bucketName(), objectKey, s3Client, config.formatConfig().partSize());
     // We only need one output stream as we only have one input stream. This is reasonably performant.
     this.outputStream = uploadManager.getMultiPartOutputStreams().get(0);
     this.csvPrinter = new CSVPrinter(new PrintWriter(outputStream, true, StandardCharsets.UTF_8),

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/jsonl/S3JsonlFormatConfig.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/jsonl/S3JsonlFormatConfig.java
@@ -10,21 +10,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.integrations.destination.s3.S3Format;
 import io.airbyte.integrations.destination.s3.S3FormatConfig;
 
-public class S3JsonlFormatConfig implements S3FormatConfig {
-
-  private final Long partSize;
+public record S3JsonlFormatConfig(Long partSize) implements S3FormatConfig {
 
   public S3JsonlFormatConfig(final JsonNode formatConfig) {
-    this.partSize = formatConfig.get(PART_SIZE_MB_ARG_NAME) != null ? formatConfig.get(PART_SIZE_MB_ARG_NAME).asLong() : null;
+    this(formatConfig.get(PART_SIZE_MB_ARG_NAME) != null ? formatConfig.get(PART_SIZE_MB_ARG_NAME).asLong() : null);
   }
 
   @Override
-  public S3Format getFormat() {
+  public S3Format format() {
     return S3Format.JSONL;
   }
-
-  public Long getPartSize() {
-    return partSize;
-  }
-
 }

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/jsonl/S3JsonlWriter.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/jsonl/S3JsonlWriter.java
@@ -51,7 +51,7 @@ public class S3JsonlWriter extends BaseS3Writer implements S3Writer {
         objectKey);
 
     this.uploadManager = S3StreamTransferManagerHelper.getDefault(
-        config.bucketName(), objectKey, s3Client, config.formatConfig().getPartSize());
+        config.bucketName(), objectKey, s3Client, config.formatConfig().partSize());
     // We only need one output stream as we only have one input stream. This is reasonably performant.
     this.outputStream = uploadManager.getMultiPartOutputStreams().get(0);
     this.printWriter = new PrintWriter(outputStream, true, StandardCharsets.UTF_8);

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/jsonl/S3JsonlWriter.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/jsonl/S3JsonlWriter.java
@@ -47,11 +47,11 @@ public class S3JsonlWriter extends BaseS3Writer implements S3Writer {
     final String outputFilename = BaseS3Writer.getOutputFilename(uploadTimestamp, S3Format.JSONL);
     final String objectKey = String.join("/", outputPrefix, outputFilename);
 
-    LOGGER.info("Full S3 path for stream '{}': s3://{}/{}", stream.getName(), config.getBucketName(),
+    LOGGER.info("Full S3 path for stream '{}': s3://{}/{}", stream.getName(), config.bucketName(),
         objectKey);
 
     this.uploadManager = S3StreamTransferManagerHelper.getDefault(
-        config.getBucketName(), objectKey, s3Client, config.getFormatConfig().getPartSize());
+        config.bucketName(), objectKey, s3Client, config.formatConfig().getPartSize());
     // We only need one output stream as we only have one input stream. This is reasonably performant.
     this.outputStream = uploadManager.getMultiPartOutputStreams().get(0);
     this.printWriter = new PrintWriter(outputStream, true, StandardCharsets.UTF_8);

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/parquet/S3ParquetFormatConfig.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/parquet/S3ParquetFormatConfig.java
@@ -9,76 +9,35 @@ import io.airbyte.integrations.destination.s3.S3Format;
 import io.airbyte.integrations.destination.s3.S3FormatConfig;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
-public class S3ParquetFormatConfig implements S3FormatConfig {
-
-  private final CompressionCodecName compressionCodec;
-  private final int blockSize;
-  private final int maxPaddingSize;
-  private final int pageSize;
-  private final int dictionaryPageSize;
-  private final boolean dictionaryEncoding;
+public record S3ParquetFormatConfig(
+    CompressionCodecName compressionCodec,
+    int blockSize,
+    int maxPaddingSize,
+    int pageSize,
+    int dictionaryPageSize,
+    boolean dictionaryEncoding
+) implements S3FormatConfig {
 
   public S3ParquetFormatConfig(final JsonNode formatConfig) {
-    final int blockSizeMb = S3FormatConfig.withDefault(formatConfig, "block_size_mb", S3ParquetConstants.DEFAULT_BLOCK_SIZE_MB);
-    final int maxPaddingSizeMb = S3FormatConfig.withDefault(formatConfig, "max_padding_size_mb", S3ParquetConstants.DEFAULT_MAX_PADDING_SIZE_MB);
-    final int pageSizeKb = S3FormatConfig.withDefault(formatConfig, "page_size_kb", S3ParquetConstants.DEFAULT_PAGE_SIZE_KB);
-    final int dictionaryPageSizeKb =
-        S3FormatConfig.withDefault(formatConfig, "dictionary_page_size_kb", S3ParquetConstants.DEFAULT_DICTIONARY_PAGE_SIZE_KB);
-
-    this.compressionCodec = CompressionCodecName
-        .valueOf(S3FormatConfig.withDefault(formatConfig, "compression_codec", S3ParquetConstants.DEFAULT_COMPRESSION_CODEC.name()).toUpperCase());
-    this.blockSize = blockSizeMb * 1024 * 1024;
-    this.maxPaddingSize = maxPaddingSizeMb * 1024 * 1024;
-    this.pageSize = pageSizeKb * 1024;
-    this.dictionaryPageSize = dictionaryPageSizeKb * 1024;
-    this.dictionaryEncoding = S3FormatConfig.withDefault(formatConfig, "dictionary_encoding", S3ParquetConstants.DEFAULT_DICTIONARY_ENCODING);
+    this(
+        CompressionCodecName.valueOf(
+            S3FormatConfig.withDefault(formatConfig, "compression_codec", S3ParquetConstants.DEFAULT_COMPRESSION_CODEC.name()).toUpperCase()),
+        S3FormatConfig.withDefault(formatConfig, "block_size_mb", S3ParquetConstants.DEFAULT_BLOCK_SIZE_MB) * 1024 * 1024,
+        S3FormatConfig.withDefault(formatConfig, "max_padding_size_mb", S3ParquetConstants.DEFAULT_MAX_PADDING_SIZE_MB) * 1024 * 1024,
+        S3FormatConfig.withDefault(formatConfig, "page_size_kb", S3ParquetConstants.DEFAULT_PAGE_SIZE_KB) * 1024,
+        S3FormatConfig.withDefault(formatConfig, "dictionary_page_size_kb", S3ParquetConstants.DEFAULT_DICTIONARY_PAGE_SIZE_KB) * 1024,
+        S3FormatConfig.withDefault(formatConfig, "dictionary_encoding", S3ParquetConstants.DEFAULT_DICTIONARY_ENCODING)
+    );
   }
 
   @Override
-  public S3Format getFormat() {
+  public S3Format format() {
     return S3Format.PARQUET;
   }
 
   @Override
-  public Long getPartSize() {
+  public Long partSize() {
     // not applicable for Parquet format
     return null;
   }
-
-  public CompressionCodecName getCompressionCodec() {
-    return compressionCodec;
-  }
-
-  public int getBlockSize() {
-    return blockSize;
-  }
-
-  public int getMaxPaddingSize() {
-    return maxPaddingSize;
-  }
-
-  public int getPageSize() {
-    return pageSize;
-  }
-
-  public int getDictionaryPageSize() {
-    return dictionaryPageSize;
-  }
-
-  public boolean isDictionaryEncoding() {
-    return dictionaryEncoding;
-  }
-
-  @Override
-  public String toString() {
-    return "S3ParquetFormatConfig{" +
-        "compressionCodec=" + compressionCodec + ", " +
-        "blockSize=" + blockSize + ", " +
-        "maxPaddingSize=" + maxPaddingSize + ", " +
-        "pageSize=" + pageSize + ", " +
-        "dictionaryPageSize=" + dictionaryPageSize + ", " +
-        "dictionaryEncoding=" + dictionaryEncoding + ", " +
-        '}';
-  }
-
 }

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/parquet/S3ParquetWriter.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/parquet/S3ParquetWriter.java
@@ -51,14 +51,14 @@ public class S3ParquetWriter extends BaseS3Writer implements S3Writer {
     this.outputFilename = BaseS3Writer.getOutputFilename(uploadTimestamp, S3Format.PARQUET);
     final String objectKey = String.join("/", outputPrefix, outputFilename);
 
-    LOGGER.info("Full S3 path for stream '{}': s3://{}/{}", stream.getName(), config.getBucketName(),
+    LOGGER.info("Full S3 path for stream '{}': s3://{}/{}", stream.getName(), config.bucketName(),
         objectKey);
 
     final URI uri = new URI(
-        String.format("s3a://%s/%s/%s", config.getBucketName(), outputPrefix, outputFilename));
+        String.format("s3a://%s/%s/%s", config.bucketName(), outputPrefix, outputFilename));
     final Path path = new Path(uri);
 
-    final S3ParquetFormatConfig formatConfig = (S3ParquetFormatConfig) config.getFormatConfig();
+    final S3ParquetFormatConfig formatConfig = (S3ParquetFormatConfig) config.formatConfig();
     final Configuration hadoopConfig = getHadoopConfig(config);
     this.parquetWriter = AvroParquetWriter.<GenericData.Record>builder(HadoopOutputFile.fromPath(path, hadoopConfig))
         .withSchema(schema)
@@ -75,12 +75,12 @@ public class S3ParquetWriter extends BaseS3Writer implements S3Writer {
 
   public static Configuration getHadoopConfig(final S3DestinationConfig config) {
     final Configuration hadoopConfig = new Configuration();
-    hadoopConfig.set(Constants.ACCESS_KEY, config.getAccessKeyId());
-    hadoopConfig.set(Constants.SECRET_KEY, config.getSecretAccessKey());
-    if (config.getEndpoint().isEmpty()) {
-      hadoopConfig.set(Constants.ENDPOINT, String.format("s3.%s.amazonaws.com", config.getBucketRegion()));
+    hadoopConfig.set(Constants.ACCESS_KEY, config.accessKeyId());
+    hadoopConfig.set(Constants.SECRET_KEY, config.secretAccessKey());
+    if (config.endpoint().isEmpty()) {
+      hadoopConfig.set(Constants.ENDPOINT, String.format("s3.%s.amazonaws.com", config.bucketRegion()));
     } else {
-      hadoopConfig.set(Constants.ENDPOINT, config.getEndpoint());
+      hadoopConfig.set(Constants.ENDPOINT, config.endpoint());
       hadoopConfig.set(Constants.PATH_STYLE_ACCESS, "true");
     }
     hadoopConfig.set(Constants.AWS_CREDENTIALS_PROVIDER,

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/parquet/S3ParquetWriter.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/parquet/S3ParquetWriter.java
@@ -62,12 +62,12 @@ public class S3ParquetWriter extends BaseS3Writer implements S3Writer {
     final Configuration hadoopConfig = getHadoopConfig(config);
     this.parquetWriter = AvroParquetWriter.<GenericData.Record>builder(HadoopOutputFile.fromPath(path, hadoopConfig))
         .withSchema(schema)
-        .withCompressionCodec(formatConfig.getCompressionCodec())
-        .withRowGroupSize(formatConfig.getBlockSize())
-        .withMaxPaddingSize(formatConfig.getMaxPaddingSize())
-        .withPageSize(formatConfig.getPageSize())
-        .withDictionaryPageSize(formatConfig.getDictionaryPageSize())
-        .withDictionaryEncoding(formatConfig.isDictionaryEncoding())
+        .withCompressionCodec(formatConfig.compressionCodec())
+        .withRowGroupSize(formatConfig.blockSize())
+        .withMaxPaddingSize(formatConfig.maxPaddingSize())
+        .withPageSize(formatConfig.pageSize())
+        .withDictionaryPageSize(formatConfig.dictionaryPageSize())
+        .withDictionaryEncoding(formatConfig.dictionaryEncoding())
         .build();
     this.avroRecordFactory = new AvroRecordFactory(schema, converter);
     this.schema = schema;

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/writer/BaseS3Writer.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/writer/BaseS3Writer.java
@@ -51,7 +51,7 @@ public abstract class BaseS3Writer implements S3Writer {
     this.s3Client = s3Client;
     this.stream = configuredStream.getStream();
     this.syncMode = configuredStream.getDestinationSyncMode();
-    this.outputPrefix = S3OutputPathHelper.getOutputPrefix(config.getBucketPath(), stream);
+    this.outputPrefix = S3OutputPathHelper.getOutputPrefix(config.bucketPath(), stream);
   }
 
   public String getOutputPrefix() {
@@ -66,7 +66,7 @@ public abstract class BaseS3Writer implements S3Writer {
    */
   @Override
   public void initialize() {
-    final String bucket = config.getBucketName();
+    final String bucket = config.bucketName();
     if (!s3Client.doesBucketExistV2(bucket)) {
       LOGGER.info("Bucket {} does not exist; creating...", bucket);
       s3Client.createBucket(bucket);

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/writer/ProductionWriterFactory.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/writer/ProductionWriterFactory.java
@@ -30,7 +30,7 @@ public class ProductionWriterFactory implements S3WriterFactory {
                          final ConfiguredAirbyteStream configuredStream,
                          final Timestamp uploadTimestamp)
       throws Exception {
-    final S3Format format = config.getFormatConfig().getFormat();
+    final S3Format format = config.formatConfig().getFormat();
 
     if (format == S3Format.AVRO || format == S3Format.PARQUET) {
       final AirbyteStream stream = configuredStream.getStream();

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/writer/ProductionWriterFactory.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/writer/ProductionWriterFactory.java
@@ -30,7 +30,7 @@ public class ProductionWriterFactory implements S3WriterFactory {
                          final ConfiguredAirbyteStream configuredStream,
                          final Timestamp uploadTimestamp)
       throws Exception {
-    final S3Format format = config.formatConfig().getFormat();
+    final S3Format format = config.formatConfig().format();
 
     if (format == S3Format.AVRO || format == S3Format.PARQUET) {
       final AirbyteStream stream = configuredStream.getStream();

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/java/io/airbyte/integrations/destination/s3/S3DestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/java/io/airbyte/integrations/destination/s3/S3DestinationAcceptanceTest.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * When adding a new S3 destination acceptance test, extend this class and do the following:
  * <li>Implement {@link #getFormatConfig} that returns a {@link S3FormatConfig}</li>
  * <li>Implement {@link #retrieveRecords} that returns the Json records for the test</li>
- *
+ * <p>
  * Under the hood, a {@link S3DestinationConfig} is constructed as follows:
  * <li>Retrieve the secrets from "secrets/config.json"</li>
  * <li>Get the S3 bucket path from the constructor</li>
@@ -82,9 +82,9 @@ public abstract class S3DestinationAcceptanceTest extends DestinationAcceptanceT
    */
   protected List<S3ObjectSummary> getAllSyncedObjects(final String streamName, final String namespace) {
     final String outputPrefix = S3OutputPathHelper
-        .getOutputPrefix(config.getBucketPath(), namespace, streamName);
+        .getOutputPrefix(config.bucketPath(), namespace, streamName);
     final List<S3ObjectSummary> objectSummaries = s3Client
-        .listObjects(config.getBucketName(), outputPrefix)
+        .listObjects(config.bucketName(), outputPrefix)
         .getObjectSummaries()
         .stream()
         .filter(o -> o.getKey().contains(AvroConstants.NAME_TRANSFORMER.convertStreamName(streamName) + "/"))
@@ -117,7 +117,7 @@ public abstract class S3DestinationAcceptanceTest extends DestinationAcceptanceT
         .set("format", getFormatConfig());
     this.configJson = configJson;
     this.config = S3DestinationConfig.getS3DestinationConfig(configJson);
-    LOGGER.info("Test full path: {}/{}", config.getBucketName(), config.getBucketPath());
+    LOGGER.info("Test full path: {}/{}", config.bucketName(), config.bucketPath());
 
     this.s3Client = config.getS3Client();
   }
@@ -129,17 +129,17 @@ public abstract class S3DestinationAcceptanceTest extends DestinationAcceptanceT
   protected void tearDown(final TestDestinationEnv testEnv) {
     final List<KeyVersion> keysToDelete = new LinkedList<>();
     final List<S3ObjectSummary> objects = s3Client
-        .listObjects(config.getBucketName(), config.getBucketPath())
+        .listObjects(config.bucketName(), config.bucketPath())
         .getObjectSummaries();
     for (final S3ObjectSummary object : objects) {
       keysToDelete.add(new KeyVersion(object.getKey()));
     }
 
     if (keysToDelete.size() > 0) {
-      LOGGER.info("Tearing down test bucket path: {}/{}", config.getBucketName(),
-          config.getBucketPath());
+      LOGGER.info("Tearing down test bucket path: {}/{}", config.bucketName(),
+          config.bucketPath());
       final DeleteObjectsResult result = s3Client
-          .deleteObjects(new DeleteObjectsRequest(config.getBucketName()).withKeys(keysToDelete));
+          .deleteObjects(new DeleteObjectsRequest(config.bucketName()).withKeys(keysToDelete));
       LOGGER.info("Deleted {} file(s).", result.getDeletedObjects().size());
     }
   }

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/S3FormatConfigsTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/S3FormatConfigsTest.java
@@ -30,10 +30,10 @@ public class S3FormatConfigsTest {
     final ObjectNode stubConfig = mapper.createObjectNode();
     stubConfig.set("format", stubFormatConfig);
     final S3FormatConfig formatConfig = S3FormatConfigs.getS3FormatConfig(stubConfig);
-    assertEquals(formatConfig.getFormat(), S3Format.CSV);
+    assertEquals(formatConfig.format(), S3Format.CSV);
     assertTrue(formatConfig instanceof S3CsvFormatConfig);
     final S3CsvFormatConfig csvFormatConfig = (S3CsvFormatConfig) formatConfig;
-    assertEquals(csvFormatConfig.getFlattening(), Flattening.ROOT_LEVEL);
+    assertEquals(csvFormatConfig.flattening(), Flattening.ROOT_LEVEL);
   }
 
 }

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/avro/S3AvroFormatConfigTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/avro/S3AvroFormatConfigTest.java
@@ -113,13 +113,13 @@ class S3AvroFormatConfigTest {
         .getS3DestinationConfig(config);
     ConfigTestUtils.assertBaseConfig(s3DestinationConfig);
 
-    final S3FormatConfig formatConfig = s3DestinationConfig.getFormatConfig();
+    final S3FormatConfig formatConfig = s3DestinationConfig.formatConfig();
     assertEquals("AVRO", formatConfig.getFormat().name());
     assertEquals(6, formatConfig.getPartSize());
     // Assert that is set properly in config
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
-        s3DestinationConfig.getBucketName(), "objectKey", null,
-        s3DestinationConfig.getFormatConfig().getPartSize());
+        s3DestinationConfig.bucketName(), "objectKey", null,
+        s3DestinationConfig.formatConfig().getPartSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 6, partSizeBytes);
@@ -137,8 +137,8 @@ class S3AvroFormatConfigTest {
     ConfigTestUtils.assertBaseConfig(s3DestinationConfig);
 
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
-        s3DestinationConfig.getBucketName(), "objectKey", null,
-        s3DestinationConfig.getFormatConfig().getPartSize());
+        s3DestinationConfig.bucketName(), "objectKey", null,
+        s3DestinationConfig.formatConfig().getPartSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 5, partSizeBytes); // 5MB is a default value if nothing provided explicitly

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/avro/S3AvroFormatConfigTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/avro/S3AvroFormatConfigTest.java
@@ -114,12 +114,12 @@ class S3AvroFormatConfigTest {
     ConfigTestUtils.assertBaseConfig(s3DestinationConfig);
 
     final S3FormatConfig formatConfig = s3DestinationConfig.formatConfig();
-    assertEquals("AVRO", formatConfig.getFormat().name());
-    assertEquals(6, formatConfig.getPartSize());
+    assertEquals("AVRO", formatConfig.format().name());
+    assertEquals(6, formatConfig.partSize());
     // Assert that is set properly in config
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
         s3DestinationConfig.bucketName(), "objectKey", null,
-        s3DestinationConfig.formatConfig().getPartSize());
+        s3DestinationConfig.formatConfig().partSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 6, partSizeBytes);
@@ -138,7 +138,7 @@ class S3AvroFormatConfigTest {
 
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
         s3DestinationConfig.bucketName(), "objectKey", null,
-        s3DestinationConfig.formatConfig().getPartSize());
+        s3DestinationConfig.formatConfig().partSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 5, partSizeBytes); // 5MB is a default value if nothing provided explicitly

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/csv/S3CsvFormatConfigTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/csv/S3CsvFormatConfigTest.java
@@ -5,7 +5,8 @@
 package io.airbyte.integrations.destination.s3.csv;
 
 import static com.amazonaws.services.s3.internal.Constants.MB;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import alex.mojaki.s3upload.StreamTransferManager;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -47,13 +48,13 @@ public class S3CsvFormatConfigTest {
         .getS3DestinationConfig(config);
     ConfigTestUtils.assertBaseConfig(s3DestinationConfig);
 
-    final S3FormatConfig formatConfig = s3DestinationConfig.getFormatConfig();
+    final S3FormatConfig formatConfig = s3DestinationConfig.formatConfig();
     assertEquals("CSV", formatConfig.getFormat().name());
     assertEquals(6, formatConfig.getPartSize());
     // Assert that is set properly in config
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
-        s3DestinationConfig.getBucketName(), "objectKey", null,
-        s3DestinationConfig.getFormatConfig().getPartSize());
+        s3DestinationConfig.bucketName(), "objectKey", null,
+        s3DestinationConfig.formatConfig().getPartSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 6, partSizeBytes);
@@ -72,8 +73,8 @@ public class S3CsvFormatConfigTest {
     ConfigTestUtils.assertBaseConfig(s3DestinationConfig);
 
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
-        s3DestinationConfig.getBucketName(), "objectKey", null,
-        s3DestinationConfig.getFormatConfig().getPartSize());
+        s3DestinationConfig.bucketName(), "objectKey", null,
+        s3DestinationConfig.formatConfig().getPartSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 5, partSizeBytes); // 5MB is a default value if nothing provided explicitly

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/csv/S3CsvFormatConfigTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/csv/S3CsvFormatConfigTest.java
@@ -49,12 +49,12 @@ public class S3CsvFormatConfigTest {
     ConfigTestUtils.assertBaseConfig(s3DestinationConfig);
 
     final S3FormatConfig formatConfig = s3DestinationConfig.formatConfig();
-    assertEquals("CSV", formatConfig.getFormat().name());
-    assertEquals(6, formatConfig.getPartSize());
+    assertEquals("CSV", formatConfig.format().name());
+    assertEquals(6, formatConfig.partSize());
     // Assert that is set properly in config
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
         s3DestinationConfig.bucketName(), "objectKey", null,
-        s3DestinationConfig.formatConfig().getPartSize());
+        s3DestinationConfig.formatConfig().partSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 6, partSizeBytes);
@@ -74,7 +74,7 @@ public class S3CsvFormatConfigTest {
 
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
         s3DestinationConfig.bucketName(), "objectKey", null,
-        s3DestinationConfig.formatConfig().getPartSize());
+        s3DestinationConfig.formatConfig().partSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 5, partSizeBytes); // 5MB is a default value if nothing provided explicitly

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/jsonl/S3JsonlFormatConfigTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/jsonl/S3JsonlFormatConfigTest.java
@@ -34,13 +34,13 @@ public class S3JsonlFormatConfigTest {
     ConfigTestUtils.assertBaseConfig(s3DestinationConfig);
 
     final S3FormatConfig formatConfig = s3DestinationConfig.formatConfig();
-    assertEquals("JSONL", formatConfig.getFormat().name());
-    assertEquals(6, formatConfig.getPartSize());
+    assertEquals("JSONL", formatConfig.format().name());
+    assertEquals(6, formatConfig.partSize());
 
     // Assert that is set properly in config
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
         s3DestinationConfig.bucketName(), "objectKey", null,
-        s3DestinationConfig.formatConfig().getPartSize());
+        s3DestinationConfig.formatConfig().partSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 6, partSizeBytes);
@@ -59,7 +59,7 @@ public class S3JsonlFormatConfigTest {
 
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
         s3DestinationConfig.bucketName(), "objectKey", null,
-        s3DestinationConfig.formatConfig().getPartSize());
+        s3DestinationConfig.formatConfig().partSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 5, partSizeBytes); // 5MB is a default value if nothing provided explicitly

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/jsonl/S3JsonlFormatConfigTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/jsonl/S3JsonlFormatConfigTest.java
@@ -33,14 +33,14 @@ public class S3JsonlFormatConfigTest {
         .getS3DestinationConfig(config);
     ConfigTestUtils.assertBaseConfig(s3DestinationConfig);
 
-    final S3FormatConfig formatConfig = s3DestinationConfig.getFormatConfig();
+    final S3FormatConfig formatConfig = s3DestinationConfig.formatConfig();
     assertEquals("JSONL", formatConfig.getFormat().name());
     assertEquals(6, formatConfig.getPartSize());
 
     // Assert that is set properly in config
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
-        s3DestinationConfig.getBucketName(), "objectKey", null,
-        s3DestinationConfig.getFormatConfig().getPartSize());
+        s3DestinationConfig.bucketName(), "objectKey", null,
+        s3DestinationConfig.formatConfig().getPartSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 6, partSizeBytes);
@@ -58,8 +58,8 @@ public class S3JsonlFormatConfigTest {
     ConfigTestUtils.assertBaseConfig(s3DestinationConfig);
 
     final StreamTransferManager streamTransferManager = S3StreamTransferManagerHelper.getDefault(
-        s3DestinationConfig.getBucketName(), "objectKey", null,
-        s3DestinationConfig.getFormatConfig().getPartSize());
+        s3DestinationConfig.bucketName(), "objectKey", null,
+        s3DestinationConfig.formatConfig().getPartSize());
 
     final Integer partSizeBytes = (Integer) FieldUtils.readField(streamTransferManager, "partSize", true);
     assertEquals(MB * 5, partSizeBytes); // 5MB is a default value if nothing provided explicitly

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/parquet/S3ParquetFormatConfigTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/parquet/S3ParquetFormatConfigTest.java
@@ -28,13 +28,13 @@ class S3ParquetFormatConfigTest {
     final S3ParquetFormatConfig config = new S3ParquetFormatConfig(formatConfig);
 
     // The constructor should automatically convert MB or KB to bytes.
-    assertEquals(1024 * 1024, config.getBlockSize());
-    assertEquals(1024 * 1024, config.getMaxPaddingSize());
-    assertEquals(1024, config.getPageSize());
-    assertEquals(1024, config.getDictionaryPageSize());
+    assertEquals(1024 * 1024, config.blockSize());
+    assertEquals(1024 * 1024, config.maxPaddingSize());
+    assertEquals(1024, config.pageSize());
+    assertEquals(1024, config.dictionaryPageSize());
 
-    assertEquals(CompressionCodecName.GZIP, config.getCompressionCodec());
-    assertFalse(config.isDictionaryEncoding());
+    assertEquals(CompressionCodecName.GZIP, config.compressionCodec());
+    assertFalse(config.dictionaryEncoding());
   }
 
 }

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/util/ConfigTestUtils.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/util/ConfigTestUtils.java
@@ -25,12 +25,12 @@ public class ConfigTestUtils {
   }
 
   public static void assertBaseConfig(final S3DestinationConfig s3DestinationConfig) {
-    assertEquals("some_test-endpoint", s3DestinationConfig.getEndpoint());
-    assertEquals("test-bucket-name", s3DestinationConfig.getBucketName());
-    assertEquals("test_path", s3DestinationConfig.getBucketPath());
-    assertEquals("us-east-2", s3DestinationConfig.getBucketRegion());
-    assertEquals("some-test-key-id", s3DestinationConfig.getAccessKeyId());
-    assertEquals("some-test-access-key", s3DestinationConfig.getSecretAccessKey());
+    assertEquals("some_test-endpoint", s3DestinationConfig.endpoint());
+    assertEquals("test-bucket-name", s3DestinationConfig.bucketName());
+    assertEquals("test_path", s3DestinationConfig.bucketPath());
+    assertEquals("us-east-2", s3DestinationConfig.bucketRegion());
+    assertEquals("some-test-key-id", s3DestinationConfig.accessKeyId());
+    assertEquals("some-test-access-key", s3DestinationConfig.secretAccessKey());
   }
 
 }

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeS3StreamCopier.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeS3StreamCopier.java
@@ -22,14 +22,14 @@ public class SnowflakeS3StreamCopier extends S3StreamCopier {
   private static final int FILE_PREFIX_LENGTH = 5;
 
   public SnowflakeS3StreamCopier(final String stagingFolder,
-      final DestinationSyncMode destSyncMode,
-      final String schema,
-      final String streamName,
-      final AmazonS3 client,
-      final JdbcDatabase db,
-      final S3DestinationConfig s3Config,
-      final ExtendedNameTransformer nameTransformer,
-      final SqlOperations sqlOperations) {
+                                 final DestinationSyncMode destSyncMode,
+                                 final String schema,
+                                 final String streamName,
+                                 final AmazonS3 client,
+                                 final JdbcDatabase db,
+                                 final S3DestinationConfig s3Config,
+                                 final ExtendedNameTransformer nameTransformer,
+                                 final SqlOperations sqlOperations) {
     super(stagingFolder, destSyncMode, schema, streamName, Strings.addRandomSuffix("", "", FILE_PREFIX_LENGTH) + "_" + streamName,
         client, db, s3Config, nameTransformer, sqlOperations);
   }
@@ -49,8 +49,8 @@ public class SnowflakeS3StreamCopier extends S3StreamCopier {
         schema,
         tableName,
         s3FileLocation,
-        s3Config.getAccessKeyId(),
-        s3Config.getSecretAccessKey());
+        s3Config.accessKeyId(),
+        s3Config.secretAccessKey());
 
     database.execute(copyQuery);
   }


### PR DESCRIPTION
## What
we're on java 17 now! let's take advantage of that fact.

this was clearly a better use of time than the 2 minutes it would have taken for Intellij to generate `equals` methods for me.

## How
S3DestinationConfig and the S3FormatConfig implementations are now all record classes.

## Recommended reading order
1. `S3DestinationConfig.java`
2. `S3FormatConfig.java`, `S3CsvFormatConfig.java`, `S3AvroFormatConfig.java`, `S3JsonlFormatConfig.java`, `S3ParqueFormatConfig.java`
3. Other files - these are purely formatting + method renames (e.g. `getFoo` -> `foo`)

## 🚨 User Impact 🚨
None

## Pre-merge Checklist
<strong> Updating a connector </strong>
<p>
   
#### Community member or Airbyter
   
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [x] Connector's `README.md`
    - [x] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [x] Create a non-forked branch based on this PR and test the below items on it
- [x] Build is successful
- [x] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>
