### PR TITLE
Add connector release stage labels

### DIFF
--- a/airbyte-webapp/src/core/domain/connector/types.ts
+++ b/airbyte-webapp/src/core/domain/connector/types.ts
@@ -4,6 +4,15 @@ import {
 } from "core/domain/connection";
 import { DestinationSyncMode } from "core/domain/catalog";
 
+export enum releaseStage {
+  "ALPHA" = "alpha",
+  "BETA" = "beta",
+  "GENERALLY_AVAILABLE" = "generally_available",
+  "CUSTOM" = "custom",
+  "RELEASE" = "release",
+  "NEW_RELEASE" = "new_release",
+}
+
 export interface DestinationDefinition {
   destinationDefinitionId: string;
   name: string;
@@ -12,6 +21,7 @@ export interface DestinationDefinition {
   latestDockerImageTag: string;
   documentationUrl: string;
   icon: string;
+  releaseStage?: releaseStage;
 }
 
 export interface SourceDefinition {
@@ -22,6 +32,7 @@ export interface SourceDefinition {
   latestDockerImageTag: string;
   documentationUrl: string;
   icon: string;
+  releaseStage?: releaseStage;
 }
 
 export type ConnectorDefinition = SourceDefinition | DestinationDefinition;

--- a/airbyte-webapp/src/core/domain/connector/types.ts
+++ b/airbyte-webapp/src/core/domain/connector/types.ts
@@ -4,13 +4,11 @@ import {
 } from "core/domain/connection";
 import { DestinationSyncMode } from "core/domain/catalog";
 
-export enum releaseStage {
+export enum ReleaseStage {
   "ALPHA" = "alpha",
   "BETA" = "beta",
   "GENERALLY_AVAILABLE" = "generally_available",
   "CUSTOM" = "custom",
-  "RELEASE" = "release",
-  "NEW_RELEASE" = "new_release",
 }
 
 export interface DestinationDefinition {
@@ -21,7 +19,7 @@ export interface DestinationDefinition {
   latestDockerImageTag: string;
   documentationUrl: string;
   icon: string;
-  releaseStage?: releaseStage;
+  releaseStage?: ReleaseStage;
 }
 
 export interface SourceDefinition {
@@ -32,7 +30,7 @@ export interface SourceDefinition {
   latestDockerImageTag: string;
   documentationUrl: string;
   icon: string;
-  releaseStage?: releaseStage;
+  releaseStage?: ReleaseStage;
 }
 
 export type ConnectorDefinition = SourceDefinition | DestinationDefinition;

--- a/airbyte-webapp/src/core/resources/DestinationDefinition.ts
+++ b/airbyte-webapp/src/core/resources/DestinationDefinition.ts
@@ -4,7 +4,7 @@ import { getService } from "core/servicesProvider";
 
 import BaseResource from "./BaseResource";
 import { DestinationDefinitionService } from "core/domain/connector/DestinationDefinitionService";
-import { DestinationDefinition } from "../domain/connector";
+import { DestinationDefinition, releaseStage } from "core/domain/connector";
 
 export default class DestinationDefinitionResource
   extends BaseResource
@@ -16,6 +16,7 @@ export default class DestinationDefinitionResource
   readonly latestDockerImageTag: string = "";
   readonly documentationUrl: string = "";
   readonly icon: string = "";
+  readonly releaseStage?: releaseStage = undefined;
 
   pk(): string {
     return this.destinationDefinitionId?.toString();

--- a/airbyte-webapp/src/core/resources/DestinationDefinition.ts
+++ b/airbyte-webapp/src/core/resources/DestinationDefinition.ts
@@ -4,7 +4,7 @@ import { getService } from "core/servicesProvider";
 
 import BaseResource from "./BaseResource";
 import { DestinationDefinitionService } from "core/domain/connector/DestinationDefinitionService";
-import { DestinationDefinition, releaseStage } from "core/domain/connector";
+import { DestinationDefinition } from "core/domain/connector";
 
 export default class DestinationDefinitionResource
   extends BaseResource
@@ -16,7 +16,6 @@ export default class DestinationDefinitionResource
   readonly latestDockerImageTag: string = "";
   readonly documentationUrl: string = "";
   readonly icon: string = "";
-  readonly releaseStage?: releaseStage = undefined;
 
   pk(): string {
     return this.destinationDefinitionId?.toString();

--- a/airbyte-webapp/src/core/resources/SourceDefinition.ts
+++ b/airbyte-webapp/src/core/resources/SourceDefinition.ts
@@ -3,7 +3,7 @@ import { MutateShape, ReadShape, Resource, SchemaDetail } from "rest-hooks";
 import BaseResource from "./BaseResource";
 import { getService } from "core/servicesProvider";
 import { SourceDefinitionService } from "core/domain/connector/SourceDefinitionService";
-import { SourceDefinition } from "core/domain/connector";
+import { SourceDefinition, releaseStage } from "core/domain/connector";
 
 export default class SourceDefinitionResource
   extends BaseResource
@@ -15,6 +15,7 @@ export default class SourceDefinitionResource
   readonly latestDockerImageTag: string = "";
   readonly documentationUrl: string = "";
   readonly icon: string = "";
+  readonly releaseStage?: releaseStage = undefined;
 
   pk(): string {
     return this.sourceDefinitionId?.toString();

--- a/airbyte-webapp/src/core/resources/SourceDefinition.ts
+++ b/airbyte-webapp/src/core/resources/SourceDefinition.ts
@@ -3,7 +3,7 @@ import { MutateShape, ReadShape, Resource, SchemaDetail } from "rest-hooks";
 import BaseResource from "./BaseResource";
 import { getService } from "core/servicesProvider";
 import { SourceDefinitionService } from "core/domain/connector/SourceDefinitionService";
-import { SourceDefinition, releaseStage } from "core/domain/connector";
+import { SourceDefinition } from "core/domain/connector";
 
 export default class SourceDefinitionResource
   extends BaseResource
@@ -15,7 +15,6 @@ export default class SourceDefinitionResource
   readonly latestDockerImageTag: string = "";
   readonly documentationUrl: string = "";
   readonly icon: string = "";
-  readonly releaseStage?: releaseStage = undefined;
 
   pk(): string {
     return this.sourceDefinitionId?.toString();

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -431,6 +431,12 @@
   "connector.email.placeholder": "richard@piedpiper.com",
   "connector.source": "Source",
   "connector.destination": "Destination",
+  "connector.releaseStage.alpha": "alpha",
+  "connector.releaseStage.beta": "beta",
+  "connector.releaseStage.custom": "custom",
+  "connector.releaseStage.generally_available": "generally available",
+  "connector.releaseStage.release": "release",
+  "connector.releaseStage.new_release": "new",
 
   "credits.credits": "Credits",
   "credits.whatAreCredits": "What are credits?",

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -435,8 +435,6 @@
   "connector.releaseStage.beta": "beta",
   "connector.releaseStage.custom": "custom",
   "connector.releaseStage.generally_available": "generally available",
-  "connector.releaseStage.release": "release",
-  "connector.releaseStage.new_release": "new",
 
   "credits.credits": "Credits",
   "credits.whatAreCredits": "What are credits?",

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -14,10 +14,18 @@ import {
 } from "components";
 
 import { FormBaseItem } from "core/form/types";
-import { Connector, ConnectorDefinition } from "core/domain/connector";
+import {
+  Connector,
+  ConnectorDefinition,
+  releaseStage,
+} from "core/domain/connector";
 
 import Instruction from "./Instruction";
-import { IDataItem } from "components/base/DropDown/components/Option";
+import {
+  IDataItem,
+  IProps as OptionProps,
+  OptionView,
+} from "components/base/DropDown/components/Option";
 
 const BottomElement = styled.div`
   background: ${(props) => props.theme.greyColro0};
@@ -34,6 +42,32 @@ const Block = styled.div`
   &:hover {
     color: ${({ theme }) => theme.primaryColor};
   }
+`;
+
+const Text = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const Label = styled.div`
+  margin-left: 13px;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 17px;
+`;
+
+const Stage = styled.div<{ isNew?: boolean }>`
+  padding: 2px 6px;
+  height: 14px;
+  background: ${({ theme, isNew }) =>
+    isNew ? theme.successColor : theme.greyColor20};
+  border-radius: 25px;
+  text-transform: uppercase;
+  font-weight: 500;
+  font-size: 8px;
+  line-height: 10px;
+  color: ${({ theme, isNew }) => (isNew ? theme.whiteColor : theme.textColor)};
 `;
 
 type MenuWithRequestButtonProps = MenuListComponentProps<IDataItem, false>;
@@ -53,6 +87,31 @@ const ConnectorList: React.FC<MenuWithRequestButtonProps> = ({
     </BottomElement>
   </>
 );
+
+const Option: React.FC<OptionProps> = (props) => {
+  return (
+    <components.Option {...props}>
+      <OptionView
+        data-testid={props.data.label}
+        isSelected={props.isSelected}
+        isDisabled={props.isDisabled}
+      >
+        <Text>
+          {props.data.img || null}
+          <Label>{props.label}</Label>
+        </Text>
+        {props.data.releaseStage ? (
+          <Stage isNew={props.data.releaseStage === releaseStage.NEW_RELEASE}>
+            <FormattedMessage
+              id={`connector.releaseStage.${props.data.releaseStage}`}
+              defaultMessage={props.data.releaseStage}
+            />
+          </Stage>
+        ) : null}
+      </OptionView>
+    </components.Option>
+  );
+};
 
 const ConnectorServiceTypeControl: React.FC<{
   property: FormBaseItem;
@@ -102,6 +161,7 @@ const ConnectorServiceTypeControl: React.FC<{
           label: item.name,
           value: Connector.id(item),
           img: <ImageBlock img={item.icon} />,
+          releaseStage: item.releaseStage,
         }))
         .sort(defaultDataItemSort),
     [availableServices]
@@ -135,6 +195,7 @@ const ConnectorServiceTypeControl: React.FC<{
           {...field}
           components={{
             MenuList: ConnectorList,
+            Option,
           }}
           selectProps={{ onOpenRequestConnectorModal }}
           error={!!fieldMeta.error && fieldMeta.touched}

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -17,7 +17,7 @@ import { FormBaseItem } from "core/form/types";
 import {
   Connector,
   ConnectorDefinition,
-  releaseStage,
+  ReleaseStage,
 } from "core/domain/connector";
 
 import Instruction from "./Instruction";
@@ -57,17 +57,16 @@ const Label = styled.div`
   line-height: 17px;
 `;
 
-const Stage = styled.div<{ isNew?: boolean }>`
+const Stage = styled.div`
   padding: 2px 6px;
   height: 14px;
-  background: ${({ theme, isNew }) =>
-    isNew ? theme.successColor : theme.greyColor20};
+  background: ${({ theme }) => theme.greyColor20};
   border-radius: 25px;
   text-transform: uppercase;
   font-weight: 500;
   font-size: 8px;
   line-height: 10px;
-  color: ${({ theme, isNew }) => (isNew ? theme.whiteColor : theme.textColor)};
+  color: ${({ theme }) => theme.textColor};
 `;
 
 type MenuWithRequestButtonProps = MenuListComponentProps<IDataItem, false>;
@@ -100,8 +99,9 @@ const Option: React.FC<OptionProps> = (props) => {
           {props.data.img || null}
           <Label>{props.label}</Label>
         </Text>
-        {props.data.releaseStage ? (
-          <Stage isNew={props.data.releaseStage === releaseStage.NEW_RELEASE}>
+        {props.data.releaseStage &&
+        props.data.releaseStage !== ReleaseStage.GENERALLY_AVAILABLE ? (
+          <Stage>
             <FormattedMessage
               id={`connector.releaseStage.${props.data.releaseStage}`}
               defaultMessage={props.data.releaseStage}


### PR DESCRIPTION
## What
Add release stage labels for Source/Destination creation


Next statuses were added:
- alpha
- beta
- generally_available (without a label)
- custom

This statuses was taken from [issue discussion](https://github.com/airbytehq/airbyte/issues/9711) and [api config](https://github.com/airbytehq/airbyte/pull/10051/files#diff-8d2a55215b7d1dbfdb14f80e5fb444c9b940be967bdfb8cfbf1e24703579095eR2110)

<img width="795" alt="Снимок экрана 2022-02-10 в 23 14 07" src="https://user-images.githubusercontent.com/9026944/153490263-6d738bb9-e44b-4ae8-9af4-0436b519fd43.png">

Closed #9711