### PR TITLE
Source Google Ads: make streams incremental

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -252,7 +252,7 @@
 - name: Google Ads
   sourceDefinitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
   dockerRepository: airbyte/source-google-ads
-  dockerImageTag: 0.1.26
+  dockerImageTag: 0.1.27
   documentationUrl: https://docs.airbyte.io/integrations/sources/google-ads
   icon: google-adwords.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -2306,7 +2306,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-google-ads:0.1.26"
+- dockerImage: "airbyte/source-google-ads:0.1.27"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/google-ads"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-google-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-ads/Dockerfile
@@ -13,5 +13,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.26
+LABEL io.airbyte.version=0.1.27
 LABEL io.airbyte.name=airbyte/source-google-ads

--- a/airbyte-integrations/connectors/source-google-ads/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-google-ads/integration_tests/configured_catalog.json
@@ -30,6 +30,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
+        "source_defined_primary_key": [["click_view.gclid", "segments.date"]],
         "default_cursor_field": ["segments.date"]
       },
       "sync_mode": "incremental",
@@ -102,7 +103,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "source_defined_primary_key": [["ad_group_ad.ad.id"]],
+        "source_defined_primary_key": [["ad_group_ad.ad.id", "segments.date"]],
         "default_cursor_field": ["segments.date"]
       },
       "sync_mode": "incremental",
@@ -116,7 +117,7 @@
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
         "default_cursor_field": ["segments.date"],
-        "source_defined_primary_key": [["ad_group.id"]]
+        "source_defined_primary_key": [["ad_group.id", "segments.date"]]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "overwrite",
@@ -129,7 +130,7 @@
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
         "default_cursor_field": ["segments.date"],
-        "source_defined_primary_key": [["customer.id"]]
+        "source_defined_primary_key": [["customer.id", "segments.date"]]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "overwrite",
@@ -142,7 +143,7 @@
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
         "default_cursor_field": ["segments.date"],
-        "source_defined_primary_key": [["campaign.id"]]
+        "source_defined_primary_key": [["campaign.id", "segments.date"]]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "overwrite",

--- a/airbyte-integrations/connectors/source-google-ads/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-google-ads/integration_tests/configured_catalog.json
@@ -30,7 +30,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "source_defined_primary_key": [["click_view.gclid", "segments.date"]],
+        "source_defined_primary_key": [["click_view.gclid"], ["segments.date"]],
         "default_cursor_field": ["segments.date"]
       },
       "sync_mode": "incremental",
@@ -103,7 +103,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "source_defined_primary_key": [["ad_group_ad.ad.id", "segments.date"]],
+        "source_defined_primary_key": [["ad_group_ad.ad.id"], ["segments.date"]],
         "default_cursor_field": ["segments.date"]
       },
       "sync_mode": "incremental",
@@ -117,7 +117,7 @@
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
         "default_cursor_field": ["segments.date"],
-        "source_defined_primary_key": [["ad_group.id", "segments.date"]]
+        "source_defined_primary_key": [["ad_group.id"], ["segments.date"]]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "overwrite",
@@ -130,7 +130,7 @@
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
         "default_cursor_field": ["segments.date"],
-        "source_defined_primary_key": [["customer.id", "segments.date"]]
+        "source_defined_primary_key": [["customer.id"], ["segments.date"]]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "overwrite",
@@ -143,7 +143,7 @@
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
         "default_cursor_field": ["segments.date"],
-        "source_defined_primary_key": [["campaign.id", "segments.date"]]
+        "source_defined_primary_key": [["campaign.id"], ["segments.date"]]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "overwrite",

--- a/airbyte-integrations/connectors/source-google-ads/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-google-ads/integration_tests/configured_catalog.json
@@ -100,41 +100,53 @@
       "stream": {
         "name": "ad_group_ads",
         "json_schema": {},
-        "supported_sync_modes": ["full_refresh"],
-        "source_defined_primary_key": [["ad_group_ad.ad.id"]]
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "source_defined_primary_key": [["ad_group_ad.ad.id"]],
+        "default_cursor_field": ["segments.date"]
       },
