### PR TITLE
Configure kube pod process per job type

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
@@ -10,6 +10,7 @@ import io.airbyte.config.storage.CloudStorageConfigs;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -245,7 +246,27 @@ public interface Configs {
   /**
    * Define one or more Job pod node selectors. Each kv-pair is separated by a `,`.
    */
-  Map<String, String> getJobKubeNodeSelectors();
+  Optional<Map<String, String>> getJobKubeNodeSelectors();
+
+  /**
+   * Define node selectors for Spec job pods specifically. Each kv-pair is separated by a `,`.
+   */
+  Optional<Map<String, String>> getSpecJobKubeNodeSelectors();
+
+  /**
+   * Define node selectors for Check job pods specifically. Each kv-pair is separated by a `,`.
+   */
+  Optional<Map<String, String>> getCheckJobKubeNodeSelectors();
+
+  /**
+   * Define node selectors for Discover job pods specifically. Each kv-pair is separated by a `,`.
+   */
+  Optional<Map<String, String>> getDiscoverJobKubeNodeSelectors();
+
+  /**
+   * Define node selectors for Sync job pods specifically. Each kv-pair is separated by a `,`.
+   */
+  Optional<Map<String, String>> getSyncJobKubeNodeSelectors();
 
   /**
    * Define the Job pod connector image pull policy.

--- a/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
@@ -264,11 +264,6 @@ public interface Configs {
   Optional<Map<String, String>> getDiscoverJobKubeNodeSelectors();
 
   /**
-   * Define node selectors for Sync job pods specifically. Each kv-pair is separated by a `,`.
-   */
-  Optional<Map<String, String>> getSyncJobKubeNodeSelectors();
-
-  /**
    * Define the Job pod connector image pull policy.
    */
   String getJobKubeMainContainerImagePullPolicy();

--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -111,7 +111,11 @@ public class EnvConfigs implements Configs {
   public static final String SPEC_JOB_KUBE_NODE_SELECTORS = "SPEC_JOB_KUBE_NODE_SELECTORS";
   public static final String CHECK_JOB_KUBE_NODE_SELECTORS = "CHECK_JOB_KUBE_NODE_SELECTORS";
   public static final String DISCOVER_JOB_KUBE_NODE_SELECTORS = "DISCOVER_JOB_KUBE_NODE_SELECTORS";
-  public static final String SYNC_JOB_KUBE_NODE_SELECTORS = "SYNC_JOB_KUBE_NODE_SELECTORS";
+
+  private static final String REPLICATION_ORCHESTRATOR_CPU_REQUEST = "REPLICATION_ORCHESTRATOR_CPU_REQUEST";
+  private static final String REPLICATION_ORCHESTRATOR_CPU_LIMIT = "REPLICATION_ORCHESTRATOR_CPU_LIMIT";
+  private static final String REPLICATION_ORCHESTRATOR_MEMORY_REQUEST = "REPLICATION_ORCHESTRATOR_MEMORY_REQUEST";
+  private static final String REPLICATION_ORCHESTRATOR_MEMORY_LIMIT = "REPLICATION_ORCHESTRATOR_MEMORY_LIMIT";
 
   // defaults
   private static final String DEFAULT_SPEC_CACHE_BUCKET = "io-airbyte-cloud-spec-cache";
@@ -135,10 +139,6 @@ public class EnvConfigs implements Configs {
   public static final long DEFAULT_MAX_SYNC_WORKERS = 5;
 
   public static final String DEFAULT_NETWORK = "host";
-  private static final String REPLICATION_ORCHESTRATOR_CPU_REQUEST = "REPLICATION_ORCHESTRATOR_CPU_REQUEST";
-  private static final String REPLICATION_ORCHESTRATOR_CPU_LIMIT = "REPLICATION_ORCHESTRATOR_CPU_LIMIT";
-  private static final String REPLICATION_ORCHESTRATOR_MEMORY_REQUEST = "REPLICATION_ORCHESTRATOR_MEMORY_REQUEST";
-  private static final String REPLICATION_ORCHESTRATOR_MEMORY_LIMIT = "REPLICATION_ORCHESTRATOR_MEMORY_LIMIT";
 
   private final Function<String, String> getEnv;
   private final Supplier<Set<String>> getAllEnvKeys;
@@ -475,16 +475,6 @@ public class EnvConfigs implements Configs {
   @Override
   public Optional<Map<String, String>> getDiscoverJobKubeNodeSelectors() {
     return getNodeSelectorsFromEnvString(getEnvOrDefault(DISCOVER_JOB_KUBE_NODE_SELECTORS, ""));
-  }
-
-  /**
-   * Returns a map of node selectors for Sync job pods specifically.
-   *
-   * @return map containing kv pairs of node selectors, or empty optional if none present.
-   */
-  @Override
-  public Optional<Map<String, String>> getSyncJobKubeNodeSelectors() {
-    return getNodeSelectorsFromEnvString(getEnvOrDefault(SYNC_JOB_KUBE_NODE_SELECTORS, ""));
   }
 
   /**

--- a/airbyte-config/models/src/test/java/io/airbyte/config/EnvConfigsTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/EnvConfigsTest.java
@@ -255,24 +255,6 @@ class EnvConfigsTest {
   }
 
   @Test
-  void testSyncKubeNodeSelectors() {
-    envMap.put(EnvConfigs.SYNC_JOB_KUBE_NODE_SELECTORS, null);
-    Assertions.assertFalse(config.getSyncJobKubeNodeSelectors().isPresent());
-
-    envMap.put(EnvConfigs.SYNC_JOB_KUBE_NODE_SELECTORS, ",,,");
-    Assertions.assertFalse(config.getSyncJobKubeNodeSelectors().isPresent());
-
-    envMap.put(EnvConfigs.SYNC_JOB_KUBE_NODE_SELECTORS, "key=k,,;$%&^#");
-    Assertions.assertEquals(config.getSyncJobKubeNodeSelectors().get(), Map.of("key", "k"));
-
-    envMap.put(EnvConfigs.SYNC_JOB_KUBE_NODE_SELECTORS, "one=two");
-    Assertions.assertEquals(config.getSyncJobKubeNodeSelectors().get(), Map.of("one", "two"));
-
-    envMap.put(EnvConfigs.SYNC_JOB_KUBE_NODE_SELECTORS, "airbyte=server,something=nothing");
-    Assertions.assertEquals(config.getSyncJobKubeNodeSelectors().get(), Map.of("airbyte", "server", "something", "nothing"));
-  }
-
-  @Test
   void testEmptyEnvMapRetrieval() {
     Assertions.assertEquals(Map.of(), config.getJobDefaultEnvMap());
   }

--- a/airbyte-config/models/src/test/java/io/airbyte/config/EnvConfigsTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/EnvConfigsTest.java
@@ -183,21 +183,93 @@ class EnvConfigsTest {
   }
 
   @Test
-  void testworkerKubeNodeSelectors() {
+  void testJobKubeNodeSelectors() {
     envMap.put(EnvConfigs.JOB_KUBE_NODE_SELECTORS, null);
-    Assertions.assertEquals(config.getJobKubeNodeSelectors(), Map.of());
+    Assertions.assertFalse(config.getJobKubeNodeSelectors().isPresent());
 
     envMap.put(EnvConfigs.JOB_KUBE_NODE_SELECTORS, ",,,");
-    Assertions.assertEquals(config.getJobKubeNodeSelectors(), Map.of());
+    Assertions.assertFalse(config.getJobKubeNodeSelectors().isPresent());
 
     envMap.put(EnvConfigs.JOB_KUBE_NODE_SELECTORS, "key=k,,;$%&^#");
-    Assertions.assertEquals(config.getJobKubeNodeSelectors(), Map.of("key", "k"));
+    Assertions.assertEquals(config.getJobKubeNodeSelectors().get(), Map.of("key", "k"));
 
     envMap.put(EnvConfigs.JOB_KUBE_NODE_SELECTORS, "one=two");
-    Assertions.assertEquals(config.getJobKubeNodeSelectors(), Map.of("one", "two"));
+    Assertions.assertEquals(config.getJobKubeNodeSelectors().get(), Map.of("one", "two"));
 
     envMap.put(EnvConfigs.JOB_KUBE_NODE_SELECTORS, "airbyte=server,something=nothing");
-    Assertions.assertEquals(config.getJobKubeNodeSelectors(), Map.of("airbyte", "server", "something", "nothing"));
+    Assertions.assertEquals(config.getJobKubeNodeSelectors().get(), Map.of("airbyte", "server", "something", "nothing"));
+  }
+
+  @Test
+  void testSpecKubeNodeSelectors() {
+    envMap.put(EnvConfigs.SPEC_JOB_KUBE_NODE_SELECTORS, null);
+    Assertions.assertFalse(config.getSpecJobKubeNodeSelectors().isPresent());
+
+    envMap.put(EnvConfigs.SPEC_JOB_KUBE_NODE_SELECTORS, ",,,");
+    Assertions.assertFalse(config.getSpecJobKubeNodeSelectors().isPresent());
+
+    envMap.put(EnvConfigs.SPEC_JOB_KUBE_NODE_SELECTORS, "key=k,,;$%&^#");
+    Assertions.assertEquals(config.getSpecJobKubeNodeSelectors().get(), Map.of("key", "k"));
+
+    envMap.put(EnvConfigs.SPEC_JOB_KUBE_NODE_SELECTORS, "one=two");
+    Assertions.assertEquals(config.getSpecJobKubeNodeSelectors().get(), Map.of("one", "two"));
+
+    envMap.put(EnvConfigs.SPEC_JOB_KUBE_NODE_SELECTORS, "airbyte=server,something=nothing");
+    Assertions.assertEquals(config.getSpecJobKubeNodeSelectors().get(), Map.of("airbyte", "server", "something", "nothing"));
+  }
+
+  @Test
+  void testCheckKubeNodeSelectors() {
+    envMap.put(EnvConfigs.CHECK_JOB_KUBE_NODE_SELECTORS, null);
+    Assertions.assertFalse(config.getCheckJobKubeNodeSelectors().isPresent());
+
+    envMap.put(EnvConfigs.CHECK_JOB_KUBE_NODE_SELECTORS, ",,,");
+    Assertions.assertFalse(config.getCheckJobKubeNodeSelectors().isPresent());
+
+    envMap.put(EnvConfigs.CHECK_JOB_KUBE_NODE_SELECTORS, "key=k,,;$%&^#");
+    Assertions.assertEquals(config.getCheckJobKubeNodeSelectors().get(), Map.of("key", "k"));
+
+    envMap.put(EnvConfigs.CHECK_JOB_KUBE_NODE_SELECTORS, "one=two");
+    Assertions.assertEquals(config.getCheckJobKubeNodeSelectors().get(), Map.of("one", "two"));
+
+    envMap.put(EnvConfigs.CHECK_JOB_KUBE_NODE_SELECTORS, "airbyte=server,something=nothing");
+    Assertions.assertEquals(config.getCheckJobKubeNodeSelectors().get(), Map.of("airbyte", "server", "something", "nothing"));
+  }
+
+  @Test
+  void testDiscoverKubeNodeSelectors() {
+    envMap.put(EnvConfigs.DISCOVER_JOB_KUBE_NODE_SELECTORS, null);
+    Assertions.assertFalse(config.getDiscoverJobKubeNodeSelectors().isPresent());
+
+    envMap.put(EnvConfigs.DISCOVER_JOB_KUBE_NODE_SELECTORS, ",,,");
+    Assertions.assertFalse(config.getDiscoverJobKubeNodeSelectors().isPresent());
+
+    envMap.put(EnvConfigs.DISCOVER_JOB_KUBE_NODE_SELECTORS, "key=k,,;$%&^#");
+    Assertions.assertEquals(config.getDiscoverJobKubeNodeSelectors().get(), Map.of("key", "k"));
+
+    envMap.put(EnvConfigs.DISCOVER_JOB_KUBE_NODE_SELECTORS, "one=two");
+    Assertions.assertEquals(config.getDiscoverJobKubeNodeSelectors().get(), Map.of("one", "two"));
+
+    envMap.put(EnvConfigs.DISCOVER_JOB_KUBE_NODE_SELECTORS, "airbyte=server,something=nothing");
+    Assertions.assertEquals(config.getDiscoverJobKubeNodeSelectors().get(), Map.of("airbyte", "server", "something", "nothing"));
+  }
+
+  @Test
+  void testSyncKubeNodeSelectors() {
+    envMap.put(EnvConfigs.SYNC_JOB_KUBE_NODE_SELECTORS, null);
+    Assertions.assertFalse(config.getSyncJobKubeNodeSelectors().isPresent());
+
+    envMap.put(EnvConfigs.SYNC_JOB_KUBE_NODE_SELECTORS, ",,,");
+    Assertions.assertFalse(config.getSyncJobKubeNodeSelectors().isPresent());
+
+    envMap.put(EnvConfigs.SYNC_JOB_KUBE_NODE_SELECTORS, "key=k,,;$%&^#");
+    Assertions.assertEquals(config.getSyncJobKubeNodeSelectors().get(), Map.of("key", "k"));
+
+    envMap.put(EnvConfigs.SYNC_JOB_KUBE_NODE_SELECTORS, "one=two");
+    Assertions.assertEquals(config.getSyncJobKubeNodeSelectors().get(), Map.of("one", "two"));
+
+    envMap.put(EnvConfigs.SYNC_JOB_KUBE_NODE_SELECTORS, "airbyte=server,something=nothing");
+    Assertions.assertEquals(config.getSyncJobKubeNodeSelectors().get(), Map.of("airbyte", "server", "something", "nothing"));
   }
 
   @Test

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -91,14 +91,20 @@ public class WorkerApp {
   public static final Path STATE_STORAGE_PREFIX = Path.of("/state");
 
   private final Path workspaceRoot;
-  private final ProcessFactory jobProcessFactory;
+  private final ProcessFactory specProcessFactory;
+  private final ProcessFactory checkProcessFactory;
+  private final ProcessFactory discoverProcessFactory;
+  private final ProcessFactory syncProcessFactory;
   private final SecretsHydrator secretsHydrator;
   private final WorkflowServiceStubs temporalService;
   private final ConfigRepository configRepository;
   private final MaxWorkersConfig maxWorkers;
   private final WorkerEnvironment workerEnvironment;
   private final LogConfigs logConfigs;
-  private final WorkerConfigs workerConfigs;
+  private final WorkerConfigs specWorkerConfigs;
+  private final WorkerConfigs checkWorkerConfigs;
+  private final WorkerConfigs discoverWorkerConfigs;
+  private final WorkerConfigs syncWorkerConfigs;
   private final String airbyteVersion;
   private final SyncJobFactory jobFactory;
   private final JobPersistence jobPersistence;
@@ -126,7 +132,7 @@ public class WorkerApp {
     final Worker specWorker = factory.newWorker(TemporalJobType.GET_SPEC.name(), getWorkerOptions(maxWorkers.getMaxSpecWorkers()));
     specWorker.registerWorkflowImplementationTypes(SpecWorkflowImpl.class);
     specWorker.registerActivitiesImplementations(
-        new SpecActivityImpl(workerConfigs, jobProcessFactory, workspaceRoot, workerEnvironment, logConfigs, jobPersistence,
+        new SpecActivityImpl(specWorkerConfigs, specProcessFactory, workspaceRoot, workerEnvironment, logConfigs, jobPersistence,
             airbyteVersion));
 
     final Worker checkConnectionWorker =
@@ -134,21 +140,22 @@ public class WorkerApp {
     checkConnectionWorker.registerWorkflowImplementationTypes(CheckConnectionWorkflowImpl.class);
     checkConnectionWorker
         .registerActivitiesImplementations(
-            new CheckConnectionActivityImpl(workerConfigs, jobProcessFactory, secretsHydrator, workspaceRoot, workerEnvironment, logConfigs,
+            new CheckConnectionActivityImpl(checkWorkerConfigs, checkProcessFactory, secretsHydrator, workspaceRoot, workerEnvironment, logConfigs,
                 jobPersistence, airbyteVersion));
 
     final Worker discoverWorker = factory.newWorker(TemporalJobType.DISCOVER_SCHEMA.name(), getWorkerOptions(maxWorkers.getMaxDiscoverWorkers()));
     discoverWorker.registerWorkflowImplementationTypes(DiscoverCatalogWorkflowImpl.class);
     discoverWorker
         .registerActivitiesImplementations(
-            new DiscoverCatalogActivityImpl(workerConfigs, jobProcessFactory, secretsHydrator, workspaceRoot, workerEnvironment, logConfigs,
+            new DiscoverCatalogActivityImpl(discoverWorkerConfigs, discoverProcessFactory, secretsHydrator, workspaceRoot, workerEnvironment,
+                logConfigs,
                 jobPersistence, airbyteVersion));
 
     final NormalizationActivityImpl normalizationActivity =
         new NormalizationActivityImpl(
             containerOrchestratorConfig,
-            workerConfigs,
-            jobProcessFactory,
+            syncWorkerConfigs,
+            syncProcessFactory,
             secretsHydrator,
             workspaceRoot,
             workerEnvironment,
@@ -158,8 +165,8 @@ public class WorkerApp {
     final DbtTransformationActivityImpl dbtTransformationActivity =
         new DbtTransformationActivityImpl(
             containerOrchestratorConfig,
-            workerConfigs,
-            jobProcessFactory,
+            syncWorkerConfigs,
+            syncProcessFactory,
             secretsHydrator,
             workspaceRoot,
             workerEnvironment,
@@ -171,8 +178,8 @@ public class WorkerApp {
     final Worker syncWorker = factory.newWorker(TemporalJobType.SYNC.name(), getWorkerOptions(maxWorkers.getMaxSyncWorkers()));
     final ReplicationActivityImpl replicationActivity = getReplicationActivityImpl(
         containerOrchestratorConfig,
-        workerConfigs,
-        jobProcessFactory,
+        syncWorkerConfigs,
+        syncProcessFactory,
         secretsHydrator,
         workspaceRoot,
         workerEnvironment,
@@ -238,9 +245,7 @@ public class WorkerApp {
         airbyteVersion);
   }
 
-  private static ProcessFactory getJobProcessFactory(final Configs configs) throws IOException {
-    final WorkerConfigs workerConfigs = new WorkerConfigs(configs);
-
+  private static ProcessFactory getJobProcessFactory(final Configs configs, final WorkerConfigs workerConfigs) throws IOException {
     if (configs.getWorkerEnvironment() == Configs.WorkerEnvironment.KUBERNETES) {
       final KubernetesClient fabricClient = new DefaultKubernetesClient();
       final String localIp = InetAddress.getLocalHost().getHostAddress();
@@ -312,7 +317,18 @@ public class WorkerApp {
       KubePortManagerSingleton.init(configs.getTemporalWorkerPorts());
     }
 
-    final ProcessFactory jobProcessFactory = getJobProcessFactory(configs);
+    // for now, only Check jobs have job-specific configs, but since this will evolve, we instantiate
+    // separate configs
+    // for each job type to ease future customization.
+    final WorkerConfigs specWorkerConfigs = WorkerConfigs.buildSpecWorkerConfigs(configs);
+    final WorkerConfigs checkWorkerConfigs = WorkerConfigs.buildCheckWorkerConfigs(configs);
+    final WorkerConfigs discoverWorkerConfigs = WorkerConfigs.buildDiscoverWorkerConfigs(configs);
+    final WorkerConfigs syncWorkerConfigs = WorkerConfigs.buildSyncWorkerConfigs(configs);
+
+    final ProcessFactory specProcessFactory = getJobProcessFactory(configs, specWorkerConfigs);
+    final ProcessFactory checkProcessFactory = getJobProcessFactory(configs, checkWorkerConfigs);
+    final ProcessFactory discoverProcessFactory = getJobProcessFactory(configs, discoverWorkerConfigs);
+    final ProcessFactory syncProcessFactory = getJobProcessFactory(configs, syncWorkerConfigs);
 
     final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService(temporalHost);
 
@@ -364,7 +380,7 @@ public class WorkerApp {
     final ConnectionHelper connectionHelper = new ConnectionHelper(
         configRepository,
         workspaceHelper,
-        workerConfigs);
+        new WorkerConfigs(configs));
 
     final Optional<ContainerOrchestratorConfig> containerOrchestratorConfig = getContainerOrchestratorConfig(configs);
 
@@ -378,14 +394,20 @@ public class WorkerApp {
 
     new WorkerApp(
         workspaceRoot,
-        jobProcessFactory,
+        specProcessFactory,
+        checkProcessFactory,
+        discoverProcessFactory,
+        syncProcessFactory,
         secretsHydrator,
         temporalService,
         configRepository,
         configs.getMaxWorkers(),
         configs.getWorkerEnvironment(),
         configs.getLogConfigs(),
-        workerConfigs,
+        specWorkerConfigs,
+        checkWorkerConfigs,
+        discoverWorkerConfigs,
+        syncWorkerConfigs,
         configs.getAirbyteVersionOrWarning(),
         jobFactory,
         jobPersistence,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerConfigs.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerConfigs.java
@@ -7,10 +7,20 @@ package io.airbyte.workers;
 import io.airbyte.config.Configs;
 import io.airbyte.config.ResourceRequirements;
 import io.airbyte.config.TolerationPOJO;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
 
+@AllArgsConstructor
 public class WorkerConfigs {
+
+  private static final Duration DEFAULT_WORKER_STATUS_CHECK_INTERVAL = Duration.ofSeconds(30);
+  private static final Duration SPEC_WORKER_STATUS_CHECK_INTERVAL = Duration.ofSeconds(1);
+  private static final Duration CHECK_WORKER_STATUS_CHECK_INTERVAL = Duration.ofSeconds(1);
+  private static final Duration DISCOVER_WORKER_STATUS_CHECK_INTERVAL = Duration.ofSeconds(1);
+  private static final Duration SYNC_WORKER_STATUS_CHECK_INTERVAL = Duration.ofSeconds(30);
 
   private final Configs.WorkerEnvironment workerEnvironment;
 
@@ -21,34 +31,166 @@ public class WorkerConfigs {
   private final ResourceRequirements replicationOrchestratorResourceRequirements;
 
   private final List<TolerationPOJO> workerKubeTolerations;
-  private final Map<String, String> workerKubeNodeSelectors;
+  private final Optional<Map<String, String>> workerKubeNodeSelectors;
   private final String jobImagePullSecret;
   private final String jobImagePullPolicy;
   private final String jobSocatImage;
   private final String jobBusyboxImage;
   private final String jobCurlImage;
   private final Map<String, String> envMap;
+  private final Duration workerStatusCheckInterval;
 
+
+  /**
+   * Constructs a job-type-agnostic WorkerConfigs. For WorkerConfigs customized for specific
+   * job-types, use static `build*JOBTYPE*WorkerConfigs` method if one exists.
+   */
   public WorkerConfigs(final Configs configs) {
-    this.workerEnvironment = configs.getWorkerEnvironment();
-    this.resourceRequirements = new ResourceRequirements()
-        .withCpuRequest(configs.getJobMainContainerCpuRequest())
-        .withCpuLimit(configs.getJobMainContainerCpuLimit())
-        .withMemoryRequest(configs.getJobMainContainerMemoryRequest())
-        .withMemoryLimit(configs.getJobMainContainerMemoryLimit());
-    this.replicationOrchestratorResourceRequirements = new ResourceRequirements()
-        .withCpuRequest(configs.getReplicationOrchestratorCpuRequest())
-        .withCpuLimit(configs.getReplicationOrchestratorCpuLimit())
-        .withMemoryRequest(configs.getReplicationOrchestratorMemoryRequest())
-        .withMemoryLimit(configs.getReplicationOrchestratorMemoryLimit());
-    this.workerKubeTolerations = configs.getJobKubeTolerations();
-    this.workerKubeNodeSelectors = configs.getJobKubeNodeSelectors();
-    this.jobImagePullSecret = configs.getJobKubeMainContainerImagePullSecret();
-    this.jobImagePullPolicy = configs.getJobKubeMainContainerImagePullPolicy();
-    this.jobSocatImage = configs.getJobKubeSocatImage();
-    this.jobBusyboxImage = configs.getJobKubeBusyboxImage();
-    this.jobCurlImage = configs.getJobKubeCurlImage();
-    this.envMap = configs.getJobDefaultEnvMap();
+    this(
+        configs.getWorkerEnvironment(),
+        new ResourceRequirements()
+            .withCpuRequest(configs.getJobMainContainerCpuRequest())
+            .withCpuLimit(configs.getJobMainContainerCpuLimit())
+            .withMemoryRequest(configs.getJobMainContainerMemoryRequest())
+            .withMemoryLimit(configs.getJobMainContainerMemoryLimit()),
+        new ResourceRequirements()
+            .withCpuRequest(configs.getReplicationOrchestratorCpuRequest())
+            .withCpuLimit(configs.getReplicationOrchestratorCpuLimit())
+            .withMemoryRequest(configs.getReplicationOrchestratorMemoryRequest())
+            .withMemoryLimit(configs.getReplicationOrchestratorMemoryLimit()),
+        configs.getJobKubeTolerations(),
+        configs.getJobKubeNodeSelectors(),
+        configs.getJobKubeMainContainerImagePullSecret(),
+        configs.getJobKubeMainContainerImagePullPolicy(),
+        configs.getJobKubeSocatImage(),
+        configs.getJobKubeBusyboxImage(),
+        configs.getJobKubeCurlImage(),
+        configs.getJobDefaultEnvMap(),
+        DEFAULT_WORKER_STATUS_CHECK_INTERVAL);
+  }
+
+  /**
+   * Builds a WorkerConfigs with some configs that are specific to the Spec job type.
+   */
+  public static WorkerConfigs buildSpecWorkerConfigs(final Configs configs) {
+    final Optional<Map<String, String>> nodeSelectors = configs.getSpecJobKubeNodeSelectors().isPresent()
+        ? configs.getSpecJobKubeNodeSelectors()
+        : configs.getJobKubeNodeSelectors();
+
+    return new WorkerConfigs(
+        configs.getWorkerEnvironment(),
+        new ResourceRequirements()
+            .withCpuRequest(configs.getJobMainContainerCpuRequest())
+            .withCpuLimit(configs.getJobMainContainerCpuLimit())
+            .withMemoryRequest(configs.getJobMainContainerMemoryRequest())
+            .withMemoryLimit(configs.getJobMainContainerMemoryLimit()),
+        new ResourceRequirements()
+            .withCpuRequest(configs.getReplicationOrchestratorCpuRequest())
+            .withCpuLimit(configs.getReplicationOrchestratorCpuLimit())
+            .withMemoryRequest(configs.getReplicationOrchestratorMemoryRequest())
+            .withMemoryLimit(configs.getReplicationOrchestratorMemoryLimit()),
+        configs.getJobKubeTolerations(),
+        nodeSelectors,
+        configs.getJobKubeMainContainerImagePullSecret(),
+        configs.getJobKubeMainContainerImagePullPolicy(),
+        configs.getJobKubeSocatImage(),
+        configs.getJobKubeBusyboxImage(),
+        configs.getJobKubeCurlImage(),
+        configs.getJobDefaultEnvMap(),
+        SPEC_WORKER_STATUS_CHECK_INTERVAL);
+  }
+
+  /**
+   * Builds a WorkerConfigs with some configs that are specific to the Check job type.
+   */
+  public static WorkerConfigs buildCheckWorkerConfigs(final Configs configs) {
+    final Optional<Map<String, String>> nodeSelectors = configs.getCheckJobKubeNodeSelectors().isPresent()
+        ? configs.getCheckJobKubeNodeSelectors()
+        : configs.getJobKubeNodeSelectors();
+
+    return new WorkerConfigs(
+        configs.getWorkerEnvironment(),
+        new ResourceRequirements()
+            .withCpuRequest(configs.getJobMainContainerCpuRequest())
+            .withCpuLimit(configs.getJobMainContainerCpuLimit())
+            .withMemoryRequest(configs.getJobMainContainerMemoryRequest())
+            .withMemoryLimit(configs.getJobMainContainerMemoryLimit()),
+        new ResourceRequirements()
+            .withCpuRequest(configs.getReplicationOrchestratorCpuRequest())
+            .withCpuLimit(configs.getReplicationOrchestratorCpuLimit())
+            .withMemoryRequest(configs.getReplicationOrchestratorMemoryRequest())
+            .withMemoryLimit(configs.getReplicationOrchestratorMemoryLimit()),
+        configs.getJobKubeTolerations(),
+        nodeSelectors,
+        configs.getJobKubeMainContainerImagePullSecret(),
+        configs.getJobKubeMainContainerImagePullPolicy(),
+        configs.getJobKubeSocatImage(),
+        configs.getJobKubeBusyboxImage(),
+        configs.getJobKubeCurlImage(),
+        configs.getJobDefaultEnvMap(),
+        CHECK_WORKER_STATUS_CHECK_INTERVAL);
+  }
+
+  /**
+   * Builds a WorkerConfigs with some configs that are specific to the Discover job type.
+   */
+  public static WorkerConfigs buildDiscoverWorkerConfigs(final Configs configs) {
+    final Optional<Map<String, String>> nodeSelectors = configs.getDiscoverJobKubeNodeSelectors().isPresent()
+        ? configs.getDiscoverJobKubeNodeSelectors()
+        : configs.getJobKubeNodeSelectors();
+
+    return new WorkerConfigs(
+        configs.getWorkerEnvironment(),
+        new ResourceRequirements()
+            .withCpuRequest(configs.getJobMainContainerCpuRequest())
+            .withCpuLimit(configs.getJobMainContainerCpuLimit())
+            .withMemoryRequest(configs.getJobMainContainerMemoryRequest())
+            .withMemoryLimit(configs.getJobMainContainerMemoryLimit()),
+        new ResourceRequirements()
+            .withCpuRequest(configs.getReplicationOrchestratorCpuRequest())
+            .withCpuLimit(configs.getReplicationOrchestratorCpuLimit())
+            .withMemoryRequest(configs.getReplicationOrchestratorMemoryRequest())
+            .withMemoryLimit(configs.getReplicationOrchestratorMemoryLimit()),
+        configs.getJobKubeTolerations(),
+        nodeSelectors,
+        configs.getJobKubeMainContainerImagePullSecret(),
+        configs.getJobKubeMainContainerImagePullPolicy(),
+        configs.getJobKubeSocatImage(),
+        configs.getJobKubeBusyboxImage(),
+        configs.getJobKubeCurlImage(),
+        configs.getJobDefaultEnvMap(),
+        DISCOVER_WORKER_STATUS_CHECK_INTERVAL);
+  }
+
+  /**
+   * Builds a WorkerConfigs with some configs that are specific to the Sync job type.
+   */
+  public static WorkerConfigs buildSyncWorkerConfigs(final Configs configs) {
+    final Optional<Map<String, String>> nodeSelectors = configs.getSyncJobKubeNodeSelectors().isPresent()
+        ? configs.getSyncJobKubeNodeSelectors()
+        : configs.getJobKubeNodeSelectors();
+
+    return new WorkerConfigs(
+        configs.getWorkerEnvironment(),
+        new ResourceRequirements()
+            .withCpuRequest(configs.getJobMainContainerCpuRequest())
+            .withCpuLimit(configs.getJobMainContainerCpuLimit())
+            .withMemoryRequest(configs.getJobMainContainerMemoryRequest())
+            .withMemoryLimit(configs.getJobMainContainerMemoryLimit()),
+        new ResourceRequirements()
+            .withCpuRequest(configs.getReplicationOrchestratorCpuRequest())
+            .withCpuLimit(configs.getReplicationOrchestratorCpuLimit())
+            .withMemoryRequest(configs.getReplicationOrchestratorMemoryRequest())
+            .withMemoryLimit(configs.getReplicationOrchestratorMemoryLimit()),
+        configs.getJobKubeTolerations(),
+        nodeSelectors,
+        configs.getJobKubeMainContainerImagePullSecret(),
+        configs.getJobKubeMainContainerImagePullPolicy(),
+        configs.getJobKubeSocatImage(),
+        configs.getJobKubeBusyboxImage(),
+        configs.getJobKubeCurlImage(),
+        configs.getJobDefaultEnvMap(),
+        SYNC_WORKER_STATUS_CHECK_INTERVAL);
   }
 
   public Configs.WorkerEnvironment getWorkerEnvironment() {
@@ -63,7 +205,7 @@ public class WorkerConfigs {
     return workerKubeTolerations;
   }
 
-  public Map<String, String> getworkerKubeNodeSelectors() {
+  public Optional<Map<String, String>> getworkerKubeNodeSelectors() {
     return workerKubeNodeSelectors;
   }
 
@@ -93,6 +235,10 @@ public class WorkerConfigs {
 
   public ResourceRequirements getReplicationOrchestratorResourceRequirements() {
     return replicationOrchestratorResourceRequirements;
+  }
+
+  public Duration getWorkerStatusCheckInterval() {
+    return workerStatusCheckInterval;
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerConfigs.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerConfigs.java
@@ -20,16 +20,10 @@ public class WorkerConfigs {
   private static final Duration SPEC_WORKER_STATUS_CHECK_INTERVAL = Duration.ofSeconds(1);
   private static final Duration CHECK_WORKER_STATUS_CHECK_INTERVAL = Duration.ofSeconds(1);
   private static final Duration DISCOVER_WORKER_STATUS_CHECK_INTERVAL = Duration.ofSeconds(1);
-  private static final Duration SYNC_WORKER_STATUS_CHECK_INTERVAL = Duration.ofSeconds(30);
+  private static final Duration REPLICATION_WORKER_STATUS_CHECK_INTERVAL = Duration.ofSeconds(30);
 
   private final Configs.WorkerEnvironment workerEnvironment;
-
-  // for running source, destination, normalization, dbt, normalization orchestrator, and dbt
-  // orchestrator pods
   private final ResourceRequirements resourceRequirements;
-  // for running replication orchestrator pods
-  private final ResourceRequirements replicationOrchestratorResourceRequirements;
-
   private final List<TolerationPOJO> workerKubeTolerations;
   private final Optional<Map<String, String>> workerKubeNodeSelectors;
   private final String jobImagePullSecret;
@@ -39,7 +33,6 @@ public class WorkerConfigs {
   private final String jobCurlImage;
   private final Map<String, String> envMap;
   private final Duration workerStatusCheckInterval;
-
 
   /**
    * Constructs a job-type-agnostic WorkerConfigs. For WorkerConfigs customized for specific
@@ -53,11 +46,6 @@ public class WorkerConfigs {
             .withCpuLimit(configs.getJobMainContainerCpuLimit())
             .withMemoryRequest(configs.getJobMainContainerMemoryRequest())
             .withMemoryLimit(configs.getJobMainContainerMemoryLimit()),
-        new ResourceRequirements()
-            .withCpuRequest(configs.getReplicationOrchestratorCpuRequest())
-            .withCpuLimit(configs.getReplicationOrchestratorCpuLimit())
-            .withMemoryRequest(configs.getReplicationOrchestratorMemoryRequest())
-            .withMemoryLimit(configs.getReplicationOrchestratorMemoryLimit()),
         configs.getJobKubeTolerations(),
         configs.getJobKubeNodeSelectors(),
         configs.getJobKubeMainContainerImagePullSecret(),
@@ -84,11 +72,6 @@ public class WorkerConfigs {
             .withCpuLimit(configs.getJobMainContainerCpuLimit())
             .withMemoryRequest(configs.getJobMainContainerMemoryRequest())
             .withMemoryLimit(configs.getJobMainContainerMemoryLimit()),
-        new ResourceRequirements()
-            .withCpuRequest(configs.getReplicationOrchestratorCpuRequest())
-            .withCpuLimit(configs.getReplicationOrchestratorCpuLimit())
-            .withMemoryRequest(configs.getReplicationOrchestratorMemoryRequest())
-            .withMemoryLimit(configs.getReplicationOrchestratorMemoryLimit()),
         configs.getJobKubeTolerations(),
         nodeSelectors,
         configs.getJobKubeMainContainerImagePullSecret(),
@@ -115,11 +98,6 @@ public class WorkerConfigs {
             .withCpuLimit(configs.getJobMainContainerCpuLimit())
             .withMemoryRequest(configs.getJobMainContainerMemoryRequest())
             .withMemoryLimit(configs.getJobMainContainerMemoryLimit()),
-        new ResourceRequirements()
-            .withCpuRequest(configs.getReplicationOrchestratorCpuRequest())
-            .withCpuLimit(configs.getReplicationOrchestratorCpuLimit())
-            .withMemoryRequest(configs.getReplicationOrchestratorMemoryRequest())
-            .withMemoryLimit(configs.getReplicationOrchestratorMemoryLimit()),
         configs.getJobKubeTolerations(),
         nodeSelectors,
         configs.getJobKubeMainContainerImagePullSecret(),
@@ -146,11 +124,6 @@ public class WorkerConfigs {
             .withCpuLimit(configs.getJobMainContainerCpuLimit())
             .withMemoryRequest(configs.getJobMainContainerMemoryRequest())
             .withMemoryLimit(configs.getJobMainContainerMemoryLimit()),
-        new ResourceRequirements()
-            .withCpuRequest(configs.getReplicationOrchestratorCpuRequest())
-            .withCpuLimit(configs.getReplicationOrchestratorCpuLimit())
-            .withMemoryRequest(configs.getReplicationOrchestratorMemoryRequest())
-            .withMemoryLimit(configs.getReplicationOrchestratorMemoryLimit()),
         configs.getJobKubeTolerations(),
         nodeSelectors,
         configs.getJobKubeMainContainerImagePullSecret(),
@@ -162,35 +135,23 @@ public class WorkerConfigs {
         DISCOVER_WORKER_STATUS_CHECK_INTERVAL);
   }
 
-  /**
-   * Builds a WorkerConfigs with some configs that are specific to the Sync job type.
-   */
-  public static WorkerConfigs buildSyncWorkerConfigs(final Configs configs) {
-    final Optional<Map<String, String>> nodeSelectors = configs.getSyncJobKubeNodeSelectors().isPresent()
-        ? configs.getSyncJobKubeNodeSelectors()
-        : configs.getJobKubeNodeSelectors();
-
+  public static WorkerConfigs buildReplicationWorkerConfigs(final Configs configs) {
     return new WorkerConfigs(
         configs.getWorkerEnvironment(),
-        new ResourceRequirements()
-            .withCpuRequest(configs.getJobMainContainerCpuRequest())
-            .withCpuLimit(configs.getJobMainContainerCpuLimit())
-            .withMemoryRequest(configs.getJobMainContainerMemoryRequest())
-            .withMemoryLimit(configs.getJobMainContainerMemoryLimit()),
         new ResourceRequirements()
             .withCpuRequest(configs.getReplicationOrchestratorCpuRequest())
             .withCpuLimit(configs.getReplicationOrchestratorCpuLimit())
             .withMemoryRequest(configs.getReplicationOrchestratorMemoryRequest())
             .withMemoryLimit(configs.getReplicationOrchestratorMemoryLimit()),
         configs.getJobKubeTolerations(),
-        nodeSelectors,
+        configs.getJobKubeNodeSelectors(),
         configs.getJobKubeMainContainerImagePullSecret(),
         configs.getJobKubeMainContainerImagePullPolicy(),
         configs.getJobKubeSocatImage(),
         configs.getJobKubeBusyboxImage(),
         configs.getJobKubeCurlImage(),
         configs.getJobDefaultEnvMap(),
-        SYNC_WORKER_STATUS_CHECK_INTERVAL);
+        REPLICATION_WORKER_STATUS_CHECK_INTERVAL);
   }
 
   public Configs.WorkerEnvironment getWorkerEnvironment() {
@@ -231,10 +192,6 @@ public class WorkerConfigs {
 
   public Map<String, String> getEnvMap() {
     return envMap;
-  }
-
-  public ResourceRequirements getReplicationOrchestratorResourceRequirements() {
-    return replicationOrchestratorResourceRequirements;
   }
 
   public Duration getWorkerStatusCheckInterval() {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -45,6 +45,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -95,7 +96,6 @@ public class KubePodProcess extends Process implements KubePod {
   private static final Logger LOGGER = LoggerFactory.getLogger(KubePodProcess.class);
 
   private static final String INIT_CONTAINER_NAME = "init";
-  public static final Duration DEFAULT_STATUS_CHECK_INTERVAL = Duration.ofSeconds(30);
   private static final String DEFAULT_MEMORY_REQUEST = "25Mi";
   private static final String DEFAULT_MEMORY_LIMIT = "50Mi";
   private static final ResourceRequirements DEFAULT_SIDECAR_RESOURCES = new ResourceRequirements()
@@ -343,7 +343,7 @@ public class KubePodProcess extends Process implements KubePod {
                         final ResourceRequirements resourceRequirements,
                         final String imagePullSecret,
                         final List<TolerationPOJO> tolerations,
-                        final Map<String, String> nodeSelectors,
+                        final Optional<Map<String, String>> nodeSelectors,
                         final Map<String, String> labels,
                         final String socatImage,
                         final String busyboxImage,
@@ -469,7 +469,7 @@ public class KubePodProcess extends Process implements KubePod {
 
     final Pod pod = podBuilder.withTolerations(buildPodTolerations(tolerations))
         .withImagePullSecrets(new LocalObjectReference(imagePullSecret)) // An empty string turns this into a no-op setting.
-        .withNodeSelector(nodeSelectors.isEmpty() ? null : nodeSelectors)
+        .withNodeSelector(nodeSelectors.orElse(null))
         .withRestartPolicy("Never")
         .withInitContainers(init)
         .withContainers(containers)

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
@@ -12,7 +12,6 @@ import io.airbyte.workers.WorkerException;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import java.net.InetAddress;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -51,7 +50,6 @@ public class KubeProcessFactory implements ProcessFactory {
   private final String kubeHeartbeatUrl;
   private final String processRunnerHost;
   private final boolean isOrchestrator;
-  private final Duration statusCheckInterval;
 
   /**
    * Sets up a process factory with the default processRunnerHost.
@@ -61,8 +59,13 @@ public class KubeProcessFactory implements ProcessFactory {
                             final KubernetesClient fabricClient,
                             final String kubeHeartbeatUrl,
                             final boolean isOrchestrator) {
-    this(workerConfigs, namespace, fabricClient, kubeHeartbeatUrl,
-        Exceptions.toRuntime(() -> InetAddress.getLocalHost().getHostAddress()), isOrchestrator, KubePodProcess.DEFAULT_STATUS_CHECK_INTERVAL);
+    this(
+        workerConfigs,
+        namespace,
+        fabricClient,
+        kubeHeartbeatUrl,
+        Exceptions.toRuntime(() -> InetAddress.getLocalHost().getHostAddress()),
+        isOrchestrator);
   }
 
   /**
@@ -73,8 +76,6 @@ public class KubeProcessFactory implements ProcessFactory {
    * @param processRunnerHost is the local host or ip of the machine running the process factory.
    *        injectable for testing.
    * @param isOrchestrator determines if this should run as airbyte-admin
-   * @param statusCheckInterval specifies how often the Kubernetes API should be consulted when
-   *        attempting to get the exit code after termination
    */
   @VisibleForTesting
   public KubeProcessFactory(final WorkerConfigs workerConfigs,
@@ -82,15 +83,13 @@ public class KubeProcessFactory implements ProcessFactory {
                             final KubernetesClient fabricClient,
                             final String kubeHeartbeatUrl,
                             final String processRunnerHost,
-                            final boolean isOrchestrator,
-                            final Duration statusCheckInterval) {
+                            final boolean isOrchestrator) {
     this.workerConfigs = workerConfigs;
     this.namespace = namespace;
     this.fabricClient = fabricClient;
     this.kubeHeartbeatUrl = kubeHeartbeatUrl;
     this.processRunnerHost = processRunnerHost;
     this.isOrchestrator = isOrchestrator;
-    this.statusCheckInterval = statusCheckInterval;
   }
 
   @Override
@@ -123,7 +122,7 @@ public class KubeProcessFactory implements ProcessFactory {
           isOrchestrator,
           processRunnerHost,
           fabricClient,
-          statusCheckInterval,
+          workerConfigs.getWorkerStatusCheckInterval(),
           podName,
           namespace,
           imageName,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationLauncherWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationLauncherWorker.java
@@ -41,7 +41,7 @@ public class ReplicationLauncherWorker extends LauncherWorker<StandardSyncInput,
             INIT_FILE_SOURCE_LAUNCHER_CONFIG, Jsons.serialize(sourceLauncherConfig),
             INIT_FILE_DESTINATION_LAUNCHER_CONFIG, Jsons.serialize(destinationLauncherConfig)),
         containerOrchestratorConfig,
-        workerConfigs.getReplicationOrchestratorResourceRequirements(),
+        workerConfigs.getResourceRequirements(),
         ReplicationOutput.class);
   }
 

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
@@ -24,7 +24,6 @@ import java.net.Inet4Address;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -85,8 +84,7 @@ public class KubePodProcessIntegrationTest {
             fabricClient,
             heartbeatUrl,
             getHost(),
-            false,
-            Duration.ofSeconds(1));
+            false);
   }
 
   @BeforeEach

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultCheckConnectionWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultCheckConnectionWorkerTest.java
@@ -50,7 +50,7 @@ public class DefaultCheckConnectionWorkerTest {
 
   @BeforeEach
   public void setup() throws IOException, WorkerException {
-    workerConfigs = new WorkerConfigs(new EnvConfigs());
+    workerConfigs = WorkerConfigs.buildCheckWorkerConfigs(new EnvConfigs());
     input = new StandardCheckConnectionInput().withConnectionConfiguration(CREDS);
 
     jobRoot = Files.createTempDirectory(Files.createDirectories(TEST_ROOT), "");

--- a/airbyte-workers/src/test/java/io/airbyte/workers/WorkerConfigsTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/WorkerConfigsTest.java
@@ -10,85 +10,111 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.config.Configs;
 import io.airbyte.config.EnvConfigs;
+import io.airbyte.config.ResourceRequirements;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class WorkerConfigsTest {
 
+  private static final Map<String, String> DEFAULT_NODE_SELECTORS = ImmutableMap.of("job", "default");
+  private static final Map<String, String> SPEC_NODE_SELECTORS = ImmutableMap.of("job", "spec");
+  private static final Map<String, String> CHECK_NODE_SELECTORS = ImmutableMap.of("job", "check");
+  private static final Map<String, String> DISCOVER_NODE_SELECTORS = ImmutableMap.of("job", "discover");
+  private static final String DEFAULT_CPU_REQUEST = "0.1";
+  private static final String DEFAULT_CPU_LIMIT = "0.2";
+  private static final String DEFAULT_MEMORY_REQUEST = "100Mi";
+  private static final String DEFAULT_MEMORY_LIMIT = "200Mi";
+  private static final ResourceRequirements DEFAULT_RESOURCE_REQUIREMENTS = new ResourceRequirements()
+      .withCpuRequest(DEFAULT_CPU_REQUEST)
+      .withCpuLimit(DEFAULT_CPU_LIMIT)
+      .withMemoryRequest(DEFAULT_MEMORY_REQUEST)
+      .withMemoryLimit(DEFAULT_MEMORY_LIMIT);
+
+  private static final String REPLICATION_CPU_REQUEST = "0.3";
+  private static final String REPLICATION_CPU_LIMIT = "0.4";
+  private static final String REPLICATION_MEMORY_REQUEST = "300Mi";
+  private static final String REPLICATION_MEMORY_LIMIT = "400Mi";
+  private static final ResourceRequirements REPLICATION_RESOURCE_REQUIREMENTS = new ResourceRequirements()
+      .withCpuRequest(REPLICATION_CPU_REQUEST)
+      .withCpuLimit(REPLICATION_CPU_LIMIT)
+      .withMemoryRequest(REPLICATION_MEMORY_REQUEST)
+      .withMemoryLimit(REPLICATION_MEMORY_LIMIT);
+
   private Configs configs;
-  private WorkerConfigs specWorkerConfigs;
-  private WorkerConfigs checkWorkerConfigs;
-  private WorkerConfigs discoverWorkerConfigs;
-  private WorkerConfigs syncWorkerConfigs;
 
-  @Nested
-  public class NodeSelectorsSetForJobType {
-
-    private static final Map<String, String> SPEC_NODE_SELECTORS = ImmutableMap.of("job", "spec");
-    private static final Map<String, String> CHECK_NODE_SELECTORS = ImmutableMap.of("job", "check");
-    private static final Map<String, String> DISCOVER_NODE_SELECTORS = ImmutableMap.of("job", "discover");
-    private static final Map<String, String> SYNC_NODE_SELECTORS = ImmutableMap.of("job", "sync");
-
-    @BeforeEach
-    public void setup() {
-      configs = mock(EnvConfigs.class);
-      when(configs.getCheckJobKubeNodeSelectors()).thenReturn(Optional.of(CHECK_NODE_SELECTORS));
-      when(configs.getSpecJobKubeNodeSelectors()).thenReturn(Optional.of(SPEC_NODE_SELECTORS));
-      when(configs.getDiscoverJobKubeNodeSelectors()).thenReturn(Optional.of(DISCOVER_NODE_SELECTORS));
-      when(configs.getSyncJobKubeNodeSelectors()).thenReturn(Optional.of(SYNC_NODE_SELECTORS));
-
-      specWorkerConfigs = WorkerConfigs.buildSpecWorkerConfigs(configs);
-      checkWorkerConfigs = WorkerConfigs.buildCheckWorkerConfigs(configs);
-      discoverWorkerConfigs = WorkerConfigs.buildDiscoverWorkerConfigs(configs);
-      syncWorkerConfigs = WorkerConfigs.buildSyncWorkerConfigs(configs);
-    }
-
-    @Test
-    @DisplayName("worker configs use job-specific node selectors")
-    public void testNodeSelectors() {
-      Assertions.assertEquals(SPEC_NODE_SELECTORS, specWorkerConfigs.getworkerKubeNodeSelectors().get());
-      Assertions.assertEquals(CHECK_NODE_SELECTORS, checkWorkerConfigs.getworkerKubeNodeSelectors().get());
-      Assertions.assertEquals(DISCOVER_NODE_SELECTORS, discoverWorkerConfigs.getworkerKubeNodeSelectors().get());
-      Assertions.assertEquals(SYNC_NODE_SELECTORS, syncWorkerConfigs.getworkerKubeNodeSelectors().get());
-    }
-
+  @BeforeEach
+  public void setup() {
+    configs = mock(EnvConfigs.class);
+    when(configs.getJobKubeNodeSelectors()).thenReturn(Optional.of(DEFAULT_NODE_SELECTORS));
+    when(configs.getJobMainContainerCpuRequest()).thenReturn(DEFAULT_CPU_REQUEST);
+    when(configs.getJobMainContainerCpuLimit()).thenReturn(DEFAULT_CPU_LIMIT);
+    when(configs.getJobMainContainerMemoryRequest()).thenReturn(DEFAULT_MEMORY_REQUEST);
+    when(configs.getJobMainContainerMemoryLimit()).thenReturn(DEFAULT_MEMORY_LIMIT);
   }
 
-  @Nested
-  public class DefaultNodeSelectors {
+  @Test
+  @DisplayName("default workerConfigs use default node selectors")
+  public void testDefaultNodeSelectors() {
+    final WorkerConfigs defaultWorkerConfigs = new WorkerConfigs(configs);
 
-    private static final Map<String, String> NODE_SELECTORS = ImmutableMap.of("job", "all");
+    Assertions.assertEquals(DEFAULT_NODE_SELECTORS, defaultWorkerConfigs.getworkerKubeNodeSelectors().get());
+  }
 
-    @BeforeEach
-    public void setup() {
-      configs = mock(EnvConfigs.class);
-      when(configs.getCheckJobKubeNodeSelectors()).thenReturn(Optional.empty());
-      when(configs.getSpecJobKubeNodeSelectors()).thenReturn(Optional.empty());
-      when(configs.getDiscoverJobKubeNodeSelectors()).thenReturn(Optional.empty());
-      when(configs.getSyncJobKubeNodeSelectors()).thenReturn(Optional.empty());
+  @Test
+  @DisplayName("spec, check, and discover workerConfigs use job-specific node selectors if set")
+  public void testCustomNodeSelectors() {
+    when(configs.getCheckJobKubeNodeSelectors()).thenReturn(Optional.of(CHECK_NODE_SELECTORS));
+    when(configs.getSpecJobKubeNodeSelectors()).thenReturn(Optional.of(SPEC_NODE_SELECTORS));
+    when(configs.getDiscoverJobKubeNodeSelectors()).thenReturn(Optional.of(DISCOVER_NODE_SELECTORS));
 
-      when(configs.getJobKubeNodeSelectors()).thenReturn(Optional.of(NODE_SELECTORS));
+    final WorkerConfigs specWorkerConfigs = WorkerConfigs.buildSpecWorkerConfigs(configs);
+    final WorkerConfigs checkWorkerConfigs = WorkerConfigs.buildCheckWorkerConfigs(configs);
+    final WorkerConfigs discoverWorkerConfigs = WorkerConfigs.buildDiscoverWorkerConfigs(configs);
 
-      specWorkerConfigs = WorkerConfigs.buildSpecWorkerConfigs(configs);
-      checkWorkerConfigs = WorkerConfigs.buildCheckWorkerConfigs(configs);
-      discoverWorkerConfigs = WorkerConfigs.buildDiscoverWorkerConfigs(configs);
-      syncWorkerConfigs = WorkerConfigs.buildSyncWorkerConfigs(configs);
-    }
+    Assertions.assertEquals(SPEC_NODE_SELECTORS, specWorkerConfigs.getworkerKubeNodeSelectors().get());
+    Assertions.assertEquals(CHECK_NODE_SELECTORS, checkWorkerConfigs.getworkerKubeNodeSelectors().get());
+    Assertions.assertEquals(DISCOVER_NODE_SELECTORS, discoverWorkerConfigs.getworkerKubeNodeSelectors().get());
+  }
 
-    @Test
-    @DisplayName("worker configs use default node selectors when no job-specific selectors set")
-    public void testNodeSelectors() {
-      Assertions.assertEquals(NODE_SELECTORS, specWorkerConfigs.getworkerKubeNodeSelectors().get());
-      Assertions.assertEquals(NODE_SELECTORS, checkWorkerConfigs.getworkerKubeNodeSelectors().get());
-      Assertions.assertEquals(NODE_SELECTORS, discoverWorkerConfigs.getworkerKubeNodeSelectors().get());
-      Assertions.assertEquals(NODE_SELECTORS, syncWorkerConfigs.getworkerKubeNodeSelectors().get());
-    }
+  @Test
+  @DisplayName("spec, check, and discover workerConfigs use default node selectors when custom selectors are not set")
+  public void testNodeSelectorsFallbackToDefault() {
+    when(configs.getCheckJobKubeNodeSelectors()).thenReturn(Optional.empty());
+    when(configs.getSpecJobKubeNodeSelectors()).thenReturn(Optional.empty());
+    when(configs.getDiscoverJobKubeNodeSelectors()).thenReturn(Optional.empty());
 
+    final WorkerConfigs specWorkerConfigs = WorkerConfigs.buildSpecWorkerConfigs(configs);
+    final WorkerConfigs checkWorkerConfigs = WorkerConfigs.buildCheckWorkerConfigs(configs);
+    final WorkerConfigs discoverWorkerConfigs = WorkerConfigs.buildDiscoverWorkerConfigs(configs);
+
+    Assertions.assertEquals(DEFAULT_NODE_SELECTORS, specWorkerConfigs.getworkerKubeNodeSelectors().get());
+    Assertions.assertEquals(DEFAULT_NODE_SELECTORS, checkWorkerConfigs.getworkerKubeNodeSelectors().get());
+    Assertions.assertEquals(DEFAULT_NODE_SELECTORS, discoverWorkerConfigs.getworkerKubeNodeSelectors().get());
+  }
+
+  @Test
+  @DisplayName("default workerConfigs use default resourceRequirements")
+  public void testDefaultResourceRequirements() {
+    final WorkerConfigs defaultWorkerConfigs = new WorkerConfigs(configs);
+
+    Assertions.assertEquals(DEFAULT_RESOURCE_REQUIREMENTS, defaultWorkerConfigs.getResourceRequirements());
+  }
+
+  @Test
+  @DisplayName("replication workerConfigs use replication-specific resourceRequirements")
+  public void testCustomResourceRequirements() {
+    when(configs.getReplicationOrchestratorCpuRequest()).thenReturn(REPLICATION_CPU_REQUEST);
+    when(configs.getReplicationOrchestratorCpuLimit()).thenReturn(REPLICATION_CPU_LIMIT);
+    when(configs.getReplicationOrchestratorMemoryRequest()).thenReturn(REPLICATION_MEMORY_REQUEST);
+    when(configs.getReplicationOrchestratorMemoryLimit()).thenReturn(REPLICATION_MEMORY_LIMIT);
+
+    final WorkerConfigs replicationWorkerConfigs = WorkerConfigs.buildReplicationWorkerConfigs(configs);
+
+    Assertions.assertEquals(REPLICATION_RESOURCE_REQUIREMENTS, replicationWorkerConfigs.getResourceRequirements());
   }
 
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/WorkerConfigsTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/WorkerConfigsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.config.Configs;
+import io.airbyte.config.EnvConfigs;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class WorkerConfigsTest {
+
+  private Configs configs;
+  private WorkerConfigs specWorkerConfigs;
+  private WorkerConfigs checkWorkerConfigs;
+  private WorkerConfigs discoverWorkerConfigs;
+  private WorkerConfigs syncWorkerConfigs;
+
+  @Nested
+  public class NodeSelectorsSetForJobType {
+
+    private static final Map<String, String> SPEC_NODE_SELECTORS = ImmutableMap.of("job", "spec");
+    private static final Map<String, String> CHECK_NODE_SELECTORS = ImmutableMap.of("job", "check");
+    private static final Map<String, String> DISCOVER_NODE_SELECTORS = ImmutableMap.of("job", "discover");
+    private static final Map<String, String> SYNC_NODE_SELECTORS = ImmutableMap.of("job", "sync");
+
+    @BeforeEach
+    public void setup() {
+      configs = mock(EnvConfigs.class);
+      when(configs.getCheckJobKubeNodeSelectors()).thenReturn(Optional.of(CHECK_NODE_SELECTORS));
+      when(configs.getSpecJobKubeNodeSelectors()).thenReturn(Optional.of(SPEC_NODE_SELECTORS));
+      when(configs.getDiscoverJobKubeNodeSelectors()).thenReturn(Optional.of(DISCOVER_NODE_SELECTORS));
+      when(configs.getSyncJobKubeNodeSelectors()).thenReturn(Optional.of(SYNC_NODE_SELECTORS));
+
+      specWorkerConfigs = WorkerConfigs.buildSpecWorkerConfigs(configs);
+      checkWorkerConfigs = WorkerConfigs.buildCheckWorkerConfigs(configs);
+      discoverWorkerConfigs = WorkerConfigs.buildDiscoverWorkerConfigs(configs);
+      syncWorkerConfigs = WorkerConfigs.buildSyncWorkerConfigs(configs);
+    }
+
+    @Test
+    @DisplayName("worker configs use job-specific node selectors")
+    public void testNodeSelectors() {
+      Assertions.assertEquals(SPEC_NODE_SELECTORS, specWorkerConfigs.getworkerKubeNodeSelectors().get());
+      Assertions.assertEquals(CHECK_NODE_SELECTORS, checkWorkerConfigs.getworkerKubeNodeSelectors().get());
+      Assertions.assertEquals(DISCOVER_NODE_SELECTORS, discoverWorkerConfigs.getworkerKubeNodeSelectors().get());
+      Assertions.assertEquals(SYNC_NODE_SELECTORS, syncWorkerConfigs.getworkerKubeNodeSelectors().get());
+    }
+
+  }
+
+  @Nested
+  public class DefaultNodeSelectors {
+
+    private static final Map<String, String> NODE_SELECTORS = ImmutableMap.of("job", "all");
+
+    @BeforeEach
+    public void setup() {
+      configs = mock(EnvConfigs.class);
+      when(configs.getCheckJobKubeNodeSelectors()).thenReturn(Optional.empty());
+      when(configs.getSpecJobKubeNodeSelectors()).thenReturn(Optional.empty());
+      when(configs.getDiscoverJobKubeNodeSelectors()).thenReturn(Optional.empty());
+      when(configs.getSyncJobKubeNodeSelectors()).thenReturn(Optional.empty());
+
+      when(configs.getJobKubeNodeSelectors()).thenReturn(Optional.of(NODE_SELECTORS));
+
+      specWorkerConfigs = WorkerConfigs.buildSpecWorkerConfigs(configs);
+      checkWorkerConfigs = WorkerConfigs.buildCheckWorkerConfigs(configs);
+      discoverWorkerConfigs = WorkerConfigs.buildDiscoverWorkerConfigs(configs);
+      syncWorkerConfigs = WorkerConfigs.buildSyncWorkerConfigs(configs);
+    }
+
+    @Test
+    @DisplayName("worker configs use default node selectors when no job-specific selectors set")
+    public void testNodeSelectors() {
+      Assertions.assertEquals(NODE_SELECTORS, specWorkerConfigs.getworkerKubeNodeSelectors().get());
+      Assertions.assertEquals(NODE_SELECTORS, checkWorkerConfigs.getworkerKubeNodeSelectors().get());
+      Assertions.assertEquals(NODE_SELECTORS, discoverWorkerConfigs.getworkerKubeNodeSelectors().get());
+      Assertions.assertEquals(NODE_SELECTORS, syncWorkerConfigs.getworkerKubeNodeSelectors().get());
+    }
+
+  }
+
+}


### PR DESCRIPTION
## What

Issue: https://github.com/airbytehq/airbyte/issues/10208

Rather than defining a single WorkerConfigs and KubePodProcess to serve every job type, we want job-type-specific configurations so that we can, for example, run Check job pods in a node pool that is tailored to the needs of that particular job type.

## How
Before this PR, the WorkerApp instantiated a single WorkerConfigs instance and a single ProcessFactory instance, which were shared across every type of job.

Now, the WorkerApp instantiates one WorkerConfigs for each job type, and one ProcessFactory for each job type. 

For now, only the Check job has new behavior (it will pull node selectors from a new environment variable, `CHECK_JOB_KUBE_NODE_SELECTORS`, and will use a status check interval of 1 second instead of 30). But the scaffolding is now in place to make further job-type-specific customization easier going forward.
