### PR TITLE
increase reliability of frontend and kubernetes tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -345,7 +345,13 @@ jobs:
           node-version: "16.13.0"
 
       - name: Install Cypress Test Dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+        run: |
+          // wait to receive lock (see https://askubuntu.com/questions/132059/how-to-make-a-package-manager-wait-if-another-instance-of-apt-is-running)
+          while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do
+             sleep 1
+          done
+
+          sudo apt-get update && sudo apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
       - name: Set up CI Gradle Properties
         run: |
@@ -448,6 +454,11 @@ jobs:
 
       - name: Install socat (required for port forwarding)
         run: |
+          // wait to receive lock (see https://askubuntu.com/questions/132059/how-to-make-a-package-manager-wait-if-another-instance-of-apt-is-running)
+          while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do
+             sleep 1
+          done
+
           sudo apt-get update
           sudo apt-get install socat
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -346,7 +346,7 @@ jobs:
 
       - name: Install Cypress Test Dependencies
         run: |
-          // wait to receive lock (see https://askubuntu.com/questions/132059/how-to-make-a-package-manager-wait-if-another-instance-of-apt-is-running)
+          # wait to receive lock (see https://askubuntu.com/questions/132059/how-to-make-a-package-manager-wait-if-another-instance-of-apt-is-running)
           while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do
              sleep 1
           done
@@ -454,7 +454,7 @@ jobs:
 
       - name: Install socat (required for port forwarding)
         run: |
-          // wait to receive lock (see https://askubuntu.com/questions/132059/how-to-make-a-package-manager-wait-if-another-instance-of-apt-is-running)
+          # wait to receive lock (see https://askubuntu.com/questions/132059/how-to-make-a-package-manager-wait-if-another-instance-of-apt-is-running)
           while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do
              sleep 1
           done


### PR DESCRIPTION
Not very DRY but should allow us to fail much less frequently while waiting for a dpkg lock (also doesn't require us to actually install these tools on the shared image, although that's something we may want to do in the future).