### PR TITLE
Add totalStats and streamStats in Attempts API response

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -3114,6 +3114,37 @@ components:
         recordsSynced:
           type: integer
           format: int64
+        totalStats:
+          $ref: "#/components/schemas/AttemptStats"
+        streamStats:
+          type: array
+          items:
+            $ref: "#/components/schemas/AttemptStreamStats"
+    AttemptStats:
+      type: object
+      properties:
+        recordsEmitted:
+          type: integer
+          format: int64
+        bytesEmitted:
+          type: integer
+          format: int64
+        stateMessagesEmitted:
+          type: integer
+          format: int64
+        recordsCommitted:
+          type: integer
+          format: int64
+    AttemptStreamStats:
+      type: object
+      required:
+        - streamName
+        - stats
+      properties:
+        streamName:
+          type: string
+        stats:
+          $ref: "#/components/schemas/AttemptStats"
     AttemptStatus:
       type: string
       enum:

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
@@ -4,7 +4,6 @@
 
 package io.airbyte.server.converters;
 
-import com.google.common.collect.Lists;
 import io.airbyte.api.model.AttemptInfoRead;
 import io.airbyte.api.model.AttemptRead;
 import io.airbyte.api.model.AttemptStats;

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
@@ -4,9 +4,12 @@
 
 package io.airbyte.server.converters;
 
+import com.google.common.collect.Lists;
 import io.airbyte.api.model.AttemptInfoRead;
 import io.airbyte.api.model.AttemptRead;
+import io.airbyte.api.model.AttemptStats;
 import io.airbyte.api.model.AttemptStatus;
+import io.airbyte.api.model.AttemptStreamStats;
 import io.airbyte.api.model.JobConfigType;
 import io.airbyte.api.model.JobInfoRead;
 import io.airbyte.api.model.JobRead;
@@ -19,6 +22,8 @@ import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.JobOutput;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.StandardSyncSummary;
+import io.airbyte.config.StreamSyncStats;
+import io.airbyte.config.SyncStats;
 import io.airbyte.config.helpers.LogClientSingleton;
 import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.scheduler.client.SynchronousJobMetadata;
