### PR TITLE
bug: correct env var copied to orchestrator for namespace

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -72,7 +72,7 @@ public class EnvConfigs implements Configs {
   public static final String MAX_SYNC_WORKERS = "MAX_SYNC_WORKERS";
   private static final String TEMPORAL_HOST = "TEMPORAL_HOST";
   private static final String TEMPORAL_WORKER_PORTS = "TEMPORAL_WORKER_PORTS";
-  private static final String JOB_KUBE_NAMESPACE = "JOB_KUBE_NAMESPACE";
+  public static final String JOB_KUBE_NAMESPACE = "JOB_KUBE_NAMESPACE";
   private static final String SUBMITTER_NUM_THREADS = "SUBMITTER_NUM_THREADS";
   public static final String JOB_MAIN_CONTAINER_CPU_REQUEST = "JOB_MAIN_CONTAINER_CPU_REQUEST";
   public static final String JOB_MAIN_CONTAINER_CPU_LIMIT = "JOB_MAIN_CONTAINER_CPU_LIMIT";

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/OrchestratorConstants.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/OrchestratorConstants.java
@@ -30,7 +30,7 @@ public class OrchestratorConstants {
       EnvConfigs.LOCAL_DOCKER_MOUNT,
       EnvConfigs.WORKSPACE_DOCKER_MOUNT,
       EnvConfigs.WORKSPACE_ROOT,
-      EnvConfigs.DEFAULT_JOB_KUBE_NAMESPACE,
+      EnvConfigs.JOB_KUBE_NAMESPACE,
       EnvConfigs.JOB_MAIN_CONTAINER_CPU_REQUEST,
       EnvConfigs.JOB_MAIN_CONTAINER_CPU_LIMIT,
       EnvConfigs.JOB_MAIN_CONTAINER_MEMORY_REQUEST,


### PR DESCRIPTION
This was the value of the default namespace "default", not the actual namespace, like "jobs".