### PR TITLE
fix(charts): Get minio secrets from Values

### DIFF
--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -38,8 +38,8 @@ data:
   S3_PATH_STYLE_ACCESS: {{ include "airbyte.s3PathStyleAccess" . | quote }}
   STATE_STORAGE_MINIO_BUCKET_NAME: airbyte-state-storage
   STATE_STORAGE_MINIO_ENDPOINT: {{ include "airbyte.minio.endpoint" . | quote }}
-  STATE_STORAGE_MINIO_ACCESS_KEY: {{ include "airbyte.minio.accessKey.password" . | quote }}
-  STATE_STORAGE_MINIO_SECRET_ACCESS_KEY: {{ include "airbyte.minio.secretKey.password" . | quote }}
+  STATE_STORAGE_MINIO_ACCESS_KEY: {{ .Values.minio.accessKey.password | quote }}
+  STATE_STORAGE_MINIO_SECRET_ACCESS_KEY: {{ .Values.minio.secretKey.password | quote }}
   SUBMITTER_NUM_THREADS: "10"
   TEMPORAL_HOST: {{ include "common.names.fullname" . }}-temporal:{{ .Values.temporal.service.port }}
   TEMPORAL_WORKER_PORTS: 9001,9002,9003,9004,9005,9006,9007,9008,9009,9010,9011,9012,9013,9014,9015,9016,9017,9018,9019,9020,9021,9022,9023,9024,9025,9026,9027,9028,9029,9030,9031,9032,9033,9034,9035,9036,9037,9038,9039,9040


### PR DESCRIPTION
## What

Applying the helm chart is failing with the following error:
```
STDERR: Error: template: airbyte/templates/env-configmap.yaml:41:37: 
executing "airbyte/templates/env-configmap.yaml" at <include "airbyte.minio.accessKey.password" .>:
error calling include: template: no template "airbyte.minio.accessKey.password" associated with 
template "gotpl"
``` 

It happens because the method doesn't exist in the `_helpers.tpl`. But the value exists in the `Values.yaml`


## How

Just replace calls to methods to values instead, and enjoy the full power of helm!


## 🚨 User Impact 🚨

None. Applying the fix will at the contrary improve helmers' life


## Pre-merge Checklist

No checklist fits the MR