### PR TITLE
remove health query for migration test

### DIFF
--- a/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
+++ b/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
@@ -318,8 +318,7 @@ public class MigrationAcceptanceTest {
   private static void healthCheck(final ApiClient apiClient) {
     final HealthApi healthApi = new HealthApi(apiClient);
     try {
-      final HealthCheckRead healthCheck = healthApi.getHealthCheck();
-      assertTrue(healthCheck.getAvailable());
+      healthApi.getHealthCheck();
     } catch (final ApiException e) {
       throw new RuntimeException("Health check failed, usually due to auto migration failure. Please check the logs for details.");
     }

--- a/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
+++ b/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
@@ -22,7 +22,6 @@ import io.airbyte.api.client.invoker.ApiException;
 import io.airbyte.api.client.model.ConnectionRead;
 import io.airbyte.api.client.model.ConnectionStatus;
 import io.airbyte.api.client.model.DestinationDefinitionRead;
-import io.airbyte.api.client.model.HealthCheckRead;
 import io.airbyte.api.client.model.ImportRead;
 import io.airbyte.api.client.model.ImportRead.StatusEnum;
 import io.airbyte.api.client.model.SourceDefinitionRead;


### PR DESCRIPTION
The API endpoint changed but this test also runs on an old version which has the old implementation. All we really care is that it returns a 200 though.