### PR TITLE
Add API endpoint and handlers to delete SourceDefinitions and DestinationDefinitions

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -314,6 +314,25 @@ paths:
           $ref: "#/components/responses/NotFoundResponse"
         "422":
           $ref: "#/components/responses/InvalidInputResponse"
+  /v1/source_definitions/delete:
+    post:
+      tags:
+        - source_definition
+      summary: Delete a source definition
+      operationId: deleteSourceDefinition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SourceDefinitionIdRequestBody"
+        required: true
+      responses:
+        "204":
+          description: The resource was deleted successfully.
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+        "422":
+          $ref: "#/components/responses/InvalidInputResponse"
   /v1/source_definition_specifications/get:
     post:
       tags:
@@ -626,6 +645,25 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DestinationDefinitionRead"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+        "422":
+          $ref: "#/components/responses/InvalidInputResponse"
+  /v1/destination_definitions/delete:
+    post:
+      tags:
+        - destination_definition
+      summary: Delete a destination definition
+      operationId: deleteDestinationDefinition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DestinationDefinitionIdRequestBody"
+        required: true
+      responses:
+        "204":
+          description: The resource was deleted successfully.
         "404":
           $ref: "#/components/responses/NotFoundResponse"
         "422":

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -184,12 +184,12 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
         temporalService,
         new OAuthConfigSupplier(configRepository, trackingClient), workerEnvironment, logConfigs);
     final WorkspaceHelper workspaceHelper = new WorkspaceHelper(configRepository, jobPersistence);
-    sourceDefinitionsHandler = new SourceDefinitionsHandler(configRepository, synchronousSchedulerClient);
     connectionsHandler = new ConnectionsHandler(configRepository, workspaceHelper, trackingClient, workerConfigs);
-    operationsHandler = new OperationsHandler(configRepository);
-    destinationDefinitionsHandler = new DestinationDefinitionsHandler(configRepository, synchronousSchedulerClient);
-    destinationHandler = new DestinationHandler(configRepository, schemaValidator, connectionsHandler);
     sourceHandler = new SourceHandler(configRepository, schemaValidator, connectionsHandler);
+    sourceDefinitionsHandler = new SourceDefinitionsHandler(configRepository, synchronousSchedulerClient, sourceHandler);
+    operationsHandler = new OperationsHandler(configRepository);
+    destinationHandler = new DestinationHandler(configRepository, schemaValidator, connectionsHandler);
+    destinationDefinitionsHandler = new DestinationDefinitionsHandler(configRepository, synchronousSchedulerClient, destinationHandler);
     workspacesHandler = new WorkspacesHandler(configRepository, connectionsHandler, destinationHandler, sourceHandler);
     jobHistoryHandler = new JobHistoryHandler(jobPersistence, workerEnvironment, logConfigs);
     oAuthHandler = new OAuthHandler(configRepository, httpClient, trackingClient);
@@ -287,6 +287,14 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   @Override
   public SourceDefinitionRead updateSourceDefinition(final SourceDefinitionUpdate sourceDefinitionUpdate) {
     return execute(() -> sourceDefinitionsHandler.updateSourceDefinition(sourceDefinitionUpdate));
+  }
+
+  @Override
+  public void deleteSourceDefinition(final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody) {
+    execute(() -> {
+      sourceDefinitionsHandler.deleteSourceDefinition(sourceDefinitionIdRequestBody);
+      return null;
+    });
   }
 
   // SOURCE SPECIFICATION
