### PR TITLE
Track const config values in analytics

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
@@ -4,6 +4,9 @@
 
 package io.airbyte.commons.json;
 
+import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toMap;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
@@ -19,9 +22,12 @@ import io.airbyte.commons.stream.MoreStreams;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -198,8 +204,57 @@ public class Jsons {
   }
 
   /**
-   * By the Jackson DefaultPrettyPrinter prints objects with an extra space as follows: {"name" :
-   * "airbyte"}. We prefer {"name": "airbyte"}.
+   * Flattens an ObjectNode, or dumps it into a {null: value} map if it's not an object.
+   */
+  public static Map<String, Object> flatten(final JsonNode node) {
+    if (node.isObject()) {
+      final Map<String, Object> output = new HashMap<>();
+      for (final Iterator<Entry<String, JsonNode>> it = node.fields(); it.hasNext(); ) {
+        final Entry<String, JsonNode> entry = it.next();
+        final String field = entry.getKey();
+        final JsonNode value = entry.getValue();
+        mergeMaps(output, field, flatten(value));
+      }
+      return output;
+    } else {
+      final Object value;
+      if (node.isBoolean()) {
+        value = node.asBoolean();
+      } else if (node.isLong()) {
+        value = node.asLong();
+      } else if (node.isDouble()) {
+        value = node.asDouble();
+      } else if (node.isValueNode() && !node.isNull()) {
+        value = node.asText();
+      } else {
+        // Fallback handling for e.g. arrays
+        value = node.toString();
+      }
+      return singletonMap(null, value);
+    }
+  }
+
+  /**
+   * Prepend all keys in subMap with prefix, then merge that map into originalMap.
+   * <p>
+   * If subMap contains a null key, then instead it is replaced with prefix. I.e. {null: value} is treated as {prefix: value} when merging into
+   * originalMap.
+   */
+  public static void mergeMaps(final Map<String, Object> originalMap, final String prefix, final Map<String, Object> subMap) {
+    originalMap.putAll(subMap.entrySet().stream().collect(toMap(
+        e -> {
+          final String key = e.getKey();
+          if (key != null) {
+            return prefix + "." + key;
+          } else {
+            return prefix;
+          }
+        },
+        Entry::getValue)));
+  }
+
+  /**
+   * By the Jackson DefaultPrettyPrinter prints objects with an extra space as follows: {"name" : "airbyte"}. We prefer {"name": "airbyte"}.
    */
   private static class JsonPrettyPrinter extends DefaultPrettyPrinter {
 

--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
@@ -222,6 +222,8 @@ public class Jsons {
         value = node.asBoolean();
       } else if (node.isLong()) {
         value = node.asLong();
+      } else if (node.isInt()) {
+        value = node.asInt();
       } else if (node.isDouble()) {
         value = node.asDouble();
       } else if (node.isValueNode() && !node.isNull()) {

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -242,7 +242,6 @@ public class JobTracker {
       output.put(null, config.asBoolean());
     } else if ((!config.isTextual() && !config.isNull()) || (config.isTextual() && !config.asText().isEmpty())) {
       // This is either non-textual (i.e. array) or non-empty text
-      // TODO Why do we ignore non-text values (integer/number)?
       output.put(null, SET);
     }
     // Otherwise, this is an empty string, so just ignore it

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -197,7 +197,8 @@ public class JobTracker {
   }
 
   /**
-   * Does the actually interesting bits of configToMetadata. Returns a map of {null: value} if config is not an object.
+   * Does the actually interesting bits of configToMetadata. If config is an object, returns a flattened map. If config is _not_ an object (i.e. it's
+   * a primitive string/number/etc, or it's an array) then returns a map of {null: toMetadataValue(config)}.
    */
   private static Map<String, Object> configToMetadata(final JsonNode config, final JsonNode schema) {
     final Map<String, Object> output = new HashMap<>();

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -180,13 +180,16 @@ public class JobTracker {
   }
 
   /**
-   * Flattens a config into a map. Uses the schema to determine which fields are const (i.e. non-sensitive). Non-const, non-boolean values are
-   * replaced with {@link #SET} to avoid leaking potentially-sensitive information.
+   * Flattens a config into a map. Uses the schema to determine which fields are const (i.e.
+   * non-sensitive). Non-const, non-boolean values are replaced with {@link #SET} to avoid leaking
+   * potentially-sensitive information.
    * <p>
-   * anyOf/allOf schemas are treated as non-const values. These aren't (currently) used in config schemas anyway.
+   * anyOf/allOf schemas are treated as non-const values. These aren't (currently) used in config
+   * schemas anyway.
    *
-   * @param jsonPath A prefix to add to all the keys in the returned map, with a period (`.`) separator
-   * @param schema   The JSON schema that {@code config} conforms to
+   * @param jsonPath A prefix to add to all the keys in the returned map, with a period (`.`)
+   *        separator
+   * @param schema The JSON schema that {@code config} conforms to
    */
   protected static Map<String, Object> configToMetadata(final String jsonPath, final JsonNode config, final JsonNode schema) {
     final Map<String, Object> metadata = configToMetadata(config, schema);
@@ -198,21 +201,23 @@ public class JobTracker {
   }
 
   /**
-   * Does the actually interesting bits of configToMetadata. If config is an object, returns a flattened map. If config is _not_ an object (i.e. it's
-   * a primitive string/number/etc, or it's an array) then returns a map of {null: toMetadataValue(config)}.
+   * Does the actually interesting bits of configToMetadata. If config is an object, returns a
+   * flattened map. If config is _not_ an object (i.e. it's a primitive string/number/etc, or it's an
+   * array) then returns a map of {null: toMetadataValue(config)}.
    */
   private static Map<String, Object> configToMetadata(final JsonNode config, final JsonNode schema) {
     if (schema.hasNonNull("const")) {
       // If this schema is a const, then just dump it into a map:
       // * If it's an object, flatten it
       // * Otherwise, do some basic conversions to value-ish data.
-      // It would be a weird thing to declare const: null, but in that case we don't want to report null anyway, so explicitly use hasNonNull.
+      // It would be a weird thing to declare const: null, but in that case we don't want to report null
+      // anyway, so explicitly use hasNonNull.
       return flatten(config);
     } else if (schema.has("oneOf")) {
       // If this schema is a oneOf, then find the first sub-schema which the config matches
       // and use that sub-schema to convert the config to a map
       final JsonSchemaValidator validator = new JsonSchemaValidator();
-      for (final Iterator<JsonNode> it = schema.get("oneOf").elements(); it.hasNext(); ) {
+      for (final Iterator<JsonNode> it = schema.get("oneOf").elements(); it.hasNext();) {
         final JsonNode subSchema = it.next();
         if (validator.test(subSchema, config)) {
           return configToMetadata(config, subSchema);
@@ -223,11 +228,12 @@ public class JobTracker {
     } else if (config.isObject()) {
       // If the schema is not a oneOf, but the config is an object (i.e. the schema has "type": "object")
       // then we need to recursively convert each field of the object to a map.
-      // Note: this doesn't handle additionalProperties, so if a config contains properties that are not explicitly declared in the schema, they will be ignored.
+      // Note: this doesn't handle additionalProperties, so if a config contains properties that are not
+      // explicitly declared in the schema, they will be ignored.
       final Map<String, Object> output = new HashMap<>();
       final JsonNode maybeProperties = schema.get("properties");
       if (maybeProperties != null) {
-        for (final Iterator<Entry<String, JsonNode>> it = config.fields(); it.hasNext(); ) {
+        for (final Iterator<Entry<String, JsonNode>> it = config.fields(); it.hasNext();) {
           final Entry<String, JsonNode> entry = it.next();
           final String field = entry.getKey();
           final JsonNode value = entry.getValue();
@@ -249,13 +255,13 @@ public class JobTracker {
   }
 
   /**
-   * Naively flattens a JsonNode, or dumps it into a {null: node} map. Does _not_ mask values; ONLY use this if you're sure that node does NOT contain
-   * potentially-sensitive data.
+   * Naively flattens a JsonNode, or dumps it into a {null: node} map. Does _not_ mask values; ONLY
+   * use this if you're sure that node does NOT contain potentially-sensitive data.
    */
   private static Map<String, Object> flatten(final JsonNode node) {
     if (node.isObject()) {
       final Map<String, Object> output = new HashMap<>();
-      for (final Iterator<Entry<String, JsonNode>> it = node.fields(); it.hasNext(); ) {
+      for (final Iterator<Entry<String, JsonNode>> it = node.fields(); it.hasNext();) {
         final Entry<String, JsonNode> entry = it.next();
         final String field = entry.getKey();
         final JsonNode value = entry.getValue();
@@ -283,8 +289,8 @@ public class JobTracker {
   /**
    * Prepend all keys in subMap with prefix, then merge that map into originalMap.
    * <p>
-   * If subMap contains a null key, then instead it is replaced with prefix. I.e. {null: value} is treated as {prefix: value} when merging into
-   * originalMap.
+   * If subMap contains a null key, then instead it is replaced with prefix. I.e. {null: value} is
+   * treated as {prefix: value} when merging into originalMap.
    */
   private static void mergeMaps(final Map<String, Object> originalMap, final String prefix, final Map<String, Object> subMap) {
     originalMap.putAll(subMap.entrySet().stream().collect(toMap(
@@ -296,8 +302,7 @@ public class JobTracker {
             return prefix;
           }
         },
-        Entry::getValue
-    )));
+        Entry::getValue)));
   }
 
   private Map<String, Object> generateSyncMetadata(final UUID connectionId) throws ConfigNotFoundException, IOException, JsonValidationException {

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -207,11 +207,7 @@ public class JobTracker {
       // * If it's an object, flatten it
       // * Otherwise, do some basic conversions to value-ish data.
       // It would be a weird thing to declare const: null, but in that case we don't want to report null anyway, so explicitly use hasNonNull.
-      if (config.isObject()) {
-        return flatten(config);
-      } else {
-        return singletonMap(null, toMetadataValue(config));
-      }
+      return flatten(config);
     } else if (schema.has("oneOf")) {
       // If this schema is a oneOf, then find the first sub-schema which the config matches
       // and use that sub-schema to convert the config to a map
@@ -252,43 +248,43 @@ public class JobTracker {
     }
   }
 
-  private static Map<String, Object> flatten(final JsonNode node) {
-    final Map<String, Object> output = new HashMap<>();
-    for (final Iterator<Entry<String, JsonNode>> it = node.fields(); it.hasNext(); ) {
-      final Entry<String, JsonNode> entry = it.next();
-      final String field = entry.getKey();
-      final JsonNode value = entry.getValue();
-      if (value.isObject()) {
-        mergeMaps(output, field, flatten(value));
-      } else {
-        output.put(field, toMetadataValue(value));
-      }
-    }
-    return output;
-  }
-
   /**
-   * @param node Should not be an object. You may want to use {@link #flatten(JsonNode)} for that case.
+   * Naively flattens a JsonNode, or dumps it into a {null: node} map. Does _not_ mask values; ONLY use this if you're sure that node does NOT contain
+   * potentially-sensitive data.
    */
-  private static Object toMetadataValue(final JsonNode node) {
-    if (node.isBoolean()) {
-      return node.asBoolean();
-    } else if (node.isLong()) {
-      return node.asLong();
-    } else if (node.isDouble()) {
-      return node.asDouble();
-    } else if (node.isValueNode() && !node.isNull()) {
-      return node.asText();
+  private static Map<String, Object> flatten(final JsonNode node) {
+    if (node.isObject()) {
+      final Map<String, Object> output = new HashMap<>();
+      for (final Iterator<Entry<String, JsonNode>> it = node.fields(); it.hasNext(); ) {
+        final Entry<String, JsonNode> entry = it.next();
+        final String field = entry.getKey();
+        final JsonNode value = entry.getValue();
+        mergeMaps(output, field, flatten(value));
+      }
+      return output;
     } else {
-      // Fallback handling for e.g. arrays
-      return node.toString();
+      final Object metadataValue;
+      if (node.isBoolean()) {
+        metadataValue = node.asBoolean();
+      } else if (node.isLong()) {
+        metadataValue = node.asLong();
+      } else if (node.isDouble()) {
+        metadataValue = node.asDouble();
+      } else if (node.isValueNode() && !node.isNull()) {
+        metadataValue = node.asText();
+      } else {
+        // Fallback handling for e.g. arrays
+        metadataValue = node.toString();
+      }
+      return singletonMap(null, metadataValue);
     }
   }
 
   /**
    * Prepend all keys in subMap with prefix, then merge that map into originalMap.
    * <p>
-   * If subMap contains a null key, then it is replaced with prefix. I.e. {null: value} is treated as {prefix: value} when merging into originalMap.
+   * If subMap contains a null key, then instead it is replaced with prefix. I.e. {null: value} is treated as {prefix: value} when merging into
+   * originalMap.
    */
   private static void mergeMaps(final Map<String, Object> originalMap, final String prefix, final Map<String, Object> subMap) {
     originalMap.putAll(subMap.entrySet().stream().collect(toMap(

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -240,7 +240,7 @@ public class JobTracker {
     } else if (config.isBoolean()) {
       return singletonMap(null, config.asBoolean());
     } else if ((!config.isTextual() && !config.isNull()) || (config.isTextual() && !config.asText().isEmpty())) {
-      // This is either non-textual (i.e. array) or non-empty text
+      // This is either non-textual (e.g. integer, array, etc) or non-empty text
       return singletonMap(null, SET);
     } else {
       // Otherwise, this is an empty string, so just ignore it

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -207,6 +207,7 @@ public class JobTracker {
       // If this schema is a const, then just dump it into a map:
       // * If it's an object, flatten it
       // * Otherwise, do some basic conversions to value-ish data.
+      // It would be a weird thing to declare const: null, but in that case we don't want to report null anyway, so explicitly use hasNonNull.
       if (config.isObject()) {
         output.putAll(flatten(config));
       } else {

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -202,7 +202,6 @@ public class JobTracker {
   private static Map<String, Object> configToMetadata(final JsonNode config, final JsonNode schema) {
     final Map<String, Object> output = new HashMap<>();
 
-    final JsonNode maybeOneOfSchemas = schema.get("oneOf");
     if (schema.hasNonNull("const")) {
       // If this schema is a const, then just dump it into a map:
       // * If it's an object, flatten it
@@ -212,11 +211,11 @@ public class JobTracker {
       } else {
         output.put(null, toMetadataValue(config));
       }
-    } else if (maybeOneOfSchemas != null && maybeOneOfSchemas.isArray()) {
+    } else if (schema.has("oneOf")) {
       // If this schema is a oneOf, then find the first sub-schema which the config matches
       // and use that sub-schema to convert the config to a map
       final JsonSchemaValidator validator = new JsonSchemaValidator();
-      for (final Iterator<JsonNode> it = maybeOneOfSchemas.elements(); it.hasNext(); ) {
+      for (final Iterator<JsonNode> it = schema.get("oneOf").elements(); it.hasNext(); ) {
         final JsonNode subSchema = it.next();
         if (validator.test(subSchema, config)) {
           return configToMetadata(config, subSchema);

--- a/airbyte-scheduler/persistence/src/main/resources/example_config.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config.json
@@ -6,7 +6,8 @@
   "null_value": null,
   "one_of": {
     "type_key": "foo",
-    "some_key": 100
+    "some_key": 100,
+    "some_undeclared_key": "ignored"
   },
   "const_object": {
     "sub_key": "bar",

--- a/airbyte-scheduler/persistence/src/main/resources/example_config.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config.json
@@ -14,5 +14,6 @@
     "sub_object": {
       "sub_sub_key": "baz"
     }
-  }
+  },
+  "const_null": null
 }

--- a/airbyte-scheduler/persistence/src/main/resources/example_config.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config.json
@@ -6,8 +6,7 @@
   "null_value": null,
   "one_of": {
     "type_key": "foo",
-    "some_key": 100,
-    "some_undeclared_key": "ignored"
+    "some_key": 100
   },
   "const_object": {
     "sub_key": "bar",
@@ -16,5 +15,17 @@
       "sub_sub_key": "baz"
     }
   },
-  "const_null": null
+  "const_null": null,
+  "additionalPropertiesUnset": {
+    "foo": "bar"
+  },
+  "additionalPropertiesBoolean": {
+    "foo": "bar"
+  },
+  "additionalPropertiesSchema": {
+    "foo": 42
+  },
+  "additionalPropertiesConst": {
+    "foo": 42
+  }
 }

--- a/airbyte-scheduler/persistence/src/main/resources/example_config.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config.json
@@ -5,6 +5,7 @@
   "empty_string": "",
   "null_value": null,
   "one_of": {
+    "type_key": "foo",
     "some_key": 100
   }
 }

--- a/airbyte-scheduler/persistence/src/main/resources/example_config.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config.json
@@ -9,6 +9,10 @@
     "some_key": 100
   },
   "const_object": {
-    "sub_key": "bar"
+    "sub_key": "bar",
+    "sub_array": [1, 2, 3],
+    "sub_object": {
+      "sub_sub_key": "baz"
+    }
   }
 }

--- a/airbyte-scheduler/persistence/src/main/resources/example_config.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config.json
@@ -7,5 +7,8 @@
   "one_of": {
     "type_key": "foo",
     "some_key": 100
+  },
+  "const_object": {
+    "sub_key": "bar"
   }
 }

--- a/airbyte-scheduler/persistence/src/main/resources/example_config_schema.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config_schema.json
@@ -34,7 +34,11 @@
     },
     "const_object": {
       "const": {
-        "sub_key": "bar"
+        "sub_key": "bar",
+        "sub_array": [1, 2, 3],
+        "sub_object": {
+          "sub_sub_key": "baz"
+        }
       }
     }
   }

--- a/airbyte-scheduler/persistence/src/main/resources/example_config_schema.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config_schema.json
@@ -40,6 +40,9 @@
           "sub_sub_key": "baz"
         }
       }
+    },
+    "const_null": {
+      "const": null
     }
   }
 }

--- a/airbyte-scheduler/persistence/src/main/resources/example_config_schema.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config_schema.json
@@ -31,6 +31,11 @@
           }
         }
       ]
+    },
+    "const_object": {
+      "const": {
+        "sub_key": "bar"
+      }
     }
   }
 }

--- a/airbyte-scheduler/persistence/src/main/resources/example_config_schema.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config_schema.json
@@ -43,6 +43,25 @@
     },
     "const_null": {
       "const": null
+    },
+    "additionalPropertiesUnset": {
+      "type": "object"
+    },
+    "additionalPropertiesBoolean": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "additionalPropertiesSchema": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      }
+    },
+    "additionalPropertiesConst": {
+      "type": "object",
+      "additionalProperties": {
+        "const": 42
+      }
     }
   }
 }

--- a/airbyte-scheduler/persistence/src/main/resources/example_config_schema.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config_schema.json
@@ -1,0 +1,36 @@
+{
+  "type": "object",
+  "properties": {
+    "username": {
+      "type": "string"
+    },
+    "password": {
+      "type": "string"
+    },
+    "has_ssl": {
+      "type": "boolean"
+    },
+    "empty_string": {
+      "type": "string"
+    },
+    "null_value": {
+      "type": "null"
+    },
+    "one_of": {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type_key": {
+              "const": "foo"
+            },
+            "some_key": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
@@ -259,13 +259,17 @@ class JobTrackerTest {
     final String configJson = MoreResources.readResource("example_config.json");
     final JsonNode config = Jsons.deserialize(configJson);
 
+    final String schemaJson = MoreResources.readResource("example_config_schema.json");
+    final JsonNode schema = Jsons.deserialize(schemaJson);
+
     final Map<String, Object> expected = ImmutableMap.of(
         JobTracker.CONFIG + ".username", JobTracker.SET,
         JobTracker.CONFIG + ".has_ssl", false,
         JobTracker.CONFIG + ".password", JobTracker.SET,
+        JobTracker.CONFIG + ".one_of.type_key", "foo",
         JobTracker.CONFIG + ".one_of.some_key", JobTracker.SET);
 
-    final Map<String, Object> actual = JobTracker.configToMetadata(JobTracker.CONFIG, config);
+    final Map<String, Object> actual = JobTracker.configToMetadata(JobTracker.CONFIG, config, schema);
 
     assertEquals(expected, actual);
   }

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
@@ -267,7 +267,8 @@ class JobTrackerTest {
         JobTracker.CONFIG + ".has_ssl", false,
         JobTracker.CONFIG + ".password", JobTracker.SET,
         JobTracker.CONFIG + ".one_of.type_key", "foo",
-        JobTracker.CONFIG + ".one_of.some_key", JobTracker.SET);
+        JobTracker.CONFIG + ".one_of.some_key", JobTracker.SET,
+        JobTracker.CONFIG + ".const_object.sub_key", "bar");
 
     final Map<String, Object> actual = JobTracker.configToMetadata(JobTracker.CONFIG, config, schema);
 

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
@@ -268,7 +268,9 @@ class JobTrackerTest {
         JobTracker.CONFIG + ".password", JobTracker.SET,
         JobTracker.CONFIG + ".one_of.type_key", "foo",
         JobTracker.CONFIG + ".one_of.some_key", JobTracker.SET,
-        JobTracker.CONFIG + ".const_object.sub_key", "bar");
+        JobTracker.CONFIG + ".const_object.sub_key", "bar",
+        JobTracker.CONFIG + ".const_object.sub_array", "[1,2,3]",
+        JobTracker.CONFIG + ".const_object.sub_object.sub_sub_key", "baz");
 
     final Map<String, Object> actual = JobTracker.configToMetadata(JobTracker.CONFIG, config, schema);
 

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
@@ -112,26 +112,26 @@ class JobTrackerTest {
     try {
       SOURCE_SPEC = new ConnectorSpecification().withConnectionSpecification(OBJECT_MAPPER.readTree(
           """
-              {
-                "type": "object",
-                "properties": {
-                  "key": {
-                    "type": "string"
-                  }
-                }
+          {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
               }
-              """));
+            }
+          }
+          """));
       DESTINATION_SPEC = new ConnectorSpecification().withConnectionSpecification(OBJECT_MAPPER.readTree(
           """
-              {
-                "type": "object",
-                "properties": {
-                  "key": {
-                    "type": "boolean"
-                  }
-                }
+          {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "boolean"
               }
-              """));
+            }
+          }
+          """));
     } catch (final JsonProcessingException e) {
       throw new RuntimeException(e);
     }

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
@@ -299,15 +299,20 @@ class JobTrackerTest {
     final String schemaJson = MoreResources.readResource("example_config_schema.json");
     final JsonNode schema = Jsons.deserialize(schemaJson);
 
-    final Map<String, Object> expected = ImmutableMap.of(
-        JobTracker.CONFIG + ".username", JobTracker.SET,
-        JobTracker.CONFIG + ".has_ssl", false,
-        JobTracker.CONFIG + ".password", JobTracker.SET,
-        JobTracker.CONFIG + ".one_of.type_key", "foo",
-        JobTracker.CONFIG + ".one_of.some_key", JobTracker.SET,
-        JobTracker.CONFIG + ".const_object.sub_key", "bar",
-        JobTracker.CONFIG + ".const_object.sub_array", "[1,2,3]",
-        JobTracker.CONFIG + ".const_object.sub_object.sub_sub_key", "baz");
+    final Map<String, Object> expected = new ImmutableMap.Builder<String, Object>()
+        .put(JobTracker.CONFIG + ".username", JobTracker.SET)
+        .put(JobTracker.CONFIG + ".has_ssl", false)
+        .put(JobTracker.CONFIG + ".password", JobTracker.SET)
+        .put(JobTracker.CONFIG + ".one_of.type_key", "foo")
+        .put(JobTracker.CONFIG + ".one_of.some_key", JobTracker.SET)
+        .put(JobTracker.CONFIG + ".const_object.sub_key", "bar")
+        .put(JobTracker.CONFIG + ".const_object.sub_array", "[1,2,3]")
+        .put(JobTracker.CONFIG + ".const_object.sub_object.sub_sub_key", "baz")
+        .put(JobTracker.CONFIG + ".additionalPropertiesUnset.foo", JobTracker.SET)
+        .put(JobTracker.CONFIG + ".additionalPropertiesBoolean.foo", JobTracker.SET)
+        .put(JobTracker.CONFIG + ".additionalPropertiesSchema.foo", JobTracker.SET)
+        .put(JobTracker.CONFIG + ".additionalPropertiesConst.foo", 42)
+        .build();
 
     final Map<String, Object> actual = JobTracker.configToMetadata(JobTracker.CONFIG, config, schema);
 


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/9618

## How
JobTracker now uses the config spec to determine which values are `const`, and inserts them into the event metadata appropriately.

Notably:
* Nested config objects will recursively pull the schema out of the `properties` field
* `oneOf` schemas are manually matched against the config. This is pretty inefficient - a deeply-nested config with many `oneOf`s would match the "leaf" nodes many times. But that doesn't seem likely to actually happen.

## Recommended reading order
1. JobTracker - take a look at `mergeMaps`, `flatten`, and then the two `configToMetadata` methods. Then read the rest of the file
2. JobTrackerTest + example_config.json / example_config_schema.json - start with `testConfigToMetadata`;  everything else is just to fix the mocked ConfigRepository objects

## 🚨 User Impact 🚨
Nope