### PR TITLE
Added associations to some CRM Object streams in Hubspot connector

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/client.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/client.py
@@ -37,9 +37,9 @@ class Client(BaseClient):
             "campaigns": CampaignStream(**common_params),
             "companies": CRMObjectIncrementalStream(entity="company", associations=["contacts"], **common_params),
             "contact_lists": ContactListStream(**common_params),
-            "contacts": CRMObjectIncrementalStream(entity="contact", **common_params),
+            "contacts": CRMObjectIncrementalStream(entity="contact", associations=["companies"], **common_params),
             "deal_pipelines": DealPipelineStream(**common_params),
-            "deals": DealStream(associations=["contacts"], **common_params),
+            "deals": DealStream(associations=["contacts", "companies"], **common_params),
             "email_events": EmailEventStream(**common_params),
             "engagements": EngagementStream(**common_params),
             "forms": FormStream(**common_params),
@@ -48,7 +48,7 @@ class Client(BaseClient):
             "owners": OwnerStream(**common_params),
             "products": CRMObjectIncrementalStream(entity="product", **common_params),
             "subscription_changes": SubscriptionChangeStream(**common_params),
-            "tickets": CRMObjectIncrementalStream(entity="ticket", **common_params),
+            "tickets": CRMObjectIncrementalStream(entity="ticket", associations=["companies"], **common_params),
             "workflows": WorkflowStream(**common_params),
         }
 

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/schemas/contacts.json
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/schemas/contacts.json
@@ -15,6 +15,12 @@
     },
     "archived": {
       "type": ["null", "boolean"]
+    },
+    "companies": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
     }
   }
 }

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/schemas/tickets.json
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/schemas/tickets.json
@@ -15,6 +15,12 @@
     },
     "archived": {
       "type": ["null", "boolean"]
+    },
+    "companies": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
     }
   }
 }


### PR DESCRIPTION
## What
Very minor change - added company associations to contacts, deals and tickets CRM object streams.

## :rotating_light: User Impact :rotating_light:
None, the only change is the instantiation of the streams in the `client.py` file in the Hubspot source connector.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/airbytehq/airbyte/9027)
<!-- Reviewable:end -->
