### PR TITLE
🐛 Fix syntax errors in Airbyte specification docs

### DIFF
--- a/docs/understanding-airbyte/airbyte-specification.md
+++ b/docs/understanding-airbyte/airbyte-specification.md
@@ -107,9 +107,7 @@ read(Config, ConfiguredAirbyteCatalog, State) -> Stream<AirbyteMessage>
                     "type": "string"
                   },
                   "age": {
-                    "type": {
-                      "number"
-                    }
+                    "type": "number"
                   }
                 }
               }
@@ -150,8 +148,8 @@ read(Config, ConfiguredAirbyteCatalog, State) -> Stream<AirbyteMessage>
                       "type": "object",
                       "required": ["name", "productId"],
                       "properties": {
-                        "name": "string",
-                        "productId": "number"
+                        "name": { "type": "string" },
+                        "productId": { "type": "number" }
                       }
                     }
                   }


### PR DESCRIPTION
## What

Fixes some syntax errors in the [Specification documentation](https://docs.airbyte.com/understanding-airbyte/airbyte-specification) I came across when reading them.