### PR TITLE
Pass user information to fullstory

### DIFF
--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -148,7 +148,7 @@ const MainViewRoutes = () => {
 export const Routing: React.FC = () => {
   const { user, inited, emailVerified } = useAuthService();
   const config = useConfig();
-  useFullStory(config.fullstory, config.fullstory.enabled);
+  useFullStory(config.fullstory, config.fullstory.enabled, user);
 
   const analyticsContext = useMemo(
     () =>

--- a/airbyte-webapp/src/packages/cloud/services/thirdParty/fullstory/useFullStory.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/thirdParty/fullstory/useFullStory.tsx
@@ -1,6 +1,7 @@
-import type { User } from "packages/cloud/lib/domain/users";
 import { useEffect } from "react";
 import * as FullStory from "@fullstory/browser";
+
+import type { User } from "packages/cloud/lib/domain/users";
 
 let inited = false;
 

--- a/airbyte-webapp/src/packages/cloud/services/thirdParty/fullstory/useFullStory.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/thirdParty/fullstory/useFullStory.tsx
@@ -1,3 +1,4 @@
+import type { User } from "packages/cloud/lib/domain/users";
 import { useEffect } from "react";
 import * as FullStory from "@fullstory/browser";
 
@@ -5,7 +6,8 @@ let inited = false;
 
 const useFullStory = (
   config: FullStory.SnippetOptions,
-  enabled: boolean
+  enabled: boolean,
+  user: User | null
 ): boolean => {
   useEffect(() => {
     if (!inited && enabled) {
@@ -17,6 +19,23 @@ const useFullStory = (
       }
     }
   }, [config]);
+
+  useEffect(() => {
+    if (enabled) {
+      if (user) {
+        // We have a user, so identify that user information against fullstory
+        FullStory.identify(user.userId, {
+          email: user.email,
+          displayName: user.name,
+          intercomHash: user.intercomHash,
+          status: user.status,
+        });
+      } else {
+        // If there is no user or the user logs out, we anonymize that fullstory session again.
+        FullStory.anonymize();
+      }
+    }
+  }, [user]);
 
   return inited;
 };


### PR DESCRIPTION
## What

Fixes #9747 

Pass `user` information of the authenticated user to FullStory's `identify` method, to be able to filter for user in fullstory.

Strictly spoken since we pass through that method once before we have the information from the auth service, even when logged in, we call `anonymize` once also for logged in users. I validated how this looks in fullstory, and this is not causing any troubles.
