### PR TITLE
Add tombstone field to actor_definitions table

### DIFF
--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -80,7 +80,7 @@ public class BootloaderAppTest {
         mockedConfigs.getConfigDatabaseUrl())
             .getAndInitialize();
     val configsMigrator = new ConfigsDatabaseMigrator(configDatabase, this.getClass().getName());
-    assertEquals("0.35.3.001", configsMigrator.getLatestMigration().getVersion().getVersion());
+    assertEquals("0.35.14.001", configsMigrator.getLatestMigration().getVersion().getVersion());
 
     val jobsPersistence = new DefaultJobPersistence(jobDatabase);
     assertEquals(version, jobsPersistence.getVersion().get());

--- a/airbyte-config/init/src/main/java/io/airbyte/config/init/YamlSeedConfigPersistence.java
+++ b/airbyte-config/init/src/main/java/io/airbyte/config/init/YamlSeedConfigPersistence.java
@@ -5,6 +5,7 @@
 package io.airbyte.config.init;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
@@ -54,12 +55,18 @@ public class YamlSeedConfigPersistence implements ConfigPersistence {
     final Map<String, JsonNode> sourceDefinitionConfigs = getConfigs(seedResourceClass, SeedType.STANDARD_SOURCE_DEFINITION);
     final Map<String, JsonNode> sourceSpecConfigs = getConfigs(seedResourceClass, SeedType.SOURCE_SPEC);
     final Map<String, JsonNode> fullSourceDefinitionConfigs = sourceDefinitionConfigs.entrySet().stream()
-        .collect(Collectors.toMap(Entry::getKey, e -> mergeSpecIntoDefinition(e.getValue(), sourceSpecConfigs)));
+        .collect(Collectors.toMap(Entry::getKey, e -> {
+          final JsonNode withTombstone = addMissingTombstoneField(e.getValue());
+          return mergeSpecIntoDefinition(withTombstone, sourceSpecConfigs);
+        }));
 
     final Map<String, JsonNode> destinationDefinitionConfigs = getConfigs(seedResourceClass, SeedType.STANDARD_DESTINATION_DEFINITION);
     final Map<String, JsonNode> destinationSpecConfigs = getConfigs(seedResourceClass, SeedType.DESTINATION_SPEC);
     final Map<String, JsonNode> fullDestinationDefinitionConfigs = destinationDefinitionConfigs.entrySet().stream()
-        .collect(Collectors.toMap(Entry::getKey, e -> mergeSpecIntoDefinition(e.getValue(), destinationSpecConfigs)));
+        .collect(Collectors.toMap(Entry::getKey, e -> {
+          final JsonNode withTombstone = addMissingTombstoneField(e.getValue());
+          return mergeSpecIntoDefinition(withTombstone, destinationSpecConfigs);
+        }));
 
     this.allSeedConfigs = ImmutableMap.<SeedType, Map<String, JsonNode>>builder()
         .put(SeedType.STANDARD_SOURCE_DEFINITION, fullSourceDefinitionConfigs)
@@ -86,7 +93,16 @@ public class YamlSeedConfigPersistence implements ConfigPersistence {
     return definitionJson;
   }
 
+  private JsonNode addMissingTombstoneField(final JsonNode definitionJson) {
+    final JsonNode currTombstone = definitionJson.get("tombstone");
+    if (currTombstone == null || currTombstone.isNull()) {
+      ((ObjectNode) definitionJson).set("tombstone", BooleanNode.FALSE);
+    }
+    return definitionJson;
+  }
+
   @SuppressWarnings("UnstableApiUsage")
+
   private static Map<String, JsonNode> getConfigs(final Class<?> seedDefinitionsResourceClass, final SeedType seedType) throws IOException {
     final URL url = Resources.getResource(seedDefinitionsResourceClass, seedType.getResourcePath());
     final String yamlString = Resources.toString(url, StandardCharsets.UTF_8);

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -365,7 +365,8 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
         .withName(record.get(ACTOR_DEFINITION.NAME))
         .withSourceType(record.get(ACTOR_DEFINITION.SOURCE_TYPE) == null ? null
             : Enums.toEnum(record.get(ACTOR_DEFINITION.SOURCE_TYPE, String.class), SourceType.class).orElseThrow())
-        .withSpec(Jsons.deserialize(record.get(ACTOR_DEFINITION.SPEC).data(), ConnectorSpecification.class));
+        .withSpec(Jsons.deserialize(record.get(ACTOR_DEFINITION.SPEC).data(), ConnectorSpecification.class))
+        .withTombstone(record.get(ACTOR_DEFINITION.TOMBSTONE));
   }
 
   private List<ConfigWithMetadata<StandardDestinationDefinition>> listStandardDestinationDefinitionWithMetadata() throws IOException {
@@ -404,7 +405,8 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
         .withDockerRepository(record.get(ACTOR_DEFINITION.DOCKER_REPOSITORY))
         .withDocumentationUrl(record.get(ACTOR_DEFINITION.DOCUMENTATION_URL))
         .withName(record.get(ACTOR_DEFINITION.NAME))
-        .withSpec(Jsons.deserialize(record.get(ACTOR_DEFINITION.SPEC).data(), ConnectorSpecification.class));
+        .withSpec(Jsons.deserialize(record.get(ACTOR_DEFINITION.SPEC).data(), ConnectorSpecification.class))
+        .withTombstone(record.get(ACTOR_DEFINITION.TOMBSTONE));
   }
 
   private List<ConfigWithMetadata<SourceConnection>> listSourceConnectionWithMetadata() throws IOException {
@@ -773,6 +775,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                     : Enums.toEnum(standardSourceDefinition.getSourceType().value(),
                         io.airbyte.db.instance.configs.jooq.enums.SourceType.class).orElseThrow())
             .set(ACTOR_DEFINITION.SPEC, JSONB.valueOf(Jsons.serialize(standardSourceDefinition.getSpec())))
+            .set(ACTOR_DEFINITION.TOMBSTONE, standardSourceDefinition.getTombstone())
             .set(ACTOR_DEFINITION.UPDATED_AT, timestamp)
             .where(ACTOR_DEFINITION.ID.eq(standardSourceDefinition.getSourceDefinitionId()))
             .execute();
@@ -791,6 +794,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                     : Enums.toEnum(standardSourceDefinition.getSourceType().value(),
                         io.airbyte.db.instance.configs.jooq.enums.SourceType.class).orElseThrow())
             .set(ACTOR_DEFINITION.SPEC, JSONB.valueOf(Jsons.serialize(standardSourceDefinition.getSpec())))
