### PR TITLE
fix partial success check

### DIFF
--- a/airbyte-webapp/src/components/JobItem/JobItem.tsx
+++ b/airbyte-webapp/src/components/JobItem/JobItem.tsx
@@ -46,7 +46,10 @@ const JobCurrentLogs: React.FC<{
 };
 
 const isPartialSuccessCheck = (attempts: Attempt[]) => {
-  if (attempts[attempts.length - 1].status === Status.FAILED) {
+  if (
+    attempts.length > 0 &&
+    attempts[attempts.length - 1].status === Status.FAILED
+  ) {
     return attempts.some(
       (attempt) =>
         attempt.failureSummary && attempt.failureSummary.partialSuccess


### PR DESCRIPTION
Fixes the partial success check logic by first verifying that the attempts array of a job has at least one element before trying to index into it.

Without this change, the UI crashes whenever a manual sync is kicked off, as it tries to index into the `attempts` array of the new Job before it has any attempts, causing the `attempts[attempts.length - 1].status` statement to fail.