### PR TITLE
Use worker config resource requirements by default in jobs

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -110,8 +110,8 @@ public class EnvConfigs implements Configs {
   // defaults
   private static final String DEFAULT_SPEC_CACHE_BUCKET = "io-airbyte-cloud-spec-cache";
   public static final String DEFAULT_JOB_KUBE_NAMESPACE = "default";
-  private static final String DEFAULT_JOB_CPU_REQUIREMENT = "0.2";
-  private static final String DEFAULT_JOB_MEMORY_REQUIREMENT = "500Mi";
+  private static final String DEFAULT_JOB_CPU_REQUIREMENT = null;
+  private static final String DEFAULT_JOB_MEMORY_REQUIREMENT = null;
   private static final String DEFAULT_JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_POLICY = "IfNotPresent";
   private static final String SECRET_STORE_GCP_PROJECT_ID = "SECRET_STORE_GCP_PROJECT_ID";
   private static final String SECRET_STORE_GCP_CREDENTIALS = "SECRET_STORE_GCP_CREDENTIALS";

--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -110,8 +110,8 @@ public class EnvConfigs implements Configs {
   // defaults
   private static final String DEFAULT_SPEC_CACHE_BUCKET = "io-airbyte-cloud-spec-cache";
   public static final String DEFAULT_JOB_KUBE_NAMESPACE = "default";
-  private static final String DEFAULT_JOB_CPU_REQUIREMENT = null;
-  private static final String DEFAULT_JOB_MEMORY_REQUIREMENT = null;
+  private static final String DEFAULT_JOB_CPU_REQUIREMENT = "0.2";
+  private static final String DEFAULT_JOB_MEMORY_REQUIREMENT = "500Mi";
   private static final String DEFAULT_JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_POLICY = "IfNotPresent";
   private static final String SECRET_STORE_GCP_PROJECT_ID = "SECRET_STORE_GCP_PROJECT_ID";
   private static final String SECRET_STORE_GCP_CREDENTIALS = "SECRET_STORE_GCP_CREDENTIALS";

--- a/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/JobScheduler.java
+++ b/airbyte-scheduler/app/src/main/java/io/airbyte/scheduler/app/JobScheduler.java
@@ -17,6 +17,7 @@ import io.airbyte.scheduler.persistence.job_factory.DefaultSyncJobFactory;
 import io.airbyte.scheduler.persistence.job_factory.OAuthConfigSupplier;
 import io.airbyte.scheduler.persistence.job_factory.SyncJobFactory;
 import io.airbyte.validation.json.JsonValidationException;
+import io.airbyte.workers.WorkerConfigs;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
@@ -48,13 +49,14 @@ public class JobScheduler implements Runnable {
 
   public JobScheduler(final JobPersistence jobPersistence,
                       final ConfigRepository configRepository,
-                      final TrackingClient trackingClient) {
+                      final TrackingClient trackingClient,
+                      final WorkerConfigs workerConfigs) {
     this(
         jobPersistence,
         configRepository,
         new ScheduleJobPredicate(Instant::now),
         new DefaultSyncJobFactory(
-            new DefaultJobCreator(jobPersistence, configRepository),
+            new DefaultJobCreator(jobPersistence, configRepository, workerConfigs.getResourceRequirements()),
             configRepository,
             new OAuthConfigSupplier(configRepository, trackingClient)));
   }

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
@@ -27,7 +27,9 @@ public class DefaultJobCreator implements JobCreator {
   private final ConfigRepository configRepository;
   private final ResourceRequirements workerResourceRequirements;
 
-  public DefaultJobCreator(final JobPersistence jobPersistence, final ConfigRepository configRepository, final ResourceRequirements workerResourceRequirements) {
+  public DefaultJobCreator(final JobPersistence jobPersistence,
+                           final ConfigRepository configRepository,
+                           final ResourceRequirements workerResourceRequirements) {
     this.jobPersistence = jobPersistence;
     this.configRepository = configRepository;
     this.workerResourceRequirements = workerResourceRequirements;
@@ -118,4 +120,5 @@ public class DefaultJobCreator implements JobCreator {
 
     return jobResourceRequirements;
   }
+
 }

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
@@ -116,7 +116,7 @@ public class DefaultJobCreatorTest {
   void setup() {
     jobPersistence = mock(JobPersistence.class);
     configRepository = mock(ConfigRepository.class);
-    workerResourceRequirements = mock(ResourceRequirements.class);
+    workerResourceRequirements = new ResourceRequirements().withCpuLimit("0.2").withCpuRequest("0.2").withMemoryLimit("200Mi").withMemoryRequest("200Mi");
     jobCreator = new DefaultJobCreator(jobPersistence, configRepository, workerResourceRequirements);
   }
 
@@ -131,7 +131,8 @@ public class DefaultJobCreatorTest {
         .withDestinationConfiguration(DESTINATION_CONNECTION.getConfiguration())
         .withDestinationDockerImage(DESTINATION_IMAGE_NAME)
         .withConfiguredAirbyteCatalog(STANDARD_SYNC.getCatalog())
-        .withOperationSequence(List.of(STANDARD_SYNC_OPERATION));
+        .withOperationSequence(List.of(STANDARD_SYNC_OPERATION))
+        .withResourceRequirements(workerResourceRequirements);
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(JobConfig.ConfigType.SYNC)
@@ -161,7 +162,8 @@ public class DefaultJobCreatorTest {
         .withDestinationConfiguration(DESTINATION_CONNECTION.getConfiguration())
         .withDestinationDockerImage(DESTINATION_IMAGE_NAME)
         .withConfiguredAirbyteCatalog(STANDARD_SYNC.getCatalog())
-        .withOperationSequence(List.of(STANDARD_SYNC_OPERATION));
+        .withOperationSequence(List.of(STANDARD_SYNC_OPERATION))
+        .withResourceRequirements(workerResourceRequirements);
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(JobConfig.ConfigType.SYNC)
@@ -195,7 +197,8 @@ public class DefaultJobCreatorTest {
         .withDestinationConfiguration(DESTINATION_CONNECTION.getConfiguration())
         .withDestinationDockerImage(DESTINATION_IMAGE_NAME)
         .withConfiguredAirbyteCatalog(expectedCatalog)
-        .withOperationSequence(List.of(STANDARD_SYNC_OPERATION));
+        .withOperationSequence(List.of(STANDARD_SYNC_OPERATION))
+        .withResourceRequirements(workerResourceRequirements);
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(ConfigType.RESET_CONNECTION)
@@ -228,7 +231,8 @@ public class DefaultJobCreatorTest {
         .withDestinationConfiguration(DESTINATION_CONNECTION.getConfiguration())
         .withDestinationDockerImage(DESTINATION_IMAGE_NAME)
         .withConfiguredAirbyteCatalog(expectedCatalog)
-        .withOperationSequence(List.of(STANDARD_SYNC_OPERATION));
+        .withOperationSequence(List.of(STANDARD_SYNC_OPERATION))
+        .withResourceRequirements(workerResourceRequirements);
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(ConfigType.RESET_CONNECTION)

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
@@ -116,7 +116,11 @@ public class DefaultJobCreatorTest {
   void setup() {
     jobPersistence = mock(JobPersistence.class);
     configRepository = mock(ConfigRepository.class);
-    workerResourceRequirements = new ResourceRequirements().withCpuLimit("0.2").withCpuRequest("0.2").withMemoryLimit("200Mi").withMemoryRequest("200Mi");
+    workerResourceRequirements = new ResourceRequirements()
+        .withCpuLimit("0.2")
+        .withCpuRequest("0.2")
+        .withMemoryLimit("200Mi")
+        .withMemoryRequest("200Mi");
     jobCreator = new DefaultJobCreator(jobPersistence, configRepository, workerResourceRequirements);
   }
 

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
@@ -20,6 +20,7 @@ import io.airbyte.config.JobSyncConfig;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
 import io.airbyte.config.OperatorNormalization;
 import io.airbyte.config.OperatorNormalization.Option;
+import io.airbyte.config.ResourceRequirements;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOperation;
@@ -55,6 +56,7 @@ public class DefaultJobCreatorTest {
   private JobPersistence jobPersistence;
   private ConfigRepository configRepository;
   private JobCreator jobCreator;
+  private ResourceRequirements workerResourceRequirements;
 
   static {
     final UUID workspaceId = UUID.randomUUID();
@@ -114,7 +116,8 @@ public class DefaultJobCreatorTest {
   void setup() {
     jobPersistence = mock(JobPersistence.class);
     configRepository = mock(ConfigRepository.class);
-    jobCreator = new DefaultJobCreator(jobPersistence, configRepository);
+    workerResourceRequirements = mock(ResourceRequirements.class);
+    jobCreator = new DefaultJobCreator(jobPersistence, configRepository, workerResourceRequirements);
   }
 
   @Test

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -185,7 +185,8 @@ public class ServerApp implements ServerRunnable {
     final TemporalClient temporalClient = TemporalClient.production(configs.getTemporalHost(), configs.getWorkspaceRoot(), configs);
     final OAuthConfigSupplier oAuthConfigSupplier = new OAuthConfigSupplier(configRepository, trackingClient);
     final SchedulerJobClient schedulerJobClient =
-        new DefaultSchedulerJobClient(jobPersistence, new DefaultJobCreator(jobPersistence, configRepository, workerConfigs.getResourceRequirements()));
+        new DefaultSchedulerJobClient(jobPersistence,
+            new DefaultJobCreator(jobPersistence, configRepository, workerConfigs.getResourceRequirements()));
     final DefaultSynchronousSchedulerClient syncSchedulerClient =
         new DefaultSynchronousSchedulerClient(temporalClient, jobTracker, oAuthConfigSupplier);
     final HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -141,6 +141,7 @@ public class ServerApp implements ServerRunnable {
 
   public static ServerRunnable getServer(final ServerFactory apiFactory, final ConfigPersistence seed) throws Exception {
     final Configs configs = new EnvConfigs();
+    final WorkerConfigs workerConfigs = new WorkerConfigs(configs);
 
     LogClientSingleton.getInstance().setWorkspaceMdc(
         configs.getWorkerEnvironment(),
@@ -184,7 +185,7 @@ public class ServerApp implements ServerRunnable {
     final TemporalClient temporalClient = TemporalClient.production(configs.getTemporalHost(), configs.getWorkspaceRoot(), configs);
     final OAuthConfigSupplier oAuthConfigSupplier = new OAuthConfigSupplier(configRepository, trackingClient);
     final SchedulerJobClient schedulerJobClient =
-        new DefaultSchedulerJobClient(jobPersistence, new DefaultJobCreator(jobPersistence, configRepository));
+        new DefaultSchedulerJobClient(jobPersistence, new DefaultJobCreator(jobPersistence, configRepository, workerConfigs.getResourceRequirements()));
     final DefaultSynchronousSchedulerClient syncSchedulerClient =
         new DefaultSynchronousSchedulerClient(temporalClient, jobTracker, oAuthConfigSupplier);
     final HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
@@ -209,7 +210,7 @@ public class ServerApp implements ServerRunnable {
         trackingClient,
         configs.getWorkerEnvironment(),
         configs.getLogConfigs(),
-        new WorkerConfigs(configs),
+        workerConfigs,
         configs.getWebappUrl(),
         configs.getAirbyteVersion(),
         configs.getWorkspaceRoot(),

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -183,7 +183,7 @@ public class WorkerApp {
 
     syncWorker.registerActivitiesImplementations(replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
 
-    final JobCreator jobCreator = new DefaultJobCreator(jobPersistence, configRepository);
+    final JobCreator jobCreator = new DefaultJobCreator(jobPersistence, configRepository, workerConfigs.getResourceRequirements());
 
     final Worker connectionUpdaterWorker =
         factory.newWorker(TemporalJobType.CONNECTION_UPDATER.toString(), getWorkerOptions(maxWorkers.getMaxSyncWorkers()));
@@ -272,7 +272,7 @@ public class WorkerApp {
                                                    String containerOrchestratorImage,
                                                    String googleApplicationCredentials) {}
 
-  static Optional<ContainerOrchestratorConfig> getContainerOrchestratorConfig(Configs configs) {
+  static Optional<ContainerOrchestratorConfig> getContainerOrchestratorConfig(final Configs configs) {
     if (configs.getContainerOrchestratorEnabled()) {
       final var kubernetesClient = new DefaultKubernetesClient();
 
@@ -295,6 +295,7 @@ public class WorkerApp {
 
   private static void launchWorkerApp() throws IOException {
     final Configs configs = new EnvConfigs();
+    final WorkerConfigs workerConfigs = new WorkerConfigs(configs);
 
     LogClientSingleton.getInstance().setWorkspaceMdc(configs.getWorkerEnvironment(), configs.getLogConfigs(),
         LogClientSingleton.getInstance().getSchedulerLogsRoot(configs.getWorkspaceRoot()));
@@ -342,7 +343,7 @@ public class WorkerApp {
         configRepository);
     final TrackingClient trackingClient = TrackingClientSingleton.get();
     final SyncJobFactory jobFactory = new DefaultSyncJobFactory(
-        new DefaultJobCreator(jobPersistence, configRepository),
+        new DefaultJobCreator(jobPersistence, configRepository, workerConfigs.getResourceRequirements()),
         configRepository,
         new OAuthConfigSupplier(configRepository, trackingClient));
 
@@ -359,8 +360,6 @@ public class WorkerApp {
     final WorkspaceHelper workspaceHelper = new WorkspaceHelper(
         configRepository,
         jobPersistence);
-
-    final WorkerConfigs workerConfigs = new WorkerConfigs(configs);
 
     final ConnectionHelper connectionHelper = new ConnectionHelper(
         configRepository,
@@ -401,7 +400,7 @@ public class WorkerApp {
   public static void main(final String[] args) {
     try {
       launchWorkerApp();
-    } catch (Throwable t) {
+    } catch (final Throwable t) {
       LOGGER.error("Worker app failed", t);
       System.exit(1);
     }


### PR DESCRIPTION
We noticed that resource requirements were not actually being populated on jobs in cloud, so this PR causes the DefaultJobCreator to use the resource requirements from WorkerConfigs by default if they are not populated in the StandardSync