### PR TITLE
fix KubePodProcess port offering race condition

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -520,7 +520,7 @@ public class KubePodProcess extends Process {
   private void close() {
     // short-circuit if close was already called, so we don't re-offer ports multiple times
     // since the offer call is non-atomic
-    if(closed) {
+    if (closed) {
       return;
     } else {
       closed = true;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -117,9 +117,9 @@ public class KubePodProcess extends Process {
   // This variable should be set in functions where the pod is forcefully terminated. See
   // getReturnCode() for more info.
   private final AtomicBoolean wasKilled = new AtomicBoolean(false);
+  private final AtomicBoolean wasClosed = new AtomicBoolean(false);
 
   private final OutputStream stdin;
-  private boolean closed = false;
   private InputStream stdout;
   private InputStream stderr;
   private Integer returnCode = null;
@@ -518,12 +518,12 @@ public class KubePodProcess extends Process {
    * implementation with OS processes and resources, which are automatically reaped by the OS.
    */
   private void close() {
+    final boolean previouslyClosed = wasClosed.getAndSet(true);
+
     // short-circuit if close was already called, so we don't re-offer ports multiple times
     // since the offer call is non-atomic
-    if (closed) {
+    if (previouslyClosed) {
       return;
-    } else {
-      closed = true;
     }
 
     if (this.stdin != null) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -119,6 +119,7 @@ public class KubePodProcess extends Process {
   private final AtomicBoolean wasKilled = new AtomicBoolean(false);
 
   private final OutputStream stdin;
+  private boolean closed = false;
   private InputStream stdout;
   private InputStream stderr;
   private Integer returnCode = null;
@@ -517,6 +518,14 @@ public class KubePodProcess extends Process {
    * implementation with OS processes and resources, which are automatically reaped by the OS.
    */
   private void close() {
+    // short-circuit if close was already called, so we don't re-offer ports multiple times
+    // since the offer call is non-atomic
+    if(closed) {
+      return;
+    } else {
+      closed = true;
+    }
+
     if (this.stdin != null) {
       Exceptions.swallow(this.stdin::close);
     }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
@@ -101,6 +101,7 @@ public class KubeProcessFactory implements ProcessFactory {
     try {
       // used to differentiate source and destination processes with the same id and attempt
       final String podName = createPodName(imageName, jobId, attempt);
+      LOGGER.info("Attempting to start pod = {}", podName);
 
       final int stdoutLocalPort = KubePortManagerSingleton.getInstance().take();
       LOGGER.info("{} stdoutLocalPort = {}", podName, stdoutLocalPort);
@@ -173,7 +174,6 @@ public class KubeProcessFactory implements ProcessFactory {
       imageName = imageName.substring(extra);
       podName = imageName + "-" + suffix;
     }
-    System.out.println(podName);
     final Matcher m = ALPHABETIC.matcher(podName);
     // Since we add sync-UUID as a suffix a couple of lines up, there will always be a substring
     // starting with an alphabetic character.

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
@@ -124,12 +124,15 @@ public class KubePodProcessIntegrationTest {
     }
 
     // stop taking from available ports
-    executor.shutdown();
+    executor.shutdownNow();
 
     // prior to fixing this race condition, the close method would offer ports every time it was called.
     // without the race condition, we should have only been able to pull each of the originally
     // available ports once
     assertEquals(availablePortsBefore, portsTaken.size());
+
+    // release ports for next tests
+    portsTaken.forEach(KubePortManagerSingleton.getInstance()::offer);
   }
 
   @Test

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -88,6 +89,47 @@ public class KubePodProcessIntegrationTest {
     assertFalse(process.isAlive());
     assertEquals(availablePortsBefore, KubePortManagerSingleton.getInstance().getNumAvailablePorts());
     assertEquals(0, process.exitValue());
+  }
+
+  @Test
+  public void testPortsReintroducedIntoPoolOnlyOnce() throws Exception {
+    final var availablePortsBefore = KubePortManagerSingleton.getInstance().getNumAvailablePorts();
+
+    // run a finite process
+    final Process process = getProcess("echo hi; sleep 1; echo hi2");
+    process.waitFor();
+
+    // the pod should be dead and in a good state
+    assertFalse(process.isAlive());
+
+    // run a background process to continuously consume available ports
+    final var portsTaken = new ArrayList<Integer>();
+    final var executor = Executors.newSingleThreadExecutor();
+
+    executor.submit(() -> {
+      try {
+        while (true) {
+          portsTaken.add(KubePortManagerSingleton.getInstance().take());
+        }
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+        throw new RuntimeException(e);
+      }
+    });
+
+    // repeatedly call exitValue (and therefore the close method)
+    for (int i = 0; i < 100; i++) {
+      // if exitValue no longer calls close in the future this test will fail and need to be updated.
+      process.exitValue();
+    }
+
+    // stop taking from available ports
+    executor.shutdown();
+
+    // prior to fixing this race condition, the close method would offer ports every time it was called.
+    // without the race condition, we should have only been able to pull each of the originally
+    // available ports once
+    assertEquals(availablePortsBefore, portsTaken.size());
   }
 
   @Test


### PR DESCRIPTION
There's a race condition when we `offer` a port back after closing a `KubePodProcess` since the unique. check of the offering isn't atomic:
```
    if (!workerPorts.contains(port)) {
      workerPorts.add(port);
    }
```

The problem happens where we `close()` multiple times, calling the above code multiple times. It's possible for the port to already be picked up (so the contains check allows it to add a port) when the port was already consumed by a different process.

This tests for the prior case and and fixes the issue. 

This issue would manifest by one pod process failing before causing another to fail due to the same address already being in use. This shows up rarely in cloud logs (but we would have expected it to show up much more often before this fix).