### PR TITLE
Add AttemptFailureSummary to API response

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -3267,7 +3267,7 @@ components:
         - unknown
         - source
         - destination
-        - replication_worker
+        - replication
         - persistence
         - normalization
         - dbt
@@ -3276,9 +3276,8 @@ components:
       type: string
       enum:
         - unknown
-        - user_error
+        - config_error
         - system_error
-        - transient
     AttemptStatus:
       type: string
       enum:

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -3204,6 +3204,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AttemptStreamStats"
+        failureSummary:
+          $ref: "#/components/schemas/AttemptFailureSummary"
     AttemptStats:
       type: object
       properties:
@@ -3229,6 +3231,58 @@ components:
           type: string
         stats:
           $ref: "#/components/schemas/AttemptStats"
+    AttemptFailureSummary:
+      type: object
+      required:
+        - failures
+      properties:
+        failures:
+          type: array
+          items:
+            $ref: "#/components/schemas/AttemptFailureReason"
+        partialSuccess:
+          description: True if the number of committed records for this attempt was greater than 0. False if 0 records were committed. Blank if number of committed records is unknown.
+          type: boolean
+    AttemptFailureReason:
+      type: object
+      required:
+        - failureOrigin
+        - timestamp
+      properties:
+        failureOrigin:
+          $ref: "#/components/schemas/AttemptFailureOrigin"
+        failureType:
+          $ref: "#/components/schemas/AttemptFailureType"
+        externalMessage:
+          type: string
+        stacktrace:
+          type: string
+        timestamp:
+          type: integer
+          format: int64
+    AttemptFailureOrigin:
+      description: Indicates where the error originated. If not set, the origin of error is not well known.
+      type: string
+      enum:
+        - unknown
+        - source
+        - destination
+        - replicationWorker
+        - persistence
+        - normalization
+        - dbt
+    AttemptFailureType:
+      description: Categorizes well known errors into types for programmatic handling. If not set, the type of error is not well known.
+      type: string
+      enum:
+        - unknown
+        - source
+        - destination
+        - replicationWorker
+        - persistence
+        - normalization
+        - dbt
+
     AttemptStatus:
       type: string
       enum:

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -3241,12 +3241,11 @@ components:
           items:
             $ref: "#/components/schemas/AttemptFailureReason"
         partialSuccess:
-          description: True if the number of committed records for this attempt was greater than 0. False if 0 records were committed. Blank if number of committed records is unknown.
+          description: True if the number of committed records for this attempt was greater than 0. False if 0 records were committed. If not set, the number of committed records is unknown.
           type: boolean
     AttemptFailureReason:
       type: object
       required:
-        - failureOrigin
         - timestamp
       properties:
         failureOrigin:
@@ -3257,6 +3256,9 @@ components:
           type: string
         stacktrace:
           type: string
+        retryable:
+          description: True if it is known that retrying may succeed, e.g. for a transient failure. False if it is known that a retry will not succeed, e.g. for a configuration issue. If not set, retryable status is not well known.
+          type: boolean
         timestamp:
           type: integer
           format: int64
@@ -3264,7 +3266,6 @@ components:
       description: Indicates where the error originated. If not set, the origin of error is not well known.
       type: string
       enum:
-        - unknown
         - source
         - destination
         - replication
@@ -3275,9 +3276,9 @@ components:
       description: Categorizes well known errors into types for programmatic handling. If not set, the type of error is not well known.
       type: string
       enum:
-        - unknown
         - config_error
         - system_error
+        - manual_cancellation
     AttemptStatus:
       type: string
       enum:

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -3267,7 +3267,7 @@ components:
         - unknown
         - source
         - destination
-        - replicationWorker
+        - replication_worker
         - persistence
         - normalization
         - dbt
@@ -3276,13 +3276,9 @@ components:
       type: string
       enum:
         - unknown
