### PR TITLE
add heartbeating when setting up the TemporalAttemptExecution

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CancellationHandler.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/CancellationHandler.java
@@ -38,16 +38,20 @@ public interface CancellationHandler {
     @Override
     public void checkAndHandleCancellation(final Runnable onCancellationCallback) {
       try {
-        /*
+        /**
          * Heartbeat is somewhat misleading here. What it does is check the current Temporal activity's
          * context and throw an exception if the sync has been cancelled or timed out. The input to this
          * heartbeat function is available as a field in thrown ActivityCompletionExceptions, which we
          * aren't using for now.
+         *
+         * We should use this only as a check for the ActivityCompletionException. See
+         * {@link TemporalUtils#withBackgroundHeartbeat} for where we actually send heartbeats to ensure
+         * that we don't time out the activity.
          */
         context.heartbeat(null);
       } catch (final ActivityCompletionException e) {
         onCancellationCallback.run();
-        LOGGER.warn("Job either timeout-ed or was cancelled.");
+        LOGGER.warn("Job either timed out or was cancelled.");
       }
     }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
@@ -19,7 +19,6 @@ import io.airbyte.workers.WorkerUtils;
 import io.temporal.activity.Activity;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -40,8 +39,6 @@ import org.slf4j.MDC;
 public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TemporalAttemptExecution.class);
-
-  private static final Duration HEARTBEAT_INTERVAL = Duration.ofSeconds(10);
 
   private final JobRunConfig jobRunConfig;
   private final WorkerEnvironment workerEnvironment;
@@ -135,7 +132,7 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
       cancellationChecker.run();
 
       workerThread.start();
-      scheduledExecutor.scheduleAtFixedRate(cancellationChecker, 0, HEARTBEAT_INTERVAL.toSeconds(), TimeUnit.SECONDS);
+      scheduledExecutor.scheduleAtFixedRate(cancellationChecker, 0, TemporalUtils.SEND_HEARTBEAT_INTERVAL.toSeconds(), TimeUnit.SECONDS);
 
       try {
         // block and wait for the output


### PR DESCRIPTION
After doing this I'm kind of convinced we should just provide a factory for `workerFactory` and `inputSupplier` when passing them into the `TemporalAttemptExecution` constructor so we don't have to wrap all of the different workers with the heartbeat logic and so we don't have dual heartbeating methods.