### PR TITLE
Extract secrets handling out of ConfigRepository

### DIFF
--- a/airbyte-bootloader/src/main/java/io/airbyte/bootloader/BootloaderApp.java
+++ b/airbyte-bootloader/src/main/java/io/airbyte/bootloader/BootloaderApp.java
@@ -114,7 +114,7 @@ public class BootloaderApp {
 
       final ConfigPersistence configPersistence = DatabaseConfigPersistence.createWithValidation(configDatabase);
       final ConfigRepository configRepository =
-          new ConfigRepository(configPersistence, null, Optional.empty(), Optional.empty(), configDatabase);
+          new ConfigRepository(configPersistence, configDatabase);
 
       createWorkspaceIfNoneExists(configRepository);
       LOGGER.info("Default workspace created..");

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -66,8 +66,8 @@ public class ConfigRepository {
   private final ConfigPersistence persistence;
   private final ExceptionWrappingDatabase database;
 
-  // todo (cgardens) - very bad that this exposed. queries that rely on this endpoint should be pushed
-  // into this class.
+  // todo (cgardens) - very bad that this exposed. usages should be removed. do not use it.
+  @Deprecated
   public ExceptionWrappingDatabase getDatabase() {
     return database;
   }

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -725,7 +725,7 @@ public class ConfigRepository {
    * @param seedPersistenceWithoutSecrets - seed persistence WITHOUT secrets
    * @throws IOException - you never know when you IO
    */
-  void loadDataNoSecrets(final ConfigPersistence seedPersistenceWithoutSecrets) throws IOException {
+  public void loadDataNoSecrets(final ConfigPersistence seedPersistenceWithoutSecrets) throws IOException {
     persistence.loadData(seedPersistenceWithoutSecrets);
   }
 

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -16,7 +16,6 @@ import com.google.common.base.Charsets;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.commons.lang.MoreBooleans;
 import io.airbyte.config.ActorCatalog;
 import io.airbyte.config.ActorCatalogFetchEvent;
@@ -33,22 +32,15 @@ import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncState;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.State;
-import io.airbyte.config.persistence.split_secrets.SecretPersistence;
-import io.airbyte.config.persistence.split_secrets.SecretsHelpers;
-import io.airbyte.config.persistence.split_secrets.SecretsHydrator;
-import io.airbyte.config.persistence.split_secrets.SplitSecretConfig;
 import io.airbyte.db.Database;
 import io.airbyte.db.ExceptionWrappingDatabase;
 import io.airbyte.db.instance.configs.jooq.enums.ActorType;
 import io.airbyte.protocol.models.AirbyteCatalog;
-import io.airbyte.protocol.models.ConnectorSpecification;
-import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -67,33 +59,22 @@ import org.jooq.Result;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class ConfigRepository {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigRepository.class);
 
-  private static final UUID NO_WORKSPACE = UUID.fromString("00000000-0000-0000-0000-000000000000");
-
   private final ConfigPersistence persistence;
-  private final SecretsHydrator secretsHydrator;
-  private final Optional<SecretPersistence> longLivedSecretPersistence;
-  private final Optional<SecretPersistence> ephemeralSecretPersistence;
   private final ExceptionWrappingDatabase database;
 
-  public ConfigRepository(final ConfigPersistence persistence,
-                          final SecretsHydrator secretsHydrator,
-                          final Optional<SecretPersistence> longLivedSecretPersistence,
-                          final Optional<SecretPersistence> ephemeralSecretPersistence,
-                          final Database database) {
-    this.persistence = persistence;
-    this.secretsHydrator = secretsHydrator;
-    this.longLivedSecretPersistence = longLivedSecretPersistence;
-    this.ephemeralSecretPersistence = ephemeralSecretPersistence;
-    this.database = new ExceptionWrappingDatabase(database);
-  }
-
+  // todo (cgardens) - very bad that this exposed. queries that rely on this endpoint should be pushed
+  // into this class.
   public ExceptionWrappingDatabase getDatabase() {
     return database;
+  }
+
+  public ConfigRepository(final ConfigPersistence persistence, final Database database) {
+    this.persistence = persistence;
+    this.database = new ExceptionWrappingDatabase(database);;
   }
 
   public StandardWorkspace getStandardWorkspace(final UUID workspaceId, final boolean includeTombstone)
@@ -318,168 +299,87 @@ public class ConfigRepository {
     persistence.deleteConfig(definitionType, definitionId.toString());
   }
 
+  /**
+   * Returns source with a given id. Does not contain secrets. To hydrate with secrets see { @link
+   * SecretsRepositoryReader#getSourceConnectionWithSecrets(final UUID sourceId) }.
+   *
+   * @param sourceId - id of source to fetch.
+   * @return sources
+   * @throws JsonValidationException - throws if returned sources are invalid
+   * @throws IOException - you never know when you IO
+   * @throws ConfigNotFoundException - throws if no source with that id can be found.
+   */
   public SourceConnection getSourceConnection(final UUID sourceId) throws JsonValidationException, ConfigNotFoundException, IOException {
     return persistence.getConfig(ConfigSchema.SOURCE_CONNECTION, sourceId.toString(), SourceConnection.class);
   }
 
-  public SourceConnection getSourceConnectionWithSecrets(final UUID sourceId) throws JsonValidationException, IOException, ConfigNotFoundException {
-    final var source = getSourceConnection(sourceId);
-    final var fullConfig = secretsHydrator.hydrate(source.getConfiguration());
-    return Jsons.clone(source).withConfiguration(fullConfig);
-  }
-
-  private Optional<SourceConnection> getOptionalSourceConnection(final UUID sourceId) throws JsonValidationException, IOException {
-    try {
-      return Optional.of(getSourceConnection(sourceId));
-    } catch (final ConfigNotFoundException e) {
-      return Optional.empty();
-    }
-  }
-
-  public void writeSourceConnection(final SourceConnection source, final ConnectorSpecification connectorSpecification)
-      throws JsonValidationException, IOException {
-    // actual validation is only for sanity checking
-    final JsonSchemaValidator validator = new JsonSchemaValidator();
-    validator.ensure(connectorSpecification.getConnectionSpecification(), source.getConfiguration());
-
-    final var previousSourceConnection = getOptionalSourceConnection(source.getSourceId())
-        .map(SourceConnection::getConfiguration);
-
-    final var partialConfig =
-        statefulUpdateSecrets(source.getWorkspaceId(), previousSourceConnection, source.getConfiguration(), connectorSpecification);
-    final var partialSource = Jsons.clone(source).withConfiguration(partialConfig);
-
-    persistence.writeConfig(ConfigSchema.SOURCE_CONNECTION, source.getSourceId().toString(), partialSource);
+  /**
+   * MUST NOT ACCEPT SECRETS - Should only be called from { @link SecretsRepositoryWriter }
+   *
+   * Write a SourceConnection to the database. The configuration of the Source will be a partial
+   * configuration (no secrets, just pointer to the secrets store).
+   *
+   * @param partialSource - The configuration of the Source will be a partial configuration (no
+   *        secrets, just pointer to the secrets store)
+   * @throws JsonValidationException - throws is the source is invalid
+   * @throws IOException - you never know when you IO
+   */
+  public void writeSourceConnectionNoSecrets(final SourceConnection partialSource) throws JsonValidationException, IOException {
+    persistence.writeConfig(ConfigSchema.SOURCE_CONNECTION, partialSource.getSourceId().toString(), partialSource);
   }
 
   /**
-   * @param workspaceId workspace id for the config
-   * @param fullConfig full config
-   * @param spec connector specification
-   * @return partial config
+   * Returns all sources in the database. Does not contain secrets. To hydrate with secrets see
+   * { @link SecretsRepositoryReader#listSourceConnectionWithSecrets() }.
+   *
+   * @return sources
+   * @throws JsonValidationException - throws if returned sources are invalid
+   * @throws IOException - you never know when you IO
    */
-  public JsonNode statefulSplitSecrets(final UUID workspaceId, final JsonNode fullConfig, final ConnectorSpecification spec) {
-    return splitSecretConfig(workspaceId, fullConfig, spec, longLivedSecretPersistence);
-  }
-
-  /**
-   * @param workspaceId workspace id for the config
-   * @param oldConfig old full config
-   * @param fullConfig new full config
-   * @param spec connector specification
-   * @return partial config
-   */
-  public JsonNode statefulUpdateSecrets(final UUID workspaceId,
-                                        final Optional<JsonNode> oldConfig,
-                                        final JsonNode fullConfig,
-                                        final ConnectorSpecification spec) {
-    if (longLivedSecretPersistence.isPresent()) {
-      if (oldConfig.isPresent()) {
-        final var splitSecretConfig = SecretsHelpers.splitAndUpdateConfig(
-            workspaceId,
-            oldConfig.get(),
-            fullConfig,
-            spec,
-            longLivedSecretPersistence.get());
-
-        splitSecretConfig.getCoordinateToPayload().forEach(longLivedSecretPersistence.get()::write);
-
-        return splitSecretConfig.getPartialConfig();
-      } else {
-        final var splitSecretConfig = SecretsHelpers.splitConfig(
-            workspaceId,
-            fullConfig,
-            spec);
-
-        splitSecretConfig.getCoordinateToPayload().forEach(longLivedSecretPersistence.get()::write);
-
-        return splitSecretConfig.getPartialConfig();
-      }
-    } else {
-      return fullConfig;
-    }
-  }
-
-  /**
-   * @param fullConfig full config
-   * @param spec connector specification
-   * @return partial config
-   */
-  public JsonNode statefulSplitEphemeralSecrets(final JsonNode fullConfig, final ConnectorSpecification spec) {
-    return splitSecretConfig(NO_WORKSPACE, fullConfig, spec, ephemeralSecretPersistence);
-  }
-
-  private JsonNode splitSecretConfig(final UUID workspaceId,
-                                     final JsonNode fullConfig,
-                                     final ConnectorSpecification spec,
-                                     final Optional<SecretPersistence> secretPersistence) {
-    if (secretPersistence.isPresent()) {
-      final SplitSecretConfig splitSecretConfig = SecretsHelpers.splitConfig(workspaceId, fullConfig, spec);
-      splitSecretConfig.getCoordinateToPayload().forEach(secretPersistence.get()::write);
-      return splitSecretConfig.getPartialConfig();
-    } else {
-      return fullConfig;
-    }
-  }
-
   public List<SourceConnection> listSourceConnection() throws JsonValidationException, IOException {
     return persistence.listConfigs(ConfigSchema.SOURCE_CONNECTION, SourceConnection.class);
   }
 
-  public List<SourceConnection> listSourceConnectionWithSecrets() throws JsonValidationException, IOException {
-    final var sources = listSourceConnection();
-
-    return sources.stream()
-        .map(partialSource -> Exceptions.toRuntime(() -> getSourceConnectionWithSecrets(partialSource.getSourceId())))
-        .collect(Collectors.toList());
-  }
-
+  /**
+   * Returns destination with a given id. Does not contain secrets. To hydrate with secrets see
+   * { @link SecretsRepositoryReader#getDestinationConnectionWithSecrets(final UUID destinationId) }.
+   *
+   * @param destinationId - id of destination to fetch.
+   * @return destinations
+   * @throws JsonValidationException - throws if returned destinations are invalid
+   * @throws IOException - you never know when you IO
+   * @throws ConfigNotFoundException - throws if no destination with that id can be found.
+   */
   public DestinationConnection getDestinationConnection(final UUID destinationId)
       throws JsonValidationException, IOException, ConfigNotFoundException {
     return persistence.getConfig(ConfigSchema.DESTINATION_CONNECTION, destinationId.toString(), DestinationConnection.class);
   }
 
-  public DestinationConnection getDestinationConnectionWithSecrets(final UUID destinationId)
-      throws JsonValidationException, IOException, ConfigNotFoundException {
-    final var destination = getDestinationConnection(destinationId);
-    final var fullConfig = secretsHydrator.hydrate(destination.getConfiguration());
-    return Jsons.clone(destination).withConfiguration(fullConfig);
+  /**
+   * MUST NOT ACCEPT SECRETS - Should only be called from { @link SecretsRepositoryWriter }
+   *
+   * Write a DestinationConnection to the database. The configuration of the Destination will be a
+   * partial configuration (no secrets, just pointer to the secrets store).
+   *
+   * @param partialDestination - The configuration of the Destination will be a partial configuration
+   *        (no secrets, just pointer to the secrets store)
+   * @throws JsonValidationException - throws is the destination is invalid
+   * @throws IOException - you never know when you IO
+   */
+  public void writeDestinationConnectionNoSecrets(final DestinationConnection partialDestination) throws JsonValidationException, IOException {
+    persistence.writeConfig(ConfigSchema.DESTINATION_CONNECTION, partialDestination.getDestinationId().toString(), partialDestination);
   }
 
-  private Optional<DestinationConnection> getOptionalDestinationConnection(final UUID destinationId) throws JsonValidationException, IOException {
-    try {
-      return Optional.of(getDestinationConnection(destinationId));
-    } catch (final ConfigNotFoundException e) {
-      return Optional.empty();
-    }
-  }
-
-  public void writeDestinationConnection(final DestinationConnection destination, final ConnectorSpecification connectorSpecification)
-      throws JsonValidationException, IOException {
-    // actual validation is only for sanity checking
-    final JsonSchemaValidator validator = new JsonSchemaValidator();
-    validator.ensure(connectorSpecification.getConnectionSpecification(), destination.getConfiguration());
-
-    final var previousDestinationConnection = getOptionalDestinationConnection(destination.getDestinationId())
-        .map(DestinationConnection::getConfiguration);
-
-    final var partialConfig =
-        statefulUpdateSecrets(destination.getWorkspaceId(), previousDestinationConnection, destination.getConfiguration(), connectorSpecification);
-    final var partialDestination = Jsons.clone(destination).withConfiguration(partialConfig);
-
-    persistence.writeConfig(ConfigSchema.DESTINATION_CONNECTION, destination.getDestinationId().toString(), partialDestination);
-  }
-
+  /**
+   * Returns all destinations in the database. Does not contain secrets. To hydrate with secrets see
+   * { @link SecretsRepositoryReader#listDestinationConnectionWithSecrets() }.
+   *
+   * @return destinations
+   * @throws JsonValidationException - throws if returned destinations are invalid
+   * @throws IOException - you never know when you IO
+   */
   public List<DestinationConnection> listDestinationConnection() throws JsonValidationException, IOException {
     return persistence.listConfigs(ConfigSchema.DESTINATION_CONNECTION, DestinationConnection.class);
-  }
-
-  public List<DestinationConnection> listDestinationConnectionWithSecrets() throws JsonValidationException, IOException {
-    final var destinations = listDestinationConnection();
-
-    return destinations.stream()
-        .map(partialDestination -> Exceptions.toRuntime(() -> getDestinationConnectionWithSecrets(partialDestination.getDestinationId())))
-        .collect(Collectors.toList());
   }
 
   public StandardSync getStandardSync(final UUID connectionId) throws JsonValidationException, IOException, ConfigNotFoundException {
@@ -790,110 +690,43 @@ public class ConfigRepository {
   }
 
   /**
-   * Converts between a dumpConfig() output and a replaceAllConfigs() input, by deserializing the
-   * string/jsonnode into the AirbyteConfig, Stream&lt;Object&lt;AirbyteConfig.getClassName()&gt;&gt;
+   * MUST NOT ACCEPT SECRETS - Package private so that secrets are not accidentally passed in. Should
+   * only be called from { @link SecretsRepositoryWriter }
    *
-   * @param configurations from dumpConfig()
-   * @return input suitable for replaceAllConfigs()
+   * Takes as inputs configurations that it then uses to overwrite the contents of the existing Config
+   * Database.
+   *
+   * @param configs - configurations to load.
+   * @param dryRun - whether to test run of the load
+   * @throws IOException - you never know when you IO.
    */
-  public static Map<AirbyteConfig, Stream<?>> deserialize(final Map<String, Stream<JsonNode>> configurations) {
-    final Map<AirbyteConfig, Stream<?>> deserialized = new LinkedHashMap<AirbyteConfig, Stream<?>>();
-    for (final String configSchemaName : configurations.keySet()) {
-      deserialized.put(
-          ConfigSchema.valueOf(configSchemaName),
-          configurations.get(configSchemaName).map(jsonNode -> Jsons.object(jsonNode, ConfigSchema.valueOf(configSchemaName).getClassName())));
-    }
-    return deserialized;
+  void replaceAllConfigsNoSecrets(final Map<AirbyteConfig, Stream<?>> configs, final boolean dryRun) throws IOException {
+    persistence.replaceAllConfigs(configs, dryRun);
   }
 
-  public void replaceAllConfigsDeserializing(final Map<String, Stream<JsonNode>> configs, final boolean dryRun) throws IOException {
-    replaceAllConfigs(deserialize(configs), dryRun);
+  /**
+   * Dumps all configurations in the Config Database. Note: It will not contain secrets as the Config
+   * Database does not contain connector configurations that include secrets. In order to hydrate with
+   * secrets see { @link SecretsRepositoryReader#dumpConfigs() }.
+   *
+   * @return all configurations in the Config Database
+   * @throws IOException - you never know when you IO
+   */
+  public Map<String, Stream<JsonNode>> dumpConfigsNoSecrets() throws IOException {
+    return persistence.dumpConfigs();
   }
 
-  public void replaceAllConfigs(final Map<AirbyteConfig, Stream<?>> configs, final boolean dryRun) throws IOException {
-    if (longLivedSecretPersistence.isPresent()) {
-      final var augmentedMap = new HashMap<>(configs);
-
-      // get all source defs so that we can use their specs when storing secrets.
-      @SuppressWarnings("unchecked")
-      final List<StandardSourceDefinition> sourceDefs =
-          (List<StandardSourceDefinition>) augmentedMap.get(ConfigSchema.STANDARD_SOURCE_DEFINITION).collect(Collectors.toList());
-      // restore data in the map that gets consumed downstream.
-      augmentedMap.put(ConfigSchema.STANDARD_SOURCE_DEFINITION, sourceDefs.stream());
-      final Map<UUID, ConnectorSpecification> sourceDefIdToSpec = sourceDefs
-          .stream()
-          .collect(Collectors.toMap(StandardSourceDefinition::getSourceDefinitionId, StandardSourceDefinition::getSpec));
-
-      // get all destination defs so that we can use their specs when storing secrets.
-      @SuppressWarnings("unchecked")
-      final List<StandardDestinationDefinition> destinationDefs =
-          (List<StandardDestinationDefinition>) augmentedMap.get(ConfigSchema.STANDARD_DESTINATION_DEFINITION).collect(Collectors.toList());
-      augmentedMap.put(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destinationDefs.stream());
-      final Map<UUID, ConnectorSpecification> destinationDefIdToSpec = destinationDefs
-          .stream()
-          .collect(Collectors.toMap(StandardDestinationDefinition::getDestinationDefinitionId, StandardDestinationDefinition::getSpec));
-
-      if (augmentedMap.containsKey(ConfigSchema.SOURCE_CONNECTION)) {
-        final Stream<?> augmentedValue = augmentedMap.get(ConfigSchema.SOURCE_CONNECTION)
-            .map(config -> {
-              final SourceConnection source = (SourceConnection) config;
-
-              if (!sourceDefIdToSpec.containsKey(source.getSourceDefinitionId())) {
-                throw new RuntimeException(new ConfigNotFoundException(ConfigSchema.STANDARD_SOURCE_DEFINITION, source.getSourceDefinitionId()));
-              }
-
-              final var connectionConfig =
-                  statefulSplitSecrets(source.getWorkspaceId(), source.getConfiguration(), sourceDefIdToSpec.get(source.getSourceDefinitionId()));
-
-              return source.withConfiguration(connectionConfig);
-            });
-        augmentedMap.put(ConfigSchema.SOURCE_CONNECTION, augmentedValue);
-      }
-
-      if (augmentedMap.containsKey(ConfigSchema.DESTINATION_CONNECTION)) {
-        final Stream<?> augmentedValue = augmentedMap.get(ConfigSchema.DESTINATION_CONNECTION)
-            .map(config -> {
-              final DestinationConnection destination = (DestinationConnection) config;
-
-              if (!destinationDefIdToSpec.containsKey(destination.getDestinationDefinitionId())) {
-                throw new RuntimeException(
-                    new ConfigNotFoundException(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destination.getDestinationDefinitionId()));
-              }
-
-              final var connectionConfig = statefulSplitSecrets(destination.getWorkspaceId(), destination.getConfiguration(),
-                  destinationDefIdToSpec.get(destination.getDestinationDefinitionId()));
-
-              return destination.withConfiguration(connectionConfig);
-            });
-        augmentedMap.put(ConfigSchema.DESTINATION_CONNECTION, augmentedValue);
-      }
-
-      persistence.replaceAllConfigs(augmentedMap, dryRun);
-    } else {
-      persistence.replaceAllConfigs(configs, dryRun);
-    }
-  }
-
-  public Map<String, Stream<JsonNode>> dumpConfigs() throws IOException {
-    final var map = new HashMap<>(persistence.dumpConfigs());
-    final var sourceKey = ConfigSchema.SOURCE_CONNECTION.name();
-    final var destinationKey = ConfigSchema.DESTINATION_CONNECTION.name();
-
-    if (map.containsKey(sourceKey)) {
-      final Stream<JsonNode> augmentedValue = map.get(sourceKey).map(secretsHydrator::hydrate);
-      map.put(sourceKey, augmentedValue);
-    }
-
-    if (map.containsKey(destinationKey)) {
-      final Stream<JsonNode> augmentedValue = map.get(destinationKey).map(secretsHydrator::hydrate);
-      map.put(destinationKey, augmentedValue);
-    }
-
-    return map;
-  }
-
-  public void loadData(final ConfigPersistence seedPersistence) throws IOException {
-    persistence.loadData(seedPersistence);
+  /**
+   * MUST NOT ACCEPT SECRETS - Package private so that secrets are not accidentally passed in. Should
+   * only be called from { @link SecretsRepositoryWriter }
+   *
+   * Loads all Data from a ConfigPersistence into the database.
+   *
+   * @param seedPersistenceWithoutSecrets - seed persistence WITHOUT secrets
+   * @throws IOException - you never know when you IO
+   */
+  void loadDataNoSecrets(final ConfigPersistence seedPersistenceWithoutSecrets) throws IOException {
+    persistence.loadData(seedPersistenceWithoutSecrets);
   }
 
 }

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/SecretsRepositoryReader.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/SecretsRepositoryReader.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.persistence;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.lang.Exceptions;
+import io.airbyte.config.ConfigSchema;
+import io.airbyte.config.DestinationConnection;
+import io.airbyte.config.SourceConnection;
+import io.airbyte.config.persistence.split_secrets.SecretsHydrator;
+import io.airbyte.validation.json.JsonValidationException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is responsible for fetching both connectors and their secrets (from separate secrets
+ * stores). All methods in this class return secrets! Use it carefully.
+ */
+public class SecretsRepositoryReader {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SecretsRepositoryReader.class);
+
+  // private final ConfigPersistence persistence;
+  private final ConfigRepository configRepository;
+  private final SecretsHydrator secretsHydrator;
+
+  public SecretsRepositoryReader(final ConfigRepository configRepository,
+                                 final SecretsHydrator secretsHydrator) {
+    this.configRepository = configRepository;
+    this.secretsHydrator = secretsHydrator;
+  }
+
+  public SourceConnection getSourceConnectionWithSecrets(final UUID sourceId) throws JsonValidationException, IOException, ConfigNotFoundException {
+    final var source = configRepository.getSourceConnection(sourceId);
+    final var fullConfig = secretsHydrator.hydrate(source.getConfiguration());
+    return Jsons.clone(source).withConfiguration(fullConfig);
+  }
+
+  public List<SourceConnection> listSourceConnectionWithSecrets() throws JsonValidationException, IOException {
+    final var sources = configRepository.listSourceConnection();
+
+    return sources
+        .stream()
+        .map(partialSource -> Exceptions.toRuntime(() -> getSourceConnectionWithSecrets(partialSource.getSourceId())))
+        .collect(Collectors.toList());
+  }
+
+  public DestinationConnection getDestinationConnectionWithSecrets(final UUID destinationId)
+      throws JsonValidationException, IOException, ConfigNotFoundException {
+    final var destination = configRepository.getDestinationConnection(destinationId);
+    final var fullConfig = secretsHydrator.hydrate(destination.getConfiguration());
+    return Jsons.clone(destination).withConfiguration(fullConfig);
+  }
+
+  public List<DestinationConnection> listDestinationConnectionWithSecrets() throws JsonValidationException, IOException {
+    final var destinations = configRepository.listDestinationConnection();
+
+    return destinations
+        .stream()
+        .map(partialDestination -> Exceptions.toRuntime(() -> getDestinationConnectionWithSecrets(partialDestination.getDestinationId())))
+        .collect(Collectors.toList());
+  }
+
+  public Map<String, Stream<JsonNode>> dumpConfigs() throws IOException {
+    final var map = new HashMap<>(configRepository.dumpConfigsNoSecrets());
+    final var sourceKey = ConfigSchema.SOURCE_CONNECTION.name();
+    final var destinationKey = ConfigSchema.DESTINATION_CONNECTION.name();
+
+    if (map.containsKey(sourceKey)) {
+      final Stream<JsonNode> augmentedValue = map.get(sourceKey).map(secretsHydrator::hydrate);
+      map.put(sourceKey, augmentedValue);
+    }
+
+    if (map.containsKey(destinationKey)) {
+      final Stream<JsonNode> augmentedValue = map.get(destinationKey).map(secretsHydrator::hydrate);
+      map.put(destinationKey, augmentedValue);
+    }
+
+    return map;
+  }
+
+}

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/SecretsRepositoryWriter.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/SecretsRepositoryWriter.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.persistence;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.AirbyteConfig;
+import io.airbyte.config.ConfigSchema;
+import io.airbyte.config.DestinationConnection;
+import io.airbyte.config.SourceConnection;
+import io.airbyte.config.StandardDestinationDefinition;
+import io.airbyte.config.StandardSourceDefinition;
+import io.airbyte.config.persistence.split_secrets.SecretPersistence;
+import io.airbyte.config.persistence.split_secrets.SecretsHelpers;
+import io.airbyte.config.persistence.split_secrets.SplitSecretConfig;
+import io.airbyte.protocol.models.ConnectorSpecification;
+import io.airbyte.validation.json.JsonSchemaValidator;
+import io.airbyte.validation.json.JsonValidationException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class takes secrets as arguments but never returns a secrets as return values (even the ones
+ * that are passed in as arguments). It is responsible for writing connector secrets to the correct
+ * secrets store and then making sure the remainder of the configuration is written to the Config
+ * Database.
+ */
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+public class SecretsRepositoryWriter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SecretsRepositoryWriter.class);
+
+  private static final UUID NO_WORKSPACE = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
+  private final ConfigRepository configRepository;
+  private final JsonSchemaValidator validator;
+  private final Optional<SecretPersistence> longLivedSecretPersistence;
+  private final Optional<SecretPersistence> ephemeralSecretPersistence;
+
+  public SecretsRepositoryWriter(final ConfigRepository configRepository,
+                                 final Optional<SecretPersistence> longLivedSecretPersistence,
+                                 final Optional<SecretPersistence> ephemeralSecretPersistence) {
+    this(configRepository, new JsonSchemaValidator(), longLivedSecretPersistence, ephemeralSecretPersistence);
+  }
+
+  @VisibleForTesting
+  SecretsRepositoryWriter(final ConfigRepository configRepository,
+                          final JsonSchemaValidator validator,
+                          final Optional<SecretPersistence> longLivedSecretPersistence,
+                          final Optional<SecretPersistence> ephemeralSecretPersistence) {
+    this.configRepository = configRepository;
+    this.validator = validator;
+    this.longLivedSecretPersistence = longLivedSecretPersistence;
+    this.ephemeralSecretPersistence = ephemeralSecretPersistence;
+  }
+
+  private Optional<SourceConnection> getOptionalSourceConnection(final UUID sourceId) throws JsonValidationException, IOException {
+    try {
+      return Optional.of(configRepository.getSourceConnection(sourceId));
+    } catch (final ConfigNotFoundException e) {
+      return Optional.empty();
+    }
+  }
+
+  // validates too!
+  public void writeSourceConnection(final SourceConnection source, final ConnectorSpecification connectorSpecification)
+      throws JsonValidationException, IOException {
+
+    final var previousSourceConnection = getOptionalSourceConnection(source.getSourceId())
+        .map(SourceConnection::getConfiguration);
+
+    // strip secrets
+    final JsonNode partialConfig = statefulUpdateSecrets(
+        source.getWorkspaceId(),
+        previousSourceConnection,
+        source.getConfiguration(),
+        connectorSpecification);
+    final SourceConnection partialSource = Jsons.clone(source).withConfiguration(partialConfig);
+
+    // validate partial to avoid secret leak issues.
+    validator.ensure(connectorSpecification.getConnectionSpecification(), partialSource.getConfiguration());
+
+    configRepository.writeSourceConnectionNoSecrets(partialSource);
+  }
+
+  private Optional<DestinationConnection> getOptionalDestinationConnection(final UUID destinationId) throws JsonValidationException, IOException {
+    try {
+      return Optional.of(configRepository.getDestinationConnection(destinationId));
+    } catch (final ConfigNotFoundException e) {
+      return Optional.empty();
+    }
+  }
+
+  public void writeDestinationConnection(final DestinationConnection destination, final ConnectorSpecification connectorSpecification)
+      throws JsonValidationException, IOException {
+    final var previousDestinationConnection = getOptionalDestinationConnection(destination.getDestinationId())
+        .map(DestinationConnection::getConfiguration);
+
+    final JsonNode partialConfig = statefulUpdateSecrets(
+        destination.getWorkspaceId(),
+        previousDestinationConnection,
+        destination.getConfiguration(),
+        connectorSpecification);
+    final DestinationConnection partialDestination = Jsons.clone(destination).withConfiguration(partialConfig);
+
+    // validate partial to avoid secret leak issues.
+    validator.ensure(connectorSpecification.getConnectionSpecification(), partialDestination.getConfiguration());
+
+    configRepository.writeDestinationConnectionNoSecrets(partialDestination);
+  }
+
+  /**
+   * Detects secrets in the configuration. Writes them to the secrets store. It returns the config
+   * stripped of secrets (replaced with pointers to the secrets store).
+   *
+   * @param workspaceId workspace id for the config
+   * @param fullConfig full config
+   * @param spec connector specification
+   * @return partial config
+   */
+  public JsonNode statefulSplitSecrets(final UUID workspaceId, final JsonNode fullConfig, final ConnectorSpecification spec) {
+    return splitSecretConfig(workspaceId, fullConfig, spec, longLivedSecretPersistence);
+  }
+
+  /**
+   * @param workspaceId workspace id for the config
+   * @param oldConfig old full config
+   * @param fullConfig new full config
+   * @param spec connector specification
+   * @return partial config
+   */
+  public JsonNode statefulUpdateSecrets(final UUID workspaceId,
+                                        final Optional<JsonNode> oldConfig,
+                                        final JsonNode fullConfig,
+                                        final ConnectorSpecification spec) {
+    if (longLivedSecretPersistence.isPresent()) {
+      if (oldConfig.isPresent()) {
+        final var splitSecretConfig = SecretsHelpers.splitAndUpdateConfig(
+            workspaceId,
+            oldConfig.get(),
+            fullConfig,
+            spec,
+            longLivedSecretPersistence.get());
+
+        splitSecretConfig.getCoordinateToPayload().forEach(longLivedSecretPersistence.get()::write);
+
+        return splitSecretConfig.getPartialConfig();
+      } else {
+        final var splitSecretConfig = SecretsHelpers.splitConfig(
+            workspaceId,
+            fullConfig,
+            spec);
+
+        splitSecretConfig.getCoordinateToPayload().forEach(longLivedSecretPersistence.get()::write);
+
+        return splitSecretConfig.getPartialConfig();
+      }
+    } else {
+      return fullConfig;
+    }
+  }
+
+  /**
+   * @param fullConfig full config
+   * @param spec connector specification
+   * @return partial config
+   */
+  public JsonNode statefulSplitEphemeralSecrets(final JsonNode fullConfig, final ConnectorSpecification spec) {
+    return splitSecretConfig(NO_WORKSPACE, fullConfig, spec, ephemeralSecretPersistence);
+  }
+
+  private JsonNode splitSecretConfig(final UUID workspaceId,
+                                     final JsonNode fullConfig,
+                                     final ConnectorSpecification spec,
+                                     final Optional<SecretPersistence> secretPersistence) {
+    if (secretPersistence.isPresent()) {
+      final SplitSecretConfig splitSecretConfig = SecretsHelpers.splitConfig(workspaceId, fullConfig, spec);
+      splitSecretConfig.getCoordinateToPayload().forEach(secretPersistence.get()::write);
+      return splitSecretConfig.getPartialConfig();
+    } else {
+      return fullConfig;
+    }
+  }
+
+  public void replaceAllConfigs(final Map<AirbyteConfig, Stream<?>> configs, final boolean dryRun) throws IOException {
+    if (longLivedSecretPersistence.isPresent()) {
+      final var augmentedMap = new HashMap<>(configs);
+
+      // get all source defs so that we can use their specs when storing secrets.
+      @SuppressWarnings("unchecked")
+      final List<StandardSourceDefinition> sourceDefs =
+          (List<StandardSourceDefinition>) augmentedMap.get(ConfigSchema.STANDARD_SOURCE_DEFINITION).collect(Collectors.toList());
+      // restore data in the map that gets consumed downstream.
+      augmentedMap.put(ConfigSchema.STANDARD_SOURCE_DEFINITION, sourceDefs.stream());
+      final Map<UUID, ConnectorSpecification> sourceDefIdToSpec = sourceDefs
+          .stream()
+          .collect(Collectors.toMap(StandardSourceDefinition::getSourceDefinitionId, StandardSourceDefinition::getSpec));
+
+      // get all destination defs so that we can use their specs when storing secrets.
+      @SuppressWarnings("unchecked")
+      final List<StandardDestinationDefinition> destinationDefs =
+          (List<StandardDestinationDefinition>) augmentedMap.get(ConfigSchema.STANDARD_DESTINATION_DEFINITION).collect(Collectors.toList());
+      augmentedMap.put(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destinationDefs.stream());
+      final Map<UUID, ConnectorSpecification> destinationDefIdToSpec = destinationDefs
+          .stream()
+          .collect(Collectors.toMap(StandardDestinationDefinition::getDestinationDefinitionId, StandardDestinationDefinition::getSpec));
+
+      if (augmentedMap.containsKey(ConfigSchema.SOURCE_CONNECTION)) {
+        final Stream<?> augmentedValue = augmentedMap.get(ConfigSchema.SOURCE_CONNECTION)
+            .map(config -> {
+              final SourceConnection source = (SourceConnection) config;
+
+              if (!sourceDefIdToSpec.containsKey(source.getSourceDefinitionId())) {
+                throw new RuntimeException(new ConfigNotFoundException(ConfigSchema.STANDARD_SOURCE_DEFINITION, source.getSourceDefinitionId()));
+              }
+
+              final var partialConfig = statefulSplitSecrets(
+                  source.getWorkspaceId(),
+                  source.getConfiguration(),
+                  sourceDefIdToSpec.get(source.getSourceDefinitionId()));
+
+              return source.withConfiguration(partialConfig);
+            });
+        augmentedMap.put(ConfigSchema.SOURCE_CONNECTION, augmentedValue);
+      }
+
+      if (augmentedMap.containsKey(ConfigSchema.DESTINATION_CONNECTION)) {
+        final Stream<?> augmentedValue = augmentedMap.get(ConfigSchema.DESTINATION_CONNECTION)
+            .map(config -> {
+              final DestinationConnection destination = (DestinationConnection) config;
+
+              if (!destinationDefIdToSpec.containsKey(destination.getDestinationDefinitionId())) {
+                throw new RuntimeException(
+                    new ConfigNotFoundException(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destination.getDestinationDefinitionId()));
+              }
+
+              final var partialConfig = statefulSplitSecrets(
+                  destination.getWorkspaceId(),
+                  destination.getConfiguration(),
+                  destinationDefIdToSpec.get(destination.getDestinationDefinitionId()));
+
+              return destination.withConfiguration(partialConfig);
+            });
+        augmentedMap.put(ConfigSchema.DESTINATION_CONNECTION, augmentedValue);
+      }
+
+      configRepository.replaceAllConfigsNoSecrets(augmentedMap, dryRun);
+    } else {
+      configRepository.replaceAllConfigsNoSecrets(configs, dryRun);
+    }
+  }
+
+  public void loadData(final ConfigPersistence seedPersistence) throws IOException {
+    configRepository.loadDataNoSecrets(seedPersistence);
+  }
+
+}

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/split_secrets/MemorySecretPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/split_secrets/MemorySecretPersistence.java
@@ -25,4 +25,8 @@ public class MemorySecretPersistence implements SecretPersistence {
     secretMap.put(coordinate, payload);
   }
 
+  public Map<SecretCoordinate, String> getMap() {
+    return new HashMap<>(secretMap);
+  }
+
 }

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/split_secrets/SecretsHelpers.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/split_secrets/SecretsHelpers.java
@@ -60,7 +60,12 @@ public class SecretsHelpers {
   public static SplitSecretConfig splitConfig(final UUID workspaceId,
                                               final JsonNode fullConfig,
                                               final ConnectorSpecification spec) {
-    return internalSplitAndUpdateConfig(UUID::randomUUID, workspaceId, (coordinate) -> Optional.empty(), Jsons.emptyObject(), fullConfig,
+    return internalSplitAndUpdateConfig(
+        UUID::randomUUID,
+        workspaceId,
+        (coordinate) -> Optional.empty(),
+        Jsons.emptyObject(),
+        fullConfig,
         spec.getConnectionSpecification());
   }
 
@@ -87,7 +92,12 @@ public class SecretsHelpers {
                                                        final JsonNode newFullConfig,
                                                        final ConnectorSpecification spec,
                                                        final ReadOnlySecretPersistence secretReader) {
-    return internalSplitAndUpdateConfig(UUID::randomUUID, workspaceId, secretReader, oldPartialConfig, newFullConfig,
+    return internalSplitAndUpdateConfig(
+        UUID::randomUUID,
+        workspaceId,
+        secretReader,
+        oldPartialConfig,
+        newFullConfig,
         spec.getConnectionSpecification());
   }
 
@@ -332,7 +342,7 @@ public class SecretsHelpers {
     final var secretValue = secretPersistence.read(coordinate);
 
     if (secretValue.isEmpty()) {
-      throw new RuntimeException("That secret was not found in the store!");
+      throw new RuntimeException(String.format("That secret was not found in the store! Coordinate: %s", coordinate.getFullCoordinate()));
     }
 
     return new TextNode(secretValue.get());

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryTest.java
@@ -25,8 +25,6 @@ import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncState;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.State;
-import io.airbyte.config.persistence.split_secrets.MemorySecretPersistence;
-import io.airbyte.config.persistence.split_secrets.NoOpSecretsHydrator;
 import io.airbyte.db.Database;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
@@ -54,10 +52,7 @@ class ConfigRepositoryTest {
   void setup() {
     configPersistence = mock(ConfigPersistence.class);
     database = mock(Database.class);
-    final var secretPersistence = new MemorySecretPersistence();
-    configRepository =
-        spy(new ConfigRepository(configPersistence, new NoOpSecretsHydrator(), Optional.of(secretPersistence), Optional.of(secretPersistence),
-            database));
+    configRepository = spy(new ConfigRepository(configPersistence, database));
   }
 
   @AfterEach

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/SecretsRepositoryReaderTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/SecretsRepositoryReaderTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.persistence;
+
+class SecretsRepositoryReaderTest {
+
+  // private static final UUID WORKSPACE_ID = UUID.randomUUID();
+  //
+  // private ConfigPersistence configPersistence;
+  // private ConfigRepository configRepository;
+  //
+  // @BeforeEach
+  // void setup() {
+  // configPersistence = mock(ConfigPersistence.class);
+  // final var secretPersistence = new MemorySecretPersistence();
+  // configRepository =
+  // spy(new ConfigRepository(configPersistence, new NoOpSecretsHydrator(),
+  // Optional.of(secretPersistence), Optional.of(secretPersistence)));
+  // }
+  //
+  // @AfterEach
+  // void cleanUp() {
+  // reset(configPersistence);
+  // }
+  //
+  // @Test
+  // void testWorkspaceWithNullTombstone() throws ConfigNotFoundException, IOException,
+  // JsonValidationException {
+  // assertReturnsWorkspace(new StandardWorkspace().withWorkspaceId(WORKSPACE_ID));
+  // }
+  //
+  // @Test
+  // void testWorkspaceWithFalseTombstone() throws ConfigNotFoundException, IOException,
+  // JsonValidationException {
+  // assertReturnsWorkspace(new
+  // StandardWorkspace().withWorkspaceId(WORKSPACE_ID).withTombstone(false));
+  // }
+  //
+  // @Test
+  // void testWorkspaceWithTrueTombstone() throws ConfigNotFoundException, IOException,
+  // JsonValidationException {
+  // assertReturnsWorkspace(new
+  // StandardWorkspace().withWorkspaceId(WORKSPACE_ID).withTombstone(true));
+  // }
+  //
+  // void assertReturnsWorkspace(final StandardWorkspace workspace) throws ConfigNotFoundException,
+  // IOException, JsonValidationException {
+  // when(configPersistence.getConfig(ConfigSchema.STANDARD_WORKSPACE, WORKSPACE_ID.toString(),
+  // StandardWorkspace.class)).thenReturn(workspace);
+  //
+  // assertEquals(workspace, configRepository.getStandardWorkspace(WORKSPACE_ID, true));
+  // }
+  //
+  // @ParameterizedTest
+  // @ValueSource(booleans = {true, false})
+  // void testWorkspaceByConnectionId(final boolean isTombstone) throws ConfigNotFoundException,
+  // IOException, JsonValidationException {
+  // final StandardWorkspace workspace = new
+  // StandardWorkspace().withWorkspaceId(WORKSPACE_ID).withTombstone(isTombstone);
+  //
+  // final UUID connectionId = UUID.randomUUID();
+  // final UUID sourceId = UUID.randomUUID();
+  // final StandardSync mSync = new StandardSync()
+  // .withSourceId(sourceId);
+  // final SourceConnection mSourceConnection = new SourceConnection()
+  // .withWorkspaceId(WORKSPACE_ID);
+  // final StandardWorkspace mWorkflow = new StandardWorkspace()
+  // .withWorkspaceId(WORKSPACE_ID);
+  //
+  // doReturn(mSync)
+  // .when(configRepository)
+  // .getStandardSync(connectionId);
+  // doReturn(mSourceConnection)
+  // .when(configRepository)
+  // .getSourceConnection(sourceId);
+  // doReturn(mWorkflow)
+  // .when(configRepository)
+  // .getStandardWorkspace(WORKSPACE_ID, isTombstone);
+  //
+  // configRepository.getStandardWorkspaceFromConnection(connectionId, isTombstone);
+  //
+  // verify(configRepository).getStandardWorkspace(WORKSPACE_ID, isTombstone);
+  // }
+  //
+  // @Test
+  // void testGetConnectionState() throws Exception {
+  // final UUID connectionId = UUID.randomUUID();
+  // final State state = new State().withState(Jsons.deserialize("{ \"cursor\": 1000 }"));
+  // final StandardSyncState connectionState = new
+  // StandardSyncState().withConnectionId(connectionId).withState(state);
+  //
+  // when(configPersistence.getConfig(ConfigSchema.STANDARD_SYNC_STATE, connectionId.toString(),
+  // StandardSyncState.class))
+  // .thenThrow(new ConfigNotFoundException(ConfigSchema.STANDARD_SYNC_STATE, connectionId));
+  // assertEquals(Optional.empty(), configRepository.getConnectionState(connectionId));
+  //
+  // reset(configPersistence);
+  // when(configPersistence.getConfig(ConfigSchema.STANDARD_SYNC_STATE, connectionId.toString(),
+  // StandardSyncState.class))
+  // .thenReturn(connectionState);
+  // assertEquals(Optional.of(state), configRepository.getConnectionState(connectionId));
+  // }
+  //
+  // @Test
+  // void testUpdateConnectionState() throws Exception {
+  // final UUID connectionId = UUID.randomUUID();
+  // final State state1 = new State().withState(Jsons.deserialize("{ \"cursor\": 1 }"));
+  // final StandardSyncState connectionState1 = new
+  // StandardSyncState().withConnectionId(connectionId).withState(state1);
+  // final State state2 = new State().withState(Jsons.deserialize("{ \"cursor\": 2 }"));
+  // final StandardSyncState connectionState2 = new
+  // StandardSyncState().withConnectionId(connectionId).withState(state2);
+  //
+  // configRepository.updateConnectionState(connectionId, state1);
+  // verify(configPersistence, times(1)).writeConfig(ConfigSchema.STANDARD_SYNC_STATE,
+  // connectionId.toString(), connectionState1);
+  // configRepository.updateConnectionState(connectionId, state2);
+  // verify(configPersistence, times(1)).writeConfig(ConfigSchema.STANDARD_SYNC_STATE,
+  // connectionId.toString(), connectionState2);
+  // }
+  //
+  // @Test
+  // void testDeleteSourceDefinitionAndAssociations() throws JsonValidationException, IOException,
+  // ConfigNotFoundException {
+  // final StandardSourceDefinition sourceDefToDelete = new
+  // StandardSourceDefinition().withSourceDefinitionId(UUID.randomUUID());
+  // final StandardSourceDefinition sourceDefToStay = new
+  // StandardSourceDefinition().withSourceDefinitionId(UUID.randomUUID());
+  //
+  // final SourceConnection sourceConnectionToDelete = new
+  // SourceConnection().withSourceId(UUID.randomUUID())
+  // .withSourceDefinitionId(sourceDefToDelete.getSourceDefinitionId());
+  // final SourceConnection sourceConnectionToStay = new
+  // SourceConnection().withSourceId(UUID.randomUUID())
+  // .withSourceDefinitionId(sourceDefToStay.getSourceDefinitionId());
+  // when(configPersistence.listConfigs(ConfigSchema.SOURCE_CONNECTION,
+  // SourceConnection.class)).thenReturn(List.of(
+  // sourceConnectionToDelete,
+  // sourceConnectionToStay));
+  // when(configPersistence.listConfigs(ConfigSchema.DESTINATION_CONNECTION,
+  // DestinationConnection.class)).thenReturn(List.of());
+  //
+  // final StandardSync syncToDelete = new
+  // StandardSync().withConnectionId(UUID.randomUUID()).withSourceId(sourceConnectionToDelete.getSourceId())
+  // .withDestinationId(UUID.randomUUID());
+  // final StandardSync syncToStay = new
+  // StandardSync().withConnectionId(UUID.randomUUID()).withSourceId(sourceConnectionToStay.getSourceId())
+  // .withDestinationId(UUID.randomUUID());
+  //
+  // when(configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC,
+  // StandardSync.class)).thenReturn(List.of(syncToDelete, syncToStay));
+  //
+  // configRepository.deleteSourceDefinitionAndAssociations(sourceDefToDelete.getSourceDefinitionId());
+  //
+  // // verify that all records associated with sourceDefToDelete were deleted
+  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.STANDARD_SYNC,
+  // syncToDelete.getConnectionId().toString());
+  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.SOURCE_CONNECTION,
+  // sourceConnectionToDelete.getSourceId().toString());
+  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION,
+  // sourceDefToDelete.getSourceDefinitionId().toString());
+  //
+  // // verify that none of the records associated with sourceDefToStay were deleted
+  // verify(configPersistence, never()).deleteConfig(ConfigSchema.STANDARD_SYNC,
+  // syncToStay.getConnectionId().toString());
+  // verify(configPersistence, never()).deleteConfig(ConfigSchema.SOURCE_CONNECTION,
+  // sourceConnectionToStay.getSourceId().toString());
+  // verify(configPersistence, never()).deleteConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION,
+  // sourceDefToStay.getSourceDefinitionId().toString());
+  // }
+  //
+  // @Test
+  // void testDeleteDestinationDefinitionAndAssociations() throws JsonValidationException,
+  // IOException, ConfigNotFoundException {
+  // final StandardDestinationDefinition destDefToDelete = new
+  // StandardDestinationDefinition().withDestinationDefinitionId(UUID.randomUUID());
+  // final StandardDestinationDefinition destDefToStay = new
+  // StandardDestinationDefinition().withDestinationDefinitionId(UUID.randomUUID());
+  //
+  // final DestinationConnection destConnectionToDelete = new
+  // DestinationConnection().withDestinationId(UUID.randomUUID())
+  // .withDestinationDefinitionId(destDefToDelete.getDestinationDefinitionId());
+  // final DestinationConnection destConnectionToStay = new
+  // DestinationConnection().withDestinationId(UUID.randomUUID())
+  // .withDestinationDefinitionId(destDefToStay.getDestinationDefinitionId());
+  // when(configPersistence.listConfigs(ConfigSchema.DESTINATION_CONNECTION,
+  // DestinationConnection.class)).thenReturn(List.of(
+  // destConnectionToDelete,
+  // destConnectionToStay));
+  // when(configPersistence.listConfigs(ConfigSchema.SOURCE_CONNECTION,
+  // SourceConnection.class)).thenReturn(List.of());
+  //
+  // final StandardSync syncToDelete = new StandardSync().withConnectionId(UUID.randomUUID())
+  // .withDestinationId(destConnectionToDelete.getDestinationId())
+  // .withSourceId(UUID.randomUUID());
+  // final StandardSync syncToStay = new
+  // StandardSync().withConnectionId(UUID.randomUUID()).withDestinationId(destConnectionToStay.getDestinationId())
+  // .withSourceId(UUID.randomUUID());
+  //
+  // when(configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC,
+  // StandardSync.class)).thenReturn(List.of(syncToDelete, syncToStay));
+  //
+  // configRepository.deleteDestinationDefinitionAndAssociations(destDefToDelete.getDestinationDefinitionId());
+  //
+  // // verify that all records associated with destDefToDelete were deleted
+  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.STANDARD_SYNC,
+  // syncToDelete.getConnectionId().toString());
+  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.DESTINATION_CONNECTION,
+  // destConnectionToDelete.getDestinationId().toString());
+  // verify(configPersistence, times(1)).deleteConfig(
+  // ConfigSchema.STANDARD_DESTINATION_DEFINITION,
+  // destDefToDelete.getDestinationDefinitionId().toString());
+  //
+  // // verify that none of the records associated with destDefToStay were deleted
+  // verify(configPersistence, never()).deleteConfig(ConfigSchema.STANDARD_SYNC,
+  // syncToStay.getConnectionId().toString());
+  // verify(configPersistence, never()).deleteConfig(ConfigSchema.DESTINATION_CONNECTION,
+  // destConnectionToStay.getDestinationId().toString());
+  // verify(configPersistence, never()).deleteConfig(
+  // ConfigSchema.STANDARD_DESTINATION_DEFINITION,
+  // destDefToStay.getDestinationDefinitionId().toString());
+  // }
+  //
+  // @Test
+  // public void testUpdateFeedback() throws JsonValidationException, ConfigNotFoundException,
+  // IOException {
+  // final StandardWorkspace workspace = new
+  // StandardWorkspace().withWorkspaceId(WORKSPACE_ID).withTombstone(false);
+  // doReturn(workspace)
+  // .when(configRepository)
+  // .getStandardWorkspace(WORKSPACE_ID, false);
+  //
+  // configRepository.setFeedback(WORKSPACE_ID);
+  //
+  // assertTrue(workspace.getFeedbackDone());
+  // verify(configPersistence).writeConfig(ConfigSchema.STANDARD_WORKSPACE,
+  // workspace.getWorkspaceId().toString(), workspace);
+  // }
+
+}

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/SecretsRepositoryReaderTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/SecretsRepositoryReaderTest.java
@@ -4,239 +4,116 @@
 
 package io.airbyte.config.persistence;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ConfigSchema;
+import io.airbyte.config.DestinationConnection;
+import io.airbyte.config.SourceConnection;
+import io.airbyte.config.StandardWorkspace;
+import io.airbyte.config.persistence.split_secrets.MemorySecretPersistence;
+import io.airbyte.config.persistence.split_secrets.RealSecretsHydrator;
+import io.airbyte.config.persistence.split_secrets.SecretCoordinate;
+import io.airbyte.config.persistence.split_secrets.SecretsHydrator;
+import io.airbyte.validation.json.JsonValidationException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 class SecretsRepositoryReaderTest {
 
-  // private static final UUID WORKSPACE_ID = UUID.randomUUID();
-  //
-  // private ConfigPersistence configPersistence;
-  // private ConfigRepository configRepository;
-  //
-  // @BeforeEach
-  // void setup() {
-  // configPersistence = mock(ConfigPersistence.class);
-  // final var secretPersistence = new MemorySecretPersistence();
-  // configRepository =
-  // spy(new ConfigRepository(configPersistence, new NoOpSecretsHydrator(),
-  // Optional.of(secretPersistence), Optional.of(secretPersistence)));
-  // }
-  //
-  // @AfterEach
-  // void cleanUp() {
-  // reset(configPersistence);
-  // }
-  //
-  // @Test
-  // void testWorkspaceWithNullTombstone() throws ConfigNotFoundException, IOException,
-  // JsonValidationException {
-  // assertReturnsWorkspace(new StandardWorkspace().withWorkspaceId(WORKSPACE_ID));
-  // }
-  //
-  // @Test
-  // void testWorkspaceWithFalseTombstone() throws ConfigNotFoundException, IOException,
-  // JsonValidationException {
-  // assertReturnsWorkspace(new
-  // StandardWorkspace().withWorkspaceId(WORKSPACE_ID).withTombstone(false));
-  // }
-  //
-  // @Test
-  // void testWorkspaceWithTrueTombstone() throws ConfigNotFoundException, IOException,
-  // JsonValidationException {
-  // assertReturnsWorkspace(new
-  // StandardWorkspace().withWorkspaceId(WORKSPACE_ID).withTombstone(true));
-  // }
-  //
-  // void assertReturnsWorkspace(final StandardWorkspace workspace) throws ConfigNotFoundException,
-  // IOException, JsonValidationException {
-  // when(configPersistence.getConfig(ConfigSchema.STANDARD_WORKSPACE, WORKSPACE_ID.toString(),
-  // StandardWorkspace.class)).thenReturn(workspace);
-  //
-  // assertEquals(workspace, configRepository.getStandardWorkspace(WORKSPACE_ID, true));
-  // }
-  //
-  // @ParameterizedTest
-  // @ValueSource(booleans = {true, false})
-  // void testWorkspaceByConnectionId(final boolean isTombstone) throws ConfigNotFoundException,
-  // IOException, JsonValidationException {
-  // final StandardWorkspace workspace = new
-  // StandardWorkspace().withWorkspaceId(WORKSPACE_ID).withTombstone(isTombstone);
-  //
-  // final UUID connectionId = UUID.randomUUID();
-  // final UUID sourceId = UUID.randomUUID();
-  // final StandardSync mSync = new StandardSync()
-  // .withSourceId(sourceId);
-  // final SourceConnection mSourceConnection = new SourceConnection()
-  // .withWorkspaceId(WORKSPACE_ID);
-  // final StandardWorkspace mWorkflow = new StandardWorkspace()
-  // .withWorkspaceId(WORKSPACE_ID);
-  //
-  // doReturn(mSync)
-  // .when(configRepository)
-  // .getStandardSync(connectionId);
-  // doReturn(mSourceConnection)
-  // .when(configRepository)
-  // .getSourceConnection(sourceId);
-  // doReturn(mWorkflow)
-  // .when(configRepository)
-  // .getStandardWorkspace(WORKSPACE_ID, isTombstone);
-  //
-  // configRepository.getStandardWorkspaceFromConnection(connectionId, isTombstone);
-  //
-  // verify(configRepository).getStandardWorkspace(WORKSPACE_ID, isTombstone);
-  // }
-  //
-  // @Test
-  // void testGetConnectionState() throws Exception {
-  // final UUID connectionId = UUID.randomUUID();
-  // final State state = new State().withState(Jsons.deserialize("{ \"cursor\": 1000 }"));
-  // final StandardSyncState connectionState = new
-  // StandardSyncState().withConnectionId(connectionId).withState(state);
-  //
-  // when(configPersistence.getConfig(ConfigSchema.STANDARD_SYNC_STATE, connectionId.toString(),
-  // StandardSyncState.class))
-  // .thenThrow(new ConfigNotFoundException(ConfigSchema.STANDARD_SYNC_STATE, connectionId));
-  // assertEquals(Optional.empty(), configRepository.getConnectionState(connectionId));
-  //
-  // reset(configPersistence);
-  // when(configPersistence.getConfig(ConfigSchema.STANDARD_SYNC_STATE, connectionId.toString(),
-  // StandardSyncState.class))
-  // .thenReturn(connectionState);
-  // assertEquals(Optional.of(state), configRepository.getConnectionState(connectionId));
-  // }
-  //
-  // @Test
-  // void testUpdateConnectionState() throws Exception {
-  // final UUID connectionId = UUID.randomUUID();
-  // final State state1 = new State().withState(Jsons.deserialize("{ \"cursor\": 1 }"));
-  // final StandardSyncState connectionState1 = new
-  // StandardSyncState().withConnectionId(connectionId).withState(state1);
-  // final State state2 = new State().withState(Jsons.deserialize("{ \"cursor\": 2 }"));
-  // final StandardSyncState connectionState2 = new
-  // StandardSyncState().withConnectionId(connectionId).withState(state2);
-  //
-  // configRepository.updateConnectionState(connectionId, state1);
-  // verify(configPersistence, times(1)).writeConfig(ConfigSchema.STANDARD_SYNC_STATE,
-  // connectionId.toString(), connectionState1);
-  // configRepository.updateConnectionState(connectionId, state2);
-  // verify(configPersistence, times(1)).writeConfig(ConfigSchema.STANDARD_SYNC_STATE,
-  // connectionId.toString(), connectionState2);
-  // }
-  //
-  // @Test
-  // void testDeleteSourceDefinitionAndAssociations() throws JsonValidationException, IOException,
-  // ConfigNotFoundException {
-  // final StandardSourceDefinition sourceDefToDelete = new
-  // StandardSourceDefinition().withSourceDefinitionId(UUID.randomUUID());
-  // final StandardSourceDefinition sourceDefToStay = new
-  // StandardSourceDefinition().withSourceDefinitionId(UUID.randomUUID());
-  //
-  // final SourceConnection sourceConnectionToDelete = new
-  // SourceConnection().withSourceId(UUID.randomUUID())
-  // .withSourceDefinitionId(sourceDefToDelete.getSourceDefinitionId());
-  // final SourceConnection sourceConnectionToStay = new
-  // SourceConnection().withSourceId(UUID.randomUUID())
-  // .withSourceDefinitionId(sourceDefToStay.getSourceDefinitionId());
-  // when(configPersistence.listConfigs(ConfigSchema.SOURCE_CONNECTION,
-  // SourceConnection.class)).thenReturn(List.of(
-  // sourceConnectionToDelete,
-  // sourceConnectionToStay));
-  // when(configPersistence.listConfigs(ConfigSchema.DESTINATION_CONNECTION,
-  // DestinationConnection.class)).thenReturn(List.of());
-  //
-  // final StandardSync syncToDelete = new
-  // StandardSync().withConnectionId(UUID.randomUUID()).withSourceId(sourceConnectionToDelete.getSourceId())
-  // .withDestinationId(UUID.randomUUID());
-  // final StandardSync syncToStay = new
-  // StandardSync().withConnectionId(UUID.randomUUID()).withSourceId(sourceConnectionToStay.getSourceId())
-  // .withDestinationId(UUID.randomUUID());
-  //
-  // when(configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC,
-  // StandardSync.class)).thenReturn(List.of(syncToDelete, syncToStay));
-  //
-  // configRepository.deleteSourceDefinitionAndAssociations(sourceDefToDelete.getSourceDefinitionId());
-  //
-  // // verify that all records associated with sourceDefToDelete were deleted
-  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.STANDARD_SYNC,
-  // syncToDelete.getConnectionId().toString());
-  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.SOURCE_CONNECTION,
-  // sourceConnectionToDelete.getSourceId().toString());
-  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION,
-  // sourceDefToDelete.getSourceDefinitionId().toString());
-  //
-  // // verify that none of the records associated with sourceDefToStay were deleted
-  // verify(configPersistence, never()).deleteConfig(ConfigSchema.STANDARD_SYNC,
-  // syncToStay.getConnectionId().toString());
-  // verify(configPersistence, never()).deleteConfig(ConfigSchema.SOURCE_CONNECTION,
-  // sourceConnectionToStay.getSourceId().toString());
-  // verify(configPersistence, never()).deleteConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION,
-  // sourceDefToStay.getSourceDefinitionId().toString());
-  // }
-  //
-  // @Test
-  // void testDeleteDestinationDefinitionAndAssociations() throws JsonValidationException,
-  // IOException, ConfigNotFoundException {
-  // final StandardDestinationDefinition destDefToDelete = new
-  // StandardDestinationDefinition().withDestinationDefinitionId(UUID.randomUUID());
-  // final StandardDestinationDefinition destDefToStay = new
-  // StandardDestinationDefinition().withDestinationDefinitionId(UUID.randomUUID());
-  //
-  // final DestinationConnection destConnectionToDelete = new
-  // DestinationConnection().withDestinationId(UUID.randomUUID())
-  // .withDestinationDefinitionId(destDefToDelete.getDestinationDefinitionId());
-  // final DestinationConnection destConnectionToStay = new
-  // DestinationConnection().withDestinationId(UUID.randomUUID())
-  // .withDestinationDefinitionId(destDefToStay.getDestinationDefinitionId());
-  // when(configPersistence.listConfigs(ConfigSchema.DESTINATION_CONNECTION,
-  // DestinationConnection.class)).thenReturn(List.of(
-  // destConnectionToDelete,
-  // destConnectionToStay));
-  // when(configPersistence.listConfigs(ConfigSchema.SOURCE_CONNECTION,
-  // SourceConnection.class)).thenReturn(List.of());
-  //
-  // final StandardSync syncToDelete = new StandardSync().withConnectionId(UUID.randomUUID())
-  // .withDestinationId(destConnectionToDelete.getDestinationId())
-  // .withSourceId(UUID.randomUUID());
-  // final StandardSync syncToStay = new
-  // StandardSync().withConnectionId(UUID.randomUUID()).withDestinationId(destConnectionToStay.getDestinationId())
-  // .withSourceId(UUID.randomUUID());
-  //
-  // when(configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC,
-  // StandardSync.class)).thenReturn(List.of(syncToDelete, syncToStay));
-  //
-  // configRepository.deleteDestinationDefinitionAndAssociations(destDefToDelete.getDestinationDefinitionId());
-  //
-  // // verify that all records associated with destDefToDelete were deleted
-  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.STANDARD_SYNC,
-  // syncToDelete.getConnectionId().toString());
-  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.DESTINATION_CONNECTION,
-  // destConnectionToDelete.getDestinationId().toString());
-  // verify(configPersistence, times(1)).deleteConfig(
-  // ConfigSchema.STANDARD_DESTINATION_DEFINITION,
-  // destDefToDelete.getDestinationDefinitionId().toString());
-  //
-  // // verify that none of the records associated with destDefToStay were deleted
-  // verify(configPersistence, never()).deleteConfig(ConfigSchema.STANDARD_SYNC,
-  // syncToStay.getConnectionId().toString());
-  // verify(configPersistence, never()).deleteConfig(ConfigSchema.DESTINATION_CONNECTION,
-  // destConnectionToStay.getDestinationId().toString());
-  // verify(configPersistence, never()).deleteConfig(
-  // ConfigSchema.STANDARD_DESTINATION_DEFINITION,
-  // destDefToStay.getDestinationDefinitionId().toString());
-  // }
-  //
-  // @Test
-  // public void testUpdateFeedback() throws JsonValidationException, ConfigNotFoundException,
-  // IOException {
-  // final StandardWorkspace workspace = new
-  // StandardWorkspace().withWorkspaceId(WORKSPACE_ID).withTombstone(false);
-  // doReturn(workspace)
-  // .when(configRepository)
-  // .getStandardWorkspace(WORKSPACE_ID, false);
-  //
-  // configRepository.setFeedback(WORKSPACE_ID);
-  //
-  // assertTrue(workspace.getFeedbackDone());
-  // verify(configPersistence).writeConfig(ConfigSchema.STANDARD_WORKSPACE,
-  // workspace.getWorkspaceId().toString(), workspace);
-  // }
+  private static final UUID UUID1 = UUID.randomUUID();
+
+  private static final SecretCoordinate COORDINATE = new SecretCoordinate("pointer", 2);
+  private static final String SECRET = "abc";
+  private static final JsonNode PARTIAL_CONFIG =
+      Jsons.deserialize(String.format("{ \"username\": \"airbyte\", \"password\": { \"_secret\": \"%s\" } }", COORDINATE.getFullCoordinate()));
+  private static final JsonNode FULL_CONFIG = Jsons.deserialize(String.format("{ \"username\": \"airbyte\", \"password\": \"%s\"}", SECRET));
+
+  private static final SourceConnection SOURCE_WITH_PARTIAL_CONFIG = new SourceConnection()
+      .withSourceId(UUID1)
+      .withConfiguration(PARTIAL_CONFIG);
+  private static final SourceConnection SOURCE_WITH_FULL_CONFIG = Jsons.clone(SOURCE_WITH_PARTIAL_CONFIG)
+      .withConfiguration(FULL_CONFIG);
+
+  private static final DestinationConnection DESTINATION_WITH_PARTIAL_CONFIG = new DestinationConnection()
+      .withDestinationId(UUID1)
+      .withConfiguration(PARTIAL_CONFIG);
+  private static final DestinationConnection DESTINATION_WITH_FULL_CONFIG = Jsons.clone(DESTINATION_WITH_PARTIAL_CONFIG)
+      .withConfiguration(FULL_CONFIG);
+
+  private ConfigRepository configRepository;
+  private SecretsRepositoryReader secretsRepositoryReader;
+  private MemorySecretPersistence secretPersistence;
+
+  @BeforeEach
+  void setup() {
+    configRepository = mock(ConfigRepository.class);
+    secretPersistence = new MemorySecretPersistence();
+    final SecretsHydrator secretsHydrator = new RealSecretsHydrator(secretPersistence);
+    secretsRepositoryReader = new SecretsRepositoryReader(configRepository, secretsHydrator);
+  }
+
+  @Test
+  void testGetSourceWithSecrets() throws JsonValidationException, ConfigNotFoundException, IOException {
+    secretPersistence.write(COORDINATE, SECRET);
+    when(configRepository.getSourceConnection(UUID1)).thenReturn(SOURCE_WITH_PARTIAL_CONFIG);
+    assertEquals(SOURCE_WITH_FULL_CONFIG, secretsRepositoryReader.getSourceConnectionWithSecrets(UUID1));
+  }
+
+  @Test
+  void testListSourcesWithSecrets() throws JsonValidationException, IOException {
+    secretPersistence.write(COORDINATE, SECRET);
+    when(configRepository.listSourceConnection()).thenReturn(List.of(SOURCE_WITH_PARTIAL_CONFIG));
+    assertEquals(List.of(SOURCE_WITH_FULL_CONFIG), secretsRepositoryReader.listSourceConnectionWithSecrets());
+  }
+
+  @Test
+  void testGetDestinationWithSecrets() throws JsonValidationException, ConfigNotFoundException, IOException {
+    secretPersistence.write(COORDINATE, SECRET);
+    when(configRepository.getDestinationConnection(UUID1)).thenReturn(DESTINATION_WITH_PARTIAL_CONFIG);
+    assertEquals(DESTINATION_WITH_FULL_CONFIG, secretsRepositoryReader.getDestinationConnectionWithSecrets(UUID1));
+  }
+
+  @Test
+  void testListDestinationsWithSecrets() throws JsonValidationException, IOException {
+    secretPersistence.write(COORDINATE, SECRET);
+    when(configRepository.listDestinationConnection()).thenReturn(List.of(DESTINATION_WITH_PARTIAL_CONFIG));
+    assertEquals(List.of(DESTINATION_WITH_FULL_CONFIG), secretsRepositoryReader.listDestinationConnectionWithSecrets());
+  }
+
+  @Test
+  void testDumpConfigsWithSecrets() throws IOException {
+    secretPersistence.write(COORDINATE, SECRET);
+    final StandardWorkspace workspace = new StandardWorkspace().withWorkspaceId(UUID.randomUUID());
+
+    final Map<String, Stream<JsonNode>> dumpFromConfigRepository = new HashMap<>();
+    dumpFromConfigRepository.put(ConfigSchema.STANDARD_WORKSPACE.name(), Stream.of(Jsons.jsonNode(workspace)));
+    dumpFromConfigRepository.put(ConfigSchema.SOURCE_CONNECTION.name(), Stream.of(Jsons.jsonNode(SOURCE_WITH_PARTIAL_CONFIG)));
+    dumpFromConfigRepository.put(ConfigSchema.DESTINATION_CONNECTION.name(), Stream.of(Jsons.jsonNode(DESTINATION_WITH_PARTIAL_CONFIG)));
+    when(configRepository.dumpConfigsNoSecrets()).thenReturn(dumpFromConfigRepository);
+
+    final Map<String, List<JsonNode>> expected = new HashMap<>();
+    expected.put(ConfigSchema.STANDARD_WORKSPACE.name(), List.of(Jsons.jsonNode(workspace)));
+    expected.put(ConfigSchema.SOURCE_CONNECTION.name(), List.of(Jsons.jsonNode(SOURCE_WITH_FULL_CONFIG)));
+    expected.put(ConfigSchema.DESTINATION_CONNECTION.name(), List.of(Jsons.jsonNode(DESTINATION_WITH_FULL_CONFIG)));
+
+    final Map<String, List<JsonNode>> actual = secretsRepositoryReader.dumpConfigsWithSecrets()
+        .entrySet()
+        .stream()
+        .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().collect(Collectors.toList())));
+
+    assertEquals(expected, actual);
+  }
 
 }

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/SecretsRepositoryWriterTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/SecretsRepositoryWriterTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.persistence;
+
+class SecretsRepositoryWriterTest {
+  //
+  // private static final UUID WORKSPACE_ID = UUID.randomUUID();
+  //
+  // private ConfigPersistence configPersistence;
+  // private ConfigRepository configRepository;
+  //
+  // @BeforeEach
+  // void setup() {
+  // configPersistence = mock(ConfigPersistence.class);
+  // final var secretPersistence = new MemorySecretPersistence();
+  // configRepository =
+  // spy(new ConfigRepository(configPersistence, new NoOpSecretsHydrator(),
+  // Optional.of(secretPersistence), Optional.of(secretPersistence)));
+  // }
+  //
+  // @AfterEach
+  // void cleanUp() {
+  // reset(configPersistence);
+  // }
+  //
+  // @Test
+  // void testWorkspaceWithNullTombstone() throws ConfigNotFoundException, IOException,
+  // JsonValidationException {
+  // assertReturnsWorkspace(new StandardWorkspace().withWorkspaceId(WORKSPACE_ID));
+  // }
+  //
+  // @Test
+  // void testWorkspaceWithFalseTombstone() throws ConfigNotFoundException, IOException,
+  // JsonValidationException {
+  // assertReturnsWorkspace(new
+  // StandardWorkspace().withWorkspaceId(WORKSPACE_ID).withTombstone(false));
+  // }
+  //
+  // @Test
+  // void testWorkspaceWithTrueTombstone() throws ConfigNotFoundException, IOException,
+  // JsonValidationException {
+  // assertReturnsWorkspace(new
+  // StandardWorkspace().withWorkspaceId(WORKSPACE_ID).withTombstone(true));
+  // }
+  //
+  // void assertReturnsWorkspace(final StandardWorkspace workspace) throws ConfigNotFoundException,
+  // IOException, JsonValidationException {
+  // when(configPersistence.getConfig(ConfigSchema.STANDARD_WORKSPACE, WORKSPACE_ID.toString(),
+  // StandardWorkspace.class)).thenReturn(workspace);
+  //
+  // assertEquals(workspace, configRepository.getStandardWorkspace(WORKSPACE_ID, true));
+  // }
+  //
+  // @ParameterizedTest
+  // @ValueSource(booleans = {true, false})
+  // void testWorkspaceByConnectionId(final boolean isTombstone) throws ConfigNotFoundException,
+  // IOException, JsonValidationException {
+  // final StandardWorkspace workspace = new
+  // StandardWorkspace().withWorkspaceId(WORKSPACE_ID).withTombstone(isTombstone);
+  //
+  // final UUID connectionId = UUID.randomUUID();
+  // final UUID sourceId = UUID.randomUUID();
+  // final StandardSync mSync = new StandardSync()
+  // .withSourceId(sourceId);
+  // final SourceConnection mSourceConnection = new SourceConnection()
+  // .withWorkspaceId(WORKSPACE_ID);
+  // final StandardWorkspace mWorkflow = new StandardWorkspace()
+  // .withWorkspaceId(WORKSPACE_ID);
+  //
+  // doReturn(mSync)
+  // .when(configRepository)
+  // .getStandardSync(connectionId);
+  // doReturn(mSourceConnection)
+  // .when(configRepository)
+  // .getSourceConnection(sourceId);
+  // doReturn(mWorkflow)
+  // .when(configRepository)
+  // .getStandardWorkspace(WORKSPACE_ID, isTombstone);
+  //
+  // configRepository.getStandardWorkspaceFromConnection(connectionId, isTombstone);
+  //
+  // verify(configRepository).getStandardWorkspace(WORKSPACE_ID, isTombstone);
+  // }
+  //
+  // @Test
+  // void testGetConnectionState() throws Exception {
+  // final UUID connectionId = UUID.randomUUID();
+  // final State state = new State().withState(Jsons.deserialize("{ \"cursor\": 1000 }"));
+  // final StandardSyncState connectionState = new
+  // StandardSyncState().withConnectionId(connectionId).withState(state);
+  //
+  // when(configPersistence.getConfig(ConfigSchema.STANDARD_SYNC_STATE, connectionId.toString(),
+  // StandardSyncState.class))
+  // .thenThrow(new ConfigNotFoundException(ConfigSchema.STANDARD_SYNC_STATE, connectionId));
+  // assertEquals(Optional.empty(), configRepository.getConnectionState(connectionId));
+  //
+  // reset(configPersistence);
+  // when(configPersistence.getConfig(ConfigSchema.STANDARD_SYNC_STATE, connectionId.toString(),
+  // StandardSyncState.class))
+  // .thenReturn(connectionState);
+  // assertEquals(Optional.of(state), configRepository.getConnectionState(connectionId));
+  // }
+  //
+  // @Test
+  // void testUpdateConnectionState() throws Exception {
+  // final UUID connectionId = UUID.randomUUID();
+  // final State state1 = new State().withState(Jsons.deserialize("{ \"cursor\": 1 }"));
+  // final StandardSyncState connectionState1 = new
+  // StandardSyncState().withConnectionId(connectionId).withState(state1);
+  // final State state2 = new State().withState(Jsons.deserialize("{ \"cursor\": 2 }"));
+  // final StandardSyncState connectionState2 = new
+  // StandardSyncState().withConnectionId(connectionId).withState(state2);
+  //
+  // configRepository.updateConnectionState(connectionId, state1);
+  // verify(configPersistence, times(1)).writeConfig(ConfigSchema.STANDARD_SYNC_STATE,
+  // connectionId.toString(), connectionState1);
+  // configRepository.updateConnectionState(connectionId, state2);
+  // verify(configPersistence, times(1)).writeConfig(ConfigSchema.STANDARD_SYNC_STATE,
+  // connectionId.toString(), connectionState2);
+  // }
+  //
+  // @Test
+  // void testDeleteSourceDefinitionAndAssociations() throws JsonValidationException, IOException,
+  // ConfigNotFoundException {
+  // final StandardSourceDefinition sourceDefToDelete = new
+  // StandardSourceDefinition().withSourceDefinitionId(UUID.randomUUID());
+  // final StandardSourceDefinition sourceDefToStay = new
+  // StandardSourceDefinition().withSourceDefinitionId(UUID.randomUUID());
+  //
+  // final SourceConnection sourceConnectionToDelete = new
+  // SourceConnection().withSourceId(UUID.randomUUID())
+  // .withSourceDefinitionId(sourceDefToDelete.getSourceDefinitionId());
+  // final SourceConnection sourceConnectionToStay = new
+  // SourceConnection().withSourceId(UUID.randomUUID())
+  // .withSourceDefinitionId(sourceDefToStay.getSourceDefinitionId());
+  // when(configPersistence.listConfigs(ConfigSchema.SOURCE_CONNECTION,
+  // SourceConnection.class)).thenReturn(List.of(
+  // sourceConnectionToDelete,
+  // sourceConnectionToStay));
+  // when(configPersistence.listConfigs(ConfigSchema.DESTINATION_CONNECTION,
+  // DestinationConnection.class)).thenReturn(List.of());
+  //
+  // final StandardSync syncToDelete = new
+  // StandardSync().withConnectionId(UUID.randomUUID()).withSourceId(sourceConnectionToDelete.getSourceId())
+  // .withDestinationId(UUID.randomUUID());
+  // final StandardSync syncToStay = new
+  // StandardSync().withConnectionId(UUID.randomUUID()).withSourceId(sourceConnectionToStay.getSourceId())
+  // .withDestinationId(UUID.randomUUID());
+  //
+  // when(configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC,
+  // StandardSync.class)).thenReturn(List.of(syncToDelete, syncToStay));
+  //
+  // configRepository.deleteSourceDefinitionAndAssociations(sourceDefToDelete.getSourceDefinitionId());
+  //
+  // // verify that all records associated with sourceDefToDelete were deleted
+  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.STANDARD_SYNC,
+  // syncToDelete.getConnectionId().toString());
+  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.SOURCE_CONNECTION,
+  // sourceConnectionToDelete.getSourceId().toString());
+  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION,
+  // sourceDefToDelete.getSourceDefinitionId().toString());
+  //
+  // // verify that none of the records associated with sourceDefToStay were deleted
+  // verify(configPersistence, never()).deleteConfig(ConfigSchema.STANDARD_SYNC,
+  // syncToStay.getConnectionId().toString());
+  // verify(configPersistence, never()).deleteConfig(ConfigSchema.SOURCE_CONNECTION,
+  // sourceConnectionToStay.getSourceId().toString());
+  // verify(configPersistence, never()).deleteConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION,
+  // sourceDefToStay.getSourceDefinitionId().toString());
+  // }
+  //
+  // @Test
+  // void testDeleteDestinationDefinitionAndAssociations() throws JsonValidationException,
+  // IOException, ConfigNotFoundException {
+  // final StandardDestinationDefinition destDefToDelete = new
+  // StandardDestinationDefinition().withDestinationDefinitionId(UUID.randomUUID());
+  // final StandardDestinationDefinition destDefToStay = new
+  // StandardDestinationDefinition().withDestinationDefinitionId(UUID.randomUUID());
+  //
+  // final DestinationConnection destConnectionToDelete = new
+  // DestinationConnection().withDestinationId(UUID.randomUUID())
+  // .withDestinationDefinitionId(destDefToDelete.getDestinationDefinitionId());
+  // final DestinationConnection destConnectionToStay = new
+  // DestinationConnection().withDestinationId(UUID.randomUUID())
+  // .withDestinationDefinitionId(destDefToStay.getDestinationDefinitionId());
+  // when(configPersistence.listConfigs(ConfigSchema.DESTINATION_CONNECTION,
+  // DestinationConnection.class)).thenReturn(List.of(
+  // destConnectionToDelete,
+  // destConnectionToStay));
+  // when(configPersistence.listConfigs(ConfigSchema.SOURCE_CONNECTION,
+  // SourceConnection.class)).thenReturn(List.of());
+  //
+  // final StandardSync syncToDelete = new StandardSync().withConnectionId(UUID.randomUUID())
+  // .withDestinationId(destConnectionToDelete.getDestinationId())
+  // .withSourceId(UUID.randomUUID());
+  // final StandardSync syncToStay = new
+  // StandardSync().withConnectionId(UUID.randomUUID()).withDestinationId(destConnectionToStay.getDestinationId())
+  // .withSourceId(UUID.randomUUID());
+  //
+  // when(configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC,
+  // StandardSync.class)).thenReturn(List.of(syncToDelete, syncToStay));
+  //
+  // configRepository.deleteDestinationDefinitionAndAssociations(destDefToDelete.getDestinationDefinitionId());
+  //
+  // // verify that all records associated with destDefToDelete were deleted
+  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.STANDARD_SYNC,
+  // syncToDelete.getConnectionId().toString());
+  // verify(configPersistence, times(1)).deleteConfig(ConfigSchema.DESTINATION_CONNECTION,
+  // destConnectionToDelete.getDestinationId().toString());
+  // verify(configPersistence, times(1)).deleteConfig(
+  // ConfigSchema.STANDARD_DESTINATION_DEFINITION,
+  // destDefToDelete.getDestinationDefinitionId().toString());
+  //
+  // // verify that none of the records associated with destDefToStay were deleted
+  // verify(configPersistence, never()).deleteConfig(ConfigSchema.STANDARD_SYNC,
+  // syncToStay.getConnectionId().toString());
+  // verify(configPersistence, never()).deleteConfig(ConfigSchema.DESTINATION_CONNECTION,
+  // destConnectionToStay.getDestinationId().toString());
+  // verify(configPersistence, never()).deleteConfig(
+  // ConfigSchema.STANDARD_DESTINATION_DEFINITION,
+  // destDefToStay.getDestinationDefinitionId().toString());
+  // }
+  //
+  // @Test
+  // public void testUpdateFeedback() throws JsonValidationException, ConfigNotFoundException,
+  // IOException {
+  // final StandardWorkspace workspace = new
+  // StandardWorkspace().withWorkspaceId(WORKSPACE_ID).withTombstone(false);
+  // doReturn(workspace)
+  // .when(configRepository)
+  // .getStandardWorkspace(WORKSPACE_ID, false);
+  //
+  // configRepository.setFeedback(WORKSPACE_ID);
+  //
+  // assertTrue(workspace.getFeedbackDone());
+  // verify(configPersistence).writeConfig(ConfigSchema.STANDARD_WORKSPACE,
+  // workspace.getWorkspaceId().toString(), workspace);
+  // }
+
+}

--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
@@ -24,8 +24,6 @@ import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.DatabaseConfigPersistence;
-import io.airbyte.config.persistence.split_secrets.SecretPersistence;
-import io.airbyte.config.persistence.split_secrets.SecretsHydrator;
 import io.airbyte.db.Database;
 import io.airbyte.db.instance.configs.ConfigsDatabaseInstance;
 import io.airbyte.db.instance.jobs.JobsDatabaseInstance;
@@ -47,7 +45,6 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -252,11 +249,7 @@ public class SchedulerApp {
         configs.getConfigDatabaseUrl())
             .getInitialized();
     final ConfigPersistence configPersistence = DatabaseConfigPersistence.createWithValidation(configDatabase);
-    final Optional<SecretPersistence> secretPersistence = SecretPersistence.getLongLived(configs);
-    final Optional<SecretPersistence> ephemeralSecretPersistence = SecretPersistence.getEphemeral(configs);
-    final SecretsHydrator secretsHydrator = SecretPersistence.getSecretsHydrator(configs);
-    final ConfigRepository configRepository =
-        new ConfigRepository(configPersistence, secretsHydrator, secretPersistence, ephemeralSecretPersistence, configDatabase);
+    final ConfigRepository configRepository = new ConfigRepository(configPersistence, configDatabase);
 
     final JobPersistence jobPersistence = new DefaultJobPersistence(jobDatabase);
     final JobCleaner jobCleaner = new JobCleaner(

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/WorkspaceHelperTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/WorkspaceHelperTest.java
@@ -26,7 +26,6 @@ import io.airbyte.config.StandardSyncOperation.OperatorType;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
-import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.models.Job;
 import io.airbyte.scheduler.models.JobStatus;
 import io.airbyte.validation.json.JsonValidationException;
@@ -77,7 +76,6 @@ class WorkspaceHelperTest {
   ConfigRepository configRepository;
   JobPersistence jobPersistence;
   WorkspaceHelper workspaceHelper;
-  ConnectorSpecification emptyConnectorSpec;
 
   @BeforeEach
   public void setup() throws IOException, JsonValidationException, ConfigNotFoundException {
@@ -94,9 +92,6 @@ class WorkspaceHelperTest {
     when(configRepository.getStandardSyncOperation(not(eq(OPERATION_ID)))).thenThrow(ConfigNotFoundException.class);
 
     workspaceHelper = new WorkspaceHelper(configRepository, jobPersistence);
-
-    emptyConnectorSpec = mock(ConnectorSpecification.class);
-    when(emptyConnectorSpec.getConnectionSpecification()).thenReturn(Jsons.emptyObject());
   }
 
   @Test

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpExporter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpExporter.java
@@ -16,6 +16,7 @@ import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.scheduler.persistence.WorkspaceHelper;
 import io.airbyte.validation.json.JsonValidationException;
@@ -53,11 +54,16 @@ public class ConfigDumpExporter {
   private static final String CONFIG_FOLDER_NAME = "airbyte_config";
   private static final String VERSION_FILE_NAME = "VERSION";
   private final ConfigRepository configRepository;
+  private final SecretsRepositoryReader secretsRepositoryReader;
   private final JobPersistence jobPersistence;
   private final WorkspaceHelper workspaceHelper;
 
-  public ConfigDumpExporter(final ConfigRepository configRepository, final JobPersistence jobPersistence, final WorkspaceHelper workspaceHelper) {
+  public ConfigDumpExporter(final ConfigRepository configRepository,
+                            final SecretsRepositoryReader secretsRepositoryReader,
+                            final JobPersistence jobPersistence,
+                            final WorkspaceHelper workspaceHelper) {
     this.configRepository = configRepository;
+    this.secretsRepositoryReader = secretsRepositoryReader;
     this.jobPersistence = jobPersistence;
     this.workspaceHelper = workspaceHelper;
   }
@@ -83,7 +89,7 @@ public class ConfigDumpExporter {
   }
 
   private void dumpConfigsDatabase(final Path parentFolder) throws IOException {
-    for (final Map.Entry<String, Stream<JsonNode>> configEntry : configRepository.dumpConfigs().entrySet()) {
+    for (final Map.Entry<String, Stream<JsonNode>> configEntry : secretsRepositoryReader.dumpConfigs().entrySet()) {
       writeConfigsToArchive(parentFolder, configEntry.getKey(), configEntry.getValue());
     }
   }
@@ -132,7 +138,7 @@ public class ConfigDumpExporter {
     final Collection<SourceConnection> sourceConnections = writeConfigsToArchive(
         parentFolder,
         ConfigSchema.SOURCE_CONNECTION.name(),
-        configRepository::listSourceConnectionWithSecrets,
+        secretsRepositoryReader::listSourceConnectionWithSecrets,
         (sourceConnection) -> workspaceId.equals(sourceConnection.getWorkspaceId()));
     writeConfigsToArchive(parentFolder, ConfigSchema.STANDARD_SOURCE_DEFINITION.name(),
         () -> listSourceDefinition(sourceConnections),
@@ -141,7 +147,7 @@ public class ConfigDumpExporter {
     final Collection<DestinationConnection> destinationConnections = writeConfigsToArchive(
         parentFolder,
         ConfigSchema.DESTINATION_CONNECTION.name(),
-        configRepository::listDestinationConnectionWithSecrets,
+        secretsRepositoryReader::listDestinationConnectionWithSecrets,
         (destinationConnection) -> workspaceId.equals(destinationConnection.getWorkspaceId()));
     writeConfigsToArchive(parentFolder, ConfigSchema.STANDARD_DESTINATION_DEFINITION.name(),
         () -> listDestinationDefinition(destinationConnections),

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpExporter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpExporter.java
@@ -89,7 +89,7 @@ public class ConfigDumpExporter {
   }
 
   private void dumpConfigsDatabase(final Path parentFolder) throws IOException {
-    for (final Map.Entry<String, Stream<JsonNode>> configEntry : secretsRepositoryReader.dumpConfigs().entrySet()) {
+    for (final Map.Entry<String, Stream<JsonNode>> configEntry : secretsRepositoryReader.dumpConfigsWithSecrets().entrySet()) {
       writeConfigsToArchive(parentFolder, configEntry.getKey(), configEntry.getValue());
     }
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImporter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImporter.java
@@ -75,7 +75,6 @@ public class ConfigDumpImporter {
 
   public ConfigDumpImporter(final ConfigRepository configRepository,
                             final SecretsRepositoryWriter secretsRepositoryWriter,
-
                             final JobPersistence jobPersistence,
                             final WorkspaceHelper workspaceHelper,
                             final boolean importDefinitions) {
@@ -134,7 +133,7 @@ public class ConfigDumpImporter {
 
       // 4. Import Configs and update connector definitions
       importConfigsFromArchive(sourceRoot, false);
-      secretsRepositoryWriter.loadData(seedPersistence);
+      configRepository.loadDataNoSecrets(seedPersistence);
 
       // 5. Set DB version
       LOGGER.info("Setting the DB Airbyte version to : " + targetVersion);

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImporter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImporter.java
@@ -26,6 +26,7 @@ import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.scheduler.persistence.DefaultJobPersistence;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.scheduler.persistence.WorkspaceHelper;
@@ -66,20 +67,24 @@ public class ConfigDumpImporter {
   private static final Path TMP_AIRBYTE_STAGED_RESOURCES = Path.of("/tmp/airbyte_staged_resources");
 
   private final ConfigRepository configRepository;
+  private final SecretsRepositoryWriter secretsRepositoryWriter;
   private final WorkspaceHelper workspaceHelper;
   private final JsonSchemaValidator jsonSchemaValidator;
   private final JobPersistence jobPersistence;
   private final boolean importDefinitions;
 
   public ConfigDumpImporter(final ConfigRepository configRepository,
+                            final SecretsRepositoryWriter secretsRepositoryWriter,
+
                             final JobPersistence jobPersistence,
                             final WorkspaceHelper workspaceHelper,
                             final boolean importDefinitions) {
-    this(configRepository, jobPersistence, workspaceHelper, new JsonSchemaValidator(), importDefinitions);
+    this(configRepository, secretsRepositoryWriter, jobPersistence, workspaceHelper, new JsonSchemaValidator(), importDefinitions);
   }
 
   @VisibleForTesting
   public ConfigDumpImporter(final ConfigRepository configRepository,
+                            final SecretsRepositoryWriter secretsRepositoryWriter,
                             final JobPersistence jobPersistence,
                             final WorkspaceHelper workspaceHelper,
                             final JsonSchemaValidator jsonSchemaValidator,
@@ -87,6 +92,7 @@ public class ConfigDumpImporter {
     this.jsonSchemaValidator = jsonSchemaValidator;
     this.jobPersistence = jobPersistence;
     this.configRepository = configRepository;
+    this.secretsRepositoryWriter = secretsRepositoryWriter;
     this.workspaceHelper = workspaceHelper;
     this.importDefinitions = importDefinitions;
   }
@@ -128,7 +134,7 @@ public class ConfigDumpImporter {
 
       // 4. Import Configs and update connector definitions
       importConfigsFromArchive(sourceRoot, false);
-      configRepository.loadData(seedPersistence);
+      secretsRepositoryWriter.loadData(seedPersistence);
 
       // 5. Set DB version
       LOGGER.info("Setting the DB Airbyte version to : " + targetVersion);
@@ -182,7 +188,7 @@ public class ConfigDumpImporter {
       final ConfigSchema configSchema = configSchemaOptional.get();
       data.put(configSchema, readConfigsFromArchive(sourceRoot, configSchema));
     }
-    configRepository.replaceAllConfigs(data, dryRun);
+    secretsRepositoryWriter.replaceAllConfigs(data, dryRun);
   }
 
   private <T> Stream<T> readConfigsFromArchive(final Path storageRoot, final ConfigSchema schemaType)
@@ -362,7 +368,7 @@ public class ConfigDumpImporter {
                 if (sourceDefinition.getTombstone() != null && sourceDefinition.getTombstone()) {
                   return;
                 }
-                configRepository.writeSourceConnection(sourceConnection, sourceDefinition.getSpec());
+                secretsRepositoryWriter.writeSourceConnection(sourceConnection, sourceDefinition.getSpec());
               } catch (final ConfigNotFoundException e) {
                 return;
               }
@@ -393,7 +399,7 @@ public class ConfigDumpImporter {
                 if (destinationDefinition.getTombstone() != null && destinationDefinition.getTombstone()) {
                   return;
                 }
-                configRepository.writeDestinationConnection(destinationConnection, destinationDefinition.getSpec());
+                secretsRepositoryWriter.writeDestinationConnection(destinationConnection, destinationDefinition.getSpec());
               } catch (final ConfigNotFoundException e) {
                 return;
               }

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigurationApiFactory.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigurationApiFactory.java
@@ -12,6 +12,8 @@ import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.db.Database;
 import io.airbyte.scheduler.client.EventRunner;
 import io.airbyte.scheduler.client.SchedulerJobClient;
@@ -32,6 +34,8 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
   private static ConfigRepository configRepository;
   private static JobPersistence jobPersistence;
   private static ConfigPersistence seed;
+  private static SecretsRepositoryReader secretsRepositoryReader;
+  private static SecretsRepositoryWriter secretsRepositoryWriter;
   private static SchedulerJobClient schedulerJobClient;
   private static SynchronousSchedulerClient synchronousSchedulerClient;
   private static FileTtlManager archiveTtlManager;
@@ -52,6 +56,8 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
   public static void setValues(
                                final WorkflowServiceStubs temporalService,
                                final ConfigRepository configRepository,
+                               final SecretsRepositoryReader secretsRepositoryReader,
+                               final SecretsRepositoryWriter secretsRepositoryWriter,
                                final JobPersistence jobPersistence,
                                final ConfigPersistence seed,
                                final SchedulerJobClient schedulerJobClient,
@@ -73,6 +79,8 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
     ConfigurationApiFactory.configRepository = configRepository;
     ConfigurationApiFactory.jobPersistence = jobPersistence;
     ConfigurationApiFactory.seed = seed;
+    ConfigurationApiFactory.secretsRepositoryReader = secretsRepositoryReader;
+    ConfigurationApiFactory.secretsRepositoryWriter = secretsRepositoryWriter;
     ConfigurationApiFactory.schedulerJobClient = schedulerJobClient;
     ConfigurationApiFactory.synchronousSchedulerClient = synchronousSchedulerClient;
     ConfigurationApiFactory.archiveTtlManager = archiveTtlManager;
@@ -100,6 +108,8 @@ public class ConfigurationApiFactory implements Factory<ConfigurationApi> {
         ConfigurationApiFactory.configRepository,
         ConfigurationApiFactory.jobPersistence,
         ConfigurationApiFactory.seed,
+        ConfigurationApiFactory.secretsRepositoryReader,
+        ConfigurationApiFactory.secretsRepositoryWriter,
         ConfigurationApiFactory.schedulerJobClient,
         ConfigurationApiFactory.synchronousSchedulerClient,
         ConfigurationApiFactory.archiveTtlManager,

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -20,6 +20,8 @@ import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.DatabaseConfigPersistence;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.config.persistence.split_secrets.SecretPersistence;
 import io.airbyte.config.persistence.split_secrets.SecretsHydrator;
 import io.airbyte.db.Database;
@@ -165,8 +167,10 @@ public class ServerApp implements ServerRunnable {
     final SecretsHydrator secretsHydrator = SecretPersistence.getSecretsHydrator(configs);
     final Optional<SecretPersistence> secretPersistence = SecretPersistence.getLongLived(configs);
     final Optional<SecretPersistence> ephemeralSecretPersistence = SecretPersistence.getEphemeral(configs);
-    final ConfigRepository configRepository =
-        new ConfigRepository(configPersistence, secretsHydrator, secretPersistence, ephemeralSecretPersistence, configDatabase);
+    final ConfigRepository configRepository = new ConfigRepository(configPersistence, configDatabase);
+    final SecretsRepositoryReader secretsRepositoryReader = new SecretsRepositoryReader(configRepository, secretsHydrator);
+    final SecretsRepositoryWriter secretsRepositoryWriter =
+        new SecretsRepositoryWriter(configRepository, secretPersistence, ephemeralSecretPersistence);
 
     LOGGER.info("Creating jobs persistence...");
     final Database jobDatabase = jobsDatabaseInstance.getInitialized();
@@ -204,6 +208,8 @@ public class ServerApp implements ServerRunnable {
         syncSchedulerClient,
         temporalService,
         configRepository,
+        secretsRepositoryReader,
+        secretsRepositoryWriter,
         jobPersistence,
         seed,
         configDatabase,

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerFactory.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerFactory.java
@@ -64,7 +64,6 @@ public interface ServerFactory {
                                  final ConfigPersistence seed,
                                  final Database configsDatabase,
                                  final Database jobsDatabase,
-
                                  final TrackingClient trackingClient,
                                  final WorkerEnvironment workerEnvironment,
                                  final LogConfigs logConfigs,

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerFactory.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerFactory.java
@@ -12,6 +12,8 @@ import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.db.Database;
 import io.airbyte.scheduler.client.EventRunner;
 import io.airbyte.scheduler.client.SchedulerJobClient;
@@ -32,6 +34,8 @@ public interface ServerFactory {
                         SynchronousSchedulerClient cachingSchedulerClient,
                         WorkflowServiceStubs temporalService,
                         ConfigRepository configRepository,
+                        SecretsRepositoryReader secretsRepositoryReader,
+                        SecretsRepositoryWriter secretsRepositoryWriter,
                         JobPersistence jobPersistence,
                         ConfigPersistence seed,
                         Database configsDatabase,
@@ -54,10 +58,13 @@ public interface ServerFactory {
                                  final SynchronousSchedulerClient synchronousSchedulerClient,
                                  final WorkflowServiceStubs temporalService,
                                  final ConfigRepository configRepository,
+                                 final SecretsRepositoryReader secretsRepositoryReader,
+                                 final SecretsRepositoryWriter secretsRepositoryWriter,
                                  final JobPersistence jobPersistence,
                                  final ConfigPersistence seed,
                                  final Database configsDatabase,
                                  final Database jobsDatabase,
+
                                  final TrackingClient trackingClient,
                                  final WorkerEnvironment workerEnvironment,
                                  final LogConfigs logConfigs,
@@ -72,6 +79,8 @@ public interface ServerFactory {
       ConfigurationApiFactory.setValues(
           temporalService,
           configRepository,
+          secretsRepositoryReader,
+          secretsRepositoryWriter,
           jobPersistence,
           seed,
           schedulerJobClient,

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/ConfigurationUpdate.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/ConfigurationUpdate.java
@@ -12,6 +12,7 @@ import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.validation.json.JsonValidationException;
@@ -21,21 +22,25 @@ import java.util.UUID;
 public class ConfigurationUpdate {
 
   private final ConfigRepository configRepository;
+  private final SecretsRepositoryReader secretsRepositoryReader;
   private final JsonSecretsProcessor secretsProcessor;
 
-  public ConfigurationUpdate(final ConfigRepository configRepository) {
-    this(configRepository, new JsonSecretsProcessor());
+  public ConfigurationUpdate(final ConfigRepository configRepository, final SecretsRepositoryReader secretsRepositoryReader) {
+    this(configRepository, secretsRepositoryReader, new JsonSecretsProcessor());
   }
 
-  public ConfigurationUpdate(final ConfigRepository configRepository, final JsonSecretsProcessor secretsProcessor) {
+  public ConfigurationUpdate(final ConfigRepository configRepository,
+                             final SecretsRepositoryReader secretsRepositoryReader,
+                             final JsonSecretsProcessor secretsProcessor) {
     this.configRepository = configRepository;
+    this.secretsRepositoryReader = secretsRepositoryReader;
     this.secretsProcessor = secretsProcessor;
   }
 
   public SourceConnection source(final UUID sourceId, final String sourceName, final JsonNode newConfiguration)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     // get existing source
-    final SourceConnection persistedSource = configRepository.getSourceConnectionWithSecrets(sourceId);
+    final SourceConnection persistedSource = secretsRepositoryReader.getSourceConnectionWithSecrets(sourceId);
     persistedSource.setName(sourceName);
     // get spec
     final StandardSourceDefinition sourceDefinition = configRepository.getStandardSourceDefinition(persistedSource.getSourceDefinitionId());
@@ -52,7 +57,7 @@ public class ConfigurationUpdate {
   public DestinationConnection destination(final UUID destinationId, final String destName, final JsonNode newConfiguration)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     // get existing destination
-    final DestinationConnection persistedDestination = configRepository.getDestinationConnectionWithSecrets(destinationId);
+    final DestinationConnection persistedDestination = secretsRepositoryReader.getDestinationConnectionWithSecrets(destinationId);
     persistedDestination.setName(destName);
     // get spec
     final StandardDestinationDefinition destinationDefinition = configRepository

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ArchiveHandler.java
@@ -14,6 +14,8 @@ import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.scheduler.persistence.WorkspaceHelper;
 import io.airbyte.server.ConfigDumpExporter;
@@ -38,6 +40,8 @@ public class ArchiveHandler {
 
   public ArchiveHandler(final AirbyteVersion version,
                         final ConfigRepository configRepository,
+                        final SecretsRepositoryReader secretsRepositoryReader,
+                        final SecretsRepositoryWriter secretsRepositoryWriter,
                         final JobPersistence jobPersistence,
                         final ConfigPersistence seed,
                         final WorkspaceHelper workspaceHelper,
@@ -46,8 +50,8 @@ public class ArchiveHandler {
     this(
         version,
         fileTtlManager,
-        new ConfigDumpExporter(configRepository, jobPersistence, workspaceHelper),
-        new ConfigDumpImporter(configRepository, jobPersistence, workspaceHelper, importDefinitions),
+        new ConfigDumpExporter(configRepository, secretsRepositoryReader, jobPersistence, workspaceHelper),
+        new ConfigDumpImporter(configRepository, secretsRepositoryWriter, jobPersistence, workspaceHelper, importDefinitions),
         seed);
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
@@ -287,7 +287,7 @@ public class DestinationHandler {
       throws ConfigNotFoundException, IOException, JsonValidationException {
 
     // remove secrets from config before returning the read
-    final DestinationConnection dci = Jsons.clone(configRepository.getDestinationConnectionWithSecrets(destinationId));
+    final DestinationConnection dci = Jsons.clone(secretsRepositoryReader.getDestinationConnectionWithSecrets(destinationId));
     final StandardDestinationDefinition standardDestinationDefinition =
         configRepository.getStandardDestinationDefinition(dci.getDestinationDefinitionId());
     return toDestinationRead(dci, standardDestinationDefinition);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
@@ -21,6 +21,8 @@ import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.server.converters.ConfigurationUpdate;
@@ -40,18 +42,24 @@ public class DestinationHandler {
   private final ConnectionsHandler connectionsHandler;
   private final Supplier<UUID> uuidGenerator;
   private final ConfigRepository configRepository;
+  private final SecretsRepositoryReader secretsRepositoryReader;
+  private final SecretsRepositoryWriter secretsRepositoryWriter;
   private final JsonSchemaValidator validator;
   private final ConfigurationUpdate configurationUpdate;
   private final JsonSecretsProcessor secretsProcessor;
 
   @VisibleForTesting
   DestinationHandler(final ConfigRepository configRepository,
+                     final SecretsRepositoryReader secretsRepositoryReader,
+                     final SecretsRepositoryWriter secretsRepositoryWriter,
                      final JsonSchemaValidator integrationSchemaValidation,
                      final ConnectionsHandler connectionsHandler,
                      final Supplier<UUID> uuidGenerator,
                      final JsonSecretsProcessor secretsProcessor,
                      final ConfigurationUpdate configurationUpdate) {
     this.configRepository = configRepository;
+    this.secretsRepositoryReader = secretsRepositoryReader;
+    this.secretsRepositoryWriter = secretsRepositoryWriter;
     this.validator = integrationSchemaValidation;
     this.connectionsHandler = connectionsHandler;
     this.uuidGenerator = uuidGenerator;
@@ -60,15 +68,19 @@ public class DestinationHandler {
   }
 
   public DestinationHandler(final ConfigRepository configRepository,
+                            final SecretsRepositoryReader secretsRepositoryReader,
+                            final SecretsRepositoryWriter secretsRepositoryWriter,
                             final JsonSchemaValidator integrationSchemaValidation,
                             final ConnectionsHandler connectionsHandler) {
     this(
         configRepository,
+        secretsRepositoryReader,
+        secretsRepositoryWriter,
         integrationSchemaValidation,
         connectionsHandler,
         UUID::randomUUID,
         new JsonSecretsProcessor(),
-        new ConfigurationUpdate(configRepository));
+        new ConfigurationUpdate(configRepository, secretsRepositoryReader));
   }
 
   public DestinationRead createDestination(final DestinationCreate destinationCreate)
@@ -112,7 +124,7 @@ public class DestinationHandler {
       connectionsHandler.deleteConnection(connectionRead.getConnectionId());
     }
 
-    final var fullConfig = configRepository.getDestinationConnectionWithSecrets(destination.getDestinationId()).getConfiguration();
+    final var fullConfig = secretsRepositoryReader.getDestinationConnectionWithSecrets(destination.getDestinationId()).getConfiguration();
 
     // persist
     persistDestinationConnection(
@@ -251,7 +263,7 @@ public class DestinationHandler {
         .withDestinationId(destinationId)
         .withConfiguration(configurationJson)
         .withTombstone(tombstone);
-    configRepository.writeDestinationConnection(destinationConnection, getSpec(destinationDefinitionId));
+    secretsRepositoryWriter.writeDestinationConnection(destinationConnection, getSpec(destinationDefinitionId));
   }
 
   private DestinationRead buildDestinationRead(final UUID destinationId) throws JsonValidationException, IOException, ConfigNotFoundException {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -43,6 +43,8 @@ import io.airbyte.config.State;
 import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.client.EventRunner;
@@ -77,6 +79,7 @@ public class SchedulerHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerHandler.class);
 
   private final ConfigRepository configRepository;
+  private final SecretsRepositoryWriter secretsRepositoryWriter;
   private final SchedulerJobClient schedulerJobClient;
   private final SynchronousSchedulerClient synchronousSchedulerClient;
   private final ConfigurationUpdate configurationUpdate;
@@ -92,6 +95,8 @@ public class SchedulerHandler {
   private final FeatureFlags featureFlags;
 
   public SchedulerHandler(final ConfigRepository configRepository,
+                          final SecretsRepositoryReader secretsRepositoryReader,
+                          final SecretsRepositoryWriter secretsRepositoryWriter,
                           final SchedulerJobClient schedulerJobClient,
                           final SynchronousSchedulerClient synchronousSchedulerClient,
                           final JobPersistence jobPersistence,
@@ -104,9 +109,11 @@ public class SchedulerHandler {
                           final FeatureFlags featureFlags) {
     this(
         configRepository,
+        secretsRepositoryWriter,
+        secretsRepositoryReader,
         schedulerJobClient,
         synchronousSchedulerClient,
-        new ConfigurationUpdate(configRepository),
+        new ConfigurationUpdate(configRepository, secretsRepositoryReader),
         new JsonSchemaValidator(),
         jobPersistence,
         jobNotifier,
@@ -121,6 +128,8 @@ public class SchedulerHandler {
 
   @VisibleForTesting
   SchedulerHandler(final ConfigRepository configRepository,
+                   final SecretsRepositoryWriter secretsRepositoryWriter,
+                   final SecretsRepositoryReader secretsRepositoryReader,
                    final SchedulerJobClient schedulerJobClient,
                    final SynchronousSchedulerClient synchronousSchedulerClient,
                    final ConfigurationUpdate configurationUpdate,
@@ -135,6 +144,7 @@ public class SchedulerHandler {
                    final FeatureFlags featureFlags,
                    final JobConverter jobConverter) {
     this.configRepository = configRepository;
+    this.secretsRepositoryWriter = secretsRepositoryWriter;
     this.schedulerJobClient = schedulerJobClient;
     this.synchronousSchedulerClient = synchronousSchedulerClient;
     this.configurationUpdate = configurationUpdate;
@@ -162,7 +172,7 @@ public class SchedulerHandler {
   public CheckConnectionRead checkSourceConnectionFromSourceCreate(final SourceCoreConfig sourceConfig)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final StandardSourceDefinition sourceDef = configRepository.getStandardSourceDefinition(sourceConfig.getSourceDefinitionId());
-    final var partialConfig = configRepository.statefulSplitEphemeralSecrets(
+    final var partialConfig = secretsRepositoryWriter.statefulSplitEphemeralSecrets(
         sourceConfig.getConnectionConfiguration(),
         sourceDef.getSpec());
 
@@ -202,7 +212,7 @@ public class SchedulerHandler {
   public CheckConnectionRead checkDestinationConnectionFromDestinationCreate(final DestinationCoreConfig destinationConfig)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final StandardDestinationDefinition destDef = configRepository.getStandardDestinationDefinition(destinationConfig.getDestinationDefinitionId());
-    final var partialConfig = configRepository.statefulSplitEphemeralSecrets(
+    final var partialConfig = secretsRepositoryWriter.statefulSplitEphemeralSecrets(
         destinationConfig.getConnectionConfiguration(),
         destDef.getSpec());
 
@@ -243,7 +253,7 @@ public class SchedulerHandler {
   public SourceDiscoverSchemaRead discoverSchemaForSourceFromSourceCreate(final SourceCoreConfig sourceCreate)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     final StandardSourceDefinition sourceDef = configRepository.getStandardSourceDefinition(sourceCreate.getSourceDefinitionId());
-    final var partialConfig = configRepository.statefulSplitEphemeralSecrets(
+    final var partialConfig = secretsRepositoryWriter.statefulSplitEphemeralSecrets(
         sourceCreate.getConnectionConfiguration(),
         sourceDef.getSpec());
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -259,7 +259,7 @@ public class SourceHandler {
   private SourceRead buildSourceReadWithSecrets(final UUID sourceId)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     // read configuration from db
-    final SourceConnection sourceConnection = configRepository.getSourceConnectionWithSecrets(sourceId);
+    final SourceConnection sourceConnection = secretsRepositoryReader.getSourceConnectionWithSecrets(sourceId);
     final StandardSourceDefinition standardSourceDefinition = configRepository
         .getStandardSourceDefinition(sourceConnection.getSourceDefinitionId());
     return toSourceRead(sourceConnection, standardSourceDefinition);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -20,6 +20,8 @@ import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.server.converters.ConfigurationUpdate;
@@ -34,18 +36,24 @@ public class SourceHandler {
 
   private final Supplier<UUID> uuidGenerator;
   private final ConfigRepository configRepository;
+  private final SecretsRepositoryReader secretsRepositoryReader;
+  private final SecretsRepositoryWriter secretsRepositoryWriter;
   private final JsonSchemaValidator validator;
   private final ConnectionsHandler connectionsHandler;
   private final ConfigurationUpdate configurationUpdate;
   private final JsonSecretsProcessor secretsProcessor;
 
   SourceHandler(final ConfigRepository configRepository,
+                final SecretsRepositoryReader secretsRepositoryReader,
+                final SecretsRepositoryWriter secretsRepositoryWriter,
                 final JsonSchemaValidator integrationSchemaValidation,
                 final ConnectionsHandler connectionsHandler,
                 final Supplier<UUID> uuidGenerator,
                 final JsonSecretsProcessor secretsProcessor,
                 final ConfigurationUpdate configurationUpdate) {
     this.configRepository = configRepository;
+    this.secretsRepositoryReader = secretsRepositoryReader;
+    this.secretsRepositoryWriter = secretsRepositoryWriter;
     this.validator = integrationSchemaValidation;
     this.connectionsHandler = connectionsHandler;
     this.uuidGenerator = uuidGenerator;
@@ -54,15 +62,19 @@ public class SourceHandler {
   }
 
   public SourceHandler(final ConfigRepository configRepository,
+                       final SecretsRepositoryReader secretsRepositoryReader,
+                       final SecretsRepositoryWriter secretsRepositoryWriter,
                        final JsonSchemaValidator integrationSchemaValidation,
                        final ConnectionsHandler connectionsHandler) {
     this(
         configRepository,
+        secretsRepositoryReader,
+        secretsRepositoryWriter,
         integrationSchemaValidation,
         connectionsHandler,
         UUID::randomUUID,
         new JsonSecretsProcessor(),
-        new ConfigurationUpdate(configRepository));
+        new ConfigurationUpdate(configRepository, secretsRepositoryReader));
   }
 
   public SourceRead createSource(final SourceCreate sourceCreate)
@@ -211,7 +223,7 @@ public class SourceHandler {
     }
 
     final ConnectorSpecification spec = getSpecFromSourceId(source.getSourceId());
-    final var fullConfig = configRepository.getSourceConnectionWithSecrets(source.getSourceId()).getConfiguration();
+    final var fullConfig = secretsRepositoryReader.getSourceConnectionWithSecrets(source.getSourceId()).getConfiguration();
 
     // persist
     persistSourceConnection(
@@ -286,7 +298,7 @@ public class SourceHandler {
         .withTombstone(tombstone)
         .withConfiguration(configurationJson);
 
-    configRepository.writeSourceConnection(sourceConnection, spec);
+    secretsRepositoryWriter.writeSourceConnection(sourceConnection, spec);
   }
 
   protected static SourceRead toSourceRead(final SourceConnection sourceConnection,

--- a/airbyte-server/src/test/java/io/airbyte/server/apis/ConfigurationApiTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/apis/ConfigurationApiTest.java
@@ -17,6 +17,8 @@ import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.db.Database;
 import io.airbyte.scheduler.client.EventRunner;
 import io.airbyte.scheduler.client.SchedulerJobClient;
@@ -40,6 +42,8 @@ public class ConfigurationApiTest {
         mock(ConfigRepository.class),
         mock(JobPersistence.class),
         mock(ConfigPersistence.class),
+        mock(SecretsRepositoryReader.class),
+        mock(SecretsRepositoryWriter.class),
         mock(SchedulerJobClient.class),
         mock(SynchronousSchedulerClient.class),
         mock(FileTtlManager.class),

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/ConfigurationUpdateTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/ConfigurationUpdateTest.java
@@ -17,6 +17,7 @@ import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConnectorSpecification;
@@ -73,20 +74,22 @@ class ConfigurationUpdateTest {
       .withConfiguration(NEW_CONFIGURATION);
 
   private ConfigRepository configRepository;
+  private SecretsRepositoryReader secretsRepositoryReader;
   private JsonSecretsProcessor secretsProcessor;
   private ConfigurationUpdate configurationUpdate;
 
   @BeforeEach
   void setup() {
     configRepository = mock(ConfigRepository.class);
+    secretsRepositoryReader = mock(SecretsRepositoryReader.class);
     secretsProcessor = mock(JsonSecretsProcessor.class);
 
-    configurationUpdate = new ConfigurationUpdate(configRepository, secretsProcessor);
+    configurationUpdate = new ConfigurationUpdate(configRepository, secretsRepositoryReader, secretsProcessor);
   }
 
   @Test
   void testSourceUpdate() throws JsonValidationException, IOException, ConfigNotFoundException {
-    when(configRepository.getSourceConnectionWithSecrets(UUID1)).thenReturn(ORIGINAL_SOURCE_CONNECTION);
+    when(secretsRepositoryReader.getSourceConnectionWithSecrets(UUID1)).thenReturn(ORIGINAL_SOURCE_CONNECTION);
     when(configRepository.getStandardSourceDefinition(UUID2)).thenReturn(SOURCE_DEFINITION);
     when(secretsProcessor.copySecrets(ORIGINAL_CONFIGURATION, NEW_CONFIGURATION, SPEC)).thenReturn(NEW_CONFIGURATION);
 
@@ -97,7 +100,7 @@ class ConfigurationUpdateTest {
 
   @Test
   void testDestinationUpdate() throws JsonValidationException, IOException, ConfigNotFoundException {
-    when(configRepository.getDestinationConnectionWithSecrets(UUID1)).thenReturn(ORIGINAL_DESTINATION_CONNECTION);
+    when(secretsRepositoryReader.getDestinationConnectionWithSecrets(UUID1)).thenReturn(ORIGINAL_DESTINATION_CONNECTION);
     when(configRepository.getStandardDestinationDefinition(UUID2)).thenReturn(DESTINATION_DEFINITION);
     when(secretsProcessor.copySecrets(ORIGINAL_CONFIGURATION, NEW_CONFIGURATION, SPEC)).thenReturn(NEW_CONFIGURATION);
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -33,6 +33,8 @@ import io.airbyte.config.init.YamlSeedConfigPersistence;
 import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.DatabaseConfigPersistence;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.config.persistence.split_secrets.NoOpSecretsHydrator;
 import io.airbyte.db.Database;
 import io.airbyte.db.instance.test.TestDatabaseProviders;
@@ -74,6 +76,8 @@ public class ArchiveHandlerTest {
   private Database jobDatabase;
   private Database configDatabase;
   private JobPersistence jobPersistence;
+  private SecretsRepositoryReader secretsRepositoryReader;
+  private SecretsRepositoryWriter secretsRepositoryWriter;
   private DatabaseConfigPersistence configPersistence;
   private ConfigPersistence seedPersistence;
 
@@ -114,13 +118,17 @@ public class ArchiveHandlerTest {
     configPersistence = new DatabaseConfigPersistence(jobDatabase);
     configPersistence.replaceAllConfigs(Collections.emptyMap(), false);
     configPersistence.loadData(seedPersistence);
-    configRepository = new ConfigRepository(configPersistence, new NoOpSecretsHydrator(), Optional.empty(), Optional.empty(), configDatabase);
+    configRepository = new ConfigRepository(configPersistence, configDatabase);
+    secretsRepositoryReader = new SecretsRepositoryReader(configRepository, new NoOpSecretsHydrator());
+    secretsRepositoryWriter = new SecretsRepositoryWriter(configRepository, Optional.empty(), Optional.empty());
 
     jobPersistence.setVersion(VERSION.serialize());
 
     archiveHandler = new ArchiveHandler(
         VERSION,
         configRepository,
+        secretsRepositoryReader,
+        secretsRepositoryWriter,
         jobPersistence,
         YamlSeedConfigPersistence.getDefault(),
         new WorkspaceHelper(configRepository, jobPersistence),
@@ -139,21 +147,21 @@ public class ArchiveHandlerTest {
    */
   @Test
   void testFullExportImportRoundTrip() throws Exception {
-    assertSameConfigDump(seedPersistence.dumpConfigs(), configRepository.dumpConfigs());
+    assertSameConfigDump(seedPersistence.dumpConfigs(), secretsRepositoryReader.dumpConfigs());
 
     // Export the configs.
     File archive = archiveHandler.exportData();
 
     // After deleting the configs, the dump becomes empty.
     configPersistence.replaceAllConfigs(Collections.emptyMap(), false);
-    assertSameConfigDump(Collections.emptyMap(), configRepository.dumpConfigs());
+    assertSameConfigDump(Collections.emptyMap(), secretsRepositoryReader.dumpConfigs());
 
     // After importing the configs, the dump is restored.
     assertTrue(archive.exists());
     final ImportRead importResult = archiveHandler.importData(archive);
     assertFalse(archive.exists());
     assertEquals(StatusEnum.SUCCEEDED, importResult.getStatus());
-    assertSameConfigDump(seedPersistence.dumpConfigs(), configRepository.dumpConfigs());
+    assertSameConfigDump(seedPersistence.dumpConfigs(), secretsRepositoryReader.dumpConfigs());
 
     // When a connector definition is in use, it will not be updated.
     final UUID sourceS3DefinitionId = UUID.fromString("69589781-7828-43c5-9f63-8925b1c1ccc2");
@@ -213,12 +221,12 @@ public class ArchiveHandlerTest {
 
   @Test
   void testLightWeightExportImportRoundTrip() throws Exception {
-    assertSameConfigDump(seedPersistence.dumpConfigs(), configRepository.dumpConfigs());
+    assertSameConfigDump(seedPersistence.dumpConfigs(), secretsRepositoryReader.dumpConfigs());
 
     // Insert some workspace data
     final UUID workspaceId = UUID.randomUUID();
     setupTestData(workspaceId);
-    final Map<String, Stream<JsonNode>> workspaceDump = configRepository.dumpConfigs();
+    final Map<String, Stream<JsonNode>> workspaceDump = secretsRepositoryReader.dumpConfigs();
 
     // Insert some other workspace data
     setupTestData(UUID.randomUUID());
@@ -230,11 +238,11 @@ public class ArchiveHandlerTest {
 
     // After deleting all the configs, the dump becomes empty.
     configPersistence.replaceAllConfigs(Collections.emptyMap(), false);
-    assertSameConfigDump(Collections.emptyMap(), configRepository.dumpConfigs());
+    assertSameConfigDump(Collections.emptyMap(), secretsRepositoryReader.dumpConfigs());
 
     // Restore default seed data
     configPersistence.loadData(seedPersistence);
-    assertSameConfigDump(seedPersistence.dumpConfigs(), configRepository.dumpConfigs());
+    assertSameConfigDump(seedPersistence.dumpConfigs(), secretsRepositoryReader.dumpConfigs());
 
     setupWorkspaceData(workspaceId);
 
@@ -247,11 +255,11 @@ public class ArchiveHandlerTest {
         .resourceId(uploadRead.getResourceId())
         .workspaceId(workspaceId));
     assertEquals(StatusEnum.SUCCEEDED, importResult.getStatus());
-    assertSameConfigDump(workspaceDump, configRepository.dumpConfigs());
+    assertSameConfigDump(workspaceDump, secretsRepositoryReader.dumpConfigs());
 
     // we modify first workspace
     setupTestData(workspaceId);
-    final Map<String, Stream<JsonNode>> secondWorkspaceDump = configRepository.dumpConfigs();
+    final Map<String, Stream<JsonNode>> secondWorkspaceDump = secretsRepositoryReader.dumpConfigs();
 
     final UUID secondWorkspaceId = UUID.randomUUID();
     setupWorkspaceData(secondWorkspaceId);
@@ -264,7 +272,7 @@ public class ArchiveHandlerTest {
         .workspaceId(secondWorkspaceId));
     assertEquals(StatusEnum.SUCCEEDED, secondImportResult.getStatus());
 
-    final UUID secondSourceId = configRepository.listSourceConnectionWithSecrets()
+    final UUID secondSourceId = secretsRepositoryReader.listSourceConnectionWithSecrets()
         .stream()
         .filter(sourceConnection -> secondWorkspaceId.equals(sourceConnection.getWorkspaceId()))
         .map(SourceConnection::getSourceId)
@@ -293,7 +301,7 @@ public class ArchiveHandlerTest {
     when(emptyConnectorSpec.getConnectionSpecification()).thenReturn(Jsons.emptyObject());
 
     configRepository.writeStandardSourceDefinition(standardSourceDefinition);
-    configRepository.writeSourceConnection(sourceConnection, emptyConnectorSpec);
+    secretsRepositoryWriter.writeSourceConnection(sourceConnection, emptyConnectorSpec);
 
     // check that first workspace is unchanged even though modifications were made to second workspace
     // (that contains similar connections from importing the same archive)
@@ -307,7 +315,7 @@ public class ArchiveHandlerTest {
         .resourceId(uploadRead.getResourceId())
         .workspaceId(workspaceId));
     assertEquals(StatusEnum.SUCCEEDED, importResult.getStatus());
-    assertSameConfigDump(secondWorkspaceDump, configRepository.dumpConfigs());
+    assertSameConfigDump(secondWorkspaceDump, secretsRepositoryReader.dumpConfigs());
   }
 
   private void setupWorkspaceData(final UUID workspaceId) throws IOException, JsonValidationException {

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -147,21 +147,21 @@ public class ArchiveHandlerTest {
    */
   @Test
   void testFullExportImportRoundTrip() throws Exception {
-    assertSameConfigDump(seedPersistence.dumpConfigs(), secretsRepositoryReader.dumpConfigs());
+    assertSameConfigDump(seedPersistence.dumpConfigs(), secretsRepositoryReader.dumpConfigsWithSecrets());
 
     // Export the configs.
     File archive = archiveHandler.exportData();
 
     // After deleting the configs, the dump becomes empty.
     configPersistence.replaceAllConfigs(Collections.emptyMap(), false);
-    assertSameConfigDump(Collections.emptyMap(), secretsRepositoryReader.dumpConfigs());
+    assertSameConfigDump(Collections.emptyMap(), secretsRepositoryReader.dumpConfigsWithSecrets());
 
     // After importing the configs, the dump is restored.
     assertTrue(archive.exists());
     final ImportRead importResult = archiveHandler.importData(archive);
     assertFalse(archive.exists());
     assertEquals(StatusEnum.SUCCEEDED, importResult.getStatus());
-    assertSameConfigDump(seedPersistence.dumpConfigs(), secretsRepositoryReader.dumpConfigs());
+    assertSameConfigDump(seedPersistence.dumpConfigs(), secretsRepositoryReader.dumpConfigsWithSecrets());
 
     // When a connector definition is in use, it will not be updated.
     final UUID sourceS3DefinitionId = UUID.fromString("69589781-7828-43c5-9f63-8925b1c1ccc2");
@@ -221,12 +221,12 @@ public class ArchiveHandlerTest {
 
   @Test
   void testLightWeightExportImportRoundTrip() throws Exception {
-    assertSameConfigDump(seedPersistence.dumpConfigs(), secretsRepositoryReader.dumpConfigs());
+    assertSameConfigDump(seedPersistence.dumpConfigs(), secretsRepositoryReader.dumpConfigsWithSecrets());
 
     // Insert some workspace data
     final UUID workspaceId = UUID.randomUUID();
     setupTestData(workspaceId);
-    final Map<String, Stream<JsonNode>> workspaceDump = secretsRepositoryReader.dumpConfigs();
+    final Map<String, Stream<JsonNode>> workspaceDump = secretsRepositoryReader.dumpConfigsWithSecrets();
 
     // Insert some other workspace data
     setupTestData(UUID.randomUUID());
@@ -238,11 +238,11 @@ public class ArchiveHandlerTest {
 
     // After deleting all the configs, the dump becomes empty.
     configPersistence.replaceAllConfigs(Collections.emptyMap(), false);
-    assertSameConfigDump(Collections.emptyMap(), secretsRepositoryReader.dumpConfigs());
+    assertSameConfigDump(Collections.emptyMap(), secretsRepositoryReader.dumpConfigsWithSecrets());
 
     // Restore default seed data
     configPersistence.loadData(seedPersistence);
-    assertSameConfigDump(seedPersistence.dumpConfigs(), secretsRepositoryReader.dumpConfigs());
+    assertSameConfigDump(seedPersistence.dumpConfigs(), secretsRepositoryReader.dumpConfigsWithSecrets());
 
     setupWorkspaceData(workspaceId);
 
@@ -255,11 +255,11 @@ public class ArchiveHandlerTest {
         .resourceId(uploadRead.getResourceId())
         .workspaceId(workspaceId));
     assertEquals(StatusEnum.SUCCEEDED, importResult.getStatus());
-    assertSameConfigDump(workspaceDump, secretsRepositoryReader.dumpConfigs());
+    assertSameConfigDump(workspaceDump, secretsRepositoryReader.dumpConfigsWithSecrets());
 
     // we modify first workspace
     setupTestData(workspaceId);
-    final Map<String, Stream<JsonNode>> secondWorkspaceDump = secretsRepositoryReader.dumpConfigs();
+    final Map<String, Stream<JsonNode>> secondWorkspaceDump = secretsRepositoryReader.dumpConfigsWithSecrets();
 
     final UUID secondWorkspaceId = UUID.randomUUID();
     setupWorkspaceData(secondWorkspaceId);
@@ -315,7 +315,7 @@ public class ArchiveHandlerTest {
         .resourceId(uploadRead.getResourceId())
         .workspaceId(workspaceId));
     assertEquals(StatusEnum.SUCCEEDED, importResult.getStatus());
-    assertSameConfigDump(secondWorkspaceDump, secretsRepositoryReader.dumpConfigs());
+    assertSameConfigDump(secondWorkspaceDump, secretsRepositoryReader.dumpConfigsWithSecrets());
   }
 
   private void setupWorkspaceData(final UUID workspaceId) throws IOException, JsonValidationException {

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
@@ -285,7 +285,7 @@ class DestinationHandlerTest {
     final DestinationIdRequestBody destinationIdRequestBody = new DestinationIdRequestBody().destinationId(destinationRead.getDestinationId());
 
     when(uuidGenerator.get()).thenReturn(clonedConnection.getDestinationId());
-    when(configRepository.getDestinationConnectionWithSecrets(destinationConnection.getDestinationId())).thenReturn(destinationConnection);
+    when(secretsRepositoryReader.getDestinationConnectionWithSecrets(destinationConnection.getDestinationId())).thenReturn(destinationConnection);
     when(configRepository.getDestinationConnection(clonedConnection.getDestinationId())).thenReturn(clonedConnection);
 
     when(configRepository.getStandardDestinationDefinition(destinationDefinitionSpecificationRead.getDestinationDefinitionId()))

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
@@ -27,6 +27,8 @@ import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.server.converters.ConfigurationUpdate;
@@ -43,6 +45,8 @@ import org.junit.jupiter.api.Test;
 class DestinationHandlerTest {
 
   private ConfigRepository configRepository;
+  private SecretsRepositoryReader secretsRepositoryReader;
+  private SecretsRepositoryWriter secretsRepositoryWriter;
   private StandardDestinationDefinition standardDestinationDefinition;
   private DestinationDefinitionSpecificationRead destinationDefinitionSpecificationRead;
   private DestinationConnection destinationConnection;
@@ -59,6 +63,8 @@ class DestinationHandlerTest {
   @BeforeEach
   void setUp() throws IOException {
     configRepository = mock(ConfigRepository.class);
+    secretsRepositoryReader = mock(SecretsRepositoryReader.class);
+    secretsRepositoryWriter = mock(SecretsRepositoryWriter.class);
     validator = mock(JsonSchemaValidator.class);
     uuidGenerator = mock(Supplier.class);
     connectionsHandler = mock(ConnectionsHandler.class);
@@ -91,7 +97,14 @@ class DestinationHandlerTest {
     destinationConnection = DestinationHelpers.generateDestination(standardDestinationDefinition.getDestinationDefinitionId());
 
     destinationHandler =
-        new DestinationHandler(configRepository, validator, connectionsHandler, uuidGenerator, secretsProcessor, configurationUpdate);
+        new DestinationHandler(configRepository,
+            secretsRepositoryReader,
+            secretsRepositoryWriter,
+            validator,
+            connectionsHandler,
+            uuidGenerator,
+            secretsProcessor,
+            configurationUpdate);
   }
 
   @Test
@@ -125,7 +138,7 @@ class DestinationHandlerTest {
     assertEquals(expectedDestinationRead, actualDestinationRead);
 
     verify(validator).ensure(destinationDefinitionSpecificationRead.getConnectionSpecification(), destinationConnection.getConfiguration());
-    verify(configRepository).writeDestinationConnection(destinationConnection, connectorSpecification);
+    verify(secretsRepositoryWriter).writeDestinationConnection(destinationConnection, connectorSpecification);
     verify(secretsProcessor)
         .maskSecrets(destinationConnection.getConfiguration(), destinationDefinitionSpecificationRead.getConnectionSpecification());
   }
@@ -168,7 +181,7 @@ class DestinationHandlerTest {
     assertEquals(expectedDestinationRead, actualDestinationRead);
 
     verify(secretsProcessor).maskSecrets(newConfiguration, destinationDefinitionSpecificationRead.getConnectionSpecification());
-    verify(configRepository).writeDestinationConnection(expectedDestinationConnection, connectorSpecification);
+    verify(secretsRepositoryWriter).writeDestinationConnection(expectedDestinationConnection, connectorSpecification);
     verify(validator).ensure(destinationDefinitionSpecificationRead.getConnectionSpecification(), newConfiguration);
   }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
@@ -201,7 +201,7 @@ class SourceHandlerTest {
     final SourceIdRequestBody sourceIdRequestBody = new SourceIdRequestBody().sourceId(sourceRead.getSourceId());
 
     when(uuidGenerator.get()).thenReturn(clonedConnection.getSourceId());
-    when(configRepository.getSourceConnectionWithSecrets(sourceConnection.getSourceId())).thenReturn(sourceConnection);
+    when(secretsRepositoryReader.getSourceConnectionWithSecrets(sourceConnection.getSourceId())).thenReturn(sourceConnection);
     when(configRepository.getSourceConnection(clonedConnection.getSourceId())).thenReturn(clonedConnection);
 
     when(configRepository.getStandardSourceDefinition(sourceDefinitionSpecificationRead.getSourceDefinitionId()))

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
@@ -31,6 +31,8 @@ import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.server.converters.ConfigurationUpdate;
@@ -49,6 +51,8 @@ import org.junit.jupiter.api.Test;
 class SourceHandlerTest {
 
   private ConfigRepository configRepository;
+  private SecretsRepositoryReader secretsRepositoryReader;
+  private SecretsRepositoryWriter secretsRepositoryWriter;
   private StandardSourceDefinition standardSourceDefinition;
   private SourceDefinitionSpecificationRead sourceDefinitionSpecificationRead;
   private SourceConnection sourceConnection;
@@ -65,6 +69,8 @@ class SourceHandlerTest {
   @BeforeEach
   void setUp() throws IOException {
     configRepository = mock(ConfigRepository.class);
+    secretsRepositoryReader = mock(SecretsRepositoryReader.class);
+    secretsRepositoryWriter = mock(SecretsRepositoryWriter.class);
     validator = mock(JsonSchemaValidator.class);
     connectionsHandler = mock(ConnectionsHandler.class);
     configurationUpdate = mock(ConfigurationUpdate.class);
@@ -90,7 +96,14 @@ class SourceHandlerTest {
 
     sourceConnection = SourceHelpers.generateSource(standardSourceDefinition.getSourceDefinitionId());
 
-    sourceHandler = new SourceHandler(configRepository, validator, connectionsHandler, uuidGenerator, secretsProcessor, configurationUpdate);
+    sourceHandler = new SourceHandler(configRepository,
+        secretsRepositoryReader,
+        secretsRepositoryWriter,
+        validator,
+        connectionsHandler,
+        uuidGenerator,
+        secretsProcessor,
+        configurationUpdate);
   }
 
   @Test
@@ -116,7 +129,7 @@ class SourceHandlerTest {
     assertEquals(expectedSourceRead, actualSourceRead);
 
     verify(secretsProcessor).maskSecrets(sourceCreate.getConnectionConfiguration(), sourceDefinitionSpecificationRead.getConnectionSpecification());
-    verify(configRepository).writeSourceConnection(sourceConnection, connectorSpecification);
+    verify(secretsRepositoryWriter).writeSourceConnection(sourceConnection, connectorSpecification);
     verify(validator).ensure(sourceDefinitionSpecificationRead.getConnectionSpecification(), sourceConnection.getConfiguration());
   }
 
@@ -157,7 +170,7 @@ class SourceHandlerTest {
     assertEquals(expectedSourceRead, actualSourceRead);
 
     verify(secretsProcessor).maskSecrets(newConfiguration, sourceDefinitionSpecificationRead.getConnectionSpecification());
-    verify(configRepository).writeSourceConnection(expectedSourceConnection, connectorSpecification);
+    verify(secretsRepositoryWriter).writeSourceConnection(expectedSourceConnection, connectorSpecification);
     verify(validator).ensure(sourceDefinitionSpecificationRead.getConnectionSpecification(), newConfiguration);
   }
 
@@ -281,7 +294,7 @@ class SourceHandlerTest {
     when(configRepository.getSourceConnection(sourceConnection.getSourceId()))
         .thenReturn(sourceConnection)
         .thenReturn(expectedSourceConnection);
-    when(configRepository.getSourceConnectionWithSecrets(sourceConnection.getSourceId()))
+    when(secretsRepositoryReader.getSourceConnectionWithSecrets(sourceConnection.getSourceId()))
         .thenReturn(sourceConnection)
         .thenReturn(expectedSourceConnection);
     when(configRepository.getStandardSourceDefinition(sourceDefinitionSpecificationRead.getSourceDefinitionId()))
@@ -293,7 +306,7 @@ class SourceHandlerTest {
 
     sourceHandler.deleteSource(sourceIdRequestBody);
 
-    verify(configRepository).writeSourceConnection(expectedSourceConnection, connectorSpecification);
+    verify(secretsRepositoryWriter).writeSourceConnection(expectedSourceConnection, connectorSpecification);
     verify(connectionsHandler).listConnectionsForWorkspace(workspaceIdRequestBody);
     final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody()
         .connectionId(connectionRead.getConnectionId());

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -366,10 +366,7 @@ public class WorkerApp {
         configs.getConfigDatabaseUrl())
             .getInitialized();
     final ConfigPersistence configPersistence = DatabaseConfigPersistence.createWithValidation(configDatabase);
-    final Optional<SecretPersistence> secretPersistence = SecretPersistence.getLongLived(configs);
-    final Optional<SecretPersistence> ephemeralSecretPersistence = SecretPersistence.getEphemeral(configs);
-    final ConfigRepository configRepository =
-        new ConfigRepository(configPersistence, secretsHydrator, secretPersistence, ephemeralSecretPersistence, configDatabase);
+    final ConfigRepository configRepository = new ConfigRepository(configPersistence, configDatabase);
 
     final Database jobDatabase = new JobsDatabaseInstance(
         configs.getDatabaseUser(),


### PR DESCRIPTION
## What
* I was auditing every where secrets are read or write in the code base. With the secrets handling hidden in `ConfigRepository` it hard for me to track where we are actually using secrets. It also means that plenty places that need not know about connector secrets handling currently need to, because it's all in that one class.

## How
* Separate out connectors secrets handling into `SecretsRepositoryReader` and `SecretsRepositoryWriter`. These new classes give better ability to audit where secrets are, remove secrets from classes that have a lot of other responsibilities, and help us have clearer contracts on secrets in our java classes.  I split into Reader and Writer so we have crystal clear visibility into what classes read versus write secrets.

## Recommended reading order
1. `SecretsRepositoryReader.java`
2. `SecretsRepositoryWriter.java`
3. `ConfigRepository.java`
4. the rest (it's all constructor updates).

## 🚨 User Impact 🚨
None. All internal refactor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/airbytehq/airbyte/8898)
<!-- Reviewable:end -->
