### PR TITLE
🎉 SAT: add assert that spec.json file does not have any `$ref` in it

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.35
+Add assert that spec.json file does not have any `$ref` in it: [#8842](https://github.com/airbytehq/airbyte/pull/8842)
+
 ## 0.1.32
 Add info about skipped failed tests in /test command message on GitHub: [#8691](https://github.com/airbytehq/airbyte/pull/8691)
 

--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.35
+## 0.1.36
 Add assert that spec.json file does not have any `$ref` in it: [#8842](https://github.com/airbytehq/airbyte/pull/8842)
 
 ## 0.1.32

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.35
+LABEL io.airbyte.version=0.1.36
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.34
+LABEL io.airbyte.version=0.1.35
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -2,10 +2,10 @@
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
 
+import json
 import logging
 import re
 from collections import Counter, defaultdict
-import json
 from functools import reduce
 from logging import Logger
 from typing import Any, Dict, List, Mapping, MutableMapping, Set
@@ -81,7 +81,7 @@ class TestSpec(BaseTest):
         if check_result is not None:
             refs_errors = check_result
 
-        assert not refs_errors, f"Found unresolved `$refs` value in spec.json file"
+        assert not refs_errors, "Found unresolved `$refs` value in spec.json file"
 
     def test_oauth_flow_parameters(self, actual_connector_spec: ConnectorSpecification):
         """

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -5,6 +5,7 @@
 import logging
 import re
 from collections import Counter, defaultdict
+import json
 from functools import reduce
 from logging import Logger
 from typing import Any, Dict, List, Mapping, MutableMapping, Set
@@ -41,6 +42,10 @@ class TestSpec(BaseTest):
             request.spec_cache = spec
         return request.spec_cache
 
+    @pytest.fixture(name="connector_spec_dict")
+    def connector_spec_dict_fixture(request: BaseTest, actual_connector_spec):
+        return json.loads(actual_connector_spec.json())
+
     def test_match_expected(
         self, connector_spec: ConnectorSpecification, actual_connector_spec: ConnectorSpecification, connector_config: SecretDict
     ):
@@ -68,6 +73,15 @@ class TestSpec(BaseTest):
 
     def test_secret_never_in_the_output(self):
         """This test should be injected into any docker command it needs to know current config and spec"""
+
+    def test_defined_refs_exist_in_json_spec_file(self, connector_spec_dict: dict):
+        """Checking for the presence of unresolved `$ref`s values within each json spec file"""
+        refs_errors = None
+        check_result = find_key_inside_schema(schema_item=connector_spec_dict)
+        if check_result is not None:
+            refs_errors = check_result
+
+        assert not refs_errors, f"Found unresolved `$refs` value in spec.json file"
 
     def test_oauth_flow_parameters(self, actual_connector_spec: ConnectorSpecification):
         """

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -76,12 +76,9 @@ class TestSpec(BaseTest):
 
     def test_defined_refs_exist_in_json_spec_file(self, connector_spec_dict: dict):
         """Checking for the presence of unresolved `$ref`s values within each json spec file"""
-        refs_errors = None
         check_result = find_key_inside_schema(schema_item=connector_spec_dict)
-        if check_result is not None:
-            refs_errors = check_result
 
-        assert not refs_errors, "Found unresolved `$refs` value in spec.json file"
+        assert not check_result, "Found unresolved `$refs` value in spec.json file"
 
     def test_oauth_flow_parameters(self, actual_connector_spec: ConnectorSpecification):
         """

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_core.py
@@ -100,6 +100,31 @@ from source_acceptance_test.tests.test_core import TestSpec as _TestSpec
             },
             False,
         ),
+        (
+            {
+                "connectionSpecification": {
+                    "type": "object",
+                    "properties": {
+                        "client_id": {"type": "string"},
+                        "client_secret": {"type": "string"},
+                        "access_token": {"type": "string"},
+                        "refresh_token": {"type": "string"},
+                    },
+                },
+                "advanced_auth": {
+                    "auth_flow_type": "oauth2.0",
+                    "predicate_key": ["credentials", "auth_type"],
+                    "predicate_value": "Client",
+                    "oauth_config_specification": {
+                        "complete_oauth_server_output_specification": {
+                            "type": "object",
+                            "properties": {"refresh_token": {"type": "string"}},
+                        }
+                    },
+                },
+            },
+            False,
+        ),
         ({"$ref": None}, True),
         ({"properties": {"user": {"$ref": None}}}, True),
         ({"properties": {"user": {"$ref": "user.json"}}}, True),

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_core.py
@@ -21,6 +21,109 @@ from source_acceptance_test.tests.test_core import TestSpec as _TestSpec
 
 
 @pytest.mark.parametrize(
+    "connector_spec, should_fail",
+    [
+        (
+            {
+                "connectionSpecification": {
+                    "type": "object",
+                    "properties": {
+                        "client_id": {"type": "string"},
+                        "client_secret": {"type": "string"},
+                        "access_token": {"type": "string"},
+                        "refresh_token": {"type": "string"},
+                        "$ref": None
+                    },
+                }
+            }, True
+        ),
+        (
+            {
+                "advanced_auth": {
+                    "auth_flow_type": "oauth2.0",
+                    "predicate_key": ["credentials", "auth_type"],
+                    "predicate_value": "Client",
+                    "oauth_config_specification": {
+                        "complete_oauth_output_specification": {
+                            "type": "object",
+                            "properties": {
+                                "refresh_token": {"type": "string"},
+                                "$ref": None
+                            }
+                        }
+                    }
+                }
+            }
+            , True
+        ),
+        (
+            {
+                "advanced_auth": {
+                    "auth_flow_type": "oauth2.0",
+                    "predicate_key": ["credentials", "auth_type"],
+                    "predicate_value": "Client",
+                    "oauth_config_specification": {
+                        "complete_oauth_server_input_specification": {
+                            "type": "object",
+                            "properties": {
+                                "refresh_token": {"type": "string"},
+                                "$ref": None
+                            }
+                        }
+                    }
+                }
+            }
+            , True
+        ),
+        (
+            {
+                "advanced_auth": {
+                    "auth_flow_type": "oauth2.0",
+                    "predicate_key": ["credentials", "auth_type"],
+                    "predicate_value": "Client",
+                    "oauth_config_specification": {
+                        "complete_oauth_server_output_specification": {
+                            "type": "object",
+                            "properties": {
+                                "refresh_token": {"type": "string"},
+                                "$ref": None
+                            }
+                        }
+                    }
+                }
+            }
+            , True
+        ),
+        (
+            {
+                "connectionSpecification": {
+                    "type": "object",
+                    "properties": {
+                        "client_id": {"type": "string"},
+                        "client_secret": {"type": "string"},
+                        "access_token": {"type": "string"},
+                        "refresh_token": {"type": "string"},
+                    },
+                }
+            }, False
+        ),
+        ({"$ref": None}, True),
+        ({"properties": {"user": {"$ref": None}}}, True),
+        ({"properties": {"user": {"$ref": "user.json"}}}, True),
+        ({"properties": {"user": {"type": "object", "properties": {"username": {"type": "string"}}}}}, False),
+        ({"properties": {"fake_items": {"type": "array", "items": {"$ref": "fake_item.json"}}}}, True),
+    ],
+)
+def test_ref_in_spec_schemas(connector_spec, should_fail):
+    t = _TestSpec()
+    if should_fail is True:
+        with pytest.raises(AssertionError):
+            t.test_defined_refs_exist_in_json_spec_file(connector_spec_dict=connector_spec)
+    else:
+        t.test_defined_refs_exist_in_json_spec_file(connector_spec_dict=connector_spec)
+
+
+@pytest.mark.parametrize(
     "schema, cursors, should_fail",
     [
         ({}, ["created"], True),

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_core.py
@@ -32,10 +32,11 @@ from source_acceptance_test.tests.test_core import TestSpec as _TestSpec
                         "client_secret": {"type": "string"},
                         "access_token": {"type": "string"},
                         "refresh_token": {"type": "string"},
-                        "$ref": None
+                        "$ref": None,
                     },
                 }
-            }, True
+            },
+            True,
         ),
         (
             {
@@ -46,15 +47,12 @@ from source_acceptance_test.tests.test_core import TestSpec as _TestSpec
                     "oauth_config_specification": {
                         "complete_oauth_output_specification": {
                             "type": "object",
-                            "properties": {
-                                "refresh_token": {"type": "string"},
-                                "$ref": None
-                            }
+                            "properties": {"refresh_token": {"type": "string"}, "$ref": None},
                         }
-                    }
+                    },
                 }
-            }
-            , True
+            },
+            True,
         ),
         (
             {
@@ -65,15 +63,12 @@ from source_acceptance_test.tests.test_core import TestSpec as _TestSpec
                     "oauth_config_specification": {
                         "complete_oauth_server_input_specification": {
                             "type": "object",
-                            "properties": {
-                                "refresh_token": {"type": "string"},
-                                "$ref": None
-                            }
+                            "properties": {"refresh_token": {"type": "string"}, "$ref": None},
                         }
-                    }
+                    },
                 }
-            }
-            , True
+            },
+            True,
         ),
         (
             {
@@ -84,15 +79,12 @@ from source_acceptance_test.tests.test_core import TestSpec as _TestSpec
                     "oauth_config_specification": {
                         "complete_oauth_server_output_specification": {
                             "type": "object",
-                            "properties": {
-                                "refresh_token": {"type": "string"},
-                                "$ref": None
-                            }
+                            "properties": {"refresh_token": {"type": "string"}, "$ref": None},
                         }
-                    }
+                    },
                 }
-            }
-            , True
+            },
+            True,
         ),
         (
             {
@@ -105,7 +97,8 @@ from source_acceptance_test.tests.test_core import TestSpec as _TestSpec
                         "refresh_token": {"type": "string"},
                     },
                 }
-            }, False
+            },
+            False,
         ),
         ({"$ref": None}, True),
         ({"properties": {"user": {"$ref": None}}}, True),


### PR DESCRIPTION
## What
Closes #8288.

## How
Add a new test to `TestSpec` testcase which checks that there are no `$ref` fields in `spec.json` file.

