### PR TITLE
:tada:  Source Shopify: Add  `BalanceTransactions` stream

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9da77001-af33-4bcd-be46-6252bf9342b9.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9da77001-af33-4bcd-be46-6252bf9342b9.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "9da77001-af33-4bcd-be46-6252bf9342b9",
   "name": "Shopify",
   "dockerRepository": "airbyte/source-shopify",
-  "dockerImageTag": "0.1.30",
+  "dockerImageTag": "0.1.31",
   "documentationUrl": "https://docs.airbyte.io/integrations/sources/shopify",
   "icon": "shopify.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -655,7 +655,7 @@
 - name: Shopify
   sourceDefinitionId: 9da77001-af33-4bcd-be46-6252bf9342b9
   dockerRepository: airbyte/source-shopify
-  dockerImageTag: 0.1.30
+  dockerImageTag: 0.1.31
   documentationUrl: https://docs.airbyte.io/integrations/sources/shopify
   icon: shopify.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -6994,7 +6994,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-shopify:0.1.30"
+- dockerImage: "airbyte/source-shopify:0.1.31"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/shopify"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-shopify/Dockerfile
+++ b/airbyte-integrations/connectors/source-shopify/Dockerfile
@@ -28,5 +28,5 @@ COPY source_shopify ./source_shopify
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.30
+LABEL io.airbyte.version=0.1.31
 LABEL io.airbyte.name=airbyte/source-shopify

--- a/airbyte-integrations/connectors/source-shopify/integration_tests/abnormal_state.json
+++ b/airbyte-integrations/connectors/source-shopify/integration_tests/abnormal_state.json
@@ -55,5 +55,8 @@
   },
   "fulfillments": {
     "updated_at": "2024-07-08T05:40:38-07:00"
+  },
+  "balance_transactions": {
+    "id": 9999999999999
   }
 }

--- a/airbyte-integrations/connectors/source-shopify/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-shopify/integration_tests/configured_catalog.json
@@ -237,6 +237,18 @@
       "sync_mode": "incremental",
       "cursor_field": ["updated_at"],
       "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "balance_transactions",
