### PR TITLE
🐛 Minor correction in the frontend tech-stack

### DIFF
--- a/docs/understanding-airbyte/tech-stack.md
+++ b/docs/understanding-airbyte/tech-stack.md
@@ -26,7 +26,8 @@ Connectors can be written in any language. However the most common languages are
 
 * CI/CD: [GitHub Actions](https://github.com/features/actions)
 * Containerization: [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/)
-* Linter \(Frontend\): [Prettier](https://prettier.io/)
+* Linter \(Frontend\): [ESLint](https://eslint.org/)
+* Formatter \(Frontend\): [Prettier](https://prettier.io/)
 * Formatter \(Backend\): [Spotless](https://github.com/diffplug/spotless)
 
 ## FAQ


### PR DESCRIPTION
## What

Make some correction on the [tech stack](https://docs.airbyte.com/understanding-airbyte/tech-stack) page wrongly stating that "Prettier" would be a Linting tool. Correct that list to clarify that ESLint is the linting tool used in Frontend and Prettier the code formatter.

#### Community member or Airbyter
   
- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
</p>
</details>
