### PR TITLE
Airbyte CDK: Log http status code and content in backoff handlers

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.44
+Log http response status code and its content.
+
 ## 0.1.43
 Fix logging of unhandled exceptions: print stacktrace. 
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
@@ -50,6 +50,8 @@ def user_defined_backoff_handler(max_tries: int, **kwargs):
     def sleep_on_ratelimit(details):
         _, exc, _ = sys.exc_info()
         if isinstance(exc, UserDefinedBackoffException):
+            if exc.response is not None:
+                logger.info(f"Status code: {exc.response.status_code}, Response Content: {exc.response.content}")
             retry_after = exc.backoff
             logger.info(f"Retrying. Sleeping for {retry_after} seconds")
             time.sleep(retry_after + 1)  # extra second to cover any fractions of second

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
@@ -21,7 +21,7 @@ logger = AirbyteLogger()
 def default_backoff_handler(max_tries: int, factor: int, **kwargs):
     def log_retry_attempt(details):
         _, exc, _ = sys.exc_info()
-        if exc.response is not None:
+        if exc.response:
             logger.info(f"Status code: {exc.response.status_code}, Response Content: {exc.response.content}")
         logger.info(
             f"Caught retryable error '{str(exc)}' after {details['tries']} tries. Waiting {details['wait']} seconds then retrying..."
@@ -50,7 +50,7 @@ def user_defined_backoff_handler(max_tries: int, **kwargs):
     def sleep_on_ratelimit(details):
         _, exc, _ = sys.exc_info()
         if isinstance(exc, UserDefinedBackoffException):
-            if exc.response is not None:
+            if exc.response:
                 logger.info(f"Status code: {exc.response.status_code}, Response Content: {exc.response.content}")
             retry_after = exc.backoff
             logger.info(f"Retrying. Sleeping for {retry_after} seconds")

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
@@ -21,6 +21,8 @@ logger = AirbyteLogger()
 def default_backoff_handler(max_tries: int, factor: int, **kwargs):
     def log_retry_attempt(details):
         _, exc, _ = sys.exc_info()
+        if exc.response is not None:
+            logger.info(f"Status code: {exc.response.status_code}, Response Content: {exc.response.content}")
         logger.info(
             f"Caught retryable error '{str(exc)}' after {details['tries']} tries. Waiting {details['wait']} seconds then retrying..."
         )

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.43",
+    version="0.1.44",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py#L227
When backoff is happened we don't know the response status code and its content (usefull message about why request was rejected from host). We only know it is 429 or 500 <= status code 600

## How
Log http response status code and content in `log_retry_attempt` inside `default_backoff_handler` and
in `sleep_on_ratelimit` inside `user_defined_backoff_handler`
## Recommended reading order
`airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py`

