### PR TITLE
Source Facebook Pages: removed deprecated field `live_encoders` from Page stream

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -182,7 +182,7 @@
 - name: Facebook Pages
   sourceDefinitionId: 010eb12f-837b-4685-892d-0a39f76a98f5
   dockerRepository: airbyte/source-facebook-pages
-  dockerImageTag: 0.1.5
+  dockerImageTag: 0.1.6
   documentationUrl: https://hub.docker.com/r/airbyte/source-facebook-pages
   icon: facebook.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -1579,7 +1579,7 @@
         oauthFlowInitParameters: []
         oauthFlowOutputParameters:
         - - "access_token"
-- dockerImage: "airbyte/source-facebook-pages:0.1.5"
+- dockerImage: "airbyte/source-facebook-pages:0.1.6"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/facebook-pages"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-facebook-pages/Dockerfile
+++ b/airbyte-integrations/connectors/source-facebook-pages/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.5
+LABEL io.airbyte.version=0.1.6
 LABEL io.airbyte.name=airbyte/source-facebook-pages

--- a/airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/metrics.py
+++ b/airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/metrics.py
@@ -248,7 +248,6 @@ PAGE_FIELDS = ",".join(
         # "insights_exports",    Tried accessing nonexisting field (insights_exports) on node type (Page)
         "instagram_accounts",
         "likes",
-        "live_encoders",
         "live_videos",
         "locations",
         "nativeoffers",

--- a/airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/schemas/page.json
+++ b/airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/schemas/page.json
@@ -1554,39 +1554,6 @@
         }
       }
     },
-    "live_encoders": {
-      "type": ["object", "null"],
-      "properties": {
-        "data": {
-          "type": ["array", "null"],
-          "items": {
-            "$ref": "liveencoder.json"
-          }
-        },
-        "paging": {
-          "type": ["object", "null"],
-          "properties": {
-            "previous": {
-              "type": ["string", "null"]
-            },
-            "next": {
-              "type": ["string", "null"]
-            },
-            "cursors": {
-              "type": "object",
-              "properties": {
-                "before": {
-                  "type": ["string", "null"]
-                },
-                "after": {
-                  "type": ["string", "null"]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "live_videos": {
       "type": ["object", "null"],
       "properties": {

--- a/docs/integrations/sources/facebook-pages.md
+++ b/docs/integrations/sources/facebook-pages.md
@@ -83,6 +83,7 @@ You can easily get the page id from the page url. For example, if you have a pag
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.6 | 2021-12-22 | [9032](https://github.com/airbytehq/airbyte/pull/9032) | Remove deprecated field `live_encoders` from Page stream |
 | 0.1.5 | 2021-11-26 | [8267](https://github.com/airbytehq/airbyte/pull/) | updated all empty objects in schemas for Page and Post streams |
 | 0.1.4 | 2021-11-26 | [](https://github.com/airbytehq/airbyte/pull/) | Remove unsupported insights_export field from Pages request |
 | 0.1.3 | 2021-10-28 | [7440](https://github.com/airbytehq/airbyte/pull/7440) | Generate Page token from config access token |


### PR DESCRIPTION
## What
Resolves [8626](https://github.com/airbytehq/airbyte/issues/8626)
## How

Removed deprecated field `live_encoders` from query params list and schema for Page stream.
![image](https://user-images.githubusercontent.com/93112548/147059594-aef1ea87-aa1c-4248-b80f-c7a6ecaef046.png)

## Recommended reading order

1. airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/metrics.py
2. airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/schemas/page.json