### PR TITLE
prevent worker initialization from getting stuck

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -301,7 +301,7 @@ public class WorkerApp {
     }
   }
 
-  public static void main(final String[] args) throws IOException, InterruptedException {
+  private static void launchWorkerApp() throws IOException {
     final Configs configs = new EnvConfigs();
 
     LogClientSingleton.getInstance().setWorkspaceMdc(configs.getWorkerEnvironment(), configs.getLogConfigs(),
@@ -407,6 +407,15 @@ public class WorkerApp {
         containerOrchestratorConfig,
         jobNotifier,
         jobTracker).start();
+  }
+
+  public static void main(final String[] args) {
+    try {
+      launchWorkerApp();
+    } catch (Throwable t) {
+      LOGGER.error("Worker app failed", t);
+      System.exit(1);
+    }
   }
 
 }


### PR DESCRIPTION
resolves https://github.com/airbytehq/airbyte/issues/9984

I'd recommend reviewing this commit by commit.
- https://github.com/airbytehq/airbyte/commit/80d56b01c7c3ab88c117463db9caa2eaaa26d17f makes sure the actual creation of the temporal service client object is part of the retry
- https://github.com/airbytehq/airbyte/commit/0b3afc7e3b728a9f7abb0f72c8cd09f9fa308e51 ensures that threads running in the background are stopped. In practice this should only happen during setup.