### PR TITLE
Add sentry release for connectors

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Create Sentry Release
         if: env.IMAGE_TYPE == 'connectors'
         run: |
-          sentry-cli releases set-commit "${{ env.IMAGE_NAME }}@${{ env.IMAGE_VERSION }}-ci-test" --auto --ignore-missing
+          sentry-cli releases set-commits "${{ env.IMAGE_NAME }}@${{ env.IMAGE_VERSION }}-ci-test" --auto --ignore-missing
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CONNECTOR_RELEASE_AUTH_TOKEN }}
           SENTRY_ORG: airbyte-5j

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -110,7 +110,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CONNECTOR_RELEASE_AUTH_TOKEN }}
           SENTRY_ORG: airbyte-5j
           SENTRY_PROJECT: airbyte-connectors
-      - name: publish ${{ github.event.inputs.connector }}
+      - name: Publish ${{ github.event.inputs.connector }}
         run: |
           echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
           ./tools/integrations/manage.sh publish airbyte-integrations/${{ github.event.inputs.connector }} ${{ github.event.inputs.run-tests }} --publish_spec_to_cache

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -99,8 +99,8 @@ jobs:
           curl -sL https://sentry.io/get-cli/ | bash
           source tools/lib/lib.sh
           DOCKERFILE=airbyte-integrations/${{ github.event.inputs.connector }}/Dockerfile
-          echo "IMAGE_TYPE=$(echo ${{ github.event.inputs.connector }} | cut -d"/" -f1 )" >> $GITHUB_ENV
-          echo "IMAGE_NAME=$(_get_docker_image_name ${DOCKERFILE})" >> $GITHUB_ENV
+          echo "IMAGE_TYPE=$(echo ${{ github.event.inputs.connector }} | cut -d"/" -f2)" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$(_get_docker_image_name ${DOCKERFILE} | cut -d"/" -f1)" >> $GITHUB_ENV
           echo "IMAGE_VERSION=$(_get_docker_image_version ${DOCKERFILE})" >> $GITHUB_ENV
       - name: Create Sentry Release
         if: env.IMAGE_TYPE == 'connectors'

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -95,7 +95,6 @@ jobs:
         env:
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       - name: Prepare Sentry Release
-        if: env.IMAGE_TYPE == 'connectors'
         run: |
           curl -sL https://sentry.io/get-cli/ | bash
           source tools/lib/lib.sh

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -110,23 +110,23 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CONNECTOR_RELEASE_AUTH_TOKEN }}
           SENTRY_ORG: airbyte-5j
           SENTRY_PROJECT: airbyte-connectors
-      - run: |
+      - name: publish ${{ github.event.inputs.connector }}
+        run: |
           echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
           ./tools/integrations/manage.sh publish airbyte-integrations/${{ github.event.inputs.connector }} ${{ github.event.inputs.run-tests }} --publish_spec_to_cache
-        name: publish ${{ github.event.inputs.connector }}
         id: publish
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
           TZ: UTC
-       - name: Finalize Sentry release
-         if: env.IMAGE_TYPE == 'connectors'
-         run: |
-           sentry-cli releases finalize "${{ env.IMAGE_NAME }}@${{ env.IMAGE_VERSION }}"
-         env:
-           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CONNECTOR_RELEASE_AUTH_TOKEN }}
-           SENTRY_ORG: airbyte-5j
-           SENTRY_PROJECT: airbyte-connectors
+      - name: Finalize Sentry release
+        if: env.IMAGE_TYPE == 'connectors'
+        run: |
+          sentry-cli releases finalize "${{ env.IMAGE_NAME }}@${{ env.IMAGE_VERSION }}"
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CONNECTOR_RELEASE_AUTH_TOKEN }}
+          SENTRY_ORG: airbyte-5j
+          SENTRY_PROJECT: airbyte-connectors
       - name: Add Success Comment
         if: github.event.inputs.comment-id && success()
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -105,52 +105,52 @@ jobs:
       - name: Create Sentry Release
         if: env.IMAGE_TYPE == 'connectors'
         run: |
-          sentry-cli releases set-commits "${{ env.IMAGE_NAME }}@${{ env.IMAGE_VERSION }}-ci-test" --auto --ignore-missing
+          sentry-cli releases set-commits "${{ env.IMAGE_NAME }}@${{ env.IMAGE_VERSION }}" --auto --ignore-missing
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CONNECTOR_RELEASE_AUTH_TOKEN }}
           SENTRY_ORG: airbyte-5j
           SENTRY_PROJECT: airbyte-connectors
