### PR TITLE
spike on using temporal crons for sync workflows

### DIFF
--- a/airbyte-workers/src/test/java/io/airbyte/workers/cron/BasicWorkflow.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/cron/BasicWorkflow.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.cron;
+
+import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@WorkflowInterface
+public interface BasicWorkflow {
+
+  Logger LOGGER = LoggerFactory.getLogger(BasicWorkflow.class);
+  String WORKFLOW_NAME = "basic-workflow";
+
+  @WorkflowMethod
+  String run(String input);
+
+  class BasicWorkflowImpl implements BasicWorkflow {
+
+    private final CountingActivity countingActivity = Workflow.newActivityStub(CountingActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
+
+    @Override
+    public String run(final String key) {
+      LOGGER.debug("workflow running");
+      LOGGER.debug("key = " + key);
+      countingActivity.incrementCounter(key);
+      return key;
+    }
+
+  }
+
+  @ActivityInterface
+  public interface CountingActivity {
+
+    @ActivityMethod
+    void incrementCounter(String key);
+
+  }
+
+  public static class CountingActivityImpl implements CountingActivity {
+
+    private final Map<String, AtomicInteger> counter;
+
+    public CountingActivityImpl(final Map<String, AtomicInteger> counter) {
+      this.counter = counter;
+    }
+
+    @Override
+    public void incrementCounter(final String key) {
+      // not actually threadsafe use of the map.
+      if (counter.containsKey(key)) {
+        counter.get(key).incrementAndGet();
+      } else {
+        counter.put(key, new AtomicInteger(1));
+      }
+    }
+
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/cron/CreateWorkflowWorkflow.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/cron/CreateWorkflowWorkflow.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.cron;
+
+import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@WorkflowInterface
+public interface CreateWorkflowWorkflow {
+
+  Logger LOGGER = LoggerFactory.getLogger(CreateWorkflowWorkflow.class);
+  String WORKFLOW_NAME = "create-workflow-workflow";
+
+  @WorkflowMethod
+  void createWorkflow(String id, String key, String cronString, String workflowName);
+
+  class CreateWorkflowWorkflowImpl implements CreateWorkflowWorkflow {
+
+    private final CreateWorkflowActivity createActivity =
+        Workflow.newActivityStub(CreateWorkflowActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
+
+    @Override
+    public void createWorkflow(final String id, final String key, final String cronString, final String workflowName) {
+      createActivity.create(id, key, cronString, workflowName);
+      // createWorkflow(id, key, cronString, workflowName);
+    }
+
+    // private static void createWorkflow(final String id, final String key, final String cronString,
+    // final String workflowName) {
+    // LOGGER.info("running create workflow");
+    // // switch to using temporal client.
+    // final ChildWorkflowOptions.Builder builder = ChildWorkflowOptions.newBuilder()
+    // .setTaskQueue(workflowName)
+    // .setParentClosePolicy(ParentClosePolicy.PARENT_CLOSE_POLICY_UNSPECIFIED)
+    // .setCancellationType(ChildWorkflowCancellationType.ABANDON)
+    // .setWorkflowId(id);
+    //
+    // // manual sync
+    // if (cronString != null) {
+    // builder.setCronSchedule(cronString);
+    // }
+    //
+    // final BasicWorkflow basicWorkflow1 = Workflow.newChildWorkflowStub(BasicWorkflow.class,
+    // builder.build());
+    //// WorkflowClient.start(basicWorkflow1::run, id, rootPath);
+    // Async.procedure((input, rootPath1) -> basicWorkflow1.run(input), id, key);
+    // final Promise<WorkflowExecution> childExecution = Workflow.getWorkflowExecution(basicWorkflow1);
+    //
+    // LOGGER.info("child workflow start: starting");
+    // // Wait for child to start
+    // childExecution.get(); // don't understand why it doesn't start running without this.
+    // LOGGER.info("child workflow start: started");
+    // }
+
+  }
+
+  @ActivityInterface
+  interface CreateWorkflowActivity {
+
+    @ActivityMethod
+    void create(final String id, final String key, final String cronString, final String workflowName);
+
+  }
+
+  class CreateWorkflowActivityImpl implements CreateWorkflowActivity {
+
+    private final WorkflowClient client;
+
+    public CreateWorkflowActivityImpl(final WorkflowClient client) {
+      this.client = client;
+    }
+
+    @Override
+    public void create(final String id, final String key, final String cronString, final String workflowName) {
+      LOGGER.info("running create workflow");
+      final WorkflowOptions.Builder builder = WorkflowOptions.newBuilder()
+          .setTaskQueue(workflowName)
+          .setWorkflowId(id);
+
+      // manual sync
+      if (cronString != null) {
+        builder.setCronSchedule(cronString);
+      }
+
+      final BasicWorkflow basicWorkflow = client.newWorkflowStub(BasicWorkflow.class, builder.build());
+
+      LOGGER.debug("child workflow start: starting");
+      WorkflowClient.start(basicWorkflow::run, key);
+      LOGGER.debug("child workflow start: started");
+    }
+
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/cron/CronTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/cron/CronTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.cron;
+
+import io.airbyte.workers.cron.BasicWorkflow.BasicWorkflowImpl;
+import io.airbyte.workers.cron.BasicWorkflow.CountingActivityImpl;
+import io.airbyte.workers.cron.CreateWorkflowWorkflow.CreateWorkflowActivityImpl;
+import io.airbyte.workers.cron.CreateWorkflowWorkflow.CreateWorkflowWorkflowImpl;
+import io.airbyte.workers.cron.DeleteWorkflowWorkflow.DeleteWorkflowWorkflowImpl;
+import io.airbyte.workers.cron.ManualWorkflowWorkflow.ManualWorkflowWorkflowImpl;
+import io.airbyte.workers.cron.UpdateWorkflowWorkflow.UpdateWorkflowWorkflowImpl;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.Worker;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class explores what it would look like to schedule each sync as a temporal cron job.
+ *
+ * Instead of our actual SyncWorkflow it is just executing a CountingWorkflow.
+ *
+ * It then shows what it would look like to use temporal workflows to create, update, delete, and
+ * schedule a manual run. It does NOT implement the equivalent of reset, though with the provided
+ * building blocks it should be straight forward.
+ *
+ * todo (cgardens) - map out composite cases. e.g. for a scheduled sync, while manual run is going,
+ * what happens when we delete the connection. this will require us to be more thoughtful about the
+ * the rules around which workflow mutation operations can run at once on a given workflow.
+ *
+ * Note: the dev rel who respond to questions on temporal seems to recommend against this approach:
+ * https://community.temporal.io/t/temporal-cron-questions/201
+ */
+public class CronTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UpdateWorkflowWorkflow.class);
+
+  private static final String WORKFLOW_ID = "123"; // this would be connection id.
+
+  @Test
+  void test() throws InterruptedException, IOException {
+    // SETUP
+    final Map<String, AtomicInteger> counter = new ConcurrentHashMap<>();
+    final TestWorkflowEnvironment testEnv = TestWorkflowEnvironment.newInstance();
+
+    final WorkflowClient client = testEnv.getWorkflowClient();
+
+    final Worker workerWorker = testEnv.newWorker(BasicWorkflow.WORKFLOW_NAME);
+    workerWorker.registerWorkflowImplementationTypes(BasicWorkflowImpl.class);
+    workerWorker.registerActivitiesImplementations(new CountingActivityImpl(counter));
+
+    final Worker creatorWorker = testEnv.newWorker(CreateWorkflowWorkflow.WORKFLOW_NAME);
+    creatorWorker.registerWorkflowImplementationTypes(CreateWorkflowWorkflowImpl.class);
+    creatorWorker.registerActivitiesImplementations(new CreateWorkflowActivityImpl(client));
+
+    final Worker updaterWorker = testEnv.newWorker(UpdateWorkflowWorkflow.WORKFLOW_NAME);
+    updaterWorker.registerWorkflowImplementationTypes(UpdateWorkflowWorkflowImpl.class);
+    updaterWorker.registerActivitiesImplementations(new UpdateWorkflowWorkflow.UpdateWorkflowActivityImpl(client));
+
+    final Worker manualWorker = testEnv.newWorker(ManualWorkflowWorkflow.WORKFLOW_NAME);
+    manualWorker.registerWorkflowImplementationTypes(ManualWorkflowWorkflowImpl.class);
+
+    final Worker deleteWorker = testEnv.newWorker(DeleteWorkflowWorkflow.WORKFLOW_NAME);
+    deleteWorker.registerWorkflowImplementationTypes(DeleteWorkflowWorkflowImpl.class);
+    deleteWorker.registerActivitiesImplementations(new DeleteWorkflowWorkflow.TerminateWorkflowActivityImpl(client));
+
+    testEnv.start();
+
+    // in practice, we would create a different stub with an id scoped to the correct workflow id
+    // (connection id). for sake of testing, just doing it statically.
+    final CreateWorkflowWorkflow createWorkflowStub =
+        client.newWorkflowStub(CreateWorkflowWorkflow.class, WorkflowOptions.newBuilder()
+            .setTaskQueue(CreateWorkflowWorkflow.WORKFLOW_NAME)
+            .setWorkflowId(WORKFLOW_ID + "-" + CreateWorkflowWorkflow.WORKFLOW_NAME)
+            .build());
+    final UpdateWorkflowWorkflow updateWorkflowStub =
+        client.newWorkflowStub(UpdateWorkflowWorkflow.class, WorkflowOptions.newBuilder()
+            .setTaskQueue(UpdateWorkflowWorkflow.WORKFLOW_NAME)
+            .setWorkflowId(WORKFLOW_ID + "-" + UpdateWorkflowWorkflow.WORKFLOW_NAME)
+            .setWorkflowId(WORKFLOW_ID + "-" + UpdateWorkflowWorkflow.WORKFLOW_NAME)
+            .build());
+    final DeleteWorkflowWorkflow deleteWorkflowStub =
+        client.newWorkflowStub(DeleteWorkflowWorkflow.class, WorkflowOptions.newBuilder()
+            .setTaskQueue(DeleteWorkflowWorkflow.WORKFLOW_NAME)
+            .setWorkflowId(WORKFLOW_ID + "-" + DeleteWorkflowWorkflow.WORKFLOW_NAME)
+            .build());
+    final ManualWorkflowWorkflow manualWorkflowStub =
+        client.newWorkflowStub(ManualWorkflowWorkflow.class, WorkflowOptions.newBuilder()
+            .setTaskQueue(ManualWorkflowWorkflow.WORKFLOW_NAME)
+            .setWorkflowId(WORKFLOW_ID + "-" + ManualWorkflowWorkflow.WORKFLOW_NAME)
+            .build());
+
+    final WorkflowServiceStubs temporalService = client.getWorkflowServiceStubs();
+
+    final WorkflowExecution workflowExecution = WorkflowExecution.newBuilder()
+        .setWorkflowId(WORKFLOW_ID)
+        .build();
+
+    // TEST RUN
+
+    // create initial workflow
+    LOGGER.info("creating initial workflow: started");
+    createWorkflowStub.createWorkflow(WORKFLOW_ID, WORKFLOW_ID, "*/2 * * * *", BasicWorkflow.WORKFLOW_NAME);
+    LOGGER.info("creating initial workflow: done");
+
+    // verify it is running, we expect the counter to be non-zero after the sleep.
+    testEnv.sleep(Duration.ofSeconds(1000));
+    logCount(counter, "0");
+
+    // verify the schedule is set.
+    TemporalUtils.logSchedule(temporalService, workflowExecution, 1);
+
+    // verify more records are produced as more time passes.
+    testEnv.sleep(Duration.ofSeconds(1000));
+    logCount(counter, "1");
+
+    // update the workflow to use a new schedule
+    LOGGER.info("updating workflow schedule: started");
+    updateWorkflowStub.updateWorkflow(WORKFLOW_ID, WORKFLOW_ID, "*/5 * * * *", BasicWorkflow.WORKFLOW_NAME);
+    LOGGER.info("updating workflow schedule: done");
+
+    // verify more records are being produced with the new schedule.
+    testEnv.sleep(Duration.ofSeconds(1000));
+    logCount(counter, "1.5");
+
+    // verify the schedule is updated.
+    TemporalUtils.logSchedule(temporalService, workflowExecution, 2);
+
+    LOGGER.info("trigger manual sync: started");
+    manualWorkflowStub.manual(WORKFLOW_ID, WORKFLOW_ID, BasicWorkflow.WORKFLOW_NAME);
+    LOGGER.info("trigger manual sync: done");
+
+    logCount(counter, "1.70");
+    testEnv.sleep(Duration.ofSeconds(1000));
+    logCount(counter, "1.75");
+
+    // terminate the workflow
+    LOGGER.info("terminating workflow: started");
+    deleteWorkflowStub.delete(WORKFLOW_ID);
+    LOGGER.info("terminating workflow: done");
+
+    logCount(counter, "2");
+
+    // verify that the counter does NOT keep increasing because the workflow has stopped.
+    testEnv.sleep(Duration.ofSeconds(1000));
+    logCount(counter, "3");
+
+    testEnv.shutdown();
+  }
+
+  private static void logCount(final Map<String, AtomicInteger> counter, final String id) {
+    LOGGER.info("counter status (checkpoint: {}) - {}", id, counter);
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/cron/CronTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/cron/CronTest.java
@@ -14,7 +14,6 @@ import io.airbyte.workers.cron.UpdateWorkflowWorkflow.UpdateWorkflowWorkflowImpl
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
-import io.temporal.client.WorkflowStub;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
@@ -145,6 +144,9 @@ public class CronTest {
     logCount(counter, "1.70");
     testEnv.sleep(Duration.ofSeconds(1000));
     logCount(counter, "1.75");
+
+    // verify the schedule is still in place after the manual run.
+    TemporalUtils.logSchedule(temporalService, workflowExecution, 3);
 
     // terminate the workflow
     LOGGER.info("terminating workflow: started");

--- a/airbyte-workers/src/test/java/io/airbyte/workers/cron/DeleteWorkflowWorkflow.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/cron/DeleteWorkflowWorkflow.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.cron;
+
+import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowStub;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@WorkflowInterface
+public interface DeleteWorkflowWorkflow {
+
+  Logger LOGGER = LoggerFactory.getLogger(DeleteWorkflowWorkflow.class);
+  String WORKFLOW_NAME = "delete-workflow-workflow";
+
+  @WorkflowMethod
+  public String delete(String id);
+
+  class DeleteWorkflowWorkflowImpl implements DeleteWorkflowWorkflow {
+
+    private final TerminateWorkflowActivity terminateWorkflowActivity =
+        Workflow.newActivityStub(TerminateWorkflowActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
+
+    @Override
+    public String delete(final String id) {
+      LOGGER.debug("running delete workflow");
+
+      // should detect if one is running and remember its cron string.
+      return terminateWorkflowActivity.terminate(id);
+    }
+
+  }
+
+  @ActivityInterface
+  interface TerminateWorkflowActivity {
+
+    @ActivityMethod
+    String terminate(final String id);
+
+  }
+
+  class TerminateWorkflowActivityImpl implements TerminateWorkflowActivity {
+
+    private final WorkflowClient client;
+
+    public TerminateWorkflowActivityImpl(final WorkflowClient client) {
+      this.client = client;
+    }
+
+    @Override
+    public String terminate(final String id) {
+
+      final WorkflowExecution workflowExecution = WorkflowExecution.newBuilder()
+          .setWorkflowId(id)
+          .build();
+
+      // either scheduled or a manual run.
+      if (TemporalUtils.isWorkflowActive(client.getWorkflowServiceStubs(), workflowExecution)) {
+        final Optional<String> scheduleIfExists = TemporalUtils.getScheduleIfExists(client.getWorkflowServiceStubs(), workflowExecution);
+
+        final WorkflowStub workflowStub = client.newUntypedWorkflowStub(id);
+        LOGGER.info("terminating: started");
+        // workflowStub.cancel();
+        workflowStub.terminate("update scheduler");
+        LOGGER.info("terminating: done");
+
+        // means scheduled workflow exists
+        if (scheduleIfExists.isPresent()) {
+          return scheduleIfExists.get();
+
+          // means manual run is in progress.
+        } else {
+          return null;
+        }
+
+      } else {
+        // do nothing.
+        return null;
+      }
+
+    }
+
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/cron/ManualWorkflowWorkflow.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/cron/ManualWorkflowWorkflow.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.cron;
+
+import io.temporal.api.enums.v1.ParentClosePolicy;
+import io.temporal.workflow.ChildWorkflowCancellationType;
+import io.temporal.workflow.ChildWorkflowOptions;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@WorkflowInterface
+public interface ManualWorkflowWorkflow {
+
+  Logger LOGGER = LoggerFactory.getLogger(ManualWorkflowWorkflow.class);
+  String WORKFLOW_NAME = "manual-workflow";
+
+  @WorkflowMethod
+  public void manual(String id, String key, String workflowName);
+
+  class ManualWorkflowWorkflowImpl implements ManualWorkflowWorkflow {
+
+    @Override
+    public void manual(final String id, final String key, final String workflowName) {
+      LOGGER.info("running update workflow (outer)");
+
+      final ChildWorkflowOptions.Builder deleteWorkflowOptionsBuilder = ChildWorkflowOptions.newBuilder()
+          .setTaskQueue(DeleteWorkflowWorkflow.WORKFLOW_NAME)
+          .setParentClosePolicy(ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE)
+          .setCancellationType(ChildWorkflowCancellationType.WAIT_CANCELLATION_COMPLETED);
+      final DeleteWorkflowWorkflow deleteWorkflowWorkflow =
+          Workflow.newChildWorkflowStub(DeleteWorkflowWorkflow.class, deleteWorkflowOptionsBuilder.build());
+      // todo (cgardens) - need to update the logic here. should be that if there is something running we
+      // can determine if is actually running or
+      // waiting to run. if it is waiting, then we terminate and do a manual. if it is running, do
+      // nothing.
+      final String originalCronSchedule = deleteWorkflowWorkflow.delete(id); // null if there was none.
+
+      final ChildWorkflowOptions.Builder createWorkflowOptionsBuilder = ChildWorkflowOptions.newBuilder()
+          .setTaskQueue(CreateWorkflowWorkflow.WORKFLOW_NAME)
+          .setParentClosePolicy(ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE)
+          .setCancellationType(ChildWorkflowCancellationType.WAIT_CANCELLATION_COMPLETED);
+      // .setWorkflowId(id);
+      final CreateWorkflowWorkflow createWorkflowWorkflow =
+          Workflow.newChildWorkflowStub(CreateWorkflowWorkflow.class, createWorkflowOptionsBuilder.build());
+
+      // run now
+      createWorkflowWorkflow.createWorkflow(id, key + "-manual", null, workflowName);
+
+      // restore workflow (if always manual do nothing)
+      if (originalCronSchedule != null) {
+        createWorkflowWorkflow.createWorkflow(id, key, originalCronSchedule, workflowName);
+      }
+      // else nothing to restore.
+    }
+
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/cron/TemporalUtils.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/cron/TemporalUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.cron;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.filter.v1.WorkflowExecutionFilter;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
+import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
+import io.temporal.api.workflowservice.v1.ListOpenWorkflowExecutionsRequest;
+import io.temporal.api.workflowservice.v1.ListOpenWorkflowExecutionsResponse;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TemporalUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TemporalUtils.class);
+
+  public static Optional<String> getScheduleIfExists(final WorkflowServiceStubs temporalService, final WorkflowExecution workflowExecution) {
+    if (isWorkflowActive(temporalService, workflowExecution)) {
+      return Optional.ofNullable(getSchedule(temporalService, workflowExecution));
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  public static boolean isWorkflowActive(final WorkflowServiceStubs temporalService, final WorkflowExecution workflowExecution) {
+    final ListOpenWorkflowExecutionsResponse listOpenWorkflowExecutionsResponse2 = temporalService.blockingStub()
+        .listOpenWorkflowExecutions(ListOpenWorkflowExecutionsRequest.newBuilder()
+            .setExecutionFilter(WorkflowExecutionFilter.newBuilder()
+                .setWorkflowId(workflowExecution.getWorkflowId()).buildPartial())
+            .build());
+
+    return !listOpenWorkflowExecutionsResponse2.getExecutionsList().isEmpty();
+  }
+
+  public static String getSchedule(final WorkflowServiceStubs temporalService, final WorkflowExecution workflowExecution) {
+    final GetWorkflowExecutionHistoryRequest request =
+        GetWorkflowExecutionHistoryRequest.newBuilder()
+            .setNamespace("default")
+            .setExecution(workflowExecution)
+            // .setMaximumPageSize(1)
+            .build();
+    final GetWorkflowExecutionHistoryResponse result =
+        temporalService.blockingStub().getWorkflowExecutionHistory(request);
+    final List<HistoryEvent> events = result.getHistory().getEventsList();
+
+    return events.get(0).getWorkflowExecutionStartedEventAttributes().getCronSchedule();
+  }
+
+  public static void logSchedule(final WorkflowServiceStubs temporalService, final WorkflowExecution workflowExecution, final int i) {
+    LOGGER.info("schedule" + i + " = " + getSchedule(temporalService, workflowExecution));
+  }
+
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/cron/UpdateWorkflowWorkflow.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/cron/UpdateWorkflowWorkflow.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.cron;
+
+import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@WorkflowInterface
+public interface UpdateWorkflowWorkflow {
+
+  Logger LOGGER = LoggerFactory.getLogger(UpdateWorkflowWorkflow.class);
+  String WORKFLOW_NAME = "update-workflow-workflow";
+
+  @WorkflowMethod
+  void updateWorkflow(String id, String key, String cronString, String workflowName);
+
+  class UpdateWorkflowWorkflowImpl implements UpdateWorkflowWorkflow {
+
+    private final UpdateWorkflowActivity updateActivity =
+        Workflow.newActivityStub(UpdateWorkflowActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
+
+    @Override
+    public void updateWorkflow(final String id, final String key, final String cronString, final String workflowName) {
+      LOGGER.info("running update workflow (outer)");
+      updateActivity.update(id, key, cronString, workflowName);
+
+    }
+
+  }
+
+  @ActivityInterface
+  public interface UpdateWorkflowActivity {
+
+    @ActivityMethod
+    void update(final String id, final String key, final String cronString, final String workflowName);
+
+  }
+
+  class UpdateWorkflowActivityImpl implements UpdateWorkflowActivity {
+
+    private final WorkflowClient client;
+
+    public UpdateWorkflowActivityImpl(final WorkflowClient client) {
+      this.client = client;
+    }
+
+    @Override
+    public void update(final String id, final String key, final String cronString, final String workflowName) {
+      LOGGER.debug("running update workflow (inner)");
+      final WorkflowStub workflowStub = client.newUntypedWorkflowStub(id);
+      // workflowStub.cancel();
+      LOGGER.debug("terminating: started");
+      workflowStub.terminate("update scheduler");
+      LOGGER.debug("terminating: done");
+
+      final WorkflowOptions.Builder builder = WorkflowOptions.newBuilder()
+          .setTaskQueue(workflowName)
+          .setWorkflowId(id);
+
+      // manual sync
+      if (cronString != null) {
+        builder.setCronSchedule(cronString);
+      }
+
+      LOGGER.debug("getting stub: started");
+      final BasicWorkflow basicWorkflow = client.newWorkflowStub(BasicWorkflow.class, builder.build());
+      LOGGER.debug("getting stub: done");
+      LOGGER.debug("running workflow: started");
+      WorkflowClient.start((input, rootPath1) -> {
+        return basicWorkflow.run(input);
+      }, id, key);
+      LOGGER.debug("running workflow: done");
+    }
+
+  }
+
+}


### PR DESCRIPTION
## What
As I was reading our current implementation of temporal for running sync workflows. Decided to spike out what that might look like to understand the tradeoffs (and improve my familiarity with temporal).

## How to read it
Start at `CronTest.java`. It is a class that executes each of the operations we might do on a sync workflow.

## Takeways
Still need to model out composite actions a little more clearly. There are basic primitives (e.g. create, update, delete), but then there are some composite ones, like run a manual sync which is really a compilation of delete: (if present), create, create (if previously scheduled). If I were to move forward with this I think I would model it this way.

* Workflow - Sync workflow would be a temporal cron workflow (i.e. what the `BasicWorkflow` is in this example.
* Basic Workflow Transformations - create, update, delete - these operations that could be applied to the workflow. only one of them could be applied to a workflow at time. this could be trivially enforced using temporal workflow ids.
* Connection Transformations (or composite transformations) - delete connection, reset connection, manual sync - these would compose the Basic Workflow Transformations. They would be prioritized in the order mentioned above. i.e. if a delete connection happens while a reset is in progress, the delete will overrule the reset. if a reset happens while a delete in progress, the reset will be a no op and will return with an error that it could not be executed because another operation was already taking place.

@benmoriceau @jrhizor maybe interesting.