### PR TITLE
🐛 Source CockroachDB: fix connector replication failure due to multiple open portals error

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -140,7 +140,7 @@
 - name: Cockroachdb
   sourceDefinitionId: 9fa5862c-da7c-11eb-8d19-0242ac130003
   dockerRepository: airbyte/source-cockroachdb
-  dockerImageTag: 0.1.9
+  dockerImageTag: 0.1.10
   documentationUrl: https://docs.airbyte.io/integrations/sources/cockroachdb
   icon: cockroachdb.svg
   sourceType: database

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -1205,7 +1205,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-cockroachdb:0.1.9"
+- dockerImage: "airbyte/source-cockroachdb:0.1.10"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/cockroachdb"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-cockroachdb-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-cockroachdb-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-cockroachdb-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.6
+LABEL io.airbyte.version=0.1.7
 LABEL io.airbyte.name=airbyte/source-cockroachdb-strict-encrypt

--- a/airbyte-integrations/connectors/source-cockroachdb/Dockerfile
+++ b/airbyte-integrations/connectors/source-cockroachdb/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-cockroachdb
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.9
+LABEL io.airbyte.version=0.1.10
 LABEL io.airbyte.name=airbyte/source-cockroachdb

--- a/airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSource.java
+++ b/airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSource.java
@@ -9,8 +9,8 @@ import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.functional.CheckedFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.util.AutoCloseableIterator;
+import io.airbyte.db.Databases;
 import io.airbyte.db.jdbc.JdbcDatabase;
