### PR TITLE
Add readmes to all gradle modules

### DIFF
--- a/airbyte-analytics/readme.md
+++ b/airbyte-analytics/readme.md
@@ -1,0 +1,3 @@
+# airbyte-analytics
+
+Java library with shared code for telemetry tracking including Segment.

--- a/airbyte-api/readme.md
+++ b/airbyte-api/readme.md
@@ -4,3 +4,8 @@ Defines the OpenApi configuration for the Airbyte Configuration API. It also is 
 * Java API client
 * Java API server - this generated code is used in `airbyte-server` to allow us to implement the Configuration API in a type safe way. See `ConfigurationApi.java` in `airbyte-server`
 * API docs
+
+## Key Files
+* src/openapi/config.yaml - Defines the config API interface using OpenApi3
+* AirbyteApiClient.java - wraps all api clients so that they can be dependency injected together
+* PatchedLogsApi.java - fixes generated code for log api.

--- a/airbyte-api/readme.md
+++ b/airbyte-api/readme.md
@@ -1,0 +1,6 @@
+# airbyte-api
+
+Defines the OpenApi configuration for the Airbyte Configuration API. It also is responsible for generating the following from the API spec:
+* Java API client
+* Java API server - this generated code is used in `airbyte-server` to allow us to implement the Configuration API in a type safe way. See `ConfigurationApi.java` in `airbyte-server`
+* API docs

--- a/airbyte-bootloader/readme.md
+++ b/airbyte-bootloader/readme.md
@@ -1,3 +1,3 @@
 # airbyte-bootloader
 
-This application runs at start up for Airbyte. It is responsible for making sure that the environment is upgraded and in a good state. e.g. It makes sure the database has be migrated to the correct version.
+This application runs at start up for Airbyte. It is responsible for making sure that the environment is upgraded and in a good state. e.g. It makes sure the database has been migrated to the correct version.

--- a/airbyte-bootloader/readme.md
+++ b/airbyte-bootloader/readme.md
@@ -1,3 +1,6 @@
 # airbyte-bootloader
 
 This application runs at start up for Airbyte. It is responsible for making sure that the environment is upgraded and in a good state. e.g. It makes sure the database has been migrated to the correct version.
+
+## Entrypoint
+* BootloaderApp.java - has the main method for running the bootloader.

--- a/airbyte-bootloader/readme.md
+++ b/airbyte-bootloader/readme.md
@@ -1,0 +1,3 @@
+# airbyte-bootloader
+
+This application runs at start up for Airbyte. It is responsible for making sure that the environment is upgraded and in a good state. e.g. It makes sure the database has be migrated to the correct version.

--- a/airbyte-cli/readme.md
+++ b/airbyte-cli/readme.md
@@ -1,0 +1,3 @@
+# airbyte-cli
+
+Thin CLI over the Airbyte Configuration API to make it easier to interact with the API from the command line.

--- a/airbyte-commons-cli/readme.md
+++ b/airbyte-commons-cli/readme.md
@@ -1,1 +1,3 @@
+# airbyte-commons-cli
+
 This module houses utility functions for the `commons-cli` library. It is separate from `commons`, because it depends on external library `commons-cli` which we do not want to introduce as a dependency to every module.

--- a/airbyte-commons-docker/readme.md
+++ b/airbyte-commons-docker/readme.md
@@ -1,0 +1,3 @@
+# airbyte-commons-docker
+
+This module contains common helpers for interacting with Docker and Docker images from Java.

--- a/airbyte-commons/build.gradle
+++ b/airbyte-commons/build.gradle
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-    // Dependencies for this module should be specified in the top-level build.gradle.
+    // Dependencies for this module should be specified in the top-level build.gradle. See readme for more explanation.
 }

--- a/airbyte-commons/readme.md
+++ b/airbyte-commons/readme.md
@@ -1,0 +1,7 @@
+# airbyte-commons
+
+Common java helpers.
+
+This submodule is inherited by all other java modules in the monorepo! It is therefore important that we do not add dependencies to it, as those dependencies will also be added to every java module. The only dependencies that this module uses are the ones declared in the `build.gradle` at the root of the Airbyte monorepo. In other words it only uses dependencies that are already shared across all modules. The `dependencies` section of the `build.gradle` of `airbyte-commons` should always be empty.
+
+For other common java code that needs to be shared across modules that requires additional dependencies, we follow this convention: `airbyte-commons-<name of lib>`. See for example `airbyte-commons-cli` and `airbyte-commons-docker`.