+            .set(ACTOR_DEFINITION.TOMBSTONE, standardSourceDefinition.getTombstone() != null && standardSourceDefinition.getTombstone())
             .set(ACTOR_DEFINITION.CREATED_AT, timestamp)
             .set(ACTOR_DEFINITION.UPDATED_AT, timestamp)
             .execute();
@@ -822,6 +826,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
             .set(ACTOR_DEFINITION.ICON, standardDestinationDefinition.getIcon())
             .set(ACTOR_DEFINITION.ACTOR_TYPE, ActorType.destination)
             .set(ACTOR_DEFINITION.SPEC, JSONB.valueOf(Jsons.serialize(standardDestinationDefinition.getSpec())))
+            .set(ACTOR_DEFINITION.TOMBSTONE, standardDestinationDefinition.getTombstone())
             .set(ACTOR_DEFINITION.UPDATED_AT, timestamp)
             .where(ACTOR_DEFINITION.ID.eq(standardDestinationDefinition.getDestinationDefinitionId()))
             .execute();
@@ -836,6 +841,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
             .set(ACTOR_DEFINITION.ICON, standardDestinationDefinition.getIcon())
             .set(ACTOR_DEFINITION.ACTOR_TYPE, ActorType.destination)
             .set(ACTOR_DEFINITION.SPEC, JSONB.valueOf(Jsons.serialize(standardDestinationDefinition.getSpec())))
