### PR TITLE
Wrap the `hook-weight` value between double quotes

### DIFF
--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -507,7 +507,7 @@ postgresql:
   existingSecret: ""
   commonAnnotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: -1
+    helm.sh/hook-weight: "-1"
 ## External PostgreSQL configuration
 ## All of these values are only used when postgresql.enabled is set to false
 ## @param externalDatabase.host Database host


### PR DESCRIPTION
## What
Fix the `hook-weight` value by wrapping between double quotes


