### PR TITLE
CDK: Ensure AirbyteLogger is thread-safe using Lock

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/logger.py
+++ b/airbyte-cdk/python/airbyte_cdk/logger.py
@@ -5,6 +5,7 @@
 import logging
 import logging.config
 import sys
+from threading import Lock
 import traceback
 from typing import List, Tuple
 
@@ -101,12 +102,14 @@ def log_by_prefix(msg: str, default_level: str) -> Tuple[int, str]:
 
     return log_level, rendered_message
 
+AIRBYTE_LOGGER_LOCK = Lock()
 
 class AirbyteLogger:
     def log(self, level, message):
         log_record = AirbyteLogMessage(level=level, message=message)
         log_message = AirbyteMessage(type="LOG", log=log_record)
-        print(log_message.json(exclude_unset=True))
+        with AIRBYTE_LOGGER_LOCK:
+            print(log_message.json(exclude_unset=True))
 
     def fatal(self, message):
         self.log("FATAL", message)

--- a/airbyte-cdk/python/airbyte_cdk/logger.py
+++ b/airbyte-cdk/python/airbyte_cdk/logger.py
@@ -2,10 +2,10 @@
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
 
+from deprecated import deprecated
 import logging
 import logging.config
 import sys
-from threading import Lock
 import traceback
 from typing import List, Tuple
 
@@ -102,14 +102,12 @@ def log_by_prefix(msg: str, default_level: str) -> Tuple[int, str]:
 
     return log_level, rendered_message
 
-AIRBYTE_LOGGER_LOCK = Lock()
-
+@deprecated(version="0.1.47", reason="Use logging.getLogger('airbyte') instead")
 class AirbyteLogger:
     def log(self, level, message):
         log_record = AirbyteLogMessage(level=level, message=message)
         log_message = AirbyteMessage(type="LOG", log=log_record)
-        with AIRBYTE_LOGGER_LOCK:
-            print(log_message.json(exclude_unset=True))
+        print(log_message.json(exclude_unset=True))
 
     def fatal(self, message):
         self.log("FATAL", message)


### PR DESCRIPTION

## What
The `logging` module is thread-safe, however `print` is not, and is currently used. This means that messages sent to stdout can clash if connectors use threading. This is obviously a huge problem when the IPC between the source/destination is stdout! We have seen this issue in one of our sources.

## How
Introduce a global lock to ensure `AirbyteLogger` is thread-safe.

Further notes:
- A `multiprocessing.Lock` could have been introduced however given that `logging` module is not multiprocess-safe I thought that thread-safety should be first goal.
- IMO the `AirbyteLogger` should be a subclass of the `logging.Logger` so you have thread-safety automatically, however I didn't want to make a huge wholesale change here.

## 🚨 User Impact 🚨
No user impact expected.

## Pre-merge Checklist
N/A