### PR TITLE
add getConfigWithMetadata method to ConfigPersistence

### DIFF
--- a/airbyte-config/init/src/main/java/io/airbyte/config/init/YamlSeedConfigPersistence.java
+++ b/airbyte-config/init/src/main/java/io/airbyte/config/init/YamlSeedConfigPersistence.java
@@ -120,6 +120,12 @@ public class YamlSeedConfigPersistence implements ConfigPersistence {
   }
 
   @Override
+  public <T> ConfigWithMetadata<T> getConfigWithMetadata(final AirbyteConfig configType, final String configId, final Class<T> clazz)
+      throws ConfigNotFoundException, JsonValidationException, IOException {
+    throw new UnsupportedOperationException("Yaml Seed Config doesn't support metadata");
+  }
+
+  @Override
   public <T> List<ConfigWithMetadata<T>> listConfigsWithMetadata(final AirbyteConfig configType, final Class<T> clazz)
       throws JsonValidationException, IOException {
     throw new UnsupportedOperationException("Yaml Seed Config doesn't support metadata");

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigPersistence.java
@@ -19,6 +19,8 @@ public interface ConfigPersistence {
 
   <T> List<T> listConfigs(AirbyteConfig configType, Class<T> clazz) throws JsonValidationException, IOException;
 
+  <T> ConfigWithMetadata<T> getConfigWithMetadata(AirbyteConfig configType, String configId, Class<T> clazz) throws ConfigNotFoundException, JsonValidationException, IOException;
+
   <T> List<ConfigWithMetadata<T>> listConfigsWithMetadata(AirbyteConfig configType, Class<T> clazz) throws JsonValidationException, IOException;
 
   <T> void writeConfig(AirbyteConfig configType, String configId, T config) throws JsonValidationException, IOException;

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigPersistence.java
@@ -19,7 +19,8 @@ public interface ConfigPersistence {
 
   <T> List<T> listConfigs(AirbyteConfig configType, Class<T> clazz) throws JsonValidationException, IOException;
 
-  <T> ConfigWithMetadata<T> getConfigWithMetadata(AirbyteConfig configType, String configId, Class<T> clazz) throws ConfigNotFoundException, JsonValidationException, IOException;
+  <T> ConfigWithMetadata<T> getConfigWithMetadata(AirbyteConfig configType, String configId, Class<T> clazz)
+      throws ConfigNotFoundException, JsonValidationException, IOException;
 
   <T> List<ConfigWithMetadata<T>> listConfigsWithMetadata(AirbyteConfig configType, Class<T> clazz) throws JsonValidationException, IOException;
 

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -204,7 +204,9 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     }
   }
 
-  private <T> ConfigWithMetadata<T> validateAndReturn(final String configId, final List<ConfigWithMetadata<T>> result, final AirbyteConfig airbyteConfig)
+  private <T> ConfigWithMetadata<T> validateAndReturn(final String configId,
+                                                      final List<ConfigWithMetadata<T>> result,
+                                                      final AirbyteConfig airbyteConfig)
       throws ConfigNotFoundException {
     validate(configId, result, airbyteConfig);
     return result.get(0);

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -139,7 +139,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     return result.get(0).getConfig();
   }
 
-  private SourceConnection getSourceConnection(String configId) throws IOException, ConfigNotFoundException {
+  private SourceConnection getSourceConnection(final String configId) throws IOException, ConfigNotFoundException {
     final List<ConfigWithMetadata<SourceConnection>> result = listSourceConnectionWithMetadata(Optional.of(UUID.fromString(configId)));
     validate(configId, result, ConfigSchema.SOURCE_CONNECTION);
     return result.get(0).getConfig();
@@ -188,7 +188,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
         .fetch());
 
     final List<UUID> ids = new ArrayList<>();
-    for (Record record : result) {
+    for (final Record record : result) {
       ids.add(record.get(CONNECTION_OPERATION.OPERATION_ID));
     }
 
@@ -204,11 +204,46 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     }
   }
 
+  private <T> ConfigWithMetadata<T> validateAndReturn(final String configId, final List<ConfigWithMetadata<T>> result, final AirbyteConfig airbyteConfig)
+      throws ConfigNotFoundException {
+    validate(configId, result, airbyteConfig);
+    return result.get(0);
+  }
+
   @Override
   public <T> List<T> listConfigs(final AirbyteConfig configType, final Class<T> clazz) throws JsonValidationException, IOException {
     final List<T> config = new ArrayList<>();
     listConfigsWithMetadata(configType, clazz).forEach(c -> config.add(c.getConfig()));
     return config;
+  }
+
+  @Override
+  public <T> ConfigWithMetadata<T> getConfigWithMetadata(final AirbyteConfig configType, final String configId, final Class<T> clazz)
+      throws ConfigNotFoundException, JsonValidationException, IOException {
+    final Optional<UUID> configIdOpt = Optional.of(UUID.fromString(configId));
+    if (configType == ConfigSchema.STANDARD_WORKSPACE) {
+      return (ConfigWithMetadata<T>) validateAndReturn(configId, listStandardWorkspaceWithMetadata(configIdOpt), configType);
+    } else if (configType == ConfigSchema.STANDARD_SOURCE_DEFINITION) {
+      return (ConfigWithMetadata<T>) validateAndReturn(configId, listStandardSourceDefinitionWithMetadata(configIdOpt), configType);
+    } else if (configType == ConfigSchema.STANDARD_DESTINATION_DEFINITION) {
+      return (ConfigWithMetadata<T>) validateAndReturn(configId, listStandardDestinationDefinitionWithMetadata(configIdOpt), configType);
+    } else if (configType == ConfigSchema.SOURCE_CONNECTION) {
+      return (ConfigWithMetadata<T>) validateAndReturn(configId, listSourceConnectionWithMetadata(configIdOpt), configType);
+    } else if (configType == ConfigSchema.DESTINATION_CONNECTION) {
+      return (ConfigWithMetadata<T>) validateAndReturn(configId, listDestinationConnectionWithMetadata(configIdOpt), configType);
+    } else if (configType == ConfigSchema.SOURCE_OAUTH_PARAM) {
+      return (ConfigWithMetadata<T>) validateAndReturn(configId, listSourceOauthParamWithMetadata(configIdOpt), configType);
+    } else if (configType == ConfigSchema.DESTINATION_OAUTH_PARAM) {
+      return (ConfigWithMetadata<T>) validateAndReturn(configId, listDestinationOauthParamWithMetadata(configIdOpt), configType);
+    } else if (configType == ConfigSchema.STANDARD_SYNC_OPERATION) {
+      return (ConfigWithMetadata<T>) validateAndReturn(configId, listStandardSyncOperationWithMetadata(configIdOpt), configType);
+    } else if (configType == ConfigSchema.STANDARD_SYNC) {
+      return (ConfigWithMetadata<T>) validateAndReturn(configId, listStandardSyncWithMetadata(configIdOpt), configType);
+    } else if (configType == ConfigSchema.STANDARD_SYNC_STATE) {
+      return (ConfigWithMetadata<T>) validateAndReturn(configId, listStandardSyncStateWithMetadata(configIdOpt), configType);
+    } else {
+      throw new IllegalArgumentException("Unknown Config Type " + configType);
+    }
   }
 
   @Override
@@ -258,7 +293,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     for (final Record record : result) {
       final List<Notification> notificationList = new ArrayList<>();
       final List fetchedNotifications = Jsons.deserialize(record.get(WORKSPACE.NOTIFICATIONS).data(), List.class);
-      for (Object notification : fetchedNotifications) {
+      for (final Object notification : fetchedNotifications) {
         notificationList.add(Jsons.convertValue(notification, Notification.class));
       }
       final StandardWorkspace workspace = buildStandardWorkspace(record, notificationList);

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/FileSystemConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/FileSystemConfigPersistence.java
@@ -80,6 +80,12 @@ public class FileSystemConfigPersistence implements ConfigPersistence {
   }
 
   @Override
+  public <T> ConfigWithMetadata<T> getConfigWithMetadata(final AirbyteConfig configType, final String configId, final Class<T> clazz)
+      throws ConfigNotFoundException, JsonValidationException, IOException {
+    throw new UnsupportedOperationException("File Persistence doesn't support metadata");
+  }
+
+  @Override
   public <T> List<ConfigWithMetadata<T>> listConfigsWithMetadata(final AirbyteConfig configType, final Class<T> clazz)
       throws JsonValidationException, IOException {
     throw new UnsupportedOperationException("File Persistence doesn't support metadata");

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ValidatingConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ValidatingConfigPersistence.java
@@ -49,6 +49,14 @@ public class ValidatingConfigPersistence implements ConfigPersistence {
   }
 
   @Override
+  public <T> ConfigWithMetadata<T> getConfigWithMetadata(final AirbyteConfig configType, final String configId, final Class<T> clazz)
+      throws ConfigNotFoundException, JsonValidationException, IOException {
+    final ConfigWithMetadata<T> config = decoratedPersistence.getConfigWithMetadata(configType, configId, clazz);
+    validateJson(config.getConfig(), configType);
+    return config;
+  }
+
+  @Override
   public <T> List<ConfigWithMetadata<T>> listConfigsWithMetadata(final AirbyteConfig configType, final Class<T> clazz)
       throws JsonValidationException, IOException {
     final List<ConfigWithMetadata<T>> configs = decoratedPersistence.listConfigsWithMetadata(configType, clazz);

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
@@ -87,6 +87,21 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
   }
 
   @Test
+  public void testGetConfigWithMetadata() throws Exception {
+    final Instant now = Instant.now().minus(Duration.ofSeconds(1));
+    writeDestination(configPersistence, DESTINATION_S3);
+    final ConfigWithMetadata<StandardDestinationDefinition> configWithMetadata = configPersistence.getConfigWithMetadata(
+        STANDARD_DESTINATION_DEFINITION,
+        DESTINATION_S3.getDestinationDefinitionId().toString(),
+        StandardDestinationDefinition.class);
+    assertEquals("STANDARD_DESTINATION_DEFINITION", configWithMetadata.getConfigType());
+    assertTrue(configWithMetadata.getCreatedAt().isAfter(now));
+    assertTrue(configWithMetadata.getUpdatedAt().isAfter(now));
+    assertEquals(DESTINATION_S3.getDestinationDefinitionId().toString(), configWithMetadata.getConfigId());
+    assertEquals(DESTINATION_S3, configWithMetadata.getConfig());
+  }
+
+  @Test
   public void testListConfigWithMetadata() throws Exception {
     final Instant now = Instant.now().minus(Duration.ofSeconds(1));
     writeDestination(configPersistence, DESTINATION_S3);

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DeprecatedDatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DeprecatedDatabaseConfigPersistenceTest.java
@@ -79,6 +79,21 @@ public class DeprecatedDatabaseConfigPersistenceTest extends BaseDeprecatedDatab
   }
 
   @Test
+  public void testGetConfigWithMetadata() throws Exception {
+    final Instant now = Instant.now().minus(Duration.ofSeconds(1));
+    writeDestination(configPersistence, DESTINATION_S3);
+    final ConfigWithMetadata<StandardDestinationDefinition> configWithMetadata = configPersistence.getConfigWithMetadata(
+        STANDARD_DESTINATION_DEFINITION,
+        DESTINATION_S3.getDestinationDefinitionId().toString(),
+        StandardDestinationDefinition.class);
+    assertEquals("STANDARD_DESTINATION_DEFINITION", configWithMetadata.getConfigType());
+    assertTrue(configWithMetadata.getCreatedAt().isAfter(now));
+    assertTrue(configWithMetadata.getUpdatedAt().isAfter(now));
+    assertEquals(DESTINATION_S3.getDestinationDefinitionId().toString(), configWithMetadata.getConfigId());
+    assertEquals(DESTINATION_S3, configWithMetadata.getConfig());
+  }
+
+  @Test
   public void testListConfigWithMetadata() throws Exception {
     final Instant now = Instant.now().minus(Duration.ofSeconds(1));
     writeDestination(configPersistence, DESTINATION_S3);


### PR DESCRIPTION
## What
Adds a method to get a _single_ config with metadata, as there is currently only a method to list all configs in a table with metadata.

## How
Looks very similar to listConfigsWithMetadata, except that it only fetches a single record.

## Recommended reading order
1. ConfigPersistence.java
2. DatabaseConfigPersistence.java 
3. DeprecatedDatabaseConfigPersistence.java
4. Tests
