### PR TITLE
Document `MAX_*_WORKERS` in Workers & Jobs

### DIFF
--- a/docs/understanding-airbyte/jobs.md
+++ b/docs/understanding-airbyte/jobs.md
@@ -39,6 +39,16 @@ Note: When a source has passed all of its messages, the docker process should au
 
 See the [architecture overview](high-level-view.md) for more information about workers.
 
+## Worker parallelization
+Airbyte exposes the following environment variable to change the maximum number of each type of worker allowed to run in parallel. 
+Tweaking these values might help you run more jobs in parallel and increase the workload of your Airbyte instance: 
+* `MAX_SPEC_WORKERS`: Maximum number of *Spec* workers allowed to run in parallel.
+* `MAX_CHECK_WORKERS`: Maximum number of *Check connection* workers allowed to run in parallel.
+* `MAX_DISCOVERY_WORKERS`: Maximum number of *Discovery* workers allowed to run in parallel.
+* `MAX_SYNC_WORKERS`: Maximum number of *Sync* workers allowed to run in parallel.
+
+The current default value for these environment variables is currently set to **5**.
+
 ## Job State Machine
 
 Jobs in the worker follow the following state machine.


### PR DESCRIPTION
We often receive messages from users (e.g. [this one](https://airbytehq.slack.com/archives/C019WEENQRM/p1640769195111100)) asking for help related to scaling and parallelization.
I found it helpful to add more details about `MAX_*_WORKERS` env var to the Worker & Jobs documentation.