### PR TITLE
use path for GOOGLE_APPLICATION_CREDENTIALS in client config

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -566,6 +566,12 @@ jobs:
       - name: Build Platform Docker Images
         run: SUB_BUILD=PLATFORM ./gradlew assemble --scan
 
+      - name: Run Logging Tests
+        run: ./tools/bin/cloud_storage_logging_test.sh
+        env:
+          AWS_S3_INTEGRATION_TEST_CREDS: ${{ secrets.AWS_S3_INTEGRATION_TEST_CREDS }}
+          GOOGLE_CLOUD_STORAGE_TEST_CREDS: ${{ secrets.GOOGLE_CLOUD_STORAGE_TEST_CREDS }}
+
       - name: Run Kubernetes End-to-End Acceptance Tests
         env:
           USER: root
@@ -581,12 +587,6 @@ jobs:
         with:
           name: Kubernetes Logs
           path: /tmp/kubernetes_logs/*
-
-      - name: Run Logging Tests
-        run: ./tools/bin/cloud_storage_logging_test.sh
-        env:
-          AWS_S3_INTEGRATION_TEST_CREDS: ${{ secrets.AWS_S3_INTEGRATION_TEST_CREDS }}
-          GOOGLE_CLOUD_STORAGE_TEST_CREDS: ${{ secrets.GOOGLE_CLOUD_STORAGE_TEST_CREDS }}
 
       - name: Show Disk Usage
         run: |

--- a/airbyte-config/models/src/main/java/io/airbyte/config/storage/DefaultGcsClientFactory.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/storage/DefaultGcsClientFactory.java
@@ -10,7 +10,8 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import io.airbyte.config.storage.CloudStorageConfigs.GcsConfig;
 import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.function.Supplier;
 
 /**
@@ -34,7 +35,7 @@ public class DefaultGcsClientFactory implements Supplier<Storage> {
   @Override
   public Storage get() {
     try {
-      final var credentialsByteStream = new ByteArrayInputStream(config.getGoogleApplicationCredentials().getBytes(StandardCharsets.UTF_8));
+      final var credentialsByteStream = new ByteArrayInputStream(Files.readAllBytes(Path.of(config.getGoogleApplicationCredentials())));
       final var credentials = ServiceAccountCredentials.fromStream(credentialsByteStream);
       return StorageOptions.newBuilder().setCredentials(credentials).build().getService();
     } catch (Exception e) {


### PR DESCRIPTION
We were seeing an error in cloud staging:
```
0: "java.lang.RuntimeException: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $"
```

This was introduced in https://github.com/airbytehq/airbyte/pull/9242 (which fixed a problem with how this was initialized for the state store but broke it for the logging). Since the kube tests were failing earlier than the logging integration tests, it wasn't obvious this was failing.