### PR TITLE
Update S3 and file sources docs: we do not support unstructured data

### DIFF
--- a/docs/integrations/sources/file.md
+++ b/docs/integrations/sources/file.md
@@ -48,6 +48,8 @@ This source produces a single table for the target file as it replicates only on
 | Parquet               | Yes        |
 | Pickle                | No         |
 
+**This connector does not support syncing non-structured data files such as raw text, audio, or videos.**
+
 ## Getting Started (Airbyte Cloud)
 
 Setup through Airbyte Cloud will be exactly the same as the open-source setup, except for the fact that local files are disabled.

--- a/docs/integrations/sources/file.md
+++ b/docs/integrations/sources/file.md
@@ -48,7 +48,7 @@ This source produces a single table for the target file as it replicates only on
 | Parquet               | Yes        |
 | Pickle                | No         |
 
-**This connector does not support syncing non-structured data files such as raw text, audio, or videos.**
+**This connector does not support syncing unstructured data files such as raw text, audio, or videos.**
 
 ## Getting Started (Airbyte Cloud)
 

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -3,7 +3,7 @@
 ## Overview
 
 The S3 source enables syncing of **file-based tables** with support for multiple files using glob-like pattern matching, and both Full Refresh and Incremental syncs, using the last\_modified property of files to determine incremental batches.
-**This connector does not support syncing non-structured data files such as raw text, audio, or videos.**
+**This connector does not support syncing unstructured data files such as raw text, audio, or videos.**
 You can choose if this connector will read only the new/updated files, or all the matching files, every time a sync is run.
 
 Connector allows using either Amazon S3 storage or 3rd party S3 compatible service like Wasabi or custom S3 services set up with minio, leofs, ceph etc.

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -2,8 +2,8 @@
 
 ## Overview
 
-The S3 source enables syncing of file-based tables with support for multiple files using glob-like pattern matching, and both Full Refresh and Incremental syncs, using the last\_modified property of files to determine incremental batches.
-
+The S3 source enables syncing of **file-based tables** with support for multiple files using glob-like pattern matching, and both Full Refresh and Incremental syncs, using the last\_modified property of files to determine incremental batches.
+**This connector does not support syncing non-structured data files such as raw text, audio, or videos.**
 You can choose if this connector will read only the new/updated files, or all the matching files, every time a sync is run.
 
 Connector allows using either Amazon S3 storage or 3rd party S3 compatible service like Wasabi or custom S3 services set up with minio, leofs, ceph etc.


### PR DESCRIPTION
Some users often ask if they can sync images, video, etc. with the file or S3 source connectors.
I think we should make clear that these connectors do not support unstructured files in their documentation.