### PR TITLE
🐛 Prevent SVG icons from leaking into DOM

### DIFF
--- a/airbyte-webapp/src/utils/imageUtils.tsx
+++ b/airbyte-webapp/src/utils/imageUtils.tsx
@@ -3,12 +3,9 @@ import styled from "styled-components";
 
 import { DefaultLogoCatalog } from "components";
 
-const IconContainer = styled.div`
+const IconContainer = styled.img`
   height: 100%;
-  & > svg {
-    height: 100%;
-    width: 100%;
-  }
+  width: 100%;
 `;
 
 const IconDefaultContainer = styled.div`
@@ -24,5 +21,10 @@ export const getIcon = (icon?: string): React.ReactNode => {
     );
   }
 
-  return <IconContainer dangerouslySetInnerHTML={{ __html: icon }} />;
+  return (
+    <IconContainer
+      alt=""
+      src={`data:image/svg+xml;utf8,${encodeURIComponent(icon)}`}
+    />
+  );
 };


### PR DESCRIPTION
## What

Currently the SVG icons returned as a string as part of the connector spec where attached to the DOM using `dangerouslySetInnerHTML`. This lead to a couple of problems:

* `styles` defined in one SVG are attached to the regular DOM, thus will affect all other elements on the page. You can actually see that in action e.g. chosing the Cart.com icon. If you now open the source type selection (and thus render all other icons too), styles from another icon will suddenly overwrite the styles from the Cart.com icon.
  ![icon-svg-leaking-bug](https://user-images.githubusercontent.com/877229/149947699-0c6ddf5e-80c9-4781-98f2-79360994be5e.gif)
* Unless we don't carefully inspect every svg icon we're adding, users would be able to inject "arbitraty" DOM into the page, thus offering an attack vector. I've checked all existing SVG icons and none of it injects anything dangerous so far.

## How

Using a simple `img` tab where we set the SVG as a data URL on, will prevent both of those things from happening, since we don't allow DOM injection from SVG elements.

The only drawback would be, that icons can't make use of some form of SVG animations anymore, which as far as I could tell none of the icons tried to do (and I guess we anyway don't want them to do).

## Side-Note
I'd personally have preferred to enable the [`react/no-danger`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger.md) linting rule to bring double care to all future `dangerouslySetInnerHTML` calls, but unfortunately the rule doesn't work together with styled components, which we are using.