### PR TITLE
🎉 End-to-end test source: support stream duplication

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -182,7 +182,7 @@
 - name: E2E Testing
   sourceDefinitionId: d53f9084-fa6b-4a5a-976c-5b8392f4ad8a
   dockerRepository: airbyte/source-e2e-test
-  dockerImageTag: 2.0.0
+  dockerImageTag: 2.1.0
   documentationUrl: https://docs.airbyte.io/integrations/sources/e2e-test
   icon: airbyte.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -1479,7 +1479,7 @@
         oauthFlowOutputParameters:
         - - "access_token"
         - - "refresh_token"
-- dockerImage: "airbyte/source-e2e-test:2.0.0"
+- dockerImage: "airbyte/source-e2e-test:2.1.0"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/e2e-test"
     connectionSpecification:
@@ -1529,8 +1529,9 @@
           type: "object"
           order: 50
           oneOf:
-          - title: "Single Stream"
-            description: "A catalog with one stream."
+          - title: "Single Schema"
+            description: "A catalog with one or multiple streams that share the same\
+              \ schema."
             required:
             - "type"
             - "stream_name"
@@ -1554,8 +1555,19 @@
                 type: "string"
                 default: "{ \"type\": \"object\", \"properties\": { \"column1\": {\
                   \ \"type\": \"string\" } } }"
-          - title: "Multi-Stream"
-            description: "A catalog with multiple data streams."
+              stream_duplication:
+                title: "Duplicate the stream N times"
+                description: "Duplicate the stream for easy load testing. Each stream\
+                  \ name will have a number suffix. For example, if the stream name\
+                  \ is \"ds\", the duplicated streams will be \"ds_0\", \"ds_1\",\
+                  \ etc."
+                type: "integer"
+                default: 1
+                min: 1
+                max: 10000
+          - title: "Multi Schema"
+            description: "A catalog with multiple data streams, each with a different\
+              \ schema."
             required:
             - "type"
             - "stream_schemas"

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/sentry/AirbyteSentry.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/sentry/AirbyteSentry.java
@@ -95,13 +95,21 @@ public class AirbyteSentry {
     }
   }
 
