### PR TITLE
🎉 Source e2e-test: integrate with Sentry

### DIFF
--- a/docs/integrations/sources/e2e-test.md
+++ b/docs/integrations/sources/e2e-test.md
@@ -62,7 +62,7 @@ The OSS and Cloud variants have the same version number. The Cloud variant was i
 
 | Version | Date | Pull request | Notes |
 | --- | --- | --- | --- |
-| 1.0.1 (unpublished) | 2021-01-29 | [\#9745](https://github.com/airbytehq/airbyte/pull/9745) | Integrate with Sentry. |
+| 1.0.1 | 2021-01-29 | [\#9745](https://github.com/airbytehq/airbyte/pull/9745) | Integrate with Sentry. |
 | 1.0.0 | 2021-01-23 | [\#9720](https://github.com/airbytehq/airbyte/pull/9720) | Add new continuous feed mode that supports arbitrary catalog specification. Initial release to cloud. |
 | 0.1.1 | 2021-12-16 | [\#8217](https://github.com/airbytehq/airbyte/pull/8217) | Fix sleep time in infinite feed mode. |
 | 0.1.0 | 2021-07-23 | [\#3290](https://github.com/airbytehq/airbyte/pull/3290) [\#4939](https://github.com/airbytehq/airbyte/pull/4939) | Initial release. |


### PR DESCRIPTION
## What
- Integrate Sentry to source e2e test.
- Publish version `1.0.1` before the legacy modes are deprecated.
- This version won't be included in the seed, because version `2.0.0` will be released soon.
  - https://github.com/airbytehq/airbyte/pull/9954