### PR TITLE
📚 Fix invalid link to Sentry website

### DIFF
--- a/docs/operator-guides/sentry-integration.md
+++ b/docs/operator-guides/sentry-integration.md
@@ -1,6 +1,6 @@
 # Sentry Integration
 
-Airbyte provides an opportunity to aggregate connectors' exceptions and errors via [Sentry](https://https://sentry.io/).
+Airbyte provides an opportunity to aggregate connectors' exceptions and errors via [Sentry](https://sentry.io).
 By default, this option is off. There are 2 possible mechanisms for its activation:
 1. Define the `SENTRY_DSN` environment variable into Dockerfile of necessary connectors.
 2. Define the `SENTRY_DSN` into the workspace environment file (`.env`). Workers will add this variable to all docker connectors automatically.


### PR DESCRIPTION
## What
Link to Sentry website in documentation was invalid (double https:// )

## How
Just removed the double https:// in link