--- a/airbyte-config/init/readme.md
+++ b/airbyte-config/init/readme.md
@@ -1,0 +1,8 @@
+# airbyte-config:init
+
+This module fulfills two responsibilities:
+1. It is where we declare what connectors should ship with the Platform. See below for more instruction on how it works.
+2. It contains the scripts and Dockerfile that allow the `docker-compose` version of Airbyte to mount the local filesystem. This is helpful in cases where a user wants to use a connector that interacts with (reads data from or writes data to) the local filesystem. e.g. `destination-local-json`.
+
+## Declaring connectors that ship with the Platform
+In order to have a connector ship with the Platform is must be present in the respective `source_definitions.yaml` or `destination_definitions.yaml` files in `src/main/resources/seed`. If a connector is added there, the build system will handle fetching its spec and adding it to `source_specs.yaml` or `destination_specs.yaml`. See the gradle tasks to understand how this all works. The logic for fetching the specs is in `airbyte-config:specs`.

--- a/airbyte-config/persistence/readme.md
+++ b/airbyte-config/persistence/readme.md
@@ -1,3 +1,7 @@
 # airbyte-config:persistence
 
 This module contains the logic for accessing the config database. This database is primarily used by the `airbyte-server` but is also accessed from `airbyte-scheduler` and `airbyte-workers`. It contains all configuration information for Airbyte.
+
+## Key files
+* `ConfigPersistence.java` is the interface over "low-level" access to the db. The most commonly used implementation of it is `DatabaseConfigPersistence.java` The only other one that is used is the `YamlSeedConfigPersistence.java` which is used for loading configs that ship with the app.
+* `ConfigRepository.java` is what is most used for accessing the databases. The `ConfigPersistence` iface was hard to work with. `ConfigRepository` builds on top of it and houses any databases queries to keep them from proliferating throughout the codebase.

--- a/airbyte-config/persistence/readme.md
+++ b/airbyte-config/persistence/readme.md
@@ -1,0 +1,3 @@
+# airbyte-config:persistence
+
+This module contains the logic for accessing the config database. This database is primarily used by the `airbyte-server` but is also accessed from `airbyte-scheduler` and `airbyte-workers`. It contains all configuration information for Airbyte.

--- a/airbyte-container-orchestrator/readme.md
+++ b/airbyte-container-orchestrator/readme.md
@@ -1,3 +1,3 @@
-# airbyte-container-orchestartor
+# airbyte-container-orchestrator
 
-This module contains logic to handle launching connector containers. It is called from the temporal workflows in `airbyte-workers`. It is called from the worker and spins up in a separate pod so that each sync workflow can be isolated from each other.
+This module contains logic to handle launching connector containers. It is called from the temporal workflows in `airbyte-workers`. It is called from the worker and spins up in a separate pod so that sync workflows can be isolated from each other.

--- a/airbyte-container-orchestrator/readme.md
+++ b/airbyte-container-orchestrator/readme.md
@@ -1,3 +1,6 @@
 # airbyte-container-orchestrator
 
 This module contains logic to handle launching connector containers. It is called from the temporal workflows in `airbyte-workers`. It is called from the worker and spins up in a separate pod so that sync workflows can be isolated from each other.
+
+## Entrypoint
+* `ContainerOrchestratorApp.java`

--- a/airbyte-container-orchestrator/readme.md
+++ b/airbyte-container-orchestrator/readme.md
@@ -1,0 +1,3 @@
+# airbyte-container-orchestartor
+
+This module contains logic to handle launching connector containers. It is called from the temporal workflows in `airbyte-workers`. It is called from the worker and spins up in a separate pod so that each sync workflow can be isolated from each other.

--- a/airbyte-integrations/bases/readme.md
+++ b/airbyte-integrations/bases/readme.md
@@ -1,3 +1,6 @@
 # airbyte-integrations:bases
 
 This directory contains modules that contain shared code or can be inherited when writing connectors.
+
+## Key Files
+todo (cgardens) - each of these submodules in this directory should have their own readmes.

--- a/airbyte-integrations/bases/readme.md
+++ b/airbyte-integrations/bases/readme.md
@@ -1,3 +1,3 @@
 # airbyte-integrations:bases
 
-This direction contains modules that contain shared code or can be inherited when writing connectors.
+This directory contains modules that contain shared code or can be inherited when writing connectors.

--- a/airbyte-integrations/bases/readme.md
+++ b/airbyte-integrations/bases/readme.md
@@ -1,0 +1,3 @@
+# airbyte-integrations:bases
+
+This direction contains modules that contain shared code or can be inherited when writing connectors.

