### PR TITLE
Fix datamodel_code_generator  exception in connector build

### DIFF
--- a/airbyte-integrations/connector-templates/source-java-jdbc/src/test-integration/java/io/airbyte/integrations/source/{{snakeCase name}}/{{pascalCase name}}SourceAcceptanceTest.java.hbs
+++ b/airbyte-integrations/connector-templates/source-java-jdbc/src/test-integration/java/io/airbyte/integrations/source/{{snakeCase name}}/{{pascalCase name}}SourceAcceptanceTest.java.hbs
@@ -11,9 +11,7 @@ import io.airbyte.integrations.standardtest.source.SourceAcceptanceTest;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConnectorSpecification;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 
 public class {{pascalCase name}}SourceAcceptanceTest extends SourceAcceptanceTest {
 

--- a/tools/code-generator/Dockerfile
+++ b/tools/code-generator/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.7-slim
-RUN pip install datamodel-code-generator==0.10.1
+FROM python:3.10-slim
+RUN pip install black==21.12b0 datamodel-code-generator==0.10.1
 ENTRYPOINT ["datamodel-codegen"]
 
 LABEL io.airbyte.version=dev

--- a/tools/code-generator/Dockerfile
+++ b/tools/code-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.7-slim
 RUN pip install datamodel-code-generator==0.10.1
 ENTRYPOINT ["datamodel-codegen"]
 

--- a/tools/code-generator/Dockerfile
+++ b/tools/code-generator/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-slim
 # pin black to version 21.12b0 because its latest version
-# seems incompatible with datamodel-code-generator
+# 22.1.0 seems incompatible with datamodel-code-generator
 RUN pip install black==21.12b0 datamodel-code-generator==0.10.1
 ENTRYPOINT ["datamodel-codegen"]
 

--- a/tools/code-generator/Dockerfile
+++ b/tools/code-generator/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.10-slim
+# pin black to version 21.12b0 because its latest version
+# seems incompatible with datamodel-code-generator
 RUN pip install black==21.12b0 datamodel-code-generator==0.10.1
 ENTRYPOINT ["datamodel-codegen"]
 


### PR DESCRIPTION
The connector build failed with the following exception:

```
> Task :airbyte-cdk:python:generateProtocolClassFiles FAILED
Traceback (most recent call last):
  File "/usr/local/bin/datamodel-codegen", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/site-packages/datamodel_code_generator/__main__.py", line 329, in main
    pyproject_toml_path = root / "pyproject.toml"
TypeError: unsupported operand type(s) for /: 'tuple' and 'str'
```

After inspecting the source code of `datamodel_code_generator`, it appeared that the `root` variable returned from the `black` library had a wrong type. Interestingly, `black` just had a new version, [`22.1.0`](https://github.com/psf/black/releases/tag/22.1.0), a few hours ago, which coincided with the time this build started to fail. I compared the version of `black` pulled by `pip` when the build was working, and it was `21.12b0`. So the new version was probably the root cause of the invalid type. This exception was gone after I pinned `black` to the old version. It could still fail because of a flaky test in `airbyte-worker`. But that's a different problem.
