### PR TITLE
make orchestrator cleanup safer

### DIFF
--- a/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/ContainerOrchestratorApp.java
+++ b/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/ContainerOrchestratorApp.java
@@ -37,6 +37,8 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
+import sun.misc.Signal;
+import sun.misc.SignalHandler;
 
 /**
  * Entrypoint for the application responsible for launching containers and handling all message
@@ -146,6 +148,12 @@ public class ContainerOrchestratorApp {
 
   public static void main(final String[] args) {
     try {
+      // otherwise the pod hangs on closing
+      Signal.handle(new Signal("TERM"), sig -> {
+        log.error("Received termination signal, failing...");
+        System.exit(1);
+      });
+
       // wait for config files to be copied
       final var successFile = Path.of(KubePodProcess.CONFIG_DIR, KubePodProcess.SUCCESS_FILE_NAME);
 
@@ -163,6 +171,7 @@ public class ContainerOrchestratorApp {
       app.run();
     } catch (Throwable t) {
       log.info("Orchestrator failed...", t);
+      // otherwise the pod hangs on closing
       System.exit(1);
     }
   }

--- a/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/ContainerOrchestratorApp.java
+++ b/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/ContainerOrchestratorApp.java
@@ -38,7 +38,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import sun.misc.Signal;
-import sun.misc.SignalHandler;
 
 /**
  * Entrypoint for the application responsible for launching containers and handling all message

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -309,7 +309,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
         while (!cancelled.get() && !destination.isFinished()) {
           final Optional<AirbyteMessage> messageOptional = destination.attemptRead();
           if (messageOptional.isPresent()) {
-            LOGGER.info("state in DefaultReplicationWorker from Destination: {}", messageOptional.get());
+            LOGGER.info("State in DefaultReplicationWorker from destination: {}", messageOptional.get());
             messageTracker.acceptFromDestination(messageOptional.get());
           }
         }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -99,9 +99,6 @@ public class WorkerApp {
   private final WorkerEnvironment workerEnvironment;
   private final LogConfigs logConfigs;
   private final WorkerConfigs workerConfigs;
-  private final String databaseUser;
-  private final String databasePassword;
-  private final String databaseUrl;
   private final String airbyteVersion;
   private final SyncJobFactory jobFactory;
   private final JobPersistence jobPersistence;
@@ -129,8 +126,7 @@ public class WorkerApp {
     final Worker specWorker = factory.newWorker(TemporalJobType.GET_SPEC.name(), getWorkerOptions(maxWorkers.getMaxSpecWorkers()));
     specWorker.registerWorkflowImplementationTypes(SpecWorkflowImpl.class);
     specWorker.registerActivitiesImplementations(
-        new SpecActivityImpl(workerConfigs, jobProcessFactory, workspaceRoot, workerEnvironment, logConfigs, databaseUser, databasePassword,
-            databaseUrl,
+        new SpecActivityImpl(workerConfigs, jobProcessFactory, workspaceRoot, workerEnvironment, logConfigs, jobPersistence,
             airbyteVersion));
 
     final Worker checkConnectionWorker =
@@ -139,16 +135,14 @@ public class WorkerApp {
     checkConnectionWorker
         .registerActivitiesImplementations(
             new CheckConnectionActivityImpl(workerConfigs, jobProcessFactory, secretsHydrator, workspaceRoot, workerEnvironment, logConfigs,
-                databaseUser,
-                databasePassword, databaseUrl, airbyteVersion));
+                jobPersistence, airbyteVersion));
 
     final Worker discoverWorker = factory.newWorker(TemporalJobType.DISCOVER_SCHEMA.name(), getWorkerOptions(maxWorkers.getMaxDiscoverWorkers()));
     discoverWorker.registerWorkflowImplementationTypes(DiscoverCatalogWorkflowImpl.class);
     discoverWorker
         .registerActivitiesImplementations(
             new DiscoverCatalogActivityImpl(workerConfigs, jobProcessFactory, secretsHydrator, workspaceRoot, workerEnvironment, logConfigs,
-                databaseUser,
-                databasePassword, databaseUrl, airbyteVersion));
+                jobPersistence, airbyteVersion));
 
     final NormalizationActivityImpl normalizationActivity =
         new NormalizationActivityImpl(
@@ -159,9 +153,7 @@ public class WorkerApp {
             workspaceRoot,
             workerEnvironment,
             logConfigs,
-            databaseUser,
-            databasePassword,
-            databaseUrl,
+            jobPersistence,
             airbyteVersion);
     final DbtTransformationActivityImpl dbtTransformationActivity =
         new DbtTransformationActivityImpl(
@@ -172,9 +164,7 @@ public class WorkerApp {
             workspaceRoot,
             workerEnvironment,
             logConfigs,
-            databaseUser,
-            databasePassword,
-            databaseUrl,
+            jobPersistence,
             airbyteVersion);
     new PersistStateActivityImpl(workspaceRoot, configRepository);
     final PersistStateActivityImpl persistStateActivity = new PersistStateActivityImpl(workspaceRoot, configRepository);
@@ -187,9 +177,7 @@ public class WorkerApp {
         workspaceRoot,
         workerEnvironment,
         logConfigs,
-        databaseUser,
-        databasePassword,
-        databaseUrl,
+        jobPersistence,
         airbyteVersion);
     syncWorker.registerWorkflowImplementationTypes(SyncWorkflowImpl.class);
 
@@ -235,9 +223,7 @@ public class WorkerApp {
                                                              final Path workspaceRoot,
                                                              final WorkerEnvironment workerEnvironment,
                                                              final LogConfigs logConfigs,
-                                                             final String databaseUser,
-                                                             final String databasePassword,
-                                                             final String databaseUrl,
+                                                             final JobPersistence jobPersistence,
                                                              final String airbyteVersion) {
 
     return new ReplicationActivityImpl(
@@ -248,9 +234,7 @@ public class WorkerApp {
         workspaceRoot,
         workerEnvironment,
         logConfigs,
-        databaseUser,
-        databasePassword,
-        databaseUrl,
+        jobPersistence,
         airbyteVersion);
   }
 
@@ -395,9 +379,6 @@ public class WorkerApp {
         configs.getWorkerEnvironment(),
         configs.getLogConfigs(),
         workerConfigs,
-        configs.getDatabaseUser(),
-        configs.getDatabasePassword(),
-        configs.getDatabaseUrl(),
         configs.getAirbyteVersionOrWarning(),
         jobFactory,
         jobPersistence,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/AsyncOrchestratorPodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/AsyncOrchestratorPodProcess.java
@@ -6,7 +6,6 @@ package io.airbyte.workers.process;
 
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.config.ResourceRequirements;
 import io.airbyte.workers.WorkerApp;
 import io.airbyte.workers.storage.DocumentStoreClient;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/AsyncOrchestratorPodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/AsyncOrchestratorPodProcess.java
@@ -6,11 +6,13 @@ package io.airbyte.workers.process;
 
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.config.ResourceRequirements;
 import io.airbyte.workers.WorkerApp;
 import io.airbyte.workers.storage.DocumentStoreClient;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
@@ -140,6 +142,7 @@ public class AsyncOrchestratorPodProcess implements KubePod {
     final var wasDestroyed = kubernetesClient.pods()
         .inNamespace(getInfo().namespace())
         .withName(getInfo().name())
+        .withPropagationPolicy(DeletionPropagation.FOREGROUND)
         .delete();
 
     if (wasDestroyed) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/AsyncOrchestratorPodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/AsyncOrchestratorPodProcess.java
@@ -243,7 +243,7 @@ public class AsyncOrchestratorPodProcess implements KubePod {
     final List<ContainerPort> containerPorts = KubePodProcess.createContainerPortList(portMap);
 
     final var mainContainer = new ContainerBuilder()
-        .withName("main")
+        .withName(KubePodProcess.MAIN_CONTAINER_NAME)
         .withImage("airbyte/container-orchestrator:" + airbyteVersion)
         .withResources(KubePodProcess.getResourceRequirementsBuilder(resourceRequirements).build())
         .withPorts(containerPorts)

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -110,6 +110,7 @@ public class KubePodProcess extends Process implements KubePod {
   private static final String TERMINATION_FILE_MAIN = TERMINATION_DIR + "/main";
   private static final String TERMINATION_FILE_CHECK = TERMINATION_DIR + "/check";
   public static final String SUCCESS_FILE_NAME = "FINISHED_UPLOADING";
+  public static final String MAIN_CONTAINER_NAME = "main";
 
   // 143 is the typical SIGTERM exit code.
   private static final int KILLED_EXIT_CODE = 143;
@@ -198,7 +199,7 @@ public class KubePodProcess extends Process implements KubePod {
         .collect(Collectors.toList());
 
     final ContainerBuilder containerBuilder = new ContainerBuilder()
-        .withName("main")
+        .withName(MAIN_CONTAINER_NAME)
         .withPorts(containerPorts)
         .withImage(image)
         .withImagePullPolicy(imagePullPolicy)
@@ -640,7 +641,7 @@ public class KubePodProcess extends Process implements KubePod {
       final ContainerStatus mainContainerStatus = pod.getStatus()
           .getContainerStatuses()
           .stream()
-          .filter(containerStatus -> containerStatus.getName().equals("main"))
+          .filter(containerStatus -> containerStatus.getName().equals(MAIN_CONTAINER_NAME))
           .collect(MoreCollectors.onlyElement());
 
       return mainContainerStatus.getState() != null && mainContainerStatus.getState().getTerminated() != null;
@@ -683,7 +684,7 @@ public class KubePodProcess extends Process implements KubePod {
 
     final ContainerStatus mainContainerStatus = refreshedPod.getStatus().getContainerStatuses()
         .stream()
-        .filter(containerStatus -> containerStatus.getName().equals("main"))
+        .filter(containerStatus -> containerStatus.getName().equals(MAIN_CONTAINER_NAME))
         .collect(MoreCollectors.onlyElement());
 
     if (mainContainerStatus.getState() == null || mainContainerStatus.getState().getTerminated() == null) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
@@ -9,10 +9,7 @@ import io.airbyte.commons.functional.CheckedSupplier;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.helpers.LogClientSingleton;
 import io.airbyte.config.helpers.LogConfigs;
-import io.airbyte.db.Database;
-import io.airbyte.db.instance.jobs.JobsDatabaseInstance;
 import io.airbyte.scheduler.models.JobRunConfig;
-import io.airbyte.scheduler.persistence.DefaultJobPersistence;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.workers.Worker;
 import io.airbyte.workers.WorkerUtils;
@@ -49,9 +46,7 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
   private final Consumer<Path> mdcSetter;
   private final CancellationHandler cancellationHandler;
   private final Supplier<String> workflowIdProvider;
-  private final String databaseUser;
-  private final String databasePassword;
-  private final String databaseUrl;
+  private final JobPersistence jobPersistence;
   private final String airbyteVersion;
 
   public TemporalAttemptExecution(final Path workspaceRoot,
@@ -61,9 +56,7 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
                                   final CheckedSupplier<Worker<INPUT, OUTPUT>, Exception> workerSupplier,
                                   final Supplier<INPUT> inputSupplier,
                                   final CancellationHandler cancellationHandler,
-                                  final String databaseUser,
-                                  final String databasePassword,
-                                  final String databaseUrl,
+                                  final JobPersistence jobPersistence,
                                   final String airbyteVersion) {
     this(
         workspaceRoot, workerEnvironment, logConfigs,
@@ -71,7 +64,8 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
         workerSupplier,
         inputSupplier,
         (path -> LogClientSingleton.getInstance().setJobMdc(workerEnvironment, logConfigs, path)),
-        cancellationHandler, databaseUser, databasePassword, databaseUrl,
+        cancellationHandler,
+        jobPersistence,
         () -> Activity.getExecutionContext().getInfo().getWorkflowId(), airbyteVersion);
   }
 
@@ -84,9 +78,7 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
                            final Supplier<INPUT> inputSupplier,
                            final Consumer<Path> mdcSetter,
                            final CancellationHandler cancellationHandler,
-                           final String databaseUser,
-                           final String databasePassword,
-                           final String databaseUrl,
+                           final JobPersistence jobPersistence,
                            final Supplier<String> workflowIdProvider,
                            final String airbyteVersion) {
     this.jobRunConfig = jobRunConfig;
@@ -100,9 +92,7 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
     this.cancellationHandler = cancellationHandler;
     this.workflowIdProvider = workflowIdProvider;
 
-    this.databaseUser = databaseUser;
-    this.databasePassword = databasePassword;
-    this.databaseUrl = databaseUrl;
+    this.jobPersistence = jobPersistence;
     this.airbyteVersion = airbyteVersion;
   }
 
@@ -120,7 +110,7 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
       LOGGER.info("Executing worker wrapper. Airbyte version: {}", airbyteVersion);
       // TODO(Davin): This will eventually run into scaling problems, since it opens a DB connection per
       // workflow. See https://github.com/airbytehq/airbyte/issues/5936.
-      saveWorkflowIdForCancellation(databaseUser, databasePassword, databaseUrl);
+      saveWorkflowIdForCancellation(jobPersistence);
 
       final Worker<INPUT, OUTPUT> worker = workerSupplier.get();
       final CompletableFuture<OUTPUT> outputFuture = new CompletableFuture<>();
@@ -146,18 +136,12 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
     }
   }
 
-  private void saveWorkflowIdForCancellation(final String databaseUser, final String databasePassword, final String databaseUrl) throws IOException {
+  private void saveWorkflowIdForCancellation(final JobPersistence jobPersistence) throws IOException {
     // If the jobId is not a number, it means the job is a synchronous job. No attempt is created for
     // it, and it cannot be cancelled, so do not save the workflowId. See
     // SynchronousSchedulerClient.java
     // for info.
     if (NumberUtils.isCreatable(jobRunConfig.getJobId())) {
-      final Database jobDatabase = new JobsDatabaseInstance(
-          databaseUser,
-          databasePassword,
-          databaseUrl)
-              .getInitialized();
-      final JobPersistence jobPersistence = new DefaultJobPersistence(jobDatabase);
       final String workflowId = workflowIdProvider.get();
       jobPersistence.setAttemptTemporalWorkflowId(Long.parseLong(jobRunConfig.getJobId()), jobRunConfig.getAttemptId().intValue(), workflowId);
     }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivityImpl.java
@@ -13,6 +13,7 @@ import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.config.persistence.split_secrets.SecretsHydrator;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.workers.DefaultCheckConnectionWorker;
 import io.airbyte.workers.Worker;
 import io.airbyte.workers.WorkerConfigs;
@@ -32,9 +33,7 @@ public class CheckConnectionActivityImpl implements CheckConnectionActivity {
   private final Path workspaceRoot;
   private final WorkerEnvironment workerEnvironment;
   private final LogConfigs logConfigs;
-  private final String databaseUser;
-  private final String databasePassword;
-  private final String databaseUrl;
+  private final JobPersistence jobPersistence;
   private final String airbyteVersion;
 
   public CheckConnectionActivityImpl(final WorkerConfigs workerConfigs,
@@ -43,9 +42,7 @@ public class CheckConnectionActivityImpl implements CheckConnectionActivity {
                                      final Path workspaceRoot,
                                      final WorkerEnvironment workerEnvironment,
                                      final LogConfigs logConfigs,
-                                     final String databaseUser,
-                                     final String databasePassword,
-                                     final String databaseUrl,
+                                     final JobPersistence jobPersistence,
                                      final String airbyteVersion) {
     this.workerConfigs = workerConfigs;
     this.processFactory = processFactory;
@@ -53,9 +50,7 @@ public class CheckConnectionActivityImpl implements CheckConnectionActivity {
     this.workspaceRoot = workspaceRoot;
     this.workerEnvironment = workerEnvironment;
     this.logConfigs = logConfigs;
-    this.databaseUser = databaseUser;
-    this.databasePassword = databasePassword;
-    this.databaseUrl = databaseUrl;
+    this.jobPersistence = jobPersistence;
     this.airbyteVersion = airbyteVersion;
   }
 
@@ -76,7 +71,9 @@ public class CheckConnectionActivityImpl implements CheckConnectionActivity {
             jobRunConfig,
             getWorkerFactory(launcherConfig),
             inputSupplier,
-            new CancellationHandler.TemporalCancellationHandler(), databaseUser, databasePassword, databaseUrl, airbyteVersion);
+            new CancellationHandler.TemporalCancellationHandler(),
+            jobPersistence,
+            airbyteVersion);
 
     return temporalAttemptExecution.get();
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/discover/catalog/DiscoverCatalogActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/discover/catalog/DiscoverCatalogActivityImpl.java
@@ -13,6 +13,7 @@ import io.airbyte.config.persistence.split_secrets.SecretsHydrator;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.workers.DefaultDiscoverCatalogWorker;
 import io.airbyte.workers.Worker;
 import io.airbyte.workers.WorkerConfigs;
@@ -34,9 +35,7 @@ public class DiscoverCatalogActivityImpl implements DiscoverCatalogActivity {
   private final Path workspaceRoot;
   private final WorkerEnvironment workerEnvironment;
   private final LogConfigs logConfigs;
-  private final String databaseUser;
-  private final String databasePassword;
-  private final String databaseUrl;
+  private final JobPersistence jobPersistence;
   private final String airbyteVersion;
 
   public DiscoverCatalogActivityImpl(final WorkerConfigs workerConfigs,
@@ -45,9 +44,7 @@ public class DiscoverCatalogActivityImpl implements DiscoverCatalogActivity {
                                      final Path workspaceRoot,
                                      final WorkerEnvironment workerEnvironment,
                                      final LogConfigs logConfigs,
-                                     final String databaseUser,
-                                     final String databasePassword,
-                                     final String databaseUrl,
+                                     final JobPersistence jobPersistence,
                                      final String airbyteVersion) {
     this.workerConfigs = workerConfigs;
     this.processFactory = processFactory;
@@ -55,9 +52,7 @@ public class DiscoverCatalogActivityImpl implements DiscoverCatalogActivity {
     this.workspaceRoot = workspaceRoot;
     this.workerEnvironment = workerEnvironment;
     this.logConfigs = logConfigs;
-    this.databaseUser = databaseUser;
-    this.databasePassword = databasePassword;
-    this.databaseUrl = databaseUrl;
+    this.jobPersistence = jobPersistence;
     this.airbyteVersion = airbyteVersion;
 
   }
@@ -80,7 +75,9 @@ public class DiscoverCatalogActivityImpl implements DiscoverCatalogActivity {
         jobRunConfig,
         getWorkerFactory(launcherConfig),
         inputSupplier,
-        new CancellationHandler.TemporalCancellationHandler(), databaseUser, databasePassword, databaseUrl, airbyteVersion);
+        new CancellationHandler.TemporalCancellationHandler(),
+        jobPersistence,
+        airbyteVersion);
 
     return temporalAttemptExecution.get();
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/spec/SpecActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/spec/SpecActivityImpl.java
@@ -11,6 +11,7 @@ import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.workers.DefaultGetSpecWorker;
 import io.airbyte.workers.Worker;
 import io.airbyte.workers.WorkerConfigs;
@@ -29,9 +30,7 @@ public class SpecActivityImpl implements SpecActivity {
   private final Path workspaceRoot;
   private final WorkerEnvironment workerEnvironment;
   private final LogConfigs logConfigs;
-  private final String databaseUser;
-  private final String databasePassword;
-  private final String databaseUrl;
+  private final JobPersistence jobPersistence;
   private final String airbyteVersion;
 
   public SpecActivityImpl(final WorkerConfigs workerConfigs,
@@ -39,18 +38,14 @@ public class SpecActivityImpl implements SpecActivity {
                           final Path workspaceRoot,
                           final WorkerEnvironment workerEnvironment,
                           final LogConfigs logConfigs,
-                          final String databaseUser,
-                          final String databasePassword,
-                          final String databaseUrl,
+                          final JobPersistence jobPersistence,
                           final String airbyteVersion) {
     this.workerConfigs = workerConfigs;
     this.processFactory = processFactory;
     this.workspaceRoot = workspaceRoot;
     this.workerEnvironment = workerEnvironment;
     this.logConfigs = logConfigs;
-    this.databaseUser = databaseUser;
-    this.databasePassword = databasePassword;
-    this.databaseUrl = databaseUrl;
+    this.jobPersistence = jobPersistence;
     this.airbyteVersion = airbyteVersion;
   }
 
@@ -64,7 +59,9 @@ public class SpecActivityImpl implements SpecActivity {
         jobRunConfig,
         getWorkerFactory(launcherConfig),
         inputSupplier,
-        new CancellationHandler.TemporalCancellationHandler(), databaseUser, databasePassword, databaseUrl, airbyteVersion);
+        new CancellationHandler.TemporalCancellationHandler(),
+        jobPersistence,
+        airbyteVersion);
 
     return temporalAttemptExecution.get();
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/DbtLauncherWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/DbtLauncherWorker.java
@@ -11,6 +11,7 @@ import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.WorkerApp;
 import io.airbyte.workers.WorkerConfigs;
 import java.util.Map;
+import java.util.UUID;
 
 public class DbtLauncherWorker extends LauncherWorker<OperatorDbtInput, Void> {
 
@@ -18,12 +19,14 @@ public class DbtLauncherWorker extends LauncherWorker<OperatorDbtInput, Void> {
   private static final String POD_NAME_PREFIX = "orchestrator-dbt";
   public static final String INIT_FILE_DESTINATION_LAUNCHER_CONFIG = "destinationLauncherConfig.json";
 
-  public DbtLauncherWorker(final IntegrationLauncherConfig destinationLauncherConfig,
+  public DbtLauncherWorker(final UUID connectionId,
+                           final IntegrationLauncherConfig destinationLauncherConfig,
                            final JobRunConfig jobRunConfig,
                            final WorkerConfigs workerConfigs,
                            final WorkerApp.ContainerOrchestratorConfig containerOrchestratorConfig,
                            final String airbyteVersion) {
     super(
+        connectionId,
         DBT,
         POD_NAME_PREFIX,
         jobRunConfig,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/DbtTransformationActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/DbtTransformationActivityImpl.java
@@ -15,6 +15,7 @@ import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.config.persistence.split_secrets.SecretsHydrator;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.workers.DbtTransformationRunner;
 import io.airbyte.workers.DbtTransformationWorker;
 import io.airbyte.workers.Worker;
@@ -38,9 +39,7 @@ public class DbtTransformationActivityImpl implements DbtTransformationActivity 
   private final AirbyteConfigValidator validator;
   private final WorkerEnvironment workerEnvironment;
   private final LogConfigs logConfigs;
-  private final String databaseUser;
-  private final String databasePassword;
-  private final String databaseUrl;
+  private final JobPersistence jobPersistence;
   private final String airbyteVersion;
   private final Optional<WorkerApp.ContainerOrchestratorConfig> containerOrchestratorConfig;
 
@@ -51,9 +50,7 @@ public class DbtTransformationActivityImpl implements DbtTransformationActivity 
                                        final Path workspaceRoot,
                                        final WorkerEnvironment workerEnvironment,
                                        final LogConfigs logConfigs,
-                                       final String databaseUser,
-                                       final String databasePassword,
-                                       final String databaseUrl,
+                                       final JobPersistence jobPersistence,
                                        final String airbyteVersion) {
     this.containerOrchestratorConfig = containerOrchestratorConfig;
     this.workerConfigs = workerConfigs;
@@ -63,9 +60,7 @@ public class DbtTransformationActivityImpl implements DbtTransformationActivity 
     this.validator = new AirbyteConfigValidator();
     this.workerEnvironment = workerEnvironment;
     this.logConfigs = logConfigs;
-    this.databaseUser = databaseUser;
-    this.databasePassword = databasePassword;
-    this.databaseUrl = databaseUrl;
+    this.jobPersistence = jobPersistence;
     this.airbyteVersion = airbyteVersion;
   }
 
@@ -96,7 +91,9 @@ public class DbtTransformationActivityImpl implements DbtTransformationActivity 
           jobRunConfig,
           workerFactory,
           inputSupplier,
-          new CancellationHandler.TemporalCancellationHandler(), databaseUser, databasePassword, databaseUrl, airbyteVersion);
+          new CancellationHandler.TemporalCancellationHandler(),
+          jobPersistence,
+          airbyteVersion);
 
       return temporalAttemptExecution.get();
     });

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/LauncherWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/LauncherWorker.java
@@ -175,8 +175,8 @@ public class LauncherWorker<INPUT, OUTPUT> implements Worker<INPUT, OUTPUT> {
 
       log.info("Attempting to delete pods: " + getPodNames(runningPods).toString());
       runningPods.stream()
-              .parallel()
-              .forEach(kubePod -> client.resource(kubePod).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete());
+          .parallel()
+          .forEach(kubePod -> client.resource(kubePod).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete());
 
       log.info("Waiting for deletion...");
       Exceptions.toRuntime(() -> Thread.sleep(1000));
@@ -184,7 +184,7 @@ public class LauncherWorker<INPUT, OUTPUT> implements Worker<INPUT, OUTPUT> {
       runningPods = getNonTerminalPodsWithLabels();
     }
 
-    if(runningPods.isEmpty()) {
+    if (runningPods.isEmpty()) {
       log.info("Successfully deleted all running pods for the connection!");
     } else {
       throw new RuntimeException("Unable to delete pods: " + getPodNames(runningPods).toString());

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/LauncherWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/LauncherWorker.java
@@ -91,7 +91,7 @@ public class LauncherWorker<INPUT, OUTPUT> implements Worker<INPUT, OUTPUT> {
             Math.toIntExact(jobRunConfig.getAttemptId()),
             Collections.emptyMap());
 
-        final var podNameAndJobPrefix = podNamePrefix + "-j-" + jobRunConfig.getJobId() + "-a-";
+        final var podNameAndJobPrefix = podNamePrefix + "-job-" + jobRunConfig.getJobId() + "-attempt-";
         killLowerAttemptIdsIfPresent(podNameAndJobPrefix, jobRunConfig.getAttemptId());
 
         final var podName = podNameAndJobPrefix + jobRunConfig.getAttemptId();
@@ -150,7 +150,10 @@ public class LauncherWorker<INPUT, OUTPUT> implements Worker<INPUT, OUTPUT> {
           containerOrchestratorConfig.kubernetesClient());
 
       try {
+        // todo: how to kill from previous job, not just previous attempt
         oldProcess.destroy();
+
+        // todo: wait for it to actually destroy with oldProcess.hasExited()
         log.info("Found and destroyed a previous attempt: " + previousAttempt);
       } catch (Exception e) {
         log.warn("Wasn't able to find and destroy a previous attempt: " + previousAttempt);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/LauncherWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/LauncherWorker.java
@@ -136,6 +136,12 @@ public class LauncherWorker<INPUT, OUTPUT> implements Worker<INPUT, OUTPUT> {
         }
       } catch (Exception e) {
         if (cancelled.get()) {
+          try {
+            log.info("Destroying process due to cancellation.");
+            process.destroy();
+          } catch (Exception e2) {
+            log.error("Failed to destroy process on cancellation.", e2);
+          }
           throw new WorkerException("Launcher " + application + " was cancelled.", e);
         } else {
           throw new WorkerException("Running the launcher " + application + " failed", e);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivityImpl.java
@@ -14,6 +14,7 @@ import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.config.persistence.split_secrets.SecretsHydrator;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.workers.DefaultNormalizationWorker;
 import io.airbyte.workers.Worker;
 import io.airbyte.workers.WorkerApp;
@@ -36,9 +37,7 @@ public class NormalizationActivityImpl implements NormalizationActivity {
   private final AirbyteConfigValidator validator;
   private final WorkerEnvironment workerEnvironment;
   private final LogConfigs logConfigs;
-  private final String databaseUser;
-  private final String databasePassword;
-  private final String databaseUrl;
+  private final JobPersistence jobPersistence;
   private final String airbyteVersion;
   private final Optional<WorkerApp.ContainerOrchestratorConfig> containerOrchestratorConfig;
 
@@ -49,9 +48,7 @@ public class NormalizationActivityImpl implements NormalizationActivity {
                                    final Path workspaceRoot,
                                    final WorkerEnvironment workerEnvironment,
                                    final LogConfigs logConfigs,
-                                   final String databaseUser,
-                                   final String databasePassword,
-                                   final String databaseUrl,
+                                   final JobPersistence jobPersistence,
                                    final String airbyteVersion) {
     this.containerOrchestratorConfig = containerOrchestratorConfig;
     this.workerConfigs = workerConfigs;
@@ -61,9 +58,7 @@ public class NormalizationActivityImpl implements NormalizationActivity {
     this.validator = new AirbyteConfigValidator();
     this.workerEnvironment = workerEnvironment;
     this.logConfigs = logConfigs;
-    this.databaseUser = databaseUser;
-    this.databasePassword = databasePassword;
-    this.databaseUrl = databaseUrl;
+    this.jobPersistence = jobPersistence;
     this.airbyteVersion = airbyteVersion;
   }
 
@@ -93,7 +88,9 @@ public class NormalizationActivityImpl implements NormalizationActivity {
           jobRunConfig,
           workerFactory,
           inputSupplier,
-          new CancellationHandler.TemporalCancellationHandler(), databaseUser, databasePassword, databaseUrl, airbyteVersion);
+          new CancellationHandler.TemporalCancellationHandler(),
+          jobPersistence,
+          airbyteVersion);
 
       return temporalAttemptExecution.get();
     });

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationLauncherWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationLauncherWorker.java
@@ -11,6 +11,7 @@ import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.WorkerApp;
 import io.airbyte.workers.WorkerConfigs;
 import java.util.Map;
+import java.util.UUID;
 
 public class NormalizationLauncherWorker extends LauncherWorker<NormalizationInput, Void> {
 
@@ -18,12 +19,14 @@ public class NormalizationLauncherWorker extends LauncherWorker<NormalizationInp
   private static final String POD_NAME_PREFIX = "orchestrator-norm";
   public static final String INIT_FILE_DESTINATION_LAUNCHER_CONFIG = "destinationLauncherConfig.json";
 
-  public NormalizationLauncherWorker(final IntegrationLauncherConfig destinationLauncherConfig,
+  public NormalizationLauncherWorker(final UUID connectionId,
+                                     final IntegrationLauncherConfig destinationLauncherConfig,
                                      final JobRunConfig jobRunConfig,
                                      final WorkerConfigs workerConfigs,
                                      final WorkerApp.ContainerOrchestratorConfig containerOrchestratorConfig,
                                      final String airbyteVersion) {
     super(
+        connectionId,
         NORMALIZATION,
         POD_NAME_PREFIX,
         jobRunConfig,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationActivityImpl.java
@@ -18,6 +18,7 @@ import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.config.persistence.split_secrets.SecretsHydrator;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.workers.DefaultReplicationWorker;
 import io.airbyte.workers.Worker;
 import io.airbyte.workers.WorkerApp;
@@ -54,9 +55,7 @@ public class ReplicationActivityImpl implements ReplicationActivity {
   private final WorkerEnvironment workerEnvironment;
   private final LogConfigs logConfigs;
 
-  private final String databaseUser;
-  private final String databasePassword;
-  private final String databaseUrl;
+  private final JobPersistence jobPersistence;
   private final String airbyteVersion;
 
   public ReplicationActivityImpl(final Optional<WorkerApp.ContainerOrchestratorConfig> containerOrchestratorConfig,
@@ -66,13 +65,10 @@ public class ReplicationActivityImpl implements ReplicationActivity {
                                  final Path workspaceRoot,
                                  final WorkerEnvironment workerEnvironment,
                                  final LogConfigs logConfigs,
-                                 final String databaseUser,
-                                 final String databasePassword,
-                                 final String databaseUrl,
+                                 final JobPersistence jobPersistence,
                                  final String airbyteVersion) {
     this(containerOrchestratorConfig, workerConfigs, processFactory, secretsHydrator, workspaceRoot, workerEnvironment, logConfigs,
-        new AirbyteConfigValidator(), databaseUser,
-        databasePassword, databaseUrl, airbyteVersion);
+        new AirbyteConfigValidator(), jobPersistence, airbyteVersion);
   }
 
   @VisibleForTesting
@@ -84,9 +80,7 @@ public class ReplicationActivityImpl implements ReplicationActivity {
                           final WorkerEnvironment workerEnvironment,
                           final LogConfigs logConfigs,
                           final AirbyteConfigValidator validator,
-                          final String databaseUser,
-                          final String databasePassword,
-                          final String databaseUrl,
+                          final JobPersistence jobPersistence,
                           final String airbyteVersion) {
     this.containerOrchestratorConfig = containerOrchestratorConfig;
     this.workerConfigs = workerConfigs;
@@ -96,9 +90,7 @@ public class ReplicationActivityImpl implements ReplicationActivity {
     this.validator = validator;
     this.workerEnvironment = workerEnvironment;
     this.logConfigs = logConfigs;
-    this.databaseUser = databaseUser;
-    this.databasePassword = databasePassword;
-    this.databaseUrl = databaseUrl;
+    this.jobPersistence = jobPersistence;
     this.airbyteVersion = airbyteVersion;
   }
 
@@ -138,9 +130,7 @@ public class ReplicationActivityImpl implements ReplicationActivity {
           workerFactory,
           inputSupplier,
           new CancellationHandler.TemporalCancellationHandler(),
-          databaseUser,
-          databasePassword,
-          databaseUrl,
+          jobPersistence,
           airbyteVersion);
 
       final ReplicationOutput attemptOutput = temporalAttempt.get();

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationLauncherWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationLauncherWorker.java
@@ -12,6 +12,7 @@ import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.WorkerApp;
 import io.airbyte.workers.WorkerConfigs;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Launches a container-orchestrator container/pod to manage the message passing for the replication
@@ -25,7 +26,7 @@ public class ReplicationLauncherWorker extends LauncherWorker<StandardSyncInput,
   public static final String INIT_FILE_SOURCE_LAUNCHER_CONFIG = "sourceLauncherConfig.json";
   public static final String INIT_FILE_DESTINATION_LAUNCHER_CONFIG = "destinationLauncherConfig.json";
 
-  public ReplicationLauncherWorker(
+  public ReplicationLauncherWorker(final UUID connectionId,
                                    final WorkerApp.ContainerOrchestratorConfig containerOrchestratorConfig,
                                    final IntegrationLauncherConfig sourceLauncherConfig,
                                    final IntegrationLauncherConfig destinationLauncherConfig,
@@ -33,6 +34,7 @@ public class ReplicationLauncherWorker extends LauncherWorker<StandardSyncInput,
                                    final String airbyteVersion,
                                    final WorkerConfigs workerConfigs) {
     super(
+        connectionId,
         REPLICATION,
         POD_NAME_PREFIX,
         jobRunConfig,

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalAttemptExecutionTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalAttemptExecutionTest.java
@@ -14,8 +14,11 @@ import static org.mockito.Mockito.when;
 
 import io.airbyte.commons.functional.CheckedSupplier;
 import io.airbyte.config.Configs;
+import io.airbyte.db.Database;
 import io.airbyte.db.instance.test.TestDatabaseProviders;
 import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.scheduler.persistence.DefaultJobPersistence;
+import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.workers.Worker;
 import io.temporal.serviceclient.CheckedExceptionWrapper;
 import java.io.IOException;
@@ -54,16 +57,14 @@ class TemporalAttemptExecutionTest {
         .withPassword(SOURCE_PASSWORD);
     container.start();
     configs = mock(Configs.class);
-    when(configs.getDatabaseUrl()).thenReturn(container.getJdbcUrl());
-    when(configs.getDatabaseUser()).thenReturn(SOURCE_USERNAME);
-    when(configs.getDatabasePassword()).thenReturn(SOURCE_PASSWORD);
   }
 
   @SuppressWarnings("unchecked")
   @BeforeEach
   void setup() throws IOException {
     final TestDatabaseProviders databaseProviders = new TestDatabaseProviders(container);
-    databaseProviders.createNewJobsDatabase();
+    final Database jobDatabase = databaseProviders.createNewJobsDatabase();
+    final JobPersistence jobPersistence = new DefaultJobPersistence(jobDatabase);
 
     final Path workspaceRoot = Files.createTempDirectory(Path.of("/tmp"), "temporal_attempt_execution_test");
     jobRoot = workspaceRoot.resolve(JOB_ID).resolve(String.valueOf(ATTEMPT_ID));
@@ -78,9 +79,7 @@ class TemporalAttemptExecutionTest {
         () -> "",
         mdcSetter,
         mock(CancellationHandler.class),
-        SOURCE_USERNAME,
-        SOURCE_PASSWORD,
-        container.getJdbcUrl(),
+        jobPersistence,
         () -> "workflow_id", configs.getAirbyteVersionOrWarning());
   }
 


### PR DESCRIPTION
While fixing the [logging errors](https://github.com/airbytehq/airbyte/pull/10117) from the [log4j2 version bump](https://github.com/airbytehq/airbyte/pull/8977), I noticed that if you cancelled a run and then made a run right afterwards, there was a brief period where the the version that was being cancelled was still running while the later step was still running. Also, while considering the [naming schemes](https://github.com/airbytehq/airbyte/issues/10124) I was worried about the permanence of the container orchestrator name structure.

This PR does the following:
- cleans up the worker interface to use `JobPersistence` instead of db creds
- uses that job persistence to retrieve the connection id
- labels container orchestrator pods with the connection id
- deletes all pods with the connection id label before running something new

The bulk of the change is in `LauncherWorker`.

I think this will be much safer since we can change the container orchestrator name to whatever we want in the future without worrying about cleanup. I think if I had added this before we could have just released this with Benoit's change out of the gate 🙃 