### PR TITLE
Fix failing sonar-scan without changes

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -36,7 +36,8 @@ jobs:
           echo "::set-output name=changed-modules::{ \"include\": $CHANGES }"
 
   run-ci-tests:
-    if: github.event.pull_request.draft == false
+    # Do only run if the PR is not a draft and the changed modules matrix contains at least one entry
+    if: github.event.pull_request.draft == false && fromJson(needs.detect-changes.outputs.changed-modules).include[0] != null
     needs: detect-changes
     name:  Tests for ${{ matrix.module }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Do not try to run the sonar-check if we don't have a matrix determined. This will currently fail (see e.g. https://github.com/airbytehq/airbyte/actions/runs/1830326733) and send notifications out for that failure. We should simply never try to run this if a PR doesn't change anything in a module requiring a sonar-scan.

See https://github.com/airbytehq/airbyte/actions/runs/1830360752 for an example run (on this PR) where this was now successfully skipped.