### PR TITLE
Fix connector base test

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
+++ b/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
@@ -240,10 +240,7 @@ class AirbyteMessage(BaseModel):
     )
     spec: Optional[ConnectorSpecification] = None
     connectionStatus: Optional[AirbyteConnectionStatus] = None
-    catalog: Optional[AirbyteCatalog] = Field(
-        None,
-        description="log message: any kind of logging you want the platform to know about.",
-    )
+    catalog: Optional[AirbyteCatalog] = Field(None, description="catalog message: the calalog")
     record: Optional[AirbyteRecordMessage] = Field(None, description="record message: the record")
     state: Optional[AirbyteStateMessage] = Field(
         None,

--- a/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
+++ b/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
@@ -226,7 +226,7 @@ class AirbyteMessage(BaseModel):
     log: Optional[AirbyteLogMessage] = Field(None, description="log message: any kind of logging you want the platform to know about.")
     spec: Optional[ConnectorSpecification] = None
     connectionStatus: Optional[AirbyteConnectionStatus] = None
-    catalog: Optional[AirbyteCatalog] = Field(None, description="log message: any kind of logging you want the platform to know about.")
+    catalog: Optional[AirbyteCatalog] = Field(None, description="catalog message: the calalog")
     record: Optional[AirbyteRecordMessage] = Field(None, description="record message: the record")
     state: Optional[AirbyteStateMessage] = Field(
         None, description="schema message: the state. Must be the last message produced. The platform uses this information"

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_utils.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_utils.py
@@ -259,12 +259,12 @@ def test_failed_reading(traceback, container_error, last_line, expected_error):
     "command,wait_timeout,expected_count",
     (
         (
-            "cnt=0; while [ $cnt -lt 10 ]; do cnt=$((cnt+1)); sleep 0.5; echo something; done",
-            0,
+            "cnt=0; while [ $cnt -lt 10 ]; do cnt=$((cnt+1)); echo something; done",
+            2,
             10,
         ),
         # Sometimes a container can finish own work before python tries to read it
-        ("echo something;", 3, 1),
+        ("echo something;", 2, 1),
     ),
     ids=["standard", "waiting"],
 )

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_utils.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_utils.py
@@ -256,27 +256,25 @@ def test_failed_reading(traceback, container_error, last_line, expected_error):
 
 
 @pytest.mark.parametrize(
-    "command,wait_timeout,expected_count",
+    "command,expected_count",
     (
         (
             "cnt=0; while [ $cnt -lt 10 ]; do cnt=$((cnt+1)); echo something; done",
-            3,
             10,
         ),
-        # Sometimes a container can finish own work before python tries to read it
-        ("echo something;", 3, 1),
+        ("echo something;", 1),
     ),
     ids=["standard", "waiting"],
 )
-def test_docker_runner(command, wait_timeout, expected_count):
+def test_docker_runner(command, expected_count):
     client = docker.from_env()
     new_container = client.containers.run(
         image="busybox",
-        command=f"""sh -c '{command}'""",
+        # Sometimes a container can finish its work before python tries to read it,
+        # so the container always sleeps for a while first.
+        command=f"""sh -c 'sleep 3; {command}'""",
         detach=True,
     )
-    if wait_timeout:
-        time.sleep(wait_timeout)
     lines = list(ConnectorRunner.read(new_container, command=command))
     assert set(lines) == set(["something\n"])
     assert len(lines) == expected_count

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_utils.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_utils.py
@@ -259,7 +259,7 @@ def test_failed_reading(traceback, container_error, last_line, expected_error):
     "command,wait_timeout,expected_count",
     (
         (
-            "cnt=0; while [ $cnt -lt 10 ]; do cnt=$((cnt+1)); echo something; done",
+            "cnt=0; while [ $cnt -lt 10 ]; do cnt=$((cnt+1)); sleep 0.5; echo something; done",
             0,
             10,
         ),

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_utils.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_utils.py
@@ -260,11 +260,11 @@ def test_failed_reading(traceback, container_error, last_line, expected_error):
     (
         (
             "cnt=0; while [ $cnt -lt 10 ]; do cnt=$((cnt+1)); echo something; done",
-            2,
+            3,
             10,
         ),
         # Sometimes a container can finish own work before python tries to read it
-        ("echo something;", 2, 1),
+        ("echo something;", 3, 1),
     ),
     ids=["standard", "waiting"],
 )

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_utils.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_utils.py
@@ -264,7 +264,7 @@ def test_failed_reading(traceback, container_error, last_line, expected_error):
             10,
         ),
         # Sometimes a container can finish own work before python tries to read it
-        ("echo something;", 0.1, 1),
+        ("echo something;", 3, 1),
     ),
     ids=["standard", "waiting"],
 )

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
@@ -127,7 +127,8 @@ public class SnowflakeInsertDestinationAcceptanceTest extends DestinationAccepta
           final ResultSet tableInfo = connection.createStatement()
               .executeQuery(String.format("SHOW TABLES LIKE '%s' IN SCHEMA %s;", tableName, schema));
           assertTrue(tableInfo.next());
-          // check that we're creating permanent tables. DBT defaults to transient tables, which have `TRANSIENT` as the value for the `kind` column.
+          // check that we're creating permanent tables. DBT defaults to transient tables, which have
+          // `TRANSIENT` as the value for the `kind` column.
           assertEquals("TABLE", tableInfo.getString("kind"));
           return connection.createStatement()
               .executeQuery(String.format("SELECT * FROM %s.%s ORDER BY %s ASC;", schema, tableName, JavaBaseConstants.COLUMN_NAME_EMITTED_AT));


### PR DESCRIPTION
- The `Connectors Base: Build` step becomes flaky after https://github.com/airbytehq/airbyte/pull/9046. It's probably due to the shorted wait time.
- This PR tries to fix the build by adding back the wait time in the `test_docker_runner` method.
- The main change is in `test_utils.py`.
