### PR TITLE
source-googlesheet: Service account json should be secret

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -259,7 +259,7 @@
 - name: Google Sheets
   sourceDefinitionId: 71607ba1-c0ac-4799-8049-7f4b90dd50f7
   dockerRepository: airbyte/source-google-sheets
-  dockerImageTag: 0.2.7
+  dockerImageTag: 0.2.8
   documentationUrl: https://docs.airbyte.io/integrations/sources/google-sheets
   icon: google-sheets.svg
   sourceType: file

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -2583,7 +2583,7 @@
         oauthFlowOutputParameters:
         - - "access_token"
         - - "refresh_token"
-- dockerImage: "airbyte/source-google-sheets:0.2.7"
+- dockerImage: "airbyte/source-google-sheets:0.2.8"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/google-sheets"
     connectionSpecification:
@@ -2639,6 +2639,7 @@
               service_account_info:
                 type: "string"
                 description: "The JSON key of the service account to use for authorization"
+                airbyte_secret: true
                 examples:
                 - "{ \"type\": \"service_account\", \"project_id\": YOUR_PROJECT_ID,\
                   \ \"private_key_id\": YOUR_PRIVATE_KEY, ... }"
@@ -2650,7 +2651,7 @@
       oauth2Specification:
         rootObject:
         - "credentials"
-        - 0
+        - "0"
         oauthFlowInitParameters:
         - - "client_id"
         - - "client_secret"

--- a/airbyte-integrations/connectors/source-google-sheets/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-sheets/Dockerfile
@@ -34,6 +34,6 @@ COPY google_sheets_source ./google_sheets_source
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.7
+LABEL io.airbyte.version=0.2.8
 LABEL io.airbyte.name=airbyte/source-google-sheets
 

--- a/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/spec.json
+++ b/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/spec.json
@@ -60,6 +60,7 @@
               "service_account_info": {
                 "type": "string",
                 "description": "The JSON key of the service account to use for authorization",
+                "airbyte_secret": true,
                 "examples": [
                   "{ \"type\": \"service_account\", \"project_id\": YOUR_PROJECT_ID, \"private_key_id\": YOUR_PRIVATE_KEY, ... }"
                 ]


### PR DESCRIPTION
## What
The service account field should be flagged as secret

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 
   
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Code reviews completed
- [x] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [x] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [x] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [x] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   