### PR TITLE
Source Clickhouse: Fix exception in case `password` field is not provided in configuration

### DIFF
--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-clickhouse-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.4
+LABEL io.airbyte.version=0.1.5
 LABEL io.airbyte.name=airbyte/source-clickhouse-strict-encrypt

--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-clickhouse-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.5
+LABEL io.airbyte.version=0.1.6
 LABEL io.airbyte.name=airbyte/source-clickhouse-strict-encrypt

--- a/airbyte-integrations/connectors/source-clickhouse/Dockerfile
+++ b/airbyte-integrations/connectors/source-clickhouse/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-clickhouse
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.7
+LABEL io.airbyte.version=0.1.8
 LABEL io.airbyte.name=airbyte/source-clickhouse

--- a/airbyte-integrations/connectors/source-clickhouse/Dockerfile
+++ b/airbyte-integrations/connectors/source-clickhouse/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-clickhouse
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.8
+LABEL io.airbyte.version=0.1.9
 LABEL io.airbyte.name=airbyte/source-clickhouse

--- a/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
@@ -93,11 +93,15 @@ public class ClickHouseSource extends AbstractJdbcSource<JDBCType> implements So
       jdbcUrl.append("?").append(String.join("&", SSL_PARAMETERS));
     }
 
-    return Jsons.jsonNode(ImmutableMap.builder()
-        .put("username", config.get("username").asText())
-        .put("password", config.get("password").asText())
-        .put("jdbc_url", jdbcUrl.toString())
-        .build());
+    ImmutableMap.Builder<Object, Object> configBuilder = ImmutableMap.builder()
+            .put("username", config.get("username").asText())
+            .put("jdbc_url", jdbcUrl.toString());
+
+    if (config.has("password")) {
+      configBuilder.put("password", config.get("password").asText());
+    }
+    
+    return Jsons.jsonNode(configBuilder.build());
   }
 
   @Override

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -78,6 +78,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date | Pull Request                                             | Subject                                                          |
 |:--------| :--- |:---------------------------------------------------------|:-----------------------------------------------------------------|
