### PR TITLE
Make sure generate.sh has docker running before trying to generate, and make sure its running from the correct directory

### DIFF
--- a/airbyte-integrations/connector-templates/generator/generate.sh
+++ b/airbyte-integrations/connector-templates/generator/generate.sh
@@ -6,6 +6,17 @@ error_handler() {
 trap 'error_handler $LINENO' ERR
 
 set -e
+
+# Ensure script always runs from this directory because thats how docker build contexts work
+cd "$(dirname "${0}")" || exit 1
+
+# Make sure docker is running before trying
+if ! docker ps; then
+  echo "docker is not running, this script requires docker to be up"
+  echo "please start up the docker daemon!"
+  exit
+fi
+
 _UID=$(id -u)
 _GID=$(id -g)
 # Remove container if already exist
@@ -28,5 +39,3 @@ else
 fi
 
 echo "Finished running generator"
-
-exit 0


### PR DESCRIPTION
## What
I often see people getting the `While trying to generate a connector, an error occurred...` message when trying to generate a connector template. Adding some checks in the script to make it easier to understand why its failing.

## How
Check if docker is up first, also ensure the script is running from the correct directory

## Recommended reading order
Easy

## 🚨 User Impact 🚨


## Pre-merge Checklist