+            .set(ACTOR_DEFINITION.TOMBSTONE, standardDestinationDefinition.getTombstone() != null && standardDestinationDefinition.getTombstone())
             .set(ACTOR_DEFINITION.CREATED_AT, timestamp)
             .set(ACTOR_DEFINITION.UPDATED_AT, timestamp)
             .execute();

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
@@ -60,7 +60,8 @@ public abstract class BaseDatabaseConfigPersistenceTest {
       .withDockerImageTag("0.2.3")
       .withDocumentationUrl("https://docs.airbyte.io/integrations/sources/github")
       .withIcon("github.svg")
-      .withSourceType(SourceType.API);
+      .withSourceType(SourceType.API)
+      .withTombstone(false);
   protected static final StandardSourceDefinition SOURCE_POSTGRES = new StandardSourceDefinition()
       .withName("Postgres")
       .withSourceDefinitionId(UUID.fromString("decd338e-5647-4c0b-adf4-da0e75f5a750"))
@@ -68,19 +69,22 @@ public abstract class BaseDatabaseConfigPersistenceTest {
       .withDockerImageTag("0.3.11")
       .withDocumentationUrl("https://docs.airbyte.io/integrations/sources/postgres")
       .withIcon("postgresql.svg")
-      .withSourceType(SourceType.DATABASE);
+      .withSourceType(SourceType.DATABASE)
+      .withTombstone(false);
   protected static final StandardDestinationDefinition DESTINATION_SNOWFLAKE = new StandardDestinationDefinition()
       .withName("Snowflake")
       .withDestinationDefinitionId(UUID.fromString("424892c4-daac-4491-b35d-c6688ba547ba"))
       .withDockerRepository("airbyte/destination-snowflake")
       .withDockerImageTag("0.3.16")
-      .withDocumentationUrl("https://docs.airbyte.io/integrations/destinations/snowflake");
+      .withDocumentationUrl("https://docs.airbyte.io/integrations/destinations/snowflake")
+      .withTombstone(false);
   protected static final StandardDestinationDefinition DESTINATION_S3 = new StandardDestinationDefinition()
       .withName("S3")
       .withDestinationDefinitionId(UUID.fromString("4816b78f-1489-44c1-9060-4b19d5fa9362"))
       .withDockerRepository("airbyte/destination-s3")
       .withDockerImageTag("0.1.12")
-      .withDocumentationUrl("https://docs.airbyte.io/integrations/destinations/s3");
+      .withDocumentationUrl("https://docs.airbyte.io/integrations/destinations/s3")
+      .withTombstone(false);
 
   protected static void writeSource(final ConfigPersistence configPersistence, final StandardSourceDefinition source) throws Exception {
     configPersistence.writeConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, source.getSourceDefinitionId().toString(), source);

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
@@ -202,7 +202,8 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
         .withSourceDefinitionId(definitionId)
         .withDockerRepository(connectorRepository)
         .withDockerImageTag("0.1.2")
-        .withName("random-name");
+        .withName("random-name")
+        .withTombstone(false);
     writeSource(configPersistence, source1);
     // write an irrelevant source to make sure that it is not changed
     writeSource(configPersistence, SOURCE_GITHUB);
@@ -214,7 +215,8 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
         .withSourceDefinitionId(definitionId)
         .withDockerRepository(connectorRepository)
         .withDockerImageTag("0.1.5")
-        .withName("random-name-2");
+        .withName("random-name-2")
+        .withTombstone(false);
     writeSource(configPersistence, source2);
     assertRecordCount(2, ACTOR_DEFINITION);
     assertHasSource(source2);

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/MockData.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/MockData.java
@@ -103,7 +103,8 @@ public class MockData {
         .withDockerRepository("repository-1")
         .withDocumentationUrl("documentation-url-1")
         .withIcon("icon-1")
-        .withSpec(connectorSpecification);
+        .withSpec(connectorSpecification)
+        .withTombstone(false);
     final StandardSourceDefinition standardSourceDefinition2 = new StandardSourceDefinition()
         .withSourceDefinitionId(SOURCE_DEFINITION_ID_2)
         .withSourceType(SourceType.DATABASE)
@@ -111,7 +112,8 @@ public class MockData {
         .withDockerImageTag("tag-2")
         .withDockerRepository("repository-2")
         .withDocumentationUrl("documentation-url-2")
-        .withIcon("icon-2");
+        .withIcon("icon-2")
+        .withTombstone(false);
     return Arrays.asList(standardSourceDefinition1, standardSourceDefinition2);
   }
 
@@ -137,7 +139,8 @@ public class MockData {
         .withDockerRepository("repository-3")
         .withDocumentationUrl("documentation-url-3")
         .withIcon("icon-3")
-        .withSpec(connectorSpecification);
+        .withSpec(connectorSpecification)
+        .withTombstone(false);
     final StandardDestinationDefinition standardDestinationDefinition2 = new StandardDestinationDefinition()
         .withDestinationDefinitionId(DESTINATION_DEFINITION_ID_2)
         .withName("random-destination-2")
@@ -145,7 +148,8 @@ public class MockData {
         .withDockerRepository("repository-4")
         .withDocumentationUrl("documentation-url-4")
         .withIcon("icon-4")
-        .withSpec(connectorSpecification);
+        .withSpec(connectorSpecification)
+        .withTombstone(false);
     return Arrays.asList(standardDestinationDefinition1, standardDestinationDefinition2);
   }
 

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinition.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinition.java
@@ -1,0 +1,29 @@
+package io.airbyte.db.instance.configs.migrations;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class V0_35_14_001__AddTombstoneToActorDefinition extends BaseJavaMigration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(V0_35_14_001__AddTombstoneToActorDefinition.class);
+
+  @Override
+  public void migrate(final Context context) throws Exception {
+    LOGGER.info("Running migration: {}", this.getClass().getSimpleName());
+
+    final DSLContext ctx = DSL.using(context.getConnection());
+    addTombstoneColumn(ctx);
+  }
+
+  public static void addTombstoneColumn(final DSLContext ctx) {
+    ctx.alterTable("actor_definition")
+        .addColumnIfNotExists(DSL.field("tombstone", SQLDataType.BOOLEAN.nullable(false).defaultValue(false)))
+        .execute();
+  }
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinition.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinition.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.db.instance.configs.migrations;
 
 import org.flywaydb.core.api.migration.BaseJavaMigration;

--- a/airbyte-db/lib/src/main/resources/configs_database/normalized_tables_schema.txt
+++ b/airbyte-db/lib/src/main/resources/configs_database/normalized_tables_schema.txt
@@ -77,6 +77,7 @@ Referenced by:
  spec              | jsonb                    |           | not null |
  created_at        | timestamp with time zone |           | not null | CURRENT_TIMESTAMP
  updated_at        | timestamp with time zone |           | not null | CURRENT_TIMESTAMP
+ tombstone         | boolean                  |           | not null | false
 Indexes:
     "actor_definition_pkey" PRIMARY KEY, btree (id)
 Referenced by:

--- a/airbyte-db/lib/src/main/resources/configs_database/schema_dump.txt
+++ b/airbyte-db/lib/src/main/resources/configs_database/schema_dump.txt
@@ -27,6 +27,7 @@ create table "public"."actor_definition"(
   "spec" jsonb not null,
   "created_at" timestamptz(35) not null default null,
   "updated_at" timestamptz(35) not null default null,
+  "tombstone" bool not null default false,
   constraint "actor_definition_pkey"
     primary key ("id")
 );

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinitionTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinitionTest.java
@@ -6,9 +6,14 @@ package io.airbyte.db.instance.configs.migrations;
 
 import io.airbyte.db.Database;
 import io.airbyte.db.instance.configs.AbstractConfigsDatabaseTest;
+import io.airbyte.db.instance.configs.migrations.V0_32_8_001__AirbyteConfigDatabaseDenormalization.ActorType;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.UUID;
 import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.jooq.Record;
+import org.jooq.Result;
 import org.jooq.impl.DSL;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -24,9 +29,30 @@ public class V0_35_14_001__AddTombstoneToActorDefinitionTest extends AbstractCon
     // necessary to add actor_definition table
     V0_32_8_001__AirbyteConfigDatabaseDenormalization.migrate(context);
 
+    final UUID id = UUID.randomUUID();
+    context.insertInto(DSL.table("actor_definition"))
+        .columns(
+            DSL.field("id"),
+            DSL.field("name"),
+            DSL.field("docker_repository"),
+            DSL.field("docker_image_tag"),
+            DSL.field("actor_type"),
+            DSL.field("spec"))
+        .values(
+            id,
+            "name",
+            "repo",
+            "1.0.0",
+            ActorType.source,
+            JSONB.valueOf("{}")
+        ).execute();
+
     Assertions.assertFalse(tombstoneColumnExists(context));
+
     V0_35_14_001__AddTombstoneToActorDefinition.addTombstoneColumn(context);
+
     Assertions.assertTrue(tombstoneColumnExists(context));
+    Assertions.assertTrue(tombstoneDefaultsToFalse(context, id));
   }
 
   protected static boolean tombstoneColumnExists(final DSLContext ctx) {
@@ -34,6 +60,14 @@ public class V0_35_14_001__AddTombstoneToActorDefinitionTest extends AbstractCon
         .from("information_schema.columns")
         .where(DSL.field("table_name").eq("actor_definition")
             .and(DSL.field("column_name").eq("tombstone"))));
+  }
+
+  protected static boolean tombstoneDefaultsToFalse(final DSLContext ctx, final UUID id) {
+    final Record record = ctx.fetchOne(DSL.select()
+        .from("actor_definition")
+        .where(DSL.field("id").eq(id)));
+
+    return record.get("tombstone").equals(false);
   }
 
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinitionTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinitionTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.db.instance.configs.migrations;
 
 import io.airbyte.db.Database;
@@ -10,6 +14,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class V0_35_14_001__AddTombstoneToActorDefinitionTest extends AbstractConfigsDatabaseTest {
+
   @Test
   public void test() throws SQLException, IOException {
 
@@ -30,4 +35,5 @@ public class V0_35_14_001__AddTombstoneToActorDefinitionTest extends AbstractCon
         .where(DSL.field("table_name").eq("actor_definition")
             .and(DSL.field("column_name").eq("tombstone"))));
   }
+
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinitionTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinitionTest.java
@@ -13,7 +13,6 @@ import java.util.UUID;
 import org.jooq.DSLContext;
 import org.jooq.JSONB;
 import org.jooq.Record;
-import org.jooq.Result;
 import org.jooq.impl.DSL;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -44,8 +43,8 @@ public class V0_35_14_001__AddTombstoneToActorDefinitionTest extends AbstractCon
             "repo",
             "1.0.0",
             ActorType.source,
-            JSONB.valueOf("{}")
-        ).execute();
+            JSONB.valueOf("{}"))
+        .execute();
 
     Assertions.assertFalse(tombstoneColumnExists(context));
 

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinitionTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinitionTest.java
@@ -1,0 +1,33 @@
+package io.airbyte.db.instance.configs.migrations;
+
+import io.airbyte.db.Database;
+import io.airbyte.db.instance.configs.AbstractConfigsDatabaseTest;
+import java.io.IOException;
+import java.sql.SQLException;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class V0_35_14_001__AddTombstoneToActorDefinitionTest extends AbstractConfigsDatabaseTest {
+  @Test
+  public void test() throws SQLException, IOException {
+
+    final Database database = getDatabase();
+    final DSLContext context = DSL.using(database.getDataSource().getConnection());
+
+    // necessary to add actor_definition table
+    V0_32_8_001__AirbyteConfigDatabaseDenormalization.migrate(context);
+
+    Assertions.assertFalse(tombstoneColumnExists(context));
+    V0_35_14_001__AddTombstoneToActorDefinition.addTombstoneColumn(context);
+    Assertions.assertTrue(tombstoneColumnExists(context));
+  }
+
+  protected static boolean tombstoneColumnExists(final DSLContext ctx) {
+    return ctx.fetchExists(DSL.select()
+        .from("information_schema.columns")
+        .where(DSL.field("table_name").eq("actor_definition")
+            .and(DSL.field("column_name").eq("tombstone"))));
+  }
+}

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -163,7 +163,8 @@ public class ArchiveHandlerTest {
         sourceS3DefinitionId.toString(),
         StandardSourceDefinition.class)
         // This source definition is on an old version
