### PR TITLE
Helm: add hooks to postgresql deployment

### DIFF
--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -505,7 +505,9 @@ postgresql:
   ## This secret is used in case of postgresql.enabled=true and we would like to specify password for newly created postgresql instance
   ##
   existingSecret: ""
-
+  commonAnnotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: -1
 ## External PostgreSQL configuration
 ## All of these values are only used when postgresql.enabled is set to false
 ## @param externalDatabase.host Database host


### PR DESCRIPTION
## What
The bootloader has  `preinstall` and `preupgrade` hooks.
The bootloader requires PostgreSQL's pod to be started.
If the DB is not ready before bootloader runs the bootloader might wait infinitely for it because of the `preinstall` hooks.

## How
Set preinstall and preupgrade hooks on PostgreSQL resources, to make sure they're ready before the bootloader starts.

