### PR TITLE
Add normalization-clickhouse docker build step

### DIFF
--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -69,10 +69,15 @@ task airbyteDockerOracle(type: Exec, dependsOn: checkSshScriptCopy) {
     configure buildAirbyteDocker('oracle')
     dependsOn assemble
 }
+task airbyteDockerClickhouse(type: Exec, dependsOn: checkSshScriptCopy) {
+    configure buildAirbyteDocker('clickhouse')
+    dependsOn assemble
+}
 
 airbyteDocker.dependsOn(airbyteDockerMSSql)
 airbyteDocker.dependsOn(airbyteDockerMySql)
 airbyteDocker.dependsOn(airbyteDockerOracle)
+airbyteDocker.dependsOn(airbyteDockerClickhouse)
 
 task("customIntegrationTestPython", type: PythonTask, dependsOn: installTestReqs) {
     module = "pytest"
@@ -86,6 +91,7 @@ task("customIntegrationTestPython", type: PythonTask, dependsOn: installTestReqs
     dependsOn ':airbyte-integrations:connectors:destination-snowflake:airbyteDocker'
     dependsOn ':airbyte-integrations:connectors:destination-oracle:airbyteDocker'
     dependsOn ':airbyte-integrations:connectors:destination-mssql:airbyteDocker'
+    dependsOn ':airbyte-integrations:connectors:destination-clickhouse:airbyteDocker'
 }
 
 integrationTest.dependsOn("customIntegrationTestPython")

--- a/airbyte-integrations/bases/base-normalization/docker-compose.yaml
+++ b/airbyte-integrations/bases/base-normalization/docker-compose.yaml
@@ -10,3 +10,5 @@ services:
     image: airbyte/normalization-mysql:${VERSION}
   normalization-oracle:
     image: airbyte/normalization-oracle:${VERSION}
+  normalization-clickhouse:
+    image: airbyte/normalization-clickhouse:${VERSION}

--- a/settings.gradle
+++ b/settings.gradle
@@ -97,6 +97,7 @@ if (!System.getenv().containsKey("SUB_BUILD") || System.getenv().get("SUB_BUILD"
     include ':airbyte-integrations:connectors:destination-snowflake'
     include ':airbyte-integrations:connectors:destination-oracle'
     include ':airbyte-integrations:connectors:destination-mssql'
+    include ':airbyte-integrations:connectors:destination-clickhouse'
 
     //Needed by destination-bigquery
     include ':airbyte-integrations:connectors:destination-s3'


### PR DESCRIPTION
## What
mysql to clickhouse normalization task fails because docker image airbyte/normalization-clickhouse:0.1.61 is missing:
```
Caused by: io.airbyte.workers.WorkerException: Normalization Failed.
	at io.airbyte.workers.DefaultNormalizationWorker.run(DefaultNormalizationWorker.java:60) ~[io.airbyte-airbyte-workers-0.35.0-alpha.jar:?]
	at io.airbyte.workers.DefaultNormalizationWorker.run(DefaultNormalizationWorker.java:18) ~[io.airbyte-airbyte-workers-0.35.0-alpha.jar:?]
	at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getWorkerThread$2(TemporalAttemptExecution.java:174) ~[io.airbyte-airbyte-workers-0.35.0-alpha.jar:?]
	... 1 more
Caused by: io.airbyte.workers.WorkerException: Could not find image: airbyte/normalization-clickhouse:0.1.61
	at io.airbyte.workers.process.DockerProcessFactory.create(DockerProcessFactory.java:97) ~[io.airbyte-airbyte-workers-0.35.0-alpha.jar:?]
	at io.airbyte.workers.normalization.DefaultNormalizationRunner.runProcess(DefaultNormalizationRunner.java:123) ~[io.airbyte-airbyte-workers-0.35.0-alpha.jar:?]
	at io.airbyte.workers.normalization.DefaultNormalizationRunner.normalize(DefaultNormalizationRunner.java:108) ~[io.airbyte-airbyte-workers-0.35.0-alpha.jar:?]
	at io.airbyte.workers.DefaultNormalizationWorker.run(DefaultNormalizationWorker.java:55) ~[io.airbyte-airbyte-workers-0.35.0-alpha.jar:?]
	at io.airbyte.workers.DefaultNormalizationWorker.run(DefaultNormalizationWorker.java:18) ~[io.airbyte-airbyte-workers-0.35.0-alpha.jar:?]
	at io.airbyte.workers.temporal.TemporalAttemptExecution.lambda$getWorkerThread$2(TemporalAttemptExecution.java:174) ~[io.airbyte-airbyte-workers-0.35.0-alpha.jar:?]
```

## How
Add clickhouse related configurations to base-normalization's build script

## Recommended reading order
1. `airbyte-integrations/bases/base-normalization/build.gradle`
2. `airbyte-integrations/bases/base-normalization/docker-compose.yaml`
