### PR TITLE
handle destination and source failures equally + fix main process failure handling

### DIFF
--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/LocalAirbyteDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/LocalAirbyteDestination.java
@@ -61,6 +61,11 @@ public class LocalAirbyteDestination implements AirbyteDestination {
   }
 
   @Override
+  public int getExitValue() {
+    return 0;
+  }
+
+  @Override
   public Optional<AirbyteMessage> attemptRead() {
     return Optional.empty();
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -127,11 +127,12 @@ public class DefaultReplicationWorker implements ReplicationWorker {
             getReplicationRunnable(source, destination, cancelled, mapper, sourceMessageTracker, mdc),
             executors);
 
-        LOGGER.info("Waiting for source and destination threads to complete!!");
+        LOGGER.info("Waiting for source and destination threads to complete.");
         // CompletableFuture#allOf waits until all futures finish before returning, even if one throws an
         // exception. So in order to handle exceptions from a future immediately without needing to wait for
         // the other future to finish, we first call CompletableFuture#anyOf.
         CompletableFuture.anyOf(replicationThreadFuture, destinationOutputThreadFuture).get();
+        LOGGER.info("One of source or destination thread complete. Waiting on the other.");
         CompletableFuture.allOf(replicationThreadFuture, destinationOutputThreadFuture).get();
         LOGGER.info("Source and destination threads complete.");
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -218,6 +218,9 @@ public class DefaultReplicationWorker implements ReplicationWorker {
           }
         }
         destination.notifyEndOfStream();
