### PR TITLE
reintroduce window in days, log warning when sampling occurs

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -245,7 +245,7 @@
 - name: Google Analytics
   sourceDefinitionId: eff3616a-f9c3-11eb-9a03-0242ac130003
   dockerRepository: airbyte/source-google-analytics-v4
-  dockerImageTag: 0.1.15
+  dockerImageTag: 0.1.16
   documentationUrl: https://docs.airbyte.io/integrations/sources/google-analytics-v4
   icon: google-analytics.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -2292,7 +2292,7 @@
         oauthFlowOutputParameters:
         - - "access_token"
         - - "refresh_token"
-- dockerImage: "airbyte/source-google-analytics-v4:0.1.15"
+- dockerImage: "airbyte/source-google-analytics-v4:0.1.16"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/google-analytics-v4"
     connectionSpecification:
@@ -2319,6 +2319,20 @@
             \ will not be replicated."
           examples:
           - "2020-06-01"
+        window_in_days:
+          type: "integer"
+          title: "Window in days"
+          description: "The amount of days for each data-chunk beginning from start_date.\
+            \ Bigger the value - faster the fetch. (Min=1, as for a Day; Max=364,\
+            \ as for a Year)."
+          examples:
+          - 30
+          - 60
+          - 90
+          - 120
+          - 200
+          - 364
+          default: 1
         custom_reports:
           order: 3
           type: "string"
@@ -2330,6 +2344,7 @@
           order: 0
           type: "object"
           title: "Credentials"
+          description: "Credentials for the service"
           oneOf:
           - title: "Authenticate via Google (Oauth)"
             type: "object"

--- a/airbyte-integrations/connectors/source-google-analytics-v4/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.15
+LABEL io.airbyte.version=0.1.16
 LABEL io.airbyte.name=airbyte/source-google-analytics-v4