-        .withDockerImageTag(sourceS3DefinitionVersion);
+        .withDockerImageTag(sourceS3DefinitionVersion)
+        .withTombstone(false);
     final Notification notification = new Notification()
         .withNotificationType(NotificationType.SLACK)
         .withSendOnFailure(true)
@@ -277,7 +278,8 @@ public class ArchiveHandlerTest {
         .withDockerRepository("repository-1")
         .withDocumentationUrl("documentation-url-1")
         .withIcon("icon-1")
-        .withSpec(new ConnectorSpecification());
+        .withSpec(new ConnectorSpecification())
+        .withTombstone(false);
 
     final SourceConnection sourceConnection = new SourceConnection()
         .withWorkspaceId(secondWorkspaceId)


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/issues/9912 was opened because connector definition deletions via API were not persisting. I added the ability to delete connector definitions while the database denormalization project was ongoing, and the new 'tombstone' field did not make it into the actor_definitions table.

This PR adds a migration to add the tombstone column, and updates configPersistence to write handle the new column.

## How
- Migration adds 'tombstone' boolean column to actor_definition table
- Modified YamlSeedConfigPersistence to set the tombstone column when loading
  - Without this, ArchiveHandler tests fail because yaml persistence and db persistence exports are directly compared
- Added a bunch of .withTombstone(false) to tests in order to get them passing

## 🚨 User Impact 🚨
This should fix connector definition deletions