### PR TITLE
Remove regex check from Java source acceptance test

### DIFF
--- a/airbyte-integrations/bases/base-standard-source-test-file/src/main/java/io/airbyte/integrations/standardtest/source/fs/ExecutableTestSource.java
+++ b/airbyte-integrations/bases/base-standard-source-test-file/src/main/java/io/airbyte/integrations/standardtest/source/fs/ExecutableTestSource.java
@@ -12,8 +12,6 @@ import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import javax.annotation.Nullable;
 
 /**

--- a/airbyte-integrations/bases/base-standard-source-test-file/src/main/java/io/airbyte/integrations/standardtest/source/fs/ExecutableTestSource.java
+++ b/airbyte-integrations/bases/base-standard-source-test-file/src/main/java/io/airbyte/integrations/standardtest/source/fs/ExecutableTestSource.java
@@ -95,11 +95,6 @@ public class ExecutableTestSource extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() throws Exception {
-    return new ArrayList<>();
-  }
-
-  @Override
   protected void setupEnvironment(final TestDestinationEnv environment) throws Exception {
     // no-op, for now
   }

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/PythonSourceAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/PythonSourceAcceptanceTest.java
@@ -4,7 +4,7 @@
 
 package io.airbyte.integrations.standardtest.source;
 
-import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
@@ -13,6 +13,7 @@ import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.io.LineGobbler;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.EnvConfigs;
+import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.workers.WorkerConfigs;
@@ -65,10 +66,15 @@ public class PythonSourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() throws IOException {
-    return Streams.stream(runExecutable(Command.GET_REGEX_TESTS).withArray("tests").elements())
-        .map(JsonNode::textValue)
-        .collect(toList());
+  protected void assertFullRefreshMessages(final List<AirbyteMessage> allMessages) throws IOException {
+    final List<String> regexTests = Streams.stream(runExecutable(Command.GET_REGEX_TESTS).withArray("tests").elements())
+        .map(JsonNode::textValue).toList();
+    final List<String> stringMessages = allMessages.stream().map(Jsons::serialize).toList();
+    LOGGER.info("Running " + regexTests.size() + " regex tests...");
+    regexTests.forEach(regex -> {
+      LOGGER.info("Looking for [" + regex + "]");
+      assertTrue(stringMessages.stream().anyMatch(line -> line.matches(regex)), "Failed to find regex: " + regex);
+    });
   }
 
   @Override

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAcceptanceTest.java
@@ -106,14 +106,6 @@ public abstract class SourceAcceptanceTest extends AbstractSourceConnectorTest {
   protected abstract JsonNode getState() throws Exception;
 
   /**
-   * List of regular expressions that should match the output of the test sync.
-   *
-   * @return the regular expressions to test
-   * @throws Exception - thrown when attempting ot access the regexes fails
-   */
-  protected abstract List<String> getRegexTests() throws Exception;
-
-  /**
    * Verify that a spec operation issued to the connector returns a valid spec.
    */
   @Test
