### PR TITLE
Fix custom dbt integration tests

### DIFF
--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -811,7 +811,7 @@ public abstract class DestinationAcceptanceTest {
     final Path transformationRoot = Files.createDirectories(jobRoot.resolve("transform"));
     final OperatorDbt dbtConfig = new OperatorDbt()
         .withGitRepoUrl("https://github.com/fishtown-analytics/dbt-learn-demo.git")
-        .withGitRepoBranch("master")
+        .withGitRepoBranch("main")
         .withDockerImage("fishtownanalytics/dbt:0.19.1")
         .withDbtArguments("debug");
     if (!runner.run(JOB_ID, JOB_ATTEMPT, transformationRoot, config, null, dbtConfig)) {


### PR DESCRIPTION
## What

We are seeing errors in integration tests for custom dbt transformations that relies on some external git repository as part of the test:

```
 2022-01-30 11:20:25 INFO i.a.w.p.DockerProcessFactory(create):157 - Preparing command: docker run --rm --init -i -w /data/job/transform --log-driver none --network host -v /tmp/airbyte_tests/test4544342936522993925:/data -v /tmp/airbyte_tests/output14089328354255834851:/local airbyte/normalization-snowflake:dev configure-dbt --integration-type snowflake --config destination_config.json --git-repo https://github.com/fishtown-analytics/dbt-learn-demo.git --git-branch master
    2022-01-30 11:20:25 normalization > WARNING: Error loading config file: .dockercfg: $HOME is not defined
    2022-01-30 11:20:26 normalization > Running: git clone --depth 5 -b master --single-branch  $GIT_REPO git_repo
    2022-01-30 11:20:26 normalization > Cloning into 'git_repo'...
    2022-01-30 11:20:26 normalization > warning: Could not find remote branch master to clone.
    2022-01-30 11:20:26 normalization > fatal: Remote branch master not found in upstream origin
  
SnowflakeGcsCopyDestinationAcceptanceTest > testCustomDbtTransformationsFailure() FAILED
```
from https://github.com/airbytehq/airbyte/runs/4996386398?check_suite_focus=true

When looking at https://github.com/fishtown-analytics/dbt-learn-demo.git I don't see a "master" branch there anymore.

## How
But it used to work:
```
2022-01-28 11:22:03 INFO i.a.w.p.DockerProcessFactory(create):157 - Preparing command: docker run --rm --init -i -w /data/job/transform --log-driver none --network host -v /tmp/airbyte_tests/test3898401597517857789:/data -v /tmp/airbyte_tests/output5331988786176588778:/local airbyte/normalization-snowflake:dev configure-dbt --integration-type snowflake --config destination_config.json --git-repo https://github.com/fishtown-analytics/dbt-learn-demo.git --git-branch master
    2022-01-28 11:22:03 normalization > WARNING: Error loading config file: .dockercfg: $HOME is not defined
    2022-01-28 11:22:03 normalization > Running: git clone --depth 5 -b master --single-branch  $GIT_REPO git_repo
    2022-01-28 11:22:03 normalization > Cloning into 'git_repo'...
    2022-01-28 11:22:03 normalization > Last 5 commits in git_repo:
    2022-01-28 11:22:03 normalization > b3cb3ab initial commit
    2022-01-28 11:22:03 normalization > /data/job/transform
    2022-01-28 11:22:03 normalization > Running: transform-config --config destination_config.json --integration-type snowflake --out /data/job/transform
```
from https://github.com/airbytehq/airbyte/runs/4979672064?check_suite_focus=true