### PR TITLE
refactor ConnectionHelper so that conversion logic can be shared

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -119,7 +119,6 @@ import io.airbyte.server.handlers.WorkspacesHandler;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.WorkerConfigs;
-import io.airbyte.workers.helper.ConnectionHelper;
 import io.airbyte.workers.worker_run.TemporalWorkerRunFactory;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.io.File;
@@ -192,14 +191,12 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
         jobNotifier,
         temporalService,
         new OAuthConfigSupplier(configRepository, trackingClient), workerEnvironment, logConfigs, temporalWorkerRunFactory);
-    final ConnectionHelper connectionHelper = new ConnectionHelper(configRepository, workspaceHelper, workerConfigs);
     connectionsHandler = new ConnectionsHandler(
         configRepository,
         workspaceHelper,
         trackingClient,
         temporalWorkerRunFactory,
         featureFlags,
-        connectionHelper,
         workerConfigs);
     sourceHandler = new SourceHandler(configRepository, schemaValidator, connectionsHandler);
     sourceDefinitionsHandler = new SourceDefinitionsHandler(configRepository, synchronousSchedulerClient, sourceHandler);
@@ -218,8 +215,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
         schedulerHandler,
         operationsHandler,
         featureFlags,
-        temporalWorkerRunFactory,
-        connectionHelper);
+        temporalWorkerRunFactory);
     healthCheckHandler = new HealthCheckHandler();
     archiveHandler = new ArchiveHandler(
         airbyteVersion,

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/ApiPojoConverters.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/ApiPojoConverters.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.server.converters;
+
+import io.airbyte.api.model.ConnectionRead;
+import io.airbyte.api.model.ConnectionSchedule;
+import io.airbyte.api.model.ConnectionStatus;
+import io.airbyte.api.model.ConnectionUpdate;
+import io.airbyte.api.model.ResourceRequirements;
+import io.airbyte.commons.enums.Enums;
+import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
+import io.airbyte.config.Schedule;
+import io.airbyte.config.StandardSync;
+import io.airbyte.workers.helper.CatalogConverter;
+
+public class ApiPojoConverters {
+
+  public static io.airbyte.config.ResourceRequirements resourceRequirementsToInternal(final ResourceRequirements resourceRequirements) {
+    return new io.airbyte.config.ResourceRequirements()
+        .withCpuRequest(resourceRequirements.getCpuRequest())
+        .withCpuLimit(resourceRequirements.getCpuLimit())
+        .withMemoryRequest(resourceRequirements.getMemoryRequest())
+        .withMemoryLimit(resourceRequirements.getMemoryLimit());
+  }
+
+  public static ResourceRequirements resourceRequirementsToApi(final io.airbyte.config.ResourceRequirements resourceRequirements) {
+    return new ResourceRequirements()
+        .cpuRequest(resourceRequirements.getCpuRequest())
+        .cpuLimit(resourceRequirements.getCpuLimit())
+        .memoryRequest(resourceRequirements.getMemoryRequest())
+        .memoryLimit(resourceRequirements.getMemoryLimit());
+  }
+
+  public static io.airbyte.config.StandardSync connectionUpdateToInternal(final ConnectionUpdate update) {
+
+    final StandardSync newConnection = new StandardSync()
+        .withNamespaceDefinition(Enums.convertTo(update.getNamespaceDefinition(), NamespaceDefinitionType.class))
+        .withNamespaceFormat(update.getNamespaceFormat())
+        .withPrefix(update.getPrefix())
+        .withOperationIds(update.getOperationIds())
+        .withCatalog(CatalogConverter.toProtocol(update.getSyncCatalog()))
+        .withStatus(toPersistenceStatus(update.getStatus()));
+
+    // update Resource Requirements
+    if (update.getResourceRequirements() != null) {
+      newConnection.withResourceRequirements(new io.airbyte.config.ResourceRequirements()
+          .withCpuRequest(update.getResourceRequirements().getCpuRequest())
+          .withCpuLimit(update.getResourceRequirements().getCpuLimit())
+          .withMemoryRequest(update.getResourceRequirements().getMemoryRequest())
+          .withMemoryLimit(update.getResourceRequirements().getMemoryLimit()));
+    }
+
+    // update sync schedule
+    if (update.getSchedule() != null) {
+      final Schedule newSchedule = new Schedule()
+          .withTimeUnit(toPersistenceTimeUnit(update.getSchedule().getTimeUnit()))
+          .withUnits(update.getSchedule().getUnits());
+      newConnection.withManual(false).withSchedule(newSchedule);
+    } else {
+      newConnection.withManual(true).withSchedule(null);
+    }
+
+    return newConnection;
+  }
+
+  public static ConnectionRead internalToConnectionRead(final StandardSync standardSync) {
+    ConnectionSchedule apiSchedule = null;
+
+    if (!standardSync.getManual()) {
+      apiSchedule = new ConnectionSchedule()
+          .timeUnit(toApiTimeUnit(standardSync.getSchedule().getTimeUnit()))
+          .units(standardSync.getSchedule().getUnits());
+    }
+
+    final ConnectionRead connectionRead = new ConnectionRead()
+        .connectionId(standardSync.getConnectionId())
+        .sourceId(standardSync.getSourceId())
+        .destinationId(standardSync.getDestinationId())
+        .operationIds(standardSync.getOperationIds())
+        .status(toApiStatus(standardSync.getStatus()))
+        .schedule(apiSchedule)
+        .name(standardSync.getName())
+        .namespaceDefinition(Enums.convertTo(standardSync.getNamespaceDefinition(), io.airbyte.api.model.NamespaceDefinitionType.class))
+        .namespaceFormat(standardSync.getNamespaceFormat())
+        .prefix(standardSync.getPrefix())
+        .syncCatalog(CatalogConverter.toApi(standardSync.getCatalog()));
+
+    if (standardSync.getResourceRequirements() != null) {
+      connectionRead.resourceRequirements(resourceRequirementsToApi(standardSync.getResourceRequirements()));
+    }
+
+    return connectionRead;
+  }
+
+  public static ConnectionSchedule.TimeUnitEnum toApiTimeUnit(final Schedule.TimeUnit apiTimeUnit) {
+    return Enums.convertTo(apiTimeUnit, ConnectionSchedule.TimeUnitEnum.class);
+  }
+
+  public static ConnectionStatus toApiStatus(final StandardSync.Status status) {
+    return Enums.convertTo(status, ConnectionStatus.class);
+  }
+
+  public static StandardSync.Status toPersistenceStatus(final ConnectionStatus apiStatus) {
+    return Enums.convertTo(apiStatus, StandardSync.Status.class);
+  }
+
+  public static Schedule.TimeUnit toPersistenceTimeUnit(final ConnectionSchedule.TimeUnitEnum apiTimeUnit) {
+    return Enums.convertTo(apiTimeUnit, Schedule.TimeUnit.class);
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/ApiPojoConverters.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/ApiPojoConverters.java
@@ -45,11 +45,7 @@ public class ApiPojoConverters {
 
     // update Resource Requirements
     if (update.getResourceRequirements() != null) {
-      newConnection.withResourceRequirements(new io.airbyte.config.ResourceRequirements()
-          .withCpuRequest(update.getResourceRequirements().getCpuRequest())
-          .withCpuLimit(update.getResourceRequirements().getCpuLimit())
-          .withMemoryRequest(update.getResourceRequirements().getMemoryRequest())
-          .withMemoryLimit(update.getResourceRequirements().getMemoryLimit()));
+      newConnection.withResourceRequirements(resourceRequirementsToInternal(update.getResourceRequirements()));
     }
 
     // update sync schedule

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -12,7 +12,6 @@ import io.airbyte.analytics.TrackingClient;
 import io.airbyte.api.model.ConnectionCreate;
 import io.airbyte.api.model.ConnectionRead;
 import io.airbyte.api.model.ConnectionReadList;
-import io.airbyte.api.model.ConnectionSchedule;
 import io.airbyte.api.model.ConnectionSearch;
 import io.airbyte.api.model.ConnectionStatus;
 import io.airbyte.api.model.ConnectionUpdate;
@@ -23,6 +22,7 @@ import io.airbyte.api.model.SourceSearch;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.features.FeatureFlags;
+import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
 import io.airbyte.config.Schedule;
@@ -35,6 +35,7 @@ import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.scheduler.persistence.WorkspaceHelper;
+import io.airbyte.server.converters.ApiPojoConverters;
 import io.airbyte.server.handlers.helpers.ConnectionMatcher;
 import io.airbyte.server.handlers.helpers.DestinationMatcher;
 import io.airbyte.server.handlers.helpers.SourceMatcher;
@@ -63,7 +64,6 @@ public class ConnectionsHandler {
   private final TrackingClient trackingClient;
   private final TemporalWorkerRunFactory temporalWorkerRunFactory;
   private final FeatureFlags featureFlags;
-  private final ConnectionHelper connectionHelper;
   private final WorkerConfigs workerConfigs;
 
   @VisibleForTesting
@@ -73,7 +73,6 @@ public class ConnectionsHandler {
                      final TrackingClient trackingClient,
                      final TemporalWorkerRunFactory temporalWorkerRunFactory,
                      final FeatureFlags featureFlags,
-                     final ConnectionHelper connectionHelper,
                      final WorkerConfigs workerConfigs) {
     this.configRepository = configRepository;
     this.uuidGenerator = uuidGenerator;
@@ -81,26 +80,21 @@ public class ConnectionsHandler {
     this.trackingClient = trackingClient;
     this.temporalWorkerRunFactory = temporalWorkerRunFactory;
     this.featureFlags = featureFlags;
-    this.connectionHelper = connectionHelper;
     this.workerConfigs = workerConfigs;
   }
 
-  public ConnectionsHandler(
-                            final ConfigRepository configRepository,
+  public ConnectionsHandler(final ConfigRepository configRepository,
                             final WorkspaceHelper workspaceHelper,
                             final TrackingClient trackingClient,
                             final TemporalWorkerRunFactory temporalWorkerRunFactory,
                             final FeatureFlags featureFlags,
-                            final ConnectionHelper connectionHelper,
                             final WorkerConfigs workerConfigs) {
-    this(
-        configRepository,
+    this(configRepository,
         UUID::randomUUID,
         workspaceHelper,
         trackingClient,
         temporalWorkerRunFactory,
         featureFlags,
-        connectionHelper,
         workerConfigs);
 
   }
@@ -110,7 +104,9 @@ public class ConnectionsHandler {
     // Validate source and destination
     configRepository.getSourceConnection(connectionCreate.getSourceId());
     configRepository.getDestinationConnection(connectionCreate.getDestinationId());
-    connectionHelper.validateWorkspace(connectionCreate.getSourceId(), connectionCreate.getDestinationId(),
+    ConnectionHelper.validateWorkspace(workspaceHelper,
+        connectionCreate.getSourceId(),
+        connectionCreate.getDestinationId(),
         new HashSet<>(connectionCreate.getOperationIds()));
 
     final UUID connectionId = uuidGenerator.get();
@@ -125,13 +121,9 @@ public class ConnectionsHandler {
         .withSourceId(connectionCreate.getSourceId())
         .withDestinationId(connectionCreate.getDestinationId())
         .withOperationIds(connectionCreate.getOperationIds())
-        .withStatus(toPersistenceStatus(connectionCreate.getStatus()));
+        .withStatus(ApiPojoConverters.toPersistenceStatus(connectionCreate.getStatus()));
     if (connectionCreate.getResourceRequirements() != null) {
-      standardSync.withResourceRequirements(new io.airbyte.config.ResourceRequirements()
-          .withCpuRequest(connectionCreate.getResourceRequirements().getCpuRequest())
-          .withCpuLimit(connectionCreate.getResourceRequirements().getCpuLimit())
-          .withMemoryRequest(connectionCreate.getResourceRequirements().getMemoryRequest())
-          .withMemoryLimit(connectionCreate.getResourceRequirements().getMemoryLimit()));
+      standardSync.withResourceRequirements(ApiPojoConverters.resourceRequirementsToInternal(connectionCreate.getResourceRequirements()));
     } else {
       standardSync.withResourceRequirements(workerConfigs.getResourceRequirements());
     }
@@ -145,7 +137,7 @@ public class ConnectionsHandler {
 
     if (connectionCreate.getSchedule() != null) {
       final Schedule schedule = new Schedule()
-          .withTimeUnit(toPersistenceTimeUnit(connectionCreate.getSchedule().getTimeUnit()))
+          .withTimeUnit(ApiPojoConverters.toPersistenceTimeUnit(connectionCreate.getSchedule().getTimeUnit()))
           .withUnits(connectionCreate.getSchedule().getUnits());
       standardSync
           .withManual(false)
@@ -169,7 +161,7 @@ public class ConnectionsHandler {
       }
     }
 
-    return connectionHelper.buildConnectionRead(connectionId);
+    return buildConnectionRead(connectionId);
   }
 
   private void trackNewConnection(final StandardSync standardSync) {
@@ -209,21 +201,45 @@ public class ConnectionsHandler {
 
   public ConnectionRead updateConnection(final ConnectionUpdate connectionUpdate)
       throws ConfigNotFoundException, IOException, JsonValidationException {
-    return updateConnection(connectionUpdate, false);
-  }
+    // retrieve and update sync
+    // retrieve and update sync
+    final StandardSync persistedSync = configRepository.getStandardSync(connectionUpdate.getConnectionId());
 
-  public ConnectionRead updateConnection(final ConnectionUpdate connectionUpdate, boolean isAReset)
-      throws ConfigNotFoundException, IOException, JsonValidationException {
-    if (featureFlags.usesNewScheduler()) {
-      connectionHelper.updateConnection(connectionUpdate);
+    ConnectionHelper.updateConnectionObject(workspaceHelper, persistedSync, ApiPojoConverters.connectionUpdateToInternal(connectionUpdate));
+    ConnectionHelper.validateWorkspace(workspaceHelper, persistedSync.getSourceId(), persistedSync.getDestinationId(),
+        new HashSet<>(connectionUpdate.getOperationIds()));
 
-      if (!isAReset) {
-        temporalWorkerRunFactory.update(connectionUpdate);
-      }
+    final StandardSync newConnection = Jsons.clone(persistedSync)
+        .withNamespaceDefinition(Enums.convertTo(connectionUpdate.getNamespaceDefinition(), NamespaceDefinitionType.class))
+        .withNamespaceFormat(connectionUpdate.getNamespaceFormat())
+        .withPrefix(connectionUpdate.getPrefix())
+        .withOperationIds(connectionUpdate.getOperationIds())
+        .withCatalog(CatalogConverter.toProtocol(connectionUpdate.getSyncCatalog()))
+        .withStatus(ApiPojoConverters.toPersistenceStatus(connectionUpdate.getStatus()));
 
-      return connectionHelper.buildConnectionRead(connectionUpdate.getConnectionId());
+    // update Resource Requirements
+    if (connectionUpdate.getResourceRequirements() != null) {
+      newConnection.withResourceRequirements(new io.airbyte.config.ResourceRequirements()
+          .withCpuRequest(connectionUpdate.getResourceRequirements().getCpuRequest())
+          .withCpuLimit(connectionUpdate.getResourceRequirements().getCpuLimit())
+          .withMemoryRequest(connectionUpdate.getResourceRequirements().getMemoryRequest())
+          .withMemoryLimit(connectionUpdate.getResourceRequirements().getMemoryLimit()));
+    } else {
+      newConnection.withResourceRequirements(persistedSync.getResourceRequirements());
     }
-    return connectionHelper.updateConnection(connectionUpdate);
+
+    // update sync schedule
+    if (connectionUpdate.getSchedule() != null) {
+      final Schedule newSchedule = new Schedule()
+          .withTimeUnit(ApiPojoConverters.toPersistenceTimeUnit(connectionUpdate.getSchedule().getTimeUnit()))
+          .withUnits(connectionUpdate.getSchedule().getUnits());
+      newConnection.withManual(false).withSchedule(newSchedule);
+    } else {
+      newConnection.withManual(true).withSchedule(null);
+    }
+
+    configRepository.writeStandardSync(newConnection);
+    return buildConnectionRead(connectionUpdate.getConnectionId());
   }
 
   public ConnectionReadList listConnectionsForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody)
@@ -248,7 +264,7 @@ public class ConnectionsHandler {
         continue;
       }
 
-      connectionReads.add(connectionHelper.buildConnectionRead(standardSync.getConnectionId()));
+      connectionReads.add(buildConnectionRead(standardSync.getConnectionId()));
     }
 
     return new ConnectionReadList().connections(connectionReads);
@@ -261,7 +277,7 @@ public class ConnectionsHandler {
       if (standardSync.getStatus() == StandardSync.Status.DEPRECATED) {
         continue;
       }
-      connectionReads.add(connectionHelper.buildConnectionRead(standardSync.getConnectionId()));
+      connectionReads.add(buildConnectionRead(standardSync.getConnectionId()));
     }
 
     return new ConnectionReadList().connections(connectionReads);
@@ -269,7 +285,7 @@ public class ConnectionsHandler {
 
   public ConnectionRead getConnection(final UUID connectionId)
       throws JsonValidationException, IOException, ConfigNotFoundException {
-    return connectionHelper.buildConnectionRead(connectionId);
+    return buildConnectionRead(connectionId);
   }
 
   public ConnectionReadList searchConnections(final ConnectionSearch connectionSearch)
@@ -277,7 +293,7 @@ public class ConnectionsHandler {
     final List<ConnectionRead> reads = Lists.newArrayList();
     for (final StandardSync standardSync : configRepository.listStandardSyncs()) {
       if (standardSync.getStatus() != StandardSync.Status.DEPRECATED) {
-        final ConnectionRead connectionRead = connectionHelper.buildConnectionRead(standardSync.getConnectionId());
+        final ConnectionRead connectionRead = buildConnectionRead(standardSync.getConnectionId());
         if (matchSearch(connectionSearch, connectionRead)) {
           reads.add(connectionRead);
         }
@@ -308,6 +324,7 @@ public class ConnectionsHandler {
         matchSearch(connectionSearch.getDestination(), destinationRead);
   }
 
+  // todo (cgardens) - make this static. requires removing one bad dependence in SourceHandlerTest
   public boolean matchSearch(final SourceSearch sourceSearch, final SourceRead sourceRead) {
     final SourceMatcher sourceMatcher = new SourceMatcher(sourceSearch);
     final SourceRead sourceReadFromSearch = sourceMatcher.match(sourceRead);
@@ -315,6 +332,8 @@ public class ConnectionsHandler {
     return (sourceReadFromSearch == null || sourceReadFromSearch.equals(sourceRead));
   }
 
+  // todo (cgardens) - make this static. requires removing one bad dependence in
+  // DestinationHandlerTest
   public boolean matchSearch(final DestinationSearch destinationSearch, final DestinationRead destinationRead) {
     final DestinationMatcher destinationMatcher = new DestinationMatcher(destinationSearch);
     final DestinationRead destinationReadFromSearch = destinationMatcher.match(destinationRead);
@@ -325,6 +344,7 @@ public class ConnectionsHandler {
   public void deleteConnection(final UUID connectionId)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     if (featureFlags.usesNewScheduler()) {
+      // todo (cgardens) - need an interface over this.
       temporalWorkerRunFactory.deleteConnection(connectionId);
     } else {
       final ConnectionRead connectionRead = getConnection(connectionId);
@@ -353,12 +373,10 @@ public class ConnectionsHandler {
     return configRepository.getSourceConnection(standardSync.getSourceId()).getWorkspaceId().equals(workspaceId);
   }
 
-  private StandardSync.Status toPersistenceStatus(final ConnectionStatus apiStatus) {
-    return Enums.convertTo(apiStatus, StandardSync.Status.class);
-  }
-
-  private Schedule.TimeUnit toPersistenceTimeUnit(final ConnectionSchedule.TimeUnitEnum apiTimeUnit) {
-    return Enums.convertTo(apiTimeUnit, Schedule.TimeUnit.class);
+  private ConnectionRead buildConnectionRead(final UUID connectionId)
+      throws ConfigNotFoundException, IOException, JsonValidationException {
+    final StandardSync standardSync = configRepository.getStandardSync(connectionId);
+    return ApiPojoConverters.internalToConnectionRead(standardSync);
   }
 
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
@@ -54,7 +53,7 @@ import io.airbyte.scheduler.persistence.job_factory.SyncJobFactory;
 import io.airbyte.server.helpers.ConnectionHelpers;
 import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.WorkerConfigs;
-import io.airbyte.workers.helper.ConnectionHelper;
+import io.airbyte.workers.helper.CatalogConverter;
 import io.airbyte.workers.worker_run.TemporalWorkerRunFactory;
 import java.io.IOException;
 import java.util.Collections;
@@ -162,60 +161,11 @@ class ConnectionsHandlerTest {
     when(featureFlags.usesNewScheduler()).thenReturn(false);
   }
 
-  // TODO: bmoric move to a mock
-  private ConnectionHelper connectionHelper;
-
-  @Nested
-  class MockedConnectionHelper {
-
-    @BeforeEach
-    void setUp() {
-      connectionHelper = mock(ConnectionHelper.class);
-
-      connectionsHandler = new ConnectionsHandler(
-          configRepository,
-          uuidGenerator,
-          workspaceHelper,
-          trackingClient,
-          temporalWorkflowHandler,
-          featureFlags,
-          connectionHelper,
-          workerConfigs);
-    }
-
-    @Test
-    void testUpdateConnectionWithNewScheduler() throws JsonValidationException, ConfigNotFoundException, IOException {
-      final ConnectionUpdate connectionUpdate = new ConnectionUpdate()
-          .connectionId(standardSync.getConnectionId());
-
-      when(featureFlags.usesNewScheduler()).thenReturn(true);
-      connectionsHandler.updateConnection(connectionUpdate, false);
-
-      verify(connectionHelper).updateConnection(connectionUpdate);
-      verify(temporalWorkflowHandler).update(connectionUpdate);
-    }
-
-    @Test
-    void testUpdateConnectionWithNewSchedulerForReset() throws JsonValidationException, ConfigNotFoundException, IOException {
-      final ConnectionUpdate connectionUpdate = new ConnectionUpdate()
-          .connectionId(standardSync.getConnectionId());
-
-      when(featureFlags.usesNewScheduler()).thenReturn(true);
-      connectionsHandler.updateConnection(connectionUpdate, true);
-
-      verify(connectionHelper).updateConnection(connectionUpdate);
-      verifyNoInteractions(temporalWorkflowHandler);
-    }
-
-  }
-
   @Nested
   class UnMockedConnectionHelper {
 
     @BeforeEach
     void setUp() {
-      connectionHelper = new ConnectionHelper(configRepository, workspaceHelper, workerConfigs);
-
       connectionsHandler = new ConnectionsHandler(
           configRepository,
           uuidGenerator,
@@ -223,7 +173,6 @@ class ConnectionsHandlerTest {
           trackingClient,
           temporalWorkflowHandler,
           featureFlags,
-          connectionHelper,
           workerConfigs);
     }
 
@@ -409,7 +358,8 @@ class ConnectionsHandlerTest {
 
       final ConnectionUpdate connectionUpdate = new ConnectionUpdate()
           .connectionId(standardSync.getConnectionId())
-          .operationIds(Collections.singletonList(operationId));
+          .operationIds(Collections.singletonList(operationId))
+          .syncCatalog(CatalogConverter.toApi(standardSync.getCatalog()));
 
       assertThrows(IllegalArgumentException.class, () -> connectionsHandler.updateConnection(connectionUpdate));
     }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -113,8 +113,14 @@ class WebBackendConnectionsHandlerTest {
     featureFlags = mock(FeatureFlags.class);
     temporalWorkerRunFactory = mock(TemporalWorkerRunFactory.class);
     connectionHelper = mock(ConnectionHelper.class);
-    wbHandler = new WebBackendConnectionsHandler(connectionsHandler, sourceHandler, destinationHandler, jobHistoryHandler, schedulerHandler,
-        operationsHandler, featureFlags, temporalWorkerRunFactory, connectionHelper);
+    wbHandler = new WebBackendConnectionsHandler(connectionsHandler,
+        sourceHandler,
+        destinationHandler,
+        jobHistoryHandler,
+        schedulerHandler,
+        operationsHandler,
+        featureFlags,
+        temporalWorkerRunFactory);
 
     final StandardSourceDefinition standardSourceDefinition = SourceDefinitionHelpers.generateSourceDefinition();
     final SourceConnection source = SourceHelpers.generateSource(UUID.randomUUID());
@@ -573,7 +579,7 @@ class WebBackendConnectionsHandlerTest {
         .status(expected.getStatus())
         .schedule(expected.getSchedule());
     when(connectionsHandler.updateConnection(any())).thenReturn(connectionRead);
-    when(connectionHelper.buildConnectionRead(any())).thenReturn(connectionRead);
+    when(connectionsHandler.getConnection(expected.getConnectionId())).thenReturn(connectionRead);
     when(featureFlags.usesNewScheduler()).thenReturn(true);
 
     final WebBackendConnectionRead result = wbHandler.webBackendUpdateConnection(updateBody);
@@ -583,7 +589,7 @@ class WebBackendConnectionsHandlerTest {
     final ConnectionIdRequestBody connectionId = new ConnectionIdRequestBody().connectionId(result.getConnectionId());
     verify(schedulerHandler, times(0)).resetConnection(connectionId);
     verify(schedulerHandler, times(0)).syncConnection(connectionId);
-    InOrder orderVerifier = inOrder(temporalWorkerRunFactory);
+    final InOrder orderVerifier = inOrder(temporalWorkerRunFactory);
     orderVerifier.verify(temporalWorkerRunFactory, times(1)).synchronousResetConnection(connectionId.getConnectionId());
     orderVerifier.verify(temporalWorkerRunFactory, times(1)).startNewManualSync(connectionId.getConnectionId());
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -378,10 +378,7 @@ public class WorkerApp {
         configRepository,
         jobPersistence);
 
-    final ConnectionHelper connectionHelper = new ConnectionHelper(
-        configRepository,
-        workspaceHelper,
-        defaultWorkerConfigs);
+    final ConnectionHelper connectionHelper = new ConnectionHelper(configRepository, workspaceHelper);
 
     final Optional<ContainerOrchestratorConfig> containerOrchestratorConfig = getContainerOrchestratorConfig(configs);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/ConnectionHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/ConnectionHelper.java
@@ -5,11 +5,6 @@
 package io.airbyte.workers.helper;
 
 import com.google.common.base.Preconditions;
-import io.airbyte.api.model.ConnectionRead;
-import io.airbyte.api.model.ConnectionSchedule;
-import io.airbyte.api.model.ConnectionStatus;
-import io.airbyte.api.model.ConnectionUpdate;
-import io.airbyte.api.model.ResourceRequirements;
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
@@ -19,85 +14,90 @@ import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.scheduler.persistence.WorkspaceHelper;
 import io.airbyte.validation.json.JsonValidationException;
-import io.airbyte.workers.WorkerConfigs;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 
+// todo (cgardens) - we are not getting any value out of instantiating this class. we should just
+// use it as statics. not doing it now, because already in the middle of another refactor.
 @AllArgsConstructor
 public class ConnectionHelper {
 
   private final ConfigRepository configRepository;
   private final WorkspaceHelper workspaceHelper;
-  private final WorkerConfigs workerConfigs;
 
   public void deleteConnection(final UUID connectionId) throws JsonValidationException, ConfigNotFoundException, IOException {
-    final ConnectionRead connectionRead = buildConnectionRead(connectionId);
-
-    final ConnectionUpdate connectionUpdate = new ConnectionUpdate()
-        .namespaceDefinition(connectionRead.getNamespaceDefinition())
-        .namespaceFormat(connectionRead.getNamespaceFormat())
-        .prefix(connectionRead.getPrefix())
-        .connectionId(connectionRead.getConnectionId())
-        .operationIds(connectionRead.getOperationIds())
-        .syncCatalog(connectionRead.getSyncCatalog())
-        .schedule(connectionRead.getSchedule())
-        .status(ConnectionStatus.DEPRECATED)
-        .resourceRequirements(connectionRead.getResourceRequirements());
-
-    updateConnection(connectionUpdate);
+    final StandardSync update = Jsons.clone(configRepository.getStandardSync(connectionId));
+    updateConnection(update);
   }
 
-  public ConnectionRead updateConnection(final ConnectionUpdate connectionUpdate)
-      throws ConfigNotFoundException, IOException, JsonValidationException {
-    // retrieve and update sync
-    // retrieve and update sync
-    final StandardSync persistedSync = configRepository.getStandardSync(connectionUpdate.getConnectionId());
+  /**
+   * Given a connection update, fetches an existing connection, applies the update, and then persists
+   * the update.
+   *
+   * @param update - updated sync info to be merged with original sync.
+   * @return new sync object
+   * @throws JsonValidationException - if provided object is invalid
+   * @throws ConfigNotFoundException - if there is no sync already persisted
+   * @throws IOException - you never know when you io
+   */
+  public StandardSync updateConnection(final StandardSync update)
+      throws JsonValidationException, ConfigNotFoundException, IOException {
+    final StandardSync original = configRepository.getStandardSync(update.getConnectionId());
+    final StandardSync newConnection = updateConnectionObject(workspaceHelper, original, update);
+    configRepository.writeStandardSync(newConnection);
+    return newConnection;
+  }
 
-    validateWorkspace(persistedSync.getSourceId(), persistedSync.getDestinationId(), new HashSet<>(connectionUpdate.getOperationIds()));
+  /**
+   * Core logic for merging an existing connection configuration with an update.
+   *
+   * @param workspaceHelper - helper class
+   * @param original - already persisted sync
+   * @param update - updated sync info to be merged with original sync.
+   * @return new sync object
+   */
+  public static StandardSync updateConnectionObject(final WorkspaceHelper workspaceHelper, final StandardSync original, final StandardSync update) {
+    validateWorkspace(workspaceHelper, original.getSourceId(), original.getDestinationId(), new HashSet<>(update.getOperationIds()));
 
-    final StandardSync newConnection = Jsons.clone(persistedSync)
-        .withNamespaceDefinition(Enums.convertTo(connectionUpdate.getNamespaceDefinition(), NamespaceDefinitionType.class))
-        .withNamespaceFormat(connectionUpdate.getNamespaceFormat())
-        .withPrefix(connectionUpdate.getPrefix())
-        .withOperationIds(connectionUpdate.getOperationIds())
-        .withCatalog(CatalogConverter.toProtocol(connectionUpdate.getSyncCatalog()))
-        .withStatus(toPersistenceStatus(connectionUpdate.getStatus()));
+    final StandardSync newConnection = Jsons.clone(original)
+        .withNamespaceDefinition(Enums.convertTo(update.getNamespaceDefinition(), NamespaceDefinitionType.class))
+        .withNamespaceFormat(update.getNamespaceFormat())
+        .withPrefix(update.getPrefix())
+        .withOperationIds(update.getOperationIds())
+        .withCatalog(update.getCatalog())
+        .withStatus(update.getStatus());
 
     // update Resource Requirements
-    if (connectionUpdate.getResourceRequirements() != null) {
+    if (update.getResourceRequirements() != null) {
       newConnection.withResourceRequirements(new io.airbyte.config.ResourceRequirements()
-          .withCpuRequest(connectionUpdate.getResourceRequirements().getCpuRequest())
-          .withCpuLimit(connectionUpdate.getResourceRequirements().getCpuLimit())
-          .withMemoryRequest(connectionUpdate.getResourceRequirements().getMemoryRequest())
-          .withMemoryLimit(connectionUpdate.getResourceRequirements().getMemoryLimit()));
+          .withCpuRequest(update.getResourceRequirements().getCpuRequest())
+          .withCpuLimit(update.getResourceRequirements().getCpuLimit())
+          .withMemoryRequest(update.getResourceRequirements().getMemoryRequest())
+          .withMemoryLimit(update.getResourceRequirements().getMemoryLimit()));
     } else {
-      newConnection.withResourceRequirements(persistedSync.getResourceRequirements());
+      newConnection.withResourceRequirements(original.getResourceRequirements());
     }
 
     // update sync schedule
-    if (connectionUpdate.getSchedule() != null) {
+    if (update.getSchedule() != null) {
       final Schedule newSchedule = new Schedule()
-          .withTimeUnit(toPersistenceTimeUnit(connectionUpdate.getSchedule().getTimeUnit()))
-          .withUnits(connectionUpdate.getSchedule().getUnits());
+          .withTimeUnit(update.getSchedule().getTimeUnit())
+          .withUnits(update.getSchedule().getUnits());
       newConnection.withManual(false).withSchedule(newSchedule);
     } else {
       newConnection.withManual(true).withSchedule(null);
     }
 
-    configRepository.writeStandardSync(newConnection);
-    return buildConnectionRead(connectionUpdate.getConnectionId());
+    return newConnection;
   }
 
-  public ConnectionRead buildConnectionRead(final UUID connectionId)
-      throws ConfigNotFoundException, IOException, JsonValidationException {
-    final StandardSync standardSync = configRepository.getStandardSync(connectionId);
-    return buildConnectionRead(standardSync);
-  }
-
-  public void validateWorkspace(final UUID sourceId, final UUID destinationId, final Set<UUID> operationIds) {
+  public static void validateWorkspace(final WorkspaceHelper workspaceHelper,
+                                       final UUID sourceId,
+                                       final UUID destinationId,
+                                       final Set<UUID> operationIds) {
     final UUID sourceWorkspace = workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(sourceId);
     final UUID destinationWorkspace = workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(destinationId);
 
@@ -120,61 +120,6 @@ public class ConnectionHelper {
               operationId,
               operationWorkspace));
     }
-  }
-
-  private ConnectionRead buildConnectionRead(final StandardSync standardSync) {
-    ConnectionSchedule apiSchedule = null;
-
-    if (!standardSync.getManual()) {
-      apiSchedule = new ConnectionSchedule()
-          .timeUnit(toApiTimeUnit(standardSync.getSchedule().getTimeUnit()))
-          .units(standardSync.getSchedule().getUnits());
-    }
-
-    final ConnectionRead connectionRead = new ConnectionRead()
-        .connectionId(standardSync.getConnectionId())
-        .sourceId(standardSync.getSourceId())
-        .destinationId(standardSync.getDestinationId())
-        .operationIds(standardSync.getOperationIds())
-        .status(toApiStatus(standardSync.getStatus()))
-        .schedule(apiSchedule)
-        .name(standardSync.getName())
-        .namespaceDefinition(Enums.convertTo(standardSync.getNamespaceDefinition(), io.airbyte.api.model.NamespaceDefinitionType.class))
-        .namespaceFormat(standardSync.getNamespaceFormat())
-        .prefix(standardSync.getPrefix())
-        .syncCatalog(CatalogConverter.toApi(standardSync.getCatalog()));
-
-    if (standardSync.getResourceRequirements() != null) {
-      connectionRead.resourceRequirements(new ResourceRequirements()
-          .cpuRequest(standardSync.getResourceRequirements().getCpuRequest())
-          .cpuLimit(standardSync.getResourceRequirements().getCpuLimit())
-          .memoryRequest(standardSync.getResourceRequirements().getMemoryRequest())
-          .memoryLimit(standardSync.getResourceRequirements().getMemoryLimit()));
-    } else {
-      final io.airbyte.config.ResourceRequirements resourceRequirements = workerConfigs.getResourceRequirements();
-      connectionRead.resourceRequirements(new ResourceRequirements()
-          .cpuRequest(resourceRequirements.getCpuRequest())
-          .cpuLimit(resourceRequirements.getCpuLimit())
-          .memoryRequest(resourceRequirements.getMemoryRequest())
-          .memoryLimit(resourceRequirements.getMemoryLimit()));
-    }
-    return connectionRead;
-  }
-
-  private ConnectionSchedule.TimeUnitEnum toApiTimeUnit(final Schedule.TimeUnit apiTimeUnit) {
-    return Enums.convertTo(apiTimeUnit, ConnectionSchedule.TimeUnitEnum.class);
-  }
-
-  private ConnectionStatus toApiStatus(final StandardSync.Status status) {
-    return Enums.convertTo(status, ConnectionStatus.class);
-  }
-
-  private StandardSync.Status toPersistenceStatus(final ConnectionStatus apiStatus) {
-    return Enums.convertTo(apiStatus, StandardSync.Status.class);
-  }
-
-  private Schedule.TimeUnit toPersistenceTimeUnit(final ConnectionSchedule.TimeUnitEnum apiTimeUnit) {
-    return Enums.convertTo(apiTimeUnit, Schedule.TimeUnit.class);
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/ConnectionHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/ConnectionHelper.java
@@ -29,7 +29,7 @@ public class ConnectionHelper {
   private final WorkspaceHelper workspaceHelper;
 
   public void deleteConnection(final UUID connectionId) throws JsonValidationException, ConfigNotFoundException, IOException {
-    final StandardSync update = Jsons.clone(configRepository.getStandardSync(connectionId));
+    final StandardSync update = Jsons.clone(configRepository.getStandardSync(connectionId).withStatus(StandardSync.Status.DEPRECATED));
     updateConnection(update);
   }
 
@@ -72,11 +72,7 @@ public class ConnectionHelper {
 
     // update Resource Requirements
     if (update.getResourceRequirements() != null) {
-      newConnection.withResourceRequirements(new io.airbyte.config.ResourceRequirements()
-          .withCpuRequest(update.getResourceRequirements().getCpuRequest())
-          .withCpuLimit(update.getResourceRequirements().getCpuLimit())
-          .withMemoryRequest(update.getResourceRequirements().getMemoryRequest())
-          .withMemoryLimit(update.getResourceRequirements().getMemoryLimit()));
+      newConnection.withResourceRequirements(Jsons.clone(update.getResourceRequirements()));
     } else {
       newConnection.withResourceRequirements(original.getResourceRequirements());
     }


### PR DESCRIPTION
## What
* While working working on adding resource limits for connection definitions https://github.com/airbytehq/airbyte/issues/10295 i got stuck because some of the logic for handling connections was moved into airbyte-workers. this meant that it couldn't access conversion logic that exists (or that i was trying to add) in airbyte-server.

## How
* this PR restructures the code so that `ConnectionHelper` does not have access to any API level classes.
* it keeps the core logic of how to update an existing `StandardSync` with a new `StandardSync` in the `airbyte-worker`. Honestly, I'm not particularly sure that's the right place for it, but for nowI think it is tolerable.
* As a follow on, I think we should turn `ConnectionHelper` into a purely static class
* As a follow on, we really need to remove `airbyte-api` as a dependency of `airbyte-worker`. It keeps making it easy to pull API code into bad places