### PR TITLE
Add release_stage and release_date to ActorDefinition table

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2110,6 +2110,16 @@ components:
           format: uri
         icon:
           type: string
+        releaseStage:
+          type: string
+          enum:
+            - alpha
+            - beta
+            - generally_available
+            - custom
+        releaseDate:
+          description: The date when this connector was first released, in yyyy-mm-dd format.
+          type: string
     SourceDefinitionReadList:
       type: object
       required:
@@ -2372,6 +2382,16 @@ components:
           type: string
           format: uri
         icon:
+          type: string
+        releaseStage:
+          type: string
+          enum:
+            - alpha
+            - beta
+            - generally_available
+            - custom
+        releaseDate:
+          description: The date when this connector was first released, in yyyy-mm-dd format.
           type: string
     DestinationDefinitionReadList:
       type: object

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2111,15 +2111,11 @@ components:
         icon:
           type: string
         releaseStage:
-          type: string
-          enum:
-            - alpha
-            - beta
-            - generally_available
-            - custom
+          $ref: "#/components/schemas/ReleaseStage"
         releaseDate:
           description: The date when this connector was first released, in yyyy-mm-dd format.
           type: string
+          format: date
     SourceDefinitionReadList:
       type: object
       required:
@@ -2384,15 +2380,11 @@ components:
         icon:
           type: string
         releaseStage:
-          type: string
-          enum:
-            - alpha
-            - beta
-            - generally_available
-            - custom
+          $ref: "#/components/schemas/ReleaseStage"
         releaseDate:
           description: The date when this connector was first released, in yyyy-mm-dd format.
           type: string
+          format: date
     DestinationDefinitionReadList:
       type: object
       required:
@@ -2532,6 +2524,14 @@ components:
           type: string
         destinationName:
           type: string
+    # SOURCE / DESTINATION RELEASE STAGE ENUM
+    ReleaseStage:
+      type: string
+      enum:
+        - alpha
+        - beta
+        - generally_available
+        - custom
     # CONNECTION
     ConnectionId:
       type: string

--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -80,7 +80,7 @@ public class BootloaderAppTest {
         mockedConfigs.getConfigDatabaseUrl())
             .getAndInitialize();
     val configsMigrator = new ConfigsDatabaseMigrator(configDatabase, this.getClass().getName());
-    assertEquals("0.35.14.001", configsMigrator.getLatestMigration().getVersion().getVersion());
+    assertEquals("0.35.15.001", configsMigrator.getLatestMigration().getVersion().getVersion());
 
     val jobsPersistence = new DefaultJobPersistence(jobDatabase);
     assertEquals(version, jobsPersistence.getVersion().get());

--- a/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
@@ -34,3 +34,13 @@ properties:
       if not set or false, the configuration is active. if true, then this
       configuration is permanently off.
     type: boolean
+  releaseStage:
+    type: string
+    enum:
+      - alpha
+      - beta
+      - generallyAvailable
+      - custom
+  releaseDate:
+    description: The date when this connector was first released, in yyyy-mm-dd format.
+    type: string

--- a/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
@@ -44,3 +44,4 @@ properties:
   releaseDate:
     description: The date when this connector was first released, in yyyy-mm-dd format.
     type: string
+    format: date

--- a/airbyte-config/models/src/main/resources/types/StandardSourceDefinition.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSourceDefinition.yaml
@@ -51,3 +51,4 @@ properties:
   releaseDate:
     description: The date when this connector was first released, in yyyy-mm-dd format.
     type: string
+    format: date

--- a/airbyte-config/models/src/main/resources/types/StandardSourceDefinition.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSourceDefinition.yaml
@@ -41,3 +41,13 @@ properties:
       if not set or false, the configuration is active. if true, then this
       configuration is permanently off.
     type: boolean
+  releaseStage:
+    type: string
+    enum:
+      - alpha
+      - beta
+      - generallyAvailable
+      - custom
+  releaseDate:
+    description: The date when this connector was first released, in yyyy-mm-dd format.
+    type: string

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -55,6 +55,7 @@ import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -366,7 +367,11 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
         .withSourceType(record.get(ACTOR_DEFINITION.SOURCE_TYPE) == null ? null
             : Enums.toEnum(record.get(ACTOR_DEFINITION.SOURCE_TYPE, String.class), SourceType.class).orElseThrow())
         .withSpec(Jsons.deserialize(record.get(ACTOR_DEFINITION.SPEC).data(), ConnectorSpecification.class))
-        .withTombstone(record.get(ACTOR_DEFINITION.TOMBSTONE));
+        .withTombstone(record.get(ACTOR_DEFINITION.TOMBSTONE))
+        .withReleaseStage(record.get(ACTOR_DEFINITION.RELEASE_STAGE) == null ? null
+            : Enums.toEnum(record.get(ACTOR_DEFINITION.RELEASE_STAGE, String.class), StandardSourceDefinition.ReleaseStage.class).orElseThrow())
+        .withReleaseDate(record.get(ACTOR_DEFINITION.RELEASE_DATE) == null ? null
+            : record.get(ACTOR_DEFINITION.RELEASE_DATE).toString());
   }
 
   private List<ConfigWithMetadata<StandardDestinationDefinition>> listStandardDestinationDefinitionWithMetadata() throws IOException {
@@ -406,7 +411,11 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
         .withDocumentationUrl(record.get(ACTOR_DEFINITION.DOCUMENTATION_URL))
         .withName(record.get(ACTOR_DEFINITION.NAME))
         .withSpec(Jsons.deserialize(record.get(ACTOR_DEFINITION.SPEC).data(), ConnectorSpecification.class))
-        .withTombstone(record.get(ACTOR_DEFINITION.TOMBSTONE));
+        .withTombstone(record.get(ACTOR_DEFINITION.TOMBSTONE))
+        .withReleaseStage(record.get(ACTOR_DEFINITION.RELEASE_STAGE) == null ? null
+            : Enums.toEnum(record.get(ACTOR_DEFINITION.RELEASE_STAGE, String.class), StandardDestinationDefinition.ReleaseStage.class).orElseThrow())
+        .withReleaseDate(record.get(ACTOR_DEFINITION.RELEASE_DATE) == null ? null
+            : record.get(ACTOR_DEFINITION.RELEASE_DATE).toString());
   }
 
   private List<ConfigWithMetadata<SourceConnection>> listSourceConnectionWithMetadata() throws IOException {
@@ -776,6 +785,11 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                         io.airbyte.db.instance.configs.jooq.enums.SourceType.class).orElseThrow())
             .set(ACTOR_DEFINITION.SPEC, JSONB.valueOf(Jsons.serialize(standardSourceDefinition.getSpec())))
             .set(ACTOR_DEFINITION.TOMBSTONE, standardSourceDefinition.getTombstone())
+            .set(ACTOR_DEFINITION.RELEASE_STAGE, standardSourceDefinition.getReleaseStage() == null ? null
+                : Enums.toEnum(standardSourceDefinition.getReleaseStage().value(),
+                    io.airbyte.db.instance.configs.jooq.enums.ReleaseStage.class).orElseThrow())
+            .set(ACTOR_DEFINITION.RELEASE_DATE, standardSourceDefinition.getReleaseDate() == null ? null
+                : LocalDate.parse(standardSourceDefinition.getReleaseDate().toString())) // TODO make sure this works
             .set(ACTOR_DEFINITION.UPDATED_AT, timestamp)
             .where(ACTOR_DEFINITION.ID.eq(standardSourceDefinition.getSourceDefinitionId()))
             .execute();