@@ -421,6 +429,14 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   @Override
   public DestinationDefinitionRead updateDestinationDefinition(final DestinationDefinitionUpdate destinationDefinitionUpdate) {
     return execute(() -> destinationDefinitionsHandler.updateDestinationDefinition(destinationDefinitionUpdate));
+  }
+
+  @Override
+  public void deleteDestinationDefinition(final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody) {
+    execute(() -> {
+      destinationDefinitionsHandler.deleteDestinationDefinition(destinationDefinitionIdRequestBody);
+      return null;
+    });
   }
 
   // DESTINATION SPECIFICATION

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -159,7 +159,8 @@ public class DestinationDefinitionsHandler {
 
   public void deleteDestinationDefinition(final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody)
       throws JsonValidationException, ConfigNotFoundException, IOException {
-    // "delete" all destinations associated with the destination definition as well. This will cascade to connections that depend on any deleted
+    // "delete" all destinations associated with the destination definition as well. This will cascade
+    // to connections that depend on any deleted
     // destinations. Delete destinations first in case a failure occurs mid-operation.
 
     final StandardDestinationDefinition persistedDestinationDefinition =

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
@@ -9,6 +9,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import io.airbyte.api.model.ConnectionRead;
 import io.airbyte.api.model.DestinationCreate;
+import io.airbyte.api.model.DestinationDefinitionIdRequestBody;
 import io.airbyte.api.model.DestinationIdRequestBody;
 import io.airbyte.api.model.DestinationRead;
 import io.airbyte.api.model.DestinationReadList;
@@ -166,6 +167,24 @@ public class DestinationHandler {
       }
 
       reads.add(buildDestinationRead(dci.getDestinationId()));
+    }
+
+    return new DestinationReadList().destinations(reads);
+  }
+
+  public DestinationReadList listDestinationsForDestinationDefinition(final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody)
+      throws JsonValidationException, IOException, ConfigNotFoundException {
+    final List<DestinationRead> reads = Lists.newArrayList();
+
+    for (final DestinationConnection destinationConnection : configRepository.listDestinationConnection()) {
+      if (!destinationConnection.getDestinationDefinitionId().equals(destinationDefinitionIdRequestBody.getDestinationDefinitionId())) {
+        continue;
+      }
+      if (destinationConnection.getTombstone() != null && destinationConnection.getTombstone()) {
+        continue;
+      }
+
+      reads.add(buildDestinationRead(destinationConnection.getDestinationId()));
     }
 
     return new DestinationReadList().destinations(reads);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -153,7 +153,8 @@ public class SourceDefinitionsHandler {
 
   public void deleteSourceDefinition(final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody)
       throws JsonValidationException, IOException, ConfigNotFoundException {
-    // "delete" all sources associated with the source definition as well. This will cascade to connections that depend on any deleted sources.
+    // "delete" all sources associated with the source definition as well. This will cascade to
+    // connections that depend on any deleted sources.
     // Delete sources first in case a failure occurs mid-operation.
 
     final StandardSourceDefinition persistedSourceDefinition =

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -12,6 +12,7 @@ import io.airbyte.api.model.SourceDefinitionIdRequestBody;
 import io.airbyte.api.model.SourceDefinitionRead;
 import io.airbyte.api.model.SourceDefinitionReadList;
 import io.airbyte.api.model.SourceDefinitionUpdate;
+import io.airbyte.api.model.SourceRead;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.config.StandardSourceDefinition;
@@ -38,22 +39,26 @@ public class SourceDefinitionsHandler {
   private final Supplier<UUID> uuidSupplier;
   private final AirbyteGithubStore githubStore;
   private final SynchronousSchedulerClient schedulerSynchronousClient;
+  private final SourceHandler sourceHandler;
 
   public SourceDefinitionsHandler(
                                   final ConfigRepository configRepository,
-                                  final SynchronousSchedulerClient schedulerSynchronousClient) {
-    this(configRepository, UUID::randomUUID, schedulerSynchronousClient, AirbyteGithubStore.production());
+                                  final SynchronousSchedulerClient schedulerSynchronousClient,
+                                  final SourceHandler sourceHandler) {
+    this(configRepository, UUID::randomUUID, schedulerSynchronousClient, AirbyteGithubStore.production(), sourceHandler);
   }
 
   public SourceDefinitionsHandler(
                                   final ConfigRepository configRepository,
                                   final Supplier<UUID> uuidSupplier,
                                   final SynchronousSchedulerClient schedulerSynchronousClient,
-                                  final AirbyteGithubStore githubStore) {
+                                  final AirbyteGithubStore githubStore,
+                                  final SourceHandler sourceHandler) {
     this.configRepository = configRepository;
     this.uuidSupplier = uuidSupplier;
     this.schedulerSynchronousClient = schedulerSynchronousClient;
     this.githubStore = githubStore;
+    this.sourceHandler = sourceHandler;
   }
 
   @VisibleForTesting
@@ -144,6 +149,22 @@ public class SourceDefinitionsHandler {
 
     configRepository.writeStandardSourceDefinition(newSource);
     return buildSourceDefinitionRead(newSource);
+  }
+
+  public void deleteSourceDefinition(final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody)
+      throws JsonValidationException, IOException, ConfigNotFoundException {
+    // "delete" all sources associated with the source definition as well. This will cascade to connections that depend on any deleted sources.
+    // Delete sources first in case a failure occurs mid-operation.
+
+    final StandardSourceDefinition persistedSourceDefinition =
+        configRepository.getStandardSourceDefinition(sourceDefinitionIdRequestBody.getSourceDefinitionId());
+
+    for (final SourceRead sourceRead : sourceHandler.listSourcesForSourceDefinition(sourceDefinitionIdRequestBody).getSources()) {
+      sourceHandler.deleteSource(sourceRead);
+    }
+
+    persistedSourceDefinition.withTombstone(true);
+    configRepository.writeStandardSourceDefinition(persistedSourceDefinition);
   }
 
   private ConnectorSpecification getSpecForImage(final String dockerRepository, final String imageTag) throws IOException {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -136,9 +136,9 @@ public class SourceHandler {
 
     final List<SourceConnection> sourceConnections = configRepository.listSourceConnection()
         .stream()
-        .filter(sc ->
-            sc.getSourceDefinitionId().equals(sourceDefinitionIdRequestBody.getSourceDefinitionId()) && !MoreBooleans.isTruthy(sc.getTombstone())
-        ).toList();
+        .filter(sc -> sc.getSourceDefinitionId().equals(sourceDefinitionIdRequestBody.getSourceDefinitionId())
+            && !MoreBooleans.isTruthy(sc.getTombstone()))
+        .toList();
 
     final List<SourceRead> reads = Lists.newArrayList();
     for (final SourceConnection sourceConnection : sourceConnections) {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -8,12 +8,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
 import io.airbyte.api.model.ConnectionRead;
 import io.airbyte.api.model.SourceCreate;
+import io.airbyte.api.model.SourceDefinitionIdRequestBody;
 import io.airbyte.api.model.SourceIdRequestBody;
 import io.airbyte.api.model.SourceRead;
 import io.airbyte.api.model.SourceReadList;
 import io.airbyte.api.model.SourceSearch;
 import io.airbyte.api.model.SourceUpdate;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
+import io.airbyte.commons.lang.MoreBooleans;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -115,17 +117,32 @@ public class SourceHandler {
 
   public SourceReadList listSourcesForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody)
       throws ConfigNotFoundException, IOException, JsonValidationException {
+
+    final List<SourceConnection> sourceConnections = configRepository.listSourceConnection()
+        .stream()
+        .filter(sc -> sc.getWorkspaceId().equals(workspaceIdRequestBody.getWorkspaceId()) && !MoreBooleans.isTruthy(sc.getTombstone()))
+        .toList();
+
     final List<SourceRead> reads = Lists.newArrayList();
+    for (final SourceConnection sc : sourceConnections) {
+      reads.add(buildSourceRead(sc.getSourceId()));
+    }
 
-    for (final SourceConnection sci : configRepository.listSourceConnection()) {
-      if (!sci.getWorkspaceId().equals(workspaceIdRequestBody.getWorkspaceId())) {
-        continue;
-      }
-      if (sci.getTombstone()) {
-        continue;
-      }
+    return new SourceReadList().sources(reads);
+  }
 
-      reads.add(buildSourceRead(sci.getSourceId()));
+  public SourceReadList listSourcesForSourceDefinition(final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody)
+      throws JsonValidationException, IOException, ConfigNotFoundException {
+
+    final List<SourceConnection> sourceConnections = configRepository.listSourceConnection()
+        .stream()
+        .filter(sc ->
+            sc.getSourceDefinitionId().equals(sourceDefinitionIdRequestBody.getSourceDefinitionId()) && !MoreBooleans.isTruthy(sc.getTombstone())
+        ).toList();
+
+    final List<SourceRead> reads = Lists.newArrayList();
+    for (final SourceConnection sourceConnection : sourceConnections) {
+      reads.add(buildSourceRead(sourceConnection.getSourceId()));
     }
 
     return new SourceReadList().sources(reads);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
@@ -5,6 +5,7 @@
 package io.airbyte.server.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -18,6 +19,8 @@ import io.airbyte.api.model.DestinationDefinitionIdRequestBody;
 import io.airbyte.api.model.DestinationDefinitionRead;
 import io.airbyte.api.model.DestinationDefinitionReadList;
 import io.airbyte.api.model.DestinationDefinitionUpdate;
+import io.airbyte.api.model.DestinationRead;
+import io.airbyte.api.model.DestinationReadList;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.JobConfig.ConfigType;
@@ -44,26 +47,28 @@ import org.junit.jupiter.api.Test;
 class DestinationDefinitionsHandlerTest {
 
   private ConfigRepository configRepository;
-  private StandardDestinationDefinition destination;
-  private DestinationDefinitionsHandler destinationHandler;
+  private StandardDestinationDefinition destinationDefinition;
+  private DestinationDefinitionsHandler destinationDefinitionsHandler;
   private Supplier<UUID> uuidSupplier;
   private SynchronousSchedulerClient schedulerSynchronousClient;
   private AirbyteGithubStore githubStore;
+  private DestinationHandler destinationHandler;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
   void setUp() {
     configRepository = mock(ConfigRepository.class);
     uuidSupplier = mock(Supplier.class);
-    destination = generateDestination();
+    destinationDefinition = generateDestinationDefinition();
     schedulerSynchronousClient = spy(SynchronousSchedulerClient.class);
     githubStore = mock(AirbyteGithubStore.class);
+    destinationHandler = mock(DestinationHandler.class);
 
-    destinationHandler =
-        new DestinationDefinitionsHandler(configRepository, uuidSupplier, schedulerSynchronousClient, githubStore);
+    destinationDefinitionsHandler =
+        new DestinationDefinitionsHandler(configRepository, uuidSupplier, schedulerSynchronousClient, githubStore, destinationHandler);
   }
 
-  private StandardDestinationDefinition generateDestination() {
+  private StandardDestinationDefinition generateDestinationDefinition() {
     final ConnectorSpecification spec = new ConnectorSpecification().withConnectionSpecification(
         Jsons.jsonNode(ImmutableMap.of("foo", "bar")));
 
@@ -81,17 +86,17 @@ class DestinationDefinitionsHandlerTest {
   @Test
   @DisplayName("listDestinationDefinition should return the right list")
   void testListDestinations() throws JsonValidationException, IOException, URISyntaxException {
-    final StandardDestinationDefinition destination2 = generateDestination();
+    final StandardDestinationDefinition destination2 = generateDestinationDefinition();
 
-    when(configRepository.listStandardDestinationDefinitions(false)).thenReturn(Lists.newArrayList(destination, destination2));
+    when(configRepository.listStandardDestinationDefinitions(false)).thenReturn(Lists.newArrayList(destinationDefinition, destination2));
 
     final DestinationDefinitionRead expectedDestinationDefinitionRead1 = new DestinationDefinitionRead()
-        .destinationDefinitionId(destination.getDestinationDefinitionId())
-        .name(destination.getName())
-        .dockerRepository(destination.getDockerRepository())
-        .dockerImageTag(destination.getDockerImageTag())
-        .documentationUrl(new URI(destination.getDocumentationUrl()))
-        .icon(DestinationDefinitionsHandler.loadIcon(destination.getIcon()));
+        .destinationDefinitionId(destinationDefinition.getDestinationDefinitionId())
+        .name(destinationDefinition.getName())
+        .dockerRepository(destinationDefinition.getDockerRepository())
+        .dockerImageTag(destinationDefinition.getDockerImageTag())
+        .documentationUrl(new URI(destinationDefinition.getDocumentationUrl()))
+        .icon(DestinationDefinitionsHandler.loadIcon(destinationDefinition.getIcon()));
 
     final DestinationDefinitionRead expectedDestinationDefinitionRead2 = new DestinationDefinitionRead()
         .destinationDefinitionId(destination2.getDestinationDefinitionId())
@@ -101,7 +106,7 @@ class DestinationDefinitionsHandlerTest {
         .documentationUrl(new URI(destination2.getDocumentationUrl()))
         .icon(DestinationDefinitionsHandler.loadIcon(destination2.getIcon()));
 
-    final DestinationDefinitionReadList actualDestinationDefinitionReadList = destinationHandler.listDestinationDefinitions();
+    final DestinationDefinitionReadList actualDestinationDefinitionReadList = destinationDefinitionsHandler.listDestinationDefinitions();
 
     assertEquals(
         Lists.newArrayList(expectedDestinationDefinitionRead1, expectedDestinationDefinitionRead2),
@@ -111,21 +116,22 @@ class DestinationDefinitionsHandlerTest {
   @Test
   @DisplayName("getDestinationDefinition should return the right destination")
   void testGetDestination() throws JsonValidationException, ConfigNotFoundException, IOException, URISyntaxException {
-    when(configRepository.getStandardDestinationDefinition(destination.getDestinationDefinitionId()))
-        .thenReturn(destination);
+    when(configRepository.getStandardDestinationDefinition(destinationDefinition.getDestinationDefinitionId()))
+        .thenReturn(destinationDefinition);
 
     final DestinationDefinitionRead expectedDestinationDefinitionRead = new DestinationDefinitionRead()
-        .destinationDefinitionId(destination.getDestinationDefinitionId())
-        .name(destination.getName())
-        .dockerRepository(destination.getDockerRepository())
-        .dockerImageTag(destination.getDockerImageTag())
-        .documentationUrl(new URI(destination.getDocumentationUrl()))
-        .icon(DestinationDefinitionsHandler.loadIcon(destination.getIcon()));
+        .destinationDefinitionId(destinationDefinition.getDestinationDefinitionId())
+        .name(destinationDefinition.getName())
+        .dockerRepository(destinationDefinition.getDockerRepository())
+        .dockerImageTag(destinationDefinition.getDockerImageTag())
+        .documentationUrl(new URI(destinationDefinition.getDocumentationUrl()))
+        .icon(DestinationDefinitionsHandler.loadIcon(destinationDefinition.getIcon()));
 
     final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody = new DestinationDefinitionIdRequestBody()
-        .destinationDefinitionId(destination.getDestinationDefinitionId());
+        .destinationDefinitionId(destinationDefinition.getDestinationDefinitionId());
 
-    final DestinationDefinitionRead actualDestinationDefinitionRead = destinationHandler.getDestinationDefinition(destinationDefinitionIdRequestBody);
+    final DestinationDefinitionRead actualDestinationDefinitionRead =
+        destinationDefinitionsHandler.getDestinationDefinition(destinationDefinitionIdRequestBody);
 
     assertEquals(expectedDestinationDefinitionRead, actualDestinationDefinitionRead);
   }
@@ -133,7 +139,7 @@ class DestinationDefinitionsHandlerTest {
   @Test
   @DisplayName("createDestinationDefinition should correctly create a destinationDefinition")
   void testCreateDestinationDefinition() throws URISyntaxException, IOException, JsonValidationException {
-    final StandardDestinationDefinition destination = generateDestination();
+    final StandardDestinationDefinition destination = generateDestinationDefinition();
     final String imageName = DockerUtils.getTaggedImageName(destination.getDockerRepository(), destination.getDockerImageTag());
 
     when(uuidSupplier.get()).thenReturn(destination.getDestinationDefinitionId());
@@ -156,7 +162,7 @@ class DestinationDefinitionsHandlerTest {
         .destinationDefinitionId(destination.getDestinationDefinitionId())
         .icon(DestinationDefinitionsHandler.loadIcon(destination.getIcon()));
 
-    final DestinationDefinitionRead actualRead = destinationHandler.createDestinationDefinition(create);
+    final DestinationDefinitionRead actualRead = destinationDefinitionsHandler.createDestinationDefinition(create);
 
     assertEquals(expectedRead, actualRead);
     verify(schedulerSynchronousClient).createGetSpecJob(imageName);
@@ -166,29 +172,53 @@ class DestinationDefinitionsHandlerTest {
   @Test
   @DisplayName("updateDestinationDefinition should correctly update a destinationDefinition")
   void testUpdateDestination() throws ConfigNotFoundException, IOException, JsonValidationException {
-    when(configRepository.getStandardDestinationDefinition(destination.getDestinationDefinitionId())).thenReturn(destination);
-    final DestinationDefinitionRead currentDestination = destinationHandler
-        .getDestinationDefinition(new DestinationDefinitionIdRequestBody().destinationDefinitionId(destination.getDestinationDefinitionId()));
+    when(configRepository.getStandardDestinationDefinition(destinationDefinition.getDestinationDefinitionId())).thenReturn(destinationDefinition);
+    final DestinationDefinitionRead currentDestination = destinationDefinitionsHandler
+        .getDestinationDefinition(
+            new DestinationDefinitionIdRequestBody().destinationDefinitionId(destinationDefinition.getDestinationDefinitionId()));
     final String currentTag = currentDestination.getDockerImageTag();
     final String dockerRepository = currentDestination.getDockerRepository();
     final String newDockerImageTag = "averydifferenttag";
     assertNotEquals(newDockerImageTag, currentTag);
 
-    final String newImageName = DockerUtils.getTaggedImageName(destination.getDockerRepository(), newDockerImageTag);
+    final String newImageName = DockerUtils.getTaggedImageName(destinationDefinition.getDockerRepository(), newDockerImageTag);
     final ConnectorSpecification newSpec = new ConnectorSpecification().withConnectionSpecification(
         Jsons.jsonNode(ImmutableMap.of("foo2", "bar2")));
     when(schedulerSynchronousClient.createGetSpecJob(newImageName)).thenReturn(new SynchronousResponse<>(
         newSpec,
         SynchronousJobMetadata.mock(ConfigType.GET_SPEC)));
 
-    final StandardDestinationDefinition updatedDestination = Jsons.clone(destination).withDockerImageTag(newDockerImageTag).withSpec(newSpec);
+    final StandardDestinationDefinition updatedDestination =
+        Jsons.clone(destinationDefinition).withDockerImageTag(newDockerImageTag).withSpec(newSpec);
 
-    final DestinationDefinitionRead destinationRead = destinationHandler.updateDestinationDefinition(
-        new DestinationDefinitionUpdate().destinationDefinitionId(this.destination.getDestinationDefinitionId()).dockerImageTag(newDockerImageTag));
+    final DestinationDefinitionRead destinationRead = destinationDefinitionsHandler.updateDestinationDefinition(
+        new DestinationDefinitionUpdate().destinationDefinitionId(this.destinationDefinition.getDestinationDefinitionId())
+            .dockerImageTag(newDockerImageTag));
 
     assertEquals(newDockerImageTag, destinationRead.getDockerImageTag());
     verify(schedulerSynchronousClient).createGetSpecJob(newImageName);
     verify(configRepository).writeStandardDestinationDefinition(updatedDestination);
+  }
+
+  @Test
+  @DisplayName("deleteDestinationDefinition should correctly delete a sourceDefinition")
+  void testDeleteDestinationDefinition() throws ConfigNotFoundException, IOException, JsonValidationException {
+    final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody =
+        new DestinationDefinitionIdRequestBody().destinationDefinitionId(destinationDefinition.getDestinationDefinitionId());
+    final StandardDestinationDefinition updatedDestinationDefinition = Jsons.clone(this.destinationDefinition).withTombstone(true);
+    final DestinationRead destination = new DestinationRead();
+
+    when(configRepository.getStandardDestinationDefinition(destinationDefinition.getDestinationDefinitionId()))
+        .thenReturn(destinationDefinition);
+    when(destinationHandler.listDestinationsForDestinationDefinition(destinationDefinitionIdRequestBody))
+        .thenReturn(new DestinationReadList().destinations(Collections.singletonList(destination)));
+
+    assertFalse(destinationDefinition.getTombstone());
+
+    destinationDefinitionsHandler.deleteDestinationDefinition(destinationDefinitionIdRequestBody);
+
+    verify(destinationHandler).deleteDestination(destination);
+    verify(configRepository).writeStandardDestinationDefinition(updatedDestinationDefinition);
   }
 
   @Nested
@@ -198,10 +228,10 @@ class DestinationDefinitionsHandlerTest {
     @Test
     @DisplayName("should return the latest list")
     void testCorrect() throws InterruptedException {
-      final StandardDestinationDefinition destinationDefinition = generateDestination();
+      final StandardDestinationDefinition destinationDefinition = generateDestinationDefinition();
       when(githubStore.getLatestDestinations()).thenReturn(Collections.singletonList(destinationDefinition));
 
-      final var destinationDefinitionReadList = destinationHandler.listLatestDestinationDefinitions().getDestinationDefinitions();
+      final var destinationDefinitionReadList = destinationDefinitionsHandler.listLatestDestinationDefinitions().getDestinationDefinitions();
       assertEquals(1, destinationDefinitionReadList.size());
 
       final var destinationDefinitionRead = destinationDefinitionReadList.get(0);
@@ -211,7 +241,7 @@ class DestinationDefinitionsHandlerTest {
     @Test
     @DisplayName("returns empty collection if cannot find latest definitions")
     void testHttpTimeout() {
-      assertEquals(0, destinationHandler.listLatestDestinationDefinitions().getDestinationDefinitions().size());
+      assertEquals(0, destinationDefinitionsHandler.listLatestDestinationDefinitions().getDestinationDefinitions().size());
     }
 
   }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -5,6 +5,7 @@
 package io.airbyte.server.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
@@ -19,6 +20,8 @@ import io.airbyte.api.model.SourceDefinitionIdRequestBody;
 import io.airbyte.api.model.SourceDefinitionRead;
 import io.airbyte.api.model.SourceDefinitionReadList;
 import io.airbyte.api.model.SourceDefinitionUpdate;
+import io.airbyte.api.model.SourceRead;
+import io.airbyte.api.model.SourceReadList;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.JobConfig.ConfigType;
@@ -45,11 +48,12 @@ import org.junit.jupiter.api.Test;
 class SourceDefinitionsHandlerTest {
 
   private ConfigRepository configRepository;
-  private StandardSourceDefinition source;
-  private SourceDefinitionsHandler sourceHandler;
+  private StandardSourceDefinition sourceDefinition;
+  private SourceDefinitionsHandler sourceDefinitionsHandler;
   private Supplier<UUID> uuidSupplier;
   private SynchronousSchedulerClient schedulerSynchronousClient;
   private AirbyteGithubStore githubStore;
+  private SourceHandler sourceHandler;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
@@ -58,19 +62,20 @@ class SourceDefinitionsHandlerTest {
     uuidSupplier = mock(Supplier.class);
     schedulerSynchronousClient = spy(SynchronousSchedulerClient.class);
     githubStore = mock(AirbyteGithubStore.class);
+    sourceHandler = mock(SourceHandler.class);
 
-    source = generateSource();
+    sourceDefinition = generateSourceDefinition();
 
-    sourceHandler = new SourceDefinitionsHandler(configRepository, uuidSupplier, schedulerSynchronousClient, githubStore);
+    sourceDefinitionsHandler = new SourceDefinitionsHandler(configRepository, uuidSupplier, schedulerSynchronousClient, githubStore, sourceHandler);
   }
 
-  private StandardSourceDefinition generateSource() {
-    final UUID sourceId = UUID.randomUUID();
+  private StandardSourceDefinition generateSourceDefinition() {
+    final UUID sourceDefinitionId = UUID.randomUUID();
     final ConnectorSpecification spec = new ConnectorSpecification().withConnectionSpecification(
         Jsons.jsonNode(ImmutableMap.of("foo", "bar")));
 
     return new StandardSourceDefinition()
-        .withSourceDefinitionId(sourceId)
+        .withSourceDefinitionId(sourceDefinitionId)
         .withName("presto")
         .withDocumentationUrl("https://netflix.com")
         .withDockerRepository("dockerstuff")
@@ -83,27 +88,27 @@ class SourceDefinitionsHandlerTest {
   @Test
   @DisplayName("listSourceDefinition should return the right list")
   void testListSourceDefinitions() throws JsonValidationException, IOException, URISyntaxException {
-    final StandardSourceDefinition source2 = generateSource();
+    final StandardSourceDefinition sourceDefinition2 = generateSourceDefinition();
 
-    when(configRepository.listStandardSourceDefinitions(false)).thenReturn(Lists.newArrayList(source, source2));
+    when(configRepository.listStandardSourceDefinitions(false)).thenReturn(Lists.newArrayList(sourceDefinition, sourceDefinition2));
 
     final SourceDefinitionRead expectedSourceDefinitionRead1 = new SourceDefinitionRead()
-        .sourceDefinitionId(source.getSourceDefinitionId())
-        .name(source.getName())
-        .dockerRepository(source.getDockerRepository())
-        .dockerImageTag(source.getDockerImageTag())
-        .documentationUrl(new URI(source.getDocumentationUrl()))
-        .icon(SourceDefinitionsHandler.loadIcon(source.getIcon()));
+        .sourceDefinitionId(sourceDefinition.getSourceDefinitionId())
+        .name(sourceDefinition.getName())
+        .dockerRepository(sourceDefinition.getDockerRepository())
+        .dockerImageTag(sourceDefinition.getDockerImageTag())
+        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()));
 
     final SourceDefinitionRead expectedSourceDefinitionRead2 = new SourceDefinitionRead()
-        .sourceDefinitionId(source2.getSourceDefinitionId())
-        .name(source2.getName())
-        .dockerRepository(source.getDockerRepository())
-        .dockerImageTag(source.getDockerImageTag())
-        .documentationUrl(new URI(source.getDocumentationUrl()))
-        .icon(SourceDefinitionsHandler.loadIcon(source.getIcon()));
+        .sourceDefinitionId(sourceDefinition2.getSourceDefinitionId())
+        .name(sourceDefinition2.getName())
+        .dockerRepository(sourceDefinition.getDockerRepository())
+        .dockerImageTag(sourceDefinition.getDockerImageTag())
+        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()));
 
-    final SourceDefinitionReadList actualSourceDefinitionReadList = sourceHandler.listSourceDefinitions();
+    final SourceDefinitionReadList actualSourceDefinitionReadList = sourceDefinitionsHandler.listSourceDefinitions();
 
     assertEquals(
         Lists.newArrayList(expectedSourceDefinitionRead1, expectedSourceDefinitionRead2),
@@ -113,21 +118,21 @@ class SourceDefinitionsHandlerTest {
   @Test
   @DisplayName("getSourceDefinition should return the right source")
   void testGetSourceDefinition() throws JsonValidationException, ConfigNotFoundException, IOException, URISyntaxException {
-    when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId()))
-        .thenReturn(source);
+    when(configRepository.getStandardSourceDefinition(sourceDefinition.getSourceDefinitionId()))
+        .thenReturn(sourceDefinition);
 
     final SourceDefinitionRead expectedSourceDefinitionRead = new SourceDefinitionRead()
-        .sourceDefinitionId(source.getSourceDefinitionId())
-        .name(source.getName())
-        .dockerRepository(source.getDockerRepository())
-        .dockerImageTag(source.getDockerImageTag())
-        .documentationUrl(new URI(source.getDocumentationUrl()))
-        .icon(SourceDefinitionsHandler.loadIcon(source.getIcon()));
+        .sourceDefinitionId(sourceDefinition.getSourceDefinitionId())
+        .name(sourceDefinition.getName())
+        .dockerRepository(sourceDefinition.getDockerRepository())
+        .dockerImageTag(sourceDefinition.getDockerImageTag())
+        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()));
 
     final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody =
-        new SourceDefinitionIdRequestBody().sourceDefinitionId(source.getSourceDefinitionId());
+        new SourceDefinitionIdRequestBody().sourceDefinitionId(sourceDefinition.getSourceDefinitionId());
 
-    final SourceDefinitionRead actualSourceDefinitionRead = sourceHandler.getSourceDefinition(sourceDefinitionIdRequestBody);
+    final SourceDefinitionRead actualSourceDefinitionRead = sourceDefinitionsHandler.getSourceDefinition(sourceDefinitionIdRequestBody);
 
     assertEquals(expectedSourceDefinitionRead, actualSourceDefinitionRead);
   }
@@ -135,62 +140,84 @@ class SourceDefinitionsHandlerTest {
   @Test
   @DisplayName("createSourceDefinition should correctly create a sourceDefinition")
   void testCreateSourceDefinition() throws URISyntaxException, IOException, JsonValidationException {
-    final StandardSourceDefinition source = generateSource();
-    final String imageName = DockerUtils.getTaggedImageName(source.getDockerRepository(), source.getDockerImageTag());
+    final StandardSourceDefinition sourceDefinition = generateSourceDefinition();
+    final String imageName = DockerUtils.getTaggedImageName(sourceDefinition.getDockerRepository(), sourceDefinition.getDockerImageTag());
 
-    when(uuidSupplier.get()).thenReturn(source.getSourceDefinitionId());
+    when(uuidSupplier.get()).thenReturn(sourceDefinition.getSourceDefinitionId());
     when(schedulerSynchronousClient.createGetSpecJob(imageName)).thenReturn(new SynchronousResponse<>(
-        source.getSpec(),
+        sourceDefinition.getSpec(),
         SynchronousJobMetadata.mock(ConfigType.GET_SPEC)));
 
     final SourceDefinitionCreate create = new SourceDefinitionCreate()
-        .name(source.getName())
-        .dockerRepository(source.getDockerRepository())
-        .dockerImageTag(source.getDockerImageTag())
-        .documentationUrl(new URI(source.getDocumentationUrl()))
-        .icon(source.getIcon());
+        .name(sourceDefinition.getName())
+        .dockerRepository(sourceDefinition.getDockerRepository())
+        .dockerImageTag(sourceDefinition.getDockerImageTag())
+        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .icon(sourceDefinition.getIcon());
 
     final SourceDefinitionRead expectedRead = new SourceDefinitionRead()
-        .name(source.getName())
-        .dockerRepository(source.getDockerRepository())
-        .dockerImageTag(source.getDockerImageTag())
-        .documentationUrl(new URI(source.getDocumentationUrl()))
-        .sourceDefinitionId(source.getSourceDefinitionId())
-        .icon(SourceDefinitionsHandler.loadIcon(source.getIcon()));
+        .name(sourceDefinition.getName())
+        .dockerRepository(sourceDefinition.getDockerRepository())
+        .dockerImageTag(sourceDefinition.getDockerImageTag())
+        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .sourceDefinitionId(sourceDefinition.getSourceDefinitionId())
+        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()));
 
-    final SourceDefinitionRead actualRead = sourceHandler.createSourceDefinition(create);
+    final SourceDefinitionRead actualRead = sourceDefinitionsHandler.createSourceDefinition(create);
 
     assertEquals(expectedRead, actualRead);
     verify(schedulerSynchronousClient).createGetSpecJob(imageName);
-    verify(configRepository).writeStandardSourceDefinition(source);
+    verify(configRepository).writeStandardSourceDefinition(sourceDefinition);
   }
 
   @Test
   @DisplayName("updateSourceDefinition should correctly update a sourceDefinition")
   void testUpdateSourceDefinition() throws ConfigNotFoundException, IOException, JsonValidationException, URISyntaxException {
-    when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId())).thenReturn(source);
+    when(configRepository.getStandardSourceDefinition(sourceDefinition.getSourceDefinitionId())).thenReturn(sourceDefinition);
     final String newDockerImageTag = "averydifferenttag";
-    final SourceDefinitionRead sourceDefinition = sourceHandler
-        .getSourceDefinition(new SourceDefinitionIdRequestBody().sourceDefinitionId(source.getSourceDefinitionId()));
+    final SourceDefinitionRead sourceDefinition = sourceDefinitionsHandler
+        .getSourceDefinition(new SourceDefinitionIdRequestBody().sourceDefinitionId(this.sourceDefinition.getSourceDefinitionId()));
     final String dockerRepository = sourceDefinition.getDockerRepository();
     final String currentTag = sourceDefinition.getDockerImageTag();
     assertNotEquals(newDockerImageTag, currentTag);
 
-    final String newImageName = DockerUtils.getTaggedImageName(source.getDockerRepository(), newDockerImageTag);
+    final String newImageName = DockerUtils.getTaggedImageName(this.sourceDefinition.getDockerRepository(), newDockerImageTag);
     final ConnectorSpecification newSpec = new ConnectorSpecification().withConnectionSpecification(
         Jsons.jsonNode(ImmutableMap.of("foo2", "bar2")));
     when(schedulerSynchronousClient.createGetSpecJob(newImageName)).thenReturn(new SynchronousResponse<>(
         newSpec,
         SynchronousJobMetadata.mock(ConfigType.GET_SPEC)));
 
-    final StandardSourceDefinition updatedSource = Jsons.clone(source).withDockerImageTag(newDockerImageTag).withSpec(newSpec);
+    final StandardSourceDefinition updatedSource = Jsons.clone(this.sourceDefinition).withDockerImageTag(newDockerImageTag).withSpec(newSpec);
 
-    final SourceDefinitionRead sourceDefinitionRead = sourceHandler
-        .updateSourceDefinition(new SourceDefinitionUpdate().sourceDefinitionId(source.getSourceDefinitionId()).dockerImageTag(newDockerImageTag));
+    final SourceDefinitionRead sourceDefinitionRead = sourceDefinitionsHandler
+        .updateSourceDefinition(
+            new SourceDefinitionUpdate().sourceDefinitionId(this.sourceDefinition.getSourceDefinitionId()).dockerImageTag(newDockerImageTag));
 
     assertEquals(newDockerImageTag, sourceDefinitionRead.getDockerImageTag());
     verify(schedulerSynchronousClient).createGetSpecJob(newImageName);
     verify(configRepository).writeStandardSourceDefinition(updatedSource);
+  }
+
+  @Test
+  @DisplayName("deleteSourceDefinition should correctly delete a sourceDefinition")
+  void testDeleteSourceDefinition() throws ConfigNotFoundException, IOException, JsonValidationException {
+    final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody =
+        new SourceDefinitionIdRequestBody().sourceDefinitionId(sourceDefinition.getSourceDefinitionId());
+    final StandardSourceDefinition updatedSourceDefinition = Jsons.clone(this.sourceDefinition).withTombstone(true);
+    final SourceRead source = new SourceRead();
+
+    when(configRepository.getStandardSourceDefinition(sourceDefinition.getSourceDefinitionId()))
+        .thenReturn(sourceDefinition);
+    when(sourceHandler.listSourcesForSourceDefinition(sourceDefinitionIdRequestBody))
+        .thenReturn(new SourceReadList().sources(Collections.singletonList(source)));
+
+    assertFalse(sourceDefinition.getTombstone());
+
+    sourceDefinitionsHandler.deleteSourceDefinition(sourceDefinitionIdRequestBody);
+
+    verify(sourceHandler).deleteSource(source);
+    verify(configRepository).writeStandardSourceDefinition(updatedSourceDefinition);
   }
 
   @Nested
@@ -200,10 +227,10 @@ class SourceDefinitionsHandlerTest {
     @Test
     @DisplayName("should return the latest list")
     void testCorrect() throws IOException, InterruptedException {
-      final StandardSourceDefinition sourceDefinition = generateSource();
+      final StandardSourceDefinition sourceDefinition = generateSourceDefinition();
       when(githubStore.getLatestSources()).thenReturn(Collections.singletonList(sourceDefinition));
 
-      final var sourceDefinitionReadList = sourceHandler.listLatestSourceDefinitions().getSourceDefinitions();
+      final var sourceDefinitionReadList = sourceDefinitionsHandler.listLatestSourceDefinitions().getSourceDefinitions();
       assertEquals(1, sourceDefinitionReadList.size());
 
       final var sourceDefinitionRead = sourceDefinitionReadList.get(0);
@@ -213,13 +240,13 @@ class SourceDefinitionsHandlerTest {
     @Test
     @DisplayName("returns empty collection if cannot find latest definitions")
     void testHttpTimeout() {
-      assertEquals(0, sourceHandler.listLatestSourceDefinitions().getSourceDefinitions().size());
+      assertEquals(0, sourceDefinitionsHandler.listLatestSourceDefinitions().getSourceDefinitions().size());
     }
 
     @Test
     @DisplayName("Icon should contain data")
     void testIconHoldsData() {
-      final String icon = SourceDefinitionsHandler.loadIcon(source.getIcon());
+      final String icon = SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon());
       assertNotNull(icon);
       assert (icon.length() > 3000);
       assert (icon.length() < 6000);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
@@ -15,6 +15,7 @@ import com.google.common.collect.Lists;
 import io.airbyte.api.model.ConnectionRead;
 import io.airbyte.api.model.ConnectionReadList;
 import io.airbyte.api.model.SourceCreate;
+import io.airbyte.api.model.SourceDefinitionIdRequestBody;
 import io.airbyte.api.model.SourceDefinitionSpecificationRead;
 import io.airbyte.api.model.SourceIdRequestBody;
 import io.airbyte.api.model.SourceRead;
@@ -191,6 +192,26 @@ class SourceHandlerTest {
         .thenReturn(sourceConnection.getConfiguration());
 
     final SourceReadList actualSourceReadList = sourceHandler.listSourcesForWorkspace(workspaceIdRequestBody);
+
+    assertEquals(expectedSourceRead, actualSourceReadList.getSources().get(0));
+    verify(secretsProcessor).maskSecrets(sourceConnection.getConfiguration(), sourceDefinitionSpecificationRead.getConnectionSpecification());
+  }
+
+  @Test
+  void testListSourcesForSourceDefinition() throws JsonValidationException, ConfigNotFoundException, IOException {
+    final SourceRead expectedSourceRead = SourceHelpers.getSourceRead(sourceConnection, standardSourceDefinition);
+    final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody =
+        new SourceDefinitionIdRequestBody().sourceDefinitionId(sourceConnection.getSourceDefinitionId());
+
+    when(configRepository.getSourceConnection(sourceConnection.getSourceId())).thenReturn(sourceConnection);
+    when(configRepository.listSourceConnection()).thenReturn(Lists.newArrayList(sourceConnection));
+    when(configRepository.getStandardSourceDefinition(sourceDefinitionSpecificationRead.getSourceDefinitionId()))
+        .thenReturn(standardSourceDefinition);
+    when(configRepository.getSourceDefinitionFromSource(sourceConnection.getSourceId())).thenReturn(standardSourceDefinition);
+    when(secretsProcessor.maskSecrets(sourceConnection.getConfiguration(), sourceDefinitionSpecificationRead.getConnectionSpecification()))
+        .thenReturn(sourceConnection.getConfiguration());
+
+    final SourceReadList actualSourceReadList = sourceHandler.listSourcesForSourceDefinition(sourceDefinitionIdRequestBody);
 
     assertEquals(expectedSourceRead, actualSourceReadList.getSources().get(0));
     verify(secretsProcessor).maskSecrets(sourceConnection.getConfiguration(), sourceDefinitionSpecificationRead.getConnectionSpecification());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -105,7 +105,7 @@ class WebBackendConnectionsHandlerTest {
     wbHandler = new WebBackendConnectionsHandler(connectionsHandler, sourceHandler, destinationHandler, jobHistoryHandler, schedulerHandler,
         operationsHandler);
 
-    final StandardSourceDefinition standardSourceDefinition = SourceDefinitionHelpers.generateSource();
+    final StandardSourceDefinition standardSourceDefinition = SourceDefinitionHelpers.generateSourceDefinition();
     final SourceConnection source = SourceHelpers.generateSource(UUID.randomUUID());
     sourceRead = SourceHelpers.getSourceRead(source, standardSourceDefinition);
 

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/SourceDefinitionHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/SourceDefinitionHelpers.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 public class SourceDefinitionHelpers {
 
-  public static StandardSourceDefinition generateSource() {
+  public static StandardSourceDefinition generateSourceDefinition() {
     return new StandardSourceDefinition()
         .withSourceDefinitionId(UUID.randomUUID())
         .withName("marketo")

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -258,6 +258,7 @@ font-style: italic;
   <h4><a href="#DestinationDefinition">DestinationDefinition</a></h4>
   <ul>
   <li><a href="#createDestinationDefinition"><code><span class="http-method">post</span> /v1/destination_definitions/create</code></a></li>
+  <li><a href="#deleteDestinationDefinition"><code><span class="http-method">post</span> /v1/destination_definitions/delete</code></a></li>
   <li><a href="#getDestinationDefinition"><code><span class="http-method">post</span> /v1/destination_definitions/get</code></a></li>
   <li><a href="#listDestinationDefinitions"><code><span class="http-method">post</span> /v1/destination_definitions/list</code></a></li>
   <li><a href="#listLatestDestinationDefinitions"><code><span class="http-method">post</span> /v1/destination_definitions/list_latest</code></a></li>
@@ -328,6 +329,7 @@ font-style: italic;
   <h4><a href="#SourceDefinition">SourceDefinition</a></h4>
   <ul>
   <li><a href="#createSourceDefinition"><code><span class="http-method">post</span> /v1/source_definitions/create</code></a></li>
+  <li><a href="#deleteSourceDefinition"><code><span class="http-method">post</span> /v1/source_definitions/delete</code></a></li>
   <li><a href="#getSourceDefinition"><code><span class="http-method">post</span> /v1/source_definitions/get</code></a></li>
   <li><a href="#listLatestSourceDefinitions"><code><span class="http-method">post</span> /v1/source_definitions/list_latest</code></a></li>
   <li><a href="#listSourceDefinitions"><code><span class="http-method">post</span> /v1/source_definitions/list</code></a></li>
@@ -2405,6 +2407,54 @@ font-style: italic;
     <h4 class="field-label">200</h4>
     Successful operation
         <a href="#DestinationDefinitionRead">DestinationDefinitionRead</a>
+    <h4 class="field-label">422</h4>
+    Input failed validation
+        <a href="#InvalidInputExceptionInfo">InvalidInputExceptionInfo</a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="deleteDestinationDefinition"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/destination_definitions/delete</code></pre></div>
+    <div class="method-summary">Delete a destination definition (<span class="nickname">deleteDestinationDefinition</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">DestinationDefinitionIdRequestBody <a href="#DestinationDefinitionIdRequestBody">DestinationDefinitionIdRequestBody</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">204</h4>
+    The resource was deleted successfully.
+        <a href="#"></a>
+    <h4 class="field-label">404</h4>
+    Object with given id was not found.
+        <a href="#NotFoundKnownExceptionInfo">NotFoundKnownExceptionInfo</a>
     <h4 class="field-label">422</h4>
     Input failed validation
         <a href="#InvalidInputExceptionInfo">InvalidInputExceptionInfo</a>
@@ -4840,6 +4890,54 @@ font-style: italic;
     <h4 class="field-label">200</h4>
     Successful operation
         <a href="#SourceDefinitionRead">SourceDefinitionRead</a>
+    <h4 class="field-label">422</h4>
+    Input failed validation
+        <a href="#InvalidInputExceptionInfo">InvalidInputExceptionInfo</a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="deleteSourceDefinition"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/source_definitions/delete</code></pre></div>
+    <div class="method-summary">Delete a source definition (<span class="nickname">deleteSourceDefinition</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">SourceDefinitionIdRequestBody <a href="#SourceDefinitionIdRequestBody">SourceDefinitionIdRequestBody</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">204</h4>
+    The resource was deleted successfully.
+        <a href="#"></a>
+    <h4 class="field-label">404</h4>
+    Object with given id was not found.
+        <a href="#NotFoundKnownExceptionInfo">NotFoundKnownExceptionInfo</a>
     <h4 class="field-label">422</h4>
     Input failed validation
         <a href="#InvalidInputExceptionInfo">InvalidInputExceptionInfo</a>


### PR DESCRIPTION
## What
As part of https://github.com/airbytehq/airbyte/issues/8732, adds a `/v1/source_definitions/delete` endpoint and a `/v1/destination_definitions/delete` endpoint.

## How
*DRAFT notes*: For now, I've only added the `SourceDefinition` changes. Wanted to get these changes up for early review before taking the same approach for `DestinationDefinitions`.

- Added endpoint to `openapi/config.yaml`
- Implemented method override in `ConfigurationApi.java`
- Added handler that finds all associated `SourceConnections` and deletes them before deleting the specified `SourceDefinition`.
  - This required injecting the `sourceHandler` as a new dependency of the `sourceDefinitionHandler`.
  - Also added a repository method to fetch all sources by a `sourceDefinitionId`

### Misc
There were a bunch of instances of `SourceDefinitions` with `source` variable names, which caused issues once I started needing to refer to `SourceConnections` alongside `SourceDefinitions`. A lot of the diff is me updating those variable names 