-      "sync_mode": "full_refresh",
-      "destination_sync_mode": "overwrite"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["segments.date"]
     },
     {
       "stream": {
         "name": "ad_groups",
         "json_schema": {},
-        "supported_sync_modes": ["full_refresh"],
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["segments.date"],
         "source_defined_primary_key": [["ad_group.id"]]
       },
-      "sync_mode": "full_refresh",
-      "destination_sync_mode": "overwrite"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["segments.date"]
     },
     {
       "stream": {
         "name": "accounts",
         "json_schema": {},
-        "supported_sync_modes": ["full_refresh"],
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["segments.date"],
         "source_defined_primary_key": [["customer.id"]]
       },
-      "sync_mode": "full_refresh",
-      "destination_sync_mode": "overwrite"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["segments.date"]
     },
     {
       "stream": {
         "name": "campaigns",
         "json_schema": {},
-        "supported_sync_modes": ["full_refresh"],
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["segments.date"],
         "source_defined_primary_key": [["campaign.id"]]
       },
-      "sync_mode": "full_refresh",
-      "destination_sync_mode": "overwrite"
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["segments.date"]
     },
     {
       "stream": {

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/accounts.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/accounts.json
@@ -64,6 +64,10 @@
     },
     "customer.tracking_url_template": {
       "type": ["null", "string"]
+    },
+    "segments.date": {
+      "type": ["null", "string"],
+      "format": "date"
     }
   }
 }

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/ad_group_ads.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/ad_group_ads.json
@@ -565,6 +565,10 @@
     },
     "ad_group_ad.status": {
       "type": ["null", "string"]
+    },
+    "segments.date": {
+      "type": ["null", "string"],
+      "format": "date"
     }
   }
 }

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/ad_groups.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/ad_groups.json
@@ -94,6 +94,10 @@
       "items": {
         "type": "string"
       }
+    },
+    "segments.date": {
+      "type": ["null", "string"],
+      "format": "date"
     }
   }
 }

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/campaigns.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/campaigns.json
@@ -238,6 +238,10 @@
     },
     "campaign.video_brand_safety_suitability": {
       "type": ["null", "string"]
+    },
+    "segments.date": {
+      "type": ["null", "string"],
+      "format": "date"
     }
   }
 }

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -29,7 +29,6 @@ from .streams import (
     KeywordReport,
     ShoppingPerformanceReport,
     UserLocationReport,
-    AccountsFullRefresh,
 )
 
 
@@ -47,8 +46,19 @@ class SourceGoogleAds(AbstractSource):
         return credentials
 
     @staticmethod
-    def get_account_info(google_api) -> dict:
-        accounts_streams = AccountsFullRefresh(api=google_api)
+    def get_incremental_stream_config(google_api, config, tz="local"):
+        incremental_stream_config = dict(
+            api=google_api,
+            conversion_window_days=config["conversion_window_days"],
+            start_date=config["start_date"],
+            time_zone=tz,
+            end_date=config.get("end_date"),
+        )
+        return incremental_stream_config
+
+    def get_account_info(self, google_api, config) -> dict:
+        incremental_stream_config = self.get_incremental_stream_config(google_api, config)
+        accounts_streams = Accounts(**incremental_stream_config)
         for stream_slice in accounts_streams.stream_slices(sync_mode=SyncMode.full_refresh):
             return next(accounts_streams.read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice), {})
 
@@ -75,7 +85,7 @@ class SourceGoogleAds(AbstractSource):
         try:
             logger.info("Checking the config")
             google_api = GoogleAds(credentials=self.get_credentials(config), customer_id=config["customer_id"])
-            account_info = self.get_account_info(google_api)
+            account_info = self.get_account_info(google_api, config)
             is_manager_account = self.is_manager_account(account_info)
 
             # Check custom query request validity by sending metric request with non-existant time window
@@ -96,16 +106,9 @@ class SourceGoogleAds(AbstractSource):
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         google_api = GoogleAds(credentials=self.get_credentials(config), customer_id=config["customer_id"])
-        account_info = self.get_account_info(google_api)
+        account_info = self.get_account_info(google_api, config)
         time_zone = self.get_time_zone(account_info)
