### PR TITLE
fix regression in pod deletion in container orchestrator

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/LauncherWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/LauncherWorker.java
@@ -101,10 +101,11 @@ public class LauncherWorker<INPUT, OUTPUT> implements Worker<INPUT, OUTPUT> {
             Math.toIntExact(jobRunConfig.getAttemptId()),
             Map.of(CONNECTION_ID_LABEL_KEY, connectionId.toString()));
 
-        killRunningPodsForConnection();
-
         final var podNameAndJobPrefix = podNamePrefix + "-job-" + jobRunConfig.getJobId() + "-attempt-";
         final var podName = podNameAndJobPrefix + jobRunConfig.getAttemptId();
+
+        killRunningPodsForConnection(podName);
+
         final var kubePodInfo = new KubePodInfo(containerOrchestratorConfig.namespace(), podName);
 
         process = new AsyncOrchestratorPodProcess(
@@ -161,8 +162,10 @@ public class LauncherWorker<INPUT, OUTPUT> implements Worker<INPUT, OUTPUT> {
    * It is imperative that we do not run multiple replications, normalizations, syncs, etc. at the
    * same time. Our best bet is to kill everything that is labelled with the connection id and wait
    * until no more pods exist with that connection id.
+   *
+   * @param podNameToKeep a nullable name of a pod we don't want to delete.
    */
-  private void killRunningPodsForConnection() {
+  private void killRunningPodsForConnection(String podNameToKeep) {
     final var client = containerOrchestratorConfig.kubernetesClient();
 
     // delete all pods with the connection id label
@@ -175,6 +178,7 @@ public class LauncherWorker<INPUT, OUTPUT> implements Worker<INPUT, OUTPUT> {
       log.info("Attempting to delete pods: " + getPodNames(runningPods).toString());
       runningPods.stream()
           .parallel()
+          .filter(pod -> !pod.getMetadata().getName().equals(podNameToKeep))
           .forEach(kubePod -> client.resource(kubePod).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete());
 
       log.info("Waiting for deletion...");
@@ -214,13 +218,13 @@ public class LauncherWorker<INPUT, OUTPUT> implements Worker<INPUT, OUTPUT> {
     }
 
     log.debug("Closing sync runner process");
-    killRunningPodsForConnection();
+    killRunningPodsForConnection(null);
 
     if (process.hasExited()) {
       log.info("Successfully cancelled process.");
     } else {
       // try again
-      killRunningPodsForConnection();
+      killRunningPodsForConnection(null);
 
       if (process.hasExited()) {
         log.info("Successfully cancelled process.");


### PR DESCRIPTION
In the changes I added Friday to improve deletion to be more strict, it actually changed the behavior when resuming (it would still kill the container). This excludes the currently running pod from the deletion process. 