### PR TITLE
Revert "Fix connector base test"

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
+++ b/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
@@ -240,7 +240,10 @@ class AirbyteMessage(BaseModel):
     )
     spec: Optional[ConnectorSpecification] = None
     connectionStatus: Optional[AirbyteConnectionStatus] = None
-    catalog: Optional[AirbyteCatalog] = Field(None, description="catalog message: the calalog")
+    catalog: Optional[AirbyteCatalog] = Field(
+        None,
+        description="log message: any kind of logging you want the platform to know about.",
+    )
     record: Optional[AirbyteRecordMessage] = Field(None, description="record message: the record")
     state: Optional[AirbyteStateMessage] = Field(
         None,

--- a/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
+++ b/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
@@ -226,7 +226,7 @@ class AirbyteMessage(BaseModel):
     log: Optional[AirbyteLogMessage] = Field(None, description="log message: any kind of logging you want the platform to know about.")
     spec: Optional[ConnectorSpecification] = None
     connectionStatus: Optional[AirbyteConnectionStatus] = None
-    catalog: Optional[AirbyteCatalog] = Field(None, description="catalog message: the calalog")
+    catalog: Optional[AirbyteCatalog] = Field(None, description="log message: any kind of logging you want the platform to know about.")
     record: Optional[AirbyteRecordMessage] = Field(None, description="record message: the record")
     state: Optional[AirbyteStateMessage] = Field(
         None, description="schema message: the state. Must be the last message produced. The platform uses this information"

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_utils.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_utils.py
@@ -256,25 +256,27 @@ def test_failed_reading(traceback, container_error, last_line, expected_error):
 
 
 @pytest.mark.parametrize(
-    "command,expected_count",
+    "command,wait_timeout,expected_count",
     (
         (
             "cnt=0; while [ $cnt -lt 10 ]; do cnt=$((cnt+1)); echo something; done",
+            0,
             10,
         ),
-        ("echo something;", 1),
+        # Sometimes a container can finish own work before python tries to read it
+        ("echo something;", 0.1, 1),
     ),
     ids=["standard", "waiting"],
 )
-def test_docker_runner(command, expected_count):
+def test_docker_runner(command, wait_timeout, expected_count):
     client = docker.from_env()
     new_container = client.containers.run(
         image="busybox",
-        # Sometimes a container can finish its work before python tries to read it,
-        # so the container always sleeps for a while first.
-        command=f"""sh -c 'sleep 3; {command}'""",
+        command=f"""sh -c '{command}'""",
         detach=True,
     )
+    if wait_timeout:
+        time.sleep(wait_timeout)
     lines = list(ConnectorRunner.read(new_container, command=command))
     assert set(lines) == set(["something\n"])
     assert len(lines) == expected_count

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
@@ -127,8 +127,7 @@ public class SnowflakeInsertDestinationAcceptanceTest extends DestinationAccepta
           final ResultSet tableInfo = connection.createStatement()
               .executeQuery(String.format("SHOW TABLES LIKE '%s' IN SCHEMA %s;", tableName, schema));
           assertTrue(tableInfo.next());
-          // check that we're creating permanent tables. DBT defaults to transient tables, which have
-          // `TRANSIENT` as the value for the `kind` column.
+          // check that we're creating permanent tables. DBT defaults to transient tables, which have `TRANSIENT` as the value for the `kind` column.
           assertEquals("TABLE", tableInfo.getString("kind"));
           return connection.createStatement()
               .executeQuery(String.format("SELECT * FROM %s.%s ORDER BY %s ASC;", schema, tableName, JavaBaseConstants.COLUMN_NAME_EMITTED_AT));


### PR DESCRIPTION
Reverts airbytehq/airbyte#9348 because it was not working. The `test_docker_runner[standard]` and `test_docker_runner[waiting]` were still failing transiently.
