### PR TITLE
postgres version doc update

### DIFF
--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -27,7 +27,7 @@ Airbyte Cloud only supports connecting to your Postgres instance with SSL or TLS
 
 To use the Postgres destination, you'll need:
 
-* A Postgres server version 9.4 or above
+* A Postgres server version 9.5 or above
 
 #### Configure Network Access
 


### PR DESCRIPTION
## What

I was running airbyte on an old computer that had Postgres 9.4 on it. The docs said it would be ok.
But I received these kind of errors when syncing (source: github, destination: postgres).

```
create  index if not exists
"ba498949f97eb58edc0d479256d87145"
on "airbyte".public."collaborators" using btree
```

It turns out `IF NOT EXISTS` was not in [9.4](https://www.postgresql.org/docs/9.4/sql-createindex.html) but was in the [9.5](https://www.postgresql.org/docs/9.5/sql-createindex.html) version.

Note: I have not actually tested on `9.5`, but I do know `9.4` doesn't work.

## How

Update documentation

## 🚨 User Impact 🚨

No functionality impact.
