### PR TITLE
Fixes editing of already selected item for array of objects editor

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/ArraySection.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/ArraySection.tsx
@@ -45,7 +45,7 @@ export const ArraySection: React.FC<{
               onStartEdit={(index) =>
                 addUnfinishedFlow(path, {
                   id: index,
-                  startValue: index < items.length ? items[index] : null,
+                  startValue: index < items.length ? items : null,
                 })
               }
               onDone={() => removeUnfinishedFlow(path)}


### PR DESCRIPTION
## What
Fixes resetting of field value when editing array of objects.

There was an issue, that value was reset to wrong value as a result objects editor was stuck.
* Closes #9417 *

## How
Reset all form path to value that was set before editing, instead of trying to reset inner value.