### PR TITLE
Persist Job Failure summaries for failed and cancelled attempts

### DIFF
--- a/airbyte-config/models/src/main/resources/types/AttemptFailureSummary.yaml
+++ b/airbyte-config/models/src/main/resources/types/AttemptFailureSummary.yaml
@@ -1,0 +1,18 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/AttemptFailureSummary.yaml
+title: AttemptFailureSummary
+description: Attempt-level summarization of failures that occurred during a sync workflow.
+type: object
+additionalProperties: false
+required:
+  - failures
+properties:
+  failures:
+    description: Ordered list of failures that occurred during the attempt.
+    type: array
+    items:
+      "$ref": FailureReason.yaml
+  partialSuccess:
+    description: True if the number of committed records for this attempt was greater than 0. False if 0 records were committed.
+    type: boolean

--- a/airbyte-config/models/src/main/resources/types/FailureReason.yaml
+++ b/airbyte-config/models/src/main/resources/types/FailureReason.yaml
@@ -1,0 +1,44 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/FailureReason.yaml
+title: FailureSummary
+type: object
+required:
+  - failureOrigin
+  - timestamp
+additionalProperties: false
+properties:
+  failureOrigin:
+    description: Indicates where the error originated. If not set, the origin of error is not well known.
+    type: string
+    enum:
+      - unknown
+      - source
+      - destination
+      - replicationWorker
+      - persistence
+      - normalization
+      - dbt
+  failureType:
+    description: Categorizes well known errors into types for programmatic handling. If not set, the type of error is not well known.
+    type: string
+    enum:
+      - unknown
+      - userError
+      - systemError
+      - transient
+  internalMessage:
+    description: Human readable failure description for consumption by technical system operators, like Airbyte engineers or OSS users.
+    type: string
+  externalMessage:
+    description: Human readable failure description for presentation in the UI to non-technical users.
+    type: string
+  metadata:
+    description: Key-value pairs of relevant data
+    type: object
+    additionalProperties: true
+  stacktrace:
+    description: Raw stacktrace associated with the failure.
+    type: string
+  timestamp:
+    type: integer

--- a/airbyte-config/models/src/main/resources/types/ReplicationOutput.yaml
+++ b/airbyte-config/models/src/main/resources/types/ReplicationOutput.yaml
@@ -16,3 +16,7 @@ properties:
     "$ref": State.yaml
   output_catalog:
     existingJavaType: io.airbyte.protocol.models.ConfiguredAirbyteCatalog
+  failures:
+    type: array
+    items:
+      "$ref": FailureReason.yaml

--- a/airbyte-config/models/src/main/resources/types/StandardSyncOutput.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSyncOutput.yaml
@@ -16,3 +16,7 @@ properties:
     "$ref": State.yaml
   output_catalog:
     existingJavaType: io.airbyte.protocol.models.ConfiguredAirbyteCatalog
+  failures:
+    type: array
+    items:
+      "$ref": FailureReason.yaml

--- a/airbyte-scheduler/models/src/main/java/io/airbyte/scheduler/models/Attempt.java
+++ b/airbyte-scheduler/models/src/main/java/io/airbyte/scheduler/models/Attempt.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.scheduler.models;
 
+import io.airbyte.config.AttemptFailureSummary;
 import io.airbyte.config.JobOutput;
 import java.nio.file.Path;
 import java.util.Objects;