+        "json_schema": {},
+        "supported_sync_modes": ["incremental", "full_refresh"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["id"]
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["id"],
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-shopify/integration_tests/state.json
+++ b/airbyte-integrations/connectors/source-shopify/integration_tests/state.json
@@ -55,5 +55,8 @@
   },
   "fulfillments": {
     "updated_at": "2021-09-10T06:48:10-07:00"
+  },
+  "balance_transactions": {
+    "id": 29427031703741
   }
 }

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/schemas/balance_transactions.json
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/schemas/balance_transactions.json
@@ -1,0 +1,52 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "type": {
+      "type": ["null", "string"]
+    },
+    "test": {
+      "type": ["null", "boolean"]
+    },
+    "payout_id": {
+      "type": ["null", "integer"]
+    },
+    "payout_status": {
+      "type": ["null", "string"]
+    },
+    "payoucurrencyt_status": {
+      "type": ["null", "string"]
+    },
+    "amount": {
+      "type": ["null", "number"]
+    },
+    "fee": {
+      "type": ["null", "number"]
+    },
+    "net": {
+      "type": ["null", "number"]
+    },
+    "source_id": {
+      "type": ["null", "integer"]
+    },
+    "source_type": {
+      "type": ["null", "string"]
+    },
+    "source_order_transaction_id": {
+      "type": ["null", "integer"]
+    },
+    "source_order_id": {
+      "type": ["null", "integer"]
+    },
+    "processed_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "shop_url": {
+      "type": ["null", "string"]
+    }
+  }
+  
+}

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/utils.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/utils.py
@@ -20,6 +20,7 @@ SCOPES_MAPPING = {
     "read_locations": ["Locations"],
     "read_inventory": ["InventoryItems", "InventoryLevels"],
     "read_merchant_managed_fulfillment_orders": ["FulfillmentOrders"],
+    "read_shopify_payments_payouts": ["BalanceTransactions"],
 }
 
 

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -102,7 +102,7 @@ This connector support both: `OAuth 2.0` and `API PASSWORD` (for private applica
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| 0.1.31 | 2021-01-26 | [XXXX](https://github.com/airbytehq/airbyte/pull/XXXX) | Added `BalanceTransactions` |
+| 0.1.31 | 2021-01-26 | [9850](https://github.com/airbytehq/airbyte/pull/9850) | Added `BalanceTransactions` |
 | 0.1.30 | 2021-01-24 | [9648](https://github.com/airbytehq/airbyte/pull/9648) | Added permission validation before sync |
 | 0.1.29 | 2022-01-20 | [9049](https://github.com/airbytehq/airbyte/pull/9248) | Added `shop_url` to the record for all streams |
 | 0.1.28 | 2022-01-19 | [9591](https://github.com/airbytehq/airbyte/pull/9591) | Implemented `OAuth2.0` authentication method for Airbyte Cloud |

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -33,6 +33,7 @@ This Source is capable of syncing the following core Streams:
 * [Orders Risks](https://shopify.dev/api/admin/rest/reference/orders/order-risk)
 * [Products](https://help.shopify.com/en/api/reference/products)
 * [Transactions](https://help.shopify.com/en/api/reference/orders/transaction)
+* [Balance Transactions](https://shopify.dev/api/admin-rest/2021-07/resources/transactions)
 * [Pages](https://help.shopify.com/en/api/reference/online-store/page)
 * [Price Rules](https://help.shopify.com/en/api/reference/discounts/pricerule)
 * [Locations](https://shopify.dev/api/admin-rest/2021-10/resources/location)
@@ -101,6 +102,7 @@ This connector support both: `OAuth 2.0` and `API PASSWORD` (for private applica
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.31 | 2021-01-26 | [XXXX](https://github.com/airbytehq/airbyte/pull/XXXX) | Added `BalanceTransactions` |
 | 0.1.30 | 2021-01-24 | [9648](https://github.com/airbytehq/airbyte/pull/9648) | Added permission validation before sync |
 | 0.1.29 | 2022-01-20 | [9049](https://github.com/airbytehq/airbyte/pull/9248) | Added `shop_url` to the record for all streams |
 | 0.1.28 | 2022-01-19 | [9591](https://github.com/airbytehq/airbyte/pull/9591) | Implemented `OAuth2.0` authentication method for Airbyte Cloud |


### PR DESCRIPTION
## What
Adds `BalanceTransactions` stream to Shopify source connector.

## How
1. Refactor incremental by `id` logic in a new class `IncrementalByIDShopifyStream` that inherits from `IncrementalShopifyStream`
2. Make existing stream `Collects` to inherit from `IncrementalByIDShopifyStream`
3. Add new stream `BalanceTransactions`

## Recommended reading order
1. `source_shopify/source.py`


## 🚨 User Impact 🚨
None.

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> New Connector </strong></summary>
<p>

#### Community member or Airbyter
   
- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
   
</p>
</details>


<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>
</details>

<details><summary> <strong> Connector Generator </strong> </summary>
<p>
   
- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed.
</p>
</details>



## Tests

<details><summary> <strong> Unit </strong> </summary>
<p>

```bash
❯ python -m pytest unit_tests
Test session starts (platform: linux, Python 3.7.9, pytest 6.2.5, pytest-sugar 0.9.4)
cachedir: .pytest_cache
rootdir: /home/da/f14/git/airbyte, configfile: pytest.ini
plugins: sugar-0.9.4, requests-mock-1.9.3, timeout-1.4.2
collecting ... 
 airbyte-integrations/connectors/source-shopify/unit_tests/test_cached_stream_state.py::test_full_refresh[Sync Started] ✓                                                                                                        5% ▌         
 airbyte-integrations/connectors/source-shopify/unit_tests/test_cached_stream_state.py::test_incremental_sync[Sync Started] ✓                                                                                                   11% █▏        
 airbyte-integrations/connectors/source-shopify/unit_tests/test_cached_stream_state.py::test_incremental_sync[Sync in progress] ✓                                                                                               16% █▋        
 airbyte-integrations/connectors/source-shopify/unit_tests/test_control_rate_limit.py::test_with_unknown_load ✓                                                                                                                 21% ██▏       
 airbyte-integrations/connectors/source-shopify/unit_tests/test_control_rate_limit.py::test_with_low_load ✓                                                                                                                     26% ██▋       
 airbyte-integrations/connectors/source-shopify/unit_tests/test_control_rate_limit.py::test_with_mid_load ✓                                                                                                                     32% ███▎      
 airbyte-integrations/connectors/source-shopify/unit_tests/test_control_rate_limit.py::test_with_high_load ✓                                                                                                                    37% ███▊      
 airbyte-integrations/connectors/source-shopify/unit_tests/test_transform.py::test_enforcer_correct_type[transform_object0-schema0-checks0] ✓                                                                                   42% ████▎     
 airbyte-integrations/connectors/source-shopify/unit_tests/test_transform.py::test_enforcer_correct_type[transform_object1-schema1-checks1] ✓                                                                                   47% ████▊     
 airbyte-integrations/connectors/source-shopify/unit_tests/test_transform.py::test_enforcer_correct_type[transform_object2-schema2-checks2] ✓                                                                                   53% █████▍    
 airbyte-integrations/connectors/source-shopify/unit_tests/test_transform.py::test_enforcer_correct_type[transform_object3-schema3-checks3] ✓                                                                                   58% █████▊    
 airbyte-integrations/connectors/source-shopify/unit_tests/test_transform.py::test_enforcer_string_to_number[transform_object0-schema0-checks0] ✓                                                                               63% ██████▍   
 airbyte-integrations/connectors/source-shopify/unit_tests/test_transform.py::test_enforcer_string_to_number[transform_object1-schema1-checks1] ✓                                                                               68% ██████▉   
 airbyte-integrations/connectors/source-shopify/unit_tests/test_transform.py::test_enforcer_nested_object[transform_object0-schema0-checks0] ✓                                                                                  74% ███████▍  
 airbyte-integrations/connectors/source-shopify/unit_tests/test_transform.py::test_enforcer_nested_array[transform_object0-schema0-checks0] ✓                                                                                   79% ███████▉  
 airbyte-integrations/connectors/source-shopify/unit_tests/test_transform.py::test_enforcer_nested_array[transform_object1-schema1-checks1] ✓                                                                                   84% ████████▌ 
 airbyte-integrations/connectors/source-shopify/unit_tests/test_transform.py::test_enforcer_string_to_number_in_array[transform_object0-schema0-checks0] ✓                                                                      89% ████████▉ 
 airbyte-integrations/connectors/source-shopify/unit_tests/unit_test.py::test_get_next_page_token ✓                                                                                                                             95% █████████▌
 airbyte-integrations/connectors/source-shopify/unit_tests/unit_test.py::test_privileges_validation ✓                                                                                                                          100% ██████████
============================================================================================================== warnings summary ==============================================================================================================
.venv/lib/python3.7/site-packages/airbyte_cdk/sources/streams/http/http.py:42: 1 warning
airbyte-integrations/connectors/source-shopify/unit_tests/unit_test.py: 21 warnings
  /home/da/f14/git/airbyte/airbyte-integrations/connectors/source-shopify/.venv/lib/python3.7/site-packages/airbyte_cdk/sources/streams/http/http.py:42: DeprecationWarning: Call to deprecated class NoAuth. (Set `authenticator=None` instead) -- Deprecated since version 0.1.20.
    self._authenticator: HttpAuthenticator = NoAuth()

.venv/lib/python3.7/site-packages/deprecated/classic.py:173: 1 warning
airbyte-integrations/connectors/source-shopify/unit_tests/unit_test.py: 21 warnings
  /home/da/f14/git/airbyte/airbyte-integrations/connectors/source-shopify/.venv/lib/python3.7/site-packages/deprecated/classic.py:173: DeprecationWarning: Call to deprecated class HttpAuthenticator. (Use requests.auth.AuthBase instead) -- Deprecated since version 0.1.20.
    return old_new1(cls, *args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/warnings.html

Results (0.20s):
      19 passed
```
</p>
</details>

<details><summary> <strong> Integration </strong> </summary>
<p>

```bash
❯ python -m pytest integration_tests
Test session starts (platform: linux, Python 3.7.9, pytest 6.2.5, pytest-sugar 0.9.4)
cachedir: .pytest_cache
rootdir: /home/da/f14/git/airbyte, configfile: pytest.ini
plugins: sugar-0.9.4, requests-mock-1.9.3, timeout-1.4.2
collecting ... 
 airbyte-integrations/connectors/source-shopify/integration_tests/integration_test.py::test_dummy_test ✓                                                                                                                       100% ██████████

Results (0.02s):
       1 passed
```
</p>
</details>

<details><summary> <strong> Acceptance </strong> </summary>
<p>

Acceptance tests for `secrets/config_oauth.json` were disabled because we only have API Password.  
There is 1 test failing because the account used for them doesn't have data for many streams. We've other shops that have a lot of data, but the tests take too much time to fetch all the data.

```bash
❯ python -m pytest integration_tests -p integration_tests.acceptance
Test session starts (platform: linux, Python 3.7.9, pytest 6.2.5, pytest-sugar 0.9.4)
cachedir: .pytest_cache
rootdir: /home/da/f14/git/airbyte, configfile: pytest.ini
plugins: sugar-0.9.4, requests-mock-1.9.3, timeout-1.4.2
collecting ... 
 airbyte-integrations/connectors/source-shopify/integration_tests/integration_test.py::test_dummy_test ✓                                                                                                                         6% ▋         
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_match_expected[inputs0] ✓                                                                                           11% █▎        
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_required[inputs0] ✓                                                                                                 17% █▋        
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_optional[inputs0] ✓                                                                                                 22% ██▎       
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_has_secret[inputs0] ✓                                                                                               28% ██▊       
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_secret_never_in_the_output[inputs0] ✓                                                                               33% ███▍      
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_defined_refs_exist_in_json_spec_file[inputs0] ✓                                                                     39% ███▉      
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_oauth_flow_parameters[inputs0] ✓                                                                                    44% ████▌     
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestConnection.test_check[inputs0] ✓                                                                                              50% █████     
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestConnection.test_check[inputs1] ✓                                                                                              56% █████▋    
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestConnection.test_check[inputs2] ✓                                                                                              61% ██████▎   
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_discover[inputs0] ✓                                                                                            67% ██████▋   
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_defined_cursors_exist_in_schema[inputs0] ✓                                                                     72% ███████▎  
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_defined_refs_exist_in_schema[inputs0] ✓                                                                        78% ███████▊  

―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― TestBasicRead.test_read[inputs0] ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

self = <source_acceptance_test.tests.test_core.TestBasicRead object at 0x7ff703922cd0>, connector_config = SecretDict(******)
configured_catalog = ConfiguredAirbyteCatalog(streams=[ConfiguredAirbyteStream(stream=AirbyteStream(name='customers', json_schema={'type': ... 'incremental'>, cursor_field=['id'], destination_sync_mode=<DestinationSyncMode.append: 'append'>, primary_key=None)])
inputs = BasicReadTestConfig(config_path='secrets/config.json', configured_catalog_path='integration_tests/configured_catalog.j...', 'abandoned_checkouts'}, expect_records=None, validate_schema=True, validate_data_points=False, timeout_seconds=3600)
expected_records = [], docker_runner = <source_acceptance_test.utils.connector_runner.ConnectorRunner object at 0x7ff703955690>
detailed_logger = <Logger detailed_logger acceptance_tests_logs/test_core.py__TestBasicRead__test_read[inputs0].txt (DEBUG)>

    def test_read(
        self,
        connector_config,
        configured_catalog,
        inputs: BasicReadTestConfig,
        expected_records: List[AirbyteMessage],
        docker_runner: ConnectorRunner,
        detailed_logger,
    ):
        output = docker_runner.call_read(connector_config, configured_catalog)
        records = [message.record for message in filter_output(output, Type.RECORD)]
    
        assert records, "At least one record should be read using provided catalog"
    
        if inputs.validate_schema:
            self._validate_schema(records=records, configured_catalog=configured_catalog)
    
>       self._validate_empty_streams(records=records, configured_catalog=configured_catalog, allowed_empty_streams=inputs.empty_streams)

../../bases/source-acceptance-test/source_acceptance_test/tests/test_core.py:327: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <source_acceptance_test.tests.test_core.TestBasicRead object at 0x7ff703922cd0>
records = [AirbyteRecordMessage(stream='collects', data={'id': 19149737197733, 'collection_id': 218563281061, 'product_id': 5630...', 'shop_url': '****', 'id': '54676127909|38210170323109'}, emitted_at=1643303891629, namespace=None), ...]
configured_catalog = ConfiguredAirbyteCatalog(streams=[ConfiguredAirbyteStream(stream=AirbyteStream(name='customers', json_schema={'type': ... 'incremental'>, cursor_field=['id'], destination_sync_mode=<DestinationSyncMode.append: 'append'>, primary_key=None)])
allowed_empty_streams = {'abandoned_checkouts', 'balance_transactions'}

    def _validate_empty_streams(self, records, configured_catalog, allowed_empty_streams):
        """
        Only certain streams allowed to be empty
        """
        counter = Counter(record.stream for record in records)
    
        all_streams = set(stream.stream.name for stream in configured_catalog.streams)
        streams_with_records = set(counter.keys())
        streams_without_records = all_streams - streams_with_records
    
        streams_without_records = streams_without_records - allowed_empty_streams
>       assert not streams_without_records, f"All streams should return some records, streams without records: {streams_without_records}"
E       AssertionError: All streams should return some records, streams without records: {'customers', 'discount_codes', 'inventory_items', 'draft_orders', 'fulfillments', 'pages', 'price_rules', 'custom_collections', 'products', 'fulfillment_orders', 'order_risks', 'order_refunds', 'metafields', 'transactions', 'orders'}
E       assert not {'custom_collections', 'customers', 'discount_codes', 'draft_orders', 'fulfillment_orders', 'fulfillments', ...}

../../bases/source-acceptance-test/source_acceptance_test/tests/test_core.py:244: AssertionError

 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestBasicRead.test_read[inputs0] ⨯                                                                                                83% ████████▍ 
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_full_refresh.py::TestFullRefresh.test_sequential_reads[inputs0] ✓                                                                          89% ████████▉ 
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py::TestIncremental.test_two_sequential_reads[inputs0] ✓                                                                       94% █████████▌
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py::TestIncremental.test_state_with_abnormally_large_values[inputs0] ✓                                                        100% ██████████
========================================================================================================== short test summary info ===========================================================================================================
FAILED ../../bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestBasicRead::test_read[inputs0] - AssertionError: All streams should return some records, streams without records: {'customers', 'discount_codes', '...

Results (119.85s):
      17 passed
       1 failed
```
</p>
</details>
