### PR TITLE
Source Google Ads: upgrade google-ads package version

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -245,7 +245,7 @@
 - name: Google Ads
   sourceDefinitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
   dockerRepository: airbyte/source-google-ads
-  dockerImageTag: 0.1.23
+  dockerImageTag: 0.1.24
   documentationUrl: https://docs.airbyte.io/integrations/sources/google-ads
   icon: google-adwords.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -2308,7 +2308,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-google-ads:0.1.23"
+- dockerImage: "airbyte/source-google-ads:0.1.24"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/google-ads"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-google-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-ads/Dockerfile
@@ -13,5 +13,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.23
+LABEL io.airbyte.version=0.1.24
 LABEL io.airbyte.name=airbyte/source-google-ads

--- a/airbyte-integrations/connectors/source-google-ads/setup.py
+++ b/airbyte-integrations/connectors/source-google-ads/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk~=0.1", "google-ads==13.0.0", "pendulum"]
+MAIN_REQUIREMENTS = ["airbyte-cdk~=0.1", "google-ads==14.1.0", "pendulum"]
 
 TEST_REQUIREMENTS = ["pytest~=6.1", "pytest-mock"]
 

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/ad_group_ads.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/ad_group_ads.json
@@ -479,9 +479,6 @@
         "type": "string"
       }
     },
-    "ad_group_ad.ad.video_ad.bumper.companion_banner": {
-      "type": ["null", "string"]
-    },
     "ad_group_ad.ad.video_ad.discovery.description1": {
       "type": ["null", "string"]
     },
@@ -495,15 +492,6 @@
       "type": ["null", "string"]
     },
     "ad_group_ad.ad.video_ad.in_stream.action_headline": {
-      "type": ["null", "string"]
-    },
-    "ad_group_ad.ad.video_ad.in_stream.companion_banner": {
-      "type": ["null", "string"]
-    },
-    "ad_group_ad.ad.video_ad.media_file": {
-      "type": ["null", "string"]
-    },
-    "ad_group_ad.ad.video_ad.non_skippable.companion_banner": {
       "type": ["null", "string"]
     },
     "ad_group_ad.ad.video_ad.out_stream.description": {

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -35,6 +35,7 @@ class SourceGoogleAds(AbstractSource):
     @staticmethod
     def get_credentials(config: Mapping[str, Any]) -> Mapping[str, Any]:
         credentials = config["credentials"]
+        credentials.update(use_proto_plus=True)
 
         # https://developers.google.com/google-ads/api/docs/concepts/call-structure#cid
         if "login_customer_id" in config and config["login_customer_id"].strip():

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -35,6 +35,8 @@ class SourceGoogleAds(AbstractSource):
     @staticmethod
     def get_credentials(config: Mapping[str, Any]) -> Mapping[str, Any]:
         credentials = config["credentials"]
+        # use_proto_plus is set to True, because setting to False returned wrong value types, which breakes the backward compatibility.
+        # For more info read the related PR's description: https://github.com/airbytehq/airbyte/pull/9996
         credentials.update(use_proto_plus=True)
 
         # https://developers.google.com/google-ads/api/docs/concepts/call-structure#cid

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -102,6 +102,7 @@ This source is constrained by whatever API limits are set for the Google Ads tha
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| `0.1.24` | 2022-02-04 | [9996](https://github.com/airbytehq/airbyte/pull/9996) | Use Google Ads API version V9. |
 | `0.1.23` | 2022-01-25 | [8669](https://github.com/airbytehq/airbyte/pull/8669) | Add end date parameter in spec. |
 | `0.1.22` | 2022-01-24 | [9608](https://github.com/airbytehq/airbyte/pull/9608) | Reduce stream slice date range. |
 | `0.1.21` | 2021-12-28 | [9149](https://github.com/airbytehq/airbyte/pull/9149) | Update title and description |


### PR DESCRIPTION
## What
Resolves #9313 
As of today, data about Performance Max campaigns in Google Ads Source connector are not pulled properly.
Manage this campaign type correctly like the others and upgrade API to **Google Ads API V9** (that has this new support)
Looks like the data is pulled with a campaign type = Unknown according to that slack discussion
https://airbytehq.slack.com/archives/C021JANJ6TY/p1641385198058300

## How
Campaign type **Performance Max** was added in **Google Ads API version V9**. To support this type in the connector we need to upgrade **google-ads** python package to the latest version [14.1.0](https://github.com/googleads/google-ads-python/blob/main/ChangeLog)

## Recommended reading order
1. `source-google-ads/setup.py`
2. `source_google_ads/schemas/ad_group_ads.json`
3. `source_google_ads/source.py`

### Additional notes

- **New required parameter**

In the package version **14.0.0** new required field `use_proto_plus` was added to `GoogleAdsClient` class. Its possible values are True or False, which specifies whether you want the library to return proto-plus messages or protobuf messages. 
For more [info](https://developers.google.com/google-ads/api/docs/client-libs/python/protobuf-messages).
In this PR `use_proto_plus` field's value is set to True, because setting to False returned wrong value types, which breakes the backward compatibility.

As an example some fields in stream `ad_group_ad_report`. Type of the field `segments.ad_network_type` is defined as `["null", "string"]` in the [schema](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/ad_group_ad_report.json#L47).

When `use_proto_plus` = True
```
"segments.ad_network_type": "SEARCH_PARTNERS",
"ad_group_ad.ad_strength": "POOR",
```

When `use_proto_plus` = False
```
"segments.ad_network_type": 3,
"ad_group_ad.ad_strength": 4,
```


- **Some fields are unavailable**

The following fields are unavailable in the new version of API (V9) for stream `ad_group_ad`
```
   ad_group_ad.ad.video_ad.in_stream.action_headline, 
   ad_group_ad.ad.video_ad.bumper.companion_banner, 
   ad_group_ad.ad.video_ad.in_stream.companion_banner, 
   ad_group_ad.ad.video_ad.media_file,
   ad_group_ad.ad.video_ad.non_skippable.companion_banner
```

![image](https://user-images.githubusercontent.com/93112548/152151549-c27df0c8-04ae-430b-8e21-88c00f6899fe.png)