@@ -795,6 +809,12 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                         io.airbyte.db.instance.configs.jooq.enums.SourceType.class).orElseThrow())
             .set(ACTOR_DEFINITION.SPEC, JSONB.valueOf(Jsons.serialize(standardSourceDefinition.getSpec())))
             .set(ACTOR_DEFINITION.TOMBSTONE, standardSourceDefinition.getTombstone() != null && standardSourceDefinition.getTombstone())
+            .set(ACTOR_DEFINITION.RELEASE_STAGE,
+                standardSourceDefinition.getReleaseStage() == null ? null
+                    : Enums.toEnum(standardSourceDefinition.getReleaseStage().value(),
+                        io.airbyte.db.instance.configs.jooq.enums.ReleaseStage.class).orElseThrow())
+            .set(ACTOR_DEFINITION.RELEASE_DATE, standardSourceDefinition.getReleaseDate() == null ? null
+                : LocalDate.parse(standardSourceDefinition.getReleaseDate().toString())) // TODO make sure this works
             .set(ACTOR_DEFINITION.CREATED_AT, timestamp)
             .set(ACTOR_DEFINITION.UPDATED_AT, timestamp)
             .execute();
@@ -827,6 +847,11 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
             .set(ACTOR_DEFINITION.ACTOR_TYPE, ActorType.destination)
             .set(ACTOR_DEFINITION.SPEC, JSONB.valueOf(Jsons.serialize(standardDestinationDefinition.getSpec())))
             .set(ACTOR_DEFINITION.TOMBSTONE, standardDestinationDefinition.getTombstone())
+            .set(ACTOR_DEFINITION.RELEASE_STAGE, standardDestinationDefinition.getReleaseStage() == null ? null
+                : Enums.toEnum(standardDestinationDefinition.getReleaseStage().value(),
+                    io.airbyte.db.instance.configs.jooq.enums.ReleaseStage.class).orElseThrow())
+            .set(ACTOR_DEFINITION.RELEASE_DATE, standardDestinationDefinition.getReleaseDate() == null ? null
+                : LocalDate.parse(standardDestinationDefinition.getReleaseDate()))
             .set(ACTOR_DEFINITION.UPDATED_AT, timestamp)
             .where(ACTOR_DEFINITION.ID.eq(standardDestinationDefinition.getDestinationDefinitionId()))
             .execute();
@@ -842,6 +867,12 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
             .set(ACTOR_DEFINITION.ACTOR_TYPE, ActorType.destination)
             .set(ACTOR_DEFINITION.SPEC, JSONB.valueOf(Jsons.serialize(standardDestinationDefinition.getSpec())))
             .set(ACTOR_DEFINITION.TOMBSTONE, standardDestinationDefinition.getTombstone() != null && standardDestinationDefinition.getTombstone())
+            .set(ACTOR_DEFINITION.RELEASE_STAGE,
+                standardDestinationDefinition.getReleaseStage() == null ? null
+                    : Enums.toEnum(standardDestinationDefinition.getReleaseStage().value(),
+                        io.airbyte.db.instance.configs.jooq.enums.ReleaseStage.class).orElseThrow())
+            .set(ACTOR_DEFINITION.RELEASE_DATE, standardDestinationDefinition.getReleaseDate() == null ? null
+                : LocalDate.parse(standardDestinationDefinition.getReleaseDate()))
             .set(ACTOR_DEFINITION.CREATED_AT, timestamp)
             .set(ACTOR_DEFINITION.UPDATED_AT, timestamp)
             .execute();

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -789,7 +789,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                 : Enums.toEnum(standardSourceDefinition.getReleaseStage().value(),
                     io.airbyte.db.instance.configs.jooq.enums.ReleaseStage.class).orElseThrow())
             .set(ACTOR_DEFINITION.RELEASE_DATE, standardSourceDefinition.getReleaseDate() == null ? null
-                : LocalDate.parse(standardSourceDefinition.getReleaseDate().toString())) // TODO make sure this works
+                : LocalDate.parse(standardSourceDefinition.getReleaseDate()))
             .set(ACTOR_DEFINITION.UPDATED_AT, timestamp)
             .where(ACTOR_DEFINITION.ID.eq(standardSourceDefinition.getSourceDefinitionId()))
             .execute();
@@ -814,7 +814,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                     : Enums.toEnum(standardSourceDefinition.getReleaseStage().value(),
                         io.airbyte.db.instance.configs.jooq.enums.ReleaseStage.class).orElseThrow())
             .set(ACTOR_DEFINITION.RELEASE_DATE, standardSourceDefinition.getReleaseDate() == null ? null
-                : LocalDate.parse(standardSourceDefinition.getReleaseDate().toString())) // TODO make sure this works
+                : LocalDate.parse(standardSourceDefinition.getReleaseDate()))
             .set(ACTOR_DEFINITION.CREATED_AT, timestamp)
             .set(ACTOR_DEFINITION.UPDATED_AT, timestamp)
             .execute();

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
@@ -4,7 +4,8 @@
 
 package io.airbyte.config.persistence;
 
-import static io.airbyte.config.ConfigSchema.*;
+import static io.airbyte.config.ConfigSchema.STANDARD_DESTINATION_DEFINITION;
+import static io.airbyte.config.ConfigSchema.STANDARD_SOURCE_DEFINITION;
 import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR_DEFINITION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,6 +23,7 @@ import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.ConfigWithMetadata;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
+import io.airbyte.config.StandardSourceDefinition.ReleaseStage;
 import io.airbyte.config.persistence.DatabaseConfigPersistence.ConnectorInfo;
 import io.airbyte.db.instance.configs.ConfigsDatabaseInstance;
 import io.airbyte.db.instance.configs.ConfigsDatabaseMigrator;
@@ -29,6 +31,7 @@ import io.airbyte.db.instance.development.DevDatabaseMigrator;
 import io.airbyte.db.instance.development.MigrationDevHelper;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -203,7 +206,9 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
         .withDockerRepository(connectorRepository)
         .withDockerImageTag("0.1.2")
         .withName("random-name")
-        .withTombstone(false);
+        .withTombstone(false)
+        .withReleaseDate(LocalDate.now().toString())
+        .withReleaseStage(ReleaseStage.ALPHA);
     writeSource(configPersistence, source1);
     // write an irrelevant source to make sure that it is not changed
     writeSource(configPersistence, SOURCE_GITHUB);
@@ -216,7 +221,9 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
         .withDockerRepository(connectorRepository)
         .withDockerImageTag("0.1.5")
         .withName("random-name-2")
-        .withTombstone(false);
+        .withTombstone(false)
+        .withReleaseDate(LocalDate.now().minusDays(1).toString())
+        .withReleaseStage(ReleaseStage.BETA);
     writeSource(configPersistence, source2);
     assertRecordCount(2, ACTOR_DEFINITION);
     assertHasSource(source2);
@@ -248,6 +255,21 @@ public class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistence
 
     final JsonNode currentWithNewFields = Jsons.deserialize("{ \"field1\": 1, \"field2\": 2, \"field3\": 3 }");
     assertEquals(currentWithNewFields, DatabaseConfigPersistence.getDefinitionWithNewFields(current, latest, newFields));
