### PR TITLE
configure temporal workflow execution ttl

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -323,6 +323,8 @@ public class WorkerApp {
 
     final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService(temporalHost);
 
+    TemporalUtils.configureTemporalNamespace(temporalService);
+
     final Database configDatabase = new ConfigsDatabaseInstance(
         configs.getConfigDatabaseUser(),
         configs.getConfigDatabasePassword(),

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
@@ -9,9 +9,12 @@ import static java.util.stream.Collectors.toSet;
 import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.namespace.v1.NamespaceConfig;
 import io.temporal.api.namespace.v1.NamespaceInfo;
+import io.temporal.api.workflowservice.v1.DescribeNamespaceRequest;
 import io.temporal.api.workflowservice.v1.DescribeNamespaceResponse;
 import io.temporal.api.workflowservice.v1.ListNamespacesRequest;
+import io.temporal.api.workflowservice.v1.UpdateNamespaceRequest;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
@@ -20,9 +23,11 @@ import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.workflow.Functions;
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +50,30 @@ public class TemporalUtils {
   public static final RetryOptions NO_RETRY = RetryOptions.newBuilder().setMaximumAttempts(1).build();
 
   public static final String DEFAULT_NAMESPACE = "default";
+
+  private static final Duration WORKFLOW_EXECUTION_TTL = Duration.ofDays(7);
+  private static final String HUMAN_READABLE_WORKFLOW_EXECUTION_TTL =
+      DurationFormatUtils.formatDurationWords(WORKFLOW_EXECUTION_TTL.toMillis(), true, true);
+
+  public static void configureTemporalNamespace(WorkflowServiceStubs temporalService) {
+    final var client = temporalService.blockingStub();
+    final var describeNamespaceRequest = DescribeNamespaceRequest.newBuilder().setNamespace(DEFAULT_NAMESPACE).build();
+    final var currentRetentionGrpcDuration = client.describeNamespace(describeNamespaceRequest).getConfig().getWorkflowExecutionRetentionTtl();
+    final var currentRetention = Duration.ofSeconds(currentRetentionGrpcDuration.getSeconds());
+
+    if (currentRetention.equals(WORKFLOW_EXECUTION_TTL)) {
+      LOGGER.info("Workflow execution TTL already set for namespace " + DEFAULT_NAMESPACE + ". Remains unchanged as: "
+          + HUMAN_READABLE_WORKFLOW_EXECUTION_TTL);
+    } else {
+      final var newGrpcDuration = com.google.protobuf.Duration.newBuilder().setSeconds(WORKFLOW_EXECUTION_TTL.getSeconds()).build();
+      final var humanReadableCurrentRetention = DurationFormatUtils.formatDurationWords(currentRetention.toMillis(), true, true);
+      final var namespaceConfig = NamespaceConfig.newBuilder().setWorkflowExecutionRetentionTtl(newGrpcDuration).build();
+      final var updateNamespaceRequest = UpdateNamespaceRequest.newBuilder().setNamespace(DEFAULT_NAMESPACE).setConfig(namespaceConfig).build();
+      LOGGER.info("Workflow execution TTL differs for namespace " + DEFAULT_NAMESPACE + ". Changing from (" + humanReadableCurrentRetention + ") to ("
+          + HUMAN_READABLE_WORKFLOW_EXECUTION_TTL + "). ");
+      client.updateNamespace(updateNamespaceRequest);
+    }
+  }
 
   @FunctionalInterface
   public interface TemporalJobCreator<T extends Serializable> {


### PR DESCRIPTION
It's hard to debug Temporal history without retaining it for a longer amount of time. This has `airbyte-worker` set the TTL every start.