### PR TITLE
Use airbyte/temporal-auto-setup image with multi-architecture support (for M1 compatibility)

### DIFF
--- a/airbyte-temporal/Dockerfile
+++ b/airbyte-temporal/Dockerfile
@@ -1,5 +1,5 @@
-# A test describe in the README is available to test a version update 
-FROM temporalio/auto-setup:1.13.0
+# A test describe in the README is available to test a version update
+FROM airbyte/temporal-auto-setup:1.13.0
 
 ENV TEMPORAL_HOME /etc/temporal
 

--- a/airbyte-temporal/README.md
+++ b/airbyte-temporal/README.md
@@ -12,3 +12,29 @@ the script does:
 - run docker compose up.
 
 At the end of the script you should be able to access a local airbyte in `localhost:8000`.
+
+## Apple Silicon (M1) Support
+
+Airbyte publishes an image called [airbyte/temporal-auto-setup](https://hub.docker.com/r/airbyte/temporal-auto-setup/tags) which is built for both
+Intel-based and ARM-based systems.
+
+This is because at the time of this writing, Temporal only offers their [temporalio/auto-setup](https://hub.docker.com/r/temporalio/auto-setup) image
+for Intel-based (amd64) systems.
+
+Airbyte re-publishes this image
+as [airbyte/temporal-auto-setup:1.13.0-amd64](https://hub.docker.com/layers/airbyte/temporal-auto-setup/1.13.0-amd64/images/sha256-46da05b202e2fa66d9c3f5af5a31b954979d8132c4f67300e884bdad8a45b94d?context=explore)
+, and also runs the `build-temporal.sh` script in this repository on an ARM-based system to build and
+publish [airbyte/temporal-auto-setup:1.13.0-arm64](https://hub.docker.com/layers/airbyte/temporal-auto-setup/1.13.0-arm64/images/sha256-05027f6a9ba658205c5e961165bb8dad55c95ae0a009eddbf491d12f3d84fe20?context=explore)
+.
+
+Finally, Airbyte creates and publishes a manifest list with both images
+as [airbyte/temporal-auto-setup:1.13.0](https://hub.docker.com/layers/airbyte/temporal-auto-setup/1.13.0/images/sha256-46da05b202e2fa66d9c3f5af5a31b954979d8132c4f67300e884bdad8a45b94d?context=explore)
+like so:
+
+```bash
+docker manifest create airbyte/temporal-auto-setup:1.13.0 \
+--amend airbyte/temporal-auto-setup:1.13.0-amd64 \
+--amend airbyte/temporal-auto-setup:1.13.0-arm64
+```
+
+This process will need to be replicated for any future version upgrades beyond `1.13.0`. See the [original issue](https://github.com/airbytehq/airbyte/issues/8849) for more info.

--- a/airbyte-temporal/scripts/build-temporal.sh
+++ b/airbyte-temporal/scripts/build-temporal.sh
@@ -6,5 +6,5 @@ TEMPORAL_VERSION=1.13.0
 
 curl -OL https://github.com/temporalio/temporal/archive/refs/tags/v"$TEMPORAL_VERSION".tar.gz
 tar -xvf v"$TEMPORAL_VERSION".tar.gz
-cd temporal-"$TEMPORAL_VERSION" && docker build . -t temporalio/auto-setup:"$TEMPORAL_VERSION" --build-arg TARGET=auto-setup
+cd temporal-"$TEMPORAL_VERSION" && docker build . -t airbyte/temporal-auto-setup:"$TEMPORAL_VERSION" --build-arg TARGET=auto-setup
 rm -rf ../temporal-"$TEMPORAL_VERSION" ../v"$TEMPORAL_VERSION".tar.gz

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -37,12 +37,6 @@ SUB_BUILD=PLATFORM ./gradlew build
 If you're using Mac M1 \(Apple Silicon\) machines, it is possible to compile Airbyte by setting
 some additional environment variables:
 
-Build temporal (This is required until official images are available Refer: https://github.com/temporalio/temporal/issues/1305)
-```bash
-cd airbyte-temporal/scripts
-./build-temporal.sh
-```
-
 ```bash
 export DOCKER_BUILD_PLATFORM=linux/arm64
 export DOCKER_BUILD_ARCH=arm64


### PR DESCRIPTION
## What
As part of https://github.com/airbytehq/airbyte/issues/8849, we now publish an image called `airbyte/temporal-auto-setup` which supports both Intel (amd64) and Apple Silicon/M1 (arm64) systems. This PR updates the `airbyte-temporal` Dockerfile to extend `airbyte/temporal-auto-setup` instead of `temporalio/auto-setup` so that M1 users don't need to build a local temporal image themselves.

## How
Update Dockerfile and READMEs to reference new image
