### PR TITLE
🐛  Source Shopify: fixed compatibility issues for legacy user config

### DIFF
--- a/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9da77001-af33-4bcd-be46-6252bf9342b9.json
+++ b/airbyte-config/init/src/main/resources/config/STANDARD_SOURCE_DEFINITION/9da77001-af33-4bcd-be46-6252bf9342b9.json
@@ -2,7 +2,7 @@
   "sourceDefinitionId": "9da77001-af33-4bcd-be46-6252bf9342b9",
   "name": "Shopify",
   "dockerRepository": "airbyte/source-shopify",
-  "dockerImageTag": "0.1.30",
+  "dockerImageTag": "0.1.31",
   "documentationUrl": "https://docs.airbyte.io/integrations/sources/shopify",
   "icon": "shopify.svg"
 }

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -669,7 +669,7 @@
 - name: Shopify
   sourceDefinitionId: 9da77001-af33-4bcd-be46-6252bf9342b9
   dockerRepository: airbyte/source-shopify
-  dockerImageTag: 0.1.30
+  dockerImageTag: 0.1.31
   documentationUrl: https://docs.airbyte.io/integrations/sources/shopify
   icon: shopify.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -7032,7 +7032,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-shopify:0.1.30"
+- dockerImage: "airbyte/source-shopify:0.1.31"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/shopify"
     connectionSpecification:
@@ -7042,7 +7042,6 @@
       required:
       - "shop"
       - "start_date"
-      - "credentials"
       additionalProperties: true
       properties:
         shop:

--- a/airbyte-integrations/connectors/source-shopify/Dockerfile
+++ b/airbyte-integrations/connectors/source-shopify/Dockerfile
@@ -28,5 +28,5 @@ COPY source_shopify ./source_shopify
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.30
+LABEL io.airbyte.version=0.1.31
 LABEL io.airbyte.name=airbyte/source-shopify

--- a/airbyte-integrations/connectors/source-shopify/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-shopify/acceptance-test-config.yml
@@ -7,12 +7,17 @@ tests:
       status: "succeed"
     - config_path: "integration_tests/invalid_config.json"
       status: "failed"
+    - config_path: "secrets/config_old.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_config_old.json"
+      status: "failed"
     - config_path: "secrets/config_oauth.json"
       status: "succeed"
     - config_path: "integration_tests/invalid_oauth_config.json"
       status: "failed"
   discovery:
     - config_path: "secrets/config.json"
+    - config_path: "secrets/config_old.json"
     - config_path: "secrets/config_oauth.json"
   basic_read:
     - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-shopify/integration_tests/invalid_config_old.json
+++ b/airbyte-integrations/connectors/source-shopify/integration_tests/invalid_config_old.json
@@ -1,0 +1,10 @@
+{
+  "shop": "SHOP_NAME",
+  "start_date": "2020-11-01",
+  "auth_method": {
+    "auth_method": "access_token",
+    "client_id": "SOME_CLIENT_ID",
+    "client_secret": "SOME_CLIENT_SECRET",
+    "access_token": "SOME_API_ACCESS_TOKEN"
+  }
+}

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/auth.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/auth.py
@@ -30,10 +30,10 @@ class ShopifyAuthenticator(TokenAuthenticator):
     def get_auth_header(self) -> Mapping[str, Any]:
 
         auth_header: str = "X-Shopify-Access-Token"
-        credentials: Dict = self.config["credentials"]
+        credentials: Dict = self.config.get("credentials", self.config.get("auth_method"))
         auth_method: str = credentials.get("auth_method")
 
-        if auth_method == "oauth2.0":
+        if auth_method in ["oauth2.0", "access_token"]:
             return {auth_header: credentials.get("access_token")}
         elif auth_method == "api_password":
             return {auth_header: credentials.get("api_password")}

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/schemas/inventory_levels.json
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/schemas/inventory_levels.json
@@ -1,6 +1,9 @@
 {
   "type": "object",
   "properties": {
+    "id": {
+      "type": ["null", "string"]
+    },
     "available": {
       "type": ["null", "integer"]
     },

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/spec.json
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/spec.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Shopify Source CDK Specifications",
     "type": "object",
-    "required": ["shop", "start_date", "credentials"],
+    "required": ["shop", "start_date"],
     "additionalProperties": true,
     "properties": {
       "shop": {

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -101,7 +101,8 @@ This connector support both: `OAuth 2.0` and `API PASSWORD` (for private applica
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| 0.1.30 | 2021-01-24 | [9648](https://github.com/airbytehq/airbyte/pull/9648) | Added permission validation before sync |
+| 0.1.31 | 2022-02-08 | [10175](https://github.com/airbytehq/airbyte/pull/10175) | Fixed compatibility issues for legacy user config |
+| 0.1.30 | 2022-01-24 | [9648](https://github.com/airbytehq/airbyte/pull/9648) | Added permission validation before sync |
 | 0.1.29 | 2022-01-20 | [9049](https://github.com/airbytehq/airbyte/pull/9248) | Added `shop_url` to the record for all streams |
 | 0.1.28 | 2022-01-19 | [9591](https://github.com/airbytehq/airbyte/pull/9591) | Implemented `OAuth2.0` authentication method for Airbyte Cloud |
 | 0.1.27 | 2021-12-22 | [9049](https://github.com/airbytehq/airbyte/pull/9049) | Update connector fields title/description |


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/airbyte/issues/9994

## How
 - added legacy check for old configs in `auth.py`
 - added missing PK in `inventory_levels` stream
 - added SAT test for legacy configs

## 🚨 User Impact 🚨
Users should only update the version of the Shopify connector to `0.1.31` in ` Airbyte UI > Settings > Sources`

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [X] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [X] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [X] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [X] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>
</details>