### PR TITLE
Helm chart: fix CONFIGS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION in env-configmap.yaml

### DIFF
--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -11,7 +11,7 @@ data:
   AWS_ACCESS_KEY_ID: {{ .Values.logs.accessKey.password }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.logs.secretKey.password }}
   CONFIG_ROOT: /configs
-  CONFIGS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION: "0.35.17.001"
+  CONFIGS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION: "0.35.15.001"
   DATA_DOCKER_MOUNT: airbyte_data
   DATABASE_DB: {{ include "airbyte.database.name" . }}
   DATABASE_HOST: {{ include "airbyte.database.host" . }}


### PR DESCRIPTION
## What
Fixes configs database minimum Flyaway migration version that is inyected to `airbyte-env` configmap. 
Currently its set to "0.35.17.001", but when deploying the latest version of the helm chart the installed database version is "0.35.15.001", resulting in the following error when booting `airbyte-server` pod:

```
2022-02-09 18:25:06 INFO i.a.d.i.MinimumFlywayMigrationVersionCheck(assertMigrations):76 - Current database migration version 0.35.15.001                                                                        
2022-02-09 18:25:06 INFO i.a.d.i.MinimumFlywayMigrationVersionCheck(assertMigrations):77 - Minimum Flyway version required 0.35.17.001  
```

## How
Changing `CONFIGS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION` in `charts/airbyte/templates/env-configmap.yaml` sets the right value to the configmap that is used for the env variables.