+| 0.1.8   | 2022-02-09 | [\#10214](https://github.com/airbytehq/airbyte/pull/10214) | Fix exception in case `password` field is not provided |
 | 0.1.7   | 2021-12-24 | [\#8958](https://github.com/airbytehq/airbyte/pull/8958) | Add support for JdbcType.ARRAY |
 | 0.1.6   | 2021-12-15 | [\#8429](https://github.com/airbytehq/airbyte/pull/8429) | Update titles and descriptions                                   |
 | 0.1.5   | 2021-12-01 | [\#8371](https://github.com/airbytehq/airbyte/pull/8371) | Fixed incorrect handling "\n" in ssh key                         |
@@ -90,6 +91,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date | Pull Request                                             | Subject                                                                    |
 |:---| :---  |:---------------------------------------------------------|:---------------------------------------------------------------------------|
+| 0.1.4 | 2022-02-09 | [\#10214](https://github.com/airbytehq/airbyte/pull/10214) | Fix exception in case `password` field is not provided |
 | 0.1.3 | 2021-12-29 | [\#9182](https://github.com/airbytehq/airbyte/pull/9182) [\#8958](https://github.com/airbytehq/airbyte/pull/8958) | Add support for JdbcType.ARRAY. Fixed tests                                |
 | 0.1.2 | 2021-12-01 | [\#8371](https://github.com/airbytehq/airbyte/pull/8371) | Fixed incorrect handling "\n" in ssh key                                   |
 | 0.1.1 | 20.10.2021 | [\#7327](https://github.com/airbytehq/airbyte/pull/7327) | Added support for connection via SSH tunnel(aka Bastion server).           |

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -91,7 +91,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date | Pull Request                                             | Subject                                                                    |
 |:---| :---  |:---------------------------------------------------------|:---------------------------------------------------------------------------|
-| 0.1.4 | 2022-02-09 | [\#10214](https://github.com/airbytehq/airbyte/pull/10214) | Fix exception in case `password` field is not provided |
+| 0.1.5 | 2022-02-09 | [\#10214](https://github.com/airbytehq/airbyte/pull/10214) | Fix exception in case `password` field is not provided |
 | 0.1.3 | 2021-12-29 | [\#9182](https://github.com/airbytehq/airbyte/pull/9182) [\#8958](https://github.com/airbytehq/airbyte/pull/8958) | Add support for JdbcType.ARRAY. Fixed tests                                |
 | 0.1.2 | 2021-12-01 | [\#8371](https://github.com/airbytehq/airbyte/pull/8371) | Fixed incorrect handling "\n" in ssh key                                   |
 | 0.1.1 | 20.10.2021 | [\#7327](https://github.com/airbytehq/airbyte/pull/7327) | Added support for connection via SSH tunnel(aka Bastion server).           |

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -78,11 +78,8 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date | Pull Request                                             | Subject                                                          |
 |:--------| :--- |:---------------------------------------------------------|:-----------------------------------------------------------------|
-<<<<<<< HEAD
+| 0.1.9   | 2022-02-09 | [\#10214](https://github.com/airbytehq/airbyte/pull/10214) | Fix exception in case `password` field is not provided |
 | 0.1.8   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option |
-=======
-| 0.1.8   | 2022-02-09 | [\#10214](https://github.com/airbytehq/airbyte/pull/10214) | Fix exception in case `password` field is not provided |
->>>>>>> b9bdfc125ad57bba27b3e1370c10e55d7f58c588
 | 0.1.7   | 2021-12-24 | [\#8958](https://github.com/airbytehq/airbyte/pull/8958) | Add support for JdbcType.ARRAY |
 | 0.1.6   | 2021-12-15 | [\#8429](https://github.com/airbytehq/airbyte/pull/8429) | Update titles and descriptions                                   |
 | 0.1.5   | 2021-12-01 | [\#8371](https://github.com/airbytehq/airbyte/pull/8371) | Fixed incorrect handling "\n" in ssh key                         |

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -92,7 +92,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date | Pull Request                                             | Subject                                                                    |
 |:---| :---  |:---------------------------------------------------------|:---------------------------------------------------------------------------|
-| 0.1.6 | 2022-02-09 | [\#10214](https://github.com/airbytehq/airbyte/pull/10214) | Fix exception in case `password` field is not provided |
+| 0.1.6 | 2022-02-09 | [\#10214](https://github.com/airbytehq/airbyte/pull/10214) | Fix exception in case `password` field is not provided  |
 | 0.1.5 | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option |
 | 0.1.3 | 2021-12-29 | [\#9182](https://github.com/airbytehq/airbyte/pull/9182) [\#8958](https://github.com/airbytehq/airbyte/pull/8958) | Add support for JdbcType.ARRAY. Fixed tests                                |
 | 0.1.2 | 2021-12-01 | [\#8371](https://github.com/airbytehq/airbyte/pull/8371) | Fixed incorrect handling "\n" in ssh key                                   |

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -92,8 +92,8 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date | Pull Request                                             | Subject                                                                    |
 |:---| :---  |:---------------------------------------------------------|:---------------------------------------------------------------------------|
-| 0.1.5 | 2022-02-09 | [\#10214](https://github.com/airbytehq/airbyte/pull/10214) | Fix exception in case `password` field is not provided |
-| 0.1.4 | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option |
+| 0.1.6 | 2022-02-09 | [\#10214](https://github.com/airbytehq/airbyte/pull/10214) | Fix exception in case `password` field is not provided |
+| 0.1.5 | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option |
 | 0.1.3 | 2021-12-29 | [\#9182](https://github.com/airbytehq/airbyte/pull/9182) [\#8958](https://github.com/airbytehq/airbyte/pull/8958) | Add support for JdbcType.ARRAY. Fixed tests                                |
 | 0.1.2 | 2021-12-01 | [\#8371](https://github.com/airbytehq/airbyte/pull/8371) | Fixed incorrect handling "\n" in ssh key                                   |
 | 0.1.1 | 20.10.2021 | [\#7327](https://github.com/airbytehq/airbyte/pull/7327) | Added support for connection via SSH tunnel(aka Bastion server).           |


### PR DESCRIPTION


## What
Fixes exception in case `password` is not provided for Clickhouse source.

Clickhouse source specification doesn't require password.
Config example:
```
{
    "host": "127.0.0.1",
    "port": 8123,
    "database": "default",
    "username": "default",
    "ssl": false,
    "tunnel_method": {
        "tunnel_method": "NO_TUNNEL"
    }
}
```


This leads to the following exception
```
Exception while checking connection:
java.lang.NullPointerException: Cannot invoke "com.fasterxml.jackson.databind.JsonNode.asText()" because the return value of "com.fasterxml.jackson.databind.JsonNode.get(String)" is null
        at io.airbyte.integrations.source.clickhouse.ClickHouseSource.toDatabaseConfig(ClickHouseSource.java:98) ~[io.airbyte.airbyte-integrations.connectors-source-clickhouse-0.35.1-alpha.jar:?]
        at io.airbyte.integrations.source.jdbc.AbstractJdbcSource.createDatabase(AbstractJdbcSource.java:282) ~[io.airbyte.airbyte-integrations.connectors-source-jdbc-0.35.1-alpha.jar:?]
        at io.airbyte.integrations.source.jdbc.AbstractJdbcSource.createDatabase(AbstractJdbcSource.java:62) ~[io.airbyte.airbyte-integrations.connectors-source-jdbc-0.35.1-alpha.jar:?]
        at io.airbyte.integrations.source.relationaldb.AbstractDbSource.createDatabaseInternal(AbstractDbSource.java:490) ~[io.airbyte.airbyte-integrations.connectors-source-relational-db-0.35.1-alpha.jar:?]
        at io.airbyte.integrations.source.relationaldb.AbstractDbSource.check(AbstractDbSource.java:65) ~[io.airbyte.airbyte-integrations.connectors-source-relational-db-0.35.1-alpha.jar:?]
        at io.airbyte.integrations.base.ssh.SshTunnel.sshWrap(SshTunnel.java:205) [io.airbyte.airbyte-integrations.bases-base-java-0.35.1-alpha.jar:?]
        at io.airbyte.integrations.base.ssh.SshWrappedSource.check(SshWrappedSource.java:37) [io.airbyte.airbyte-integrations.bases-base-java-0.35.1-alpha.jar:?]
        at io.airbyte.integrations.base.IntegrationRunner.run(IntegrationRunner.java:102) [io.airbyte.airbyte-integrations.bases-base-java-0.35.1-alpha.jar:?]
        at io.airbyte.integrations.source.clickhouse.ClickHouseSource.main(ClickHouseSource.java:111) [io.airbyte.airbyte-integrations.connectors-source-clickhouse-0.35.1-alpha.jar:?]
```

### Steps to reproduce
1. Save config example as `config.json`
2. `docker run --rm -i -v config.json:/tmp/config.json airbyte/source-clickhouse check --config /tmp/config.json`
**Actual:**
3. Receive an exception above
**Expected:**
3. Receive an exception `Connection refused` or something like that (if you don't have a running copy of Clickhouse)

## How
Simply checking if the `password` field is provided.
The same way as it is done in `PostgresSource`.

https://github.com/airbytehq/airbyte/blob/8749c7ab2c8a5b0d2e7946c8ed50eeebb19cb355/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java#L98-L106

## 🚨 User Impact 🚨
No breaking changes

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 

<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [x] Documentation updated 
    - [x] Connector's `README.md`
    - [x] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>
</details>