### PR TITLE
Set Attempt to failed status when Job is cancelled, and record cancellation failure reason

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
@@ -81,25 +81,26 @@ public class FailureHelper {
         .withPartialSuccess(partialSuccess);
   }
 
-  public static AttemptFailureSummary failureSummaryForCancellation(final Long jobId, final Integer attemptNumber, final Set<FailureReason> failures, final Boolean partialSuccess) {
+  public static AttemptFailureSummary failureSummaryForCancellation(final Long jobId,
+                                                                    final Integer attemptNumber,
+                                                                    final Set<FailureReason> failures,
+                                                                    final Boolean partialSuccess) {
     failures.add(new FailureReason()
         .withFailureType(FailureType.MANUAL_CANCELLATION)
         .withInternalMessage("Setting attempt to FAILED because the job was cancelled")
         .withExternalMessage("This attempt was cancelled")
         .withTimestamp(System.currentTimeMillis())
-        .withMetadata(jobAndAttemptMetadata(jobId, attemptNumber))
-    );
+        .withMetadata(jobAndAttemptMetadata(jobId, attemptNumber)));
 
     return failureSummary(failures, partialSuccess);
   }
 
   public static FailureReason failureReasonFromWorkflowAndActivity(
-      final String workflowType,
-      final String activityType,
-      final Throwable t,
-      final Long jobId,
-      final Integer attemptNumber
-  ) {
+                                                                   final String workflowType,
+                                                                   final String activityType,
+                                                                   final Throwable t,
+                                                                   final Long jobId,
+                                                                   final Integer attemptNumber) {
     if (workflowType.equals(WORKFLOW_TYPE_SYNC) && activityType.equals(ACTIVITY_TYPE_REPLICATE)) {
       return replicationFailure(t, jobId, attemptNumber);
     } else if (workflowType.equals(WORKFLOW_TYPE_SYNC) && activityType.equals(ACTIVITY_TYPE_PERSIST)) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -209,7 +209,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
         jobCreationAndStatusUpdateActivity.jobCancelled(new JobCancelledInput(
             maybeJobId.get(),
             maybeAttemptId.get(),
-            failures.isEmpty() ? null : FailureHelper.failureSummary(failures, partialSuccess)));
+            FailureHelper.failureSummaryForCancellation(maybeJobId.get(), maybeAttemptId.get(), failures, partialSuccess)));
         resetNewConnectionInput(connectionUpdaterInput);
       } else if (workflowState.isFailed()) {
         reportFailure(connectionUpdaterInput);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -26,7 +26,6 @@ import io.airbyte.scheduler.persistence.job_tracker.JobTracker;
 import io.airbyte.scheduler.persistence.job_tracker.JobTracker.JobState;
 import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.JobStatus;
-import io.airbyte.workers.helper.FailureHelper;
 import io.airbyte.workers.temporal.exception.RetryableException;
 import io.airbyte.workers.worker_run.TemporalWorkerRunFactory;
 import io.airbyte.workers.worker_run.WorkerRun;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -26,6 +26,7 @@ import io.airbyte.scheduler.persistence.job_tracker.JobTracker;
 import io.airbyte.scheduler.persistence.job_tracker.JobTracker.JobState;
 import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.JobStatus;
+import io.airbyte.workers.helper.FailureHelper;
 import io.airbyte.workers.temporal.exception.RetryableException;
 import io.airbyte.workers.worker_run.TemporalWorkerRunFactory;
 import io.airbyte.workers.worker_run.WorkerRun;
@@ -157,9 +158,9 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
   public void jobCancelled(final JobCancelledInput input) {
     try {
       jobPersistence.cancelJob(input.getJobId());
-      if (input.getAttemptFailureSummary() != null) {
-        jobPersistence.writeAttemptFailureSummary(input.getJobId(), input.getAttemptId(), input.getAttemptFailureSummary());
-      }
+      jobPersistence.failAttempt(input.getJobId(), input.getAttemptId());
+      jobPersistence.writeAttemptFailureSummary(input.getJobId(), input.getAttemptId(), input.getAttemptFailureSummary());
+
       final Job job = jobPersistence.getJob(input.getJobId());
       trackCompletion(job, JobStatus.FAILED);
       jobNotifier.failJob("Job was cancelled", job);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowTest.java
@@ -9,7 +9,6 @@ import io.airbyte.config.FailureReason.FailureType;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
-import io.airbyte.workers.helper.FailureHelper;
 import io.airbyte.workers.temporal.TemporalJobType;
 import io.airbyte.workers.temporal.scheduling.activities.ConfigFetchActivity;
 import io.airbyte.workers.temporal.scheduling.activities.ConfigFetchActivity.GetMaxAttemptOutput;
@@ -39,7 +38,6 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
 import java.time.Duration;
-import java.util.HashSet;
 import java.util.Queue;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
@@ -426,7 +424,6 @@ public class ConnectionManagerWorkflowTest {
       final TestStateListener testStateListener = new TestStateListener();
       final WorkflowState workflowState = new WorkflowState(testId, testStateListener);
 
-
       final ConnectionUpdaterInput input = new ConnectionUpdaterInput(
           UUID.randomUUID(),
           JOB_ID,
@@ -715,6 +712,7 @@ public class ConnectionManagerWorkflowTest {
   }
 
   private class HasFailureFromOrigin implements ArgumentMatcher<AttemptFailureInput> {
+
     private final FailureOrigin expectedFailureOrigin;
 
     public HasFailureFromOrigin(final FailureOrigin failureOrigin) {
@@ -725,9 +723,11 @@ public class ConnectionManagerWorkflowTest {
     public boolean matches(final AttemptFailureInput arg) {
       return arg.getAttemptFailureSummary().getFailures().stream().anyMatch(f -> f.getFailureOrigin().equals(expectedFailureOrigin));
     }
+
   }
 
   private class HasCancellationFailure implements ArgumentMatcher<JobCancelledInput> {
+
     private final long expectedJobId;
     private final int expectedAttemptId;
 
@@ -741,6 +741,7 @@ public class ConnectionManagerWorkflowTest {
       return arg.getAttemptFailureSummary().getFailures().stream().anyMatch(f -> f.getFailureType().equals(FailureType.MANUAL_CANCELLATION))
           && arg.getJobId() == expectedJobId && arg.getAttemptId() == expectedAttemptId;
     }
+
   }
 
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityTest.java
@@ -20,7 +20,6 @@ import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.scheduler.persistence.job_factory.SyncJobFactory;
 import io.airbyte.scheduler.persistence.job_tracker.JobTracker;
 import io.airbyte.scheduler.persistence.job_tracker.JobTracker.JobState;
-import io.airbyte.workers.helper.FailureHelper;
 import io.airbyte.workers.temporal.exception.RetryableException;
 import io.airbyte.workers.temporal.scheduling.activities.JobCreationAndStatusUpdateActivity.AttemptCreationInput;
 import io.airbyte.workers.temporal.scheduling.activities.JobCreationAndStatusUpdateActivity.AttemptCreationOutput;

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityTest.java
@@ -20,6 +20,7 @@ import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.scheduler.persistence.job_factory.SyncJobFactory;
 import io.airbyte.scheduler.persistence.job_tracker.JobTracker;
 import io.airbyte.scheduler.persistence.job_tracker.JobTracker.JobState;
+import io.airbyte.workers.helper.FailureHelper;
 import io.airbyte.workers.temporal.exception.RetryableException;
 import io.airbyte.workers.temporal.scheduling.activities.JobCreationAndStatusUpdateActivity.AttemptCreationInput;
 import io.airbyte.workers.temporal.scheduling.activities.JobCreationAndStatusUpdateActivity.AttemptCreationOutput;
@@ -215,18 +216,11 @@ public class JobCreationAndStatusUpdateActivityTest {
     }
 
     @Test
-    public void setJobCancelledWithNoFailures() throws IOException {
-      jobCreationAndStatusUpdateActivity.jobCancelled(new JobCancelledInput(JOB_ID, ATTEMPT_ID, null));
-
-      Mockito.verify(mJobPersistence).cancelJob(JOB_ID);
-      Mockito.verify(mJobPersistence, Mockito.never()).writeAttemptFailureSummary(Mockito.anyLong(), Mockito.anyInt(), Mockito.any());
-    }
-
-    @Test
-    public void setJobCancelledWithFailures() throws IOException {
+    public void setJobCancelled() throws IOException {
       jobCreationAndStatusUpdateActivity.jobCancelled(new JobCancelledInput(JOB_ID, ATTEMPT_ID, failureSummary));
 
       Mockito.verify(mJobPersistence).cancelJob(JOB_ID);
+      Mockito.verify(mJobPersistence).failAttempt(JOB_ID, ATTEMPT_ID);
       Mockito.verify(mJobPersistence).writeAttemptFailureSummary(JOB_ID, ATTEMPT_ID, failureSummary);
     }
 


### PR DESCRIPTION
## What
The new scheduler isn't marking attempts as FAILED when the job is cancelled, so they stay in a RUNNING status indefinitely. This PR ensures that the current attempt is set to FAILED when the job is cancelled, and that a 'cancellation' failure reason is recording in the attempt failure summary.