@@ -16,6 +17,7 @@ public class Attempt {
   private final long jobId;
   private final JobOutput output;
   private final AttemptStatus status;
+  private final AttemptFailureSummary failureSummary;
   private final Path logPath;
   private final long updatedAtInSecond;
   private final long createdAtInSecond;
@@ -26,6 +28,7 @@ public class Attempt {
                  final Path logPath,
                  final @Nullable JobOutput output,
                  final AttemptStatus status,
+                 final @Nullable AttemptFailureSummary failureSummary,
                  final long createdAtInSecond,
                  final long updatedAtInSecond,
                  final @Nullable Long endedAtInSecond) {
@@ -33,6 +36,7 @@ public class Attempt {
     this.jobId = jobId;
     this.output = output;
     this.status = status;
+    this.failureSummary = failureSummary;
     this.logPath = logPath;
     this.updatedAtInSecond = updatedAtInSecond;
     this.createdAtInSecond = createdAtInSecond;
@@ -53,6 +57,10 @@ public class Attempt {
 
   public AttemptStatus getStatus() {
     return status;
+  }
+
+  public Optional<AttemptFailureSummary> getFailureSummary() {
+    return Optional.ofNullable(failureSummary);
   }
 
   public Path getLogPath() {
@@ -90,13 +98,14 @@ public class Attempt {
         createdAtInSecond == attempt.createdAtInSecond &&
         Objects.equals(output, attempt.output) &&
         status == attempt.status &&
+        Objects.equals(failureSummary, attempt.failureSummary) &&
         Objects.equals(logPath, attempt.logPath) &&
         Objects.equals(endedAtInSecond, attempt.endedAtInSecond);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, jobId, output, status, logPath, updatedAtInSecond, createdAtInSecond, endedAtInSecond);
+    return Objects.hash(id, jobId, output, status, failureSummary, logPath, updatedAtInSecond, createdAtInSecond, endedAtInSecond);
   }
 
   @Override
@@ -106,6 +115,7 @@ public class Attempt {
         ", jobId=" + jobId +
         ", output=" + output +
         ", status=" + status +
+        ", failureSummary=" + failureSummary +
         ", logPath=" + logPath +
         ", updatedAtInSecond=" + updatedAtInSecond +
         ", createdAtInSecond=" + createdAtInSecond +

--- a/airbyte-scheduler/models/src/test/java/io/airbyte/scheduler/models/AttemptTest.java
+++ b/airbyte-scheduler/models/src/test/java/io/airbyte/scheduler/models/AttemptTest.java
@@ -19,7 +19,7 @@ class AttemptTest {
   }
 
   private static Attempt attemptWithStatus(final AttemptStatus attemptStatus) {
-    return new Attempt(1L, 1L, null, null, attemptStatus, 0L, 0L, null);
+    return new Attempt(1L, 1L, null, null, attemptStatus, null, 0L, 0L, null);
   }
 
 }

--- a/airbyte-scheduler/models/src/test/java/io/airbyte/scheduler/models/JobTest.java
+++ b/airbyte-scheduler/models/src/test/java/io/airbyte/scheduler/models/JobTest.java
@@ -39,7 +39,7 @@ class JobTest {
 
   private static Job jobWithAttemptWithStatus(final AttemptStatus... attemptStatuses) {
     final List<Attempt> attempts = Arrays.stream(attemptStatuses)
-        .map(attemptStatus -> new Attempt(1L, 1L, null, null, attemptStatus, 0L, 0L, null))
+        .map(attemptStatus -> new Attempt(1L, 1L, null, null, attemptStatus, null, 0L, 0L, null))
         .collect(Collectors.toList());
     return new Job(1L, null, null, null, attempts, null, 0L, 0L, 0L);
   }

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobPersistence.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobPersistence.java
@@ -5,6 +5,7 @@
 package io.airbyte.scheduler.persistence;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.config.AttemptFailureSummary;
 import io.airbyte.config.JobConfig;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.db.instance.jobs.JobsDatabaseSchema;
@@ -124,6 +125,16 @@ public interface JobPersistence {
    * ConfigRepository#updateConnectionState, which takes care of persisting the connection state.
    */
   <T> void writeOutput(long jobId, int attemptNumber, T output) throws IOException;
+
+  /**
+   * Writes a summary of all failures that occurred during the attempt.
+   *
+   * @param jobId job id
+   * @param attemptNumber attempt number
+   * @param failureSummary summary containing failure metadata and ordered list of failures
+   * @throws IOException exception due to interaction with persistence
+   */
+  void writeAttemptFailureSummary(long jobId, int attemptNumber, AttemptFailureSummary failureSummary) throws IOException;
 
   /**
    * @param configTypes - type of config, e.g. sync

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/JobHistoryHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/JobHistoryHandlerTest.java
@@ -109,7 +109,7 @@ public class JobHistoryHandlerTest {
   }
 
   private static Attempt createSuccessfulAttempt(final long jobId, final long timestamps) {
-    return new Attempt(ATTEMPT_ID, jobId, LOG_PATH, null, AttemptStatus.SUCCEEDED, timestamps, timestamps, timestamps);
+    return new Attempt(ATTEMPT_ID, jobId, LOG_PATH, null, AttemptStatus.SUCCEEDED, null, timestamps, timestamps, timestamps);
   }
 
   @BeforeEach

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.workers;
 
+import io.airbyte.config.FailureReason;
 import io.airbyte.config.ReplicationAttemptSummary;
 import io.airbyte.config.ReplicationOutput;
 import io.airbyte.config.StandardSyncInput;
@@ -14,11 +15,13 @@ import io.airbyte.config.SyncStats;
 import io.airbyte.config.WorkerDestinationConfig;
 import io.airbyte.config.WorkerSourceConfig;
 import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.workers.helper.FailureHelper;
 import io.airbyte.workers.protocols.airbyte.AirbyteDestination;
 import io.airbyte.workers.protocols.airbyte.AirbyteMapper;
 import io.airbyte.workers.protocols.airbyte.AirbyteSource;
 import io.airbyte.workers.protocols.airbyte.MessageTracker;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -27,6 +30,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,6 +108,9 @@ public class DefaultReplicationWorker implements ReplicationWorker {
     destinationConfig.setCatalog(mapper.mapCatalog(destinationConfig.getCatalog()));
 
     final long startTime = System.currentTimeMillis();
+    final AtomicReference<FailureReason> sourceFailureRef = new AtomicReference<>();
+    final AtomicReference<FailureReason> destinationFailureRef = new AtomicReference<>();
+
     try {
       LOGGER.info("configured sync modes: {}", syncInput.getCatalog().getStreams()
           .stream()
@@ -119,13 +126,23 @@ public class DefaultReplicationWorker implements ReplicationWorker {
         destination.start(destinationConfig, jobRoot);
         source.start(sourceConfig, jobRoot);
 
+        // note: `whenComplete` is used instead of `exceptionally` so that the original exception is still
+        // thrown
         final CompletableFuture<?> destinationOutputThreadFuture = CompletableFuture.runAsync(
             getDestinationOutputRunnable(destination, cancelled, messageTracker, mdc),
-            executors);
+            executors).whenComplete((msg, ex) -> {
+              if (ex != null) {
+                destinationFailureRef.set(FailureHelper.destinationFailure(ex, Long.valueOf(jobId), attempt));
+              }
+            });
 
         final CompletableFuture<?> replicationThreadFuture = CompletableFuture.runAsync(
             getReplicationRunnable(source, destination, cancelled, mapper, messageTracker, mdc),
-            executors);
+            executors).whenComplete((msg, ex) -> {
+              if (ex != null) {
+                sourceFailureRef.set(FailureHelper.sourceFailure(ex, Long.valueOf(jobId), attempt));
+              }
+            });
 
         LOGGER.info("Waiting for source and destination threads to complete.");
         // CompletableFuture#allOf waits until all futures finish before returning, even if one throws an
@@ -198,10 +215,23 @@ public class DefaultReplicationWorker implements ReplicationWorker {
           .withEndTime(System.currentTimeMillis());
 
       LOGGER.info("sync summary: {}", summary);
-
       final ReplicationOutput output = new ReplicationOutput()
           .withReplicationAttemptSummary(summary)
           .withOutputCatalog(destinationConfig.getCatalog());
+
+      // only .setFailures() if a failure occurred
+      final FailureReason sourceFailure = sourceFailureRef.get();
+      final FailureReason destinationFailure = destinationFailureRef.get();
+      final List<FailureReason> failures = new ArrayList<>();
+      if (sourceFailure != null) {
+        failures.add(sourceFailure);
+      }
+      if (destinationFailure != null) {
+        failures.add(destinationFailure);
+      }
+      if (!failures.isEmpty()) {
+        output.setFailures(failures);
+      }
 
       if (messageTracker.getSourceOutputState().isPresent()) {
         LOGGER.info("Source output at least one state message");

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.helper;
+
+import io.airbyte.config.AttemptFailureSummary;
+import io.airbyte.config.FailureReason;
+import io.airbyte.config.FailureReason.FailureOrigin;
+import io.airbyte.config.Metadata;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+public class FailureHelper {
+
+  private static final String JOB_ID_METADATA_KEY = "jobId";
+  private static final String ATTEMPT_NUMBER_METADATA_KEY = "attemptNumber";
+
+  private static final String WORKFLOW_TYPE_SYNC = "SyncWorkflow";
+  private static final String ACTIVITY_TYPE_REPLICATE = "Replicate";
+  private static final String ACTIVITY_TYPE_PERSIST = "Persist";
+  private static final String ACTIVITY_TYPE_NORMALIZE = "Normalize";
+  private static final String ACTIVITY_TYPE_DBT_RUN = "Run";
+
+  public static FailureReason genericFailure(final Throwable t, final Long jobId, final Integer attemptNumber) {
+    return new FailureReason()
+        .withInternalMessage(t.getMessage())
+        .withStacktrace(ExceptionUtils.getStackTrace(t))
+        .withTimestamp(System.currentTimeMillis())
+        .withMetadata(new Metadata()
+            .withAdditionalProperty(JOB_ID_METADATA_KEY, jobId)
+            .withAdditionalProperty(ATTEMPT_NUMBER_METADATA_KEY, attemptNumber));
+  }
+
+  public static FailureReason sourceFailure(final Throwable t, final Long jobId, final Integer attemptNumber) {
+    return genericFailure(t, jobId, attemptNumber)
+        .withFailureOrigin(FailureOrigin.SOURCE)
+        .withExternalMessage("Something went wrong within the source connector");
+  }
+
+  public static FailureReason destinationFailure(final Throwable t, final Long jobId, final Integer attemptNumber) {
+    return genericFailure(t, jobId, attemptNumber)
+        .withFailureOrigin(FailureOrigin.DESTINATION)
+        .withExternalMessage("Something went wrong within the destination connector");
+  }
+
+  public static FailureReason replicationWorkerFailure(final Throwable t, final Long jobId, final Integer attemptNumber) {
+    return genericFailure(t, jobId, attemptNumber)
+        .withFailureOrigin(FailureOrigin.REPLICATION_WORKER)
+        .withExternalMessage("Something went wrong during replication");
+  }
+
+  public static FailureReason persistenceFailure(final Throwable t, final Long jobId, final Integer attemptNumber) {
+    return genericFailure(t, jobId, attemptNumber)
+        .withFailureOrigin(FailureOrigin.PERSISTENCE)
+        .withExternalMessage("Something went wrong during state persistence");
+  }
+
+  public static FailureReason normalizationFailure(final Throwable t, final Long jobId, final Integer attemptNumber) {
+    return genericFailure(t, jobId, attemptNumber)
+        .withFailureOrigin(FailureOrigin.NORMALIZATION)
+        .withExternalMessage("Something went wrong during normalization");
+  }
+
+  public static FailureReason dbtFailure(final Throwable t, final Long jobId, final Integer attemptNumber) {
+    return genericFailure(t, jobId, attemptNumber)
+        .withFailureOrigin(FailureOrigin.DBT)
+        .withExternalMessage("Something went wrong during dbt");
+  }
+
+  public static FailureReason unknownOriginFailure(final Throwable t, final Long jobId, final Integer attemptNumber) {
+    return genericFailure(t, jobId, attemptNumber)
+        .withFailureOrigin(FailureOrigin.UNKNOWN)
+        .withExternalMessage("An unknown failure occurred");
+  }
+
+  public static AttemptFailureSummary failureSummary(final Set<FailureReason> failures, final Boolean partialSuccess) {
+    return new AttemptFailureSummary()
+        .withFailures(orderedFailures(failures))
+        .withPartialSuccess(partialSuccess);
+  }
+
+  public static FailureReason failureReasonFromWorkflowAndActivity(final String workflowType,
+                                                                   final String activityType,
+                                                                   final Throwable t,
+                                                                   final Long jobId,
+                                                                   final Integer attemptNumber) {
+    if (workflowType.equals(WORKFLOW_TYPE_SYNC) && activityType.equals(ACTIVITY_TYPE_REPLICATE)) {
+      return replicationWorkerFailure(t, jobId, attemptNumber);
+    } else if (workflowType.equals(WORKFLOW_TYPE_SYNC) && activityType.equals(ACTIVITY_TYPE_PERSIST)) {
+      return persistenceFailure(t, jobId, attemptNumber);
+    } else if (workflowType.equals(WORKFLOW_TYPE_SYNC) && activityType.equals(ACTIVITY_TYPE_NORMALIZE)) {
+      return normalizationFailure(t, jobId, attemptNumber);
+    } else if (workflowType.equals(WORKFLOW_TYPE_SYNC) && activityType.equals(ACTIVITY_TYPE_DBT_RUN)) {
+      return dbtFailure(t, jobId, attemptNumber);
+    } else {
+      return unknownOriginFailure(t, jobId, attemptNumber);
+    }
+  }
+
+  /**
+   * Orders failures by timestamp, so that earlier failures come first in the list.
+   */
+  private static List<FailureReason> orderedFailures(final Set<FailureReason> failures) {
+    return failures.stream().sorted(Comparator.comparing(FailureReason::getTimestamp)).collect(Collectors.toList());
+  }
+
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -4,9 +4,11 @@
 
 package io.airbyte.workers.temporal.scheduling;
 
+import io.airbyte.config.FailureReason;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.StandardSyncSummary;
 import io.airbyte.config.StandardSyncSummary.ReplicationStatus;
+import io.airbyte.workers.helper.FailureHelper;
 import io.airbyte.workers.temporal.TemporalJobType;
 import io.airbyte.workers.temporal.exception.RetryableException;
 import io.airbyte.workers.temporal.scheduling.activities.ConfigFetchActivity;
@@ -32,13 +34,16 @@ import io.airbyte.workers.temporal.scheduling.state.WorkflowState;
 import io.airbyte.workers.temporal.scheduling.state.listener.NoopStateListener;
 import io.airbyte.workers.temporal.sync.SyncWorkflow;
 import io.temporal.api.enums.v1.ParentClosePolicy;
+import io.temporal.failure.ActivityFailure;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.failure.ChildWorkflowFailure;
 import io.temporal.workflow.CancellationScope;
 import io.temporal.workflow.ChildWorkflowOptions;
 import io.temporal.workflow.Workflow;
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 
@@ -54,6 +59,8 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
   Optional<Integer> maybeAttemptId = Optional.empty();
 
   Optional<StandardSyncOutput> standardSyncOutput = Optional.empty();
+  final Set<FailureReason> failures = new HashSet<>();
+  Boolean partialSuccess = null;
 
   private final GenerateInputActivity getSyncInputActivity = Workflow.newActivityStub(GenerateInputActivity.class, ActivityConfiguration.OPTIONS);
   private final JobCreationAndStatusUpdateActivity jobCreationAndStatusUpdateActivity =
@@ -127,13 +134,29 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
                   syncWorkflowInputs.getSyncInput(),
                   connectionId));
 
-              StandardSyncSummary standardSyncSummary = standardSyncOutput.get().getStandardSyncSummary();
+              final StandardSyncSummary standardSyncSummary = standardSyncOutput.get().getStandardSyncSummary();
 
               if (standardSyncSummary != null && standardSyncSummary.getStatus() == ReplicationStatus.FAILED) {
+                failures.addAll(standardSyncOutput.get().getFailures());
+                partialSuccess = standardSyncSummary.getTotalStats().getRecordsCommitted() > 0;
                 workflowState.setFailed(true);
               }
             } catch (final ChildWorkflowFailure childWorkflowFailure) {
-              if (!(childWorkflowFailure.getCause() instanceof CanceledFailure)) {
+              if (childWorkflowFailure.getCause() instanceof CanceledFailure) {
+                // do nothing, cancellation handled by cancellationScope
+
+              } else if (childWorkflowFailure.getCause() instanceof ActivityFailure) {
+                final ActivityFailure af = (ActivityFailure) childWorkflowFailure.getCause();
+                failures.add(FailureHelper.failureReasonFromWorkflowAndActivity(
+                    childWorkflowFailure.getWorkflowType(),
+                    af.getActivityType(),
+                    af.getCause(),
+                    maybeJobId.get(),
+                    maybeAttemptId.get()));
+                throw childWorkflowFailure;
+              } else {
+                failures.add(
+                    FailureHelper.unknownOriginFailure(childWorkflowFailure.getCause(), maybeJobId.get(), maybeAttemptId.get()));
                 throw childWorkflowFailure;
               }
             }
@@ -166,7 +189,9 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
         return;
       } else if (workflowState.isCancelled()) {
         jobCreationAndStatusUpdateActivity.jobCancelled(new JobCancelledInput(
-            maybeJobId.get()));
+            maybeJobId.get(),
+            maybeAttemptId.get(),
+            failures.isEmpty() ? null : FailureHelper.failureSummary(failures, partialSuccess)));
         resetNewConnectionInput(connectionUpdaterInput);
       } else if (workflowState.isFailed()) {
         reportFailure(connectionUpdaterInput);
@@ -196,7 +221,8 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
     jobCreationAndStatusUpdateActivity.attemptFailure(new AttemptFailureInput(
         connectionUpdaterInput.getJobId(),
         connectionUpdaterInput.getAttemptId(),
-        standardSyncOutput.orElse(null)));
+        standardSyncOutput.orElse(null),
+        FailureHelper.failureSummary(failures, partialSuccess)));
 
     final int maxAttempt = configFetchActivity.getMaxAttempt().getMaxAttempt();
     final int attemptNumber = connectionUpdaterInput.getAttemptNumber();
