### PR TITLE
Disable kube acceptance tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -611,13 +611,13 @@ jobs:
   stop-kube-acceptance-test-runner:
      # Disable kube acceptance tests for now, since they are flaky/broken and prevent any successfull CI run
     if: false
+    # if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     name: Stop Kube Acceptance Test EC2 Runner
     timeout-minutes: 10
     needs:
       - start-kube-acceptance-test-runner # required to get output from the start-runner job
       - kube-acceptance-test # required to wait when the main job is done
     runs-on: ubuntu-latest
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -469,6 +469,8 @@ jobs:
   # In case of self-hosted EC2 errors, remove this block.
   # Docker acceptance tests run as part of the build job.
   start-kube-acceptance-test-runner:
+    # Disable kube acceptance tests for now, since they are flaky/broken and prevent any successfull CI run
+    if: false
     name: Start Kube Acceptance Test EC2 Runner
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -488,6 +490,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
   kube-acceptance-test:
+    # Disable kube acceptance tests for now, since they are flaky/broken and prevent any successfull CI run
+    if: false
     # In case of self-hosted EC2 errors, removed the `needs` line and switch back to running on ubuntu-latest.
     needs: start-kube-acceptance-test-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-kube-acceptance-test-runner.outputs.label }} # run the job on the newly created runner
@@ -605,6 +609,8 @@ jobs:
 
   # In case of self-hosted EC2 errors, remove this block.
   stop-kube-acceptance-test-runner:
+     # Disable kube acceptance tests for now, since they are flaky/broken and prevent any successfull CI run
+    if: false
     name: Stop Kube Acceptance Test EC2 Runner
     timeout-minutes: 10
     needs:


### PR DESCRIPTION
## What

Disable the Kube Acceptance tests for now, since they are too flaky (or broken) and therefore failing every CI run on every PR.
Thus I'd disable them for now, until they are more stabilized and we rely on the acceptence tests running via docker.