+  public static ISpan createSpan(final String operationName) {
+    return createChildSpan(Sentry.getSpan(), operationName, Collections.emptyMap());
+  }
+
+  public static ISpan createSpan(final String operationName, final Map<String, Object> metadata) {
+    return createChildSpan(Sentry.getSpan(), operationName, metadata);
+  }
+
   private static ISpan createChildSpan(final ISpan currentSpan, final String operationName, final Map<String, Object> metadata) {
-    final String name = Strings.isBlank(operationName) ? DEFAULT_UNKNOWN_OPERATION : operationName;
+    final String spanOperation = Strings.isBlank(operationName) ? DEFAULT_UNKNOWN_OPERATION : operationName;
     final ISpan childSpan;
     if (currentSpan == null) {
-      childSpan = Sentry.startTransaction(DEFAULT_ROOT_TRANSACTION, operationName);
+      childSpan = Sentry.startTransaction(DEFAULT_ROOT_TRANSACTION, spanOperation);
     } else {
-      childSpan = currentSpan.startChild(operationName);
+      childSpan = currentSpan.startChild(spanOperation);
     }
     if (metadata != null && !metadata.isEmpty()) {
       metadata.forEach(childSpan::setData);

--- a/airbyte-integrations/connectors/source-e2e-test-cloud/Dockerfile
+++ b/airbyte-integrations/connectors/source-e2e-test-cloud/Dockerfile
@@ -13,10 +13,10 @@ FROM airbyte/integration-base-java:dev
 WORKDIR /airbyte
 
 ENV APPLICATION source-e2e-test-cloud
-ENV APPLICATION_VERSION 2.0.0
+ENV APPLICATION_VERSION 2.0.1
 ENV ENABLE_SENTRY true
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=2.0.0
+LABEL io.airbyte.version=2.0.1
 LABEL io.airbyte.name=airbyte/source-e2e-test-cloud

--- a/airbyte-integrations/connectors/source-e2e-test-cloud/Dockerfile
+++ b/airbyte-integrations/connectors/source-e2e-test-cloud/Dockerfile
@@ -13,10 +13,10 @@ FROM airbyte/integration-base-java:dev
 WORKDIR /airbyte
 
 ENV APPLICATION source-e2e-test-cloud
-ENV APPLICATION_VERSION 2.0.1
+ENV APPLICATION_VERSION 2.1.0
 ENV ENABLE_SENTRY true
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=2.0.1
+LABEL io.airbyte.version=2.1.0
 LABEL io.airbyte.name=airbyte/source-e2e-test-cloud

--- a/airbyte-integrations/connectors/source-e2e-test-cloud/src/main/java/io/airbyte/integrations/source/e2e_test/CloudTestingSources.java
+++ b/airbyte-integrations/connectors/source-e2e-test-cloud/src/main/java/io/airbyte/integrations/source/e2e_test/CloudTestingSources.java
@@ -10,15 +10,12 @@ import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.base.spec_modification.SpecModifyingSource;
 import io.airbyte.protocol.models.ConnectorSpecification;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Since 2.0.0, the cloud version is the same as the OSS version. This connector should be removed.
  */
 public class CloudTestingSources extends SpecModifyingSource implements Source {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(CloudTestingSources.class);
   private static final String CLOUD_TESTING_SOURCES_TITLE = "Cloud E2E Test Source Spec";
 
   public CloudTestingSources() {

--- a/airbyte-integrations/connectors/source-e2e-test-cloud/src/test/resources/expected_spec.json
+++ b/airbyte-integrations/connectors/source-e2e-test-cloud/src/test/resources/expected_spec.json
@@ -47,8 +47,8 @@
         "order": 50,
         "oneOf": [
           {
-            "title": "Single Stream",
-            "description": "A catalog with one stream.",
+            "title": "Single Schema",
+            "description": "A catalog with one or multiple streams that share the same schema.",
             "required": ["type", "stream_name", "stream_schema"],
             "properties": {
               "type": {
@@ -67,12 +67,20 @@
                 "description": "A Json schema for the stream. The schema should be compatible with <a href=\"https://json-schema.org/draft-07/json-schema-release-notes.html\">draft-07</a>. See <a href=\"https://cswr.github.io/JsonSchema/spec/introduction/\">this doc</a> for examples.",
                 "type": "string",
                 "default": "{ \"type\": \"object\", \"properties\": { \"column1\": { \"type\": \"string\" } } }"
+              },
+              "stream_duplication": {
+                "title": "Duplicate the stream N times",
+                "description": "Duplicate the stream for easy load testing. Each stream name will have a number suffix. For example, if the stream name is \"ds\", the duplicated streams will be \"ds_0\", \"ds_1\", etc.",
+                "type": "integer",
+                "default": 1,
+                "min": 1,
+                "max": 10000
               }
             }
           },
           {
-            "title": "Multi-Stream",
-            "description": "A catalog with multiple data streams.",
+            "title": "Multi Schema",
+            "description": "A catalog with multiple data streams, each with a different schema.",
             "required": ["type", "stream_schemas"],
             "properties": {
               "type": {

--- a/airbyte-integrations/connectors/source-e2e-test/Dockerfile
+++ b/airbyte-integrations/connectors/source-e2e-test/Dockerfile
@@ -13,10 +13,10 @@ FROM airbyte/integration-base-java:dev
 WORKDIR /airbyte
 
 ENV APPLICATION source-e2e-test
-ENV APPLICATION_VERSION=2.0.0
+ENV APPLICATION_VERSION=2.1.0
 ENV ENABLE_SENTRY true
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=2.0.0
+LABEL io.airbyte.version=2.1.0
 LABEL io.airbyte.name=airbyte/source-e2e-test

--- a/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedConfig.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedConfig.java
@@ -5,8 +5,6 @@
 package io.airbyte.integrations.source.e2e_test;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.airbyte.commons.jackson.MoreMappers;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.string.Strings;
@@ -30,7 +28,6 @@ public class ContinuousFeedConfig {
 
   private static final JsonNode JSON_SCHEMA_DRAFT_07;
   private static final JsonSchemaValidator SCHEMA_VALIDATOR = new JsonSchemaValidator();
-  private static final ObjectMapper MAPPER = MoreMappers.initMapper();
 
   static {
     try {
@@ -72,14 +69,27 @@ public class ContinuousFeedConfig {
       case SINGLE_STREAM -> {
         final String streamName = mockCatalogConfig.get("stream_name").asText();
         final String streamSchemaText = mockCatalogConfig.get("stream_schema").asText();
+        final int streamDuplication = mockCatalogConfig.has("stream_duplication")
+            ? mockCatalogConfig.get("stream_duplication").asInt()
+            : 1;
         final Optional<JsonNode> streamSchema = Jsons.tryDeserialize(streamSchemaText);
         if (streamSchema.isEmpty()) {
           throw new JsonValidationException(String.format("Stream \"%s\" has invalid schema: %s", streamName, streamSchemaText));
         }
         checkSchema(streamName, streamSchema.get());
 
-        final AirbyteStream stream = new AirbyteStream().withName(streamName).withJsonSchema(streamSchema.get());
-        return new AirbyteCatalog().withStreams(Collections.singletonList(stream));
+        if (streamDuplication == 1) {
+          final AirbyteStream stream = new AirbyteStream().withName(streamName).withJsonSchema(streamSchema.get());
+          return new AirbyteCatalog().withStreams(Collections.singletonList(stream));
+        } else {
+          final List<AirbyteStream> streams = new ArrayList<>(streamDuplication);
+          for (int i = 0; i < streamDuplication; ++i) {
+            streams.add(new AirbyteStream()
+                .withName(String.join("_", streamName, String.valueOf(i)))
+                .withJsonSchema(streamSchema.get()));
+          }
+          return new AirbyteCatalog().withStreams(streams);
+        }
       }
       case MULTI_STREAM -> {
         final String streamSchemasText = mockCatalogConfig.get("stream_schemas").asText();

--- a/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedSource.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedSource.java
@@ -12,6 +12,7 @@ import io.airbyte.commons.util.AutoCloseableIterator;
 import io.airbyte.commons.util.AutoCloseableIterators;
 import io.airbyte.integrations.BaseConnector;
 import io.airbyte.integrations.base.Source;
+import io.airbyte.integrations.base.sentry.AirbyteSentry;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
@@ -20,10 +21,13 @@ import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
+import io.sentry.ISpan;
+import io.sentry.SpanStatus;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
@@ -68,10 +72,18 @@ public class ContinuousFeedSource extends BaseConnector implements Source {
 
       final Iterator<AirbyteMessage> streamIterator = new AbstractIterator<>() {
 
+        private ISpan span;
+
         @CheckForNull
         @Override
         protected AirbyteMessage computeNext() {
+          if (span == null) {
+            span = AirbyteSentry.createSpan("ReadStream",
+                Map.of("stream", stream.getStream().getName(), "recordCount", feedConfig.getMaxMessages()));
+          }
+
           if (emittedMessages.get() >= feedConfig.getMaxMessages()) {
+            span.finish(SpanStatus.OK);
             return endOfData();
           }
 
@@ -79,6 +91,8 @@ public class ContinuousFeedSource extends BaseConnector implements Source {
             try {
               Thread.sleep(messageIntervalMs.get());
             } catch (final InterruptedException e) {
+              span.setThrowable(e);
+              span.finish(SpanStatus.INTERNAL_ERROR);
               throw new RuntimeException(e);
             }
           }
@@ -87,6 +101,8 @@ public class ContinuousFeedSource extends BaseConnector implements Source {
           try {
             data = Jsons.jsonNode(generator.generate(schema, ContinuousFeedConstants.MOCK_JSON_MAX_TREE_SIZE));
           } catch (final JsonGeneratorException e) {
+            span.setThrowable(e);
+            span.finish(SpanStatus.INTERNAL_ERROR);
             throw new RuntimeException(e);
           }
           emittedMessages.incrementAndGet();

--- a/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/TestingSources.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/TestingSources.java
@@ -15,12 +15,8 @@ import io.airbyte.protocol.models.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestingSources extends BaseConnector implements Source {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(TestingSources.class);
 
   private final Map<TestingSourceType, Source> sourceMap;
 

--- a/airbyte-integrations/connectors/source-e2e-test/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-e2e-test/src/main/resources/spec.json
@@ -47,8 +47,8 @@
         "order": 50,
         "oneOf": [
           {
-            "title": "Single Stream",
-            "description": "A catalog with one stream.",
+            "title": "Single Schema",
+            "description": "A catalog with one or multiple streams that share the same schema.",
             "required": ["type", "stream_name", "stream_schema"],
             "properties": {
               "type": {
@@ -67,12 +67,20 @@
                 "description": "A Json schema for the stream. The schema should be compatible with <a href=\"https://json-schema.org/draft-07/json-schema-release-notes.html\">draft-07</a>. See <a href=\"https://cswr.github.io/JsonSchema/spec/introduction/\">this doc</a> for examples.",
                 "type": "string",
                 "default": "{ \"type\": \"object\", \"properties\": { \"column1\": { \"type\": \"string\" } } }"
+              },
+              "stream_duplication": {
+                "title": "Duplicate the stream N times",
+                "description": "Duplicate the stream for easy load testing. Each stream name will have a number suffix. For example, if the stream name is \"ds\", the duplicated streams will be \"ds_0\", \"ds_1\", etc.",
+                "type": "integer",
+                "default": 1,
+                "min": 1,
+                "max": 10000
               }
             }
           },
           {
-            "title": "Multi-Stream",
-            "description": "A catalog with multiple data streams.",
+            "title": "Multi Schema",
+            "description": "A catalog with multiple data streams, each with a different schema.",
             "required": ["type", "stream_schemas"],
             "properties": {
               "type": {

--- a/airbyte-integrations/connectors/source-e2e-test/src/test/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedConfigTest.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/test/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedConfigTest.java
@@ -23,12 +23,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class ContinuousFeedConfigTest {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ContinuousFeedConfigTest.class);
 
   private static final ObjectMapper MAPPER = MoreMappers.initMapper();
 
@@ -77,10 +73,10 @@ class ContinuousFeedConfigTest {
                                    final AirbyteCatalog expectedCatalog)
       throws Exception {
     if (expectedCatalog == null) {
-      assertThrows(JsonValidationException.class, () -> ContinuousFeedConfig.parseMockCatalog(mockConfig));
+      assertThrows(JsonValidationException.class, () -> ContinuousFeedConfig.parseMockCatalog(mockConfig), testCaseName);
     } else {
       final AirbyteCatalog actualCatalog = ContinuousFeedConfig.parseMockCatalog(mockConfig);
-      assertEquals(expectedCatalog.getStreams(), actualCatalog.getStreams());
+      assertEquals(expectedCatalog.getStreams(), actualCatalog.getStreams(), testCaseName);
     }
   }
 

--- a/airbyte-integrations/connectors/source-e2e-test/src/test/java/io/airbyte/integrations/source/e2e_test/GeneratorTest.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/test/java/io/airbyte/integrations/source/e2e_test/GeneratorTest.java
@@ -53,7 +53,7 @@ public class GeneratorTest {
     final Generator generator = new Generator(CONFIG, schemaStore, RANDOM);
     for (int i = 0; i < 10; ++i) {
       final JsonNode json = Jsons.jsonNode(generator.generate(schema, ContinuousFeedConstants.MOCK_JSON_MAX_TREE_SIZE));
-      assertTrue(JSON_VALIDATOR.test(jsonSchema, json));
+      assertTrue(JSON_VALIDATOR.test(jsonSchema, json), testCase);
     }
 
   }

--- a/airbyte-integrations/connectors/source-e2e-test/src/test/resources/parse_mock_catalog_test_cases.json
+++ b/airbyte-integrations/connectors/source-e2e-test/src/test/resources/parse_mock_catalog_test_cases.json
@@ -1,6 +1,6 @@
 [
   {
-    "testCase": "single stream",
+    "testCase": "single schema without duplication",
     "mockCatalog": {
       "type": "SINGLE_STREAM",
       "stream_name": "my_stream",
@@ -26,7 +26,48 @@
     }
   },
   {
-    "testCase": "single stream with malformed schema",
+    "testCase": "single schema with duplication",
+    "mockCatalog": {
+      "type": "SINGLE_STREAM",
+      "stream_name": "my_stream",
+      "stream_schema": "{ \"type\": \"object\", \"properties\": { \"field1\": { \"type\": \"string\" }, \"field2\": { \"type\": \"number\" } } }",
+      "stream_duplication": 2
+    },
+    "expectedCatalog": {
+      "streams": [
+        {
+          "name": "my_stream_0",
+          "json_schema": {
+            "type": "object",
+            "properties": {
+              "field1": {
+                "type": "string"
+              },
+              "field2": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        {
+          "name": "my_stream_1",
+          "json_schema": {
+            "type": "object",
+            "properties": {
+              "field1": {
+                "type": "string"
+              },
+              "field2": {
+                "type": "number"
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "testCase": "single schema with malformed schema",
     "mockCatalog": {
       "type": "SINGLE_STREAM",
       "stream_name": "my_stream",
@@ -35,7 +76,7 @@
     "expectedCatalog": null
   },
   {
-    "testCase": "single stream with invalid schema",
+    "testCase": "single schema with invalid schema",
     "mockCatalog": {
       "type": "SINGLE_STREAM",
       "stream_name": "my_stream",
@@ -44,7 +85,7 @@
     "expectedCatalog": null
   },
   {
-    "testCase": "multi stream",
+    "testCase": "multi schema",
     "mockCatalog": {
       "type": "MULTI_STREAM",
       "stream_schemas": "{ \"stream1\": { \"type\": \"object\", \"properties\": { \"field1\": { \"type\": \"string\" }, \"field2\": { \"type\": \"number\" } } }, \"stream2\": { \"type\": \"object\", \"properties\": { \"column1\": { \"type\": \"string\" } } } }"
@@ -80,7 +121,7 @@
     }
   },
   {
-    "testCase": "multi stream with malformed schema",
+    "testCase": "multi schema with malformed schema",
     "mockCatalog": {
       "type": "MULTI_STREAM",
       "stream_schemas": "{ \"type\": \"object\", \"properties\": { \"field1\": { \"type\": \"string\" }, \"field2\": { \"type\": \"number\" } } }"
@@ -88,7 +129,7 @@
     "expectedCatalog": null
   },
   {
-    "testCase": "multi stream with invalid schema",
+    "testCase": "multi schema with invalid schema",
     "mockCatalog": {
       "type": "MULTI_STREAM",
       "stream_schemas": "{ \"stream1\": { \"type\": \"object\", \"properties\": { \"field1\": { \"type\": \"string\" }, \"field2\": [\"invalid field spec\"] } }, \"stream2\": { \"type\": \"object\", \"properties\": { \"column1\": { \"type\": \"string\" } } } }"

--- a/docs/integrations/sources/e2e-test.md
+++ b/docs/integrations/sources/e2e-test.md
@@ -63,7 +63,7 @@ The OSS and Cloud variants have the same version number. The Cloud variant was i
 
 | Version | Date | Pull request | Notes |
 | --- | --- | --- | --- |
-| 2.0.1 | 2021-02-12 | [\#10298](https://github.com/airbytehq/airbyte/pull/10298) | Support stream duplication to quickly create a multi-stream catalog. |
+| 2.1.0 | 2021-02-12 | [\#10298](https://github.com/airbytehq/airbyte/pull/10298) | Support stream duplication to quickly create a multi-stream catalog. |
 | 2.0.0 | 2021-02-01 | [\#9954](https://github.com/airbytehq/airbyte/pull/9954) | Remove legacy modes. Use more efficient Json generator. |
 | 1.0.1 | 2021-01-29 | [\#9745](https://github.com/airbytehq/airbyte/pull/9745) | Integrate with Sentry. |
 | 1.0.0 | 2021-01-23 | [\#9720](https://github.com/airbytehq/airbyte/pull/9720) | Add new continuous feed mode that supports arbitrary catalog specification. Initial release to cloud. |

--- a/docs/integrations/sources/e2e-test.md
+++ b/docs/integrations/sources/e2e-test.md
@@ -20,6 +20,7 @@ Here is its configuration:
 | --- | --- | --- | --- | --- | --- |
 | Single-stream | stream name | string | yes | | Name of the stream in the catalog. |
 | | stream schema | json | yes | | Json schema of the stream in the catalog. It must be a valid Json schema. |
+| | stream duplication | integer | no | 1 | Duplicate the stream N times to quickly create a multi-stream catalog. |
 | Multi-stream | streams and schemas | json | yes | | A Json object specifying multiple data streams and their schemas. Each key in this object is one stream name. Each value is the schema for that stream. |
 | Both | max records | integer | yes | 100 | The number of record messages to emit from this connector. Min 1. Max 100 billion. |
 | | random seed | integer | no | current time millis | The seed is used in random Json object generation. Min 0. Max 1 million. |
@@ -62,7 +63,8 @@ The OSS and Cloud variants have the same version number. The Cloud variant was i
 
 | Version | Date | Pull request | Notes |
 | --- | --- | --- | --- |
-| 2.0.0 (unpublished) | 2021-02-01 | [\#9954](https://github.com/airbytehq/airbyte/pull/9954) | Remove legacy modes. Use more efficient Json generator. |
+| 2.0.1 | 2021-02-12 | [\#10298](https://github.com/airbytehq/airbyte/pull/10298) | Support stream duplication to quickly create a multi-stream catalog. |
+| 2.0.0 | 2021-02-01 | [\#9954](https://github.com/airbytehq/airbyte/pull/9954) | Remove legacy modes. Use more efficient Json generator. |
 | 1.0.1 | 2021-01-29 | [\#9745](https://github.com/airbytehq/airbyte/pull/9745) | Integrate with Sentry. |
 | 1.0.0 | 2021-01-23 | [\#9720](https://github.com/airbytehq/airbyte/pull/9720) | Add new continuous feed mode that supports arbitrary catalog specification. Initial release to cloud. |
 | 0.1.1 | 2021-12-16 | [\#8217](https://github.com/airbytehq/airbyte/pull/8217) | Fix sleep time in infinite feed mode. |


### PR DESCRIPTION
## What
- Support stream duplication.
- This new feature will be used in load test in cloud benchmarks.

## How
- The single stream mode is now single schema mode.
- Its schema can be duplicated N times.
- Also add Sentry trace for each stream.

## Sentry Trace

<img width="960" alt="Screen Shot 2022-02-11 at 23 56 20" src="https://user-images.githubusercontent.com/1933157/153702709-626dec91-a5ae-4e11-9868-512eb95449ed.png">


## 🚨 User Impact 🚨
- None expected.

## Pre-merge Checklist
<strong>Updating a connector</strong>
   
### Community member or Airbyter
   
- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret` 
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated 
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
   
### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items. 
   
- [x] Create a non-forked branch based on this PR and test the below items on it
- [x] Build is successful
- [x] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci). 
- [x] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing. 
- [x] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [x] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [x] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
