### PR TITLE
Helm chart: add preinstall hook to env-configmap

### DIFF
--- a/charts/airbyte/templates/bootloader/pod.yaml
+++ b/charts/airbyte/templates/bootloader/pod.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "airbyte.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
 spec:
   restartPolicy: Never
   containers:

--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: airbyte-env
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-1"
 data:
   AIRBYTE_VERSION: {{ .Values.version | default .Chart.AppVersion }}
   API_URL: {{ .Values.webapp.api.url }}


### PR DESCRIPTION
## What
The `bootloader` Pod requires value from the `airbyte-env` ConfigMap.
The `bootloader` has `pre-install` and `pre-upgrade` hooks but the `airbyte-env` doesn't. On a fresh install, the ConfigMap is missing when the bootloader starts.

## How
* Add `pre-install` and `pre-upgrade` hooks to `airbyte-env` ConfigMap
* Define `hook-weight` annotation on `airbyte-env` and `bootloader` to make sure the ConfigMap is created before the `bootloader` pod runs.

This fix comes from a bug detected in this [Slack conversion](https://airbytehq.slack.com/archives/C01MFR03D5W/p1641222074066600).

## Recommended reading order
1. `charts/airbyte/templates/env-configmap.yaml`
2. `charts/airbyte/templates/bootloader/pod.yaml`

## 🚨 User Impact 🚨
No user impact.