### PR TITLE
Jamakase/select default sync modes

### DIFF
--- a/airbyte-webapp/src/components/Markdown/__mocks__/Markdown.tsx
+++ b/airbyte-webapp/src/components/Markdown/__mocks__/Markdown.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function ReactMarkdown({ children }: React.PropsWithChildren<unknown>) {
+  return <>{children}</>;
+}
+
+export default ReactMarkdown;

--- a/airbyte-webapp/src/components/Markdown/__mocks__/index.ts
+++ b/airbyte-webapp/src/components/Markdown/__mocks__/index.ts
@@ -1,0 +1,1 @@
+export { default as Markdown } from "./Markdown";

--- a/airbyte-webapp/src/core/domain/catalog/api.ts
+++ b/airbyte-webapp/src/core/domain/catalog/api.ts
@@ -19,7 +19,7 @@ export enum DestinationSyncMode {
   Dedupted = "append_dedup",
 }
 
-export type SyncSchemaStreamInner = {
+export type AirbyteSchemaStream = {
   stream: AirbyteStream;
   config: AirbyteStreamConfiguration;
 };
@@ -52,6 +52,10 @@ export type AirbyteStreamConfiguration = {
 
 export type SyncSchema = {
   streams: SyncSchemaStream[];
+};
+
+export type AirbyteSyncSchema = {
+  streams: AirbyteSchemaStream[];
 };
 
 export type Path = string[];

--- a/airbyte-webapp/src/setupTests.tsx
+++ b/airbyte-webapp/src/setupTests.tsx
@@ -4,3 +4,13 @@
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
 import "@testing-library/jest-dom";
+import React from "react";
+
+// hack to fix tests. https://github.com/remarkjs/react-markdown/issues/635
+jest.mock(
+  "components/Markdown",
+  () =>
+    function ReactMarkdown({ children }: React.PropsWithChildren<unknown>) {
+      return <>{children}</>;
+    }
+);

--- a/airbyte-webapp/src/setupTests.tsx
+++ b/airbyte-webapp/src/setupTests.tsx
@@ -4,13 +4,6 @@
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
 import "@testing-library/jest-dom";
-import React from "react";
 
 // hack to fix tests. https://github.com/remarkjs/react-markdown/issues/635
-jest.mock(
-  "components/Markdown",
-  () =>
-    function ReactMarkdown({ children }: React.PropsWithChildren<unknown>) {
-      return <>{children}</>;
-    }
-);
+jest.mock("components/Markdown");

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.tsx
@@ -30,7 +30,7 @@ import {
 import { OperationsSection } from "./components/OperationsSection";
 
 const EditLaterMessage = styled(Label)`
-  margin: -20px 0 29px;
+  margin: 20px 0 29px;
 `;
 
 const ConnectorLabel = styled(ControlLabels)`

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/formConfig.test.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/formConfig.test.tsx
@@ -1,0 +1,358 @@
+import {
+  AirbyteStreamConfiguration,
+  DestinationSyncMode,
+  SyncMode,
+} from "core/domain/catalog";
+import { calculateInitialCatalog } from "./formConfig";
+
+describe("calculateInitialCatalog", () => {
+  it("should assign ids to all streams", () => {
+    const values = calculateInitialCatalog(
+      {
+        streams: [
+          {
+            stream: {
+              sourceDefinedCursor: null,
+              defaultCursorField: [],
+              sourceDefinedPrimaryKey: [],
+              jsonSchema: {},
+              name: "name",
+              supportedSyncModes: [],
+            },
+            config: {
+              destinationSyncMode: DestinationSyncMode.Overwrite,
+              selected: false,
+              syncMode: SyncMode.FullRefresh,
+              cursorField: [],
+              primaryKey: [],
+              aliasName: "",
+            },
+          },
+        ],
+      },
+      {
+        connectionSpecification: {},
+        destinationDefinitionId: "",
+        documentationUrl: "",
+        supportsDbt: false,
+        supportsNormalization: false,
+        supportedDestinationSyncModes: [],
+      },
+      false
+    );
+
+    values.streams.forEach((stream) => {
+      expect(stream).toHaveProperty("id");
+    });
+  });
+
+  it("should select append_dedup if destination supports it", () => {
+    const values = calculateInitialCatalog(
+      {
+        streams: [
+          {
+            stream: {
+              sourceDefinedCursor: null,
+              defaultCursorField: [],
+              sourceDefinedPrimaryKey: [],
+              jsonSchema: {},
+              name: "name",
+              supportedSyncModes: [],
+            },
+            config: {
+              destinationSyncMode: DestinationSyncMode.Overwrite,
+              selected: false,
+              syncMode: SyncMode.FullRefresh,
+              cursorField: [],
+              primaryKey: [],
+              aliasName: "",
+            },
+          },
+          {
+            stream: {
+              sourceDefinedCursor: null,
+              defaultCursorField: [],
+              sourceDefinedPrimaryKey: [],
+              jsonSchema: {},
+              name: "name",
+              supportedSyncModes: [],
+            },
+            config: {
+              destinationSyncMode: DestinationSyncMode.Dedupted,
+              selected: false,
+              syncMode: SyncMode.FullRefresh,
+              cursorField: [],
+              primaryKey: [],
+              aliasName: "",
+            },
+          },
+          {
+            stream: {
+              sourceDefinedCursor: null,
+              defaultCursorField: [],
+              sourceDefinedPrimaryKey: [],
+              jsonSchema: {},
+              name: "name",
+              supportedSyncModes: [],
+            },
+            config: {
+              destinationSyncMode: DestinationSyncMode.Append,
+              selected: false,
+              syncMode: SyncMode.FullRefresh,
+              cursorField: [],
+              primaryKey: [],
+              aliasName: "",
+            },
+          },
+        ],
+      },
+      {
+        connectionSpecification: {},
+        destinationDefinitionId: "",
+        documentationUrl: "",
+        supportsDbt: false,
+        supportsNormalization: false,
+        supportedDestinationSyncModes: [DestinationSyncMode.Dedupted],
+      },
+      false
+    );
+
+    values.streams.forEach((stream) =>
+      expect(stream).toHaveProperty(
+        "config.destinationSyncMode",
+        DestinationSyncMode.Dedupted
+      )
+    );
+  });
+
+  it("should not change syncMode and destinationSyncMode in EditMode", () => {
+    const { streams } = calculateInitialCatalog(
+      {
+        streams: [
+          {
+            stream: {
+              sourceDefinedCursor: null,
+              defaultCursorField: [],
+              sourceDefinedPrimaryKey: [],
+              jsonSchema: {},
+              name: "name",
+              supportedSyncModes: [SyncMode.Incremental],
+            },
+            config: {
+              destinationSyncMode: DestinationSyncMode.Overwrite,
+              selected: false,
+              syncMode: SyncMode.FullRefresh,
+              cursorField: [],
+              primaryKey: [],
+              aliasName: "",
+            },
+          },
+        ],
+      },
+      {
+        connectionSpecification: {},
+        destinationDefinitionId: "",
+        documentationUrl: "",
+        supportsDbt: false,
+        supportsNormalization: false,
+        supportedDestinationSyncModes: [DestinationSyncMode.Dedupted],
+      },
+      true
+    );
+
+    expect(streams[0]).toHaveProperty("config.syncMode", SyncMode.FullRefresh);
+    expect(streams[0]).toHaveProperty(
+      "config.destinationSyncMode",
+      DestinationSyncMode.Overwrite
+    );
+  });
+
+  it("should prefer incremental sync mode", () => {
+    const { streams } = calculateInitialCatalog(
+      {
+        streams: [
+          {
+            stream: {
+              sourceDefinedCursor: null,
+              defaultCursorField: [],
+              sourceDefinedPrimaryKey: [],
+              jsonSchema: {},
+              name: "name",
+              supportedSyncModes: [SyncMode.Incremental],
+            },
+            config: {
+              destinationSyncMode: DestinationSyncMode.Overwrite,
+              selected: false,
+              syncMode: SyncMode.FullRefresh,
+              cursorField: [],
+              primaryKey: [],
+              aliasName: "",
+            },
+          },
+          {
+            stream: {
+              sourceDefinedCursor: null,
+              defaultCursorField: [],
+              sourceDefinedPrimaryKey: [],
+              jsonSchema: {},
+              name: "name",
+              supportedSyncModes: [SyncMode.Incremental, SyncMode.FullRefresh],
+            },
+            config: {
+              destinationSyncMode: DestinationSyncMode.Overwrite,
+              selected: false,
+              syncMode: SyncMode.FullRefresh,
+              cursorField: [],
+              primaryKey: [],
+              aliasName: "",
+            },
+          },
+          {
+            stream: {
+              sourceDefinedCursor: null,
+              defaultCursorField: [],
+              sourceDefinedPrimaryKey: [],
+              jsonSchema: {},
+              name: "name",
+              supportedSyncModes: [SyncMode.FullRefresh],
+            },
+            config: {
+              destinationSyncMode: DestinationSyncMode.Overwrite,
+              selected: false,
+              syncMode: SyncMode.FullRefresh,
+              cursorField: [],
+              primaryKey: [],
+              aliasName: "",
+            },
+          },
+        ],
+      },
+      {
+        connectionSpecification: {},
+        destinationDefinitionId: "",
+        documentationUrl: "",
+        supportsDbt: false,
+        supportsNormalization: false,
+        supportedDestinationSyncModes: [DestinationSyncMode.Dedupted],
+      },
+      false
+    );
+
+    expect(streams[0]).toHaveProperty("config.syncMode", SyncMode.Incremental);
+    expect(streams[1]).toHaveProperty("config.syncMode", SyncMode.Incremental);
+    expect(streams[2]).toHaveProperty("config.syncMode", SyncMode.FullRefresh);
+  });
+
+  it("should assign default value cursorField when it is available and no cursorField is selected", () => {
+    const { streams } = calculateInitialCatalog(
+      {
+        streams: [
+          {
+            stream: {
+              sourceDefinedCursor: null,
+              defaultCursorField: ["default_path"],
+              sourceDefinedPrimaryKey: [],
+              jsonSchema: {},
+              name: "name",
+              supportedSyncModes: [SyncMode.Incremental],
+            },
+            config: {
+              syncMode: SyncMode.FullRefresh,
+              destinationSyncMode: DestinationSyncMode.Overwrite,
+              selected: false,
+              cursorField: [],
+              primaryKey: [],
+              aliasName: "",
+            },
+          },
+          {
+            stream: {
+              sourceDefinedCursor: null,
+              defaultCursorField: ["default_path"],
+              sourceDefinedPrimaryKey: [],
+              jsonSchema: {},
+              name: "name",
+              supportedSyncModes: [SyncMode.Incremental],
+            },
+            config: {
+              syncMode: SyncMode.FullRefresh,
+              destinationSyncMode: DestinationSyncMode.Overwrite,
+              selected: false,
+              cursorField: ["selected_path"],
+              primaryKey: [],
+              aliasName: "",
+            },
+          },
+          {
+            stream: {
+              sourceDefinedCursor: null,
+              defaultCursorField: [],
+              sourceDefinedPrimaryKey: [],
+              jsonSchema: {},
+              name: "name",
+              supportedSyncModes: [SyncMode.FullRefresh],
+            },
+            config: {
+              syncMode: SyncMode.FullRefresh,
+              destinationSyncMode: DestinationSyncMode.Overwrite,
+              selected: false,
+              cursorField: [],
+              primaryKey: [],
+              aliasName: "",
+            },
+          },
+        ],
+      },
+      {
+        connectionSpecification: {},
+        destinationDefinitionId: "",
+        documentationUrl: "",
+        supportsDbt: false,
+        supportsNormalization: false,
+        supportedDestinationSyncModes: [DestinationSyncMode.Dedupted],
+      },
+      false
+    );
+
+    expect(streams[0]).toHaveProperty("config.cursorField", ["default_path"]);
+    expect(streams[1]).toHaveProperty("config.cursorField", ["selected_path"]);
+    expect(streams[2]).toHaveProperty("config.cursorField", []);
+  });
+
+  it("should pick first syncMode when it is somehow nullable", () => {
+    const { streams } = calculateInitialCatalog(
+      {
+        streams: [
+          {
+            stream: {
+              sourceDefinedCursor: null,
+              defaultCursorField: [],
+              sourceDefinedPrimaryKey: [],
+              jsonSchema: {},
+              name: "name",
+              supportedSyncModes: [SyncMode.FullRefresh],
+            },
+            config: ({
+              destinationSyncMode: DestinationSyncMode.Overwrite,
+              selected: false,
+              cursorField: [],
+              primaryKey: [],
+              aliasName: "",
+            } as unknown) as AirbyteStreamConfiguration,
+          },
+        ],
+      },
+      {
+        connectionSpecification: {},
+        destinationDefinitionId: "",
+        documentationUrl: "",
+        supportsDbt: false,
+        supportsNormalization: false,
+        supportedDestinationSyncModes: [DestinationSyncMode.Dedupted],
+      },
+      false
+    );
+
+    expect(streams[0]).toHaveProperty("config.syncMode", SyncMode.FullRefresh);
+  });
+});

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/formConfig.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/formConfig.tsx
@@ -5,6 +5,7 @@ import { setIn } from "formik";
 
 import {
   AirbyteStreamConfiguration,
+  AirbyteSyncSchema,
   DestinationSyncMode,
   SyncMode,
   SyncSchema,
@@ -204,64 +205,59 @@ function getDefaultCursorField(streamNode: SyncSchemaStream): string[] {
   return streamNode.config.cursorField;
 }
 
-const useInitialSchema = (
-  schema: SyncSchema,
+const calculateInitialCatalog = (
+  schema: AirbyteSyncSchema,
   destDefinition: DestinationDefinitionSpecification,
   isEditMode?: boolean
-): SyncSchema =>
-  useMemo<SyncSchema>(
-    () => ({
-      streams: schema.streams.map<SyncSchemaStream>((apiNode, id) => {
-        const nodeWithId: SyncSchemaStream = { ...apiNode, id: id.toString() };
+): SyncSchema => ({
+  streams: schema.streams.map<SyncSchemaStream>((apiNode, id) => {
+    const nodeWithId: SyncSchemaStream = { ...apiNode, id: id.toString() };
 
-        // If the value in supportedSyncModes is empty assume the only supported sync mode is FULL_REFRESH.
-        // Otherwise, it supports whatever sync modes are present.
-        const streamNode = nodeWithId.stream.supportedSyncModes?.length
-          ? nodeWithId
-          : setIn(nodeWithId, "stream.supportedSyncModes", [
-              SyncMode.FullRefresh,
-            ]);
+    // If the value in supportedSyncModes is empty assume the only supported sync mode is FULL_REFRESH.
+    // Otherwise, it supports whatever sync modes are present.
+    const streamNode = nodeWithId.stream.supportedSyncModes?.length
+      ? nodeWithId
+      : setIn(nodeWithId, "stream.supportedSyncModes", [SyncMode.FullRefresh]);
 
-        // If syncMode isn't null and we are in create mode - don't change item
-        if (streamNode.config.syncMode && isEditMode) {
-          return streamNode;
-        }
+    // If syncMode isn't null and we are in create mode - don't change item
+    // According to types syncMode is a non-null field, but it is a legacy check for older versions
+    if (streamNode.config.syncMode && isEditMode) {
+      return streamNode;
+    }
 
-        const updatedConfig: AirbyteStreamConfiguration = {
-          ...streamNode.config,
-        };
+    const updatedConfig: AirbyteStreamConfiguration = {
+      ...streamNode.config,
+    };
 
-        if (
-          destDefinition.supportedDestinationSyncModes.includes(
-            DestinationSyncMode.Dedupted
-          )
-        ) {
-          updatedConfig.destinationSyncMode = DestinationSyncMode.Dedupted;
-        }
+    if (
+      destDefinition.supportedDestinationSyncModes.includes(
+        DestinationSyncMode.Dedupted
+      )
+    ) {
+      updatedConfig.destinationSyncMode = DestinationSyncMode.Dedupted;
+    }
 
-        const supportedSyncModes = streamNode.stream.supportedSyncModes;
+    const supportedSyncModes = streamNode.stream.supportedSyncModes;
 
-        // Prefer INCREMENTAL sync mode over other sync modes
-        if (supportedSyncModes.includes(SyncMode.Incremental)) {
-          updatedConfig.syncMode = SyncMode.Incremental;
-          updatedConfig.cursorField = streamNode.config.cursorField.length
-            ? streamNode.config.cursorField
-            : getDefaultCursorField(streamNode);
-        }
+    // Prefer INCREMENTAL sync mode over other sync modes
+    if (supportedSyncModes.includes(SyncMode.Incremental)) {
+      updatedConfig.syncMode = SyncMode.Incremental;
+      updatedConfig.cursorField = streamNode.config.cursorField.length
+        ? streamNode.config.cursorField
+        : getDefaultCursorField(streamNode);
+    }
 
-        // If source syncMode is somehow nullable - just pick one from supportedSyncModes
-        if (!updatedConfig.syncMode) {
-          updatedConfig.syncMode = streamNode.stream.supportedSyncModes[0];
-        }
+    // If source syncMode is somehow nullable - just pick one from supportedSyncModes
+    if (!updatedConfig.syncMode) {
+      updatedConfig.syncMode = streamNode.stream.supportedSyncModes[0];
+    }
 
-        return {
-          ...streamNode,
-          config: updatedConfig,
-        };
-      }),
-    }),
-    [schema.streams, destDefinition, isEditMode]
-  );
+    return {
+      ...streamNode,
+      config: updatedConfig,
+    };
+  }),
+});
 
 const getInitialTransformations = (operations: Operation[]): Transformation[] =>
   operations.filter(isDbtTransformation);
@@ -289,10 +285,14 @@ const useInitialValues = (
   destDefinition: DestinationDefinitionSpecification,
   isEditMode?: boolean
 ): FormikConnectionFormValues => {
-  const initialSchema = useInitialSchema(
-    connection.syncCatalog,
-    destDefinition,
-    isEditMode
+  const initialSchema = useMemo(
+    () =>
+      calculateInitialCatalog(
+        connection.syncCatalog,
+        destDefinition,
+        isEditMode
+      ),
+    [connection.syncCatalog, destDefinition, isEditMode]
   );
 
   return useMemo(() => {
@@ -350,6 +350,7 @@ const useFrequencyDropdownData = (): DropDownRow.IDataItem[] => {
 export type { ConnectionFormValues, FormikConnectionFormValues };
 export {
   connectionValidationSchema,
+  calculateInitialCatalog,
   useInitialValues,
   useFrequencyDropdownData,
   mapFormPropsToOperation,

--- a/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.test.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import userEvent from "@testing-library/user-event";
 import { getByTestId, screen, waitFor } from "@testing-library/react";
 import selectEvent from "react-select-event";
@@ -7,15 +6,6 @@ import ServiceForm from "views/Connector/ServiceForm";
 import { render } from "utils/testutils";
 import { ServiceFormValues } from "./types";
 import { AirbyteJSONSchema } from "core/jsonSchema";
-
-// hack to fix tests. https://github.com/remarkjs/react-markdown/issues/635
-jest.mock(
-  "components/Markdown",
-  () =>
-    function ReactMarkdown({ children }: React.PropsWithChildren<unknown>) {
-      return <>{children}</>;
-    }
-);
 
 jest.setTimeout(10000);
 


### PR DESCRIPTION
## What
Closes #9625 

## How
In create mode, we will try to set next values for sync mode by default:

```
If there is a source-defined cursor on a stream, the best sync modes, in order, are:

append dedupe
append
If there is no cursor defined:

full refresh overwrite
```