### PR TITLE
Specify python3 instead of python3.7 for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.7
+  python: python3
 
 repos:
   - repo: https://github.com/johann-petrak/licenseheaders.git


### PR DESCRIPTION
On an M1 mac with python3.7 and python3.10 installed, I see the following error any time I attempt to commit:

```
[INFO] Installing environment for https://github.com/johann-petrak/licenseheaders.git.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/Users/parker/.pyenv/versions/3.10.0/bin/python3.10', '-mvirtualenv', '/Users/parker/.cache/pre-commit/repoyd65z1bj/py_env-python3.7', '-p', 'python3.7')
return code: 1
expected return code: 0
stdout:
    RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.7'

stderr: (none)
Check the log at /Users/parker/.cache/pre-commit/pre-commit.log
```

Changing the default language version from `python3.7` to `python3` fixes this issue for me.

@sergei-solonitcyn, I'm not sure what the wider implications of such a change would be but if it seems safe to you, it'd help out M1 users who are running into this issue. (@edgao confirmed he has the same issue on his M1)