### PR TITLE
set env var for GCP logging for container orchestrator

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
@@ -285,6 +285,11 @@ public interface Configs {
   LogConfigs getLogConfigs();
 
   /**
+   * Defines the optional Google application credentials used for logging.
+   */
+  String getGoogleApplicationCredentials();
+
+  /**
    * Define either S3, Minio or GCS as a state storage backend. Multiple variables are involved here.
    * Please see {@link CloudStorageConfigs} for more info.
    */

--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -513,6 +513,11 @@ public class EnvConfigs implements Configs {
   }
 
   @Override
+  public String getGoogleApplicationCredentials() {
+    return getEnvOrDefault(LogClientSingleton.GOOGLE_APPLICATION_CREDENTIALS, null);
+  }
+
+  @Override
   public CloudStorageConfigs getStateStorageCloudConfigs() {
     return stateStorageCloudConfigs;
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -269,7 +269,8 @@ public class WorkerApp {
                                                    KubernetesClient kubernetesClient,
                                                    String secretName,
                                                    String secretMountPath,
-                                                   String containerOrchestratorImage) {}
+                                                   String containerOrchestratorImage,
+                                                   String googleApplicationCredentials) {}
 
   static Optional<ContainerOrchestratorConfig> getContainerOrchestratorConfig(Configs configs) {
     if (configs.getContainerOrchestratorEnabled()) {
@@ -285,7 +286,8 @@ public class WorkerApp {
           kubernetesClient,
           configs.getContainerOrchestratorSecretName(),
           configs.getContainerOrchestratorSecretMountPath(),
-          configs.getContainerOrchestratorImage()));
+          configs.getContainerOrchestratorImage(),
+          configs.getGoogleApplicationCredentials()));
     } else {
       return Optional.empty();
     }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/LauncherWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/LauncherWorker.java
@@ -114,7 +114,8 @@ public class LauncherWorker<INPUT, OUTPUT> implements Worker<INPUT, OUTPUT> {
             containerOrchestratorConfig.kubernetesClient(),
             containerOrchestratorConfig.secretName(),
             containerOrchestratorConfig.secretMountPath(),
-            containerOrchestratorConfig.containerOrchestratorImage());
+            containerOrchestratorConfig.containerOrchestratorImage(),
+            containerOrchestratorConfig.googleApplicationCredentials());
 
         if (process.getDocStoreStatus().equals(AsyncKubePodStatus.NOT_STARTED)) {
           process.create(

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/AsyncOrchestratorPodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/AsyncOrchestratorPodProcessIntegrationTest.java
@@ -108,7 +108,8 @@ public class AsyncOrchestratorPodProcessIntegrationTest {
         kubernetesClient,
         null,
         null,
-        "airbyte/container-orchestrator:dev");
+        "airbyte/container-orchestrator:dev",
+        null);
 
     final Map<Integer, Integer> portMap = Map.of(
         WorkerApp.KUBE_HEARTBEAT_PORT, WorkerApp.KUBE_HEARTBEAT_PORT,


### PR DESCRIPTION
Since our appender in log4j2 doesn't allow falling back to a system property, we need to mount the path of the `GOOGLE_APPLICATION_CREDENTIALS` directly on the container orchestrator. 

Also cleans up / fixes double `withPorts` call for port setting.