### PR TITLE
📝 Source postgres: add workaround for syncing a subset of columns

### DIFF
--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -37,18 +37,18 @@ This is dependent on your networking setup. The easiest way to verify if Airbyte
 
 #### 2. Create a dedicated read-only user with access to the relevant tables \(Recommended but optional\)
 
-This step is optional but highly recommended to allow for better permission control and auditing. Alternatively, you can use Airbyte with an existing user in your database.
+This step is optional but highly recommended for better permission control and auditing. Alternatively, you can use Airbyte with an existing user in your database.
 
 To create a dedicated database user, run the following commands against your database:
 
 ```sql
-CREATE USER airbyte PASSWORD 'your_password_here';
+CREATE USER <username> PASSWORD 'your_password_here';
 ```
 
 Then give it access to the relevant schema:
 
 ```sql
-GRANT USAGE ON SCHEMA <schema_name> TO airbyte
+GRANT USAGE ON SCHEMA <schema_name> TO <username>
 ```
 
 Note that to replicate data from multiple Postgres schemas, you can re-run the command above to grant access to all the relevant schemas, but you'll need to set up multiple sources connecting to the same db on multiple schemas.
@@ -58,8 +58,8 @@ Next, grant the user read-only access to the relevant tables. The simplest way i
 ```sql
 GRANT SELECT ON ALL TABLES IN SCHEMA <schema_name> TO airbyte;
 
-# Allow airbyte user to see tables created in the future
-ALTER DEFAULT PRIVILEGES IN SCHEMA <schema_name> GRANT SELECT ON TABLES TO airbyte;
+-- Allow user to see tables created in the future
+ALTER DEFAULT PRIVILEGES IN SCHEMA <schema_name> GRANT SELECT ON TABLES TO <username>;
 ```
 
 Currently, there is no way to sync a subset of columns using the Postgres source connector.