-        end_date = config.get("end_date")
-        incremental_stream_config = dict(
-            api=google_api,
-            conversion_window_days=config["conversion_window_days"],
-            start_date=config["start_date"],
-            time_zone=time_zone,
-            end_date=end_date,
-        )
+        incremental_stream_config = self.get_incremental_stream_config(google_api, config, tz=time_zone)
 
         streams = [
             AdGroupAds(**incremental_stream_config),

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -29,6 +29,7 @@ from .streams import (
     KeywordReport,
     ShoppingPerformanceReport,
     UserLocationReport,
+    AccountsFullRefresh,
 )
 
 
@@ -47,7 +48,7 @@ class SourceGoogleAds(AbstractSource):
 
     @staticmethod
     def get_account_info(google_api) -> dict:
-        accounts_streams = Accounts(api=google_api)
+        accounts_streams = AccountsFullRefresh(api=google_api)
         for stream_slice in accounts_streams.stream_slices(sync_mode=SyncMode.full_refresh):
             return next(accounts_streams.read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice), {})
 
@@ -107,10 +108,10 @@ class SourceGoogleAds(AbstractSource):
         )
 
         streams = [
-            AdGroupAds(api=google_api),
-            AdGroups(api=google_api),
-            Accounts(api=google_api),
-            Campaigns(api=google_api),
+            AdGroupAds(**incremental_stream_config),
+            AdGroups(**incremental_stream_config),
+            Accounts(**incremental_stream_config),
+            Campaigns(**incremental_stream_config),
             ClickView(**incremental_stream_config),
         ]
 

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -46,7 +46,7 @@ class SourceGoogleAds(AbstractSource):
         return credentials
 
     @staticmethod
-    def get_incremental_stream_config(google_api, config, tz="local"):
+    def get_incremental_stream_config(google_api: GoogleAds, config: Mapping[str, Any], tz: Union[timezone, str] = "local"):
         incremental_stream_config = dict(
             api=google_api,
             conversion_window_days=config["conversion_window_days"],
@@ -56,7 +56,7 @@ class SourceGoogleAds(AbstractSource):
         )
         return incremental_stream_config
 
-    def get_account_info(self, google_api, config) -> dict:
+    def get_account_info(self, google_api: GoogleAds, config: Mapping[str, Any]) -> dict:
         incremental_stream_config = self.get_incremental_stream_config(google_api, config)
         accounts_streams = Accounts(**incremental_stream_config)
         for stream_slice in accounts_streams.stream_slices(sync_mode=SyncMode.full_refresh):

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
@@ -223,18 +223,6 @@ class Accounts(IncrementalGoogleAdsStream):
     primary_key = "customer.id"
 
 
-class AccountsFullRefresh(GoogleAdsStream):
-    """
-    Accounts stream: https://developers.google.com/google-ads/api/fields/v8/customer
-    """
-
-    primary_key = "customer.id"
-
-    @property
-    def name(self):
-        return "accounts"
-
-
 class Campaigns(IncrementalGoogleAdsStream):
     """
     Campaigns stream: https://developers.google.com/google-ads/api/fields/v8/campaign

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
@@ -306,5 +306,6 @@ class ClickView(IncrementalGoogleAdsStream):
     ClickView stream: https://developers.google.com/google-ads/api/reference/rpc/v8/ClickView
     """
 
+    primary_key = ["click_view.gclid", "segments.date"]
     days_of_data_storage = 90
     range_days = 1

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
@@ -220,7 +220,7 @@ class Accounts(IncrementalGoogleAdsStream):
     Accounts stream: https://developers.google.com/google-ads/api/fields/v8/customer
     """
 
-    primary_key = "customer.id"
+    primary_key = ["customer.id", "segments.date"]
 
 
 class Campaigns(IncrementalGoogleAdsStream):
@@ -228,7 +228,7 @@ class Campaigns(IncrementalGoogleAdsStream):
     Campaigns stream: https://developers.google.com/google-ads/api/fields/v8/campaign
     """
 
-    primary_key = "campaign.id"
+    primary_key = ["campaign.id", "segments.date"]
 
 
 class AdGroups(IncrementalGoogleAdsStream):