+  }
+
+  @Test
+  public void testActorDefinitionReleaseDate() throws Exception {
+    final UUID definitionId = UUID.randomUUID();
+    final String connectorRepository = "airbyte/test-connector";
+
+    // when the record does not exist, it is inserted
+    final StandardSourceDefinition source1 = new StandardSourceDefinition()
+        .withSourceDefinitionId(definitionId)
+        .withDockerRepository(connectorRepository)
+        .withDockerImageTag("0.1.2")
+        .withName("random-name")
+        .withTombstone(false);
+    writeSource(configPersistence, source1);
   }
 
 }

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_15_001__AddReleaseStageAndReleaseDateToActorDefinition.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_15_001__AddReleaseStageAndReleaseDateToActorDefinition.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jooq.Catalog;
+import org.jooq.DSLContext;
+import org.jooq.EnumType;
+import org.jooq.Schema;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.jooq.impl.SchemaImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class V0_35_15_001__AddReleaseStageAndReleaseDateToActorDefinition extends BaseJavaMigration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(V0_35_15_001__AddReleaseStageAndReleaseDateToActorDefinition.class);
+
+  @Override
+  public void migrate(final Context context) throws Exception {
+    LOGGER.info("Running migration: {}", this.getClass().getSimpleName());
+
+    final DSLContext ctx = DSL.using(context.getConnection());
+    createReleaseStageEnum(ctx);
+    addReleaseStageColumn(ctx);
+    addReleaseDateColumn(ctx);
+  }
+
+  public static void createReleaseStageEnum(final DSLContext ctx) {
+    ctx.createType("release_stage").asEnum("alpha", "beta", "generally_available", "custom").execute();
+  }
+
+  public static void addReleaseStageColumn(final DSLContext ctx) {
+    ctx.alterTable("actor_definition")
+        .addColumnIfNotExists(DSL.field("release_stage", SQLDataType.VARCHAR.asEnumDataType(ReleaseStage.class).nullable(true)))
+        .execute();
+  }
+
+  public static void addReleaseDateColumn(final DSLContext ctx) {
+    ctx.alterTable("actor_definition")
+        .addColumnIfNotExists(DSL.field("release_date", SQLDataType.DATE.nullable(true)))
+        .execute();
+  }
+
+  public enum ReleaseStage implements EnumType {
+
+    alpha("alpha"),
+    beta("beta"),
+    generally_available("generally_available"),
+    custom("custom");
+
+    private final String literal;
+
+    ReleaseStage(String literal) {
+      this.literal = literal;
+    }
+
+    @Override
+    public Catalog getCatalog() {
+      return getSchema() == null ? null : getSchema().getCatalog();
+    }
+
+    @Override
+    public Schema getSchema() {
+      return new SchemaImpl(DSL.name("public"), null);
+    }
+
+    @Override
+    public String getName() {
+      return "release_stage";
+    }
+
+    @Override
+    public String getLiteral() {
+      return literal;
+    }
+
+  }
+
+}

--- a/airbyte-db/lib/src/main/resources/configs_database/normalized_tables_schema.txt
+++ b/airbyte-db/lib/src/main/resources/configs_database/normalized_tables_schema.txt
@@ -31,6 +31,10 @@
  public      | status_type               | active
  public      | status_type               | inactive
  public      | status_type               | deprecated
+ public      | release_stage             | alpha
+ public      | release_stage             | beta
+ public      | release_stage             | generally_available
+ public      | release_stage             | custom
 
 
 
@@ -78,6 +82,8 @@ Referenced by:
  created_at        | timestamp with time zone |           | not null | CURRENT_TIMESTAMP
  updated_at        | timestamp with time zone |           | not null | CURRENT_TIMESTAMP
  tombstone         | boolean                  |           | not null | false
+ release_stage     | release_stage            |           |          |
+ release_date      | date                     |           |          |
 Indexes:
     "actor_definition_pkey" PRIMARY KEY, btree (id)
 Referenced by:

--- a/airbyte-db/lib/src/main/resources/configs_database/schema_dump.txt
+++ b/airbyte-db/lib/src/main/resources/configs_database/schema_dump.txt
@@ -28,6 +28,8 @@ create table "public"."actor_definition"(
   "created_at" timestamptz(35) not null default null,
   "updated_at" timestamptz(35) not null default null,
   "tombstone" bool not null default false,
+  "release_stage" release_stage null,
+  "release_date" date null,
   constraint "actor_definition_pkey"
     primary key ("id")
 );

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinitionTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinitionTest.java
@@ -13,10 +13,6 @@ import java.util.UUID;
 import org.jooq.DSLContext;
 import org.jooq.JSONB;
 import org.jooq.Record;
-<<<<<<< HEAD
-=======
-import org.jooq.Result;
->>>>>>> eed18bb2f (add test to ensure tombstone defaults to false)
 import org.jooq.impl.DSL;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinitionTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_14_001__AddTombstoneToActorDefinitionTest.java
@@ -13,6 +13,10 @@ import java.util.UUID;
 import org.jooq.DSLContext;
 import org.jooq.JSONB;
 import org.jooq.Record;
+<<<<<<< HEAD
+=======
+import org.jooq.Result;
+>>>>>>> eed18bb2f (add test to ensure tombstone defaults to false)
 import org.jooq.impl.DSL;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_15_001__AddReleaseStageAndReleaseDateToActorDefinition_Test.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_15_001__AddReleaseStageAndReleaseDateToActorDefinition_Test.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import io.airbyte.db.Database;
