### PR TITLE
Turn off sentry before we have a global telemetry switch

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/Dockerfile
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /airbyte
 
 ENV APPLICATION destination-bigquery-denormalized
 ENV APPLICATION_VERSION 0.2.7
-ENV ENABLE_SENTRY true
+ENV ENABLE_SENTRY false
 
 COPY --from=build /airbyte /airbyte
 

--- a/airbyte-integrations/connectors/destination-bigquery/Dockerfile
+++ b/airbyte-integrations/connectors/destination-bigquery/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /airbyte
 
 ENV APPLICATION destination-bigquery
 ENV APPLICATION_VERSION 0.6.7
-ENV ENABLE_SENTRY true
+ENV ENABLE_SENTRY false
 
 COPY --from=build /airbyte /airbyte
 

--- a/airbyte-integrations/connectors/destination-snowflake/Dockerfile
+++ b/airbyte-integrations/connectors/destination-snowflake/Dockerfile
@@ -19,7 +19,7 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
 ENV APPLICATION_VERSION 0.4.8
-ENV ENABLE_SENTRY true
+ENV ENABLE_SENTRY false
 
 LABEL io.airbyte.version=0.4.8
 LABEL io.airbyte.name=airbyte/destination-snowflake


### PR DESCRIPTION
## What
Turn off Sentry before we have a global switch for telemetry.

## 🚨 User Impact 🚨
None expected.
