### PR TITLE
fix envmap test on CI

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/LauncherWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/LauncherWorker.java
@@ -6,6 +6,7 @@ package io.airbyte.workers.temporal.sync;
 
 import com.google.common.base.Stopwatch;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.config.ResourceRequirements;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.Worker;
@@ -178,11 +179,7 @@ public class LauncherWorker<INPUT, OUTPUT> implements Worker<INPUT, OUTPUT> {
           .forEach(kubePod -> client.resource(kubePod).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete());
 
       log.info("Waiting for deletion...");
-      try {
-        Thread.sleep(1000);
-      } catch (InterruptedException e) {
-        throw new RuntimeException(e);
-      }
+      Exceptions.toRuntime(() -> Thread.sleep(1000));
 
       runningPods = getNonTerminalPodsWithLabels();
     }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/LauncherWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/LauncherWorker.java
@@ -6,7 +6,6 @@ package io.airbyte.workers.temporal.sync;
 
 import com.google.common.base.Stopwatch;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.config.ResourceRequirements;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.Worker;
@@ -179,7 +178,11 @@ public class LauncherWorker<INPUT, OUTPUT> implements Worker<INPUT, OUTPUT> {
           .forEach(kubePod -> client.resource(kubePod).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete());
 
       log.info("Waiting for deletion...");
-      Exceptions.toRuntime(() -> Thread.sleep(1000));
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
 
       runningPods = getNonTerminalPodsWithLabels();
     }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
@@ -90,7 +90,7 @@ class DockerProcessFactoryTest {
   /**
    * Tests that the env var map passed in is accessible within the process.
    */
-  @RepeatedTest(20)
+  @RepeatedTest(5)
   public void testEnvMapSet() throws IOException, WorkerException {
     final Path workspaceRoot = Files.createTempDirectory(Files.createDirectories(TEST_ROOT), "process_factory");
     final Path jobRoot = workspaceRoot.resolve("job");
@@ -105,6 +105,23 @@ class DockerProcessFactoryTest {
             null,
             null,
             "host");
+
+    // for some reason, on our CI the first processFactory.create call is failing but all runs after it
+    // succeed
+    // this is why this is added and why the overall test case is repeated
+    processFactory.create(
+        "job_id2",
+        0,
+        jobRoot,
+        "busybox",
+        false,
+        Map.of(),
+        "/bin/sh",
+        workerConfigs.getResourceRequirements(),
+        Map.of(),
+        Map.of(),
+        "-c",
+        "echo ENV_VAR_1=$ENV_VAR_1");
 
     final Process process = processFactory.create(
         "job_id",

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
@@ -23,7 +23,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
@@ -106,9 +106,11 @@ class DockerProcessFactoryTest {
             null,
             "host");
 
-    // for some reason, on our CI the first processFactory.create call is failing but all runs after it
-    // succeed
-    // this is why this is added and why the overall test case is repeated
+    // For some reason, on our CI the first processFactory.create call is failing but all runs after it
+    // succeed. This is why this is added and why the overall test case is repeated.
+    // The failure case without this workaround is:
+    // Process failed with stdout: and stderr: WARNING: Error loading config file:
+    // .dockercfg: $HOME is not defined ==> expected: <0> but was: <143>
     processFactory.create(
         "job_id2",
         0,

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/DockerProcessFactoryTest.java
@@ -23,6 +23,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 // todo (cgardens) - these are not truly "unit" tests as they are check resources on the internet.
@@ -89,7 +91,7 @@ class DockerProcessFactoryTest {
   /**
    * Tests that the env var map passed in is accessible within the process.
    */
-  @Test
+  @RepeatedTest(20)
   public void testEnvMapSet() throws IOException, WorkerException {
     final Path workspaceRoot = Files.createTempDirectory(Files.createDirectories(TEST_ROOT), "process_factory");
     final Path jobRoot = workspaceRoot.resolve("job");


### PR DESCRIPTION
This test was always passing locally, but as of my recent PR https://github.com/airbytehq/airbyte/pull/10127 is failing both the platform and connector builds.

This is very strange since for some of the individual commits, one of the `:airbyte-workers:test` calls passes and others fail. This is pretty confusing.

For some reason, it's consistently the first docker run call that is breaking. I documented it in a comment here and added retries.