### PR TITLE
Fix generate.sh from bad trap for ERR signal by using bash instead of sh

### DIFF
--- a/airbyte-integrations/connector-templates/generator/generate.sh
+++ b/airbyte-integrations/connector-templates/generator/generate.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 error_handler() {
   echo "While trying to generate a connector, an error occurred on line $1 of generate.sh and the process aborted early.  This is probably a bug."
@@ -21,10 +21,10 @@ docker build --build-arg UID="$_UID" --build-arg GID="$_GID" . -t airbyte/connec
 # Run the container and mount the airbyte folder
 if [ $# -eq 2 ]; then
   echo "2 arguments supplied: 1=$1 2=$2"
-  docker run --name airbyte-connector-bootstrap --user $_UID:$_GID -e HOME=/tmp -e package_desc="$1" -e package_name="$2" -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
+  docker run --name airbyte-connector-bootstrap --user "$_UID:$_GID" -e HOME=/tmp -e package_desc="$1" -e package_name="$2" -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
 else
   echo "Running generator..."
-  docker run --rm -it --name airbyte-connector-bootstrap --user $_UID:$_GID -e HOME=/tmp -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
+  docker run --rm -it --name airbyte-connector-bootstrap --user "$_UID:$_GID" -e HOME=/tmp -v "$(pwd)/../../../.":/airbyte airbyte/connector-bootstrap
 fi
 
 echo "Finished running generator"


### PR DESCRIPTION
## What
Reports of some users seeing `bad trap` when running `airbyte-integrations/connector-templates/generator/generate.sh` because `ERR` does not exist in POSIX. 

https://github.com/airbytehq/airbyte/issues/5586

## How
Use `bash` instead. I noticed a lot of the shell scripts in the repo use `#!/usr/bin/env bash` but a lot of the connectors use `sh` in the `acceptance-test-docker.sh` scripts. I was confused at first but it seems like the reason for this is that the generator docker image takes the last created connector and creates a template based off of that. So unless there was an intentional reason for using `sh` I think changing everything to bash now would solve this for the future until a linter rule is created to require bash. 

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
No user impact

## Pre-merge Checklist

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/airbytehq/airbyte/9243)
<!-- Reviewable:end -->