-#      - run: |
-#          echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
-#          ./tools/integrations/manage.sh publish airbyte-integrations/${{ github.event.inputs.connector }} ${{ github.event.inputs.run-tests }} --publish_spec_to_cache
-#        name: publish ${{ github.event.inputs.connector }}
-#        id: publish
-#        env:
-#          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-#          # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
-#          TZ: UTC
-#       - name: Finalize Sentry release
-#         if: env.IMAGE_TYPE == 'connectors'
-#         run: |
-#           sentry-cli releases finalize "${{ env.IMAGE_NAME }}@${{ env.IMAGE_VERSION }}"
-#         env:
-#           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CONNECTOR_RELEASE_AUTH_TOKEN }}
-#           SENTRY_ORG: airbyte-5j
-#           SENTRY_PROJECT: airbyte-connectors
-#      - name: Add Success Comment
-#        if: github.event.inputs.comment-id && success()
-#        uses: peter-evans/create-or-update-comment@v1
-#        with:
-#          comment-id: ${{ github.event.inputs.comment-id }}
-#          body: |
-#            > :white_check_mark: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-#      - name: Add Failure Comment
-#        if: github.event.inputs.comment-id && !success()
-#        uses: peter-evans/create-or-update-comment@v1
-#        with:
-#          comment-id: ${{ github.event.inputs.comment-id }}
-#          body: |
-#            > :x: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-#      - name: Slack Notification - Failure
-#        if: failure()
-#        uses: rtCamp/action-slack-notify@master
-#        env:
-#          SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}
-#          SLACK_USERNAME: Buildozer
-#          SLACK_ICON: https://avatars.slack-edge.com/temp/2020-09-01/1342729352468_209b10acd6ff13a649a1.jpg
-#          SLACK_COLOR: DC143C
-#          SLACK_TITLE: "Failed to publish connector ${{ github.event.inputs.connector }} from branch ${{ github.ref	 }}"
-#          SLACK_FOOTER: ""
+      - run: |
+          echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
+          ./tools/integrations/manage.sh publish airbyte-integrations/${{ github.event.inputs.connector }} ${{ github.event.inputs.run-tests }} --publish_spec_to_cache
+        name: publish ${{ github.event.inputs.connector }}
+        id: publish
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
+          TZ: UTC
+       - name: Finalize Sentry release
+         if: env.IMAGE_TYPE == 'connectors'
+         run: |
+           sentry-cli releases finalize "${{ env.IMAGE_NAME }}@${{ env.IMAGE_VERSION }}"
+         env:
+           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CONNECTOR_RELEASE_AUTH_TOKEN }}
+           SENTRY_ORG: airbyte-5j
+           SENTRY_PROJECT: airbyte-connectors
+      - name: Add Success Comment
+        if: github.event.inputs.comment-id && success()
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ github.event.inputs.comment-id }}
+          body: |
+            > :white_check_mark: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      - name: Add Failure Comment
+        if: github.event.inputs.comment-id && !success()
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ github.event.inputs.comment-id }}
+          body: |
+            > :x: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      - name: Slack Notification - Failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}
+          SLACK_USERNAME: Buildozer
+          SLACK_ICON: https://avatars.slack-edge.com/temp/2020-09-01/1342729352468_209b10acd6ff13a649a1.jpg
+          SLACK_COLOR: DC143C
+          SLACK_TITLE: "Failed to publish connector ${{ github.event.inputs.connector }} from branch ${{ github.ref	 }}"
+          SLACK_FOOTER: ""
   # In case of self-hosted EC2 errors, remove this block.
   stop-publish-image-runner:
     name: Stop Build EC2 Runner

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -94,39 +94,64 @@ jobs:
           ci_credentials ${{ github.event.inputs.connector }}
         env:
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-      - run: |
-          echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
-          ./tools/integrations/manage.sh publish airbyte-integrations/${{ github.event.inputs.connector }} ${{ github.event.inputs.run-tests }} --publish_spec_to_cache
-        name: publish ${{ github.event.inputs.connector }}
-        id: publish
+      - name: Prepare Sentry Release
+        if: env.IMAGE_TYPE == 'connectors'
+        run: |
+          curl -sL https://sentry.io/get-cli/ | bash
+          source tools/lib/lib.sh
+          DOCKERFILE=airbyte-integrations/${{ github.event.inputs.connector }}/Dockerfile
+          echo "IMAGE_TYPE=$(echo ${{ github.event.inputs.connector }} | cut -d"/" -f1 )" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$(_get_docker_image_name ${DOCKERFILE})" >> $GITHUB_ENV
+          echo "IMAGE_VERSION=$(_get_docker_image_version ${DOCKERFILE})" >> $GITHUB_ENV
+      - name: Create Sentry Release
+        if: env.IMAGE_TYPE == 'connectors'
+        run: |
+          sentry-cli releases set-commit "${{ env.IMAGE_NAME }}@${{ env.IMAGE_VERSION }}-ci-test" --auto --ignore-missing
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
-          TZ: UTC
-      - name: Add Success Comment
-        if: github.event.inputs.comment-id && success()
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          comment-id: ${{ github.event.inputs.comment-id }}
-          body: |
-            > :white_check_mark: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-      - name: Add Failure Comment
-        if: github.event.inputs.comment-id && !success()
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          comment-id: ${{ github.event.inputs.comment-id }}
-          body: |
-            > :x: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-      - name: Slack Notification - Failure
-        if: failure()
-        uses: rtCamp/action-slack-notify@master
-        env:
-          SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}
-          SLACK_USERNAME: Buildozer
-          SLACK_ICON: https://avatars.slack-edge.com/temp/2020-09-01/1342729352468_209b10acd6ff13a649a1.jpg
-          SLACK_COLOR: DC143C
-          SLACK_TITLE: "Failed to publish connector ${{ github.event.inputs.connector }} from branch ${{ github.ref	 }}"
-          SLACK_FOOTER: ""
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CONNECTOR_RELEASE_AUTH_TOKEN }}
+          SENTRY_ORG: airbyte-5j
+          SENTRY_PROJECT: airbyte-connectors
+#      - run: |
+#          echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
+#          ./tools/integrations/manage.sh publish airbyte-integrations/${{ github.event.inputs.connector }} ${{ github.event.inputs.run-tests }} --publish_spec_to_cache
+#        name: publish ${{ github.event.inputs.connector }}
+#        id: publish
+#        env:
+#          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+#          # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
+#          TZ: UTC
+#       - name: Finalize Sentry release
+#         if: env.IMAGE_TYPE == 'connectors'
+#         run: |
+#           sentry-cli releases finalize "${{ env.IMAGE_NAME }}@${{ env.IMAGE_VERSION }}"
+#         env:
+#           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CONNECTOR_RELEASE_AUTH_TOKEN }}
+#           SENTRY_ORG: airbyte-5j
+#           SENTRY_PROJECT: airbyte-connectors
+#      - name: Add Success Comment
+#        if: github.event.inputs.comment-id && success()
+#        uses: peter-evans/create-or-update-comment@v1
+#        with:
+#          comment-id: ${{ github.event.inputs.comment-id }}
+#          body: |
+#            > :white_check_mark: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+#      - name: Add Failure Comment
+#        if: github.event.inputs.comment-id && !success()
+#        uses: peter-evans/create-or-update-comment@v1
+#        with:
+#          comment-id: ${{ github.event.inputs.comment-id }}
+#          body: |
+#            > :x: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+#      - name: Slack Notification - Failure
+#        if: failure()
+#        uses: rtCamp/action-slack-notify@master
+#        env:
+#          SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}
+#          SLACK_USERNAME: Buildozer
+#          SLACK_ICON: https://avatars.slack-edge.com/temp/2020-09-01/1342729352468_209b10acd6ff13a649a1.jpg
+#          SLACK_COLOR: DC143C
+#          SLACK_TITLE: "Failed to publish connector ${{ github.event.inputs.connector }} from branch ${{ github.ref	 }}"
+#          SLACK_FOOTER: ""
   # In case of self-hosted EC2 errors, remove this block.
   stop-publish-image-runner:
     name: Stop Build EC2 Runner

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -99,8 +99,8 @@ jobs:
           curl -sL https://sentry.io/get-cli/ | bash
           source tools/lib/lib.sh
           DOCKERFILE=airbyte-integrations/${{ github.event.inputs.connector }}/Dockerfile
