### PR TITLE
add "internal use" caveat to interval configuration comments

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
@@ -297,35 +297,35 @@ public interface Configs {
   /**
    * Define the interval for checking for a Kubernetes pod status for a worker of an unspecified type.
    *
-   * In seconds if specified by environment variable.
+   * In seconds if specified by environment variable. Airbyte internal use only.
    */
   Duration getDefaultWorkerStatusCheckInterval();
 
   /**
    * Define the interval for checking for "get spec" Kubernetes pod statuses.
    *
-   * In seconds if specified by environment variable.
+   * In seconds if specified by environment variable. Airbyte internal use only.
    */
   Duration getSpecWorkerStatusCheckInterval();
 
   /**
    * Define the interval for checking for "check connection" Kubernetes pod statuses.
    *
-   * In seconds if specified by environment variable.
+   * In seconds if specified by environment variable. Airbyte internal use only.
    */
   Duration getCheckWorkerStatusCheckInterval();
 
   /**
    * Define the interval for checking for "discover" Kubernetes pod statuses.
    *
-   * In seconds if specified by environment variable.
+   * In seconds if specified by environment variable. Airbyte internal use only.
    */
   Duration getDiscoverWorkerStatusCheckInterval();
 
   /**
    * Define the interval for checking for "replication" Kubernetes pod statuses.
    *
-   * In seconds if specified by environment variable.
+   * In seconds if specified by environment variable. Airbyte internal use only.
    */
   Duration getReplicationWorkerStatusCheckInterval();
 


### PR DESCRIPTION
follows up on https://github.com/airbytehq/airbyte/pull/10368