### PR TITLE
Remove the use of ConfigPersistence for ActorCatalog operation

### DIFF
--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -669,8 +669,8 @@ public class ConfigRepository {
         .set(ACTOR_CATALOG.ID, catalogId)
         .set(ACTOR_CATALOG.CATALOG, JSONB.valueOf(Jsons.serialize(airbyteCatalog)))
         .set(ACTOR_CATALOG.CATALOG_HASH, catalogHash)
-        .set(ACTOR_CATALOG_FETCH_EVENT.CREATED_AT, timestamp)
-        .set(ACTOR_CATALOG_FETCH_EVENT.MODIFIED_AT, timestamp).execute();
+        .set(ACTOR_CATALOG.CREATED_AT, timestamp)
+        .set(ACTOR_CATALOG.MODIFIED_AT, timestamp).execute();
     return catalogId;
   }
 

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -650,6 +650,16 @@ public class ConfigRepository {
     return result;
   }
 
+  /**
+   * Store an Airbyte catalog in DB if it is not present already
+   *
+   * Checks in the config DB if the catalog is present already, if so returns it identifier. It is
+   * not present, it is inserted in DB with a new identifier and that identifier is returned.
+   *
+   * @param airbyteCatalog An Airbyte catalog to cache
+   * @param context
+   * @return the db identifier for the cached catalog.
+   */
   private UUID getOrInsertActorCatalog(final AirbyteCatalog airbyteCatalog,
                                        final DSLContext context) {
     final OffsetDateTime timestamp = OffsetDateTime.now();
@@ -694,6 +704,24 @@ public class ConfigRepository {
 
   }
 
+  /**
+   * Stores source catalog information.
+   *
+   * This function is called each time the schema of a source is fetched. This can occur because
+   * the source is set up for the first time, because the configuration or version of the connector
+   * changed or because the user explicitly requested a schema refresh.
+   * Schemas are stored separately and de-duplicated upon insertion.
+   * Once a schema has been successfully stored, a call to getActorCatalog(sourceId,
+   * connectionVersion, configurationHash) will return the most recent schema stored for those
+   * parameters.
+   *
+   * @param catalog
+   * @param sourceId
+   * @param connectorVersion
+   * @param configurationHash
+   * @return The identifier (UUID) of the fetch event inserted in the database
+   * @throws IOException
+   */
   public UUID writeActorCatalogFetchEvent(final AirbyteCatalog catalog,
                                           final UUID sourceId,
                                           final String connectorVersion,

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -711,19 +711,19 @@ public class ConfigRepository {
    * the source is set up for the first time, because the configuration or version of the connector
    * changed or because the user explicitly requested a schema refresh.
    * Schemas are stored separately and de-duplicated upon insertion.
-   * Once a schema has been successfully stored, a call to getActorCatalog(sourceId,
+   * Once a schema has been successfully stored, a call to getActorCatalog(actorId,
    * connectionVersion, configurationHash) will return the most recent schema stored for those
    * parameters.
    *
    * @param catalog
-   * @param sourceId
+   * @param actorId
    * @param connectorVersion
    * @param configurationHash
    * @return The identifier (UUID) of the fetch event inserted in the database
    * @throws IOException
    */
   public UUID writeActorCatalogFetchEvent(final AirbyteCatalog catalog,
-                                          final UUID sourceId,
+                                          final UUID actorId,
                                           final String connectorVersion,
                                           final String configurationHash)
       throws IOException {
@@ -733,7 +733,7 @@ public class ConfigRepository {
       final UUID catalogId = getOrInsertActorCatalog(catalog, ctx);
       return ctx.insertInto(ACTOR_CATALOG_FETCH_EVENT)
           .set(ACTOR_CATALOG_FETCH_EVENT.ID, fetchEventID)
-          .set(ACTOR_CATALOG_FETCH_EVENT.ACTOR_ID, sourceId)
+          .set(ACTOR_CATALOG_FETCH_EVENT.ACTOR_ID, actorId)
           .set(ACTOR_CATALOG_FETCH_EVENT.ACTOR_CATALOG_ID, catalogId)
           .set(ACTOR_CATALOG_FETCH_EVENT.CONFIG_HASH, configurationHash)
           .set(ACTOR_CATALOG_FETCH_EVENT.ACTOR_VERSION, connectorVersion)

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -683,12 +683,10 @@ public class ConfigRepository {
         .on(ACTOR_CATALOG.ID.eq(ACTOR_CATALOG_FETCH_EVENT.ACTOR_CATALOG_ID))
         .where(ACTOR_CATALOG_FETCH_EVENT.ACTOR_ID.eq(actorId))
         .and(ACTOR_CATALOG_FETCH_EVENT.ACTOR_VERSION.eq(actorVersion))
-        .and(ACTOR_CATALOG_FETCH_EVENT.CONFIG_HASH.eq(configHash))).fetch();
+        .and(ACTOR_CATALOG_FETCH_EVENT.CONFIG_HASH.eq(configHash))
+        .orderBy(ACTOR_CATALOG_FETCH_EVENT.CREATED_AT.desc()).limit(1)).fetch();
 
-    if (records.size() > 1) {
-      throw new IllegalStateException(
-          String.format("Multiple catalog stored for ActorId=%s,ActorVersion=%s,ConfigHash=%s", actorId.toString(), actorVersion, configHash));
-    } else if (records.size() == 1) {
+    if (records.size() >= 1) {
       final JSONB record = records.get(0).get(ACTOR_CATALOG.CATALOG);
       return Optional.of(Jsons.deserialize(record.toString(), AirbyteCatalog.class));
     }

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -653,8 +653,8 @@ public class ConfigRepository {
   /**
    * Store an Airbyte catalog in DB if it is not present already
    *
-   * Checks in the config DB if the catalog is present already, if so returns it identifier. It is
-   * not present, it is inserted in DB with a new identifier and that identifier is returned.
+   * Checks in the config DB if the catalog is present already, if so returns it identifier. It is not
+   * present, it is inserted in DB with a new identifier and that identifier is returned.
    *
    * @param airbyteCatalog An Airbyte catalog to cache
    * @param context
@@ -707,13 +707,12 @@ public class ConfigRepository {
   /**
    * Stores source catalog information.
    *
-   * This function is called each time the schema of a source is fetched. This can occur because
-   * the source is set up for the first time, because the configuration or version of the connector
-   * changed or because the user explicitly requested a schema refresh.
-   * Schemas are stored separately and de-duplicated upon insertion.
-   * Once a schema has been successfully stored, a call to getActorCatalog(actorId,
-   * connectionVersion, configurationHash) will return the most recent schema stored for those
-   * parameters.
+   * This function is called each time the schema of a source is fetched. This can occur because the
+   * source is set up for the first time, because the configuration or version of the connector
+   * changed or because the user explicitly requested a schema refresh. Schemas are stored separately
+   * and de-duplicated upon insertion. Once a schema has been successfully stored, a call to
+   * getActorCatalog(actorId, connectionVersion, configurationHash) will return the most recent schema
+   * stored for those parameters.
    *
    * @param catalog
    * @param actorId

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -5,6 +5,8 @@
 package io.airbyte.config.persistence;
 
 import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR;
+import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR_CATALOG;
+import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR_CATALOG_FETCH_EVENT;
 import static io.airbyte.db.instance.configs.jooq.Tables.CONNECTION;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -41,6 +43,7 @@ import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -53,6 +56,11 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jooq.JSONB;
+import org.jooq.Record;
+import org.jooq.Record1;
+import org.jooq.Record2;
+import org.jooq.Result;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -627,35 +635,86 @@ public class ConfigRepository {
     return actorCatalogs;
   }
 
-  public void writeCatalog(final AirbyteCatalog catalog,
-                           final UUID sourceId,
-                           final String configurationHash,
-                           final String connectorVersion)
-      throws JsonValidationException, IOException {
+  public Map<UUID, AirbyteCatalog> findCatalogByHash(final String catalogHash) throws IOException {
+    final Result<Record2<UUID, JSONB>> records = database.transaction(ctx -> ctx.select(ACTOR_CATALOG.ID, ACTOR_CATALOG.CATALOG)
+        .from(ACTOR_CATALOG)
+        .where(ACTOR_CATALOG.CATALOG_HASH.eq(catalogHash))).fetch();
+
+    final Map<UUID, AirbyteCatalog> result = new HashMap<>();
+    for (final Record record : records) {
+      final AirbyteCatalog catalog = Jsons.deserialize(
+          record.get(ACTOR_CATALOG.CATALOG).toString(), AirbyteCatalog.class);
+      result.put(record.get(ACTOR_CATALOG.ID), catalog);
+    }
+    return result;
+  }
+
+  public Optional<AirbyteCatalog> getActorCatalog(final UUID actorId,
+                                                  final String actorVersion,
+                                                  final String configHash)
+      throws IOException {
+    final Result<Record1<JSONB>> records = database.transaction(ctx -> ctx.select(ACTOR_CATALOG.CATALOG)
+        .from(ACTOR_CATALOG).join(ACTOR_CATALOG_FETCH_EVENT)
+        .on(ACTOR_CATALOG.ID.eq(ACTOR_CATALOG_FETCH_EVENT.ACTOR_CATALOG_ID))
+        .where(ACTOR_CATALOG_FETCH_EVENT.ACTOR_ID.eq(actorId))
+        .and(ACTOR_CATALOG_FETCH_EVENT.ACTOR_VERSION.eq(actorVersion))
+        .and(ACTOR_CATALOG_FETCH_EVENT.CONFIG_HASH.eq(configHash))).fetch();
+
+    if (records.size() > 1) {
+      throw new IllegalStateException(
+          String.format("Multiple catalog stored for ActorId=%s,ActorVersion=%s,ConfigHash=%s", actorId.toString(), actorVersion, configHash));
+    } else if (records.size() == 1) {
+      final JSONB record = records.get(0).get(ACTOR_CATALOG.CATALOG);
+      return Optional.of(Jsons.deserialize(record.toString(), AirbyteCatalog.class));
+    }
+    return Optional.empty();
+
+  }
+
+  public UUID writeActorCatalog(final AirbyteCatalog airbyteCatalog) throws IOException {
+    final OffsetDateTime timestamp = OffsetDateTime.now();
+    final HashFunction hashFunction = Hashing.murmur3_32_fixed();
+    final UUID catalogId = UUID.randomUUID();
+    final String catalogHash = hashFunction.hashBytes(Jsons.serialize(airbyteCatalog).getBytes(
+        Charsets.UTF_8)).toString();
+    database.transaction(ctx -> ctx.insertInto(ACTOR_CATALOG)
+        .set(ACTOR_CATALOG.ID, catalogId)
+        .set(ACTOR_CATALOG.CATALOG, JSONB.valueOf(Jsons.serialize(airbyteCatalog)))
+        .set(ACTOR_CATALOG.CATALOG_HASH, catalogHash)
+        .set(ACTOR_CATALOG.CREATED_AT, timestamp)
+        .set(ACTOR_CATALOG.MODIFIED_AT, timestamp)).execute();
+    return catalogId;
+  }
+
+  public UUID writeActorCatalogFetchEvent(final AirbyteCatalog catalog,
+                                          final UUID sourceId,
+                                          final String connectorVersion,
+                                          final String configurationHash)
+      throws IOException {
+    final OffsetDateTime timestamp = OffsetDateTime.now();
     final HashFunction hashFunction = Hashing.murmur3_32_fixed();
     final String catalogHash = hashFunction.hashBytes(Jsons.serialize(catalog).getBytes(
         Charsets.UTF_8)).toString();
-    ActorCatalog actorCatalog = new ActorCatalog()
-        .withCatalog(Jsons.jsonNode(catalog))
-        .withId(UUID.randomUUID())
-        .withCatalogHash(catalogHash);
-    final Optional<ActorCatalog> existingCatalog = findExistingCatalog(actorCatalog);
-    if (existingCatalog.isPresent()) {
-      actorCatalog = existingCatalog.get();
-    } else {
-      persistence.writeConfig(ConfigSchema.ACTOR_CATALOG,
-          actorCatalog.getId().toString(),
-          actorCatalog);
+    final Map<UUID, AirbyteCatalog> catalogs = findCatalogByHash(catalogHash);
+    UUID existingCatalogId = null;
+    for (final Map.Entry<UUID, AirbyteCatalog> entry : catalogs.entrySet()) {
+      if (entry.getValue().equals(catalog)) {
+        existingCatalogId = entry.getKey();
+      }
     }
-    final ActorCatalogFetchEvent actorCatalogFetchEvent = new ActorCatalogFetchEvent()
-        .withActorCatalogId(actorCatalog.getId())
-        .withId(UUID.randomUUID())
-        .withConfigHash(configurationHash)
-        .withConnectorVersion(connectorVersion)
-        .withActorId(sourceId);
-    persistence.writeConfig(ConfigSchema.ACTOR_CATALOG_FETCH_EVENT,
-        actorCatalogFetchEvent.getId().toString(),
-        actorCatalogFetchEvent);
+
+    final UUID catalogId = existingCatalogId != null ? existingCatalogId : writeActorCatalog(catalog);
+    final UUID fetchEventID = UUID.randomUUID();
+    database.transaction(ctx -> ctx.insertInto(ACTOR_CATALOG_FETCH_EVENT)
+        .set(ACTOR_CATALOG_FETCH_EVENT.ID, fetchEventID)
+        .set(ACTOR_CATALOG_FETCH_EVENT.ACTOR_ID, sourceId)
+        .set(ACTOR_CATALOG_FETCH_EVENT.ACTOR_CATALOG_ID, catalogId)
+        .set(ACTOR_CATALOG_FETCH_EVENT.CONFIG_HASH, configurationHash)
+        .set(ACTOR_CATALOG_FETCH_EVENT.ACTOR_VERSION, connectorVersion)
+        .set(ACTOR_CATALOG_FETCH_EVENT.MODIFIED_AT, timestamp)
+        .set(ACTOR_CATALOG_FETCH_EVENT.CREATED_AT, timestamp)).execute();
+
+    return fetchEventID;
   }
 
   public int countConnectionsForWorkspace(final UUID workspaceId) throws IOException {


### PR DESCRIPTION
## What
The PR simplifies the access to the actor_catalog and actor_catalog_fetch_event tables and retrieve the information needed to cache and serve source schemas with more optimized queries

## How
This removes the use of ConfigPersistence in ConfigRepository and rely on SQL queries directly in that class.