### PR TITLE
Accelerate snowflake integration test

### DIFF
--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -791,10 +791,11 @@ public abstract class DestinationAcceptanceTest {
       throw new WorkerException("dbt test Failed.");
     }
     // 6. Generate dbt documentation for the project:
-    dbtConfig.withDbtArguments("docs generate");
-    if (!runner.transform(JOB_ID, JOB_ATTEMPT, transformationRoot, config, null, dbtConfig)) {
-      throw new WorkerException("dbt docs generate Failed.");
-    }
+    // This step is commented out because it can take a very long time to run, and is not vital for Airbyte
+    // dbtConfig.withDbtArguments("docs generate");
+    // if (!runner.transform(JOB_ID, JOB_ATTEMPT, transformationRoot, config, null, dbtConfig)) {
+    //   throw new WorkerException("dbt docs generate Failed.");
+    // }
     runner.close();
   }
 

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -791,10 +791,10 @@ public abstract class DestinationAcceptanceTest {
       throw new WorkerException("dbt test Failed.");
     }
     // 6. Generate dbt documentation for the project:
-    // This step is commented out because it can take a very long time to run, and is not vital for Airbyte
+    // This step is commented out because it takes a long time, but is not vital for Airbyte
     // dbtConfig.withDbtArguments("docs generate");
     // if (!runner.transform(JOB_ID, JOB_ATTEMPT, transformationRoot, config, null, dbtConfig)) {
-    //   throw new WorkerException("dbt docs generate Failed.");
+    // throw new WorkerException("dbt docs generate Failed.");
     // }
     runner.close();
   }

--- a/airbyte-integrations/connectors/source-snowflake/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SnowflakeSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-snowflake/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SnowflakeSourceAcceptanceTest.java
@@ -24,10 +24,12 @@ import io.airbyte.protocol.models.JsonSchemaType;
 import io.airbyte.protocol.models.SyncMode;
 import java.nio.file.Path;
 import java.util.HashMap;
+import org.apache.commons.lang3.RandomStringUtils;
 
 public class SnowflakeSourceAcceptanceTest extends SourceAcceptanceTest {
 
-  private static final String SCHEMA_NAME = "SOURCE_INTEGRATION_TEST";
+  private static final String SCHEMA_NAME = "SOURCE_INTEGRATION_TEST_"
+      + RandomStringUtils.randomAlphanumeric(4).toUpperCase();
   private static final String STREAM_NAME1 = "ID_AND_NAME1";
   private static final String STREAM_NAME2 = "ID_AND_NAME2";
 
@@ -99,7 +101,7 @@ public class SnowflakeSourceAcceptanceTest extends SourceAcceptanceTest {
             config.get("warehouse").asText(),
             config.get("database").asText()));
 
-    final String createSchemaQuery = String.format("CREATE SCHEMA %s", SCHEMA_NAME);
+    final String createSchemaQuery = String.format("CREATE SCHEMA IF NOT EXISTS %s", SCHEMA_NAME);
     final String createTableQuery1 = String
         .format("CREATE OR REPLACE TABLE %s.%s (ID INTEGER, NAME VARCHAR(200))", SCHEMA_NAME,
             STREAM_NAME1);

--- a/airbyte-integrations/connectors/source-snowflake/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SnowflakeSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-snowflake/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/SnowflakeSourceDatatypeTest.java
@@ -15,11 +15,13 @@ import io.airbyte.integrations.standardtest.source.TestDataHolder;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
 import io.airbyte.protocol.models.JsonSchemaType;
 import java.nio.file.Path;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.jooq.SQLDialect;
 
 public class SnowflakeSourceDatatypeTest extends AbstractSourceDatabaseTypeTest {
 
-  private static final String SCHEMA_NAME = "TEST";
+  private static final String SCHEMA_NAME = "SOURCE_DATA_TYPE_TEST_"
+      + RandomStringUtils.randomAlphanumeric(4).toUpperCase();
   private static final String INSERT_SEMI_STRUCTURED_SQL = "INSERT INTO %1$s (ID, TEST_COLUMN) SELECT %2$s, %3$s";
 
   private JsonNode config;
@@ -41,7 +43,7 @@ public class SnowflakeSourceDatatypeTest extends AbstractSourceDatabaseTypeTest 
 
     database = getDatabase();
 
-    final String createSchemaQuery = String.format("CREATE SCHEMA %s", SCHEMA_NAME);
+    final String createSchemaQuery = String.format("CREATE SCHEMA IF NOT EXISTS %s", SCHEMA_NAME);
     database.query(ctx -> ctx.fetch(createSchemaQuery));
     return database;
   }


### PR DESCRIPTION
- Turn off dbt doc generation saves 15 minutes for each test run.
- Fix snowflake source destination test by using a different schema each time.
