### PR TITLE
🐛  Source Recurly: avoid loading all accounts when importing account coupon redemptions

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/cd42861b-01fc-4658-a8ab-5d11d0510f01.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/cd42861b-01fc-4658-a8ab-5d11d0510f01.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "cd42861b-01fc-4658-a8ab-5d11d0510f01",
   "name": "Recurly",
   "dockerRepository": "airbyte/source-recurly",
-  "dockerImageTag": "0.3.0",
+  "dockerImageTag": "0.3.1",
   "documentationUrl": "https://docs.airbyte.io/integrations/sources/recurly",
   "icon": "recurly.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -3767,7 +3767,7 @@
     supported_destination_sync_modes:
     - "overwrite"
     - "append"
-- dockerImage: "airbyte/destination-snowflake:0.4.0"
+- dockerImage: "airbyte/destination-snowflake:0.4.1"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/snowflake"
     connectionSpecification:

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -572,7 +572,7 @@
 - name: Recurly
   sourceDefinitionId: cd42861b-01fc-4658-a8ab-5d11d0510f01
   dockerRepository: airbyte/source-recurly
-  dockerImageTag: 0.3.0
+  dockerImageTag: 0.3.1
   documentationUrl: https://docs.airbyte.io/integrations/sources/recurly
   icon: recurly.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -5885,7 +5885,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-recurly:0.3.0"
+- dockerImage: "airbyte/source-recurly:0.3.1"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/recurly"
     connectionSpecification:

--- a/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
+++ b/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
@@ -226,7 +226,7 @@ class AirbyteMessage(BaseModel):
     log: Optional[AirbyteLogMessage] = Field(None, description="log message: any kind of logging you want the platform to know about.")
     spec: Optional[ConnectorSpecification] = None
     connectionStatus: Optional[AirbyteConnectionStatus] = None
-    catalog: Optional[AirbyteCatalog] = Field(None, description="log message: any kind of logging you want the platform to know about.")
+    catalog: Optional[AirbyteCatalog] = Field(None, description="catalog message: the calalog")
     record: Optional[AirbyteRecordMessage] = Field(None, description="record message: the record")
     state: Optional[AirbyteStateMessage] = Field(
         None, description="schema message: the state. Must be the last message produced. The platform uses this information"

--- a/airbyte-integrations/connectors/source-recurly/.python-version
+++ b/airbyte-integrations/connectors/source-recurly/.python-version
@@ -1,0 +1,1 @@
+3.9.7/envs/airbyte-recurly

--- a/airbyte-integrations/connectors/source-recurly/Dockerfile
+++ b/airbyte-integrations/connectors/source-recurly/Dockerfile
@@ -34,5 +34,5 @@ COPY source_recurly ./source_recurly
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.3.0
+LABEL io.airbyte.version=0.3.1
 LABEL io.airbyte.name=airbyte/source-recurly

--- a/airbyte-integrations/connectors/source-recurly/source_recurly/streams.py
+++ b/airbyte-integrations/connectors/source-recurly/source_recurly/streams.py
@@ -169,7 +169,7 @@ class AccountCouponRedemptions(BaseStream):
             params.update({BEGIN_TIME_PARAM: self.begin_time})
 
         # Call the Recurly client methods
-        accounts = self._client.list_accounts().items()
+        accounts = self._client.list_accounts(params=params).items()
         for account in accounts:
             coupons = self._client.list_account_coupon_redemptions(account_id=account.id, params=params).items()
             for coupon in coupons:

--- a/airbyte-server/src/test/resources/migration/dummy_data/config/STANDARD_SOURCE_DEFINITION/cd42861b-01fc-4658-a8ab-5d11d0510f01.json
+++ b/airbyte-server/src/test/resources/migration/dummy_data/config/STANDARD_SOURCE_DEFINITION/cd42861b-01fc-4658-a8ab-5d11d0510f01.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "cd42861b-01fc-4658-a8ab-5d11d0510f01",
   "name": "Recurly",
   "dockerRepository": "airbyte/source-recurly",
-  "dockerImageTag": "0.2.0",
+  "dockerImageTag": "0.3.1",
   "documentationUrl": "https://hub.docker.com/r/airbyte/source-recurly",
   "spec": {
     "documentationUrl": "https://docs.airbyte.io/integrations/sources/recurly",

--- a/docs/integrations/sources/recurly.md
+++ b/docs/integrations/sources/recurly.md
@@ -54,6 +54,7 @@ We recommend creating a restricted, read-only key specifically for Airbyte acces
 
 | Version | Date       | Pull Request | Subject |
 |:--------|:-----------| :--- | :--- |
-| 0.3.0   | 2021-12-08 | [8468](https://github.com/airbytehq/airbyte/pull/8468) | Support Incremental Sync Mode |
 | 0.3.1   | 2022-01-10 | [9382](https://github.com/airbytehq/airbyte/pull/9382) | Source Recurly: avoid loading all accounts when importing account coupon redemptions |
+| 0.3.0   | 2021-12-08 | [8468](https://github.com/airbytehq/airbyte/pull/8468) | Support Incremental Sync Mode |
+
 

--- a/docs/integrations/sources/recurly.md
+++ b/docs/integrations/sources/recurly.md
@@ -55,4 +55,5 @@ We recommend creating a restricted, read-only key specifically for Airbyte acces
 | Version | Date       | Pull Request | Subject |
 |:--------|:-----------| :--- | :--- |
 | 0.3.0   | 2021-12-08 | [8468](https://github.com/airbytehq/airbyte/pull/8468) | Support Incremental Sync Mode |
+| 0.3.1   | 2022-01-10 | [9382](https://github.com/airbytehq/airbyte/pull/9382) | Source Recurly: avoid loading all accounts when importing account coupon redemptions |
 


### PR DESCRIPTION
## What
Avoid loading all Recurly accounts when importing account code redemptions. Only import the accounts having coupon redemptions created.

## How
Only import the accounts having coupon redemptions created by setting the `params` field when sending the request to Recurly API.

#### Community member or Airbyter
   
- [x] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [x] Code reviews completed
- [x] Documentation updated 
    - [x] Connector's `README.md`
    - [x] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] `docs/SUMMARY.md`
    - [x] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [x] `docs/integrations/README.md`
    - [x] `airbyte-integrations/builds.md`
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   

