### PR TITLE
Tweak dbt configuration parameters to reasonable values 

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -28,5 +28,5 @@ WORKDIR /airbyte
 ENV AIRBYTE_ENTRYPOINT "/airbyte/entrypoint.sh"
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.64
+LABEL io.airbyte.version=0.1.65
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_config/transform.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_config/transform.py
@@ -133,8 +133,8 @@ class TransformConfig:
             "project": config["project_id"],
             "dataset": config["dataset_id"],
             "priority": config.get("transformation_priority", "interactive"),
-            "threads": 32,
-            "retries": 1,
+            "threads": 8,
+            "retries": 3,
         }
         if "credentials_json" in config:
             dbt_config["method"] = "service-account-json"
@@ -161,7 +161,7 @@ class TransformConfig:
             "port": config["port"],
             "dbname": config["database"],
             "schema": config["schema"],
-            "threads": 32,
+            "threads": 8,
         }
 
         # if unset, we assume true.
@@ -182,7 +182,7 @@ class TransformConfig:
             "port": config["port"],
             "dbname": config["database"],
             "schema": config["schema"],
-            "threads": 32,
+            "threads": 4,
         }
         return dbt_config
 
@@ -202,9 +202,13 @@ class TransformConfig:
             "database": config["database"].upper(),
             "warehouse": config["warehouse"].upper(),
             "schema": config["schema"].upper(),
-            "threads": 32,
+            "threads": 5,
             "client_session_keep_alive": False,
             "query_tag": "normalization",
+            "retry_all": True,
+            "retry_on_database_errors": True,
+            "connect_retries": 3,
+            "connect_timeout": 15,
         }
         return dbt_config
 
@@ -259,7 +263,7 @@ class TransformConfig:
             "database": config["database"],
             "user": config["username"],
             "password": config["password"],
-            "threads": 32,
+            "threads": 8,
             # "authentication": "sql",
             # "trusted_connection": True,
         }

--- a/airbyte-integrations/bases/base-normalization/unit_tests/test_transform_config.py
+++ b/airbyte-integrations/bases/base-normalization/unit_tests/test_transform_config.py
@@ -147,8 +147,8 @@ class TestTransformConfig:
             "priority": "interactive",
             "keyfile_json": {"type": "service_account-json"},
             "location": "EU",
-            "retries": 1,
-            "threads": 32,
+            "retries": 3,
+            "threads": 8,
         }
 
         actual_keyfile = actual_output["keyfile_json"]
@@ -167,8 +167,8 @@ class TestTransformConfig:
             "project": "my_project_id",
             "dataset": "my_dataset_id",
             "priority": "interactive",
-            "retries": 1,
-            "threads": 32,
+            "retries": 3,
+            "threads": 8,
         }
 
         assert expected_output == actual_output
@@ -192,7 +192,7 @@ class TestTransformConfig:
             "pass": "password123",
             "port": 5432,
             "schema": "public",
-            "threads": 32,
+            "threads": 8,
             "user": "a user",
         }
 
@@ -225,7 +225,7 @@ class TestTransformConfig:
             "pass": "password123",
             "port": port,
             "schema": "public",
-            "threads": 32,
+            "threads": 8,
             "user": "a user",
         }
 
@@ -252,7 +252,11 @@ class TestTransformConfig:
             "query_tag": "normalization",
             "role": "AIRBYTE_ROLE",
             "schema": "AIRBYTE_SCHEMA",
-            "threads": 32,
+            "threads": 5,
+            "retry_all": True,
+            "retry_on_database_errors": True,
+            "connect_retries": 3,
+            "connect_timeout": 15,
             "type": "snowflake",
             "user": "AIRBYTE_USER",
             "warehouse": "AIRBYTE_WAREHOUSE",
@@ -332,7 +336,7 @@ class TestTransformConfig:
             "pass": "password123",
             "port": 5432,
             "schema": "public",
-            "threads": 32,
+            "threads": 8,
             "user": "a user",
         }
         actual = TransformConfig().transform(DestinationType.postgres, input)

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 public class NormalizationRunnerFactory {
 
   public static final String BASE_NORMALIZATION_IMAGE_NAME = "airbyte/normalization";
-  public static final String NORMALIZATION_VERSION = "0.1.64";
+  public static final String NORMALIZATION_VERSION = "0.1.65";
 
   static final Map<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>> NORMALIZATION_MAPPING =
       ImmutableMap.<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>>builder()

--- a/docs/understanding-airbyte/basic-normalization.md
+++ b/docs/understanding-airbyte/basic-normalization.md
@@ -350,6 +350,8 @@ Therefore, in order to "upgrade" to the desired normalization version, you need 
 
 | Airbyte Version | Normalization Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- | :--- |
+| 0.35.13-alpha | 0.1.65 | 2021-01-28 | [\#9846](https://github.com/airbytehq/airbyte/pull/9846) | Tweak dbt multi-thread parameter down |
+| 0.35.12-alpha | 0.1.64 | 2021-01-28 | [\#9793](https://github.com/airbytehq/airbyte/pull/9793) | Support PEM format for ssh-tunnel keys |
 | 0.35.4-alpha | 0.1.63 | 2021-01-07 | [\#9301](https://github.com/airbytehq/airbyte/pull/9301) | Fix Snowflake prefix tables starting with numbers |
 |  | 0.1.62 | 2021-01-07 | [\#9340](https://github.com/airbytehq/airbyte/pull/9340) | Use TCP-port support for clickhouse |
 |  | 0.1.62 | 2021-01-07 | [\#9063](https://github.com/airbytehq/airbyte/pull/9063) | Change Snowflake-specific materialization settings |


### PR DESCRIPTION
## What
Normalization parameters for multi-threading were set by default to 32

In the past (before implementing internal staging for snowflake, we've seen time-out errors from snowflake trying to shut us off from spamming their API (with insert writes).

So, following up on https://github.com/airbytehq/oncall/issues/120, I'm wondering if dbt is sometimes hitting some similar thresholds/limits randomly?

For instance, In the docs, I've seen recommendations or people mentioning using 5 to 10 threads:
 
From dbt docs:
> threads: [between 1 and 8]
https://docs.getdbt.com/reference/warehouse-profiles/snowflake-profile

From Snowflake docs:
> In Snowflake the parameter MAX_CONCURRENCY_LEVEL defines the maximum number of parallel or concurrent statements a warehouse can execute.
> By default the value is set to 8. This means at any given point of time the warehouse will allow a maximum of 8 queries to run concurrently if the resources on that warehouse can fit all of them simultaneously.
> In reality, we can have more than 8 concurrent queries as well. But it depends on the factors such as the complexity of the queries, their resource consumptions etc.
https://community.snowflake.com/s/article/Warehouse-Concurrency-and-Statement-Timeout-Parameters

## How
This PR is tuning the parameters down to match recommendations or default values in dbt docs for some destinations.

It also tunes dbt to take advantage of some retries mechanisms with backoff timeouts.

Hopefully, these small changes would improve overall performances and stability
(atm we don't have benchmarks to verify the impacts of these changes, right @tuliren?)

