### PR TITLE
Fix issue when not found docs were failing the app

### DIFF
--- a/airbyte-webapp/src/hooks/services/useDocumentation.ts
+++ b/airbyte-webapp/src/hooks/services/useDocumentation.ts
@@ -22,6 +22,8 @@ const useDocumentation = (documentationUrl: string): UseDocumentationResult => {
       enabled: !!documentationUrl,
       refetchOnMount: false,
       refetchOnWindowFocus: false,
+      retry: false,
+      suspense: false,
     }
   );
 };

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -431,6 +431,7 @@
   "demo.message.title": "This Airbyte demo is read-only",
   "demo.message.body": "You cannot add or edit any connectors. You will see error messages on purpose if you try to do so.",
 
+  "docs.notFoundError": "We were not able to receive docs. Please click the link above to open docs on our website",
   "errorView.startOver": "Continue using the app",
   "errorView.notFound": "Resource not found"
 }

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/Instruction.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/Instruction.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { useToggle } from "react-use";
 
 import useDocumentation from "hooks/services/useDocumentation";
+import { LoadingPage } from "components";
 import { SideView } from "components/SideView";
 import { Markdown } from "components/Markdown";
 import { DestinationDefinition, SourceDefinition } from "core/domain/connector";
@@ -46,7 +47,7 @@ const Instruction: React.FC<IProps> = ({
   documentationUrl,
 }) => {
   const [isSideViewOpen, setIsSideViewOpen] = useToggle(false);
-  const { data: docs } = useDocumentation(documentationUrl);
+  const { data: docs, isLoading } = useDocumentation(documentationUrl);
 
   return (
     <>
@@ -66,7 +67,13 @@ const Instruction: React.FC<IProps> = ({
             </HeaderLink>
           }
         >
-          <Markdown content={docs} />
+          {isLoading ? (
+            <LoadingPage />
+          ) : docs ? (
+            <Markdown content={docs} />
+          ) : (
+            <FormattedMessage id="docs.notFoundError" />
+          )}
         </SideView>
       )}
       <LinkToInstruction onClick={() => setIsSideViewOpen(true)}>


### PR DESCRIPTION
## What
Fix a problem that crashed app if doc markdown file was not present when selecting the connector ( #9015 )

## How
Load file without suspense mode
