### PR TITLE
🐛  SAT: add network host mode

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.39
+LABEL io.airbyte.version=0.1.40
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/connector_runner.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/connector_runner.py
@@ -98,6 +98,7 @@ class ConnectorRunner:
             command=cmd,
             working_dir="/data",
             volumes=volumes,
+            network_mode="host",
             detach=True,
             **kwargs,
         )


### PR DESCRIPTION
## What
all test containers should be run with network_mode=host, because periodically a software tries to load some data from a localhost instance

## How
add this option