--- a/airbyte-json-validation/readme.md
+++ b/airbyte-json-validation/readme.md
@@ -1,3 +1,3 @@
 # airbyte-json-validation
 
-This module contains shared Java code for validation JSON objects.
+This module contains shared Java code for validating JSON objects.

--- a/airbyte-json-validation/readme.md
+++ b/airbyte-json-validation/readme.md
@@ -1,3 +1,7 @@
 # airbyte-json-validation
 
 This module contains shared Java code for validating JSON objects.
+
+## Key Files
+* `JsonSchemaValidator.java` is the main entrypoint into this library, defining convenience methods for validation.
+* `ConfigSchemaValidator.java` is additional sugar to make it easy to validate objects whose schemas are defined in `ConfigSchema`.

--- a/airbyte-json-validation/readme.md
+++ b/airbyte-json-validation/readme.md
@@ -1,0 +1,3 @@
+# airbyte-json-validation
+
+This module contains shared Java code for validation JSON objects.

--- a/airbyte-metrics/readme.md
+++ b/airbyte-metrics/readme.md
@@ -1,0 +1,3 @@
+# airbyte-metrics
+
+Responsible for logic related to pushing monitoring and performance metrics to external aggregates. This is only used if explicitly turned on by the user.

--- a/airbyte-notification/readme.md
+++ b/airbyte-notification/readme.md
@@ -1,3 +1,6 @@
 # airbyte-notification
 
 Logic for handling notifications (e.g. success / failure) that are emitted from jobs.
+
+## Key Files
+* `NotificationClient.java` wraps the clients for the different notification providers that we integrate with. Additional clients for each integration are houses in this module (e.g. SlackNotificationClient).

--- a/airbyte-notification/readme.md
+++ b/airbyte-notification/readme.md
@@ -1,0 +1,3 @@
+# airbyte-notification
+
+Logic for handling notifications (e.g. success / failure) that are emitted from jobs.

--- a/airbyte-oauth/readme.md
+++ b/airbyte-oauth/readme.md
@@ -1,3 +1,7 @@
 # airbyte-oauth
 
 Library for request handling for OAuth Connectors. While Connectors define many OAuth attributes in their spec, the request sequence is executed in the `airbyte-server`. This module contains that logic.
+
+## Key Files
+* `OAuthFlowImplementation.java` - interface that a source has to implement in order to do OAuth with Airbyte.
+* `OAuthImplementationFactory.java` - catalog of the sources for which we support OAuth.

--- a/airbyte-oauth/readme.md
+++ b/airbyte-oauth/readme.md
@@ -1,0 +1,3 @@
+# airbyte-oauth
+
+Library for request handling for OAuth Connectors. While Connectors define many OAuth attributes in their spec, the request sequence is executed in the `airbyte-server`. This module contains that logic.

--- a/airbyte-protocol/readme.md
+++ b/airbyte-protocol/readme.md
@@ -1,3 +1,7 @@
 # airbyte-protocol
 
 Declares the Airbyte Protocol.
+
+## Key Files
+* `airbyte_protocol.yaml` - declares the Airbyte Protocol (in JSONSchema)
+* `io.airbyte.protocol.models` - this package contains various java helpers for working with the protocol.

--- a/airbyte-protocol/readme.md
+++ b/airbyte-protocol/readme.md
@@ -1,0 +1,3 @@
+# airbyte-protocol
+
+Declares the Airbyte Protocol.

--- a/airbyte-queue/readme.md
+++ b/airbyte-queue/readme.md
@@ -1,3 +1,6 @@
 # airbyte-queue
 
 Wraps an external tool that provides an on-disk queue.
+
+## Entrypoint
+* `OnDiskQueue.java`

--- a/airbyte-queue/readme.md
+++ b/airbyte-queue/readme.md
@@ -1,0 +1,3 @@
+# airbyte-queue
+
+Wraps an external tool that provides an on-disk queue.

--- a/airbyte-scheduler/app/readme.md
+++ b/airbyte-scheduler/app/readme.md
@@ -1,0 +1,7 @@
+# airbyte-scheduler:app
+
+This module contains the Scheduler App. The main method can be found in `SchedulerApp.java`. The Scheduler is responsible for:
+1. Determining if it is time to schedule a Sync Job for a Connection.
+2. Submitting pending Jobs to the Workers.
+3. Retrying failing Jobs.
+4. Clearing out old Job History (so it does not become a space concern).

