### PR TITLE
🎉 SAT: test_check for "status: exception" check stdout for new airbyte_cdk

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -118,8 +118,9 @@ class TestConnection(BaseTest):
             with pytest.raises(ContainerError) as err:
                 docker_runner.call_check(config=connector_config)
 
+            stdout = err.value.container.logs(stderr=False).decode("utf-8")
             assert err.value.exit_status != 0, "Connector should exit with error code"
-            assert "Traceback" in err.value.stderr, "Connector should print exception"
+            assert "Traceback" in err.value.stderr or "Traceback" in stdout, "Connector should print exception"
 
 
 @pytest.mark.default_timeout(30)


### PR DESCRIPTION
Signed-off-by: Sergey Chvalyuk <grubberr@gmail.com>

## What
Test work "Traceback" on both `stdout` and `stderr` streams.
airbyte_cdk < 0.1.41 prints Traceback to `stderr`, airbyte_cdk >= 0.1.41 prints Traceback to `stdout` 

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.