@@ -216,7 +242,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
     }
   }
 
-  private void resetNewConnectionInput(ConnectionUpdaterInput connectionUpdaterInput) {
+  private void resetNewConnectionInput(final ConnectionUpdaterInput connectionUpdaterInput) {
     connectionUpdaterInput.setJobId(null);
     connectionUpdaterInput.setAttemptNumber(1);
     connectionUpdaterInput.setFromFailure(false);
@@ -280,7 +306,9 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
   private void continueAsNew(final ConnectionUpdaterInput connectionUpdaterInput) {
     // Continue the workflow as new
     connectionUpdaterInput.setAttemptId(null);
-    boolean isDeleted = workflowState.isDeleted();
+    failures.clear();
+    partialSuccess = null;
+    final boolean isDeleted = workflowState.isDeleted();
     workflowState.reset();
     if (!isDeleted) {
       Workflow.continueAsNew(connectionUpdaterInput);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivity.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivity.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.workers.temporal.scheduling.activities;
 
+import io.airbyte.config.AttemptFailureSummary;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.workers.temporal.exception.RetryableException;
 import io.temporal.activity.ActivityInterface;
@@ -112,6 +113,7 @@ public interface JobCreationAndStatusUpdateActivity {
     private long jobId;
     private int attemptId;
     private StandardSyncOutput standardSyncOutput;
+    private AttemptFailureSummary attemptFailureSummary;
 
   }
 
@@ -127,6 +129,8 @@ public interface JobCreationAndStatusUpdateActivity {
   class JobCancelledInput {
 
     private long jobId;
+    private int attemptId;
+    private AttemptFailureSummary attemptFailureSummary;
 
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationActivityImpl.java
@@ -166,6 +166,7 @@ public class ReplicationActivityImpl implements ReplicationActivity {
     standardSyncOutput.setState(output.getState());
     standardSyncOutput.setOutputCatalog(output.getOutputCatalog());
     standardSyncOutput.setStandardSyncSummary(syncSummary);
+    standardSyncOutput.setFailures(output.getFailures());
 
     return standardSyncOutput;
   }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
@@ -23,6 +23,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.string.Strings;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.Configs.WorkerEnvironment;
+import io.airbyte.config.FailureReason.FailureOrigin;
 import io.airbyte.config.ReplicationAttemptSummary;
 import io.airbyte.config.ReplicationOutput;
 import io.airbyte.config.StandardSync;
@@ -149,6 +150,7 @@ class DefaultReplicationWorkerTest {
 
     final ReplicationOutput output = worker.run(syncInput, jobRoot);
     assertEquals(ReplicationStatus.FAILED, output.getReplicationAttemptSummary().getStatus());
+    assertTrue(output.getFailures().stream().anyMatch(f -> f.getFailureOrigin().equals(FailureOrigin.SOURCE)));
   }
 
   @Test
@@ -165,6 +167,7 @@ class DefaultReplicationWorkerTest {
 
     final ReplicationOutput output = worker.run(syncInput, jobRoot);
     assertEquals(ReplicationStatus.FAILED, output.getReplicationAttemptSummary().getStatus());
+    assertTrue(output.getFailures().stream().anyMatch(f -> f.getFailureOrigin().equals(FailureOrigin.DESTINATION)));
   }
 
   @Test

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowTest.java
@@ -4,11 +4,13 @@
 
 package io.airbyte.workers.temporal.scheduling;
 
+import io.airbyte.config.FailureReason.FailureOrigin;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.temporal.TemporalJobType;
 import io.airbyte.workers.temporal.scheduling.activities.ConfigFetchActivity;
+import io.airbyte.workers.temporal.scheduling.activities.ConfigFetchActivity.GetMaxAttemptOutput;
 import io.airbyte.workers.temporal.scheduling.activities.ConfigFetchActivity.ScheduleRetrieverOutput;
 import io.airbyte.workers.temporal.scheduling.activities.ConnectionDeletionActivity;
 import io.airbyte.workers.temporal.scheduling.activities.GenerateInputActivity.SyncInput;
@@ -16,13 +18,19 @@ import io.airbyte.workers.temporal.scheduling.activities.GenerateInputActivity.S
 import io.airbyte.workers.temporal.scheduling.activities.GenerateInputActivityImpl;
 import io.airbyte.workers.temporal.scheduling.activities.JobCreationAndStatusUpdateActivity;
 import io.airbyte.workers.temporal.scheduling.activities.JobCreationAndStatusUpdateActivity.AttemptCreationOutput;
+import io.airbyte.workers.temporal.scheduling.activities.JobCreationAndStatusUpdateActivity.AttemptFailureInput;
 import io.airbyte.workers.temporal.scheduling.activities.JobCreationAndStatusUpdateActivity.JobCreationOutput;
 import io.airbyte.workers.temporal.scheduling.state.WorkflowState;
 import io.airbyte.workers.temporal.scheduling.state.listener.TestStateListener;
 import io.airbyte.workers.temporal.scheduling.state.listener.WorkflowStateChangedListener.ChangedStateEvent;
 import io.airbyte.workers.temporal.scheduling.state.listener.WorkflowStateChangedListener.StateField;
+import io.airbyte.workers.temporal.scheduling.testsyncworkflow.DbtFailureSyncWorkflow;
 import io.airbyte.workers.temporal.scheduling.testsyncworkflow.EmptySyncWorkflow;
+import io.airbyte.workers.temporal.scheduling.testsyncworkflow.NormalizationFailureSyncWorkflow;
+import io.airbyte.workers.temporal.scheduling.testsyncworkflow.PersistFailureSyncWorkflow;
+import io.airbyte.workers.temporal.scheduling.testsyncworkflow.ReplicateFailureSyncWorkflow;
 import io.airbyte.workers.temporal.scheduling.testsyncworkflow.SleepingSyncWorkflow;
+import io.airbyte.workers.temporal.scheduling.testsyncworkflow.SourceAndDestinationFailureSyncWorkflow;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
@@ -35,6 +43,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
 public class ConnectionManagerWorkflowTest {
@@ -432,6 +441,144 @@ public class ConnectionManagerWorkflowTest {
       Mockito.verify(mJobCreationAndStatusUpdateActivity).jobCancelled(Mockito.any());
 
       testEnv.shutdown();
+    }
+
+  }
+
+  @Nested
+  @DisplayName("Test that sync workflow failures are recorded")
+  class SyncWorkflowReplicationFailuresRecorded {
+
+    private static final long JOB_ID = 111L;
+    private static final int ATTEMPT_ID = 222;
+
+    @BeforeEach
+    public void setup() {
+      testEnv = TestWorkflowEnvironment.newInstance();
+      worker = testEnv.newWorker(TemporalJobType.CONNECTION_UPDATER.name());
+      client = testEnv.getWorkflowClient();
+      worker.registerActivitiesImplementations(mConfigFetchActivity, mConnectionDeletionActivity, mGenerateInputActivityImpl,
+          mJobCreationAndStatusUpdateActivity);
+      workflow = client.newWorkflowStub(ConnectionManagerWorkflow.class,
+          WorkflowOptions.newBuilder().setTaskQueue(TemporalJobType.CONNECTION_UPDATER.name()).build());
+
+      Mockito.when(mConfigFetchActivity.getMaxAttempt()).thenReturn(new GetMaxAttemptOutput(1));
+    }
+
+    @Test
+    @DisplayName("Test that source and destination failures are recorded")
+    public void testSourceAndDestinationFailuresRecorded() {
+      worker.registerWorkflowImplementationTypes(ConnectionManagerWorkflowImpl.class, SourceAndDestinationFailureSyncWorkflow.class);
+      testEnv.start();
+
+      final UUID testId = UUID.randomUUID();
+      final TestStateListener testStateListener = new TestStateListener();
+      final WorkflowState workflowState = new WorkflowState(testId, testStateListener);
+      final ConnectionUpdaterInput input = new ConnectionUpdaterInput(UUID.randomUUID(), JOB_ID, ATTEMPT_ID, false, 1, workflowState, false);
+
+      WorkflowClient.start(workflow::run, input);
+      testEnv.sleep(Duration.ofMinutes(2L));
+      workflow.submitManualSync();
+
+      Mockito.verify(mJobCreationAndStatusUpdateActivity).attemptFailure(Mockito.argThat(new HasFailureFromSource(FailureOrigin.SOURCE)));
+      Mockito.verify(mJobCreationAndStatusUpdateActivity).attemptFailure(Mockito.argThat(new HasFailureFromSource(FailureOrigin.DESTINATION)));
+
+      testEnv.shutdown();
+    }
+
+    @Test
+    @DisplayName("Test that normalization failure is recorded")
+    public void testNormalizationFailure() {
+      worker.registerWorkflowImplementationTypes(ConnectionManagerWorkflowImpl.class, NormalizationFailureSyncWorkflow.class);
+      testEnv.start();
+
+      final UUID testId = UUID.randomUUID();
+      final TestStateListener testStateListener = new TestStateListener();
+      final WorkflowState workflowState = new WorkflowState(testId, testStateListener);
+      final ConnectionUpdaterInput input = new ConnectionUpdaterInput(UUID.randomUUID(), JOB_ID, ATTEMPT_ID, false, 1, workflowState, false);
+
+      WorkflowClient.start(workflow::run, input);
+      testEnv.sleep(Duration.ofMinutes(2L));
+      workflow.submitManualSync();
+
+      Mockito.verify(mJobCreationAndStatusUpdateActivity).attemptFailure(Mockito.argThat(new HasFailureFromSource(FailureOrigin.NORMALIZATION)));
+
+      testEnv.shutdown();
+    }
+
+    @Test
+    @DisplayName("Test that dbt failure is recorded")
+    public void testDbtFailureRecorded() {
+      worker.registerWorkflowImplementationTypes(ConnectionManagerWorkflowImpl.class, DbtFailureSyncWorkflow.class);
+      testEnv.start();
+
+      final UUID testId = UUID.randomUUID();
+      final TestStateListener testStateListener = new TestStateListener();
+      final WorkflowState workflowState = new WorkflowState(testId, testStateListener);
+      final ConnectionUpdaterInput input = new ConnectionUpdaterInput(UUID.randomUUID(), JOB_ID, ATTEMPT_ID, false, 1, workflowState, false);
+
+      WorkflowClient.start(workflow::run, input);
+      testEnv.sleep(Duration.ofMinutes(2L));
+      workflow.submitManualSync();
+
+      Mockito.verify(mJobCreationAndStatusUpdateActivity).attemptFailure(Mockito.argThat(new HasFailureFromSource(FailureOrigin.DBT)));
+
+      testEnv.shutdown();
+    }
+
+    @Test
+    @DisplayName("Test that persistence failure is recorded")
+    public void testPersistenceFailureRecorded() {
+      worker.registerWorkflowImplementationTypes(ConnectionManagerWorkflowImpl.class, PersistFailureSyncWorkflow.class);
+      testEnv.start();
+
+      final UUID testId = UUID.randomUUID();
+      final TestStateListener testStateListener = new TestStateListener();
+      final WorkflowState workflowState = new WorkflowState(testId, testStateListener);
+      final ConnectionUpdaterInput input = new ConnectionUpdaterInput(UUID.randomUUID(), JOB_ID, ATTEMPT_ID, false, 1, workflowState, false);
+
+      WorkflowClient.start(workflow::run, input);
+      testEnv.sleep(Duration.ofMinutes(2L));
+      workflow.submitManualSync();
+
+      Mockito.verify(mJobCreationAndStatusUpdateActivity).attemptFailure(Mockito.argThat(new HasFailureFromSource(FailureOrigin.PERSISTENCE)));
+
+      testEnv.shutdown();
+    }
+
+    @Test
+    @DisplayName("Test that replication worker failure is recorded")
+    public void testReplicationFailureRecorded() {
+      worker.registerWorkflowImplementationTypes(ConnectionManagerWorkflowImpl.class, ReplicateFailureSyncWorkflow.class);
+      testEnv.start();
+
+      final UUID testId = UUID.randomUUID();
+      final TestStateListener testStateListener = new TestStateListener();
+      final WorkflowState workflowState = new WorkflowState(testId, testStateListener);
+      final ConnectionUpdaterInput input = new ConnectionUpdaterInput(UUID.randomUUID(), JOB_ID, ATTEMPT_ID, false, 1, workflowState, false);
+
+      WorkflowClient.start(workflow::run, input);
+      testEnv.sleep(Duration.ofMinutes(2L));
+      workflow.submitManualSync();
+
+      Mockito.verify(mJobCreationAndStatusUpdateActivity).attemptFailure(Mockito.argThat(new HasFailureFromSource(FailureOrigin.REPLICATION_WORKER)));
+
+      testEnv.shutdown();
+    }
+
+  }
+
+  private class HasFailureFromSource implements ArgumentMatcher<AttemptFailureInput> {
+
+    private final FailureOrigin expectedFailureOrigin;
+
+    public HasFailureFromSource(final FailureOrigin failureOrigin) {
+      this.expectedFailureOrigin = failureOrigin;
+    }
+
+    @Override
+    public boolean matches(final AttemptFailureInput arg) {
+      return arg.getAttemptFailureSummary().getFailures().stream().anyMatch(f -> f.getFailureOrigin().equals(expectedFailureOrigin));
     }
 
   }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityTest.java
@@ -4,7 +4,10 @@
 
 package io.airbyte.workers.temporal.scheduling.activities;
 
+import io.airbyte.config.AttemptFailureSummary;
 import io.airbyte.config.Configs.WorkerEnvironment;
+import io.airbyte.config.FailureReason;
+import io.airbyte.config.FailureReason.FailureOrigin;
 import io.airbyte.config.JobOutput;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.StandardSyncSummary;
@@ -30,6 +33,7 @@ import io.airbyte.workers.worker_run.TemporalWorkerRunFactory;
 import io.airbyte.workers.worker_run.WorkerRun;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -71,13 +75,18 @@ public class JobCreationAndStatusUpdateActivityTest {
 
   private static final UUID CONNECTION_ID = UUID.randomUUID();
   private static final long JOB_ID = 123L;
-  private static final int ATTEMPT_ID = 321;
+  private static final int ATTEMPT_ID = 0;
   private static final StandardSyncOutput standardSyncOutput = new StandardSyncOutput()
       .withStandardSyncSummary(
           new StandardSyncSummary()
               .withStatus(ReplicationStatus.COMPLETED));
 
   private static final JobOutput jobOutput = new JobOutput().withSync(standardSyncOutput);
+
+  private static final AttemptFailureSummary failureSummary = new AttemptFailureSummary()
+      .withFailures(Collections.singletonList(
+          new FailureReason()
+              .withFailureOrigin(FailureOrigin.SOURCE)));
 
   @Nested
   class Creation {
@@ -186,10 +195,11 @@ public class JobCreationAndStatusUpdateActivityTest {
 
     @Test
     public void setAttemptFailure() throws IOException {
-      jobCreationAndStatusUpdateActivity.attemptFailure(new AttemptFailureInput(JOB_ID, ATTEMPT_ID, standardSyncOutput));
+      jobCreationAndStatusUpdateActivity.attemptFailure(new AttemptFailureInput(JOB_ID, ATTEMPT_ID, standardSyncOutput, failureSummary));
 
       Mockito.verify(mJobPersistence).failAttempt(JOB_ID, ATTEMPT_ID);
       Mockito.verify(mJobPersistence).writeOutput(JOB_ID, ATTEMPT_ID, jobOutput);
+      Mockito.verify(mJobPersistence).writeAttemptFailureSummary(JOB_ID, ATTEMPT_ID, failureSummary);
     }
 
     @Test
@@ -197,16 +207,27 @@ public class JobCreationAndStatusUpdateActivityTest {
       Mockito.doThrow(new IOException())
           .when(mJobPersistence).failAttempt(JOB_ID, ATTEMPT_ID);
 
-      Assertions.assertThatThrownBy(() -> jobCreationAndStatusUpdateActivity.attemptFailure(new AttemptFailureInput(JOB_ID, ATTEMPT_ID, null)))
+      Assertions
+          .assertThatThrownBy(
+              () -> jobCreationAndStatusUpdateActivity.attemptFailure(new AttemptFailureInput(JOB_ID, ATTEMPT_ID, null, failureSummary)))
           .isInstanceOf(RetryableException.class)
           .hasCauseInstanceOf(IOException.class);
     }
 
     @Test
-    public void setJobCancelled() throws IOException {
-      jobCreationAndStatusUpdateActivity.jobCancelled(new JobCancelledInput(JOB_ID));
+    public void setJobCancelledWithNoFailures() throws IOException {
+      jobCreationAndStatusUpdateActivity.jobCancelled(new JobCancelledInput(JOB_ID, ATTEMPT_ID, null));
 
       Mockito.verify(mJobPersistence).cancelJob(JOB_ID);
+      Mockito.verify(mJobPersistence, Mockito.never()).writeAttemptFailureSummary(Mockito.anyLong(), Mockito.anyInt(), Mockito.any());
+    }
+
+    @Test
+    public void setJobCancelledWithFailures() throws IOException {
+      jobCreationAndStatusUpdateActivity.jobCancelled(new JobCancelledInput(JOB_ID, ATTEMPT_ID, failureSummary));
+
+      Mockito.verify(mJobPersistence).cancelJob(JOB_ID);
+      Mockito.verify(mJobPersistence).writeAttemptFailureSummary(JOB_ID, ATTEMPT_ID, failureSummary);
     }
 
     @Test
@@ -214,7 +235,7 @@ public class JobCreationAndStatusUpdateActivityTest {
       Mockito.doThrow(new IOException())
           .when(mJobPersistence).cancelJob(JOB_ID);
 
-      Assertions.assertThatThrownBy(() -> jobCreationAndStatusUpdateActivity.jobCancelled(new JobCancelledInput(JOB_ID)))
+      Assertions.assertThatThrownBy(() -> jobCreationAndStatusUpdateActivity.jobCancelled(new JobCancelledInput(JOB_ID, ATTEMPT_ID, null)))
           .isInstanceOf(RetryableException.class)
           .hasCauseInstanceOf(IOException.class);
     }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/testsyncworkflow/DbtFailureSyncWorkflow.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/testsyncworkflow/DbtFailureSyncWorkflow.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.temporal.scheduling.testsyncworkflow;
+
+import io.airbyte.config.StandardSyncInput;
+import io.airbyte.config.StandardSyncOutput;
+import io.airbyte.scheduler.models.IntegrationLauncherConfig;
+import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.workers.temporal.sync.SyncWorkflow;
+import io.temporal.api.enums.v1.RetryState;
+import io.temporal.failure.ActivityFailure;
+import java.util.UUID;
+
+public class DbtFailureSyncWorkflow implements SyncWorkflow {
+
+  // Should match activity types from FailureHelper.java
+  private static final String ACTIVITY_TYPE_DBT_RUN = "Run";
+
+  public static final Throwable CAUSE = new Exception("dbt failed");
+
+  @Override
+  public StandardSyncOutput run(final JobRunConfig jobRunConfig,
+                                final IntegrationLauncherConfig sourceLauncherConfig,
+                                final IntegrationLauncherConfig destinationLauncherConfig,
+                                final StandardSyncInput syncInput,
+                                final UUID connectionId) {
+
+    throw new ActivityFailure(1L, 1L, ACTIVITY_TYPE_DBT_RUN, "someId", RetryState.RETRY_STATE_UNSPECIFIED, "someIdentity", CAUSE);
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/testsyncworkflow/NormalizationFailureSyncWorkflow.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/testsyncworkflow/NormalizationFailureSyncWorkflow.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.temporal.scheduling.testsyncworkflow;
+
+import io.airbyte.config.StandardSyncInput;
+import io.airbyte.config.StandardSyncOutput;
+import io.airbyte.scheduler.models.IntegrationLauncherConfig;
+import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.workers.temporal.sync.SyncWorkflow;
+import io.temporal.api.enums.v1.RetryState;
+import io.temporal.failure.ActivityFailure;
+import java.util.UUID;
+
+public class NormalizationFailureSyncWorkflow implements SyncWorkflow {
+
+  // Should match activity types from FailureHelper.java
+  private static final String ACTIVITY_TYPE_NORMALIZE = "Normalize";
+
+  public static final Throwable CAUSE = new Exception("normalization failed");
+
+  @Override
+  public StandardSyncOutput run(final JobRunConfig jobRunConfig,
+                                final IntegrationLauncherConfig sourceLauncherConfig,
+                                final IntegrationLauncherConfig destinationLauncherConfig,
+                                final StandardSyncInput syncInput,
+                                final UUID connectionId) {
+
+    throw new ActivityFailure(1L, 1L, ACTIVITY_TYPE_NORMALIZE, "someId", RetryState.RETRY_STATE_UNSPECIFIED, "someIdentity", CAUSE);
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/testsyncworkflow/PersistFailureSyncWorkflow.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/testsyncworkflow/PersistFailureSyncWorkflow.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.temporal.scheduling.testsyncworkflow;
+
+import io.airbyte.config.StandardSyncInput;
+import io.airbyte.config.StandardSyncOutput;
+import io.airbyte.scheduler.models.IntegrationLauncherConfig;
+import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.workers.temporal.sync.SyncWorkflow;
+import io.temporal.api.enums.v1.RetryState;
+import io.temporal.failure.ActivityFailure;
+import java.util.UUID;
+
+public class PersistFailureSyncWorkflow implements SyncWorkflow {
+
+  // Should match activity types from FailureHelper.java
+  private static final String ACTIVITY_TYPE_PERSIST = "Persist";
+
+  public static final Throwable CAUSE = new Exception("persist failed");
+
+  @Override
+  public StandardSyncOutput run(final JobRunConfig jobRunConfig,
+                                final IntegrationLauncherConfig sourceLauncherConfig,
+                                final IntegrationLauncherConfig destinationLauncherConfig,
+                                final StandardSyncInput syncInput,
+                                final UUID connectionId) {
+
+    throw new ActivityFailure(1L, 1L, ACTIVITY_TYPE_PERSIST, "someId", RetryState.RETRY_STATE_UNSPECIFIED, "someIdentity", CAUSE);
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/testsyncworkflow/ReplicateFailureSyncWorkflow.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/testsyncworkflow/ReplicateFailureSyncWorkflow.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.temporal.scheduling.testsyncworkflow;
+
+import io.airbyte.config.StandardSyncInput;
+import io.airbyte.config.StandardSyncOutput;
+import io.airbyte.scheduler.models.IntegrationLauncherConfig;
+import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.workers.temporal.sync.SyncWorkflow;
+import io.temporal.api.enums.v1.RetryState;
+import io.temporal.failure.ActivityFailure;
+import java.util.UUID;
+
+public class ReplicateFailureSyncWorkflow implements SyncWorkflow {
+
+  // Should match activity types from FailureHelper.java
+  private static final String ACTIVITY_TYPE_REPLICATE = "Replicate";
+
+  public static final Throwable CAUSE = new Exception("replicate failed");
+
+  @Override
+  public StandardSyncOutput run(final JobRunConfig jobRunConfig,
+                                final IntegrationLauncherConfig sourceLauncherConfig,
+                                final IntegrationLauncherConfig destinationLauncherConfig,
+                                final StandardSyncInput syncInput,
+                                final UUID connectionId) {
+
+    throw new ActivityFailure(1L, 1L, ACTIVITY_TYPE_REPLICATE, "someId", RetryState.RETRY_STATE_UNSPECIFIED, "someIdentity", CAUSE);
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/testsyncworkflow/SourceAndDestinationFailureSyncWorkflow.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/testsyncworkflow/SourceAndDestinationFailureSyncWorkflow.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.temporal.scheduling.testsyncworkflow;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airbyte.config.FailureReason;
+import io.airbyte.config.FailureReason.FailureOrigin;
+import io.airbyte.config.StandardSyncInput;
+import io.airbyte.config.StandardSyncOutput;
+import io.airbyte.config.StandardSyncSummary;
+import io.airbyte.config.StandardSyncSummary.ReplicationStatus;
+import io.airbyte.config.SyncStats;
+import io.airbyte.scheduler.models.IntegrationLauncherConfig;
+import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.workers.temporal.sync.SyncWorkflow;
+import java.util.Set;
+import java.util.UUID;
+import org.assertj.core.util.Sets;
+
+public class SourceAndDestinationFailureSyncWorkflow implements SyncWorkflow {
+
+  @VisibleForTesting
+  public static Set<FailureReason> FAILURE_REASONS = Sets.newLinkedHashSet(
+      new FailureReason().withFailureOrigin(FailureOrigin.SOURCE).withTimestamp(System.currentTimeMillis()),
+      new FailureReason().withFailureOrigin(FailureOrigin.DESTINATION).withTimestamp(System.currentTimeMillis()));
+
+  @Override
+  public StandardSyncOutput run(final JobRunConfig jobRunConfig,
+                                final IntegrationLauncherConfig sourceLauncherConfig,
+                                final IntegrationLauncherConfig destinationLauncherConfig,
+                                final StandardSyncInput syncInput,
+                                final UUID connectionId) {
+
+    return new StandardSyncOutput()
+        .withFailures(FAILURE_REASONS.stream().toList())
+        .withStandardSyncSummary(new StandardSyncSummary()
+            .withStatus(ReplicationStatus.FAILED)
+            .withTotalStats(new SyncStats()
+                .withRecordsCommitted(10L) // should lead to partialSuccess = true
+                .withRecordsEmitted(20L)));
+  }
+
+}


### PR DESCRIPTION
## What
This PR introduces a schema for capturing information about failures that occur during sync jobs.

## How
The `ConnectionManagerWorkflow` collects failure information and persists it to the `Attempts` table when an attempt fails or is cancelled. The `DefaultReplicationWorker` now records failures thrown from within the source and/or destination, and includes failure information in the `ReplicationOutput`. This failure information is then written to `StandardSyncOutput` in the replication activity, so that the `ConnectionManagerWorkflow` can access and persist it.

The `ConnectionManagerWorkflow` also catches all `childWorkflowExceptions` from the sync workflow. If the exception originated from an activity (for example, normalization), then the failure source is identified from the ActivityFailure. Otherwise, the failure source is recorded as 'unknown'.

## Recommended reading order
I recommend reading commit by commit

## Misc
- WIP as I still need to write tests, I wanted to get this up for feedback ASAP
- This PR doesn't include failure recording in the old scheduler, should we add failure recording logic to the old schedulerApp code as well? I have a local branch with some progress on the old scheduler but depending on the timeline for switching over to the new one, it may not be worth pursuing.
- I haven't written a migration to add the new column, so it just logs what it would have persisted for now.
- This is branched off of Benoit's WIP branch, I'll periodically rebase onto his to keep things up to date