### PR TITLE
Documentation securing Airbyte: link in summary

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -31,6 +31,7 @@
     * [Transformations with Airbyte (Part 3/3)](operator-guides/transformation-and-normalization/transformations-with-airbyte.md)
   * [Configuring Airbyte](operator-guides/configuring-airbyte.md)
   * [Scaling Airbyte](operator-guides/scaling-airbyte.md)
+  * [Securing Airbyte](operator-guides/securing-airbyte.md)
 * [Connector Catalog](integrations/README.md)
   * [Sources](integrations/sources/README.md)
     * [3PL Central](integrations/sources/tplcentral.md)


### PR DESCRIPTION
Forgot to add the link to the document in the summary.
https://github.com/airbytehq/airbyte/pull/9448