### PR TITLE
Make sure that the cancellation scope is not cancel more than once in…

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -278,6 +278,12 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
 
   @Override
   public void cancelJob() {
+    if (workflowState.isCancelled()) {
+      workflowState.hasMultipleCancels();
+      log.info("A cancel has already been submitted for connection {}", connectionId);
+      return;
+    }
+
     if (!workflowState.isRunning()) {
       log.info("Can't cancel a non-running sync for connection {}", connectionId);
       return;
@@ -288,6 +294,11 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
 
   @Override
   public void deleteConnection() {
+    if (workflowState.isDeleted()) {
+      workflowState.hasMultipleDeletes();
+      log.info("A deletion has already been submitted for connection {}", connectionId);
+      return;
+    }
     workflowState.setDeleted(true);
     cancelJob();
   }
@@ -299,6 +310,11 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
 
   @Override
   public void resetConnection() {
+    if (workflowState.isResetConnection()) {
+      workflowState.hasMultipleResets();
+      log.info("A reset has already been submitted for connection {}", connectionId);
+      return;
+    }
     workflowState.setResetConnection(true);
     if (workflowState.isRunning()) {
       workflowState.setCancelledForReset(true);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/state/WorkflowState.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/state/WorkflowState.java
@@ -104,6 +104,27 @@ public class WorkflowState {
     this.cancelledForReset = cancelledForReset;
   }
 
+  public void hasMultipleCancels() {
+    final ChangedStateEvent event = new ChangedStateEvent(
+        StateField.MULTIPLE_CANCEL,
+        true);
+    stateChangedListener.addEvent(id, event);
+  }
+
+  public void hasMultipleDeletes() {
+    final ChangedStateEvent event = new ChangedStateEvent(
+        StateField.MULTIPLE_DELETE,
+        true);
+    stateChangedListener.addEvent(id, event);
+  }
+
+  public void hasMultipleResets() {
+    final ChangedStateEvent event = new ChangedStateEvent(
+        StateField.MULTIPLE_RESET,
+        true);
+    stateChangedListener.addEvent(id, event);
+  }
+
   public void reset() {
     this.setRunning(false);
     this.setDeleted(false);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/state/listener/WorkflowStateChangedListener.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/state/listener/WorkflowStateChangedListener.java
@@ -31,7 +31,10 @@ public interface WorkflowStateChangedListener {
     FAILED,
     RESET,
     CONTINUE_AS_RESET,
-    CANCELLED_FOR_RESET
+    CANCELLED_FOR_RESET,
+    MULTIPLE_CANCEL,
+    MULTIPLE_DELETE,
+    MULTIPLE_RESET
   }
 
   @Value


### PR DESCRIPTION
… case of a delete/reset/cancel

## What
In order to make sure to avoid any issue if we call the same signal multiple time while the cancellation scope is being cancel, we first check is if a similar operation is ongoing before performing a reset.