### PR TITLE
Normalization mysql: install dbt-mysql from github

### DIFF
--- a/airbyte-integrations/bases/base-normalization/mysql.Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/mysql.Dockerfile
@@ -20,8 +20,8 @@ RUN pip install .
 
 WORKDIR /airbyte/normalization_code
 RUN pip install .
-# Based of https://github.com/dbeatty10/dbt-mysql/tree/dev/0.19.0
-RUN pip install dbt-mysql==0.19.0
+
+RUN pip install git+https://github.com/dbeatty10/dbt-mysql.git@dev/0.19.0
 
 WORKDIR /airbyte/normalization_code/dbt-template/
 # Download external dbt dependencies


### PR DESCRIPTION
## What
Our MySQL normalization image can't benefit from the latest fixes on [dbt-mysql](https://github.com/dbeatty10/dbt-mysql) because these are not released on Pypi since February 2021

## How
Install the dependency directly from the GitHub branch.

I'm not familiar with the release process of a new normalization version, let me know if something is missing in my PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/airbytehq/airbyte/9485)
<!-- Reviewable:end -->