@@ -236,7 +236,7 @@ class AdGroups(IncrementalGoogleAdsStream):
     AdGroups stream: https://developers.google.com/google-ads/api/fields/v8/ad_group
     """
 
-    primary_key = "ad_group.id"
+    primary_key = ["ad_group.id", "segments.date"]
 
 
 class AdGroupAds(IncrementalGoogleAdsStream):
@@ -244,7 +244,7 @@ class AdGroupAds(IncrementalGoogleAdsStream):
     AdGroups stream: https://developers.google.com/google-ads/api/fields/v8/ad_group_ad
     """
 
-    primary_key = "ad_group_ad.ad.id"
+    primary_key = ["ad_group_ad.ad.id", "segments.date"]
 
 
 class AccountPerformanceReport(IncrementalGoogleAdsStream):

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
@@ -215,7 +215,7 @@ class IncrementalGoogleAdsStream(GoogleAdsStream, ABC):
         return query
 
 
-class Accounts(GoogleAdsStream):
+class Accounts(IncrementalGoogleAdsStream):
     """
     Accounts stream: https://developers.google.com/google-ads/api/fields/v8/customer
     """
@@ -223,7 +223,19 @@ class Accounts(GoogleAdsStream):
     primary_key = "customer.id"
 
 
-class Campaigns(GoogleAdsStream):
+class AccountsFullRefresh(GoogleAdsStream):
+    """
+    Accounts stream: https://developers.google.com/google-ads/api/fields/v8/customer
+    """
+
+    primary_key = "customer.id"
+
+    @property
+    def name(self):
+        return "accounts"
+
+
+class Campaigns(IncrementalGoogleAdsStream):
     """
     Campaigns stream: https://developers.google.com/google-ads/api/fields/v8/campaign
     """
@@ -231,7 +243,7 @@ class Campaigns(GoogleAdsStream):
     primary_key = "campaign.id"
 
 
-class AdGroups(GoogleAdsStream):
+class AdGroups(IncrementalGoogleAdsStream):
     """
     AdGroups stream: https://developers.google.com/google-ads/api/fields/v8/ad_group
     """
@@ -239,7 +251,7 @@ class AdGroups(GoogleAdsStream):
     primary_key = "ad_group.id"
 
 
-class AdGroupAds(GoogleAdsStream):
+class AdGroupAds(IncrementalGoogleAdsStream):
     """
     AdGroups stream: https://developers.google.com/google-ads/api/fields/v8/ad_group_ad
     """

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -102,6 +102,7 @@ This source is constrained by whatever API limits are set for the Google Ads tha
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| `0.1.27` | 2022-02-16 | [10315](https://github.com/airbytehq/airbyte/pull/10315) | Make `ad_group_ads` and other streams support incremental sync. |
 | `0.1.26` | 2022-02-11 | [10150](https://github.com/airbytehq/airbyte/pull/10150) | Add support for multiple customer IDs. |
 | `0.1.25` | 2022-02-04 | [9812](https://github.com/airbytehq/airbyte/pull/9812) | Handle `EXPIRED_PAGE_TOKEN` exception and retry with updated state. |
 | `0.1.24` | 2022-02-04 | [9996](https://github.com/airbytehq/airbyte/pull/9996) | Use Google Ads API version V9. |


### PR DESCRIPTION
## What
Resolves [#103](https://github.com/airbytehq/oncall/issues/103)
In the logs provided [here](https://github.com/airbytehq/oncall/issues/103#issuecomment-1035018564) I see that when reading `ad_group_ads` stream page token has expired, because currently filtering by `segments.date` is not implemented for this stream.

## How
Make streams: `ad_group_ads`, `ad_groups`, `accounts`, `campaigns` support incremental.

One thing to note, when filtering by `segments.date` records returned from stream `ad_group_ad` might be duplicated, this is discussed in the resources below:
[link1](https://groups.google.com/g/adwords-api/c/ZducYAR2gSo)
[link2](https://stackoverflow.com/questions/70570254/does-the-google-ads-ad-group-ad-has-an-unique-atribute)

## Recommended reading order 
1. `source_google_ads/streams.py`
2. `source_google_ads/source.py`

