### PR TITLE
Revert "update to log4j 2.17.0 (#8965)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -273,10 +273,10 @@ subprojects {
 
 
         // SLF4J as a facade over Log4j2 required dependencies
-        implementation 'org.apache.logging.log4j:log4j-api:2.17.0'
-        implementation 'org.apache.logging.log4j:log4j-core:2.17.0'
-        implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
-        implementation 'org.apache.logging.log4j:log4j-web:2.17.0'
+        implementation 'org.apache.logging.log4j:log4j-api:2.16.0'
+        implementation 'org.apache.logging.log4j:log4j-core:2.16.0'
+        implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.16.0'
+        implementation 'org.apache.logging.log4j:log4j-web:2.16.0'
 
         // Bridges from other logging implementations to SLF4J
         implementation 'org.slf4j:jul-to-slf4j:1.7.30' // JUL bridge
@@ -284,7 +284,7 @@ subprojects {
         implementation 'org.slf4j:log4j-over-slf4j:1.7.30' // log4j1.2 bridge
 
         // Dependencies for logging to cloud storage, as well as the various clients used to do so.
-        implementation 'com.therealvan:appender-log4j2:3.5.0'
+        implementation 'com.therealvan:appender-log4j2:3.3.0'
         implementation 'com.amazonaws:aws-java-sdk-s3:1.12.6'
         implementation 'com.google.cloud:google-cloud-storage:2.2.2'
 


### PR DESCRIPTION
This reverts commit c5fc568061f00b99dac9ec3f0f1573e3a30c096a.

See slack thread: https://airbytehq.slack.com/archives/C0229LM09T4/p1640030021249200

The reason for this is that the bump to log4j 2.17.0 caused the following errors to be repeatedly thrown on server startup:
```
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 2021-12-20 19:43:43,235 main ERROR Could not create plugin of type class com.van.logging.log4j2.Log4j2Appender for element Log4j2Appender: java.lang.RuntimeException: Cannot build appender due to errors java.lang.RuntimeException: Cannot build appender due to errors
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at com.van.logging.log4j2.Log4j2AppenderBuilder.build(Log4j2AppenderBuilder.java:142)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at com.van.logging.log4j2.Log4j2AppenderBuilder.build(Log4j2AppenderBuilder.java:25)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.plugins.util.PluginBuilder.build(PluginBuilder.java:122)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.AbstractConfiguration.createPluginObject(AbstractConfiguration.java:1120)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.AbstractConfiguration.createConfiguration(AbstractConfiguration.java:1045)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.appender.routing.RoutingAppender.createAppender(RoutingAppender.java:299)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.appender.routing.RoutingAppender.getControl(RoutingAppender.java:271)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.appender.routing.RoutingAppender.append(RoutingAppender.java:229)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.AppenderControl.tryCallAppender(AppenderControl.java:161)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.AppenderControl.callAppender0(AppenderControl.java:134)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.AppenderControl.callAppenderPreventRecursion(AppenderControl.java:125)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.AppenderControl.callAppender(AppenderControl.java:89)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.LoggerConfig.callAppenders(LoggerConfig.java:542)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.LoggerConfig.processLogEvent(LoggerConfig.java:500)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:483)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.LoggerConfig.logParent(LoggerConfig.java:533)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.LoggerConfig.processLogEvent(LoggerConfig.java:502)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:483)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:388)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.AwaitCompletionReliabilityStrategy.log(AwaitCompletionReliabilityStrategy.java:63)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.Logger.logMessage(Logger.java:153)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.slf4j.Log4jLogger.log(Log4jLogger.java:376)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.util.log.JettyAwareLogger.log(JettyAwareLogger.java:625)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.util.log.JettyAwareLogger.info(JettyAwareLogger.java:314)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.util.log.Slf4jLog.info(Slf4jLog.java:77)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.server.AbstractConnector.doStart(AbstractConnector.java:331)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:81)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:234)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:72)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.server.Server.doStart(Server.java:386)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:72)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at io.airbyte.server.ServerApp.start(ServerApp.java:109)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at io.airbyte.server.ServerApp.main(ServerApp.java:203)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container Caused by: java.lang.IllegalArgumentException: Cannot create enum from ${sys:S3_LOG_BUCKET_REGION:-} value!
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at com.amazonaws.regions.Regions.fromName(Regions.java:99)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at com.van.logging.aws.S3Configuration.resolveRegion(S3Configuration.java:188)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at com.van.logging.aws.S3Configuration.setRegion(S3Configuration.java:122)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at com.van.logging.log4j2.Log4j2AppenderBuilder.getS3ConfigIfEnabled(Log4j2AppenderBuilder.java:167)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at com.van.logging.log4j2.Log4j2AppenderBuilder.createCachePublisher(Log4j2AppenderBuilder.java:264)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at com.van.logging.log4j2.Log4j2AppenderBuilder.build(Log4j2AppenderBuilder.java:137)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	... 32 more
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 2021-12-20 19:43:43,236 main ERROR Unable to invoke factory method in class com.van.logging.log4j2.Log4j2Appender for element Log4j2Appender: java.lang.IllegalStateException: No factory method found for class com.van.logging.log4j2.Log4j2Appender java.lang.IllegalStateException: No factory method found for class com.van.logging.log4j2.Log4j2Appender
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.plugins.util.PluginBuilder.findFactoryMethod(PluginBuilder.java:236)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.plugins.util.PluginBuilder.build(PluginBuilder.java:134)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.AbstractConfiguration.createPluginObject(AbstractConfiguration.java:1120)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.AbstractConfiguration.createConfiguration(AbstractConfiguration.java:1045)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.appender.routing.RoutingAppender.createAppender(RoutingAppender.java:299)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.appender.routing.RoutingAppender.getControl(RoutingAppender.java:271)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.appender.routing.RoutingAppender.append(RoutingAppender.java:229)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.AppenderControl.tryCallAppender(AppenderControl.java:161)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.AppenderControl.callAppender0(AppenderControl.java:134)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.AppenderControl.callAppenderPreventRecursion(AppenderControl.java:125)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.AppenderControl.callAppender(AppenderControl.java:89)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.LoggerConfig.callAppenders(LoggerConfig.java:542)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.LoggerConfig.processLogEvent(LoggerConfig.java:500)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:483)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.LoggerConfig.logParent(LoggerConfig.java:533)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.LoggerConfig.processLogEvent(LoggerConfig.java:502)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:483)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:388)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.config.AwaitCompletionReliabilityStrategy.log(AwaitCompletionReliabilityStrategy.java:63)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.log4j.core.Logger.logMessage(Logger.java:153)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.apache.logging.slf4j.Log4jLogger.log(Log4jLogger.java:376)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.util.log.JettyAwareLogger.log(JettyAwareLogger.java:625)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.util.log.JettyAwareLogger.info(JettyAwareLogger.java:314)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.util.log.Slf4jLog.info(Slf4jLog.java:77)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.server.AbstractConnector.doStart(AbstractConnector.java:331)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:81)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:234)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:72)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.server.Server.doStart(Server.java:386)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:72)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at io.airbyte.server.ServerApp.start(ServerApp.java:109)
airbyte-server-7b7c989ff9-8f9xs airbyte-server-container 	at io.airbyte.server.ServerApp.main(ServerApp.java:203)
```
So it likely requires some additional changes to successfully upgrade to version 2.17

## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> New Connector </strong></summary>
<p>

#### Community member or Airbyter
   
- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
</p>
</details>


<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>
</details>

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>