-        - source
-        - destination
-        - replicationWorker
-        - persistence
-        - normalization
-        - dbt
-
+        - user_error
+        - system_error
+        - transient
     AttemptStatus:
       type: string
       enum:

--- a/airbyte-config/models/src/main/resources/types/AttemptFailureSummary.yaml
+++ b/airbyte-config/models/src/main/resources/types/AttemptFailureSummary.yaml
@@ -14,5 +14,5 @@ properties:
     items:
       "$ref": FailureReason.yaml
   partialSuccess:
-    description: True if the number of committed records for this attempt was greater than 0. False if 0 records were committed.
+    description: True if the number of committed records for this attempt was greater than 0. False if 0 records were committed. Blank if number of committed records is unknown.
     type: boolean

--- a/airbyte-config/models/src/main/resources/types/FailureReason.yaml
+++ b/airbyte-config/models/src/main/resources/types/FailureReason.yaml
@@ -4,7 +4,6 @@
 title: FailureSummary
 type: object
 required:
-  - failureOrigin
   - timestamp
 additionalProperties: false
 properties:
@@ -12,7 +11,6 @@ properties:
     description: Indicates where the error originated. If not set, the origin of error is not well known.
     type: string
     enum:
-      - unknown
       - source
       - destination
       - replication
@@ -23,9 +21,9 @@ properties:
     description: Categorizes well known errors into types for programmatic handling. If not set, the type of error is not well known.
     type: string
     enum:
-      - unknown
       - configError
       - systemError
+      - manualCancellation
   internalMessage:
     description: Human readable failure description for consumption by technical system operators, like Airbyte engineers or OSS users.
     type: string
@@ -39,5 +37,8 @@ properties:
   stacktrace:
     description: Raw stacktrace associated with the failure.
     type: string
+  retryable:
+    description: True if it is known that retrying may succeed, e.g. for a transient failure. False if it is known that a retry will not succeed, e.g. for a configuration issue. If not set, retryable status is not well known.
+    type: boolean
   timestamp:
     type: integer

--- a/airbyte-config/models/src/main/resources/types/FailureReason.yaml
+++ b/airbyte-config/models/src/main/resources/types/FailureReason.yaml
@@ -15,7 +15,7 @@ properties:
       - unknown
       - source
       - destination
-      - replicationWorker
+      - replication
       - persistence
       - normalization
       - dbt
@@ -24,9 +24,8 @@ properties:
     type: string
     enum:
       - unknown
-      - userError
+      - configError
       - systemError
-      - transient
   internalMessage:
     description: Human readable failure description for consumption by technical system operators, like Airbyte engineers or OSS users.
     type: string

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
@@ -167,7 +167,8 @@ public class JobConverter {
             .failureType(Enums.convertTo(failure.getFailureType(), AttemptFailureType.class))
             .externalMessage(failure.getExternalMessage())
             .stacktrace(failure.getStacktrace())
-            .timestamp(failure.getTimestamp()))
+            .timestamp(failure.getTimestamp())
+            .retryable(failure.getRetryable()))
             .collect(Collectors.toList()))
         .partialSuccess(failureSummary.getPartialSuccess());
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
@@ -163,11 +163,11 @@ public class JobConverter {
 
     return new AttemptFailureSummary()
         .failures(failureSummary.getFailures().stream().map(failure -> new AttemptFailureReason()
-                .failureOrigin(Enums.convertTo(failure.getFailureOrigin(), AttemptFailureOrigin.class))
-                .failureType(Enums.convertTo(failure.getFailureType(), AttemptFailureType.class))
-                .externalMessage(failure.getExternalMessage())
-                .stacktrace(failure.getStacktrace())
-                .timestamp(failure.getTimestamp()))
+            .failureOrigin(Enums.convertTo(failure.getFailureOrigin(), AttemptFailureOrigin.class))
+            .failureType(Enums.convertTo(failure.getFailureType(), AttemptFailureType.class))
+            .externalMessage(failure.getExternalMessage())
+            .stacktrace(failure.getStacktrace())
+            .timestamp(failure.getTimestamp()))
             .collect(Collectors.toList()))
         .partialSuccess(failureSummary.getPartialSuccess());
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
@@ -47,9 +47,9 @@ public class FailureHelper {
         .withExternalMessage("Something went wrong within the destination connector");
   }
 
