### PR TITLE
Add the Graveyarded HTTP Request back to docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -76,6 +76,7 @@
     * [Google Workspace Admin Reports](integrations/sources/google-workspace-admin-reports.md)
     * [Greenhouse](integrations/sources/greenhouse.md)
     * [Harvest](integrations/sources/harvest.md)
+    * [HTTP Request (Graveyarded)](integrations/sources/http-request.md) 
     * [HubSpot](integrations/sources/hubspot.md)
     * [Instagram](integrations/sources/instagram.md)
     * [Intercom](integrations/sources/intercom.md)

--- a/docs/integrations/sources/http-request.md
+++ b/docs/integrations/sources/http-request.md
@@ -1,0 +1,18 @@
+# HTTP Request (Graveyarded)
+
+{% hint style="warning" %}
+This connector is graveyarded and will not be receiving any updates from the Airbyte team. Its functionalities have been replaced by the [Airbyte CDK](../../connector-development/cdk-python/README.md), which allows you to create source connectors for any HTTP API.
+{% endhint %}
+
+## Overview
+
+This connector allows you to generally connect to any HTTP API. In order to use this connector, you must manually bring it in as a custom connector. The steps to do this can be found [here](../../connector-development/tutorials/cdk-tutorial-python-http/7-use-connector-in-airbyte.md). 
+
+## Where do I find the Docker image?
+
+The Docker image for the HTTP Request connector image can be found at our DockerHub [here](https://hub.docker.com/r/airbyte/source-http-request). 
+
+## Why was this connector graveyarded?
+
+We found that there are lots of cases in which using a general connector leads to poor user experience, as there are countless edge cases for different API structures, different authentication policies, and varied approaches to rate-limiting. We believe that enabling users to more easily
+create connectors is a more scalable and resilient approach to maximizing the quality of the user experience. 


### PR DESCRIPTION
## Main Changes
- Some people are still interested in using the old HTTP Request connector, so this shows how that can be done, but explains why we stopped updating and supporting it as a first class citizen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/airbytehq/airbyte/9451)
<!-- Reviewable:end -->
