### PR TITLE
allow serializing to yaml without quoting strings

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/yaml/Yamls.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/yaml/Yamls.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
 import com.google.common.collect.AbstractIterator;
 import io.airbyte.commons.jackson.MoreMappers;
@@ -27,9 +28,32 @@ public class Yamls {
   private static final YAMLFactory YAML_FACTORY = new YAMLFactory();
   private static final ObjectMapper OBJECT_MAPPER = MoreMappers.initYamlMapper(YAML_FACTORY);
 
+  private static final YAMLFactory YAML_FACTORY_WITHOUT_QUOTES = new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
+  private static final ObjectMapper OBJECT_MAPPER_WITHOUT_QUOTES = MoreMappers.initYamlMapper(YAML_FACTORY_WITHOUT_QUOTES);
+
+  /**
+   * Serialize object to YAML string. String values WILL be wrapped in double quotes.
+   *
+   * @param object - object to serialize
+   * @return YAML string version of object
+   */
   public static <T> String serialize(final T object) {
     try {
       return OBJECT_MAPPER.writeValueAsString(object);
+    } catch (final JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Serialize object to YAML string. String values will NOT be wrapped in double quotes.
+   *
+   * @param object - object to serialize
+   * @return YAML string version of object
+   */
+  public static String serializeWithoutQuotes(final Object object) {
+    try {
+      return OBJECT_MAPPER_WITHOUT_QUOTES.writeValueAsString(object);
     } catch (final JsonProcessingException e) {
       throw new RuntimeException(e);
     }

--- a/airbyte-commons/src/test/java/io/airbyte/commons/yaml/YamlsTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/yaml/YamlsTest.java
@@ -48,6 +48,25 @@ class YamlsTest {
   }
 
   @Test
+  void testSerializeWithoutQuotes() {
+    assertEquals(
+        "---\n"
+            + "str: abc\n"
+            + "num: 999\n"
+            + "numLong: 888\n",
+        Yamls.serializeWithoutQuotes(new ToClass("abc", 999, 888L)));
+
+    assertEquals(
+        "---\n"
+            + "test: abc\n"
+            + "test2: def\n",
+        Yamls.serializeWithoutQuotes(
+            ImmutableMap.of(
+                "test", "abc",
+                "test2", "def")));
+  }
+
+  @Test
   void testSerializeJsonNode() {
     assertEquals(
         "---\n"


### PR DESCRIPTION
## What
* See todo [here](https://github.com/airbytehq/airbyte-cloud/pull/327/files#diff-20a722eb01503549f3f7e9fb28031a8e03c92cea9c34ef325eebcd64c550cde0R104)
* When serializing to Yaml (e.g. for connector definitions) there is no need to wrap strings in double quotes.