### PR TITLE
🐛 Source Delighted: output only records in which cursor field is greater than the value in state for incremental streams

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -154,7 +154,7 @@
 - name: Delighted
   sourceDefinitionId: cc88c43f-6f53-4e8a-8c4d-b284baaf9635
   dockerRepository: airbyte/source-delighted
-  dockerImageTag: 0.1.2
+  dockerImageTag: 0.1.3
   documentationUrl: https://docs.airbyte.io/integrations/sources/delighted
   icon: delighted.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -1307,7 +1307,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-delighted:0.1.2"
+- dockerImage: "airbyte/source-delighted:0.1.3"
   spec:
     documentationUrl: "https://docsurl.com"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-delighted/Dockerfile
+++ b/airbyte-integrations/connectors/source-delighted/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/source-delighted

--- a/airbyte-integrations/connectors/source-delighted/setup.py
+++ b/airbyte-integrations/connectors/source-delighted/setup.py
@@ -12,6 +12,7 @@ MAIN_REQUIREMENTS = [
 TEST_REQUIREMENTS = [
     "pytest~=6.1",
     "source-acceptance-test",
+    "responses~=0.13.3",
 ]
 
 setup(

--- a/airbyte-integrations/connectors/source-delighted/source_delighted/source.py
+++ b/airbyte-integrations/connectors/source-delighted/source_delighted/source.py
@@ -18,7 +18,6 @@ from airbyte_cdk.sources.streams.http.auth import TokenAuthenticator
 
 # Basic full refresh stream
 class DelightedStream(HttpStream, ABC):
-
     url_base = "https://api.delighted.com/v1/"
 
     # Page size
@@ -52,7 +51,7 @@ class DelightedStream(HttpStream, ABC):
 
 
 class IncrementalDelightedStream(DelightedStream, ABC):
-    # Getting page size as 'limit' from parrent class
+    # Getting page size as 'limit' from parent class
     @property
     def limit(self):
         return super().limit
@@ -72,6 +71,11 @@ class IncrementalDelightedStream(DelightedStream, ABC):
         if stream_state:
             params["since"] = stream_state.get(self.cursor_field)
         return params
+
+    def parse_response(self, response: requests.Response, stream_state: Mapping[str, Any], **kwargs) -> Iterable[Mapping]:
+        for record in super().parse_response(response=response, stream_state=stream_state, **kwargs):
+            if self.cursor_field not in stream_state or record[self.cursor_field] > stream_state[self.cursor_field]:
+                yield record
 
 
 class People(IncrementalDelightedStream):

--- a/airbyte-integrations/connectors/source-delighted/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-delighted/unit_tests/unit_test.py
@@ -2,6 +2,82 @@
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
 
+import pytest
+import responses
+from airbyte_cdk.models import SyncMode
+from source_delighted.source import Bounces, People, SourceDelighted, SurveyResponses, Unsubscribes
+
+
+@pytest.fixture(scope="module")
+def test_config():
+    return {
+        "api_key": "test_api_key",
+        "since": "1641289584",
+    }
+
+
+@pytest.fixture(scope="module")
+def state():
+    return {
+        "bounces": {"bounced_at": 1641455286},
+        "people": {"created_at": 1641455285},
+        "survey_responses": {"updated_at": 1641289816},
+        "unsubscribes": {"unsubscribed_at": 1641289584},
+    }
+
+
+BOUNCES_RESPONSE = """
+[
+    {"person_id": "1046789984", "email": "foo_test204@airbyte.io", "name": "Foo Test204", "bounced_at": 1641455286},
+    {"person_id": "1046789989", "email": "foo_test205@airbyte.io", "name": "Foo Test205", "bounced_at": 1641455286}
+]
+"""
+
+
+PEOPLE_RESPONSE = """
+[
+    {"id": "1046789989", "name": "Foo Test205", "email": "foo_test205@airbyte.io", "created_at": 1641455285, "last_sent_at": 1641455285, "last_responded_at": null, "next_survey_scheduled_at": null}
+]
+"""
+
+
+SURVEY_RESPONSES_RESPONSE = """
+[
+    {"id": "210554887", "person": "1042205953", "survey_type": "nps", "score": 0, "comment": "Test Comment202", "permalink": "https://app.delighted.com/r/0q7QEdWzosv5G5c3w9gakivDwEIM5Hq0", "created_at": 1641289816, "updated_at": 1641289816, "person_properties": null, "notes": [], "tags": [], "additional_answers": []},
+    {"id": "210554885", "person": "1042205947", "survey_type": "nps", "score": 5, "comment": "Test Comment201", "permalink": "https://app.delighted.com/r/GhWWrBT2wayswOc0AfT7fxpM3UwSpitN", "created_at": 1641289816, "updated_at": 1641289816, "person_properties": null, "notes": [], "tags": [], "additional_answers": []}
+]
+"""
+
+
+UNSUBSCRIBES_RESPONSE = """
+[
+    {"person_id": "1040826319", "email": "foo_test64@airbyte.io", "name": "Foo Test64", "unsubscribed_at": 1641289584}
+]
+"""
+
+
+@pytest.mark.parametrize(
+    ("stream_class", "url", "response_body"),
+    [
+        (Bounces, "https://api.delighted.com/v1/bounces.json", BOUNCES_RESPONSE),
+        (People, "https://api.delighted.com/v1/people.json", PEOPLE_RESPONSE),
+        (SurveyResponses, "https://api.delighted.com/v1/survey_responses.json", SURVEY_RESPONSES_RESPONSE),
+        (Unsubscribes, "https://api.delighted.com/v1/unsubscribes.json", UNSUBSCRIBES_RESPONSE),
+    ],
+)
+@responses.activate
+def test_not_output_records_where_cursor_field_equals_state(state, test_config, stream_class, url, response_body):
+    responses.add(
+        responses.GET,
+        url,
+        body=response_body,
+        status=200,
+    )
+
+    stream = stream_class(test_config["since"], authenticator=SourceDelighted()._get_authenticator(config=test_config))
+    records = [r for r in stream.read_records(SyncMode.incremental, stream_state=state[stream.name])]
+    assert not records
+
 
 def test_example_method():
     assert True

--- a/docs/integrations/sources/delighted.md
+++ b/docs/integrations/sources/delighted.md
@@ -37,6 +37,7 @@ This connector supports `API PASSWORD` as the authentication method.
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.3 | 2022-01-18 | [9550](https://github.com/airbytehq/airbyte/pull/9550) | Output only records in which cursor field is greater than the value in state for incremental streams |
 | 0.1.2 | 2022-01-06 | [9333](https://github.com/airbytehq/airbyte/pull/9333) | Add incremental sync mode to streams in `integration_tests/configured_catalog.json` |
 | 0.1.1 | 2022-01-04 | [9275](https://github.com/airbytehq/airbyte/pull/9275) | Fix pagination handling for `survey_responses`, `bounces` and `unsubscribes` streams |
 | 0.1.0 | 2021-10-27 | [4551](https://github.com/airbytehq/airbyte/pull/4551) | Add Delighted source connector |

--- a/docs/integrations/sources/delighted.md
+++ b/docs/integrations/sources/delighted.md
@@ -37,7 +37,7 @@ This connector supports `API PASSWORD` as the authentication method.
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| 0.1.3 | 2022-01-18 | [9550](https://github.com/airbytehq/airbyte/pull/9550) | Output only records in which cursor field is greater than the value in state for incremental streams |
+| 0.1.3 | 2022-01-31 | [9550](https://github.com/airbytehq/airbyte/pull/9550) | Output only records in which cursor field is greater than the value in state for incremental streams |
 | 0.1.2 | 2022-01-06 | [9333](https://github.com/airbytehq/airbyte/pull/9333) | Add incremental sync mode to streams in `integration_tests/configured_catalog.json` |
 | 0.1.1 | 2022-01-04 | [9275](https://github.com/airbytehq/airbyte/pull/9275) | Fix pagination handling for `survey_responses`, `bounces` and `unsubscribes` streams |
 | 0.1.0 | 2021-10-27 | [4551](https://github.com/airbytehq/airbyte/pull/4551) | Add Delighted source connector |


### PR DESCRIPTION
# Bug-fix Request

Fixes #9551.

---

## Reason
Link to message with details is [here](https://github.com/airbytehq/airbyte/issues/8906#issuecomment-1009884559).
The Delighted API supports `since` or `updated_since` parameters and they require Unix timestamp in order to restrict responses to those `updated on or after this time`. So, for example, if we send `since=1641289583` this means that records which were created at 1641289583 or later will be returned.

## Confirmation
 - [x] **Was reproduced locally**

## How does the code change in the PR fix the issue?
Filter records in python code and output records in which cursor field value is greater then value in state.

---


