### PR TITLE
fix: check image workflow is failing for external images

### DIFF
--- a/tools/bin/check_images_exist.sh
+++ b/tools/bin/check_images_exist.sh
@@ -5,9 +5,19 @@ set -e
 . tools/lib/lib.sh
 
 function docker_tag_exists() {
+  # Added check for images pushed to github container registry
+  if [[ $1 == ghcr* ]]
+  then
+    TOKEN_URL=https://ghcr.io/token\?scope\="repository:$1:pull"
+    token=$(curl $TOKEN_URL | jq -r '.token')
+    URL=https://ghcr.io/v2/$1/manifests/$2
+    printf "\tURL: %s\n" "$URL"
+    curl --silent -H "Authorization: Bearer $token" -f -lSL "$URL" > /dev/null
+  else
     URL=https://hub.docker.com/v2/repositories/"$1"/tags/"$2"
     printf "\tURL: %s\n" "$URL"
     curl --silent -f -lSL "$URL" > /dev/null
+  fi
 }
 
 checkPlatformImages() {


### PR DESCRIPTION
## What
Added a new check for github container registry images in check_image_exists workflow