### PR TITLE
Use kubectl cp to copy files instead of kube java clients

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -3722,7 +3722,7 @@
     supported_destination_sync_modes:
     - "overwrite"
     - "append"
-- dockerImage: "airbyte/destination-snowflake:0.3.21"
+- dockerImage: "airbyte/destination-snowflake:0.3.22"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/snowflake"
     connectionSpecification:
@@ -3770,7 +3770,9 @@
           order: 3
         schema:
           description: "The default Snowflake schema tables are written to if the\
-            \ source does not specify a namespace."
+            \ source does not specify a namespace. Schema name would be transformed\
+            \ to allowed by Snowflake if it not follow Snowflake Naming Conventions\
+            \ https://docs.airbyte.io/integrations/destinations/snowflake#notes-about-snowflake-naming-conventions "
           examples:
           - "AIRBYTE_SCHEMA"
           type: "string"

--- a/airbyte-container-orchestrator/build.gradle
+++ b/airbyte-container-orchestrator/build.gradle
@@ -4,9 +4,6 @@ plugins {
 
 dependencies {
     implementation 'io.fabric8:kubernetes-client:5.3.1'
-    implementation 'io.kubernetes:client-java-api:10.0.0'
-    implementation 'io.kubernetes:client-java:10.0.0'
-    implementation 'io.kubernetes:client-java-extended:10.0.0'
     implementation 'io.temporal:temporal-sdk:1.0.4'
     implementation 'org.apache.commons:commons-lang3:3.11'
     implementation 'org.apache.commons:commons-text:1.9'

--- a/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/ContainerOrchestratorApp.java
+++ b/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/ContainerOrchestratorApp.java
@@ -34,8 +34,6 @@ import io.airbyte.workers.protocols.airbyte.NamespacingMapper;
 import io.airbyte.workers.temporal.sync.ReplicationLauncherWorker;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.kubernetes.client.openapi.ApiClient;
-import io.kubernetes.client.util.Config;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.file.Files;
@@ -126,7 +124,7 @@ public class ContainerOrchestratorApp {
     LOGGER.info("Replication runner complete!");
   }
 
-  public static void main(String[] args) throws Exception {
+  public static void main(final String[] args) throws Exception {
     WorkerHeartbeatServer heartbeatServer = null;
 
     try {
@@ -163,7 +161,6 @@ public class ContainerOrchestratorApp {
    */
   private static ProcessFactory getProcessBuilderFactory(final Configs configs, final WorkerConfigs workerConfigs) throws IOException {
     if (configs.getWorkerEnvironment() == Configs.WorkerEnvironment.KUBERNETES) {
-      final ApiClient officialClient = Config.defaultClient();
       final KubernetesClient fabricClient = new DefaultKubernetesClient();
       final String localIp = InetAddress.getLocalHost().getHostAddress();
       final String kubeHeartbeatUrl = localIp + ":" + WorkerApp.KUBE_HEARTBEAT_PORT;
@@ -173,7 +170,7 @@ public class ContainerOrchestratorApp {
       // exposed)
       KubePortManagerSingleton.init(ReplicationLauncherWorker.PORTS);
 
-      return new KubeProcessFactory(workerConfigs, configs.getJobPodKubeNamespace(), officialClient, fabricClient, kubeHeartbeatUrl, false);
+      return new KubeProcessFactory(workerConfigs, configs.getJobPodKubeNamespace(), fabricClient, kubeHeartbeatUrl, false);
     } else {
       return new DockerProcessFactory(
           workerConfigs,

--- a/airbyte-scheduler/app/build.gradle
+++ b/airbyte-scheduler/app/build.gradle
@@ -4,9 +4,6 @@ plugins {
 
 dependencies {
     implementation 'io.fabric8:kubernetes-client:5.9.0'
-    implementation 'io.kubernetes:client-java-api:10.0.0'
-    implementation 'io.kubernetes:client-java:10.0.0'
-    implementation 'io.kubernetes:client-java-extended:10.0.0'
     implementation 'io.temporal:temporal-sdk:1.6.0'
 
     implementation project(':airbyte-analytics')

--- a/airbyte-workers/Dockerfile
+++ b/airbyte-workers/Dockerfile
@@ -18,6 +18,12 @@ RUN add-apt-repository \
        stable"
 RUN apt-get update && apt-get install -y docker-ce-cli jq
 
+# Install kubectl for copying files to kube pods. Eventually should be replaced with a kube java client.
+# See https://github.com/airbytehq/airbyte/issues/8643 for more information on why we are using kubectl for copying.
+RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
+RUN apt-get update && apt-get install -y kubectl
+
 ENV APPLICATION airbyte-workers
 
 WORKDIR /app

--- a/airbyte-workers/Dockerfile
+++ b/airbyte-workers/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y docker-ce-cli jq
 
 # Install kubectl for copying files to kube pods. Eventually should be replaced with a kube java client.
 # See https://github.com/airbytehq/airbyte/issues/8643 for more information on why we are using kubectl for copying.
+# The following commands were taken from https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
 RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 RUN apt-get update && apt-get install -y kubectl

--- a/airbyte-workers/build.gradle
+++ b/airbyte-workers/build.gradle
@@ -12,9 +12,6 @@ configurations {
 
 dependencies {
     implementation 'io.fabric8:kubernetes-client:5.3.1'
-    implementation 'io.kubernetes:client-java-api:10.0.0'
-    implementation 'io.kubernetes:client-java:10.0.0'
-    implementation 'io.kubernetes:client-java-extended:10.0.0'
     implementation 'io.temporal:temporal-sdk:1.6.0'
     implementation 'org.apache.ant:ant:1.10.10'
     implementation 'org.apache.commons:commons-lang3:3.11'

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultNormalizationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultNormalizationWorker.java
@@ -11,7 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.commons.lang.time.DurationFormatUtils;
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -37,8 +37,6 @@ import io.airbyte.workers.temporal.sync.ReplicationActivityImpl;
 import io.airbyte.workers.temporal.sync.SyncWorkflowImpl;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.kubernetes.client.openapi.ApiClient;
-import io.kubernetes.client.util.Config;
 import io.temporal.client.WorkflowClient;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.Worker;
@@ -223,12 +221,11 @@ public class WorkerApp {
     final WorkerConfigs workerConfigs = new WorkerConfigs(configs);
 
     if (configs.getWorkerEnvironment() == Configs.WorkerEnvironment.KUBERNETES) {
-      final ApiClient officialClient = Config.defaultClient();
       final KubernetesClient fabricClient = new DefaultKubernetesClient();
       final String localIp = InetAddress.getLocalHost().getHostAddress();
       final String kubeHeartbeatUrl = localIp + ":" + KUBE_HEARTBEAT_PORT;
       LOGGER.info("Using Kubernetes namespace: {}", configs.getJobPodKubeNamespace());
-      return new KubeProcessFactory(workerConfigs, configs.getJobPodKubeNamespace(), officialClient, fabricClient, kubeHeartbeatUrl, false);
+      return new KubeProcessFactory(workerConfigs, configs.getJobPodKubeNamespace(), fabricClient, kubeHeartbeatUrl, false);
     } else {
       return new DockerProcessFactory(
           workerConfigs,
@@ -244,12 +241,11 @@ public class WorkerApp {
     final WorkerConfigs workerConfigs = new WorkerConfigs(configs);
 
     if (configs.getWorkerEnvironment() == Configs.WorkerEnvironment.KUBERNETES) {
-      final ApiClient officialClient = Config.defaultClient();
       final KubernetesClient fabricClient = new DefaultKubernetesClient();
       final String localIp = InetAddress.getLocalHost().getHostAddress();
       final String kubeHeartbeatUrl = localIp + ":" + KUBE_HEARTBEAT_PORT;
       LOGGER.info("Using Kubernetes namespace: {}", configs.getJobPodKubeNamespace());
-      return new KubeProcessFactory(workerConfigs, configs.getJobPodKubeNamespace(), officialClient, fabricClient, kubeHeartbeatUrl, true);
+      return new KubeProcessFactory(workerConfigs, configs.getJobPodKubeNamespace(), fabricClient, kubeHeartbeatUrl, true);
     } else {
       return new DockerProcessFactory(
           workerConfigs,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -154,7 +154,7 @@ public class KubePodProcess extends Process {
       initEntrypointStr = String.format("mkfifo %s && ", STDIN_PIPE_FILE) + initEntrypointStr;
     }
 
-    initEntrypointStr = initEntrypointStr + String.format(" && until [ -f %s ]; do sleep 0.00001; done;", SUCCESS_FILE_NAME);
+    initEntrypointStr = initEntrypointStr + String.format(" && until [ -f %s ]; do sleep 0.1; done;", SUCCESS_FILE_NAME);
 
     return new ContainerBuilder()
         .withName(INIT_CONTAINER_NAME)

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -229,7 +229,7 @@ public class KubePodProcess extends Process {
 
         // using kubectl cp directly here, because both fabric and the official kube client APIs both have
         // several issues with copying files. See https://github.com/airbytehq/airbyte/issues/8643 for
-        // detauls.
+        // details.
         final String command = String.format("kubectl cp %s %s/%s:%s -c %s", tmpFile, namespace, podName, containerPath, INIT_CONTAINER_NAME);
         LOGGER.info(command);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -236,10 +236,12 @@ public class KubePodProcess extends Process {
 
         proc = Runtime.getRuntime().exec(command);
         LOGGER.info("Waiting for kubectl cp to complete");
+
         final int exitCode = proc.waitFor();
         if (exitCode != 0) {
           throw new IOException("kubectl cp failed with exit code " + exitCode);
         }
+
         LOGGER.info("kubectl cp complete, closing process");
       } catch (final IOException | InterruptedException e) {
         throw new RuntimeException(e);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
@@ -10,7 +10,6 @@ import io.airbyte.config.ResourceRequirements;
 import io.airbyte.workers.WorkerConfigs;
 import io.airbyte.workers.WorkerException;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.kubernetes.client.openapi.ApiClient;
 import java.net.InetAddress;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -48,7 +47,6 @@ public class KubeProcessFactory implements ProcessFactory {
 
   private final WorkerConfigs workerConfigs;
   private final String namespace;
-  private final ApiClient officialClient;
   private final KubernetesClient fabricClient;
   private final String kubeHeartbeatUrl;
   private final String processRunnerHost;
@@ -60,17 +58,15 @@ public class KubeProcessFactory implements ProcessFactory {
    */
   public KubeProcessFactory(final WorkerConfigs workerConfigs,
                             final String namespace,
-                            final ApiClient officialClient,
                             final KubernetesClient fabricClient,
                             final String kubeHeartbeatUrl,
                             final boolean isOrchestrator) {
-    this(workerConfigs, namespace, officialClient, fabricClient, kubeHeartbeatUrl,
+    this(workerConfigs, namespace, fabricClient, kubeHeartbeatUrl,
         Exceptions.toRuntime(() -> InetAddress.getLocalHost().getHostAddress()), isOrchestrator, KubePodProcess.DEFAULT_STATUS_CHECK_INTERVAL);
   }
 
   /**
    * @param namespace kubernetes namespace where spawned pods will live
-   * @param officialClient official kubernetes client
    * @param fabricClient fabric8 kubernetes client
    * @param kubeHeartbeatUrl a url where if the response is not 200 the spawned process will fail
    *        itself
@@ -83,7 +79,6 @@ public class KubeProcessFactory implements ProcessFactory {
   @VisibleForTesting
   public KubeProcessFactory(final WorkerConfigs workerConfigs,
                             final String namespace,
-                            final ApiClient officialClient,
                             final KubernetesClient fabricClient,
                             final String kubeHeartbeatUrl,
                             final String processRunnerHost,
@@ -91,7 +86,6 @@ public class KubeProcessFactory implements ProcessFactory {
                             final Duration statusCheckInterval) {
     this.workerConfigs = workerConfigs;
     this.namespace = namespace;
-    this.officialClient = officialClient;
     this.fabricClient = fabricClient;
     this.kubeHeartbeatUrl = kubeHeartbeatUrl;
     this.processRunnerHost = processRunnerHost;
@@ -133,7 +127,6 @@ public class KubeProcessFactory implements ProcessFactory {
       return new KubePodProcess(
           isOrchestrator,
           processRunnerHost,
-          officialClient,
           fabricClient,
           statusCheckInterval,
           podName,


### PR DESCRIPTION
Resolves https://github.com/airbytehq/airbyte/issues/8643
See issue for full details.

To summarize, the existing kube java clients (official and fabric) both have several issues with copying files to kube pods. The `kubectl cp` command has no such issues, so we have opted to use that for now instead of trying to get the java clients to work.

This PR adds an integration test, and I also tested out deploying this on my local kube cluster, and was able to successfully run a sync.