### PR TITLE
Change severity of StateDeltaTrackerException from error to warning

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteMessageTracker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/protocols/airbyte/AirbyteMessageTracker.java
@@ -117,7 +117,9 @@ public class AirbyteMessageTracker implements MessageTracker {
         stateDeltaTracker.addState(stateHash, streamToRunningCount);
       }
     } catch (final StateDeltaTrackerException e) {
-      log.error(e.getMessage(), e);
+      log.warn("The message tracker encountered an issue that prevents committed record counts from being reliably computed.");
+      log.warn("This only impacts metadata and does not indicate a problem with actual sync data.");
+      log.warn(e.getMessage(), e);
       unreliableCommittedCounts = true;
     }
     streamToRunningCount.clear();
@@ -134,7 +136,9 @@ public class AirbyteMessageTracker implements MessageTracker {
         stateDeltaTracker.commitStateHash(getStateHashCode(stateMessage));
       }
     } catch (final StateDeltaTrackerException e) {
-      log.error(e.getMessage(), e);
+      log.warn("The message tracker encountered an issue that prevents committed record counts from being reliably computed.");
+      log.warn("This only impacts metadata and does not indicate a problem with actual sync data.");
+      log.warn(e.getMessage(), e);
       unreliableCommittedCounts = true;
     }
   }


### PR DESCRIPTION
## What
When the MessageTracker sees a state hash that it has already counted, it throws an exception because it can no longer reliably compute the number of committed records during the sync. This error has caused some confusion recently (see https://github.com/airbytehq/oncall/issues/110 and https://github.com/airbytehq/airbyte/issues/9629) because it currently reads like a severe error. In reality, this error only impacts the metadata that we summarize at the end of the sync, and does not indicate an issue with the sync data itself.

## How
This PR changes the severity of the log from `error` to `warning`, and adds additional text to clarify that only sync metadata is impacted.

