### PR TITLE
fix auto migration test

### DIFF
--- a/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
+++ b/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
@@ -208,9 +208,12 @@ public class MigrationAcceptanceTest {
       } else if (sourceDefinitionRead.getSourceDefinitionId().toString().equals("decd338e-5647-4c0b-adf4-da0e75f5a750")) {
         final String[] tagBrokenAsArray = sourceDefinitionRead.getDockerImageTag().replace(".", ",").split(",");
         assertEquals(3, tagBrokenAsArray.length);
+        // todo (cgardens) - this is very brittle. depending on when this connector gets updated in
+        // source_definitions.yaml this test can start to break. for now just doing quick fix, but we should
+        // be able to do an actual version comparison like we do with AirbyteVersion.
         assertTrue(Integer.parseInt(tagBrokenAsArray[0]) >= 0, "actual tag: " + sourceDefinitionRead.getDockerImageTag());
         assertTrue(Integer.parseInt(tagBrokenAsArray[1]) >= 3, "actual tag: " + sourceDefinitionRead.getDockerImageTag());
-        assertTrue(Integer.parseInt(tagBrokenAsArray[2]) >= 4, "actual tag: " + sourceDefinitionRead.getDockerImageTag());
+        assertTrue(Integer.parseInt(tagBrokenAsArray[2]) >= 0, "actual tag: " + sourceDefinitionRead.getDockerImageTag());
         assertTrue(sourceDefinitionRead.getName().contains("Postgres"));
         foundPostgresSourceDefinition = true;
       }

--- a/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
+++ b/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
@@ -208,9 +208,9 @@ public class MigrationAcceptanceTest {
       } else if (sourceDefinitionRead.getSourceDefinitionId().toString().equals("decd338e-5647-4c0b-adf4-da0e75f5a750")) {
         final String[] tagBrokenAsArray = sourceDefinitionRead.getDockerImageTag().replace(".", ",").split(",");
         assertEquals(3, tagBrokenAsArray.length);
-        assertTrue(Integer.parseInt(tagBrokenAsArray[0]) >= 0);
-        assertTrue(Integer.parseInt(tagBrokenAsArray[1]) >= 3);
-        assertTrue(Integer.parseInt(tagBrokenAsArray[2]) >= 4);
+        assertTrue(Integer.parseInt(tagBrokenAsArray[0]) >= 0, "actual tag: " + sourceDefinitionRead.getDockerImageTag());
+        assertTrue(Integer.parseInt(tagBrokenAsArray[1]) >= 3, "actual tag: " + sourceDefinitionRead.getDockerImageTag());
+        assertTrue(Integer.parseInt(tagBrokenAsArray[2]) >= 4, "actual tag: " + sourceDefinitionRead.getDockerImageTag());
         assertTrue(sourceDefinitionRead.getName().contains("Postgres"));
         foundPostgresSourceDefinition = true;
       }


### PR DESCRIPTION
## What
* The automigration acceptance test has been failing since this [commit](https://github.com/airbytehq/airbyte/commit/ff4b83bb1fe8099bb7075e43037630623d9cead9).
* It was failing because that commit bumped source-postgres to a new minor version which meant that one of the asserts about the connector version that the test was making didn't pass anymore. The test should be robust to this.

## How
* just made the constraint less strict for now. this is a short term fix, we should improve our version comparison for connector versions, just like we have for `AirbyteVersion` for the platform