+import io.airbyte.db.instance.configs.AbstractConfigsDatabaseTest;
+import io.airbyte.db.instance.configs.migrations.V0_32_8_001__AirbyteConfigDatabaseDenormalization.ActorType;
+import io.airbyte.db.instance.configs.migrations.V0_35_15_001__AddReleaseStageAndReleaseDateToActorDefinition.ReleaseStage;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.UUID;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class V0_35_15_001__AddReleaseStageAndReleaseDateToActorDefinition_Test extends AbstractConfigsDatabaseTest {
+
+  @Test
+  public void test() throws SQLException, IOException {
+
+    final Database database = getDatabase();
+    final DSLContext context = DSL.using(database.getDataSource().getConnection());
+
+    // necessary to add actor_definition table
+    V0_32_8_001__AirbyteConfigDatabaseDenormalization.migrate(context);
+
+    Assertions.assertFalse(releaseStageColumnExists(context));
+    Assertions.assertFalse(releaseDateColumnExists(context));
+
+    V0_35_15_001__AddReleaseStageAndReleaseDateToActorDefinition.createReleaseStageEnum(context);
+    V0_35_15_001__AddReleaseStageAndReleaseDateToActorDefinition.addReleaseStageColumn(context);
+    V0_35_15_001__AddReleaseStageAndReleaseDateToActorDefinition.addReleaseDateColumn(context);
+
+    Assertions.assertTrue(releaseStageColumnExists(context));
+    Assertions.assertTrue(releaseDateColumnExists(context));
+
+    assertReleaseStageEnumWorks(context);
+  }
+
+  private static boolean releaseStageColumnExists(final DSLContext ctx) {
+    return ctx.fetchExists(DSL.select()
+        .from("information_schema.columns")
+        .where(DSL.field("table_name").eq("actor_definition")
+            .and(DSL.field("column_name").eq("release_stage"))));
+  }
+
+  private static boolean releaseDateColumnExists(final DSLContext ctx) {
+    return ctx.fetchExists(DSL.select()
+        .from("information_schema.columns")
+        .where(DSL.field("table_name").eq("actor_definition")
+            .and(DSL.field("column_name").eq("release_date"))));
+  }
+
+  private static void assertReleaseStageEnumWorks(final DSLContext ctx) {
+    Assertions.assertDoesNotThrow(() -> {
+      insertWithReleaseStage(ctx, ReleaseStage.alpha);
+      insertWithReleaseStage(ctx, ReleaseStage.beta);
+      insertWithReleaseStage(ctx, ReleaseStage.generally_available);
+      insertWithReleaseStage(ctx, ReleaseStage.custom);
+    });
+  }
+
+  private static void insertWithReleaseStage(final DSLContext ctx, final ReleaseStage releaseStage) {
+    ctx.insertInto(DSL.table("actor_definition"))
+        .columns(
+            DSL.field("id"),
+            DSL.field("name"),
+            DSL.field("docker_repository"),
+            DSL.field("docker_image_tag"),
+            DSL.field("actor_type"),
+            DSL.field("spec"),
+            DSL.field("release_stage"))
+        .values(
+            UUID.randomUUID(),
+            "name",
+            "repo",
+            "1.0.0",
+            ActorType.source,
+            JSONB.valueOf("{}"),
+            releaseStage)
+        .execute();
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -307,7 +307,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
 
   @Override
   public SourceDefinitionRead createSourceDefinition(final SourceDefinitionCreate sourceDefinitionCreate) {
-    return execute(() -> sourceDefinitionsHandler.createSourceDefinition(sourceDefinitionCreate));
+    return execute(() -> sourceDefinitionsHandler.createCustomSourceDefinition(sourceDefinitionCreate));
   }
 
   @Override
@@ -449,7 +449,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
 
   @Override
   public DestinationDefinitionRead createDestinationDefinition(final DestinationDefinitionCreate destinationDefinitionCreate) {
-    return execute(() -> destinationDefinitionsHandler.createDestinationDefinition(destinationDefinitionCreate));
+    return execute(() -> destinationDefinitionsHandler.createCustomDestinationDefinition(destinationDefinitionCreate));
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -10,14 +10,13 @@ import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.api.model.DestinationDefinitionCreate;
 import io.airbyte.api.model.DestinationDefinitionIdRequestBody;
 import io.airbyte.api.model.DestinationDefinitionRead;
-import io.airbyte.api.model.DestinationDefinitionRead.ReleaseStageEnum;
 import io.airbyte.api.model.DestinationDefinitionReadList;
 import io.airbyte.api.model.DestinationDefinitionUpdate;
 import io.airbyte.api.model.DestinationRead;
+import io.airbyte.api.model.ReleaseStage;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardDestinationDefinition.ReleaseStage;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.ConnectorSpecification;
@@ -30,6 +29,7 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -77,17 +77,17 @@ public class DestinationDefinitionsHandler {
           .documentationUrl(new URI(standardDestinationDefinition.getDocumentationUrl()))
           .icon(loadIcon(standardDestinationDefinition.getIcon()))
           .releaseStage(getReleaseStage(standardDestinationDefinition))
-          .releaseDate(standardDestinationDefinition.getReleaseDate());
+          .releaseDate(LocalDate.parse(standardDestinationDefinition.getReleaseDate()));
     } catch (final URISyntaxException | NullPointerException e) {
       throw new InternalServerKnownException("Unable to process retrieved latest destination definitions list", e);
     }
   }
 
-  private static ReleaseStageEnum getReleaseStage(final StandardDestinationDefinition standardDestinationDefinition) {
+  private static ReleaseStage getReleaseStage(final StandardDestinationDefinition standardDestinationDefinition) {
     if (standardDestinationDefinition.getReleaseStage() == null) {
       return null;
     }
-    return ReleaseStageEnum.fromValue(standardDestinationDefinition.getReleaseStage().value());
+    return ReleaseStage.fromValue(standardDestinationDefinition.getReleaseStage().value());
   }
 
   public DestinationDefinitionReadList listDestinationDefinitions() throws IOException, JsonValidationException {
@@ -135,7 +135,7 @@ public class DestinationDefinitionsHandler {
         .withIcon(destinationDefinitionCreate.getIcon())
         .withSpec(spec)
         .withTombstone(false)
-        .withReleaseStage(ReleaseStage.CUSTOM);
+        .withReleaseStage(StandardDestinationDefinition.ReleaseStage.CUSTOM);
 
     configRepository.writeStandardDestinationDefinition(destinationDefinition);
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -119,7 +119,7 @@ public class DestinationDefinitionsHandler {
         configRepository.getStandardDestinationDefinition(destinationDefinitionIdRequestBody.getDestinationDefinitionId()));
   }
 
-  public DestinationDefinitionRead createDestinationDefinition(final DestinationDefinitionCreate destinationDefinitionCreate)
+  public DestinationDefinitionRead createCustomDestinationDefinition(final DestinationDefinitionCreate destinationDefinitionCreate)
       throws JsonValidationException, IOException {
     final ConnectorSpecification spec = getSpecForImage(
         destinationDefinitionCreate.getDockerRepository(),

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -77,7 +77,7 @@ public class DestinationDefinitionsHandler {
           .documentationUrl(new URI(standardDestinationDefinition.getDocumentationUrl()))
           .icon(loadIcon(standardDestinationDefinition.getIcon()))
           .releaseStage(getReleaseStage(standardDestinationDefinition))
-          .releaseDate(LocalDate.parse(standardDestinationDefinition.getReleaseDate()));
+          .releaseDate(getReleaseDate(standardDestinationDefinition));
     } catch (final URISyntaxException | NullPointerException e) {
       throw new InternalServerKnownException("Unable to process retrieved latest destination definitions list", e);
     }
@@ -88,6 +88,14 @@ public class DestinationDefinitionsHandler {
       return null;
     }
     return ReleaseStage.fromValue(standardDestinationDefinition.getReleaseStage().value());
+  }
+
+  private static LocalDate getReleaseDate(final StandardDestinationDefinition standardDestinationDefinition) {
+    if (standardDestinationDefinition.getReleaseDate() == null || standardDestinationDefinition.getReleaseDate().isBlank()) {
+      return null;
+    }
+
+    return LocalDate.parse(standardDestinationDefinition.getReleaseDate());
   }
 
   public DestinationDefinitionReadList listDestinationDefinitions() throws IOException, JsonValidationException {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -115,7 +115,7 @@ public class SourceDefinitionsHandler {
     return buildSourceDefinitionRead(configRepository.getStandardSourceDefinition(sourceDefinitionIdRequestBody.getSourceDefinitionId()));
   }
 
-  public SourceDefinitionRead createSourceDefinition(final SourceDefinitionCreate sourceDefinitionCreate)
+  public SourceDefinitionRead createCustomSourceDefinition(final SourceDefinitionCreate sourceDefinitionCreate)
       throws JsonValidationException, IOException {
     final ConnectorSpecification spec = getSpecForImage(sourceDefinitionCreate.getDockerRepository(), sourceDefinitionCreate.getDockerImageTag());
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -74,7 +74,7 @@ public class SourceDefinitionsHandler {
           .documentationUrl(new URI(standardSourceDefinition.getDocumentationUrl()))
           .icon(loadIcon(standardSourceDefinition.getIcon()))
           .releaseStage(getReleaseStage(standardSourceDefinition))
-          .releaseDate(LocalDate.parse(standardSourceDefinition.getReleaseDate()));
+          .releaseDate(getReleaseDate(standardSourceDefinition));
     } catch (final URISyntaxException | NullPointerException e) {
       throw new InternalServerKnownException("Unable to process retrieved latest source definitions list", e);
     }
@@ -85,6 +85,14 @@ public class SourceDefinitionsHandler {
       return null;
     }
     return ReleaseStage.fromValue(standardSourceDefinition.getReleaseStage().value());
+  }
+
+  private static LocalDate getReleaseDate(final StandardSourceDefinition standardSourceDefinition) {
+    if (standardSourceDefinition.getReleaseDate() == null || standardSourceDefinition.getReleaseDate().isBlank()) {
+      return null;
+    }
+
+    return LocalDate.parse(standardSourceDefinition.getReleaseDate());
   }
 
   public SourceDefinitionReadList listSourceDefinitions() throws IOException, JsonValidationException {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -7,17 +7,16 @@ package io.airbyte.server.handlers;
 import static io.airbyte.server.ServerConstants.DEV_IMAGE_TAG;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.airbyte.api.model.ReleaseStage;
 import io.airbyte.api.model.SourceDefinitionCreate;
 import io.airbyte.api.model.SourceDefinitionIdRequestBody;
 import io.airbyte.api.model.SourceDefinitionRead;
-import io.airbyte.api.model.SourceDefinitionRead.ReleaseStageEnum;
 import io.airbyte.api.model.SourceDefinitionReadList;
 import io.airbyte.api.model.SourceDefinitionUpdate;
 import io.airbyte.api.model.SourceRead;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.config.StandardSourceDefinition;
-import io.airbyte.config.StandardSourceDefinition.ReleaseStage;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.ConnectorSpecification;
@@ -30,6 +29,7 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -74,17 +74,17 @@ public class SourceDefinitionsHandler {
           .documentationUrl(new URI(standardSourceDefinition.getDocumentationUrl()))
           .icon(loadIcon(standardSourceDefinition.getIcon()))
           .releaseStage(getReleaseStage(standardSourceDefinition))
-          .releaseDate(standardSourceDefinition.getReleaseDate());
+          .releaseDate(LocalDate.parse(standardSourceDefinition.getReleaseDate()));
     } catch (final URISyntaxException | NullPointerException e) {
       throw new InternalServerKnownException("Unable to process retrieved latest source definitions list", e);
     }
   }
 
-  private static ReleaseStageEnum getReleaseStage(final StandardSourceDefinition standardSourceDefinition) {
+  private static ReleaseStage getReleaseStage(final StandardSourceDefinition standardSourceDefinition) {
     if (standardSourceDefinition.getReleaseStage() == null) {
       return null;
     }
-    return ReleaseStageEnum.fromValue(standardSourceDefinition.getReleaseStage().value());
+    return ReleaseStage.fromValue(standardSourceDefinition.getReleaseStage().value());
   }
 
   public SourceDefinitionReadList listSourceDefinitions() throws IOException, JsonValidationException {
@@ -129,7 +129,7 @@ public class SourceDefinitionsHandler {
         .withIcon(sourceDefinitionCreate.getIcon())
         .withSpec(spec)
         .withTombstone(false)
-        .withReleaseStage(ReleaseStage.CUSTOM);
+        .withReleaseStage(StandardSourceDefinition.ReleaseStage.CUSTOM);
 
     configRepository.writeStandardSourceDefinition(sourceDefinition);
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
@@ -17,16 +17,15 @@ import com.google.common.collect.Lists;
 import io.airbyte.api.model.DestinationDefinitionCreate;
 import io.airbyte.api.model.DestinationDefinitionIdRequestBody;
 import io.airbyte.api.model.DestinationDefinitionRead;
-import io.airbyte.api.model.DestinationDefinitionRead.ReleaseStageEnum;
 import io.airbyte.api.model.DestinationDefinitionReadList;
 import io.airbyte.api.model.DestinationDefinitionUpdate;
 import io.airbyte.api.model.DestinationRead;
 import io.airbyte.api.model.DestinationReadList;
+import io.airbyte.api.model.ReleaseStage;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardDestinationDefinition.ReleaseStage;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.ConnectorSpecification;
@@ -86,7 +85,7 @@ class DestinationDefinitionsHandlerTest {
         .withIcon("http.svg")
         .withSpec(spec)
         .withTombstone(false)
-        .withReleaseStage(ReleaseStage.ALPHA)
+        .withReleaseStage(StandardDestinationDefinition.ReleaseStage.ALPHA)
         .withReleaseDate(TODAY_DATE_STRING);
   }
 
@@ -104,8 +103,8 @@ class DestinationDefinitionsHandlerTest {
         .dockerImageTag(destinationDefinition.getDockerImageTag())
         .documentationUrl(new URI(destinationDefinition.getDocumentationUrl()))
         .icon(DestinationDefinitionsHandler.loadIcon(destinationDefinition.getIcon()))
-        .releaseStage(ReleaseStageEnum.fromValue(destinationDefinition.getReleaseStage().value()))
-        .releaseDate(destinationDefinition.getReleaseDate());;
+        .releaseStage(ReleaseStage.fromValue(destinationDefinition.getReleaseStage().value()))
+        .releaseDate(LocalDate.parse(destinationDefinition.getReleaseDate()));
 
     final DestinationDefinitionRead expectedDestinationDefinitionRead2 = new DestinationDefinitionRead()
         .destinationDefinitionId(destination2.getDestinationDefinitionId())
@@ -114,8 +113,8 @@ class DestinationDefinitionsHandlerTest {
         .dockerImageTag(destination2.getDockerImageTag())
         .documentationUrl(new URI(destination2.getDocumentationUrl()))
         .icon(DestinationDefinitionsHandler.loadIcon(destination2.getIcon()))
-        .releaseStage(ReleaseStageEnum.fromValue(destinationDefinition.getReleaseStage().value()))
-        .releaseDate(destinationDefinition.getReleaseDate());
+        .releaseStage(ReleaseStage.fromValue(destinationDefinition.getReleaseStage().value()))
+        .releaseDate(LocalDate.parse(destinationDefinition.getReleaseDate()));
 
     final DestinationDefinitionReadList actualDestinationDefinitionReadList = destinationDefinitionsHandler.listDestinationDefinitions();
 
@@ -137,8 +136,8 @@ class DestinationDefinitionsHandlerTest {
         .dockerImageTag(destinationDefinition.getDockerImageTag())
         .documentationUrl(new URI(destinationDefinition.getDocumentationUrl()))
         .icon(DestinationDefinitionsHandler.loadIcon(destinationDefinition.getIcon()))
-        .releaseStage(ReleaseStageEnum.fromValue(destinationDefinition.getReleaseStage().value()))
-        .releaseDate(destinationDefinition.getReleaseDate());;
+        .releaseStage(ReleaseStage.fromValue(destinationDefinition.getReleaseStage().value()))
+        .releaseDate(LocalDate.parse(destinationDefinition.getReleaseDate()));
 
     final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody = new DestinationDefinitionIdRequestBody()
         .destinationDefinitionId(destinationDefinition.getDestinationDefinitionId());
@@ -174,13 +173,14 @@ class DestinationDefinitionsHandlerTest {
         .documentationUrl(new URI(destination.getDocumentationUrl()))
         .destinationDefinitionId(destination.getDestinationDefinitionId())
         .icon(DestinationDefinitionsHandler.loadIcon(destination.getIcon()))
-        .releaseStage(ReleaseStageEnum.CUSTOM);
+        .releaseStage(ReleaseStage.CUSTOM);
 
     final DestinationDefinitionRead actualRead = destinationDefinitionsHandler.createCustomDestinationDefinition(create);
 
     assertEquals(expectedRead, actualRead);
     verify(schedulerSynchronousClient).createGetSpecJob(imageName);
-    verify(configRepository).writeStandardDestinationDefinition(destination.withReleaseDate(null).withReleaseStage(ReleaseStage.CUSTOM));
+    verify(configRepository).writeStandardDestinationDefinition(destination.withReleaseDate(null).withReleaseStage(
+        StandardDestinationDefinition.ReleaseStage.CUSTOM));
   }
 
   @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.Test;
 
 class DestinationDefinitionsHandlerTest {
 
-  private static String TODAY_DATE_STRING = LocalDate.now().toString();
+  private static final String TODAY_DATE_STRING = LocalDate.now().toString();
 
   private ConfigRepository configRepository;
   private StandardDestinationDefinition destinationDefinition;
@@ -176,7 +176,7 @@ class DestinationDefinitionsHandlerTest {
         .icon(DestinationDefinitionsHandler.loadIcon(destination.getIcon()))
         .releaseStage(ReleaseStageEnum.CUSTOM);
 
-    final DestinationDefinitionRead actualRead = destinationDefinitionsHandler.createDestinationDefinition(create);
+    final DestinationDefinitionRead actualRead = destinationDefinitionsHandler.createCustomDestinationDefinition(create);
 
     assertEquals(expectedRead, actualRead);
     verify(schedulerSynchronousClient).createGetSpecJob(imageName);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import io.airbyte.api.model.SourceDefinitionCreate;
 import io.airbyte.api.model.SourceDefinitionIdRequestBody;
 import io.airbyte.api.model.SourceDefinitionRead;
+import io.airbyte.api.model.SourceDefinitionRead.ReleaseStageEnum;
 import io.airbyte.api.model.SourceDefinitionReadList;
 import io.airbyte.api.model.SourceDefinitionUpdate;
 import io.airbyte.api.model.SourceRead;
@@ -26,6 +27,7 @@ import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.StandardSourceDefinition;
+import io.airbyte.config.StandardSourceDefinition.ReleaseStage;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.ConnectorSpecification;
@@ -37,6 +39,7 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -46,6 +49,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class SourceDefinitionsHandlerTest {
+
+  private static final String TODAY_DATE_STRING = LocalDate.now().toString();
 
   private ConfigRepository configRepository;
   private StandardSourceDefinition sourceDefinition;
@@ -82,7 +87,9 @@ class SourceDefinitionsHandlerTest {
         .withDockerImageTag("12.3")
         .withIcon("http.svg")
         .withSpec(spec)
-        .withTombstone(false);
+        .withTombstone(false)
+        .withReleaseStage(ReleaseStage.ALPHA)
+        .withReleaseDate(TODAY_DATE_STRING);
   }
 
   @Test
@@ -98,7 +105,9 @@ class SourceDefinitionsHandlerTest {
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
         .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
-        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()));
+        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
+        .releaseStage(ReleaseStageEnum.fromValue(sourceDefinition.getReleaseStage().value()))
+        .releaseDate(sourceDefinition.getReleaseDate());
 
     final SourceDefinitionRead expectedSourceDefinitionRead2 = new SourceDefinitionRead()
         .sourceDefinitionId(sourceDefinition2.getSourceDefinitionId())
@@ -106,7 +115,9 @@ class SourceDefinitionsHandlerTest {
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
         .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
-        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()));
+        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
+        .releaseStage(ReleaseStageEnum.fromValue(sourceDefinition.getReleaseStage().value()))
+        .releaseDate(sourceDefinition.getReleaseDate());
 
     final SourceDefinitionReadList actualSourceDefinitionReadList = sourceDefinitionsHandler.listSourceDefinitions();
 
@@ -127,7 +138,9 @@ class SourceDefinitionsHandlerTest {
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
         .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
-        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()));
+        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
+        .releaseStage(ReleaseStageEnum.fromValue(sourceDefinition.getReleaseStage().value()))
+        .releaseDate(sourceDefinition.getReleaseDate());;
 
     final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody =
         new SourceDefinitionIdRequestBody().sourceDefinitionId(sourceDefinition.getSourceDefinitionId());
@@ -161,13 +174,14 @@ class SourceDefinitionsHandlerTest {
         .dockerImageTag(sourceDefinition.getDockerImageTag())
         .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
         .sourceDefinitionId(sourceDefinition.getSourceDefinitionId())
-        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()));
+        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
+        .releaseStage(ReleaseStageEnum.CUSTOM);
 
     final SourceDefinitionRead actualRead = sourceDefinitionsHandler.createSourceDefinition(create);
 
     assertEquals(expectedRead, actualRead);
     verify(schedulerSynchronousClient).createGetSpecJob(imageName);
-    verify(configRepository).writeStandardSourceDefinition(sourceDefinition);
+    verify(configRepository).writeStandardSourceDefinition(sourceDefinition.withReleaseDate(null).withReleaseStage(ReleaseStage.CUSTOM));
   }
 
   @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -15,10 +15,10 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import io.airbyte.api.model.ReleaseStage;
 import io.airbyte.api.model.SourceDefinitionCreate;
 import io.airbyte.api.model.SourceDefinitionIdRequestBody;
 import io.airbyte.api.model.SourceDefinitionRead;
-import io.airbyte.api.model.SourceDefinitionRead.ReleaseStageEnum;
 import io.airbyte.api.model.SourceDefinitionReadList;
 import io.airbyte.api.model.SourceDefinitionUpdate;
 import io.airbyte.api.model.SourceRead;
@@ -27,7 +27,6 @@ import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.StandardSourceDefinition;
-import io.airbyte.config.StandardSourceDefinition.ReleaseStage;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.ConnectorSpecification;
@@ -88,7 +87,7 @@ class SourceDefinitionsHandlerTest {
         .withIcon("http.svg")
         .withSpec(spec)
         .withTombstone(false)
-        .withReleaseStage(ReleaseStage.ALPHA)
+        .withReleaseStage(StandardSourceDefinition.ReleaseStage.ALPHA)
         .withReleaseDate(TODAY_DATE_STRING);
   }
 
@@ -106,8 +105,8 @@ class SourceDefinitionsHandlerTest {
         .dockerImageTag(sourceDefinition.getDockerImageTag())
         .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
-        .releaseStage(ReleaseStageEnum.fromValue(sourceDefinition.getReleaseStage().value()))
-        .releaseDate(sourceDefinition.getReleaseDate());
+        .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
+        .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()));
 
     final SourceDefinitionRead expectedSourceDefinitionRead2 = new SourceDefinitionRead()
         .sourceDefinitionId(sourceDefinition2.getSourceDefinitionId())
@@ -116,8 +115,8 @@ class SourceDefinitionsHandlerTest {
         .dockerImageTag(sourceDefinition.getDockerImageTag())
         .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
-        .releaseStage(ReleaseStageEnum.fromValue(sourceDefinition.getReleaseStage().value()))
-        .releaseDate(sourceDefinition.getReleaseDate());
+        .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
+        .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()));
 
     final SourceDefinitionReadList actualSourceDefinitionReadList = sourceDefinitionsHandler.listSourceDefinitions();
 
@@ -139,8 +138,8 @@ class SourceDefinitionsHandlerTest {
         .dockerImageTag(sourceDefinition.getDockerImageTag())
         .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
-        .releaseStage(ReleaseStageEnum.fromValue(sourceDefinition.getReleaseStage().value()))
-        .releaseDate(sourceDefinition.getReleaseDate());;
+        .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
+        .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()));
 
     final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody =
         new SourceDefinitionIdRequestBody().sourceDefinitionId(sourceDefinition.getSourceDefinitionId());
@@ -175,13 +174,14 @@ class SourceDefinitionsHandlerTest {
         .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
         .sourceDefinitionId(sourceDefinition.getSourceDefinitionId())
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
-        .releaseStage(ReleaseStageEnum.CUSTOM);
+        .releaseStage(ReleaseStage.CUSTOM);
 
     final SourceDefinitionRead actualRead = sourceDefinitionsHandler.createCustomSourceDefinition(create);
 
     assertEquals(expectedRead, actualRead);
     verify(schedulerSynchronousClient).createGetSpecJob(imageName);
-    verify(configRepository).writeStandardSourceDefinition(sourceDefinition.withReleaseDate(null).withReleaseStage(ReleaseStage.CUSTOM));
+    verify(configRepository)
+        .writeStandardSourceDefinition(sourceDefinition.withReleaseDate(null).withReleaseStage(StandardSourceDefinition.ReleaseStage.CUSTOM));
   }
 
   @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -177,7 +177,7 @@ class SourceDefinitionsHandlerTest {
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .releaseStage(ReleaseStageEnum.CUSTOM);
 
-    final SourceDefinitionRead actualRead = sourceDefinitionsHandler.createSourceDefinition(create);
+    final SourceDefinitionRead actualRead = sourceDefinitionsHandler.createCustomSourceDefinition(create);
 
     assertEquals(expectedRead, actualRead);
     verify(schedulerSynchronousClient).createGetSpecJob(imageName);

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -2514,9 +2514,8 @@ font-style: italic;
     <pre class="example"><code>{
   "documentationUrl" : "https://openapi-generator.tech",
   "dockerImageTag" : "dockerImageTag",
-  "releaseDate" : "releaseDate",
+  "releaseDate" : "2000-01-23",
   "dockerRepository" : "dockerRepository",
-  "releaseStage" : "alpha",
   "name" : "name",
   "icon" : "icon",
   "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -2624,9 +2623,8 @@ font-style: italic;
     <pre class="example"><code>{
   "documentationUrl" : "https://openapi-generator.tech",
   "dockerImageTag" : "dockerImageTag",
-  "releaseDate" : "releaseDate",
+  "releaseDate" : "2000-01-23",
   "dockerRepository" : "dockerRepository",
-  "releaseStage" : "alpha",
   "name" : "name",
   "icon" : "icon",
   "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -2678,18 +2676,16 @@ font-style: italic;
   "destinationDefinitions" : [ {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
-    "releaseDate" : "releaseDate",
+    "releaseDate" : "2000-01-23",
     "dockerRepository" : "dockerRepository",
-    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
   }, {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
-    "releaseDate" : "releaseDate",
+    "releaseDate" : "2000-01-23",
     "dockerRepository" : "dockerRepository",
-    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -2736,18 +2732,16 @@ font-style: italic;
   "destinationDefinitions" : [ {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
-    "releaseDate" : "releaseDate",
+    "releaseDate" : "2000-01-23",
     "dockerRepository" : "dockerRepository",
-    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
   }, {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
-    "releaseDate" : "releaseDate",
+    "releaseDate" : "2000-01-23",
     "dockerRepository" : "dockerRepository",
-    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -2805,9 +2799,8 @@ font-style: italic;
     <pre class="example"><code>{
   "documentationUrl" : "https://openapi-generator.tech",
   "dockerImageTag" : "dockerImageTag",
-  "releaseDate" : "releaseDate",
+  "releaseDate" : "2000-01-23",
   "dockerRepository" : "dockerRepository",
-  "releaseStage" : "alpha",
   "name" : "name",
   "icon" : "icon",
   "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -3169,9 +3162,8 @@ font-style: italic;
     "sourceDefinition" : {
       "documentationUrl" : "https://openapi-generator.tech",
       "dockerImageTag" : "dockerImageTag",
-      "releaseDate" : "releaseDate",
+      "releaseDate" : "2000-01-23",
       "dockerRepository" : "dockerRepository",
-      "releaseStage" : "alpha",
       "name" : "name",
       "icon" : "icon",
       "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -3181,9 +3173,8 @@ font-style: italic;
     "destinationDefinition" : {
       "documentationUrl" : "https://openapi-generator.tech",
       "dockerImageTag" : "dockerImageTag",
-      "releaseDate" : "releaseDate",
+      "releaseDate" : "2000-01-23",
       "dockerRepository" : "dockerRepository",
-      "releaseStage" : "alpha",
       "name" : "name",
       "icon" : "icon",
       "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -5488,9 +5479,8 @@ font-style: italic;
     <pre class="example"><code>{
   "documentationUrl" : "https://openapi-generator.tech",
   "dockerImageTag" : "dockerImageTag",
-  "releaseDate" : "releaseDate",
+  "releaseDate" : "2000-01-23",
   "dockerRepository" : "dockerRepository",
-  "releaseStage" : "alpha",
   "name" : "name",
   "icon" : "icon",
   "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -5598,9 +5588,8 @@ font-style: italic;
     <pre class="example"><code>{
   "documentationUrl" : "https://openapi-generator.tech",
   "dockerImageTag" : "dockerImageTag",
-  "releaseDate" : "releaseDate",
+  "releaseDate" : "2000-01-23",
   "dockerRepository" : "dockerRepository",
-  "releaseStage" : "alpha",
   "name" : "name",
   "icon" : "icon",
   "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -5652,18 +5641,16 @@ font-style: italic;
   "sourceDefinitions" : [ {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
-    "releaseDate" : "releaseDate",
+    "releaseDate" : "2000-01-23",
     "dockerRepository" : "dockerRepository",
-    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
   }, {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
-    "releaseDate" : "releaseDate",
+    "releaseDate" : "2000-01-23",
     "dockerRepository" : "dockerRepository",
-    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -5710,18 +5697,16 @@ font-style: italic;
   "sourceDefinitions" : [ {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
-    "releaseDate" : "releaseDate",
+    "releaseDate" : "2000-01-23",
     "dockerRepository" : "dockerRepository",
-    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
   }, {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
-    "releaseDate" : "releaseDate",
+    "releaseDate" : "2000-01-23",
     "dockerRepository" : "dockerRepository",
-    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -5779,9 +5764,8 @@ font-style: italic;
     <pre class="example"><code>{
   "documentationUrl" : "https://openapi-generator.tech",
   "dockerImageTag" : "dockerImageTag",
-  "releaseDate" : "releaseDate",
+  "releaseDate" : "2000-01-23",
   "dockerRepository" : "dockerRepository",
-  "releaseStage" : "alpha",
   "name" : "name",
   "icon" : "icon",
   "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -7850,6 +7834,7 @@ font-style: italic;
     <li><a href="#OperatorNormalization"><code>OperatorNormalization</code> - </a></li>
     <li><a href="#OperatorType"><code>OperatorType</code> - </a></li>
     <li><a href="#Pagination"><code>Pagination</code> - </a></li>
+    <li><a href="#ReleaseStage"><code>ReleaseStage</code> - </a></li>
     <li><a href="#ResourceRequirements"><code>ResourceRequirements</code> - </a></li>
     <li><a href="#SetInstancewideDestinationOauthParamsRequestBody"><code>SetInstancewideDestinationOauthParamsRequestBody</code> - </a></li>
     <li><a href="#SetInstancewideSourceOauthParamsRequestBody"><code>SetInstancewideSourceOauthParamsRequestBody</code> - </a></li>
@@ -8273,10 +8258,8 @@ font-style: italic;
 <div class="param">dockerImageTag </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">documentationUrl </div><div class="param-desc"><span class="param-type"><a href="#URI">URI</a></span>  format: uri</div>
 <div class="param">icon (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">releaseStage (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-        <div class="param-enum-header">Enum:</div>
-        <div class="param-enum">alpha</div><div class="param-enum">beta</div><div class="param-enum">generally_available</div><div class="param-enum">custom</div>
-<div class="param">releaseDate (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The date when this connector was first released, in yyyy-mm-dd format. </div>
+<div class="param">releaseStage (optional)</div><div class="param-desc"><span class="param-type"><a href="#ReleaseStage">ReleaseStage</a></span>  </div>
+<div class="param">releaseDate (optional)</div><div class="param-desc"><span class="param-type"><a href="#date">date</a></span> The date when this connector was first released, in yyyy-mm-dd format. format: date</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -8688,6 +8671,12 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
     </div>  <!-- field-items -->
   </div>
   <div class="model">
+    <h3><a name="ReleaseStage"><code>ReleaseStage</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+          </div>  <!-- field-items -->
+  </div>
+  <div class="model">
     <h3><a name="ResourceRequirements"><code>ResourceRequirements</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'>optional resource requirements to run workers (blank for unbounded allocations)</div>
     <div class="field-items">
@@ -8773,10 +8762,8 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
 <div class="param">dockerImageTag </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">documentationUrl (optional)</div><div class="param-desc"><span class="param-type"><a href="#URI">URI</a></span>  format: uri</div>
 <div class="param">icon (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">releaseStage (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-        <div class="param-enum-header">Enum:</div>
-        <div class="param-enum">alpha</div><div class="param-enum">beta</div><div class="param-enum">generally_available</div><div class="param-enum">custom</div>
-<div class="param">releaseDate (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The date when this connector was first released, in yyyy-mm-dd format. </div>
+<div class="param">releaseStage (optional)</div><div class="param-desc"><span class="param-type"><a href="#ReleaseStage">ReleaseStage</a></span>  </div>
+<div class="param">releaseDate (optional)</div><div class="param-desc"><span class="param-type"><a href="#date">date</a></span> The date when this connector was first released, in yyyy-mm-dd format. format: date</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -2514,7 +2514,9 @@ font-style: italic;
     <pre class="example"><code>{
   "documentationUrl" : "https://openapi-generator.tech",
   "dockerImageTag" : "dockerImageTag",
+  "releaseDate" : "releaseDate",
   "dockerRepository" : "dockerRepository",
+  "releaseStage" : "alpha",
   "name" : "name",
   "icon" : "icon",
   "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -2622,7 +2624,9 @@ font-style: italic;
     <pre class="example"><code>{
   "documentationUrl" : "https://openapi-generator.tech",
   "dockerImageTag" : "dockerImageTag",
+  "releaseDate" : "releaseDate",
   "dockerRepository" : "dockerRepository",
+  "releaseStage" : "alpha",
   "name" : "name",
   "icon" : "icon",
   "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -2674,14 +2678,18 @@ font-style: italic;
   "destinationDefinitions" : [ {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
+    "releaseDate" : "releaseDate",
     "dockerRepository" : "dockerRepository",
+    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
   }, {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
+    "releaseDate" : "releaseDate",
     "dockerRepository" : "dockerRepository",
+    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -2728,14 +2736,18 @@ font-style: italic;
   "destinationDefinitions" : [ {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
+    "releaseDate" : "releaseDate",
     "dockerRepository" : "dockerRepository",
+    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
   }, {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
+    "releaseDate" : "releaseDate",
     "dockerRepository" : "dockerRepository",
+    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -2793,7 +2805,9 @@ font-style: italic;
     <pre class="example"><code>{
   "documentationUrl" : "https://openapi-generator.tech",
   "dockerImageTag" : "dockerImageTag",
+  "releaseDate" : "releaseDate",
   "dockerRepository" : "dockerRepository",
+  "releaseStage" : "alpha",
   "name" : "name",
   "icon" : "icon",
   "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -3155,7 +3169,9 @@ font-style: italic;
     "sourceDefinition" : {
       "documentationUrl" : "https://openapi-generator.tech",
       "dockerImageTag" : "dockerImageTag",
+      "releaseDate" : "releaseDate",
       "dockerRepository" : "dockerRepository",
+      "releaseStage" : "alpha",
       "name" : "name",
       "icon" : "icon",
       "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -3165,7 +3181,9 @@ font-style: italic;
     "destinationDefinition" : {
       "documentationUrl" : "https://openapi-generator.tech",
       "dockerImageTag" : "dockerImageTag",
+      "releaseDate" : "releaseDate",
       "dockerRepository" : "dockerRepository",
+      "releaseStage" : "alpha",
       "name" : "name",
       "icon" : "icon",
       "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -5470,7 +5488,9 @@ font-style: italic;
     <pre class="example"><code>{
   "documentationUrl" : "https://openapi-generator.tech",
   "dockerImageTag" : "dockerImageTag",
+  "releaseDate" : "releaseDate",
   "dockerRepository" : "dockerRepository",
+  "releaseStage" : "alpha",
   "name" : "name",
   "icon" : "icon",
   "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -5578,7 +5598,9 @@ font-style: italic;
     <pre class="example"><code>{
   "documentationUrl" : "https://openapi-generator.tech",
   "dockerImageTag" : "dockerImageTag",
+  "releaseDate" : "releaseDate",
   "dockerRepository" : "dockerRepository",
+  "releaseStage" : "alpha",
   "name" : "name",
   "icon" : "icon",
   "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -5630,14 +5652,18 @@ font-style: italic;
   "sourceDefinitions" : [ {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
+    "releaseDate" : "releaseDate",
     "dockerRepository" : "dockerRepository",
+    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
   }, {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
+    "releaseDate" : "releaseDate",
     "dockerRepository" : "dockerRepository",
+    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -5684,14 +5710,18 @@ font-style: italic;
   "sourceDefinitions" : [ {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
+    "releaseDate" : "releaseDate",
     "dockerRepository" : "dockerRepository",
+    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
   }, {
     "documentationUrl" : "https://openapi-generator.tech",
     "dockerImageTag" : "dockerImageTag",
+    "releaseDate" : "releaseDate",
     "dockerRepository" : "dockerRepository",
+    "releaseStage" : "alpha",
     "name" : "name",
     "icon" : "icon",
     "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -5749,7 +5779,9 @@ font-style: italic;
     <pre class="example"><code>{
   "documentationUrl" : "https://openapi-generator.tech",
   "dockerImageTag" : "dockerImageTag",
+  "releaseDate" : "releaseDate",
   "dockerRepository" : "dockerRepository",
+  "releaseStage" : "alpha",
   "name" : "name",
   "icon" : "icon",
   "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
@@ -8241,6 +8273,10 @@ font-style: italic;
 <div class="param">dockerImageTag </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">documentationUrl </div><div class="param-desc"><span class="param-type"><a href="#URI">URI</a></span>  format: uri</div>
 <div class="param">icon (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">releaseStage (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+        <div class="param-enum-header">Enum:</div>
+        <div class="param-enum">alpha</div><div class="param-enum">beta</div><div class="param-enum">generally_available</div><div class="param-enum">custom</div>
+<div class="param">releaseDate (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The date when this connector was first released, in yyyy-mm-dd format. </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -8737,6 +8773,10 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
 <div class="param">dockerImageTag </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">documentationUrl (optional)</div><div class="param-desc"><span class="param-type"><a href="#URI">URI</a></span>  format: uri</div>
 <div class="param">icon (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">releaseStage (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+        <div class="param-enum-header">Enum:</div>
+        <div class="param-enum">alpha</div><div class="param-enum">beta</div><div class="param-enum">generally_available</div><div class="param-enum">custom</div>
+<div class="param">releaseDate (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The date when this connector was first released, in yyyy-mm-dd format. </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What
Issue: https://github.com/airbytehq/airbyte/issues/9711
Internal slack conversation with some more context: https://airbytehq-team.slack.com/archives/C02TL38U5L7/p1643247936054200

We want to mark connectors with different release stages (Alpha, Beta, Custom, Generally Available), and eventually want to mark new connectors with a 'New' badge. 

This PR introduces `release_date` and `release_stage` as optional columns/fields on our connector definition table/schemas.

## How
- Write migration to add release_stage enum, release_stage column, and release_date column
- Update json schemas to include these new fields
- Update API handlers to surface new fields
- Renamed `create*Definition` handler methods to `createCustom*Definition` because we now assume that any definition created via API should be marked with `custom` release_stage

Side note: I have [another PR](https://github.com/airbytehq/airbyte/pull/9988) that adds a 'tombstone' column to actor_definition. Subodh informed me about upgrading the `CONFIGS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION` for cloud releases, so I will be sure to handle that for both of my PRs that introduce new columns. (I will bundle these two PRs as a single release and then release them to Cloud together).

## Recommended reading order
1. Migration file
2. *.yaml schema changes
3. *Handler.java changes
4. the rest

## 🚨 User Impact 🚨
No user impact yet, this just introduces the columns and fields that will later be populated with release stage/date information through our connector seeds.