### PR TITLE
do not wipe out existing connection resource requirements on update

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/ConnectionHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/ConnectionHelper.java
@@ -79,21 +79,7 @@ public class ConnectionHelper {
           .withMemoryRequest(connectionUpdate.getResourceRequirements().getMemoryRequest())
           .withMemoryLimit(connectionUpdate.getResourceRequirements().getMemoryLimit()));
     } else {
-      final io.airbyte.config.ResourceRequirements resourceRequirements = Optional.ofNullable(persistedSync.getResourceRequirements())
-          .orElse(new io.airbyte.config.ResourceRequirements());
-      if (resourceRequirements.getCpuRequest() == null) {
-        resourceRequirements.setCpuRequest(workerConfigs.getResourceRequirements().getCpuRequest());
-      }
-      if (resourceRequirements.getCpuLimit() == null) {
-        resourceRequirements.setCpuLimit(workerConfigs.getResourceRequirements().getCpuLimit());
-      }
-      if (resourceRequirements.getMemoryRequest() == null) {
-        resourceRequirements.setMemoryRequest(workerConfigs.getResourceRequirements().getMemoryRequest());
-      }
-      if (resourceRequirements.getMemoryLimit() == null) {
-        resourceRequirements.setMemoryLimit(workerConfigs.getResourceRequirements().getMemoryLimit());
-      }
-      newConnection.withResourceRequirements(resourceRequirements);
+      newConnection.withResourceRequirements(persistedSync.getResourceRequirements());
     }
 
     // update sync schedule

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/ConnectionHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/ConnectionHelper.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 @AllArgsConstructor
 public class ConnectionHelper {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(ConnectionHelper.class);
 
   private final ConfigRepository configRepository;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/ConnectionHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/ConnectionHelper.java
@@ -22,17 +22,12 @@ import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.WorkerConfigs;
 import java.io.IOException;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @AllArgsConstructor
 public class ConnectionHelper {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ConnectionHelper.class);
 
   private final ConfigRepository configRepository;
   private final WorkspaceHelper workspaceHelper;


### PR DESCRIPTION
## What
Today when a connection is updated, its currently-set `resource_requirements` are wiped out if the update input does not include new resource requirements.

This is bad because we are currently using connection `resource_requirements` to bump the resource limits of a connection, and wiping these out can lead to more failures. This has already happened once: https://airbytehq-team.slack.com/archives/C02U46QK5C3/p1644618998737659?thread_ts=1644599694.890299&cid=C02U46QK5C3

## How
This PR solves the issue by adding logic to use already-existing resource_requirement values on connection update if the update input does not include new values.