@@ -160,26 +152,15 @@ public abstract class SourceAcceptanceTest extends AbstractSourceConnectorTest {
   public void testFullRefreshRead() throws Exception {
     final ConfiguredAirbyteCatalog catalog = withFullRefreshSyncModes(getConfiguredCatalog());
     final List<AirbyteMessage> allMessages = runRead(catalog);
-    final List<AirbyteRecordMessage> recordMessages = filterRecords(allMessages);
-    // the worker validates the message formats, so we just validate the message content
-    // We don't need to validate message format as long as we use the worker, which we will not want to
-    // do long term.
-    assertFalse(recordMessages.isEmpty(), "Expected a full refresh sync to produce records");
-    assertFullRefreshRecordMessages(recordMessages);
 
-    final List<String> regexTests = getRegexTests();
-    final List<String> stringMessages = allMessages.stream().map(Jsons::serialize).collect(Collectors.toList());
-    LOGGER.info("Running " + regexTests.size() + " regex tests...");
-    regexTests.forEach(regex -> {
-      LOGGER.info("Looking for [" + regex + "]");
-      assertTrue(stringMessages.stream().anyMatch(line -> line.matches(regex)), "Failed to find regex: " + regex);
-    });
+    assertFalse(filterRecords(allMessages).isEmpty(), "Expected a full refresh sync to produce records");
+    assertFullRefreshMessages(allMessages);
   }
 
   /**
-   * Override this method to perform more specific assertion on the record messages.
+   * Override this method to perform more specific assertion on the messages.
    */
-  protected void assertFullRefreshRecordMessages(final List<AirbyteRecordMessage> recordMessages) {
+  protected void assertFullRefreshMessages(final List<AirbyteMessage> allMessages) throws Exception {
     // do nothing by default
   }
 
@@ -290,7 +271,7 @@ public abstract class SourceAcceptanceTest extends AbstractSourceConnectorTest {
     checkEntrypointEnvVariable();
   }
 
-  private List<AirbyteRecordMessage> filterRecords(final Collection<AirbyteMessage> messages) {
+  protected static List<AirbyteRecordMessage> filterRecords(final Collection<AirbyteMessage> messages) {
     return messages.stream()
         .filter(m -> m.getType() == Type.RECORD)
         .map(AirbyteMessage::getRecord)

--- a/airbyte-integrations/connector-templates/source-java-jdbc/src/test-integration/java/io/airbyte/integrations/source/{{snakeCase name}}/{{pascalCase name}}SourceAcceptanceTest.java.hbs
+++ b/airbyte-integrations/connector-templates/source-java-jdbc/src/test-integration/java/io/airbyte/integrations/source/{{snakeCase name}}/{{pascalCase name}}SourceAcceptanceTest.java.hbs
@@ -56,11 +56,6 @@ public class {{pascalCase name}}SourceAcceptanceTest extends SourceAcceptanceTes
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-bigquery/src/test-integration/java/io/airbyte/integrations/source/bigquery/BigQuerySourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-bigquery/src/test-integration/java/io/airbyte/integrations/source/bigquery/BigQuerySourceAcceptanceTest.java
@@ -96,11 +96,6 @@ public class BigQuerySourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-clickhouse/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractSshClickHouseSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractSshClickHouseSourceAcceptanceTest.java
@@ -84,11 +84,6 @@ public abstract class AbstractSshClickHouseSourceAcceptanceTest extends SourceAc
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected void setupEnvironment(final TestDestinationEnv environment) throws Exception {
     startTestContainers();
     config = bastion.getTunnelConfig(getTunnelMethod(), bastion.getBasicDbConfigBuider(db, "default"));

--- a/airbyte-integrations/connectors/source-clickhouse/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/ClickHouseSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/ClickHouseSourceAcceptanceTest.java
@@ -80,11 +80,6 @@ public class ClickHouseSourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected void setupEnvironment(final TestDestinationEnv environment) throws Exception {
     db = new ClickHouseContainer("yandex/clickhouse-server:21.8.8.29-alpine");
     db.start();

--- a/airbyte-integrations/connectors/source-cockroachdb-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/cockroachdb/CockroachDbEncryptSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-cockroachdb-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/cockroachdb/CockroachDbEncryptSourceAcceptanceTest.java
@@ -117,11 +117,6 @@ public class CockroachDbEncryptSourceAcceptanceTest extends SourceAcceptanceTest
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-cockroachdb/src/test-integration/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-cockroachdb/src/test-integration/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSourceAcceptanceTest.java
@@ -119,11 +119,6 @@ public class CockroachDbSourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-db2-strict-encrypt/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/Db2StrictEncryptSourceCertificateAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-db2-strict-encrypt/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/Db2StrictEncryptSourceCertificateAcceptanceTest.java
@@ -91,20 +91,15 @@ public class Db2StrictEncryptSourceCertificateAcceptanceTest extends SourceAccep
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
-  protected void setupEnvironment(TestDestinationEnv environment) throws Exception {
+  protected void setupEnvironment(final TestDestinationEnv environment) throws Exception {
     db = new Db2Container("ibmcom/db2:11.5.5.0").withCommand().acceptLicense()
         .withExposedPorts(50000);
     db.start();
 
-    var certificate = getCertificate();
+    final var certificate = getCertificate();
     try {
       convertAndImportCertificate(certificate);
-    } catch (IOException | InterruptedException e) {
+    } catch (final IOException | InterruptedException e) {
       throw new RuntimeException("Failed to import certificate into Java Keystore");
     }
 
@@ -121,7 +116,7 @@ public class Db2StrictEncryptSourceCertificateAcceptanceTest extends SourceAccep
             .build()))
         .build());
 
-    String jdbcUrl = String.format("jdbc:db2://%s:%s/%s",
+    final String jdbcUrl = String.format("jdbc:db2://%s:%s/%s",
         config.get("host").asText(),
         db.getMappedPort(50000),
         config.get("db").asText()) + SSL_CONFIG;
@@ -154,7 +149,7 @@ public class Db2StrictEncryptSourceCertificateAcceptanceTest extends SourceAccep
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     new File("certificate.pem").delete();
     new File("certificate.der").delete();
     new File(KEY_STORE_FILE_PATH).delete();
@@ -186,9 +181,9 @@ public class Db2StrictEncryptSourceCertificateAcceptanceTest extends SourceAccep
     return db.execInContainer("su", "-", "db2inst1", "-c", "cat server.arm").getStdout();
   }
 
-  private static void convertAndImportCertificate(String certificate) throws IOException, InterruptedException {
-    Runtime run = Runtime.getRuntime();
-    try (PrintWriter out = new PrintWriter("certificate.pem")) {
+  private static void convertAndImportCertificate(final String certificate) throws IOException, InterruptedException {
+    final Runtime run = Runtime.getRuntime();
+    try (final PrintWriter out = new PrintWriter("certificate.pem")) {
       out.print(certificate);
     }
     runProcess("openssl x509 -outform der -in certificate.pem -out certificate.der", run);
@@ -198,8 +193,8 @@ public class Db2StrictEncryptSourceCertificateAcceptanceTest extends SourceAccep
         run);
   }
 
-  private static void runProcess(String cmd, Runtime run) throws IOException, InterruptedException {
-    Process pr = run.exec(cmd);
+  private static void runProcess(final String cmd, final Runtime run) throws IOException, InterruptedException {
+    final Process pr = run.exec(cmd);
     if (!pr.waitFor(30, TimeUnit.SECONDS)) {
       pr.destroy();
       throw new RuntimeException("Timeout while executing: " + cmd);

--- a/airbyte-integrations/connectors/source-db2/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/Db2SourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-db2/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/Db2SourceAcceptanceTest.java
@@ -82,11 +82,6 @@ public class Db2SourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() throws Exception {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected void setupEnvironment(final TestDestinationEnv environment) throws Exception {
     db = new Db2Container("ibmcom/db2:11.5.5.0").acceptLicense();
     db.start();

--- a/airbyte-integrations/connectors/source-db2/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/Db2SourceCertificateAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-db2/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/Db2SourceCertificateAcceptanceTest.java
@@ -89,20 +89,15 @@ public class Db2SourceCertificateAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
-  protected void setupEnvironment(TestDestinationEnv environment) throws Exception {
+  protected void setupEnvironment(final TestDestinationEnv environment) throws Exception {
     db = new Db2Container("ibmcom/db2:11.5.5.0").withCommand().acceptLicense()
         .withExposedPorts(50000);
     db.start();
 
-    var certificate = getCertificate();
+    final var certificate = getCertificate();
     try {
       convertAndImportCertificate(certificate);
-    } catch (IOException | InterruptedException e) {
+    } catch (final IOException | InterruptedException e) {
       throw new RuntimeException("Failed to import certificate into Java Keystore");
     }
 
@@ -119,7 +114,7 @@ public class Db2SourceCertificateAcceptanceTest extends SourceAcceptanceTest {
             .build()))
         .build());
 
-    String jdbcUrl = String.format("jdbc:db2://%s:%s/%s",
+    final String jdbcUrl = String.format("jdbc:db2://%s:%s/%s",
         config.get("host").asText(),
         db.getMappedPort(50000),
         config.get("db").asText()) + ":sslConnection=true;sslTrustStoreLocation=" + KEY_STORE_FILE_PATH +
@@ -153,7 +148,7 @@ public class Db2SourceCertificateAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv) {
+  protected void tearDown(final TestDestinationEnv testEnv) {
     new File("certificate.pem").delete();
     new File("certificate.der").delete();
     new File(KEY_STORE_FILE_PATH).delete();
@@ -180,9 +175,9 @@ public class Db2SourceCertificateAcceptanceTest extends SourceAcceptanceTest {
     return db.execInContainer("su", "-", "db2inst1", "-c", "cat server.arm").getStdout();
   }
 
-  private static void convertAndImportCertificate(String certificate) throws IOException, InterruptedException {
-    Runtime run = Runtime.getRuntime();
-    try (PrintWriter out = new PrintWriter("certificate.pem")) {
+  private static void convertAndImportCertificate(final String certificate) throws IOException, InterruptedException {
+    final Runtime run = Runtime.getRuntime();
+    try (final PrintWriter out = new PrintWriter("certificate.pem")) {
       out.print(certificate);
     }
     runProcess("openssl x509 -outform der -in certificate.pem -out certificate.der", run);
@@ -192,8 +187,8 @@ public class Db2SourceCertificateAcceptanceTest extends SourceAcceptanceTest {
         run);
   }
 
-  private static void runProcess(String cmd, Runtime run) throws IOException, InterruptedException {
-    Process pr = run.exec(cmd);
+  private static void runProcess(final String cmd, final Runtime run) throws IOException, InterruptedException {
+    final Process pr = run.exec(cmd);
     if (!pr.waitFor(30, TimeUnit.SECONDS)) {
       pr.destroy();
       throw new RuntimeException("Timeout while executing: " + cmd);

--- a/airbyte-integrations/connectors/source-e2e-test-cloud/src/test-integration/java/io/airbyte/integrations/source/e2e_test/CloudTestingSourcesAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-e2e-test-cloud/src/test-integration/java/io/airbyte/integrations/source/e2e_test/CloudTestingSourcesAcceptanceTest.java
@@ -15,6 +15,7 @@ import io.airbyte.integrations.source.e2e_test.ContinuousFeedConfig.MockCatalogT
 import io.airbyte.integrations.source.e2e_test.TestingSources.TestingSourceType;
 import io.airbyte.integrations.standardtest.source.SourceAcceptanceTest;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
@@ -22,7 +23,6 @@ import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -115,12 +115,9 @@ public class CloudTestingSourcesAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
+  protected void assertFullRefreshMessages(final List<AirbyteMessage> allMessages) {
+    final List<AirbyteRecordMessage> recordMessages = filterRecords(allMessages);
 
-  @Override
-  protected void assertFullRefreshRecordMessages(final List<AirbyteRecordMessage> recordMessages) {
     int index = 0;
     // the first N messages are from stream 1
     while (index < MAX_MESSAGES) {

--- a/airbyte-integrations/connectors/source-e2e-test/src/test-integration/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/test-integration/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedSourceAcceptanceTest.java
@@ -15,6 +15,7 @@ import io.airbyte.integrations.source.e2e_test.ContinuousFeedConfig.MockCatalogT
 import io.airbyte.integrations.source.e2e_test.TestingSources.TestingSourceType;
 import io.airbyte.integrations.standardtest.source.SourceAcceptanceTest;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
@@ -22,7 +23,6 @@ import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -111,12 +111,9 @@ public class ContinuousFeedSourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
+  protected void assertFullRefreshMessages(final List<AirbyteMessage> allMessages) {
+    final List<AirbyteRecordMessage> recordMessages = filterRecords(allMessages);
 
-  @Override
-  protected void assertFullRefreshRecordMessages(final List<AirbyteRecordMessage> recordMessages) {
     int index = 0;
     // the first N messages are from stream 1
     while (index < MAX_MESSAGES) {

--- a/airbyte-integrations/connectors/source-e2e-test/src/test-integration/java/io/airbyte/integrations/source/e2e_test/LegacyInfiniteFeedSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/test-integration/java/io/airbyte/integrations/source/e2e_test/LegacyInfiniteFeedSourceAcceptanceTest.java
@@ -60,9 +60,4 @@ public class LegacyInfiniteFeedSourceAcceptanceTest extends SourceAcceptanceTest
     return Jsons.jsonNode(new HashMap<>());
   }
 
-  @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
 }

--- a/airbyte-integrations/connectors/source-jdbc/src/test-integration/java/io/airbyte/integrations/source/jdbc/JdbcSourceSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test-integration/java/io/airbyte/integrations/source/jdbc/JdbcSourceSourceAcceptanceTest.java
@@ -97,9 +97,4 @@ public class JdbcSourceSourceAcceptanceTest extends SourceAcceptanceTest {
     return Jsons.jsonNode(new HashMap<>());
   }
 
-  @Override
-  protected List<String> getRegexTests() throws Exception {
-    return new ArrayList<>();
-  }
-
 }

--- a/airbyte-integrations/connectors/source-kafka/src/test-integration/java/io/airbyte/integrations/source/kafka/KafkaSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-kafka/src/test-integration/java/io/airbyte/integrations/source/kafka/KafkaSourceAcceptanceTest.java
@@ -125,9 +125,4 @@ public class KafkaSourceAcceptanceTest extends SourceAcceptanceTest {
     return Jsons.jsonNode(new HashMap<>());
   }
 
-  @Override
-  protected List<String> getRegexTests() throws Exception {
-    return Collections.emptyList();
-  }
-
 }

--- a/airbyte-integrations/connectors/source-mongodb-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/mongodb/MongodbSourceStrictEncryptAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/mongodb/MongodbSourceStrictEncryptAcceptanceTest.java
@@ -137,11 +137,6 @@ public class MongodbSourceStrictEncryptAcceptanceTest extends SourceAcceptanceTe
     return Jsons.jsonNode(new HashMap<>());
   }
 
-  @Override
-  protected List<String> getRegexTests() throws Exception {
-    return Collections.emptyList();
-  }
-
   @Test
   void testSpec() throws Exception {
     final ConnectorSpecification actual = new MongodbSourceStrictEncrypt().spec();

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/MongoDbSourceAbstractAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/MongoDbSourceAbstractAcceptanceTest.java
@@ -72,9 +72,4 @@ public abstract class MongoDbSourceAbstractAcceptanceTest extends SourceAcceptan
     return Jsons.jsonNode(new HashMap<>());
   }
 
-  @Override
-  protected List<String> getRegexTests() throws Exception {
-    return Collections.emptyList();
-  }
-
 }

--- a/airbyte-integrations/connectors/source-mssql-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/mssql/MssqlStrictEncryptSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mssql-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/mssql/MssqlStrictEncryptSourceAcceptanceTest.java
@@ -114,9 +114,4 @@ public class MssqlStrictEncryptSourceAcceptanceTest extends SourceAcceptanceTest
     return Jsons.jsonNode(new HashMap<>());
   }
 
-  @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
 }

--- a/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/AbstractSshMssqlSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/AbstractSshMssqlSourceAcceptanceTest.java
@@ -150,11 +150,6 @@ public abstract class AbstractSshMssqlSourceAcceptanceTest extends SourceAccepta
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/CdcMssqlSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/CdcMssqlSourceAcceptanceTest.java
@@ -88,11 +88,6 @@ public class CdcMssqlSourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected void setupEnvironment(final TestDestinationEnv environment) throws InterruptedException {
     container = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-latest").acceptLicense();
     container.addEnv("MSSQL_AGENT_ENABLED", "True"); // need this running for cdc to work

--- a/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/MssqlSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test-integration/java/io/airbyte/integrations/source/mssql/MssqlSourceAcceptanceTest.java
@@ -97,11 +97,6 @@ public class MssqlSourceAcceptanceTest extends SourceAcceptanceTest {
     return Jsons.jsonNode(new HashMap<>());
   }
 
-  @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
   private static Database getDatabase(final JsonNode config) {
     return Databases.createDatabase(
         config.get("username").asText(),

--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/mysql_strict_encrypt/MySqlStrictEncryptSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/mysql_strict_encrypt/MySqlStrictEncryptSourceAcceptanceTest.java
@@ -119,11 +119,6 @@ public class MySqlStrictEncryptSourceAcceptanceTest extends SourceAcceptanceTest
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/source/mysql/AbstractSshMySqlSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/source/mysql/AbstractSshMySqlSourceAcceptanceTest.java
@@ -82,11 +82,6 @@ public abstract class AbstractSshMySqlSourceAcceptanceTest extends SourceAccepta
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/source/mysql/CdcMySqlSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/source/mysql/CdcMySqlSourceAcceptanceTest.java
@@ -84,11 +84,6 @@ public class CdcMySqlSourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected void setupEnvironment(final TestDestinationEnv environment) {
     container = new MySQLContainer<>("mysql:8.0");
     container.start();

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/source/mysql/MySqlSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/java/io/airbyte/integrations/source/mysql/MySqlSourceAcceptanceTest.java
@@ -115,11 +115,6 @@ public class MySqlSourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-oracle-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/oracle_strict_encrypt/OracleStrictEncryptSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-oracle-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/oracle_strict_encrypt/OracleStrictEncryptSourceAcceptanceTest.java
@@ -122,11 +122,6 @@ public class OracleStrictEncryptSourceAcceptanceTest extends SourceAcceptanceTes
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/AbstractSshOracleSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/AbstractSshOracleSourceAcceptanceTest.java
@@ -139,11 +139,6 @@ public abstract class AbstractSshOracleSourceAcceptanceTest extends SourceAccept
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/OracleSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/OracleSourceAcceptanceTest.java
@@ -118,11 +118,6 @@ public class OracleSourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-postgres-strict-encrypt/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceStrictEncryptAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres-strict-encrypt/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceStrictEncryptAcceptanceTest.java
@@ -119,11 +119,6 @@ public class PostgresSourceStrictEncryptAcceptanceTest extends SourceAcceptanceT
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractSshPostgresSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractSshPostgresSourceAcceptanceTest.java
@@ -124,11 +124,6 @@ public abstract class AbstractSshPostgresSourceAcceptanceTest extends SourceAcce
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcPostgresSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/CdcPostgresSourceAcceptanceTest.java
@@ -154,11 +154,6 @@ public class CdcPostgresSourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceAcceptanceTest.java
@@ -129,11 +129,6 @@ public class PostgresSourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-redshift/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/RedshiftSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-redshift/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/RedshiftSourceAcceptanceTest.java
@@ -120,11 +120,6 @@ public class RedshiftSourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-scaffold-java-jdbc/src/test-integration/java/io/airbyte/integrations/source/scaffold_java_jdbc/ScaffoldJavaJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-scaffold-java-jdbc/src/test-integration/java/io/airbyte/integrations/source/scaffold_java_jdbc/ScaffoldJavaJdbcSourceAcceptanceTest.java
@@ -56,11 +56,6 @@ public class ScaffoldJavaJdbcSourceAcceptanceTest extends SourceAcceptanceTest {
   }
 
   @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
-  @Override
   protected JsonNode getState() {
     return Jsons.jsonNode(new HashMap<>());
   }

--- a/airbyte-integrations/connectors/source-snowflake/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SnowflakeSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-snowflake/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SnowflakeSourceAcceptanceTest.java
@@ -86,11 +86,6 @@ public class SnowflakeSourceAcceptanceTest extends SourceAcceptanceTest {
     return Jsons.jsonNode(new HashMap<>());
   }
 
-  @Override
-  protected List<String> getRegexTests() {
-    return Collections.emptyList();
-  }
-
   // for each test we create a new schema in the database. run the test in there and then remove it.
   @Override
   protected void setupEnvironment(final TestDestinationEnv environment) throws Exception {


### PR DESCRIPTION
## What
- In the source acceptance test, we check all messages by converting them to string, and match them with regex.
- However, the regex check is only used in the python source acceptance test. All the other tests extending from the source acceptance test simply return an empty list of regex to check.

## How
- This PR move the regex check to the python source acceptance test.
  - It replaces the `getRegexTests` method with the `assertFullRefreshMessages` method.
- The `getRegexTests` method is not useful for Java tests, because we can verify the `AirbyteMessage` objects directly, and do not need to convert Java POJOs to strings for verification.
  - There is a newly introduced `assertFullRefreshMessages` that can perform this assertion.
