### PR TITLE
Remove `RUN_DATABASE_MIGRATION_ON_STARTUP` from `bootloader`

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,6 @@ services:
       - DATABASE_URL=${DATABASE_URL}
       - DATABASE_USER=${DATABASE_USER}
       - LOG_LEVEL=${LOG_LEVEL}
-      - RUN_DATABASE_MIGRATION_ON_STARTUP=${RUN_DATABASE_MIGRATION_ON_STARTUP}
   db:
     image: airbyte/db:${VERSION}
     logging: *default-logging


### PR DESCRIPTION
Looks like this might be a copy and paste error when configuring the new `bootloader` service. The `RUN_DATABASE_MIGRATION_ON_STARTUP` environment variable was recently removed from the other services and is no longer present in the `.env` file.

## What
Removed unused variable from `bootloader` service.

## 🚨 User Impact 🚨
None
