### PR TITLE
fix docker process factory test on ci

### DIFF
--- a/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/ContainerOrchestratorApp.java
+++ b/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/ContainerOrchestratorApp.java
@@ -196,8 +196,7 @@ public class ContainerOrchestratorApp {
           configs.getWorkspaceRoot(),
           configs.getWorkspaceDockerMount(),
           configs.getLocalDockerMount(),
-          configs.getDockerNetwork(),
-          false);
+          configs.getDockerNetwork());
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -269,8 +269,7 @@ public class WorkerApp {
           configs.getWorkspaceRoot(),
           configs.getWorkspaceDockerMount(),
           configs.getLocalDockerMount(),
-          configs.getDockerNetwork(),
-          false);
+          configs.getDockerNetwork());
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
@@ -38,7 +38,6 @@ public class DockerProcessFactory implements ProcessFactory {
   private final Path workspaceRoot;
   private final String localMountSource;
   private final String networkName;
-  private final boolean isOrchestrator;
   private final Path imageExistsScriptPath;
 
   /**
@@ -48,20 +47,17 @@ public class DockerProcessFactory implements ProcessFactory {
    * @param workspaceMountSource workspace volume
    * @param localMountSource local volume
    * @param networkName docker network
-   * @param isOrchestrator if the process needs to be able to launch containers
    */
   public DockerProcessFactory(final WorkerConfigs workerConfigs,
                               final Path workspaceRoot,
                               final String workspaceMountSource,
                               final String localMountSource,
-                              final String networkName,
-                              final boolean isOrchestrator) {
+                              final String networkName) {
     this.workerConfigs = workerConfigs;
     this.workspaceRoot = workspaceRoot;
     this.workspaceMountSource = workspaceMountSource;
     this.localMountSource = localMountSource;
     this.networkName = networkName;
-    this.isOrchestrator = isOrchestrator;
     this.imageExistsScriptPath = prepareImageExistsScript();
   }
 
@@ -105,46 +101,30 @@ public class DockerProcessFactory implements ProcessFactory {
         IOs.writeFile(jobRoot, file.getKey(), file.getValue());
       }
 
-      List<String> cmd;
+      final List<String> cmd = Lists.newArrayList(
+          "docker",
+          "run",
+          "--rm",
+          "--init",
+          "-i",
+          "-w",
+          rebasePath(jobRoot).toString(), // rebases the job root on the job data mount
+          "--log-driver",
+          "none");
 
-      // todo: add --expose 80 to each
+      if(networkName != null) {
+        cmd.add("--network");
+        cmd.add(networkName);
+      }
 
-      if (isOrchestrator) {
-        cmd = Lists.newArrayList(
-            "docker",
-            "run",
-            "--rm",
-            "--init",
-            "-i",
-            "-v",
-            String.format("%s:%s", workspaceMountSource, workspaceRoot), // real workspace root, not a rebased version
-            "-v",
-            String.format("%s:%s", localMountSource, LOCAL_MOUNT_DESTINATION),
-            "-v",
-            "/var/run/docker.sock:/var/run/docker.sock", // needs to be able to run docker in docker
-            "-w",
-            jobRoot.toString(), // real jobroot, not rebased version
-            "--network",
-            networkName,
-            "--log-driver",
-            "none");
-      } else {
-        cmd = Lists.newArrayList(
-            "docker",
-            "run",
-            "--rm",
-            "--init",
-            "-i",
-            "-v",
-            String.format("%s:%s", workspaceMountSource, DATA_MOUNT_DESTINATION), // uses job data mount
-            "-v",
-            String.format("%s:%s", localMountSource, LOCAL_MOUNT_DESTINATION),
-            "-w",
-            rebasePath(jobRoot).toString(), // rebases the job root on the job data mount
-            "--network",
-            networkName,
-            "--log-driver",
-            "none");
+      if (workspaceMountSource != null) {
+        cmd.add("-v");
+        cmd.add(String.format("%s:%s", workspaceMountSource, DATA_MOUNT_DESTINATION));
+      }
+
+      if (localMountSource != null) {
+        cmd.add("-v");
+        cmd.add(String.format("%s:%s", localMountSource, LOCAL_MOUNT_DESTINATION));
       }
 
       for (final var envEntry : workerConfigs.getEnvMap().entrySet()) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
@@ -112,7 +112,7 @@ public class DockerProcessFactory implements ProcessFactory {
           "--log-driver",
           "none");
 
-      if(networkName != null) {
+      if (networkName != null) {
         cmd.add("--network");
         cmd.add(networkName);
       }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
@@ -24,8 +24,6 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 // todo (cgardens) - these are not truly "unit" tests as they are check resources on the internet.
 // we should move them to "integration" tests, when we have facility to do so.
@@ -61,7 +59,7 @@ class DockerProcessFactoryTest {
   public void testImageExists() throws IOException, WorkerException {
     final Path workspaceRoot = Files.createTempDirectory(Files.createDirectories(TEST_ROOT), "process_factory");
 
-    final DockerProcessFactory processFactory = new DockerProcessFactory(new WorkerConfigs(new EnvConfigs()), workspaceRoot, "", "", "", false);
+    final DockerProcessFactory processFactory = new DockerProcessFactory(new WorkerConfigs(new EnvConfigs()), workspaceRoot, null, null, null);
     assertTrue(processFactory.checkImageExists("busybox"));
   }
 
@@ -69,18 +67,17 @@ class DockerProcessFactoryTest {
   public void testImageDoesNotExist() throws IOException, WorkerException {
     final Path workspaceRoot = Files.createTempDirectory(Files.createDirectories(TEST_ROOT), "process_factory");
 
-    final DockerProcessFactory processFactory = new DockerProcessFactory(new WorkerConfigs(new EnvConfigs()), workspaceRoot, "", "", "", false);
+    final DockerProcessFactory processFactory = new DockerProcessFactory(new WorkerConfigs(new EnvConfigs()), workspaceRoot, null, null, null);
     assertFalse(processFactory.checkImageExists("airbyte/fake:0.1.2"));
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testFileWriting(boolean isOrchestrator) throws IOException, WorkerException {
+  @Test
+  public void testFileWriting() throws IOException, WorkerException {
     final Path workspaceRoot = Files.createTempDirectory(Files.createDirectories(TEST_ROOT), "process_factory");
     final Path jobRoot = workspaceRoot.resolve("job");
 
     final DockerProcessFactory processFactory =
-        new DockerProcessFactory(new WorkerConfigs(new EnvConfigs()), workspaceRoot, "", "", "", isOrchestrator);
+        new DockerProcessFactory(new WorkerConfigs(new EnvConfigs()), workspaceRoot, null, null, null);
     processFactory.create("job_id", 0, jobRoot, "busybox", false, ImmutableMap.of("config.json", "{\"data\": 2}"), "echo hi",
         new WorkerConfigs(new EnvConfigs()).getResourceRequirements(), Map.of(), Map.of());
 
@@ -92,9 +89,8 @@ class DockerProcessFactoryTest {
   /**
    * Tests that the env var map passed in is accessible within the process.
    */
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testEnvMapSet(boolean isOrchestrator) throws IOException, WorkerException {
+  @Test
+  public void testEnvMapSet() throws IOException, WorkerException {
     final Path workspaceRoot = Files.createTempDirectory(Files.createDirectories(TEST_ROOT), "process_factory");
     final Path jobRoot = workspaceRoot.resolve("job");
 
@@ -105,10 +101,9 @@ class DockerProcessFactoryTest {
         new DockerProcessFactory(
             workerConfigs,
             workspaceRoot,
-            "",
-            "",
-            "host",
-            isOrchestrator);
+            null,
+            null,
+            "host");
 
     final Process process = processFactory.create(
         "job_id",


### PR DESCRIPTION
It looks like the Kube acceptance tests have been failing since https://github.com/airbytehq/airbyte/pull/9329 due to an environment difference (?) resulting in the following error on CI:
```
docker: Error response from daemon: failed to create shim: OCI runtime create failed: invalid mount {Destination::/local Type:bind Source:/var/lib/docker/volumes/9e2237677284de36d32eeec83ea11d127e1fef5252c5ec64e70afe96fdbaab6a/_data Options:[rbind]}: mount destination :/local not absolute: unknown.
```

On Mac this didn't run into any issue at all.

I didn't catch this because the tests were flaky and both the Docker and Kubernetes tests were running successfully locally (and they were on latest master as well). 

I'm doing two things in this PR:
1. Removing the unused `isOrchestrator` flag that isn't used so I don't have to make the following fix twice (this is replaced by the async process creation -- it may return in some form when we add async process creation for Docker, but we can worry about it then).
2. Make all of the inputs nullable so they can pass on CI.

I still need to double check this works on CI. Ideally we would run the `DockerProcessFactoryTest` as part of the main Docker platform build so it shows up as a failure there. Also, I'm not 100% sure why this is failing when in the same class `testFileWriting` was passing. It also passes when Kubernetes isn't running since this is run as part of the main platform build? Since the mounting behavior is still tested as part of the Docker acceptance tests, I don't think we're losing coverage here either way.