@@ -27,6 +32,8 @@ import io.airbyte.scheduler.models.Attempt;
 import io.airbyte.scheduler.models.Job;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class JobConverter {
@@ -72,19 +79,57 @@ public class JobConverter {
     return new AttemptRead()
         .id(attempt.getId())
         .status(Enums.convertTo(attempt.getStatus(), AttemptStatus.class))
-        .bytesSynced(attempt.getOutput()
+        .bytesSynced(attempt.getOutput() // TODO (parker) remove after frontend switches to totalStats
             .map(JobOutput::getSync)
             .map(StandardSyncOutput::getStandardSyncSummary)
             .map(StandardSyncSummary::getBytesSynced)
             .orElse(null))
-        .recordsSynced(attempt.getOutput()
+        .recordsSynced(attempt.getOutput() // TODO (parker) remove after frontend switches to totalStats
             .map(JobOutput::getSync)
             .map(StandardSyncOutput::getStandardSyncSummary)
             .map(StandardSyncSummary::getRecordsSynced)
             .orElse(null))
+        .totalStats(getTotalAttemptStats(attempt))
+        .streamStats(getAttemptStreamStats(attempt))
         .createdAt(attempt.getCreatedAtInSecond())
         .updatedAt(attempt.getUpdatedAtInSecond())
         .endedAt(attempt.getEndedAtInSecond().orElse(null));
+  }
+
+  public static AttemptStats getTotalAttemptStats(final Attempt attempt) {
+    final SyncStats totalStats = attempt.getOutput()
+        .map(JobOutput::getSync)
+        .map(StandardSyncOutput::getStandardSyncSummary)
+        .map(StandardSyncSummary::getTotalStats)
+        .orElse(null);
+
+    if (totalStats == null) {
+      return null;
+    }
+
+    return new AttemptStats()
+        .bytesEmitted(totalStats.getBytesEmitted())
+        .recordsEmitted(totalStats.getRecordsEmitted())
+        .stateMessagesEmitted(totalStats.getStateMessagesEmitted())
+        .recordsCommitted(totalStats.getRecordsCommitted());
+  }
+
+  public static List<AttemptStreamStats> getAttemptStreamStats(final Attempt attempt) {
+    final List<StreamSyncStats> streamStats = attempt.getOutput()
+        .map(JobOutput::getSync)
+        .map(StandardSyncOutput::getStandardSyncSummary)
+        .map(StandardSyncSummary::getStreamStats)
+        .orElse(Collections.emptyList());
+
+    return streamStats.stream()
+        .map(streamStat -> new AttemptStreamStats()
+            .streamName(streamStat.getStreamName())
+            .stats(new AttemptStats()
+                .bytesEmitted(streamStat.getStats().getBytesEmitted())
+                .recordsEmitted(streamStat.getStats().getRecordsEmitted())
+                .stateMessagesEmitted(streamStat.getStats().getStateMessagesEmitted())
+                .recordsCommitted(streamStat.getStats().getRecordsCommitted())))
+        .collect(Collectors.toList());
   }
 
   public LogRead getLogRead(final Path logPath) {

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -1023,9 +1023,32 @@ font-style: italic;
   },
   "attempts" : [ {
     "attempt" : {
+      "totalStats" : {
+        "stateMessagesEmitted" : 7,
+        "recordsCommitted" : 1,
+        "bytesEmitted" : 4,
+        "recordsEmitted" : 2
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
+      "streamStats" : [ {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      }, {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      } ],
       "id" : 5,
       "recordsSynced" : 3,
       "updatedAt" : 2
@@ -1035,9 +1058,32 @@ font-style: italic;
     }
   }, {
     "attempt" : {
+      "totalStats" : {
+        "stateMessagesEmitted" : 7,
+        "recordsCommitted" : 1,
+        "bytesEmitted" : 4,
+        "recordsEmitted" : 2
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
+      "streamStats" : [ {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      }, {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      } ],
       "id" : 5,
       "recordsSynced" : 3,
       "updatedAt" : 2
@@ -1262,9 +1308,32 @@ font-style: italic;
   },
   "attempts" : [ {
     "attempt" : {
+      "totalStats" : {
+        "stateMessagesEmitted" : 7,
+        "recordsCommitted" : 1,
+        "bytesEmitted" : 4,
+        "recordsEmitted" : 2
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
+      "streamStats" : [ {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      }, {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      } ],
       "id" : 5,
       "recordsSynced" : 3,
       "updatedAt" : 2
@@ -1274,9 +1343,32 @@ font-style: italic;
     }
   }, {
     "attempt" : {
+      "totalStats" : {
+        "stateMessagesEmitted" : 7,
+        "recordsCommitted" : 1,
+        "bytesEmitted" : 4,
+        "recordsEmitted" : 2
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
+      "streamStats" : [ {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      }, {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      } ],
       "id" : 5,
       "recordsSynced" : 3,
       "updatedAt" : 2
@@ -2845,9 +2937,32 @@ font-style: italic;
   },
   "attempts" : [ {
     "attempt" : {
+      "totalStats" : {
+        "stateMessagesEmitted" : 7,
+        "recordsCommitted" : 1,
+        "bytesEmitted" : 4,
+        "recordsEmitted" : 2
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
+      "streamStats" : [ {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      }, {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      } ],
       "id" : 5,
       "recordsSynced" : 3,
       "updatedAt" : 2
@@ -2857,9 +2972,32 @@ font-style: italic;
     }
   }, {
     "attempt" : {
+      "totalStats" : {
+        "stateMessagesEmitted" : 7,
+        "recordsCommitted" : 1,
+        "bytesEmitted" : 4,
+        "recordsEmitted" : 2
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
+      "streamStats" : [ {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      }, {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      } ],
       "id" : 5,
       "recordsSynced" : 3,
       "updatedAt" : 2
@@ -2933,9 +3071,32 @@ font-style: italic;
   },
   "attempts" : [ {
     "attempt" : {
+      "totalStats" : {
+        "stateMessagesEmitted" : 7,
+        "recordsCommitted" : 1,
+        "bytesEmitted" : 4,
+        "recordsEmitted" : 2
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
+      "streamStats" : [ {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      }, {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      } ],
       "id" : 5,
       "recordsSynced" : 3,
       "updatedAt" : 2
@@ -2945,9 +3106,32 @@ font-style: italic;
     }
   }, {
     "attempt" : {
+      "totalStats" : {
+        "stateMessagesEmitted" : 7,
+        "recordsCommitted" : 1,
+        "bytesEmitted" : 4,
+        "recordsEmitted" : 2
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
+      "streamStats" : [ {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      }, {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      } ],
       "id" : 5,
       "recordsSynced" : 3,
       "updatedAt" : 2
@@ -3021,16 +3205,62 @@ font-style: italic;
       "updatedAt" : 1
     },
     "attempts" : [ {
+      "totalStats" : {
+        "stateMessagesEmitted" : 7,
+        "recordsCommitted" : 1,
+        "bytesEmitted" : 4,
+        "recordsEmitted" : 2
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
+      "streamStats" : [ {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      }, {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      } ],
       "id" : 5,
       "recordsSynced" : 3,
       "updatedAt" : 2
     }, {
+      "totalStats" : {
+        "stateMessagesEmitted" : 7,
+        "recordsCommitted" : 1,
+        "bytesEmitted" : 4,
+        "recordsEmitted" : 2
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
+      "streamStats" : [ {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      }, {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      } ],
       "id" : 5,
       "recordsSynced" : 3,
       "updatedAt" : 2
@@ -3043,16 +3273,62 @@ font-style: italic;
       "updatedAt" : 1
     },
     "attempts" : [ {
+      "totalStats" : {
+        "stateMessagesEmitted" : 7,
+        "recordsCommitted" : 1,
+        "bytesEmitted" : 4,
+        "recordsEmitted" : 2
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
+      "streamStats" : [ {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      }, {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      } ],
       "id" : 5,
       "recordsSynced" : 3,
       "updatedAt" : 2
     }, {
+      "totalStats" : {
+        "stateMessagesEmitted" : 7,
+        "recordsCommitted" : 1,
+        "bytesEmitted" : 4,
+        "recordsEmitted" : 2
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
+      "streamStats" : [ {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      }, {
+        "stats" : {
+          "stateMessagesEmitted" : 7,
+          "recordsCommitted" : 1,
+          "bytesEmitted" : 4,
+          "recordsEmitted" : 2
+        },
+        "streamName" : "streamName"
+      } ],
       "id" : 5,
       "recordsSynced" : 3,
       "updatedAt" : 2
@@ -7033,7 +7309,9 @@ font-style: italic;
     <li><a href="#AirbyteStreamConfiguration"><code>AirbyteStreamConfiguration</code> - </a></li>
     <li><a href="#AttemptInfoRead"><code>AttemptInfoRead</code> - </a></li>
     <li><a href="#AttemptRead"><code>AttemptRead</code> - </a></li>
+    <li><a href="#AttemptStats"><code>AttemptStats</code> - </a></li>
     <li><a href="#AttemptStatus"><code>AttemptStatus</code> - </a></li>
+    <li><a href="#AttemptStreamStats"><code>AttemptStreamStats</code> - </a></li>
     <li><a href="#AuthSpecification"><code>AuthSpecification</code> - </a></li>
     <li><a href="#CheckConnectionRead"><code>CheckConnectionRead</code> - </a></li>
     <li><a href="#CheckOperationRead"><code>CheckOperationRead</code> - </a></li>
@@ -7213,6 +7491,18 @@ font-style: italic;
 <div class="param">endedAt (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
 <div class="param">bytesSynced (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
 <div class="param">recordsSynced (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
+<div class="param">totalStats (optional)</div><div class="param-desc"><span class="param-type"><a href="#AttemptStats">AttemptStats</a></span>  </div>
+<div class="param">streamStats (optional)</div><div class="param-desc"><span class="param-type"><a href="#AttemptStreamStats">array[AttemptStreamStats]</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AttemptStats"><code>AttemptStats</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">recordsEmitted (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
+<div class="param">bytesEmitted (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
+<div class="param">stateMessagesEmitted (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
+<div class="param">recordsCommitted (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -7220,6 +7510,14 @@ font-style: italic;
     <div class='model-description'></div>
     <div class="field-items">
           </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AttemptStreamStats"><code>AttemptStreamStats</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">streamName </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">stats </div><div class="param-desc"><span class="param-type"><a href="#AttemptStats">AttemptStats</a></span>  </div>
+    </div>  <!-- field-items -->
   </div>
   <div class="model">
     <h3><a name="AuthSpecification"><code>AuthSpecification</code> - </a> <a class="up" href="#__Models">Up</a></h3>


### PR DESCRIPTION
## What
We now store attempt stats organized by total and per-stream categories, with clearer names than the existing `recordsSynced` and `bytesSynced` stats (as of https://github.com/airbytehq/airbyte/pull/9327).

This PR updates the `AttemptRead` API response object to include these new stat fields. This will enable the frontend to move off of the `recordsSynced` and `bytesSynced` fields. Once the frontend is reading and displaying the new fields, we can delete those old fields and close out https://github.com/airbytehq/airbyte/issues/3247

## How
Updates `AttemptRead` to include`totalStats` and `streamStats`. 
Updates `JobConverter#getAttemptRead` to add in `totalStats` and `streamStats` from the `StandardSyncSummary`.