@@ -70,7 +70,7 @@ The short-term workaround for both issues is to create a view on the specific co
 
 ```sql
 CREATE VIEW <view_name> as SELECT <columns> FROM <table>;
-GRANT SELECT ON TABLE <view_name> to <user_name>;
+GRANT SELECT ON TABLE <view_name> IN SCHEMA <schema_name> to <user_name>;
 ```
 
 A bug related to partial table permission is track in [issue #9771](https://github.com/airbytehq/airbyte/issues/9771).

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -66,7 +66,7 @@ Currently, there is no way to sync a subset of columns using the Postgres source
 - When setting up a connection, you can only choose which tables to sync, but not columns (issue [#2227](https://github.com/airbytehq/airbyte/issues/2227)).
 - If the user account can only access a subset of columns (i.e. has no `SELECT` permission for the full table), the connection check will pass. However, the data sync will fail with permission denied exception (issue [#9771](https://github.com/airbytehq/airbyte/issues/9771)).
 
-The short-term workaround for both issues is to create a view on the specific columns, and grant the user read permission of that view. This workaround also applies to the scenario when you only want to sync a subset of columns:
+The short-term workaround for both issues is to create a view on the specific columns, and grant the user read permission of that view:
 
 ```sql
 CREATE VIEW <view_name> as SELECT <columns> FROM <table>;

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -63,8 +63,8 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA <schema_name> GRANT SELECT ON TABLES TO airby
 ```
 
 Currently, there is no way to sync a subset of columns using the Postgres source connector.
-- When setting up a connection, you can only choose which tables to sync, but not columns. Issue [#2227](https://github.com/airbytehq/airbyte/issues/2227).
-- If the user account used for setting up the connection can only access a subset of columns, the connection check will pass. However, the data sync will fail with permission denied exception. Issue [#9771](https://github.com/airbytehq/airbyte/issues/9771).
+- When setting up a connection, you can only choose which tables to sync, but not columns (issue [#2227](https://github.com/airbytehq/airbyte/issues/2227)).
+- If the user account can only access a subset of columns (i.e. has no `SELECT` permission for the full table), the connection check will pass. However, the data sync will fail with permission denied exception (issue [#9771](https://github.com/airbytehq/airbyte/issues/9771)).
 
 The short-term workaround for both issues is to create a view on the specific columns, and grant the user read permission of that view. This workaround also applies to the scenario when you only want to sync a subset of columns:
 

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -62,14 +62,14 @@ GRANT SELECT ON ALL TABLES IN SCHEMA <schema_name> TO airbyte;
 ALTER DEFAULT PRIVILEGES IN SCHEMA <schema_name> GRANT SELECT ON TABLES TO airbyte;
 ```
 
-Currently, the user must have `SELECT` permission on the full table for the Postgres connector to sync the data. If the user only have read access to a subset of columns on the table, the data sync will fail with a `permission denied` exception. The workaround is to create a view on the specific columns, and grant the user read permission of that view:
+Currently, the user must have `SELECT` permission on the full table for the Postgres connector to sync the data. If the user only have read access to a subset of columns on the table, the data sync will fail with a `permission denied` exception. The workaround is to create a view on the specific columns, and grant the user read permission of that view. This workaround also applies to the scenario when you only want to sync a subset of columns:
 
 ```sql
 CREATE VIEW <view_name> as SELECT <columns> FROM <table>;
 GRANT SELECT ON TABLE <view_name> to <user_name>;
 ```
 
-A bug related to partial table permission is track in [issue #\9771](https://github.com/airbytehq/airbyte/issues/9771).
+A bug related to partial table permission is track in [issue #9771](https://github.com/airbytehq/airbyte/issues/9771).
 
 #### 3. Optionally, set up CDC. Follow the guide [below](postgres.md#setting-up-cdc-for-postgres) to do so.
 

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -62,6 +62,15 @@ GRANT SELECT ON ALL TABLES IN SCHEMA <schema_name> TO airbyte;
 ALTER DEFAULT PRIVILEGES IN SCHEMA <schema_name> GRANT SELECT ON TABLES TO airbyte;
 ```
 
+Currently, the user must have `SELECT` permission on the full table for the Postgres connector to sync the data. If the user only have read access to a subset of columns on the table, the data sync will fail with a `permission denied` exception. The workaround is to create a view on the specific columns, and grant the user read permission of that view:
+
+```sql
+CREATE VIEW <view_name> as SELECT <columns> FROM <table>;
+GRANT SELECT ON TABLE <view_name> to <user_name>;
+```
+
+A bug related to partial table permission is track in [issue #\9771](https://github.com/airbytehq/airbyte/issues/9771).
+
 #### 3. Optionally, set up CDC. Follow the guide [below](postgres.md#setting-up-cdc-for-postgres) to do so.
 
 #### 4. That's it!

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -62,7 +62,11 @@ GRANT SELECT ON ALL TABLES IN SCHEMA <schema_name> TO airbyte;
 ALTER DEFAULT PRIVILEGES IN SCHEMA <schema_name> GRANT SELECT ON TABLES TO airbyte;
 ```
 
-Currently, the user must have `SELECT` permission on the full table for the Postgres connector to sync the data. If the user only have read access to a subset of columns on the table, the data sync will fail with a `permission denied` exception. The workaround is to create a view on the specific columns, and grant the user read permission of that view. This workaround also applies to the scenario when you only want to sync a subset of columns:
+Currently, there is no way to sync a subset of columns using the Postgres source connector.
+- When setting up a connection, you can only choose which tables to sync, but not columns. Issue [#2227](https://github.com/airbytehq/airbyte/issues/2227).
+- If the user account used for setting up the connection can only access a subset of columns, the connection check will pass. However, the data sync will fail with permission denied exception. Issue [#9771](https://github.com/airbytehq/airbyte/issues/9771).
+
+The short-term workaround for both issues is to create a view on the specific columns, and grant the user read permission of that view. This workaround also applies to the scenario when you only want to sync a subset of columns:
 
 ```sql
 CREATE VIEW <view_name> as SELECT <columns> FROM <table>;


### PR DESCRIPTION
- This PR add a workaround in the documentation about how to create a connector to read a subset of columns in the table.
- Relate to https://github.com/airbytehq/airbyte/issues/2227, https://github.com/airbytehq/airbyte/issues/9771
