### PR TITLE
Add platform project automation github workflow

### DIFF
--- a/.github/workflows/platform-project-automation.yml
+++ b/.github/workflows/platform-project-automation.yml
@@ -1,0 +1,18 @@
+name: Platform Project Automation
+on:
+  issues:
+    types: [labeled]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  add-area-platform-issues-to-platform-project:
+    runs-on: ubuntu-latest
+    name: Add area/platform Issues to Platform Project
+    steps:
+      - uses: srggrs/assign-one-project-github-action@1.2.0
+        if: contains(github.event.issue.labels.*.name, 'area/platform')
+        with:
+          with:
+            project: "https://github.com/orgs/airbytehq/projects/6"
+            column_name: "Todo"


### PR DESCRIPTION
This workflow is intended to automatically add any `area/platform` labeled issues to the new Platform Scrum github project that I'm setting up