--- a/airbyte-scheduler/client/readme.md
+++ b/airbyte-scheduler/client/readme.md
@@ -1,3 +1,7 @@
 # airbyte-scheduler:client
 
 Java clients for submitting Jobs.
+
+## Key Files
+* `SchedulerJobClient` - interface for scheduling _asynchronous_ jobs (i.e. sync and reset).
+* `SynchronousSchedulerClient` - interface for scheduling _synchronous_ jobs.

--- a/airbyte-scheduler/client/readme.md
+++ b/airbyte-scheduler/client/readme.md
@@ -1,0 +1,3 @@
+# airbyte-scheduler:client
+
+Java clients for submitting Jobs.

--- a/airbyte-scheduler/models/readme.md
+++ b/airbyte-scheduler/models/readme.md
@@ -3,3 +3,6 @@
 This module declares models that belong to the Scheduler.
 
 These models are generated in the same way as `airbyte-config:models`. See that module for reference.
+
+## Key Files
+* `Job.java` and `Attempt.java` are the top-level models in this schema.

--- a/airbyte-scheduler/models/readme.md
+++ b/airbyte-scheduler/models/readme.md
@@ -1,0 +1,5 @@
+# airbyte-scheduler:models
+
+This module declares models that belong to the Scheduler.
+
+These models are generated in the same way as `airbyte-config:models`. See that module for reference.

--- a/airbyte-scheduler/persistence/readme.md
+++ b/airbyte-scheduler/persistence/readme.md
@@ -1,3 +1,7 @@
 # airbyte-scheduler:persistence
 
 This module encapsulates the logic for the Jobs Database. This Database is primarily used by the `airbyte-scheduler` and `airbyte-workers` but it is also access from the `airbyte-server`.
+
+## Key Files
+* `DefaultJobPersistence` is where all queries for interacting with the Jobs Database live.
+* everything else is abstraction on top of that to make it easier to create / interact with / test jobs.

--- a/airbyte-scheduler/persistence/readme.md
+++ b/airbyte-scheduler/persistence/readme.md
@@ -1,0 +1,3 @@
+# airbyte-scheduler:persistence
+
+This module encapsulates the logic for the Jobs Database. This Database is primarily used by the `airbyte-scheduler` and `airbyte-workers` but it is also access from the `airbyte-server`.

--- a/airbyte-server/readme.md
+++ b/airbyte-server/readme.md
@@ -1,3 +1,5 @@
 # airbyte-server
 
-This module contains the actual app that runs the Airbyte Configuration API. The main method can be found in `ServerApp.java`. The external API interface that it implements is declared in `airbyte-api`.
+This module contains the actual app that runs the Airbyte Configuration API. The main method can be found in `ServerApp.java`.
+
+The external API interface that it implements is declared in `airbyte-api`. The class that actually implements that interface is called `ConfigurationApi`. You will notice that class is very large, because generates a method for every endpoint. To keep it manageable, that class just delegates all requests to more tightly-scoped, resource-based handlers. For example, the `workspace/get` endpoint is present in `ConfigurationApi`, but all it does it delegate the call to the `WorkspaceHandler` which contains all Workspace-specific logic. Unit tests for the server happen at the Handler-level, not for the `ConfigurationApi`.

--- a/airbyte-server/readme.md
+++ b/airbyte-server/readme.md
@@ -1,0 +1,3 @@
+# airbyte-server
+
+This module contains the actual app that runs the Airbyte Configuration API. The main method can be found in `ServerApp.java`. The external API interface that it implements is declared in `airbyte-api`.

--- a/airbyte-temporal/README.md
+++ b/airbyte-temporal/README.md
@@ -1,3 +1,7 @@
+# airbyte-temporal
+
+This module wraps the publicly available Temporal Docker image (temporal.io). It decorates it with functionality that makes it so that users of Airbyte do not need to do anything manual when the Airbyte platform upgrades the version of Temporal that it is using.
+
 ## Testing a temporal migration
 
 `tools/bin/test_temporal_migration.sh` is available to test that a bump of the temporal version won't break the docker compose build. Here is what 

--- a/airbyte-temporal/README.md
+++ b/airbyte-temporal/README.md
@@ -1,6 +1,6 @@
 # airbyte-temporal
 
-This module wraps the publicly available Temporal Docker image (temporal.io). It decorates it with functionality that makes it so that users of Airbyte do not need to do anything manual when the Airbyte platform upgrades the version of Temporal that it is using.
+This module implements a custom version of what the Temporal autosetup image is doing. Because Temporal does not recommend the autosetup be used in production, we had to add some modifications. It ensures that the temporalDB schema will get upgraded if the temporal version is updated.
 
 ## Testing a temporal migration
 

