### PR TITLE
decrease cost of health check

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -3198,9 +3198,9 @@ components:
     HealthCheckRead:
       type: object
       required:
-        - db
+        - available
       properties:
-        db:
+        available:
           type: boolean
     # General
     CheckConnectionRead:

--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/SchedulerApp.java
@@ -205,7 +205,7 @@ public class SchedulerApp {
     while (!isHealthy) {
       try {
         final HealthCheckRead healthCheck = apiClient.getHealthApi().getHealthCheck();
-        isHealthy = healthCheck.getDb();
+        isHealthy = healthCheck.getAvailable();
       } catch (final ApiException e) {
         LOGGER.info("Waiting for server to become available...");
         Thread.sleep(2000);

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -214,7 +214,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
         jobHistoryHandler,
         schedulerHandler,
         operationsHandler);
-    healthCheckHandler = new HealthCheckHandler(configRepository);
+    healthCheckHandler = new HealthCheckHandler();
     archiveHandler = new ArchiveHandler(
         airbyteVersion,
         configRepository,

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/HealthCheckHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/HealthCheckHandler.java
@@ -5,31 +5,11 @@
 package io.airbyte.server.handlers;
 
 import io.airbyte.api.model.HealthCheckRead;
-import io.airbyte.config.persistence.ConfigRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class HealthCheckHandler {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckHandler.class);
-
-  private final ConfigRepository configRepository;
-
-  public HealthCheckHandler(final ConfigRepository configRepository) {
-    this.configRepository = configRepository;
-  }
-
-  // todo (cgardens) - add more checks as we go.
   public HealthCheckRead health() {
-    boolean databaseHealth = false;
-    try {
-      configRepository.listStandardWorkspaces(true);
-      databaseHealth = true;
-    } catch (final Exception e) {
-      LOGGER.error("database health check failed.");
-    }
-
-    return new HealthCheckRead().db(databaseHealth);
+    return new HealthCheckRead().available(true);
   }
 
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/HealthCheckHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/HealthCheckHandlerTest.java
@@ -5,31 +5,16 @@
 package io.airbyte.server.handlers;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import io.airbyte.api.model.HealthCheckRead;
-import io.airbyte.config.StandardWorkspace;
-import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.validation.json.JsonValidationException;
-import java.io.IOException;
-import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class HealthCheckHandlerTest {
 
   @Test
-  void testDbHealth() throws IOException, JsonValidationException {
-    final ConfigRepository configRepository = mock(ConfigRepository.class);
-    final HealthCheckHandler healthCheckHandler = new HealthCheckHandler(configRepository);
-
-    // check db healthy
-    when(configRepository.listStandardWorkspaces(true)).thenReturn(Collections.singletonList(new StandardWorkspace()));
-    assertEquals(new HealthCheckRead().db(true), healthCheckHandler.health());
-
-    doThrow(IOException.class).when(configRepository).listStandardWorkspaces(true);
-    assertEquals(new HealthCheckRead().db(false), healthCheckHandler.health());
+  void testDbHealth() {
+    final HealthCheckHandler healthCheckHandler = new HealthCheckHandler();
+    assertEquals(new HealthCheckRead().available(true), healthCheckHandler.health());
   }
 
 }

--- a/airbyte-webapp/src/config/defaultConfig.ts
+++ b/airbyte-webapp/src/config/defaultConfig.ts
@@ -18,7 +18,7 @@ const features: Feature[] = [
 const defaultConfig: Config = {
   ui: uiConfig,
   segment: { enabled: true, token: "" },
-  healthCheckInterval: 10000,
+  healthCheckInterval: 20000,
   version: "dev",
   apiUrl: `${window.location.protocol}//${window.location.hostname}:8001/api/v1/`,
   integrationUrl: "/docs",

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -2784,7 +2784,7 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "db" : true
+  "available" : true
 }</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -7572,7 +7572,7 @@ font-style: italic;
     <h3><a name="HealthCheckRead"><code>HealthCheckRead</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">db </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+      <div class="param">available </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
As far as I can tell, nobody actually needs to use the db value (`HealthService` just calls it and checks for an error and the scheduler app won't reach the point where the server is live if the db is not on startup).