--- a/airbyte-integrations/connectors/source-google-analytics-v4/setup.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk", "PyJWT", "cryptography"]
+MAIN_REQUIREMENTS = ["airbyte-cdk", "PyJWT", "cryptography", "requests"]
 
 TEST_REQUIREMENTS = [
     "pytest~=6.1",

--- a/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
@@ -431,7 +431,7 @@ class GoogleAnalyticsServiceOauth2Authenticator(Oauth2Authenticator):
     def __init__(self, config):
         self.credentials_json = json.loads(config["credentials_json"])
         self.client_email = self.credentials_json["client_email"]
-        self.scope = "https://www.googleapis .com/auth/analytics.readonly"
+        self.scope = "https://www.googleapis.com/auth/analytics.readonly"
 
         super().__init__(
             token_refresh_endpoint="https://oauth2.googleapis.com/token",

--- a/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
@@ -9,17 +9,7 @@ import pkgutil
 import time
 from abc import ABC
 from datetime import datetime
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
-    MutableMapping,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Union
 
 import jwt
 import pendulum

--- a/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
@@ -4,11 +4,22 @@
 
 
 import json
+import logging
 import pkgutil
 import time
 from abc import ABC
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import jwt
 import pendulum
@@ -39,14 +50,14 @@ class GoogleAnalyticsV4TypesList(HttpStream):
     # Column id completely match for v3 and v4.
     url_base = "https://www.googleapis.com/analytics/v3/metadata/ga/columns"
 
-    def path(self, **kwargs) -> str:
+    def path(self, **kwargs: MutableMapping) -> str:
         return ""
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         """Abstractmethod HTTPStream CDK dependency"""
         return None
 
-    def parse_response(self, response: requests.Response, **kwargs) -> Tuple[dict, dict]:
+    def parse_response(self, response: requests.Response, **kwargs: Any) -> Tuple[dict, dict]:
         """
         Returns a map of (dimensions, metrics) hashes, example:
           ({"ga:userType": "STRING", "ga:sessionCount": "STRING"}, {"ga:pageviewsPerSession": "FLOAT", "ga:sessions": "INTEGER"})
@@ -95,15 +106,17 @@ class GoogleAnalyticsV4Stream(HttpStream, ABC):
 
     map_type = dict(INTEGER="integer", FLOAT="number", PERCENT="number", TIME="number")
 
-    def __init__(self, config: Dict):
+    def __init__(self, config: MutableMapping):
         super().__init__(authenticator=config["authenticator"])
         self.start_date = config["start_date"]
-        self.window_in_days = config.get("window_in_days", 1)
+        self.window_in_days: int = config.get("window_in_days", 1)
         self.view_id = config["view_id"]
         self.metrics = config["metrics"]
         self.dimensions = config["dimensions"]
         self._config = config
         self.dimensions_ref, self.metrics_ref = GoogleAnalyticsV4TypesList().read_records(sync_mode=None)
+
+        self._raise_on_http_errors: bool = True
 
     @property
     def state_checkpoint_interval(self) -> int:
@@ -122,7 +135,7 @@ class GoogleAnalyticsV4Stream(HttpStream, ABC):
     def to_iso_datetime_str(date: str) -> str:
         return datetime.strptime(date, "%Y%m%d").strftime("%Y-%m-%d")
 
-    def path(self, **kwargs) -> str:
+    def path(self, **kwargs: Any) -> str:
         # need add './' for correct urllib.parse.urljoin work due to path contains ':'
         return "./reports:batchGet"
 
@@ -138,15 +151,17 @@ class GoogleAnalyticsV4Stream(HttpStream, ABC):
 
         if response.status_code == 400:
             self.logger.info(f"{response.json()['error']['message']}")
-            self.raise_on_http_errors = False
+            self._raise_on_http_errors = False
 
-        return super().should_retry(response)
+        result: bool = HttpStream.should_retry(self, response)
+        return result
 
+    @property
     def raise_on_http_errors(self) -> bool:
-        return True
+        return self._raise_on_http_errors
 
     def request_body_json(
-        self, stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None, **kwargs
+        self, stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None, **kwargs: Any
     ) -> Optional[Mapping]:
 
         metrics = [{"expression": metric} for metric in self.metrics]
@@ -173,7 +188,7 @@ class GoogleAnalyticsV4Stream(HttpStream, ABC):
         Override get_json_schema CDK method to retrieve the schema information for GoogleAnalyticsV4 Object dynamically.
         """
 
-        schema = {
+        schema: Dict[str, Any] = {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": ["null", "object"],
             "additionalProperties": False,
@@ -188,7 +203,7 @@ class GoogleAnalyticsV4Stream(HttpStream, ABC):
             data_format = self.lookup_data_format(dimension)
             dimension = dimension.replace("ga:", "ga_")
 
-            dimension_data = {"type": [data_type]}
+            dimension_data: Dict[str, Any] = {"type": [data_type]}
             if data_format:
                 dimension_data["format"] = data_format
             schema["properties"][dimension] = dimension_data
@@ -200,14 +215,14 @@ class GoogleAnalyticsV4Stream(HttpStream, ABC):
             metric = metric.replace("ga:", "ga_")
 
             # metrics are allowed to also have null values
-            metric_data = {"type": ["null", data_type]}
+            metric_data: Dict[str, Any] = {"type": ["null", data_type]}
             if data_format:
                 metric_data["format"] = data_format
             schema["properties"][metric] = metric_data
 
         return schema
 
-    def stream_slices(self, stream_state: Mapping[str, Any] = None, **kwargs) -> Iterable[Optional[Mapping[str, Any]]]:
+    def stream_slices(self, stream_state: Mapping[str, Any] = None, **kwargs: Any) -> Iterable[Optional[Mapping[str, Any]]]:
         """
         Override default stream_slices CDK method to provide date_slices as page chunks for data fetch.
         Returns list of dict, example: [{
@@ -240,7 +255,8 @@ class GoogleAnalyticsV4Stream(HttpStream, ABC):
             start_date = end_date_slice.add(days=1)
         return date_slices
 
-    def get_data(self, data):
+    #   TODO: the method has to be updated for more logical and obvious
+    def get_data(self, data):  # type: ignore[no-untyped-def]
         for data_field in self.data_fields:
             if data and isinstance(data, dict):
                 data = data.get(data_field, [])
@@ -248,7 +264,7 @@ class GoogleAnalyticsV4Stream(HttpStream, ABC):
                 return []
         return data
 
-    def lookup_data_type(self, field_type, attribute):
+    def lookup_data_type(self, field_type: str, attribute: str) -> str:
         """
         Get the data type of a metric or a dimension
         """
@@ -287,9 +303,8 @@ class GoogleAnalyticsV4Stream(HttpStream, ABC):
     def lookup_data_format(attribute: str) -> Union[str, None]:
         if attribute == "ga:date":
             return "date"
-        return
 
-    def convert_to_type(self, header, value, data_type):
+    def convert_to_type(self, header: str, value: Any, data_type: str) -> Any:
         if data_type == "integer":
             return int(value)
         if data_type == "number":
@@ -298,7 +313,7 @@ class GoogleAnalyticsV4Stream(HttpStream, ABC):
             return self.to_iso_datetime_str(value)
         return value
 
-    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
+    def parse_response(self, response: requests.Response, **kwargs: Any) -> Iterable[Mapping]:
         """
         Default response:
 
@@ -405,7 +420,7 @@ class GoogleAnalyticsV4Stream(HttpStream, ABC):
 
                 yield record
 
-    def check_for_sampled_result(self, data):
+    def check_for_sampled_result(self, data: Mapping) -> None:
         if not data.get("isDataGolden", True):
             self.logger.warning(DATA_IS_NOT_GOLDEN_MSG)
         if data.get("samplesReadCounts", False):
@@ -428,7 +443,7 @@ class GoogleAnalyticsServiceOauth2Authenticator(Oauth2Authenticator):
     https://oauth2.googleapis.com/token?grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=signed_JWT
     """
 
-    def __init__(self, config):
+    def __init__(self, config: Mapping):
         self.credentials_json = json.loads(config["credentials_json"])
         self.client_email = self.credentials_json["client_email"]
         self.scope = "https://www.googleapis.com/auth/analytics.readonly"
@@ -462,7 +477,7 @@ class GoogleAnalyticsServiceOauth2Authenticator(Oauth2Authenticator):
         else:
             return response_json["access_token"], response_json["expires_in"]
 
-    def get_refresh_request_params(self) -> Mapping[str, any]:
+    def get_refresh_request_params(self) -> Mapping[str, Any]:
         """
         Sign the JWT with RSA-256 using the private key found in service account JSON file.
         """
@@ -496,7 +511,7 @@ class TestStreamConnection(GoogleAnalyticsV4Stream):
         """For test reading pagination is not required"""
         return None
 
-    def stream_slices(self, stream_state: Mapping[str, Any] = None, **kwargs) -> Iterable[Optional[Mapping[str, Any]]]:
+    def stream_slices(self, stream_state: Mapping[str, Any] = None, **kwargs: Any) -> Iterable[Optional[Mapping[str, Any]]]:
         """
         Override this method to fetch records from start_date up to now for testing case
         """
@@ -509,7 +524,7 @@ class SourceGoogleAnalyticsV4(AbstractSource):
     """Google Analytics lets you analyze data about customer engagement with your website or application."""
 
     @staticmethod
-    def get_authenticator(config):
+    def get_authenticator(config: Mapping) -> Oauth2Authenticator:
         # backwards compatibility, credentials_json used to be in the top level of the connector
         if config.get("credentials_json"):
             return GoogleAnalyticsServiceOauth2Authenticator(config)
@@ -527,7 +542,7 @@ class SourceGoogleAnalyticsV4(AbstractSource):
                 scopes=["https://www.googleapis.com/auth/analytics.readonly"],
             )
 
-    def check_connection(self, logger, config) -> Tuple[bool, any]:
+    def check_connection(self, logger: logging.Logger, config: MutableMapping) -> Tuple[bool, Any]:
 
         # declare additional variables
         authenticator = self.get_authenticator(config)
@@ -560,7 +575,7 @@ class SourceGoogleAnalyticsV4(AbstractSource):
             else:
                 return False, f"{error_msg}"
 
-    def streams(self, config: Mapping[str, Any]) -> List[Stream]:
+    def streams(self, config: MutableMapping[str, Any]) -> List[Stream]:
         streams: List[GoogleAnalyticsV4Stream] = []
 
         authenticator = self.get_authenticator(config)

--- a/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
@@ -40,7 +40,7 @@ class GoogleAnalyticsV4TypesList(HttpStream):
     # Column id completely match for v3 and v4.
     url_base = "https://www.googleapis.com/analytics/v3/metadata/ga/columns"
 
-    def path(self, **kwargs: MutableMapping) -> str:
+    def path(self, **kwargs: Any) -> str:
         return ""
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:

--- a/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/spec.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/spec.json
@@ -22,9 +22,10 @@
       },
       "window_in_days": {
         "type": "integer",
-        "description": "The amount of days for each data-chunk begining from start_date. Bigger the value - faster the fetch. (Min=1, as for a Day; Max=364, as for a Year).",
+        "title": "Window in days",
+        "description": "The amount of days for each data-chunk beginning from start_date. Bigger the value - faster the fetch. (Min=1, as for a Day; Max=364, as for a Year).",
         "examples": [30, 60, 90, 120, 200, 364],
-        "default": 90
+        "default": 1
       },
       "custom_reports": {
         "order": 3,
@@ -36,6 +37,7 @@
         "order": 0,
         "type": "object",
         "title": "Credentials",
+        "description": "Credentials for the service",
         "oneOf": [
           {
             "title": "Authenticate via Google (Oauth)",

--- a/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/spec.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/spec.json
@@ -20,6 +20,12 @@
         "description": "The date in the format YYYY-MM-DD. Any data before this date will not be replicated.",
         "examples": ["2020-06-01"]
       },
+      "window_in_days": {
+        "type": "integer",
+        "description": "The amount of days for each data-chunk begining from start_date. Bigger the value - faster the fetch. (Min=1, as for a Day; Max=364, as for a Year).",
+        "examples": [30, 60, 90, 120, 200, 364],
+        "default": 90
+      },
       "custom_reports": {
         "order": 3,
         "type": "string",

--- a/airbyte-integrations/connectors/source-google-analytics-v4/unit_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/unit_tests/configured_catalog.json
@@ -44,6 +44,5 @@
       "cursor_field": ["ga_date"],
       "destination_sync_mode": "append"
     }
-
   ]
 }

--- a/airbyte-integrations/connectors/source-google-analytics-v4/unit_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/unit_tests/configured_catalog.json
@@ -1,0 +1,49 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "website_overview",
+        "json_schema": {},
+        "supported_sync_modes": ["incremental"],
+        "source_defined_cursor": true
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["ga_date"],
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "pages",
+        "json_schema": {},
+        "supported_sync_modes": ["incremental"],
+        "source_defined_cursor": true
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["ga_date"],
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "monthly_active_users",
+        "json_schema": {},
+        "supported_sync_modes": ["incremental"],
+        "source_defined_cursor": true
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["ga_date"],
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "devices",
+        "json_schema": {},
+        "supported_sync_modes": ["incremental"],
+        "source_defined_cursor": true
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["ga_date"],
+      "destination_sync_mode": "append"
+    }
+
+  ]
+}

--- a/airbyte-integrations/connectors/source-google-analytics-v4/unit_tests/response_is_data_golden_false.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/unit_tests/response_is_data_golden_false.json
@@ -1,0 +1,47 @@
+{
+  "reports": [
+    {
+      "columnHeader": {
+        "dimensions": ["ga: date"],
+        "metricHeader": {
+          "metricHeaderEntries": [
+            {
+              "name": "ga: 14dayUsers",
+              "type": "INTEGER"
+            }
+          ]
+        }
+      },
+      "data": {
+        "rows": [
+          {
+            "dimensions": ["20201027"],
+            "metrics": [
+              {
+                "values": ["1"]
+              }
+            ]
+          }
+        ],
+        "isDataGolden": false,
+        "totals": [
+          {
+            "values": ["158"]
+          }
+        ],
+        "rowCount": 134,
+        "minimums": [
+          {
+            "values": ["0"]
+          }
+        ],
+        "maximums": [
+          {
+            "values": ["3"]
+          }
+        ]
+      },
+      "nextPageToken": "1"
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-google-analytics-v4/unit_tests/response_with_sampling.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/unit_tests/response_with_sampling.json
@@ -1,0 +1,48 @@
+{
+  "reports": [
+    {
+      "columnHeader": {
+        "dimensions": ["ga: date"],
+        "metricHeader": {
+          "metricHeaderEntries": [
+            {
+              "name": "ga: 14dayUsers",
+              "type": "INTEGER"
+            }
+          ]
+        }
+      },
+      "data": {
+        "rows": [
+          {
+            "dimensions": ["20201027"],
+            "metrics": [
+              {
+                "values": ["1"]
+              }
+            ]
+          }
+        ],
+        "samplesReadCounts": [ "499630","499630"],
+        "samplingSpaceSizes": ["15328013","15328013"],
+        "totals": [
+          {
+            "values": ["158"]
+          }
+        ],
+        "rowCount": 134,
+        "minimums": [
+          {
+            "values": ["0"]
+          }
+        ],
+        "maximums": [
+          {
+            "values": ["3"]
+          }
+        ]
+      },
+      "nextPageToken": "1"
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-google-analytics-v4/unit_tests/response_with_sampling.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/unit_tests/response_with_sampling.json
@@ -23,8 +23,8 @@
             ]
           }
         ],
-        "samplesReadCounts": [ "499630","499630"],
-        "samplingSpaceSizes": ["15328013","15328013"],
+        "samplesReadCounts": ["499630", "499630"],
+        "samplingSpaceSizes": ["15328013", "15328013"],
         "totals": [
           {
             "values": ["158"]

--- a/airbyte-integrations/connectors/source-google-analytics-v4/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/unit_tests/unit_test.py
@@ -14,6 +14,8 @@ from airbyte_cdk.models import ConfiguredAirbyteCatalog
 from airbyte_cdk.sources.streams.http.auth import NoAuth
 from freezegun import freeze_time
 from source_google_analytics_v4.source import (
+    DATA_IS_NOT_GOLDEN_MSG,
+    RESULT_IS_SAMPLED_MSG,
     GoogleAnalyticsV4IncrementalObjectsBase,
     GoogleAnalyticsV4Stream,
     GoogleAnalyticsV4TypesList,
@@ -27,24 +29,34 @@ def read_file(file_name):
     return file
 
 
-expected_metrics_dimensions_type_map = ({"ga:users": "INTEGER", "ga:newUsers": "INTEGER"}, {"ga:date": "STRING", "ga:country": "STRING"})
+expected_metrics_dimensions_type_map = (
+    {"ga:users": "INTEGER", "ga:newUsers": "INTEGER"},
+    {"ga:date": "STRING", "ga:country": "STRING"},
+)
 
 
 @pytest.fixture
 def mock_metrics_dimensions_type_list_link(requests_mock):
     requests_mock.get(
-        "https://www.googleapis.com/analytics/v3/metadata/ga/columns", json=json.loads(read_file("metrics_dimensions_type_list.json"))
+        "https://www.googleapis.com/analytics/v3/metadata/ga/columns",
+        json=json.loads(read_file("metrics_dimensions_type_list.json")),
     )
 
 
 @pytest.fixture
 def mock_auth_call(requests_mock):
-    yield requests_mock.post("https://oauth2.googleapis.com/token", json={"access_token": "", "expires_in": 0})
+    yield requests_mock.post(
+        "https://oauth2.googleapis.com/token",
+        json={"access_token": "", "expires_in": 0},
+    )
 
 
 @pytest.fixture
 def mock_auth_check_connection(requests_mock):
-    yield requests_mock.post("https://analyticsreporting.googleapis.com/v4/reports:batchGet", json={"data": {"test": "value"}})
+    yield requests_mock.post(
+        "https://analyticsreporting.googleapis.com/v4/reports:batchGet",
+        json={"data": {"test": "value"}},
+    )
 
 
 @pytest.fixture
@@ -60,7 +72,8 @@ def mock_unknown_metrics_or_dimensions_error(requests_mock):
 def mock_api_returns_no_records(requests_mock):
     """API returns empty data for given date based slice"""
     yield requests_mock.post(
-        "https://analyticsreporting.googleapis.com/v4/reports:batchGet", json=json.loads(read_file("empty_response.json"))
+        "https://analyticsreporting.googleapis.com/v4/reports:batchGet",
+        json=json.loads(read_file("empty_response.json")),
     )
 
 
@@ -68,16 +81,27 @@ def mock_api_returns_no_records(requests_mock):
 def mock_api_returns_valid_records(requests_mock):
     """API returns valid data for given date based slice"""
     yield requests_mock.post(
-        "https://analyticsreporting.googleapis.com/v4/reports:batchGet", json=json.loads(read_file("response_with_records.json"))
+        "https://analyticsreporting.googleapis.com/v4/reports:batchGet",
+        json=json.loads(read_file("response_with_records.json")),
     )
+
 
 @pytest.fixture
 def mock_api_returns_sampled_results(requests_mock):
     """API returns valid data for given date based slice"""
     yield requests_mock.post(
-        "https://analyticsreporting.googleapis.com/v4/reports:batchGet", json=json.loads(read_file("response_with_sampling.json"))
+        "https://analyticsreporting.googleapis.com/v4/reports:batchGet",
+        json=json.loads(read_file("response_with_sampling.json")),
     )
 
+
+@pytest.fixture
+def mock_api_returns_is_data_golden_false(requests_mock):
+    """API returns valid data for given date based slice"""
+    yield requests_mock.post(
+        "https://analyticsreporting.googleapis.com/v4/reports:batchGet",
+        json=json.loads(read_file("response_is_data_golden_false.json")),
+    )
 
 
 @pytest.fixture()
@@ -113,28 +137,60 @@ def get_metrics_dimensions_mapping():
 def test_lookup_metrics_dimensions_data_type(test_config, metrics_dimensions_mapping, mock_metrics_dimensions_type_list_link):
     field_type, attribute, expected = metrics_dimensions_mapping
     g = GoogleAnalyticsV4Stream(config=test_config)
-
     test = g.lookup_data_type(field_type, attribute)
-
     assert test == expected
 
 
-
-def test_sampled_result_is_logged_as_warning(mock_api_returns_sampled_results, test_config, mock_metrics_dimensions_type_list_link, capsys):
-    g = GoogleAnalyticsV4Stream(config=test_config)
-
+def test_data_is_not_golden_is_logged_as_warning(
+    mock_api_returns_is_data_golden_false,
+    test_config,
+    mock_metrics_dimensions_type_list_link,
+    mock_auth_call,
+    caplog,
+):
     source = SourceGoogleAnalyticsV4()
     del test_config["custom_reports"]
-    catalog = ConfiguredAirbyteCatalog.parse_obj(json.loads(read_file("../integration_tests/configured_catalog.json")))
+    catalog = ConfiguredAirbyteCatalog.parse_obj(json.loads(read_file("./configured_catalog.json")))
     list(source.read(logging.getLogger(), test_config, catalog))
-    output = capsys.readouterr()
+    assert DATA_IS_NOT_GOLDEN_MSG in caplog.text
 
-    assert "Sampled results" in str(output)
+
+def test_sampled_result_is_logged_as_warning(
+    mock_api_returns_sampled_results,
+    test_config,
+    mock_metrics_dimensions_type_list_link,
+    mock_auth_call,
+    caplog,
+):
+    source = SourceGoogleAnalyticsV4()
+    del test_config["custom_reports"]
+    catalog = ConfiguredAirbyteCatalog.parse_obj(json.loads(read_file("./configured_catalog.json")))
+    list(source.read(logging.getLogger(), test_config, catalog))
+    assert RESULT_IS_SAMPLED_MSG in caplog.text
+
+
+def test_no_regressions_for_result_is_sampled_and_data_is_golden_warnings(
+    mock_api_returns_valid_records,
+    test_config,
+    mock_metrics_dimensions_type_list_link,
+    mock_auth_call,
+    caplog,
+):
+    source = SourceGoogleAnalyticsV4()
+    del test_config["custom_reports"]
+    catalog = ConfiguredAirbyteCatalog.parse_obj(json.loads(read_file("./configured_catalog.json")))
+    list(source.read(logging.getLogger(), test_config, catalog))
+    assert RESULT_IS_SAMPLED_MSG not in caplog.text
+    assert DATA_IS_NOT_GOLDEN_MSG not in caplog.text
 
 
 @patch("source_google_analytics_v4.source.jwt")
 def test_check_connection_fails_jwt(
-    jwt_encode_mock, mocker, mock_metrics_dimensions_type_list_link, mock_auth_call, mock_api_returns_no_records
+    jwt_encode_mock,
+    mocker,
+    mock_metrics_dimensions_type_list_link,
+    mock_auth_call,
+    mock_api_returns_no_records,
 ):
     """
     check_connection fails because of the API returns no records,
@@ -159,7 +215,11 @@ def test_check_connection_fails_jwt(
 
 @patch("source_google_analytics_v4.source.jwt")
 def test_check_connection_success_jwt(
-    jwt_encode_mock, mocker, mock_metrics_dimensions_type_list_link, mock_auth_call, mock_api_returns_valid_records
+    jwt_encode_mock,
+    mocker,
+    mock_metrics_dimensions_type_list_link,
+    mock_auth_call,
+    mock_api_returns_valid_records,
 ):
     """
     check_connection succeeds because of the API returns valid records for the latest date based slice,
@@ -182,7 +242,11 @@ def test_check_connection_success_jwt(
 
 @patch("source_google_analytics_v4.source.jwt")
 def test_check_connection_fails_oauth(
-    jwt_encode_mock, mocker, mock_metrics_dimensions_type_list_link, mock_auth_call, mock_api_returns_no_records
+    jwt_encode_mock,
+    mocker,
+    mock_metrics_dimensions_type_list_link,
+    mock_auth_call,
+    mock_api_returns_no_records,
 ):
     """
     check_connection fails because of the API returns no records,
@@ -213,7 +277,11 @@ def test_check_connection_fails_oauth(
 
 @patch("source_google_analytics_v4.source.jwt")
 def test_check_connection_success_oauth(
-    jwt_encode_mock, mocker, mock_metrics_dimensions_type_list_link, mock_auth_call, mock_api_returns_valid_records
+    jwt_encode_mock,
+    mocker,
+    mock_metrics_dimensions_type_list_link,
+    mock_auth_call,
+    mock_api_returns_valid_records,
 ):
     """
     check_connection succeeds because of the API returns valid records for the latest date based slice,

--- a/docs/integrations/sources/google-analytics-v4.md
+++ b/docs/integrations/sources/google-analytics-v4.md
@@ -142,6 +142,7 @@ Google Analytics API may return provisional or incomplete data. When this occurs
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.16 | 2022-01-26 | [9480](https://github.com/airbytehq/airbyte/pull/9480) | Reintroduce `window_in_days` and log warning when sampling occurs |
 | 0.1.15 | 2021-12-28 | [9165](https://github.com/airbytehq/airbyte/pull/9165) | Update titles and descriptions |
 | 0.1.14 | 2021-12-09 | [8656](https://github.com/airbytehq/airbyte/pull/8656) | Fix date-format in schemas |
 | 0.1.13 | 2021-12-09 | [8676](https://github.com/airbytehq/airbyte/pull/8676) | Fix `window_in_days` validation issue |

--- a/docs/integrations/sources/google-analytics-v4.md
+++ b/docs/integrations/sources/google-analytics-v4.md
@@ -128,6 +128,16 @@ Incremental sync supports only if you add `ga:date` dimension to your custom rep
 
 The Google Analytics connector should not run into Google Analytics API limitations under normal usage. Please [create an issue](https://github.com/airbytehq/airbyte/issues) if you see any rate limit issues that are not automatically retried successfully.
 
+## Sampling in reports 
+
+Google Analytics API may, under certain circumstances, limit the returned data based on sampling. This is done to reduce the amount of data that is returned as described in https://developers.google.com/analytics/devguides/reporting/core/v4/basics#sampling
+The window_in_day parameter is used to specify the number of days to look back and can be used to avoid sampling.
+When sampling occurs, a warning is logged to the sync log.
+
+## IsDataGolden
+
+Google Analytics API may return provisional or incomplete data. When this occurs, the returned data will set the fleg isDataGolden to false, and the connector will log a warning to the sync log.
+
 ## Changelog
 
 | Version | Date | Pull Request | Subject |


### PR DESCRIPTION
# Improve sampling awareness and reintroduce parameter for mitigation in source google analytics

Fixes #8570

## Reason
Google analytics may return sampled data when there are too many sessions (about 500k) in a given period. 
Also, it may return provisional data (isDataGolden=false) meaning that the report can change if requested again in the future. 
The Sampling issue can be partially mitigated (but not completely eliminated) by using smaller values for window_in_days parameter. 
For those cases when even using window_in_days equal to one is not enough to avoid sampling (when there are more than 500k sessions or other dimension values in a report in a day) the user should be warned in the logs. 
Also, when isDataGolden=false the user should be warned in logs

## Confirmation
 - Generating millions of data records in an analytics api using the instrumentation api in a script reproduces the issue, which is also described in the documentation


## How does the code change in the PR fix the issue?
 - Changed the default value for the window_in_days parameter
- Re-exposed the window_in_days parameter on configuration for better user ergonomics based on their usage profile (users with lots of analytics data will choose smaller values to avoid sampling, users with less data will prefer higher values to improve initial sync speed. 
-  Added logging warning for when isDataGolden is false
-  Added logging warning for when analytics api is sampling data.  
---

### Recommended reading order
1. source.py
2. spec.json
3. unit_test.py