-  public static FailureReason replicationWorkerFailure(final Throwable t, final Long jobId, final Integer attemptNumber) {
+  public static FailureReason replicationFailure(final Throwable t, final Long jobId, final Integer attemptNumber) {
     return genericFailure(t, jobId, attemptNumber)
-        .withFailureOrigin(FailureOrigin.REPLICATION_WORKER)
+        .withFailureOrigin(FailureOrigin.REPLICATION)
         .withExternalMessage("Something went wrong during replication");
   }
 
@@ -89,7 +89,7 @@ public class FailureHelper {
                                                                    final Long jobId,
                                                                    final Integer attemptNumber) {
     if (workflowType.equals(WORKFLOW_TYPE_SYNC) && activityType.equals(ACTIVITY_TYPE_REPLICATE)) {
-      return replicationWorkerFailure(t, jobId, attemptNumber);
+      return replicationFailure(t, jobId, attemptNumber);
     } else if (workflowType.equals(WORKFLOW_TYPE_SYNC) && activityType.equals(ACTIVITY_TYPE_PERSIST)) {
       return persistenceFailure(t, jobId, attemptNumber);
     } else if (workflowType.equals(WORKFLOW_TYPE_SYNC) && activityType.equals(ACTIVITY_TYPE_NORMALIZE)) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
@@ -73,7 +73,6 @@ public class FailureHelper {
 
   public static FailureReason unknownOriginFailure(final Throwable t, final Long jobId, final Integer attemptNumber) {
     return genericFailure(t, jobId, attemptNumber)
-        .withFailureOrigin(FailureOrigin.UNKNOWN)
         .withExternalMessage("An unknown failure occurred");
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowTest.java
@@ -665,7 +665,7 @@ public class ConnectionManagerWorkflowTest {
       testEnv.sleep(Duration.ofMinutes(2L));
       workflow.submitManualSync();
 
-      Mockito.verify(mJobCreationAndStatusUpdateActivity).attemptFailure(Mockito.argThat(new HasFailureFromSource(FailureOrigin.REPLICATION_WORKER)));
+      Mockito.verify(mJobCreationAndStatusUpdateActivity).attemptFailure(Mockito.argThat(new HasFailureFromSource(FailureOrigin.REPLICATION)));
 
       testEnv.shutdown();
     }

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -1034,10 +1034,12 @@ font-style: italic;
       },
       "failureSummary" : {
         "failures" : [ {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
         }, {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
@@ -1081,10 +1083,12 @@ font-style: italic;
       },
       "failureSummary" : {
         "failures" : [ {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
         }, {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
@@ -1343,10 +1347,12 @@ font-style: italic;
       },
       "failureSummary" : {
         "failures" : [ {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
         }, {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
@@ -1390,10 +1396,12 @@ font-style: italic;
       },
       "failureSummary" : {
         "failures" : [ {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
         }, {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
@@ -2996,10 +3004,12 @@ font-style: italic;
       },
       "failureSummary" : {
         "failures" : [ {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
         }, {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
@@ -3043,10 +3053,12 @@ font-style: italic;
       },
       "failureSummary" : {
         "failures" : [ {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
         }, {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
@@ -3169,10 +3181,12 @@ font-style: italic;
       },
       "failureSummary" : {
         "failures" : [ {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
         }, {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
@@ -3216,10 +3230,12 @@ font-style: italic;
       },
       "failureSummary" : {
         "failures" : [ {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
         }, {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
@@ -3327,10 +3343,12 @@ font-style: italic;
       },
       "failureSummary" : {
         "failures" : [ {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
         }, {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
@@ -3374,10 +3392,12 @@ font-style: italic;
       },
       "failureSummary" : {
         "failures" : [ {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
         }, {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
@@ -3485,10 +3505,12 @@ font-style: italic;
       },
       "failureSummary" : {
         "failures" : [ {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
         }, {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
@@ -3527,10 +3549,12 @@ font-style: italic;
       },
       "failureSummary" : {
         "failures" : [ {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
         }, {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
@@ -3577,10 +3601,12 @@ font-style: italic;
       },
       "failureSummary" : {
         "failures" : [ {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
         }, {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
@@ -3619,10 +3645,12 @@ font-style: italic;
       },
       "failureSummary" : {
         "failures" : [ {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
         }, {
+          "retryable" : true,
           "stacktrace" : "stacktrace",
           "externalMessage" : "externalMessage",
           "timestamp" : 1
@@ -7891,10 +7919,11 @@ font-style: italic;
     <h3><a name="AttemptFailureReason"><code>AttemptFailureReason</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">failureOrigin </div><div class="param-desc"><span class="param-type"><a href="#AttemptFailureOrigin">AttemptFailureOrigin</a></span>  </div>
+      <div class="param">failureOrigin (optional)</div><div class="param-desc"><span class="param-type"><a href="#AttemptFailureOrigin">AttemptFailureOrigin</a></span>  </div>
 <div class="param">failureType (optional)</div><div class="param-desc"><span class="param-type"><a href="#AttemptFailureType">AttemptFailureType</a></span>  </div>
 <div class="param">externalMessage (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">stacktrace (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">retryable (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> True if it is known that retrying may succeed, e.g. for a transient failure. False if it is known that a retry will not succeed, e.g. for a configuration issue. If not set, retryable status is not well known. </div>
 <div class="param">timestamp </div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
     </div>  <!-- field-items -->
   </div>
@@ -7903,7 +7932,7 @@ font-style: italic;
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">failures </div><div class="param-desc"><span class="param-type"><a href="#AttemptFailureReason">array[AttemptFailureReason]</a></span>  </div>
-<div class="param">partialSuccess (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> True if the number of committed records for this attempt was greater than 0. False if 0 records were committed. Blank if number of committed records is unknown. </div>
+<div class="param">partialSuccess (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> True if the number of committed records for this attempt was greater than 0. False if 0 records were committed. If not set, the number of committed records is unknown. </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -1032,6 +1032,18 @@ font-style: italic;
         "bytesEmitted" : 4,
         "recordsEmitted" : 2
       },
+      "failureSummary" : {
+        "failures" : [ {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        }, {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        } ],
+        "partialSuccess" : true
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
@@ -1066,6 +1078,18 @@ font-style: italic;
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
         "recordsEmitted" : 2
+      },
+      "failureSummary" : {
+        "failures" : [ {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        }, {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        } ],
+        "partialSuccess" : true
       },
       "createdAt" : 5,
       "bytesSynced" : 9,
@@ -1317,6 +1341,18 @@ font-style: italic;
         "bytesEmitted" : 4,
         "recordsEmitted" : 2
       },
+      "failureSummary" : {
+        "failures" : [ {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        }, {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        } ],
+        "partialSuccess" : true
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
@@ -1351,6 +1387,18 @@ font-style: italic;
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
         "recordsEmitted" : 2
+      },
+      "failureSummary" : {
+        "failures" : [ {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        }, {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        } ],
+        "partialSuccess" : true
       },
       "createdAt" : 5,
       "bytesSynced" : 9,
@@ -2946,6 +2994,18 @@ font-style: italic;
         "bytesEmitted" : 4,
         "recordsEmitted" : 2
       },
+      "failureSummary" : {
+        "failures" : [ {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        }, {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        } ],
+        "partialSuccess" : true
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
@@ -2980,6 +3040,18 @@ font-style: italic;
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
         "recordsEmitted" : 2
+      },
+      "failureSummary" : {
+        "failures" : [ {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        }, {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        } ],
+        "partialSuccess" : true
       },
       "createdAt" : 5,
       "bytesSynced" : 9,
@@ -3095,6 +3167,18 @@ font-style: italic;
         "bytesEmitted" : 4,
         "recordsEmitted" : 2
       },
+      "failureSummary" : {
+        "failures" : [ {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        }, {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        } ],
+        "partialSuccess" : true
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
@@ -3129,6 +3213,18 @@ font-style: italic;
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
         "recordsEmitted" : 2
+      },
+      "failureSummary" : {
+        "failures" : [ {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        }, {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        } ],
+        "partialSuccess" : true
       },
       "createdAt" : 5,
       "bytesSynced" : 9,
@@ -3229,6 +3325,18 @@ font-style: italic;
         "bytesEmitted" : 4,
         "recordsEmitted" : 2
       },
+      "failureSummary" : {
+        "failures" : [ {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        }, {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        } ],
+        "partialSuccess" : true
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
@@ -3263,6 +3371,18 @@ font-style: italic;
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
         "recordsEmitted" : 2
+      },
+      "failureSummary" : {
+        "failures" : [ {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        }, {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        } ],
+        "partialSuccess" : true
       },
       "createdAt" : 5,
       "bytesSynced" : 9,
@@ -3363,6 +3483,18 @@ font-style: italic;
         "bytesEmitted" : 4,
         "recordsEmitted" : 2
       },
+      "failureSummary" : {
+        "failures" : [ {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        }, {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        } ],
+        "partialSuccess" : true
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
@@ -3392,6 +3524,18 @@ font-style: italic;
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
         "recordsEmitted" : 2
+      },
+      "failureSummary" : {
+        "failures" : [ {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        }, {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        } ],
+        "partialSuccess" : true
       },
       "createdAt" : 5,
       "bytesSynced" : 9,
@@ -3431,6 +3575,18 @@ font-style: italic;
         "bytesEmitted" : 4,
         "recordsEmitted" : 2
       },
+      "failureSummary" : {
+        "failures" : [ {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        }, {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        } ],
+        "partialSuccess" : true
+      },
       "createdAt" : 5,
       "bytesSynced" : 9,
       "endedAt" : 7,
@@ -3460,6 +3616,18 @@ font-style: italic;
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
         "recordsEmitted" : 2
+      },
+      "failureSummary" : {
+        "failures" : [ {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        }, {
+          "stacktrace" : "stacktrace",
+          "externalMessage" : "externalMessage",
+          "timestamp" : 1
+        } ],
+        "partialSuccess" : true
       },
       "createdAt" : 5,
       "bytesSynced" : 9,
@@ -7541,6 +7709,10 @@ font-style: italic;
     <li><a href="#AirbyteStream"><code>AirbyteStream</code> - </a></li>
     <li><a href="#AirbyteStreamAndConfiguration"><code>AirbyteStreamAndConfiguration</code> - </a></li>
     <li><a href="#AirbyteStreamConfiguration"><code>AirbyteStreamConfiguration</code> - </a></li>
+    <li><a href="#AttemptFailureOrigin"><code>AttemptFailureOrigin</code> - </a></li>
+    <li><a href="#AttemptFailureReason"><code>AttemptFailureReason</code> - </a></li>
+    <li><a href="#AttemptFailureSummary"><code>AttemptFailureSummary</code> - </a></li>
+    <li><a href="#AttemptFailureType"><code>AttemptFailureType</code> - </a></li>
     <li><a href="#AttemptInfoRead"><code>AttemptInfoRead</code> - </a></li>
     <li><a href="#AttemptRead"><code>AttemptRead</code> - </a></li>
     <li><a href="#AttemptStats"><code>AttemptStats</code> - </a></li>
@@ -7710,6 +7882,37 @@ font-style: italic;
     </div>  <!-- field-items -->
   </div>
   <div class="model">
+    <h3><a name="AttemptFailureOrigin"><code>AttemptFailureOrigin</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'>Indicates where the error originated. If not set, the origin of error is not well known.</div>
+    <div class="field-items">
+          </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AttemptFailureReason"><code>AttemptFailureReason</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">failureOrigin </div><div class="param-desc"><span class="param-type"><a href="#AttemptFailureOrigin">AttemptFailureOrigin</a></span>  </div>
+<div class="param">failureType (optional)</div><div class="param-desc"><span class="param-type"><a href="#AttemptFailureType">AttemptFailureType</a></span>  </div>
+<div class="param">externalMessage (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">stacktrace (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">timestamp </div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AttemptFailureSummary"><code>AttemptFailureSummary</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">failures </div><div class="param-desc"><span class="param-type"><a href="#AttemptFailureReason">array[AttemptFailureReason]</a></span>  </div>
+<div class="param">partialSuccess (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> True if the number of committed records for this attempt was greater than 0. False if 0 records were committed. Blank if number of committed records is unknown. </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AttemptFailureType"><code>AttemptFailureType</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'>Categorizes well known errors into types for programmatic handling. If not set, the type of error is not well known.</div>
+    <div class="field-items">
+          </div>  <!-- field-items -->
+  </div>
+  <div class="model">
     <h3><a name="AttemptInfoRead"><code>AttemptInfoRead</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
@@ -7730,6 +7933,7 @@ font-style: italic;
 <div class="param">recordsSynced (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
 <div class="param">totalStats (optional)</div><div class="param-desc"><span class="param-type"><a href="#AttemptStats">AttemptStats</a></span>  </div>
 <div class="param">streamStats (optional)</div><div class="param-desc"><span class="param-type"><a href="#AttemptStreamStats">array[AttemptStreamStats]</a></span>  </div>
+<div class="param">failureSummary (optional)</div><div class="param-desc"><span class="param-type"><a href="#AttemptFailureSummary">AttemptFailureSummary</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/understanding-airbyte/glossary.md
+++ b/docs/understanding-airbyte/glossary.md
@@ -30,6 +30,10 @@ A **Full Refresh Sync** will attempt to retrieve all data from the source every 
 
 An **Incremental Sync** will only retrieve new data from the source when a sync occurs. The first sync will always attempt to retrieve all the data. If the [destination supports it](https://discuss.airbyte.io/t/what-destinations-support-the-incremental-deduped-sync-mode/89), you can have your data deduplicated. Simply put, this just means that if you sync an updated version of a record you've already synced, it will remove the old record.
 
+### Partial Success
+
+A **Partial Success** indicates that some records were successfully committed to the destination during a sync, even when the overall sync status was reported as a failure. 
+
 ### Raw Tables
 
 Airbyte spits out tables with the prefix `_airbyte_raw_`. This is your replicated data, but the prefix indicates that it's not normalized. If you select basic normalization, Airbyte will create renamed versions without the prefix.


### PR DESCRIPTION
## What
Now that failure summaries are stored for each attempt, we want to include this information in API responses so that this information can be surfaced to our users.

## How
Adds attempt failure information to the AttemptRead response object.
Includes the following fields from the persisted failure summary
- failures
  - List of AttemptFailureReason objects with failureOrigin, failureType, externalMessage, stacktrace, and timestamp.
  - Note that internalMessage and metaData are not included, as these fields may contain internal information that we don't want surfaced to clients. (stacktrace is also potentially sensitive, I could be convinced that we shouldn't include this. That said, we do expose stacktraces in the UI log view today so it probably is ok for now)
- partialSuccess
  - boolean indicating whether or not any records were committed during this attempt

This PR also adds a brief definition of 'Partial Success' to the glossary page in the Airbyte docs. We may want to expand on this once partial success information is surfaced more prominently in the UI.