### PR TITLE
🐛 Postgres source: avoid system column name collision in normalization

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -28,5 +28,5 @@ WORKDIR /airbyte
 ENV AIRBYTE_ENTRYPOINT "/airbyte/entrypoint.sh"
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.67
+LABEL io.airbyte.version=0.1.68
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/reserved_keywords.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/reserved_keywords.py
@@ -268,6 +268,7 @@ REDSHIFT = {
 }
 
 # https://www.postgresql.org/docs/current/sql-keywords-appendix.html
+# https://www.postgresql.org/docs/14/ddl-system-columns.html
 POSTGRES = {
     "A",
     "ABORT",
@@ -362,6 +363,8 @@ POSTGRES = {
     "CLOB",
     "CLOSE",
     "CLUSTER",
+    "CMAX",
+    "CMIN",
     "COALESCE",
     "COBOL",
     "COLLATE",
@@ -412,6 +415,7 @@ POSTGRES = {
     "CREATE",
     "CROSS",
     "CSV",
+    "CTID",
     "CUBE",
     "CUME_DIST",
     "CURRENT",
@@ -966,6 +970,7 @@ POSTGRES = {
     "TABLESAMPLE",
     "TABLESPACE",
     "TABLE_NAME",
+    "TABLEOID",
     "TAN",
     "TANH",
     "TEMP",
@@ -1065,6 +1070,8 @@ POSTGRES = {
     "WORK",
     "WRAPPER",
     "WRITE",
+    "XMAX",
+    "XMIN",
     "XML",
     "XMLAGG",
     "XMLATTRIBUTES",

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 public class NormalizationRunnerFactory {
 
   public static final String BASE_NORMALIZATION_IMAGE_NAME = "airbyte/normalization";
-  public static final String NORMALIZATION_VERSION = "0.1.67";
+  public static final String NORMALIZATION_VERSION = "0.1.68";
 
   static final Map<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>> NORMALIZATION_MAPPING =
       ImmutableMap.<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>>builder()

--- a/docs/understanding-airbyte/basic-normalization.md
+++ b/docs/understanding-airbyte/basic-normalization.md
@@ -350,6 +350,8 @@ Therefore, in order to "upgrade" to the desired normalization version, you need 
 
 | Airbyte Version | Normalization Version | Date | Pull Request | Subject |
 |:----------------| :--- | :--- | :--- | :--- |
+|                 | 0.1.68 | 2022-02-17 | [\#10210](https://github.com/airbytehq/airbyte/pull/10210) | Fix normalization for postgres to avoid system column name collision |
+|                 | 0.1.67 | 2022-02-16 | [\#10219](https://github.com/airbytehq/airbyte/pull/10219) | Fix normalization for clickhouse when password is not provided |
 |                 | 0.1.66 | 2022-02-04 | [\#9341](https://github.com/airbytehq/airbyte/pull/9341) | Fix normalization for bigquery datasetId and tables |
 | 0.35.13-alpha   | 0.1.65 | 2021-01-28 | [\#9846](https://github.com/airbytehq/airbyte/pull/9846) | Tweak dbt multi-thread parameter down |
 | 0.35.12-alpha   | 0.1.64 | 2021-01-28 | [\#9793](https://github.com/airbytehq/airbyte/pull/9793) | Support PEM format for ssh-tunnel keys |


### PR DESCRIPTION
## What
- Close https://github.com/airbytehq/airbyte-internal-issues/issues/420.
- Reference: https://www.postgresql.org/docs/14/ddl-system-columns.html

## 🚨 User Impact 🚨
- None expected. It should not be possible for users to successfully run normalization with those column names.

## Pre-merge Checklist
<strong>Updating a connector </strong>

### Community member or Airbyter
   
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [x] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
