### PR TITLE
fix editorconfig for non-python

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,20 +1,5 @@
 root = true
 
-[*]
-charset = utf-8
-indent_size = 4
-indent_style = space
-insert_final_newline = true
-max_line_length = 140
-tab_width = 4
-ij_continuation_indent_size = 8
-ij_formatter_off_tag = @formatter:off
-ij_formatter_on_tag = @formatter:on
-ij_formatter_tags_enabled = false
-ij_smart_tabs = false
-ij_visual_guides = none
-ij_wrap_on_typing = false
-
 [{*.bash,*.sh,*.zsh}]
 indent_size = 2
 tab_width = 2
@@ -52,6 +37,20 @@ ij_markdown_min_lines_around_header = 1
 ij_markdown_min_lines_between_paragraphs = 1
 
 [{*.py,*.pyw,Tiltfile}]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 140
+tab_width = 4
+ij_continuation_indent_size = 8
+ij_formatter_off_tag = @formatter:off
+ij_formatter_on_tag = @formatter:on
+ij_formatter_tags_enabled = false
+ij_smart_tabs = false
+ij_visual_guides = none
+ij_wrap_on_typing = false
+
 ij_python_align_collections_and_comprehensions = true
 ij_python_align_multiline_imports = true
 ij_python_align_multiline_parameters = true


### PR DESCRIPTION
moved global rules to `python` section to avoid mess for different languages