### PR TITLE
exclude destination_specs.yaml from commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,8 @@ repos:
         exclude: |
           (?x)^.*(
               .github/|
-              source_specs.yaml
+              source_specs.yaml|
+              destination_specs.yaml
           ).?$
 
   - repo: https://gitlab.com/pycqa/flake8


### PR DESCRIPTION
## What
It has no benefit, as the file is autogenerated anyway, and forces you to commit changes with `--no-verify` to avoid breaking the build.

Also, source_specs.yaml is already excluded anyway.