--- a/airbyte-test-utils/readme.md
+++ b/airbyte-test-utils/readme.md
@@ -1,0 +1,3 @@
+# airbyte-test-utils
+
+Shared Java code for executing TestContainers and other helpers.

--- a/airbyte-tests/readme.md
+++ b/airbyte-tests/readme.md
@@ -1,0 +1,5 @@
+# airbyte-tests
+
+This module contains two major test suites:
+1. Acceptance Tests - These are feature-level tests that run as part of the build. They spin up Airbyte and test functionality by executing commands against the Airbyte Configuration API. It is possible to run them both on `docker-compose` and `kuberenetes`. We do both in the build. These tests are designed to verify that large features work in broad strokes. More detailed testing should happen in unit tests.
+2. Auto Migration Acceptance Tests - These tests verify that it is possible to upgrade from older version of Airbyte (as far back as 0.17.0) all the way up to the current version.

--- a/airbyte-webapp/README.md
+++ b/airbyte-webapp/README.md
@@ -25,3 +25,7 @@ Builds the app for production to the `build` folder.<br />
 
 Builds the app and Docker image and tags the image with `yourtag`.
 Note: needs to be run from the root directory of the Airbyte project.
+
+## Entrypoints
+* `airbyte-webapp/src/App.tsx` is the entrypoint into the OSS version of the webapp.
+* `airbyte-webapp/src/packages/cloud/App.tsx` is the entrypoint into the Cloud version of the webapp.

--- a/airbyte-webapp/README.md
+++ b/airbyte-webapp/README.md
@@ -1,6 +1,6 @@
 # airbyte-webapp
 
-This module contains the Airbyte Webapp. It is a React app written in TypeScript. It runs in Docker container. A very lightweight nginx server runs in that Docker container and serves the webapp.
+This module contains the Airbyte Webapp. It is a React app written in TypeScript. It runs in a Docker container. A very lightweight nginx server runs in that Docker container and serves the webapp.
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 

--- a/airbyte-webapp/README.md
+++ b/airbyte-webapp/README.md
@@ -1,3 +1,7 @@
+# airbyte-webapp
+
+This module contains the Airbyte Webapp. It is a React app written in TypeScript. It runs in Docker container. A very lightweight nginx server runs in that Docker container and serves the webapp.
+
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 ## Available Scripts

--- a/airbyte-workers/README.md
+++ b/airbyte-workers/README.md
@@ -1,6 +1,10 @@
-# Temporal Development
+# airbyte-workers
 
-## Versioning
+This module contains the logic for how Jobs are executed. Jobs are executed using a tool called Temporal.
+
+## Temporal Development
+
+### Versioning
 
 Temporal is maintaining an internal history of the activity it runs. This history is based on a specific order. If we restart a temporal workflow with
 a new implementation that has a different order, the workflow will be stuck and will need manual action to be properly restarted. Temporal provides
@@ -38,7 +42,7 @@ if (version <= 4 && version >= MINIMAL_VERSION) {
 }
 ```
 
-## Removing a version
+### Removing a version
 
 Removing a version is a potential breaking change and should be done version carefully. We should maintain a MINIMAL_VERSION to keep track of the
 current minimal version. Both MINIMAL_VERSION and CURRENT_VERSION needs to be present on the workflow file even if they are unused (if they have been

--- a/buildSrc/readme.md
+++ b/buildSrc/readme.md
@@ -1,0 +1,3 @@
+# buildSrc
+
+This module contains custom Gradle modules that we have written to improve our build.

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -1,5 +1,7 @@
 # airbyte
 
+Helm charts for Airbyte.
+
 ## Parameters
 
 ### Global Parameters

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,0 +1,3 @@
+# docs (by Gitbook)
+
+This directory contains our docs that are hosted at docs.airbyte.io. We leverage a tool called Gitbook. For instructions on how to work with our docs, check out this [article](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#workflow-for-updating-docs).

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,5 +1,7 @@
 # Tools
 
+Contains various tools (usually bash scripts) to improve quality of life or the build system.
+
 ## Releasing a new version
 ```
 Trigger the Github Action Release Open Source Airbyte (https://github.com/airbytehq/airbyte/actions/workflows/release-airbyte-os.yml)


### PR DESCRIPTION
## What
* Every time I onboard a new hire, I walk through the project structure. To make that more efficient I have added readmes to each, so that the new hire can read them first and then we can go through and answer questions.

@pmossman would love your feedback on how to make this so it would have been as useful as possible.