### PR TITLE
rm schedule to close and start and more retries

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -583,7 +583,7 @@ public class EnvConfigs implements Configs {
 
   @Override
   public int getActivityNumberOfAttempt() {
-    return Integer.parseInt(getEnvOrDefault(ACTIVITY_MAX_ATTEMPT, "3"));
+    return Integer.parseInt(getEnvOrDefault(ACTIVITY_MAX_ATTEMPT, "10"));
   }
 
   // Helpers

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/shared/ActivityConfiguration.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/shared/ActivityConfiguration.java
@@ -34,9 +34,7 @@ public class ActivityConfiguration {
       .build();
 
   public static final ActivityOptions SHORT_ACTIVITY_OPTIONS = ActivityOptions.newBuilder()
-      .setScheduleToCloseTimeout(DB_INTERACTION_TIMEOUT)
       .setStartToCloseTimeout(DB_INTERACTION_TIMEOUT)
-      .setScheduleToStartTimeout(DB_INTERACTION_TIMEOUT)
       .setCancellationType(ActivityCancellationType.WAIT_CANCELLATION_COMPLETED)
       .setRetryOptions(TemporalUtils.RETRY)
       .setHeartbeatTimeout(TemporalUtils.HEARTBEAT_TIMEOUT)


### PR DESCRIPTION
## What
Update retry policies for short running jobs.

Some activites were failing because the schedule to close timeout got reach. This timeout is not retryable but the heartbeat is. Also we don't care about the schedule to start or to close timeout because what is important is the time that it takes to run, if the worker queue is empty we want the job to wait for the queue to be back instead of failing.