+        if (!cancelled.get() && source.getExitValue() != 0) {
+          throw new RuntimeException("Source process exited with non-zero exit code " + source.getExitValue());
+        }
       } catch (final Exception e) {
         if (!cancelled.get()) {
           // Although this thread is closed first, it races with the source's closure and can attempt one
@@ -244,6 +247,9 @@ public class DefaultReplicationWorker implements ReplicationWorker {
             LOGGER.info("state in DefaultReplicationWorker from Destination: {}", messageOptional.get());
             destinationMessageTracker.accept(messageOptional.get());
           }
+        }
+        if (!cancelled.get() && destination.getExitValue() != 0) {
+          throw new RuntimeException("Destination process exited with non-zero exit code " + destination.getExitValue());
         }
       } catch (final Exception e) {
         if (!cancelled.get()) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -19,9 +19,9 @@ import io.airbyte.workers.protocols.airbyte.MessageTracker;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -119,26 +119,21 @@ public class DefaultReplicationWorker implements ReplicationWorker {
         destination.start(destinationConfig, jobRoot);
         source.start(sourceConfig, jobRoot);
 
-        final Future<?> destinationOutputThreadFuture = executors.submit(getDestinationOutputRunnable(
-            destination,
-            cancelled,
-            destinationMessageTracker,
-            mdc));
+        final CompletableFuture<?> destinationOutputThreadFuture = CompletableFuture.runAsync(
+            getDestinationOutputRunnable(destination, cancelled, destinationMessageTracker, mdc),
+            executors);
 
-        final Future<?> replicationThreadFuture = executors.submit(getReplicationRunnable(
-            source,
-            destination,
-            cancelled,
-            mapper,
-            sourceMessageTracker,
-            mdc));
+        final CompletableFuture<?> replicationThreadFuture = CompletableFuture.runAsync(
+            getReplicationRunnable(source, destination, cancelled, mapper, sourceMessageTracker, mdc),
+            executors);
 
-        LOGGER.info("Waiting for source thread to join.");
-        replicationThreadFuture.get();
-        LOGGER.info("Source thread complete.");
-        LOGGER.info("Waiting for destination thread to join.");
-        destinationOutputThreadFuture.get();
-        LOGGER.info("Destination thread complete.");
+        LOGGER.info("Waiting for source and destination threads to complete!!");
+        // CompletableFuture#allOf waits until all futures finish before returning, even if one throws an
+        // exception. So in order to handle exceptions from a future immediately without needing to wait for
+        // the other future to finish, we first call CompletableFuture#anyOf.
+        CompletableFuture.anyOf(replicationThreadFuture, destinationOutputThreadFuture).get();
+        CompletableFuture.allOf(replicationThreadFuture, destinationOutputThreadFuture).get();
+        LOGGER.info("Source and destination threads complete.");
 
       } catch (final Exception e) {
         hasFailed.set(true);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteDestination.java
@@ -7,7 +7,6 @@ package io.airbyte.workers.protocols.airbyte;
 import io.airbyte.commons.functional.CheckedConsumer;
 import io.airbyte.config.WorkerDestinationConfig;
 import io.airbyte.protocol.models.AirbyteMessage;
-import io.airbyte.workers.WorkerException;
 import java.nio.file.Path;
 import java.util.Optional;
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteDestination.java
@@ -7,6 +7,7 @@ package io.airbyte.workers.protocols.airbyte;
 import io.airbyte.commons.functional.CheckedConsumer;
 import io.airbyte.config.WorkerDestinationConfig;
 import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.workers.WorkerException;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -56,8 +57,9 @@ public interface AirbyteDestination extends CheckedConsumer<AirbyteMessage, Exce
    * been emitted or because the Destination container has exited.
    *
    * @return true, if no more data will be emitted. otherwise, false.
+   * @throws WorkerException if the Source exited with a non-zero exit code.
    */
-  boolean isFinished();
+  boolean isFinished() throws WorkerException;
 
   /**
    * Attempts to read an AirbyteMessage from the Destination.

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteDestination.java
@@ -58,7 +58,7 @@ public interface AirbyteDestination extends CheckedConsumer<AirbyteMessage, Exce
    *
    * @return true, if no more data will be emitted. otherwise, false.
    */
-  boolean isFinished() throws WorkerException;
+  boolean isFinished();
 
   /**
    * Gets the exit value of the destination process. This should only be called after the destination

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteDestination.java
@@ -57,9 +57,17 @@ public interface AirbyteDestination extends CheckedConsumer<AirbyteMessage, Exce
    * been emitted or because the Destination container has exited.
    *
    * @return true, if no more data will be emitted. otherwise, false.
-   * @throws WorkerException if the Destination exited with a non-zero exit code.
    */
   boolean isFinished() throws WorkerException;
+
+  /**
+   * Gets the exit value of the destination process. This should only be called after the destination
+   * process has finished.
+   *
+   * @return exit code of the destination process
+   * @throws IllegalStateException if the destination process has not exited
+   */
+  int getExitValue();
 
   /**
    * Attempts to read an AirbyteMessage from the Destination.

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteDestination.java
@@ -57,7 +57,7 @@ public interface AirbyteDestination extends CheckedConsumer<AirbyteMessage, Exce
    * been emitted or because the Destination container has exited.
    *
    * @return true, if no more data will be emitted. otherwise, false.
-   * @throws WorkerException if the Source exited with a non-zero exit code.
+   * @throws WorkerException if the Destination exited with a non-zero exit code.
    */
   boolean isFinished() throws WorkerException;
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteSource.java
@@ -6,7 +6,6 @@ package io.airbyte.workers.protocols.airbyte;
 
 import io.airbyte.config.WorkerSourceConfig;
 import io.airbyte.protocol.models.AirbyteMessage;
-import io.airbyte.workers.WorkerException;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -31,9 +30,17 @@ public interface AirbyteSource extends AutoCloseable {
    * emitted or because the Source container has exited.
    *
    * @return true, if no more data will be emitted. otherwise, false.
-   * @throws WorkerException if the Source exited with a non-zero exit code.
    */
-  boolean isFinished() throws WorkerException;
+  boolean isFinished();
+
+  /**
+   * Gets the exit value of the source process. This should only be called after the source process
+   * has finished.
+   *
+   * @return exit code of the source process
+   * @throws IllegalStateException if the source process has not exited
+   */
+  int getExitValue();
 
   /**
    * Attempts to read an AirbyteMessage from the Source.

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteSource.java
@@ -6,6 +6,7 @@ package io.airbyte.workers.protocols.airbyte;
 
 import io.airbyte.config.WorkerSourceConfig;
 import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.workers.WorkerException;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -30,8 +31,9 @@ public interface AirbyteSource extends AutoCloseable {
    * emitted or because the Source container has exited.
    *
    * @return true, if no more data will be emitted. otherwise, false.
+   * @throws WorkerException if the Source exited with a non-zero exit code.
    */
-  boolean isFinished();
+  boolean isFinished() throws WorkerException;
 
   /**
    * Attempts to read an AirbyteMessage from the Source.

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -134,7 +134,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
   }
 
   @Override
-  public boolean isFinished() throws WorkerException {
+  public boolean isFinished() {
     Preconditions.checkState(destinationProcess != null);
     // As this check is done on every message read, it is important for this operation to be efficient.
     // Short circuit early to avoid checking the underlying process.

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestination.java
@@ -143,21 +143,13 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
       return false;
     }
 
-    // Also short circuit here to avoid checking the exit value until the process has actually finished.
-    if (destinationProcess.isAlive()) {
-      return false;
-    }
-
-    final int exitValue = getExitValue();
-    if (exitValue != 0) {
-      throw new WorkerException("Destination process exited with non-zero exit code " + exitValue);
-    }
-    return true;
+    return !destinationProcess.isAlive();
   }
 
-  private int getExitValue() {
-    Preconditions.checkState(destinationProcess != null);
-    Preconditions.checkState(!destinationProcess.isAlive());
+  @Override
+  public int getExitValue() {
+    Preconditions.checkState(destinationProcess != null, "Destination process is null, cannot retrieve exit value.");
+    Preconditions.checkState(!destinationProcess.isAlive(), "Destination process is still alive, cannot retrieve exit value.");
 
     if (exitValue == null) {
       exitValue = destinationProcess.exitValue();

--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/EmptyAirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/EmptyAirbyteSource.java
@@ -37,6 +37,11 @@ public class EmptyAirbyteSource implements AirbyteSource {
   }
 
   @Override
+  public int getExitValue() {
+    return 0;
+  }
+
+  @Override
   public Optional<AirbyteMessage> attemptRead() {
     if (!hasEmittedState.get()) {
       hasEmittedState.compareAndSet(false, true);

--- a/airbyte-workers/src/main/resources/entrypoints/main.sh
+++ b/airbyte-workers/src/main/resources/entrypoints/main.sh
@@ -16,9 +16,10 @@ fi
 ((eval "$AIRBYTE_ENTRYPOINT ARGS" 2> STDERR_PIPE_FILE > STDOUT_PIPE_FILE) OPTIONAL_STDIN) &
 CHILD_PID=$!
 
-# Check for TERMINATIOn_FILE_CHECK in a loop to handle heartbeat failure
+# Check for TERMINATION_FILE_CHECK in a loop to handle heartbeat failure
 (
   # must use $$$$ instead of $$ because kube entrypoint transforms $$ into $
+  # see https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#entrypoint for explanation
   PARENT_PID=$$$$
   echo "PARENT_PID: ${PARENT_PID}"
   while true

--- a/airbyte-workers/src/main/resources/entrypoints/main.sh
+++ b/airbyte-workers/src/main/resources/entrypoints/main.sh
@@ -12,8 +12,11 @@ else
   echo "Using existing AIRBYTE_ENTRYPOINT: $AIRBYTE_ENTRYPOINT"
 fi
 
-(OPTIONAL_STDIN (eval "$AIRBYTE_ENTRYPOINT ARGS" 2> STDERR_PIPE_FILE > STDOUT_PIPE_FILE)) &
+((eval "$AIRBYTE_ENTRYPOINT ARGS" 2> STDERR_PIPE_FILE > STDOUT_PIPE_FILE) OPTIONAL_STDIN) &
 CHILD_PID=$!
 (while true; do if [ -f TERMINATION_FILE_CHECK ]; then echo "Heartbeat to worker failed, exiting..."; exit 1; fi; sleep 1; done) &
+echo "Waiting on CHILD_PID $CHILD_PID"
 wait $CHILD_PID
-exit $?
+EXIT_STATUS=$?
+echo "EXIT_STATUS: $EXIT_STATUS"
+exit $EXIT_STATUS

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
@@ -7,7 +7,6 @@ package io.airbyte.workers.process;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.lang.Exceptions;
@@ -219,13 +218,11 @@ public class KubePodProcessIntegrationTest {
     process.getInputStream().close();
     process.getOutputStream().close();
 
-    // verify that exitValue throws IllegalThreadStateException
-    // this confirms that closing the streams does not terminate the overall process
-    assertThrows(IllegalThreadStateException.class, process::exitValue);
+    // waiting for process
+    process.waitFor();
 
-    // checking that exit code matches main would require a long wait due to STATUS_CHECK_INTERVAL_MS,
-    // so don't do that here. We have other tests confirming that exit value matches main's exit code
-    // anyway.
+    // the pod exit code should match the main container exit value
+    assertEquals(13, process.exitValue());
   }
 
   private static String getRandomFile(final int lines) {

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
@@ -4,7 +4,6 @@
 
 package io.airbyte.workers.process;
 
-import static java.lang.Thread.sleep;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -225,7 +224,8 @@ public class KubePodProcessIntegrationTest {
     assertThrows(IllegalThreadStateException.class, process::exitValue);
 
     // checking that exit code matches main would require a long wait due to STATUS_CHECK_INTERVAL_MS,
-    // so don't do that here. We have other tests confirming that exit value matches main's exit code anyway.
+    // so don't do that here. We have other tests confirming that exit value matches main's exit code
+    // anyway.
   }
 
   private static String getRandomFile(final int lines) {

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
@@ -135,12 +135,8 @@ class DefaultReplicationWorkerTest {
   }
 
   @Test
-  void testSourceFails() throws Exception {
-    when(source.isFinished())
-        .thenReturn(false)
-        .thenReturn(false)
-        .thenReturn(false)
-        .thenThrow(new WorkerException("Source exited with non-zero exit code"));
+  void testSourceNonZeroExitValue() throws Exception {
+    when(source.getExitValue()).thenReturn(1);
 
     final ReplicationWorker worker = new DefaultReplicationWorker(
         JOB_ID,
@@ -156,12 +152,8 @@ class DefaultReplicationWorkerTest {
   }
 
   @Test
-  void testDestinationFails() throws Exception {
-    when(destination.isFinished())
-        .thenReturn(false)
-        .thenReturn(false)
-        .thenReturn(false)
-        .thenThrow(new WorkerException("Destination exited with non-zero exit code"));
+  void testDestinationNonZeroExitValue() throws Exception {
+    when(destination.getExitValue()).thenReturn(1);
 
     final ReplicationWorker worker = new DefaultReplicationWorker(
         JOB_ID,

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
@@ -210,7 +210,7 @@ class DefaultReplicationWorkerTest {
 
   @SuppressWarnings({"BusyWait"})
   @Test
-  void testCancellation() throws InterruptedException, WorkerException {
+  void testCancellation() throws InterruptedException {
     final AtomicReference<ReplicationOutput> output = new AtomicReference<>();
     when(source.isFinished()).thenReturn(false);
     when(destinationMessageTracker.getOutputState()).thenReturn(Optional.of(new State().withState(STATE_MESSAGE.getState().getData())));

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
@@ -5,6 +5,7 @@
 package io.airbyte.workers.protocols.airbyte;
 
 import static io.airbyte.commons.logging.LoggingHelper.RESET;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -151,7 +152,7 @@ class DefaultAirbyteDestinationTest {
       }
     });
 
-    verify(process, times(2)).exitValue();
+    verify(process).exitValue();
   }
 
   @Test
@@ -203,6 +204,20 @@ class DefaultAirbyteDestinationTest {
     when(process.isAlive()).thenReturn(false);
     when(process.exitValue()).thenReturn(1);
     Assertions.assertThrows(WorkerException.class, destination::close);
+  }
+
+  @Test
+  public void testGetExitValue() throws Exception {
+    final AirbyteDestination destination = new DefaultAirbyteDestination(integrationLauncher);
+    destination.start(DESTINATION_CONFIG, jobRoot);
+
+    when(process.isAlive()).thenReturn(false);
+    when(process.exitValue()).thenReturn(2);
+
+    assertEquals(2, destination.getExitValue());
+    // call a second time to verify that exit value is cached
+    assertEquals(2, destination.getExitValue());
+    verify(process, times(1)).exitValue();
   }
 
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -150,7 +151,7 @@ class DefaultAirbyteDestinationTest {
       }
     });
 
-    verify(process).exitValue();
+    verify(process, times(2)).exitValue();
   }
 
   @Test

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteDestinationTest.java
@@ -208,7 +208,7 @@ class DefaultAirbyteDestinationTest {
 
   @Test
   public void testGetExitValue() throws Exception {
-    final AirbyteDestination destination = new DefaultAirbyteDestination(integrationLauncher);
+    final AirbyteDestination destination = new DefaultAirbyteDestination(workerConfigs, integrationLauncher);
     destination.start(DESTINATION_CONFIG, jobRoot);
 
     when(process.isAlive()).thenReturn(false);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
@@ -161,7 +161,7 @@ class DefaultAirbyteSourceTest {
       }
     });
 
-    verify(process, times(2)).exitValue();
+    verify(process).exitValue();
   }
 
   @Test
@@ -203,6 +203,20 @@ class DefaultAirbyteSourceTest {
     when(process.exitValue()).thenReturn(1);
 
     Assertions.assertThrows(WorkerException.class, tap::close);
+  }
+
+  @Test
+  public void testGetExitValue() throws Exception {
+    final AirbyteSource source = new DefaultAirbyteSource(integrationLauncher, streamFactory, heartbeatMonitor);
+    source.start(SOURCE_CONFIG, jobRoot);
+
+    when(process.isAlive()).thenReturn(false);
+    when(process.exitValue()).thenReturn(2);
+
+    assertEquals(2, source.getExitValue());
+    // call a second time to verify that exit value is cached
+    assertEquals(2, source.getExitValue());
+    verify(process, times(1)).exitValue();
   }
 
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
@@ -161,7 +161,7 @@ class DefaultAirbyteSourceTest {
       }
     });
 
-    verify(process).exitValue();
+    verify(process, times(2)).exitValue();
   }
 
   @Test

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/DefaultAirbyteSourceTest.java
@@ -207,7 +207,7 @@ class DefaultAirbyteSourceTest {
 
   @Test
   public void testGetExitValue() throws Exception {
-    final AirbyteSource source = new DefaultAirbyteSource(integrationLauncher, streamFactory, heartbeatMonitor);
+    final AirbyteSource source = new DefaultAirbyteSource(workerConfigs, integrationLauncher, streamFactory, heartbeatMonitor);
     source.start(SOURCE_CONFIG, jobRoot);
 
     when(process.isAlive()).thenReturn(false);


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/oncall/issues/57

I've found that when a destination process fails, the DefaultReplicationWorker does not actually fail the sync job until it calls `destination.accept()` [here](https://github.com/airbytehq/airbyte/blob/03e51605691ef069486079b021716d937873d351/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java#L216).
This means that if replication worker hangs on reading a message from the source and never gets to that line, then the job will remain in a hung RUNNING state indefinitely.

This is one symptom of the DefaultReplicationWorker not properly handling source/destination failures equally. The goal of this PR is to address this issue.

This PR also solves an issue where the `main` container of a kube process would not be terminated despite an error being thrown in the main thread. This was because the `main.sh` process was hanging waiting for the `cat /pipes/stdin` command to finish. This PR solves that issue by using redirection (`<`) instead of a pipe (`|`). 
Along with this change, the `isTerminal` and `exitValue` methods in kube pod process now only look at the main container to get the terminal status and error code. See relevant slack thread here: https://airbytehq.slack.com/archives/C0229LM09T4/p1639618364198100?thread_ts=1639439397.137400&cid=C0229LM09T4

## How
This PR addresses the issue by having the replication and destination output threads check the exit code of the source/destination processes if they see that those processes have finished. If the exit code is non-zero for either, it throws a WorkerException.

To handle these WorkerExceptions properly, I also needed to change the DefaultReplicationWorker to wait on both futures simultaneously, rather than waiting for the source thread to complete before the destination thread.
