### PR TITLE
Remove json avro schema converter hack

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/src/main/java/io/airbyte/integrations/destination/bigquery/formatter/DefaultBigQueryDenormalizedRecordFormatter.java
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/src/main/java/io/airbyte/integrations/destination/bigquery/formatter/DefaultBigQueryDenormalizedRecordFormatter.java
@@ -191,21 +191,14 @@ public class DefaultBigQueryDenormalizedRecordFormatter extends DefaultBigQueryR
 
   @Override
   public Schema getBigQuerySchema(final JsonNode jsonSchema) {
-    final String schemaString = Jsons.serialize(jsonSchema)
-        // BigQuery avro file loader doesn't support date-time
-        // https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#logical_types
-        // So we use timestamp for date-time
-        .replace("\"format\":\"date-time\"", "\"format\":\"timestamp-micros\"");
-    final JsonNode bigQuerySchema = Jsons.deserialize(schemaString);
-
-    final List<Field> fieldList = getSchemaFields(namingResolver, bigQuerySchema);
+        final List<Field> fieldList = getSchemaFields(namingResolver, jsonSchema);
     if (fieldList.stream().noneMatch(f -> f.getName().equals(JavaBaseConstants.COLUMN_NAME_AB_ID))) {
       fieldList.add(Field.of(JavaBaseConstants.COLUMN_NAME_AB_ID, StandardSQLTypeName.STRING));
     }
     if (fieldList.stream().noneMatch(f -> f.getName().equals(JavaBaseConstants.COLUMN_NAME_EMITTED_AT))) {
       fieldList.add(Field.of(JavaBaseConstants.COLUMN_NAME_EMITTED_AT, StandardSQLTypeName.TIMESTAMP));
     }
-    LOGGER.info("Airbyte Schema is transformed from {} to {}.", bigQuerySchema, fieldList);
+    LOGGER.info("Airbyte Schema is transformed from {} to {}.", jsonSchema, fieldList);
     return com.google.cloud.bigquery.Schema.of(fieldList);
   }
 

--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/src/main/java/io/airbyte/integrations/destination/bigquery/formatter/DefaultBigQueryDenormalizedRecordFormatter.java
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/src/main/java/io/airbyte/integrations/destination/bigquery/formatter/DefaultBigQueryDenormalizedRecordFormatter.java
@@ -50,26 +50,26 @@ public class DefaultBigQueryDenormalizedRecordFormatter extends DefaultBigQueryR
 
   private final Set<String> fieldsContainRefDefinitionValue = new HashSet<>();
 
