### PR TITLE
Add bootloader dependancy to generate-docker gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -354,6 +354,7 @@ subprojects {
 }
 
 task('generate-docker') {
+    dependsOn(':airbyte-bootloader:assemble')
     dependsOn(':airbyte-workers:assemble')
     dependsOn(':airbyte-webapp:assemble')
     dependsOn(':airbyte-server:assemble')


### PR DESCRIPTION
airbyte-bootloader image is required for running airbyte instance but no list on generate-docker task deps