### PR TITLE
Add detailed sentry tracing for JDBC destination stream consumer

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/AirbyteMessageConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/AirbyteMessageConsumer.java
@@ -48,7 +48,7 @@ public interface AirbyteMessageConsumer extends CheckedConsumer<AirbyteMessage, 
 
       @Override
       public void start() throws Exception {
-        AirbyteSentry.executeWithTracing("ConsumerStart", consumer::start,
+        AirbyteSentry.executeWithTracing("StartConsumer", consumer::start,
             Map.of("consumerImpl", "appendOnClose"));
       }
 
@@ -59,7 +59,7 @@ public interface AirbyteMessageConsumer extends CheckedConsumer<AirbyteMessage, 
 
       @Override
       public void close() throws Exception {
-        AirbyteSentry.executeWithTracing("ConsumerClose", () -> {
+        AirbyteSentry.executeWithTracing("CloseConsumer", () -> {
           consumer.close();
           voidCallable.call();
         }, Map.of("consumerImpl", "appendOnClose"));

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/AirbyteMessageConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/AirbyteMessageConsumer.java
@@ -6,6 +6,7 @@ package io.airbyte.integrations.base;
 
 import io.airbyte.commons.concurrency.VoidCallable;
 import io.airbyte.commons.functional.CheckedConsumer;
+import io.airbyte.integrations.base.sentry.AirbyteSentry;
 import io.airbyte.protocol.models.AirbyteMessage;
 
 /**
@@ -46,7 +47,7 @@ public interface AirbyteMessageConsumer extends CheckedConsumer<AirbyteMessage, 
 
       @Override
       public void start() throws Exception {
-        consumer.start();
+        AirbyteSentry.executeWithTracing("ConsumerStart", consumer::start);
       }
 
       @Override
@@ -56,8 +57,10 @@ public interface AirbyteMessageConsumer extends CheckedConsumer<AirbyteMessage, 
 
       @Override
       public void close() throws Exception {
-        consumer.close();
-        voidCallable.call();
+        AirbyteSentry.executeWithTracing("ConsumerClose", () -> {
+          consumer.close();
+          voidCallable.call();
+        });
       }
 
     };

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/AirbyteMessageConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/AirbyteMessageConsumer.java
@@ -8,6 +8,7 @@ import io.airbyte.commons.concurrency.VoidCallable;
 import io.airbyte.commons.functional.CheckedConsumer;
 import io.airbyte.integrations.base.sentry.AirbyteSentry;
 import io.airbyte.protocol.models.AirbyteMessage;
+import org.elasticsearch.common.collect.Map;
 
 /**
  * Interface for the destination's consumption of incoming records wrapped in an
@@ -47,7 +48,8 @@ public interface AirbyteMessageConsumer extends CheckedConsumer<AirbyteMessage, 
 
       @Override
       public void start() throws Exception {
-        AirbyteSentry.executeWithTracing("ConsumerStart", consumer::start);
+        AirbyteSentry.executeWithTracing("ConsumerStart", consumer::start,
+            Map.of("consumerImpl", "appendOnClose"));
       }
 
       @Override
@@ -60,7 +62,7 @@ public interface AirbyteMessageConsumer extends CheckedConsumer<AirbyteMessage, 
         AirbyteSentry.executeWithTracing("ConsumerClose", () -> {
           consumer.close();
           voidCallable.call();
-        });
+        }, Map.of("consumerImpl", "appendOnClose"));
       }
 
     };

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/FailureTrackingAirbyteMessageConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/FailureTrackingAirbyteMessageConsumer.java
@@ -4,7 +4,9 @@
 
 package io.airbyte.integrations.base;
 
+import io.airbyte.integrations.base.sentry.AirbyteSentry;
 import io.airbyte.protocol.models.AirbyteMessage;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +33,8 @@ public abstract class FailureTrackingAirbyteMessageConsumer implements AirbyteMe
   @Override
   public void start() throws Exception {
     try {
+      AirbyteSentry.executeWithTracing("ConsumerStart", this::startTracked,
+          Map.of("consumerImpl", FailureTrackingAirbyteMessageConsumer.class.getSimpleName()));
       startTracked();
     } catch (final Exception e) {
       hasFailed = true;
@@ -59,7 +63,8 @@ public abstract class FailureTrackingAirbyteMessageConsumer implements AirbyteMe
     } else {
       LOGGER.info("Airbyte message consumer: succeeded.");
     }
-    close(hasFailed);
+    AirbyteSentry.executeWithTracing("ConsumerEnd", () -> close(hasFailed),
+        Map.of("consumerImpl", FailureTrackingAirbyteMessageConsumer.class.getSimpleName()));
   }
 
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/FailureTrackingAirbyteMessageConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/FailureTrackingAirbyteMessageConsumer.java
@@ -33,7 +33,7 @@ public abstract class FailureTrackingAirbyteMessageConsumer implements AirbyteMe
   @Override
   public void start() throws Exception {
     try {
-      AirbyteSentry.executeWithTracing("ConsumerStart", this::startTracked,
+      AirbyteSentry.executeWithTracing("StartConsumer", this::startTracked,
           Map.of("consumerImpl", FailureTrackingAirbyteMessageConsumer.class.getSimpleName()));
     } catch (final Exception e) {
       hasFailed = true;
@@ -62,7 +62,7 @@ public abstract class FailureTrackingAirbyteMessageConsumer implements AirbyteMe
     } else {
       LOGGER.info("Airbyte message consumer: succeeded.");
     }
-    AirbyteSentry.executeWithTracing("ConsumerEnd", () -> close(hasFailed),
+    AirbyteSentry.executeWithTracing("CloseConsumer", () -> close(hasFailed),
         Map.of("consumerImpl", FailureTrackingAirbyteMessageConsumer.class.getSimpleName()));
   }
 

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/FailureTrackingAirbyteMessageConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/FailureTrackingAirbyteMessageConsumer.java
@@ -35,7 +35,6 @@ public abstract class FailureTrackingAirbyteMessageConsumer implements AirbyteMe
     try {
       AirbyteSentry.executeWithTracing("ConsumerStart", this::startTracked,
           Map.of("consumerImpl", FailureTrackingAirbyteMessageConsumer.class.getSimpleName()));
-      startTracked();
     } catch (final Exception e) {
       hasFailed = true;
       throw e;

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
@@ -115,14 +115,8 @@ public class IntegrationRunner {
           validateConfig(integration.spec().getConnectionSpecification(), config, "CHECK");
         } catch (final Exception e) {
           // if validation fails don't throw an exception, return a failed connection check message
-          outputRecordCollector
-              .accept(
-                  new AirbyteMessage()
-                      .withType(Type.CONNECTION_STATUS)
-                      .withConnectionStatus(
-                          new AirbyteConnectionStatus()
-                              .withStatus(AirbyteConnectionStatus.Status.FAILED)
-                              .withMessage(e.getMessage())));
+          outputRecordCollector.accept(new AirbyteMessage().withType(Type.CONNECTION_STATUS).withConnectionStatus(
+              new AirbyteConnectionStatus().withStatus(AirbyteConnectionStatus.Status.FAILED).withMessage(e.getMessage())));
         }
 
         outputRecordCollector.accept(new AirbyteMessage().withType(Type.CONNECTION_STATUS).withConnectionStatus(integration.check(config)));

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/sentry/AirbyteSentry.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/sentry/AirbyteSentry.java
@@ -9,10 +9,12 @@ import io.sentry.Sentry;
 import io.sentry.SpanStatus;
 import java.util.Collections;
 import java.util.Map;
+import org.apache.logging.log4j.util.Strings;
 
 public class AirbyteSentry {
 
   private static final String DEFAULT_ROOT_TRANSACTION = "ROOT";
+  private static final String DEFAULT_UNKNOWN_OPERATION = "ANONYMOUS";
 
   @FunctionalInterface
   public interface ThrowingRunnable<E extends Exception> {
@@ -94,6 +96,7 @@ public class AirbyteSentry {
   }
 
   private static ISpan createChildSpan(final ISpan currentSpan, final String operationName, final Map<String, Object> metadata) {
+    final String name = Strings.isBlank(operationName) ? DEFAULT_UNKNOWN_OPERATION : operationName;
     final ISpan childSpan;
     if (currentSpan == null) {
       childSpan = Sentry.startTransaction(DEFAULT_ROOT_TRANSACTION, operationName);

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
@@ -14,6 +14,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
 import io.airbyte.integrations.base.AirbyteStreamNameNamespacePair;
 import io.airbyte.integrations.base.FailureTrackingAirbyteMessageConsumer;
+import io.airbyte.integrations.base.sentry.AirbyteSentry;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
@@ -146,10 +147,12 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
       // TODO use a more efficient way to compute bytes that doesn't require double serialization (records
       // are serialized again when writing to
       // the destination
-      long messageSizeInBytes = ByteUtils.getSizeInBytesForUTF8CharSet(Jsons.serialize(recordMessage.getData()));
+      final long messageSizeInBytes = ByteUtils.getSizeInBytesForUTF8CharSet(Jsons.serialize(recordMessage.getData()));
       if (bufferSizeInBytes + messageSizeInBytes > maxQueueSizeInBytes) {
         LOGGER.info("Flushing buffer...");
-        flushQueueToDestination();
+        AirbyteSentry.executeWithTracing("FlushBuffer",
+            this::flushQueueToDestination,
+            Map.of("stream", stream.getName(), "namespace", stream.getNamespace(), "bufferSizeInBytes", bufferSizeInBytes));
         bufferSizeInBytes = 0;
       }
 

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/AbstractJdbcDestination.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/AbstractJdbcDestination.java
@@ -11,6 +11,7 @@ import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.BaseConnector;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
 import io.airbyte.integrations.base.Destination;
+import io.airbyte.integrations.base.sentry.AirbyteSentry;
 import io.airbyte.integrations.destination.NamingConventionTransformer;
 import io.airbyte.protocol.models.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
@@ -54,7 +55,8 @@ public abstract class AbstractJdbcDestination extends BaseConnector implements D
 
     try (final JdbcDatabase database = getDatabase(config)) {
       final String outputSchema = namingResolver.getIdentifier(config.get("schema").asText());
-      attemptSQLCreateAndDropTableOperations(outputSchema, database, namingResolver, sqlOperations);
+      AirbyteSentry.executeWithTracing("CreateAndDropTable", () ->
+          attemptSQLCreateAndDropTableOperations(outputSchema, database, namingResolver, sqlOperations));
       return new AirbyteConnectionStatus().withStatus(Status.SUCCEEDED);
     } catch (final Exception e) {
       LOGGER.error("Exception while checking connection: ", e);

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/JdbcSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/JdbcSqlOperations.java
@@ -104,7 +104,7 @@ public abstract class JdbcSqlOperations implements SqlOperations {
     appendedQueries.append("COMMIT;");
     AirbyteSentry.executeWithTracing("ExecuteTransactions",
         () -> database.execute(appendedQueries.toString()),
-        Map.of("queryCount", queries.size()));
+        Map.of("queries", queries));
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/JdbcSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/JdbcSqlOperations.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.base.JavaBaseConstants;
+import io.airbyte.integrations.base.sentry.AirbyteSentry;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
 import java.io.File;
 import java.io.PrintWriter;
@@ -16,6 +17,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
@@ -31,7 +33,9 @@ public abstract class JdbcSqlOperations implements SqlOperations {
   @Override
   public void createSchemaIfNotExists(final JdbcDatabase database, final String schemaName) throws Exception {
     if (!isSchemaExists(database, schemaName)) {
-      database.execute(createSchemaQuery(schemaName));;
+      AirbyteSentry.executeWithTracing("CreateSchema",
+          () -> database.execute(createSchemaQuery(schemaName)),
+          Map.of("schema", schemaName));
     }
   }
 
@@ -41,7 +45,9 @@ public abstract class JdbcSqlOperations implements SqlOperations {
 
   @Override
   public void createTableIfNotExists(final JdbcDatabase database, final String schemaName, final String tableName) throws SQLException {
-    database.execute(createTableQuery(database, schemaName, tableName));
+    AirbyteSentry.executeWithTracing("CreateTableIfNotExists",
+        () -> database.execute(createTableQuery(database, schemaName, tableName)),
+        Map.of("schema", schemaName, "table", tableName));
   }
 
   @Override
@@ -96,12 +102,16 @@ public abstract class JdbcSqlOperations implements SqlOperations {
       appendedQueries.append(query);
     }
     appendedQueries.append("COMMIT;");
-    database.execute(appendedQueries.toString());
+    AirbyteSentry.executeWithTracing("ExecuteTransactions",
+        () -> database.execute(appendedQueries.toString()),
+        Map.of("queryCount", queries.size()));
   }
 
   @Override
   public void dropTableIfExists(final JdbcDatabase database, final String schemaName, final String tableName) throws SQLException {
-    database.execute(dropTableIfExistsQuery(schemaName, tableName));
+    AirbyteSentry.executeWithTracing("DropTableIfExists",
+        () -> database.execute(dropTableIfExistsQuery(schemaName, tableName)),
+        Map.of("schema", schemaName, "table", tableName));
   }
 
   private String dropTableIfExistsQuery(final String schemaName, final String tableName) {
@@ -124,8 +134,12 @@ public abstract class JdbcSqlOperations implements SqlOperations {
                                   final String schemaName,
                                   final String tableName)
       throws Exception {
-    records.forEach(airbyteRecordMessage -> getDataAdapter().adapt(airbyteRecordMessage.getData()));
-    insertRecordsInternal(database, records, schemaName, tableName);
+    AirbyteSentry.executeWithTracing("InsertRecords",
+        () -> {
+          records.forEach(airbyteRecordMessage -> getDataAdapter().adapt(airbyteRecordMessage.getData()));
+          insertRecordsInternal(database, records, schemaName, tableName);
+        },
+        Map.of("schema", schemaName, "table", tableName, "recordCount", records.size()));
   }
 
   protected abstract void insertRecordsInternal(JdbcDatabase database,

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingDestination.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingDestination.java
@@ -33,9 +33,9 @@ public class SnowflakeInternalStagingDestination extends AbstractJdbcDestination
     final SnowflakeStagingSqlOperations snowflakeStagingSqlOperations = new SnowflakeStagingSqlOperations();
     try (final JdbcDatabase database = getDatabase(config)) {
       final String outputSchema = super.getNamingResolver().getIdentifier(config.get("schema").asText());
-      AirbyteSentry.runWithSpan("CreateAndDropTable",
+      AirbyteSentry.executeWithTracing("CreateAndDropTable",
           () -> attemptSQLCreateAndDropTableOperations(outputSchema, database, nameTransformer, snowflakeStagingSqlOperations));
-      AirbyteSentry.runWithSpan("CreateAndDropStage",
+      AirbyteSentry.executeWithTracing("CreateAndDropStage",
           () -> attemptSQLCreateAndDropStages(outputSchema, database, nameTransformer, snowflakeStagingSqlOperations));
       return new AirbyteConnectionStatus().withStatus(AirbyteConnectionStatus.Status.SUCCEEDED);
     } catch (final Exception e) {


### PR DESCRIPTION
## Summary
- Add more Sentry tracing to stream consumer and JDBC destinations.
- Relate to:
  - https://github.com/airbytehq/airbyte/issues/9867
  - https://github.com/airbytehq/airbyte/issues/9614

## Sentry Screenshot

Sync two streams into Snowflake with internal staging ([link](https://sentry.io/organizations/airbyte-5j/discover/java-connectors:fcd96cea08eb49389f5bbdd051e3d22a/)):

<img width="1300" alt="Screen Shot 2022-01-31 at 01 12 41" src="https://user-images.githubusercontent.com/1933157/151767076-8e98f1d5-da0f-42cd-bae7-2793b55c1a03.png">
