### PR TITLE
fix 'cannot reach server' error on demo instance

### DIFF
--- a/terraform/aws/demo/lb/main.tf
+++ b/terraform/aws/demo/lb/main.tf
@@ -123,7 +123,7 @@ resource "aws_lb_listener_rule" "allow-read-api" {
         "/api/v1/*/list_latest",
         "/api/v1/*/get",
         "/api/v1/*/get_by_slug",
-        "/api/v1/*/health",
+        "/api/v1/health",
       ]
     }
   }


### PR DESCRIPTION
The health endpoint is returning a 401, so we see a "Cannot reach server" message after the health check fails a few times. I believe this is because we never specified the correct health endpoint in the firewall rules for the demo. In a more recent version, we added the ability to show when we aren't reaching the server, which is now always visible on the demo after a period of time.