### PR TITLE
🐛  Airbyte-webapp: Unblock shopify in connectors list in UI for Cloud

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -90,7 +90,6 @@ const ConnectorServiceTypeControl: React.FC<{
       ? [
           "200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b", // Snapchat
           "2470e835-feaf-4db6-96f3-70fd645acc77", // Salesforce Singer
-          "9da77001-af33-4bcd-be46-6252bf9342b9", // Shopify
         ]
       : [];
   const sortedDropDownData = useMemo(


### PR DESCRIPTION
## What
According to this PR https://github.com/airbytehq/airbyte/pull/6750
The `Shopify` connector was temporarily blocked for selection in a Source Type, while setting up the connector.

## How
- unblocked the UUID of the connector inside the `airbyte-webapp`

## 🚨 User Impact 🚨
User will finally can select shopify from the list of connectors in UI. No actions required.
