### PR TITLE
Source Amazon Seller Partner: extract REPORTS_MAX_WAIT_SECONDS to configurable parameter

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e55879a8-0ef8-4557-abcf-ab34c53ec460.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/e55879a8-0ef8-4557-abcf-ab34c53ec460.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "e55879a8-0ef8-4557-abcf-ab34c53ec460",
   "name": "Amazon Seller Partner",
   "dockerRepository": "airbyte/source-amazon-seller-partner",
-  "dockerImageTag": "0.2.6",
+  "dockerImageTag": "0.2.7",
   "documentationUrl": "https://docs.airbyte.io/integrations/sources/amazon-seller-partner",
   "icon": "amazonsellerpartner.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -22,7 +22,7 @@
 - name: Amazon Seller Partner
   sourceDefinitionId: e55879a8-0ef8-4557-abcf-ab34c53ec460
   dockerRepository: airbyte/source-amazon-seller-partner
-  dockerImageTag: 0.2.6
+  dockerImageTag: 0.2.7
   sourceType: api
   documentationUrl: https://docs.airbyte.io/integrations/sources/amazon-seller-partner
   icon: amazonsellerpartner.svg

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -153,7 +153,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-amazon-seller-partner:0.2.6"
+- dockerImage: "airbyte/source-amazon-seller-partner:0.2.7"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/amazon-seller-partner"
     changelogUrl: "https://docs.airbyte.io/integrations/sources/amazon-seller-partner"

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/Dockerfile
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.6
+LABEL io.airbyte.version=0.2.7
 LABEL io.airbyte.name=airbyte/source-amazon-seller-partner

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/source.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/source.py
@@ -50,6 +50,12 @@ class ConnectorConfig(BaseModel):
         description="Additional information passed to reports. This varies by report type. Must be a valid json string.",
         examples=['{"GET_BRAND_ANALYTICS_SEARCH_TERMS_REPORT": {"reportPeriod": "WEEK"}}', '{"GET_SOME_REPORT": {"custom": "true"}}'],
     )
+    max_wait_seconds: int = Field(
+        500,
+        title="Max wait time for reports (in seconds)",
+        description="Sometimes report can take up to 30 minutes to generate. This will set the limit for how long to wait for a successful report.",
+        examples=["500", "1980"],
+    )
     refresh_token: str = Field(
         description="The Refresh Token obtained via OAuth flow authorization.",
         title="Refresh Token",
@@ -105,6 +111,7 @@ class SourceAmazonSellerPartner(AbstractSource):
             "marketplace_ids": [marketplace_id],
             "period_in_days": config.period_in_days,
             "report_options": config.report_options,
+            "max_wait_seconds": config.max_wait_seconds,
         }
         return stream_kwargs
 

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/spec.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/spec.json
@@ -28,6 +28,13 @@
         ],
         "type": "string"
       },
+      "max_wait_seconds": {
+        "title": "Max wait time for reports (in seconds)",
+        "description": "Sometimes report can take up to 30 minutes to generate. This will set the limit for how long to wait for a successful report.",
+        "examples": ["500", "1980"],
+        "type": "integer",
+        "default": 500
+      },
       "refresh_token": {
         "title": "Refresh Token",
         "description": "The Refresh Token obtained via OAuth flow authorization.",

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/test_repots_streams_rate_limits.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/test_repots_streams_rate_limits.py
@@ -29,6 +29,7 @@ def reports_stream():
         authenticator=NoAuth(),
         period_in_days=0,
         report_options=None,
+        max_wait_seconds=500,
     )
     return stream
 

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -64,7 +64,7 @@ Information about rate limits you may find [here](https://github.com/amzn/sellin
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| `0.2.7` | 2021-12-21 | [\#N](https://github.com/airbytehq/airbyte/pull/N) | Extract REPORTS_MAX_WAIT_SECONDS to configurable parameter |
+| `0.2.7` | 2021-12-21 | [\#9002](https://github.com/airbytehq/airbyte/pull/9002) | Extract REPORTS_MAX_WAIT_SECONDS to configurable parameter |
 | `0.2.6` | 2021-12-10 | [\#8179](https://github.com/airbytehq/airbyte/pull/8179) | Add GET_BRAND_ANALYTICS_SEARCH_TERMS_REPORT report |
 | `0.2.5` | 2021-12-06 | [\#8425](https://github.com/airbytehq/airbyte/pull/8425) | Update title, description fields in spec |
 | `0.2.4` | 2021-11-08 | [\#8021](https://github.com/airbytehq/airbyte/pull/8021) | Added GET_SELLER_FEEDBACK_DATA report with incremental sync capability |

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -64,6 +64,7 @@ Information about rate limits you may find [here](https://github.com/amzn/sellin
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| `0.2.7` | 2021-12-21 | [\#N](https://github.com/airbytehq/airbyte/pull/N) | Extract REPORTS_MAX_WAIT_SECONDS to configurable parameter |
 | `0.2.6` | 2021-12-10 | [\#8179](https://github.com/airbytehq/airbyte/pull/8179) | Add GET_BRAND_ANALYTICS_SEARCH_TERMS_REPORT report |
 | `0.2.5` | 2021-12-06 | [\#8425](https://github.com/airbytehq/airbyte/pull/8425) | Update title, description fields in spec |
 | `0.2.4` | 2021-11-08 | [\#8021](https://github.com/airbytehq/airbyte/pull/8021) | Added GET_SELLER_FEEDBACK_DATA report with incremental sync capability |


### PR DESCRIPTION
## What
Extract the REPORTS_MAX_WAIT_SECONDS constant to configurable parameter

## How

## Recommended reading order
1. `streams.py`
2. `source.py`

## 🚨 User Impact 🚨
Users will be able to configure max wait for reports by their will.

## Pre-merge Checklist

<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>
</details>