-import io.airbyte.db.jdbc.PostgresJdbcStreamingQueryConfiguration;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.base.ssh.SshWrappedSource;
@@ -39,7 +39,7 @@ public class CockroachDbSource extends AbstractJdbcSource<JDBCType> {
   public static final List<String> PORT_KEY = List.of("port");
 
   public CockroachDbSource() {
-    super(DRIVER_CLASS, new PostgresJdbcStreamingQueryConfiguration(), new CockroachJdbcSourceOperations());
+    super(DRIVER_CLASS, null, new CockroachJdbcSourceOperations());
   }
 
   public static Source sshWrappedSource() {
@@ -110,12 +110,29 @@ public class CockroachDbSource extends AbstractJdbcSource<JDBCType> {
     return false;
   }
 
+  @Override
+  public JdbcDatabase createDatabase(final JsonNode config) throws SQLException {
+    final JsonNode jdbcConfig = toDatabaseConfig(config);
+
+    final JdbcDatabase database = Databases.createJdbcDatabase(
+            jdbcConfig.get("username").asText(),
+            jdbcConfig.has("password") ? jdbcConfig.get("password").asText() : null,
+            jdbcConfig.get("jdbc_url").asText(),
+            driverClass,
+            jdbcConfig.has("connection_properties") ? jdbcConfig.get("connection_properties").asText() : null,
+            sourceOperations);
+
+    quoteString = (quoteString == null ? database.getMetaData().getIdentifierQuoteString() : quoteString);
+
+    return new CockroachJdbcDatabase(database, sourceOperations);
+  }
+  
   private CheckedFunction<Connection, PreparedStatement, SQLException> getPrivileges(JdbcDatabase database) {
     return connection -> {
       final PreparedStatement ps = connection.prepareStatement(
           "SELECT DISTINCT table_catalog, table_schema, table_name, privilege_type\n"
               + "FROM   information_schema.table_privileges\n"
-              + "WHERE  grantee = ? AND privilege_type in ('SELECT', 'ALL')");
+              + "WHERE  (grantee  = ? AND privilege_type in ('SELECT', 'ALL')) OR (table_schema = 'public')");
       ps.setString(1, database.getDatabaseConfig().get("username").asText());
       return ps;
     };

--- a/airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachJdbcDatabase.java
+++ b/airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachJdbcDatabase.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.cockroachdb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.commons.functional.CheckedConsumer;
+import io.airbyte.commons.functional.CheckedFunction;
+import io.airbyte.db.JdbcCompatibleSourceOperations;
+import io.airbyte.db.jdbc.JdbcDatabase;
+import io.airbyte.db.jdbc.JdbcStreamingQueryConfiguration;
+
+import javax.sql.DataSource;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * This implementation uses non-streamed queries to CockroachDB. CockroachDB
+ * does not currently support multiple active pgwire portals on the same session,
+ * which makes it impossible to replicate tables that have over ~1000 rows
+ * using StreamingJdbcDatabase. See: https://go.crdb.dev/issue-v/40195/v21.2
+ * and in particular, the comment:
+ * https://github.com/cockroachdb/cockroach/issues/40195?version=v21.2#issuecomment-870570351
+ * The same situation as kafka-connect applies to StreamingJdbcDatabase
+ */
+public class CockroachJdbcDatabase
+        extends JdbcDatabase
+{
+
+  private final JdbcDatabase database;
+
+  public CockroachJdbcDatabase(final JdbcDatabase database,
+                               final JdbcCompatibleSourceOperations<?> sourceOperations) {
+    super(sourceOperations);
+    this.database = database;
+  }
+
+  @Override
+  public DatabaseMetaData getMetaData() throws SQLException {
+    return database.getMetaData();
+  }
+
+  @Override
+  public void execute(final CheckedConsumer<Connection, SQLException> query) throws SQLException {
+    database.execute(query);
+  }
+
+  @Override
+  public <T> List<T> bufferedResultSetQuery(final CheckedFunction<Connection, ResultSet, SQLException> query,
+                                            final CheckedFunction<ResultSet, T, SQLException> recordTransform)
+      throws SQLException {
+    return database.bufferedResultSetQuery(query, recordTransform);
+  }
+
+  @Override
+  public <T> Stream<T> resultSetQuery(final CheckedFunction<Connection, ResultSet, SQLException> query,
+                                      final CheckedFunction<ResultSet, T, SQLException> recordTransform)
+      throws SQLException {
+    return database.resultSetQuery(query, recordTransform);
+  }
+
+  @Override
+  public <T> Stream<T> query(final CheckedFunction<Connection, PreparedStatement, SQLException> statementCreator,
+                             final CheckedFunction<ResultSet, T, SQLException> recordTransform)
+      throws SQLException {
+    return database.query(statementCreator, recordTransform);
+  }
+
+  @Override
+  public Stream<JsonNode> query(final String sql, final String... params) throws SQLException {
+    return bufferedResultSetQuery(connection -> {
+      final PreparedStatement statement = connection.prepareStatement(sql);
+      int i = 1;
+      for (final String param : params) {
+        statement.setString(i, param);
+        ++i;
+      }
+      return statement.executeQuery();
+    }, sourceOperations::rowToJson).stream();
+
+  }
+
+  @Override
+  public void close() throws Exception {
+    database.close();
+  }
+
+}

--- a/docs/integrations/sources/cockroachdb.md
+++ b/docs/integrations/sources/cockroachdb.md
@@ -95,6 +95,7 @@ Your database user should now be ready for use with Airbyte.
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.10 | 2022-02-24 | [10235](https://github.com/airbytehq/airbyte/pull/10235) | Fix Replication Failure due Multiple portal opens |
 | 0.1.9 | 2022-02-21 | [10242](https://github.com/airbytehq/airbyte/pull/10242) | Fixed cursor for old connectors that use non-microsecond format. Now connectors work with both formats |
 | 0.1.8 | 2022-02-18 | [10242](https://github.com/airbytehq/airbyte/pull/10242) | Updated timestamp transformation with microseconds |
 | 0.1.7 | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option |


### PR DESCRIPTION
## What
This PR fixes issue: https://github.com/airbytehq/airbyte/issues/7933. CockroachDB does not implement the multiple active portals from PostgreSQL wire protocol, so any time a JDBC client satisfied the following conditions, CockroachDB throws an error:
- Uses a prepared statement.
- Sets the fetchSize of the statement to a positive number.
- After running the statement, the database returns more rows than the fetchSize.
- The client runs some other query before calling close() on the ResultSet.
See https://github.com/cockroachdb/cockroach/issues/40195?version=v21.2#issuecomment-870570351 for detailed analysis of the issue. 
As such, due to the above limitation, the CockroachDB airbyte connector fails to replicate any tables that have > 1000 rows (the fetch size set in the connector). 

## How
In this PR, I created a subclass of `JdbcDatabase` specific to CockroachDB that uses `bufferedResultSetQuery` instead of the default streaming method. By using `bufferedResultSetQuery`, we ensure that all rows are fetched and the result set is closed (which makes the CockroachDB server close the server-side session aka portal). This does mean that the results need to fit in memory, but until CockroachDB implements multiple active portals, I don't know of any other way to get around this limitation.

## Recommended reading order
1. `CockroachDbSource.java`
2. `CockroachJdbcDatabase.java`

## 🚨 User Impact 🚨
The main user impact would be memory usage by the connector - for large tables, the connector container could potentially run out of memory, resulting in sync failure. With the status quo, sync fails anyway for tables with > 1000 rows, so not sure this is a major issue. 

## Pre-merge Checklist
Expand the relevant checklist and delete the others. 



<details><summary> <strong> Updating a connector </strong></summary>
<p>
   
#### Community member or Airbyter
   
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
#### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</p>
</details>