-          echo "IMAGE_TYPE=$(echo ${{ github.event.inputs.connector }} | cut -d"/" -f2)" >> $GITHUB_ENV
-          echo "IMAGE_NAME=$(_get_docker_image_name ${DOCKERFILE} | cut -d"/" -f1)" >> $GITHUB_ENV
+          echo "IMAGE_TYPE=$(echo ${{ github.event.inputs.connector }} | cut -d"/" -f1)" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$(echo ${{ github.event.inputs.connector }} | cut -d"/" -f2)" >> $GITHUB_ENV
           echo "IMAGE_VERSION=$(_get_docker_image_version ${DOCKERFILE})" >> $GITHUB_ENV
       - name: Create Sentry Release
         if: env.IMAGE_TYPE == 'connectors'

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -95,15 +95,15 @@ jobs:
         env:
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       - name: Prepare Sentry Release
+        if: startsWith(github.event.inputs.connector, 'connectors')
         run: |
           curl -sL https://sentry.io/get-cli/ | bash
           source tools/lib/lib.sh
           DOCKERFILE=airbyte-integrations/${{ github.event.inputs.connector }}/Dockerfile
-          echo "IMAGE_TYPE=$(echo ${{ github.event.inputs.connector }} | cut -d"/" -f1)" >> $GITHUB_ENV
           echo "IMAGE_NAME=$(echo ${{ github.event.inputs.connector }} | cut -d"/" -f2)" >> $GITHUB_ENV
           echo "IMAGE_VERSION=$(_get_docker_image_version ${DOCKERFILE})" >> $GITHUB_ENV
       - name: Create Sentry Release
