### PR TITLE
raise init pod termination check timeout to 5 minutes

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -243,7 +243,7 @@ public class KubePodProcess extends Process {
           // Copying the success indicator file to the init container causes the container to immediately
           // exit, causing the `kubectl cp` command to exit with code 137. This check ensures that an error is
           // not thrown in this case if the init container exits successfully.
-          if (file.getKey().equals(SUCCESS_FILE_NAME) && waitForInitPodToTerminate(client, podDefinition, 10, TimeUnit.SECONDS) == 0) {
+          if (file.getKey().equals(SUCCESS_FILE_NAME) && waitForInitPodToTerminate(client, podDefinition, 5, TimeUnit.MINUTES) == 0) {
             LOGGER.info("Init was successful; ignoring non-zero kubectl cp exit code for success indicator file.");
           } else {
             throw new IOException("kubectl cp failed with exit code " + exitCode);


### PR DESCRIPTION
## What
See slack thread here: https://airbytehq.slack.com/archives/C0229LM09T4/p1641239861308700

In summary, the current 10 second timeout that is used to wait for the init pod to terminate is likely too low, causing errors when the init pod does not terminate in that time.

## How
This PR fixes the issue by raising the timeout to 5 minutes.
