### PR TITLE
Normalization ssh tunnel - replace '\\n' -> '\n'

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -28,5 +28,5 @@ WORKDIR /airbyte
 ENV AIRBYTE_ENTRYPOINT "/airbyte/entrypoint.sh"
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.63
+LABEL io.airbyte.version=0.1.64
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 public class NormalizationRunnerFactory {
 
   public static final String BASE_NORMALIZATION_IMAGE_NAME = "airbyte/normalization";
-  public static final String NORMALIZATION_VERSION = "0.1.63";
+  public static final String NORMALIZATION_VERSION = "0.1.64";
 
   static final Map<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>> NORMALIZATION_MAPPING =
       ImmutableMap.<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>>builder()

--- a/airbyte-workers/src/main/resources/sshtunneling.sh
+++ b/airbyte-workers/src/main/resources/sshtunneling.sh
@@ -31,7 +31,7 @@ function openssh() {
     # create a temporary file to hold ssh key and trap to delete on EXIT
     trap 'rm -f "$tmpkeyfile"' EXIT
     tmpkeyfile=$(mktemp /tmp/xyzfile.XXXXXXXXXXX) || return 1
-    echo "$(cat $1 | jq -r '.tunnel_map.ssh_key')" > $tmpkeyfile
+    cat $1 | jq -r '.tunnel_map.ssh_key | gsub("\\\\n"; "\n")' > $tmpkeyfile
     # -f=background  -N=no remote command  -M=master mode  StrictHostKeyChecking=no auto-adds host
     echo "Running: ssh -f -N -M -o StrictHostKeyChecking=no -S {control socket} -i {key file} -l ${tunnel_username} -L ${tunnel_local_port}:${tunnel_db_host}:${tunnel_db_port} ${tunnel_host}"
     ssh -f -N -M -o StrictHostKeyChecking=no -S $tmpcontrolsocket -i $tmpkeyfile -l ${tunnel_username} -L ${tunnel_local_port}:${tunnel_db_host}:${tunnel_db_port} ${tunnel_host} &&


### PR DESCRIPTION
Signed-off-by: Sergey Chvalyuk <grubberr@gmail.com>

## What
Users can provide SSH-TUNNEL key certificate in PEM format where newline characters `\n` replaced by `\\n`.
For example, this can happen if the user copy-paste the PEM certificate from the JSON file.
From the parser point of view, such PEM certificates are not correct
but because backslash symbols are not allowed in base64 encoding
we can improve user experience and safely replace back `\\n` -> `\n`
Similar PR https://github.com/airbytehq/airbyte/pull/8371 for Java connectors.

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.