### PR TITLE
fix: check image workflow is failing for external images

### DIFF
--- a/tools/bin/check_images_exist.sh
+++ b/tools/bin/check_images_exist.sh
@@ -28,7 +28,8 @@ checkNormalizationImages() {
 checkConnectorImages() {
   echo "Checking connector images exist..."
 
-  CONNECTOR_DEFINITIONS=$(grep "dockerRepository" -h -A1 airbyte-config/init/src/main/resources/seed/*.yaml | grep -v -- "^--$" | tr -d ' ')
+  # Added `: airbyte/` since we have added external images also to our source_definitions and we won't be able to verify them.
+  CONNECTOR_DEFINITIONS=$(grep "dockerRepository: airbyte/" -h -A1 airbyte-config/init/src/main/resources/seed/*.yaml | grep -v -- "^--$" | tr -d ' ')
   [ -z "CONNECTOR_DEFINITIONS" ] && echo "ERROR: Could not find any connector definition." && exit 1
 
   while IFS=":" read -r _ REPO; do


### PR DESCRIPTION
## What
Check image workflow is failing after adding external images to source_definitions. This change will ensure that those images are not taken into workflow
