### PR TITLE
🐛 Source Jira: Fix fetching and update schema for `filters` stream

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -322,7 +322,7 @@
 - name: Jira
   sourceDefinitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993
   dockerRepository: airbyte/source-jira
-  dockerImageTag: 0.2.16
+  dockerImageTag: 0.2.17
   documentationUrl: https://docs.airbyte.io/integrations/sources/jira
   icon: jira.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -3136,7 +3136,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-jira:0.2.16"
+- dockerImage: "airbyte/source-jira:0.2.17"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/jira"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-jira/Dockerfile
+++ b/airbyte-integrations/connectors/source-jira/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.16
+LABEL io.airbyte.version=0.2.17
 LABEL io.airbyte.name=airbyte/source-jira

--- a/airbyte-integrations/connectors/source-jira/source_jira/schemas/filters.json
+++ b/airbyte-integrations/connectors/source-jira/source_jira/schemas/filters.json
@@ -2,6 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "expand": {
+      "type": "string"
+    },
     "self": {
       "type": "string",
       "description": "The URL of the filter.",
@@ -2589,6 +2592,9 @@
           }
         }
       }
+    },
+    "isWritable": {
+      "type": "boolean"
     },
     "subscriptions": {
       "type": "array",

--- a/airbyte-integrations/connectors/source-jira/source_jira/schemas/filters.json
+++ b/airbyte-integrations/connectors/source-jira/source_jira/schemas/filters.json
@@ -2862,6 +2862,6 @@
       }
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "description": "Details of a filter."
 }

--- a/airbyte-integrations/connectors/source-jira/source_jira/streams.py
+++ b/airbyte-integrations/connectors/source-jira/source_jira/streams.py
@@ -286,6 +286,11 @@ class Filters(JiraStream):
     def path(self, **kwargs) -> str:
         return "filter/search"
 
+    def request_params(self, **kwargs) -> MutableMapping[str, Any]:
+        params = super().request_params(**kwargs)
+        params["expand"] = "description,owner,jql,viewUrl,searchUrl,favourite,favouritedCount,sharePermissions,isWritable,subscriptions"
+        return params
+
 
 class FilterSharing(JiraStream):
     """

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -86,7 +86,7 @@ The Jira connector should not run into Jira API limitations under normal usage. 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
 | 0.2.17 | 2021-12-23 | [\#9079](https://github.com/airbytehq/airbyte/pull/9079) | Update schema for `filters` stream + fix fetching `filters` stream |
-| 0.2.16 | 2021-12-23 | [\#8999](https://github.com/airbytehq/airbyte/pull/8999) | Update connector fields title/description |
+| 0.2.16 | 2021-12-21 | [\#8999](https://github.com/airbytehq/airbyte/pull/8999) | Update connector fields title/description |
 | 0.2.15 | 2021-11-01 | [\#7398](https://github.com/airbytehq/airbyte/pull/7398) | Add option to render fields in HTML format and fix sprint_issue ids |
 | 0.2.14 | 2021-10-27 | [\#7408](https://github.com/airbytehq/airbyte/pull/7408) | Fix normalization step error. Fix schemas. Fix `acceptance-test-config.yml`. Fix `streams.py`. |
 | 0.2.13 | 2021-10-20 | [\#7222](https://github.com/airbytehq/airbyte/pull/7222) | Source Jira: Make recently added configs optional for backwards compatibility |

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -85,8 +85,8 @@ The Jira connector should not run into Jira API limitations under normal usage. 
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| 0.2.17 | 2021-12-21 | [\#8999](https://github.com/airbytehq/airbyte/pull/8999) | Update connector fields title/description |
-| 0.2.16 | 2021-12-23 | [\#9079](https://github.com/airbytehq/airbyte/pull/9079) | Update schema for `filters` stream + fix fetching `filters` stream |
+| 0.2.17 | 2021-12-23 | [\#9079](https://github.com/airbytehq/airbyte/pull/9079) | Update schema for `filters` stream + fix fetching `filters` stream |
+| 0.2.16 | 2021-12-23 | [\#8999](https://github.com/airbytehq/airbyte/pull/8999) | Update connector fields title/description |
 | 0.2.15 | 2021-11-01 | [\#7398](https://github.com/airbytehq/airbyte/pull/7398) | Add option to render fields in HTML format and fix sprint_issue ids |
 | 0.2.14 | 2021-10-27 | [\#7408](https://github.com/airbytehq/airbyte/pull/7408) | Fix normalization step error. Fix schemas. Fix `acceptance-test-config.yml`. Fix `streams.py`. |
 | 0.2.13 | 2021-10-20 | [\#7222](https://github.com/airbytehq/airbyte/pull/7222) | Source Jira: Make recently added configs optional for backwards compatibility |

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -85,7 +85,8 @@ The Jira connector should not run into Jira API limitations under normal usage. 
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| 0.2.16 | 2021-12-21 | [\#8999](https://github.com/airbytehq/airbyte/pull/8999) | Update connector fields title/description |
+| 0.2.17 | 2021-12-21 | [\#8999](https://github.com/airbytehq/airbyte/pull/8999) | Update connector fields title/description |
+| 0.2.16 | 2021-12-23 | [\#9079](https://github.com/airbytehq/airbyte/pull/9079) | Update schema for `filters` stream + fix fetching `filters` stream |
 | 0.2.15 | 2021-11-01 | [\#7398](https://github.com/airbytehq/airbyte/pull/7398) | Add option to render fields in HTML format and fix sprint_issue ids |
 | 0.2.14 | 2021-10-27 | [\#7408](https://github.com/airbytehq/airbyte/pull/7408) | Fix normalization step error. Fix schemas. Fix `acceptance-test-config.yml`. Fix `streams.py`. |
 | 0.2.13 | 2021-10-20 | [\#7222](https://github.com/airbytehq/airbyte/pull/7222) | Source Jira: Make recently added configs optional for backwards compatibility |


### PR DESCRIPTION
# Bug-fix Request

Fixes #9017

---

## Reason
Error was in `filters` stream. I believe that earlier following fields were sent by default without explicitly specifying that we want to receive these fields:

- description
- owner
- jql
- viewUrl
- searchUrl
- favourite
- favouritedCount
- sharePermissions
- isWritable
- subscriptions

Right now if someone wants to receive those fields they need to send additional parameter - `expand` in which put wanted fields (see [docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-filters/#api-rest-api-3-filter-search-get), under `QUERY PARAMETERS` section).
That was the reason why tests were failing for that stream.

## Confirmation
 - [x] **Was reproduced locally**


## How does the code change in the PR fix the issue?
The code change sends that `expand` parameter.