-  public DefaultBigQueryDenormalizedRecordFormatter(JsonNode jsonSchema, StandardNameTransformer namingResolver) {
+  public DefaultBigQueryDenormalizedRecordFormatter(final JsonNode jsonSchema, final StandardNameTransformer namingResolver) {
     super(jsonSchema, namingResolver);
   }
 
   @Override
-  protected JsonNode formatJsonSchema(JsonNode jsonSchema) {
+  protected JsonNode formatJsonSchema(final JsonNode jsonSchema) {
     populateEmptyArrays(jsonSchema);
     surroundArraysByObjects(jsonSchema);
     return jsonSchema;
   }
 
-  private List<JsonNode> findArrays(JsonNode node) {
+  private List<JsonNode> findArrays(final JsonNode node) {
     if (node != null) {
       return node.findParents(TYPE_FIELD).stream()
           .filter(
               jsonNode -> {
-                JsonNode type = jsonNode.get(TYPE_FIELD);
+                final JsonNode type = jsonNode.get(TYPE_FIELD);
                 if (type.isArray()) {
-                  ArrayNode typeNode = (ArrayNode) type;
-                  for (JsonNode arrayTypeNode : typeNode) {
+                  final ArrayNode typeNode = (ArrayNode) type;
+                  for (final JsonNode arrayTypeNode : typeNode) {
                     if (arrayTypeNode.isTextual() && arrayTypeNode.textValue().equals("array"))
                       return true;
                   }
@@ -84,21 +84,21 @@ public class DefaultBigQueryDenormalizedRecordFormatter extends DefaultBigQueryR
     }
   }
 
-  private void populateEmptyArrays(JsonNode node) {
+  private void populateEmptyArrays(final JsonNode node) {
     findArrays(node).forEach(jsonNode -> {
       if (!jsonNode.has(ARRAY_ITEMS_FIELD)) {
-        ObjectNode nodeToChange = (ObjectNode) jsonNode;
+        final ObjectNode nodeToChange = (ObjectNode) jsonNode;
         nodeToChange.putObject(ARRAY_ITEMS_FIELD).putArray(TYPE_FIELD).add("string");
       }
     });
   }
 
-  private void surroundArraysByObjects(JsonNode node) {
+  private void surroundArraysByObjects(final JsonNode node) {
     findArrays(node).forEach(
         jsonNode -> {
-          JsonNode arrayNode = jsonNode.deepCopy();
+          final JsonNode arrayNode = jsonNode.deepCopy();
 
-          ObjectNode newNode = (ObjectNode) jsonNode;
+          final ObjectNode newNode = (ObjectNode) jsonNode;
           newNode.removeAll();
           newNode.putArray(TYPE_FIELD).add("object");
           newNode.putObject(PROPERTIES_FIELD).set(NESTED_ARRAY_FIELD, arrayNode);
@@ -127,7 +127,7 @@ public class DefaultBigQueryDenormalizedRecordFormatter extends DefaultBigQueryR
     return data;
   }
 
-  protected void addAirbyteColumns(ObjectNode data, final AirbyteRecordMessage recordMessage) {
+  protected void addAirbyteColumns(final ObjectNode data, final AirbyteRecordMessage recordMessage) {
     final long emittedAtMicroseconds = recordMessage.getEmittedAt();
     final String formattedEmittedAt = QueryParameterValue.timestamp(emittedAtMicroseconds).getValue();
 
@@ -157,7 +157,7 @@ public class DefaultBigQueryDenormalizedRecordFormatter extends DefaultBigQueryR
     }
   }
 
-  private JsonNode getArrayNode(FieldList fields, JsonNode root) {
+  private JsonNode getArrayNode(final FieldList fields, final JsonNode root) {
     // Arrays can have only one field
     final Field arrayField = fields.get(0);
     // If an array of records, we should use subfields
@@ -174,7 +174,7 @@ public class DefaultBigQueryDenormalizedRecordFormatter extends DefaultBigQueryR
     return Jsons.jsonNode(ImmutableMap.of(NESTED_ARRAY_FIELD, items));
   }
 
-  private JsonNode getObjectNode(FieldList fields, JsonNode root) {
+  private JsonNode getObjectNode(final FieldList fields, final JsonNode root) {
     final List<String> fieldNames = fields.stream().map(Field::getName).collect(Collectors.toList());
     return Jsons.jsonNode(Jsons.keys(root).stream()
         .filter(key -> {
@@ -191,14 +191,21 @@ public class DefaultBigQueryDenormalizedRecordFormatter extends DefaultBigQueryR
 
   @Override
   public Schema getBigQuerySchema(final JsonNode jsonSchema) {
-    final List<Field> fieldList = getSchemaFields(namingResolver, jsonSchema);
+    final String schemaString = Jsons.serialize(jsonSchema)
+        // BigQuery avro file loader doesn't support date-time
+        // https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#logical_types
+        // So we use timestamp for date-time
+        .replace("\"format\":\"date-time\"", "\"format\":\"timestamp-micros\"");
+    final JsonNode bigQuerySchema = Jsons.deserialize(schemaString);
+
+    final List<Field> fieldList = getSchemaFields(namingResolver, bigQuerySchema);
     if (fieldList.stream().noneMatch(f -> f.getName().equals(JavaBaseConstants.COLUMN_NAME_AB_ID))) {
       fieldList.add(Field.of(JavaBaseConstants.COLUMN_NAME_AB_ID, StandardSQLTypeName.STRING));
     }
     if (fieldList.stream().noneMatch(f -> f.getName().equals(JavaBaseConstants.COLUMN_NAME_EMITTED_AT))) {
       fieldList.add(Field.of(JavaBaseConstants.COLUMN_NAME_EMITTED_AT, StandardSQLTypeName.TIMESTAMP));
     }
-    LOGGER.info("Airbyte Schema is transformed from {} to {}.", jsonSchema, fieldList);
+    LOGGER.info("Airbyte Schema is transformed from {} to {}.", bigQuerySchema, fieldList);
     return com.google.cloud.bigquery.Schema.of(fieldList);
   }
 
@@ -206,7 +213,7 @@ public class DefaultBigQueryDenormalizedRecordFormatter extends DefaultBigQueryR
     LOGGER.info("getSchemaFields : " + jsonSchema + " namingResolver " + namingResolver);
     Preconditions.checkArgument(jsonSchema.isObject() && jsonSchema.has(PROPERTIES_FIELD));
     final ObjectNode properties = (ObjectNode) jsonSchema.get(PROPERTIES_FIELD);
-    List<Field> tmpFields = Jsons.keys(properties).stream()
+    final List<Field> tmpFields = Jsons.keys(properties).stream()
         .peek(addToRefList(properties))
         .map(key -> getField(namingResolver, key, properties.get(key))
             .build())
@@ -227,7 +234,7 @@ public class DefaultBigQueryDenormalizedRecordFormatter extends DefaultBigQueryR
    *        Currently, AirByte doesn't support parsing value by $ref key definition. The issue to
    *        track this <a href="https://github.com/airbytehq/airbyte/issues/7725">7725</a>
    */
-  private Consumer<String> addToRefList(ObjectNode properties) {
+  private Consumer<String> addToRefList(final ObjectNode properties) {
     return key -> {
       if (properties.get(key).has(REF_DEFINITION_KEY)) {
         fieldsContainRefDefinitionValue.add(key);

--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/src/main/java/io/airbyte/integrations/destination/bigquery/formatter/GcsBigQueryDenormalizedRecordFormatter.java
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/src/main/java/io/airbyte/integrations/destination/bigquery/formatter/GcsBigQueryDenormalizedRecordFormatter.java
@@ -16,20 +16,14 @@ import java.util.concurrent.TimeUnit;
 public class GcsBigQueryDenormalizedRecordFormatter extends DefaultBigQueryDenormalizedRecordFormatter {
 
   public GcsBigQueryDenormalizedRecordFormatter(
-                                                JsonNode jsonSchema,
-                                                StandardNameTransformer namingResolver) {
+          final JsonNode jsonSchema,
+          final StandardNameTransformer namingResolver) {
     super(jsonSchema, namingResolver);
   }
 
   @Override
-  protected JsonNode formatJsonSchema(JsonNode jsonSchema) {
+  protected JsonNode formatJsonSchema(final JsonNode jsonSchema) {
     var textJson = Jsons.serialize(jsonSchema);
-    /*
-     * BigQuery avro file loader doesn't support DatTime transformation
-     * https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#logical_types Replace
-     * date-time by timestamp
-     */
-    textJson = textJson.replace("\"format\":\"date-time\"", "\"format\":\"timestamp-micros\"");
     // Add string type for Refs
     // Avro header convertor requires types for all fields
     textJson = textJson.replace("{\"$ref\":\"", "{\"type\":[\"string\"], \"$ref\":\"");
@@ -37,7 +31,7 @@ public class GcsBigQueryDenormalizedRecordFormatter extends DefaultBigQueryDenor
   }
 
   @Override
-  protected void addAirbyteColumns(ObjectNode data, AirbyteRecordMessage recordMessage) {
+  protected void addAirbyteColumns(final ObjectNode data, final AirbyteRecordMessage recordMessage) {
     final long emittedAtMicroseconds = TimeUnit.MILLISECONDS.convert(recordMessage.getEmittedAt(), TimeUnit.MILLISECONDS);
 
     data.put(JavaBaseConstants.COLUMN_NAME_AB_ID, UUID.randomUUID().toString());

--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/src/main/java/io/airbyte/integrations/destination/bigquery/formatter/GcsBigQueryDenormalizedRecordFormatter.java
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/src/main/java/io/airbyte/integrations/destination/bigquery/formatter/GcsBigQueryDenormalizedRecordFormatter.java
@@ -16,8 +16,8 @@ import java.util.concurrent.TimeUnit;
 public class GcsBigQueryDenormalizedRecordFormatter extends DefaultBigQueryDenormalizedRecordFormatter {
 
   public GcsBigQueryDenormalizedRecordFormatter(
-          final JsonNode jsonSchema,
-          final StandardNameTransformer namingResolver) {
+                                                final JsonNode jsonSchema,
+                                                final StandardNameTransformer namingResolver) {
     super(jsonSchema, namingResolver);
   }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/uploader/BigQueryUploaderFactory.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/uploader/BigQueryUploaderFactory.java
@@ -36,7 +36,7 @@ public class BigQueryUploaderFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryUploaderFactory.class);
 
-  public static AbstractBigQueryUploader<?> getUploader(UploaderConfig uploaderConfig)
+  public static AbstractBigQueryUploader<?> getUploader(final UploaderConfig uploaderConfig)
       throws IOException {
     final String schemaName =
         BigQueryUtils.getSchema(uploaderConfig.getConfig(), uploaderConfig.getConfigStream());
@@ -45,11 +45,11 @@ public class BigQueryUploaderFactory {
 
     final boolean isGcsUploadingMode =
         UploadingMethod.GCS.equals(BigQueryUtils.getLoadingMethod(uploaderConfig.getConfig()));
-    BigQueryRecordFormatter recordFormatter =
+    final BigQueryRecordFormatter recordFormatter =
         (isGcsUploadingMode
             ? uploaderConfig.getFormatterMap().get(UploaderType.AVRO)
             : uploaderConfig.getFormatterMap().get(UploaderType.STANDARD));
-    Schema bigQuerySchema = recordFormatter.getBigQuerySchema();
+    final Schema bigQuerySchema = recordFormatter.getBigQuerySchema();
 
     BigQueryUtils.createSchemaAndTableIfNeeded(
         uploaderConfig.getBigQuery(),
@@ -86,20 +86,20 @@ public class BigQueryUploaderFactory {
   }
 
   private static AbstractGscBigQueryUploader<?> getGcsBigQueryUploader(
-                                                                       JsonNode config,
-                                                                       ConfiguredAirbyteStream configStream,
-                                                                       TableId targetTable,
-                                                                       TableId tmpTable,
-                                                                       BigQuery bigQuery,
-                                                                       JobInfo.WriteDisposition syncMode,
-                                                                       BigQueryRecordFormatter formatter,
-                                                                       boolean isDefaultAirbyteTmpSchema)
+      final JsonNode config,
+      final ConfiguredAirbyteStream configStream,
+      final TableId targetTable,
+      final TableId tmpTable,
+      final BigQuery bigQuery,
+      final JobInfo.WriteDisposition syncMode,
+      final BigQueryRecordFormatter formatter,
+      final boolean isDefaultAirbyteTmpSchema)
       throws IOException {
 
     final GcsDestinationConfig gcsDestinationConfig =
         GcsDestinationConfig.getGcsDestinationConfig(
             BigQueryUtils.getGcsAvroJsonNodeConfig(config));
-    JsonNode tmpTableSchema =
+    final JsonNode tmpTableSchema =
         (isDefaultAirbyteTmpSchema ? null : formatter.getJsonSchema());
     final GcsAvroWriter gcsCsvWriter =
         initGcsWriter(gcsDestinationConfig, configStream, tmpTableSchema);
@@ -119,7 +119,7 @@ public class BigQueryUploaderFactory {
   private static GcsAvroWriter initGcsWriter(
                                              final GcsDestinationConfig gcsDestinationConfig,
                                              final ConfiguredAirbyteStream configuredStream,
-                                             final JsonNode bigQuerySchema)
+                                             final JsonNode jsonSchema)
       throws IOException {
     final Timestamp uploadTimestamp = new Timestamp(System.currentTimeMillis());
 
@@ -130,17 +130,17 @@ public class BigQueryUploaderFactory {
         configuredStream,
         uploadTimestamp,
         JSON_CONVERTER,
-        bigQuerySchema);
+        jsonSchema);
   }
 
   private static BigQueryDirectUploader getBigQueryDirectUploader(
-                                                                  JsonNode config,
-                                                                  TableId targetTable,
-                                                                  TableId tmpTable,
-                                                                  BigQuery bigQuery,
-                                                                  JobInfo.WriteDisposition syncMode,
-                                                                  String datasetLocation,
-                                                                  BigQueryRecordFormatter formatter) {
+      final JsonNode config,
+      final TableId targetTable,
+      final TableId tmpTable,
+      final BigQuery bigQuery,
+      final JobInfo.WriteDisposition syncMode,
+      final String datasetLocation,
+      final BigQueryRecordFormatter formatter) {
     // https://cloud.google.com/bigquery/docs/loading-data-local#loading_data_from_a_local_data_source
     final WriteChannelConfiguration writeChannelConfiguration =
         WriteChannelConfiguration.newBuilder(tmpTable)

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/uploader/BigQueryUploaderFactory.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/uploader/BigQueryUploaderFactory.java
@@ -86,14 +86,14 @@ public class BigQueryUploaderFactory {
   }
 
   private static AbstractGscBigQueryUploader<?> getGcsBigQueryUploader(
-      final JsonNode config,
-      final ConfiguredAirbyteStream configStream,
-      final TableId targetTable,
-      final TableId tmpTable,
-      final BigQuery bigQuery,
-      final JobInfo.WriteDisposition syncMode,
-      final BigQueryRecordFormatter formatter,
-      final boolean isDefaultAirbyteTmpSchema)
+                                                                       final JsonNode config,
+                                                                       final ConfiguredAirbyteStream configStream,
+                                                                       final TableId targetTable,
+                                                                       final TableId tmpTable,
+                                                                       final BigQuery bigQuery,
+                                                                       final JobInfo.WriteDisposition syncMode,
+                                                                       final BigQueryRecordFormatter formatter,
+                                                                       final boolean isDefaultAirbyteTmpSchema)
       throws IOException {
 
     final GcsDestinationConfig gcsDestinationConfig =
@@ -134,13 +134,13 @@ public class BigQueryUploaderFactory {
   }
 
   private static BigQueryDirectUploader getBigQueryDirectUploader(
-      final JsonNode config,
-      final TableId targetTable,
-      final TableId tmpTable,
-      final BigQuery bigQuery,
-      final JobInfo.WriteDisposition syncMode,
-      final String datasetLocation,
-      final BigQueryRecordFormatter formatter) {
+                                                                  final JsonNode config,
+                                                                  final TableId targetTable,
+                                                                  final TableId tmpTable,
+                                                                  final BigQuery bigQuery,
+                                                                  final JobInfo.WriteDisposition syncMode,
+                                                                  final String datasetLocation,
+                                                                  final BigQueryRecordFormatter formatter) {
     // https://cloud.google.com/bigquery/docs/loading-data-local#loading_data_from_a_local_data_source
     final WriteChannelConfiguration writeChannelConfiguration =
         WriteChannelConfiguration.newBuilder(tmpTable)

--- a/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/avro/GcsAvroWriter.java
+++ b/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/avro/GcsAvroWriter.java
@@ -62,11 +62,12 @@ public class GcsAvroWriter extends BaseGcsWriter implements S3Writer, GscWriter,
       throws IOException {
     super(config, s3Client, configuredStream);
 
-    final Schema schema = (jsonSchema == null
+    final Schema schema = jsonSchema == null
         ? GcsUtils.getDefaultAvroSchema(stream.getName(), stream.getNamespace(), true)
         : new JsonToAvroSchemaConverter().getAvroSchema(jsonSchema, stream.getName(),
-            stream.getNamespace(), true, false, false, true));
-    LOGGER.info("Avro schema : {}", schema);
+            stream.getNamespace(), true, false, false, true);
+    LOGGER.info("Avro schema for stream {}: {}", stream.getName(), schema.toString(false));
+
     final String outputFilename = BaseGcsWriter.getOutputFilename(uploadTimestamp, S3Format.AVRO);
     objectKey = String.join("/", outputPrefix, outputFilename);
     gcsFileLocation = String.format("gs://%s/%s", config.getBucketName(), objectKey);

--- a/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/avro/GcsAvroWriter.java
+++ b/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/avro/GcsAvroWriter.java
@@ -58,12 +58,13 @@ public class GcsAvroWriter extends BaseGcsWriter implements S3Writer, GscWriter,
                        final ConfiguredAirbyteStream configuredStream,
                        final Timestamp uploadTimestamp,
                        final JsonAvroConverter converter,
-                       final JsonNode airbyteSchema)
+                       final JsonNode jsonSchema)
       throws IOException {
     super(config, s3Client, configuredStream);
 
-    Schema schema = (airbyteSchema == null ? GcsUtils.getDefaultAvroSchema(stream.getName(), stream.getNamespace(), true)
-        : new JsonToAvroSchemaConverter().getAvroSchema(airbyteSchema, stream.getName(),
+    final Schema schema = (jsonSchema == null
+        ? GcsUtils.getDefaultAvroSchema(stream.getName(), stream.getNamespace(), true)
+        : new JsonToAvroSchemaConverter().getAvroSchema(jsonSchema, stream.getName(),
             stream.getNamespace(), true, false, false, true));
     LOGGER.info("Avro schema : {}", schema);
     final String outputFilename = BaseGcsWriter.getOutputFilename(uploadTimestamp, S3Format.AVRO);
@@ -93,8 +94,8 @@ public class GcsAvroWriter extends BaseGcsWriter implements S3Writer, GscWriter,
   }
 
   @Override
-  public void write(JsonNode formattedData) throws IOException {
-    GenericData.Record record = avroRecordFactory.getAvroRecord(formattedData);
+  public void write(final JsonNode formattedData) throws IOException {
+    final GenericData.Record record = avroRecordFactory.getAvroRecord(formattedData);
     dataFileWriter.append(record);
   }
 

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/JsonToAvroSchemaConverter.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/JsonToAvroSchemaConverter.java
@@ -201,7 +201,6 @@ public class JsonToAvroSchemaConverter {
         if (fieldDefinition.has("format")) {
           final String format = fieldDefinition.get("format").asText();
           fieldSchema = switch (format) {
-            case "timestamp-micros" -> LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
             case "date-time" -> LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
             case "date" -> LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT));
             case "time" -> LogicalTypes.timeMicros().addToSchema(Schema.create(Schema.Type.LONG));


### PR DESCRIPTION
## What
- In #8788, a hack is introduced to the Json Avro schema converter.
- The BigQuery uploader converts the Json schema to both Avro and BigQuery schema.
  - The Avro schema is used to convert Json objects to Avro objects.
  - The BigQuery schema is used to create the BigQuery table.
- The correct process should be:
  1. Json schema -> Avro schema
  2. Json schema -> BigQuery schema
- The BigQuery uploader incorrectly uses the BigQuery schema as the input for 1.
  - So it is Json schema -> BigQuery schema -> Avro schema
- This is problematic because BigQuery schema is actually similar to the Avro schema.
  - The `date-time` format in the Json schema is changed to `timestamp-micros`.
- But the Json to Avro schema converter expects a pure Json schema.
- Consequently, the Json to Avro schema converter needs to handle the Avro format `timestamp-micros`, which should not be necessarily.

## How
- This PR fixes this hack by using the correct Json schema as the input to the Json to Avro schema converter.

## Review Order
- `GcsBigQueryDenormalizedRecordFormatter.java`
- `JsonToAvroSchemaConverter.java`.
- All other changes are automatic changes that add `final`s by the IDE.

## Checkline
- This PR does not change any functionality. No connector publishing is needed.