-        if: env.IMAGE_TYPE == 'connectors'
+        if: startsWith(github.event.inputs.connector, 'connectors')
         run: |
           sentry-cli releases set-commits "${{ env.IMAGE_NAME }}@${{ env.IMAGE_VERSION }}" --auto --ignore-missing
         env:
@@ -120,7 +120,7 @@ jobs:
           # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
           TZ: UTC
       - name: Finalize Sentry release
-        if: env.IMAGE_TYPE == 'connectors'
+        if: startsWith(github.event.inputs.connector, 'connectors')
         run: |
           sentry-cli releases finalize "${{ env.IMAGE_NAME }}@${{ env.IMAGE_VERSION }}"
         env:

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -48,7 +48,7 @@
 - name: E2E Testing
   destinationDefinitionId: 2eb65e87-983a-4fd7-b3e3-9d9dc6eb8537
   dockerRepository: airbyte/destination-e2e-test
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2
   documentationUrl: https://docs.airbyte.io/integrations/destinations/e2e-test
   icon: airbyte.svg
 - destinationDefinitionId: 68f351a7-2745-4bef-ad7f-996b8e51bb8c

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -917,7 +917,7 @@
     supported_destination_sync_modes:
     - "overwrite"
     - "append"
-- dockerImage: "airbyte/destination-e2e-test:0.2.1"
+- dockerImage: "airbyte/destination-e2e-test:0.2.2"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/e2e-test"
     connectionSpecification:

--- a/docs/integrations/destinations/e2e-test.md
+++ b/docs/integrations/destinations/e2e-test.md
@@ -46,7 +46,7 @@ The OSS and Cloud variants have the same version number starting from version `0
 
 | Version | Date       | Pull Request                                             | Subject |
 | :------ | :--------- | :------------------------------------------------------- | :--- |
-| 0.2.2 (unpublished) | 2022-01-29 | [\#9745](https://github.com/airbytehq/airbyte/pull/9745) | Integrate with Sentry. |
+| 0.2.2   | 2022-01-29 | [\#9745](https://github.com/airbytehq/airbyte/pull/9745) | Integrate with Sentry. |
 | 0.2.1   | 2021-12-19 | [\#8824](https://github.com/airbytehq/airbyte/pull/8905) | Fix documentation URL. |
 | 0.2.0   | 2021-12-16 | [\#8824](https://github.com/airbytehq/airbyte/pull/8824) | Add multiple logging modes. |
 | 0.1.0   | 2021-05-25 | [\#3290](https://github.com/airbytehq/airbyte/pull/3290) | Create initial version. |


### PR DESCRIPTION
## Summary
- Create a Sentry release whenever a new connector version is published.
- In this way, we can track an exception back to the version and suspicious commit.
- Sentry doc
  - https://docs.sentry.io/product/releases/suspect-commits/
  - https://docs.sentry.io/product/cli/releases/
- Relate to https://github.com/airbytehq/airbyte/issues/9104.
