### PR TITLE
validate classes in config persistence

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteConfig.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/AirbyteConfig.java
@@ -28,4 +28,6 @@ public interface AirbyteConfig {
    */
   File getConfigSchemaFile();
 
+  <T> Class<T> getClassName();
+
 }

--- a/airbyte-config/models/src/main/java/io/airbyte/config/ConfigWithMetadata.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/ConfigWithMetadata.java
@@ -5,6 +5,7 @@
 package io.airbyte.config;
 
 import java.time.Instant;
+import java.util.Objects;
 
 public class ConfigWithMetadata<T> {
 
@@ -14,7 +15,7 @@ public class ConfigWithMetadata<T> {
   private final Instant updatedAt;
   private final T config;
 
-  public ConfigWithMetadata(String configId, String configType, Instant createdAt, Instant updatedAt, T config) {
+  public ConfigWithMetadata(final String configId, final String configType, final Instant createdAt, final Instant updatedAt, final T config) {
     this.configId = configId;
     this.configType = configType;
     this.createdAt = createdAt;
@@ -40,6 +41,24 @@ public class ConfigWithMetadata<T> {
 
   public T getConfig() {
     return config;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ConfigWithMetadata<?> that = (ConfigWithMetadata<?>) o;
+    return Objects.equals(configId, that.configId) && Objects.equals(configType, that.configType) && Objects.equals(
+        createdAt, that.createdAt) && Objects.equals(updatedAt, that.updatedAt) && Objects.equals(config, that.config);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(configId, configType, createdAt, updatedAt, config);
   }
 
 }

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ClassEnforcingConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ClassEnforcingConfigPersistence.java
@@ -5,89 +5,66 @@
 package io.airbyte.config.persistence;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.airbyte.commons.json.Jsons;
+import com.google.api.client.util.Preconditions;
 import io.airbyte.config.AirbyteConfig;
 import io.airbyte.config.ConfigWithMetadata;
-import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
 /**
- * Validates that json input and outputs for the ConfigPersistence against their schemas.
+ * Validates that the class of inputs and outputs matches the class specified in the AirbyteConfig
+ * enum. Helps avoid type mistakes, which can happen because this iface can't type check at compile
+ * time.
  */
-public class ValidatingConfigPersistence implements ConfigPersistence {
+public class ClassEnforcingConfigPersistence implements ConfigPersistence {
 
-  private final JsonSchemaValidator schemaValidator;
   private final ConfigPersistence decoratedPersistence;
 
-  public ValidatingConfigPersistence(final ConfigPersistence decoratedPersistence) {
-    this(decoratedPersistence, new JsonSchemaValidator());
-  }
-
-  public ValidatingConfigPersistence(final ConfigPersistence decoratedPersistence, final JsonSchemaValidator schemaValidator) {
+  public ClassEnforcingConfigPersistence(final ConfigPersistence decoratedPersistence) {
     this.decoratedPersistence = decoratedPersistence;
-    this.schemaValidator = schemaValidator;
   }
 
   @Override
   public <T> T getConfig(final AirbyteConfig configType, final String configId, final Class<T> clazz)
       throws ConfigNotFoundException, JsonValidationException, IOException {
-    final T config = decoratedPersistence.getConfig(configType, configId, clazz);
-    validateJson(config, configType);
-    return config;
+    Preconditions.checkArgument(configType.getClassName().equals(clazz));
+    return decoratedPersistence.getConfig(configType, configId, clazz);
   }
 
   @Override
   public <T> List<T> listConfigs(final AirbyteConfig configType, final Class<T> clazz) throws JsonValidationException, IOException {
-    final List<T> configs = decoratedPersistence.listConfigs(configType, clazz);
-    for (final T config : configs) {
-      validateJson(config, configType);
-    }
-    return configs;
+    Preconditions.checkArgument(configType.getClassName().equals(clazz));
+    return decoratedPersistence.listConfigs(configType, clazz);
   }
 
   @Override
   public <T> ConfigWithMetadata<T> getConfigWithMetadata(final AirbyteConfig configType, final String configId, final Class<T> clazz)
       throws ConfigNotFoundException, JsonValidationException, IOException {
-    final ConfigWithMetadata<T> config = decoratedPersistence.getConfigWithMetadata(configType, configId, clazz);
-    validateJson(config.getConfig(), configType);
-    return config;
+    Preconditions.checkArgument(configType.getClassName().equals(clazz));
+    return decoratedPersistence.getConfigWithMetadata(configType, configId, clazz);
   }
 
   @Override
   public <T> List<ConfigWithMetadata<T>> listConfigsWithMetadata(final AirbyteConfig configType, final Class<T> clazz)
       throws JsonValidationException, IOException {
-    final List<ConfigWithMetadata<T>> configs = decoratedPersistence.listConfigsWithMetadata(configType, clazz);
-    for (final ConfigWithMetadata<T> config : configs) {
-      validateJson(config.getConfig(), configType);
-    }
-    return configs;
+    Preconditions.checkArgument(configType.getClassName().equals(clazz));
+    return decoratedPersistence.listConfigsWithMetadata(configType, clazz);
   }
 
   @Override
   public <T> void writeConfig(final AirbyteConfig configType, final String configId, final T config) throws JsonValidationException, IOException {
-
-    final Map<String, T> configIdToConfig = new HashMap<>() {
-
-      {
-        put(configId, config);
-      }
-
-    };
-
-    writeConfigs(configType, configIdToConfig);
+    Preconditions.checkArgument(configType.getClassName().equals(config.getClass()));
+    decoratedPersistence.writeConfig(configType, configId, config);
   }
 
   @Override
-  public <T> void writeConfigs(final AirbyteConfig configType, final Map<String, T> configs)
-      throws IOException, JsonValidationException {
-    for (final Map.Entry<String, T> config : configs.entrySet()) {
-      validateJson(Jsons.jsonNode(config.getValue()), configType);
-    }
+  public <T> void writeConfigs(final AirbyteConfig configType, final Map<String, T> configs) throws IOException, JsonValidationException {
+    // attempt to check the input type. if it is empty, then there is nothing to check.
+    Preconditions.checkArgument(configs.isEmpty() || configType.getClassName().equals(new ArrayList<>(configs.values()).get(0).getClass()));
     decoratedPersistence.writeConfigs(configType, configs);
   }
 
@@ -98,7 +75,7 @@ public class ValidatingConfigPersistence implements ConfigPersistence {
 
   @Override
   public void replaceAllConfigs(final Map<AirbyteConfig, Stream<?>> configs, final boolean dryRun) throws IOException {
-    // todo (cgardens) need to do validation here.
+    // todo (cgardens) need to do class enforcement here here.
     decoratedPersistence.replaceAllConfigs(configs, dryRun);
   }
 
@@ -109,12 +86,8 @@ public class ValidatingConfigPersistence implements ConfigPersistence {
 
   @Override
   public void loadData(final ConfigPersistence seedPersistence) throws IOException {
+    // todo (cgardens) need to do class enforcement here here.
     decoratedPersistence.loadData(seedPersistence);
-  }
-
-  private <T> void validateJson(final T config, final AirbyteConfig configType) throws JsonValidationException {
-    final JsonNode schema = JsonSchemaValidator.getSchema(configType.getConfigSchemaFile());
-    schemaValidator.ensure(schema, Jsons.jsonNode(config));
   }
 
 }

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -88,7 +88,8 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
   public static ConfigPersistence createWithValidation(final Database database,
                                                        final JsonSecretsProcessor jsonSecretsProcessor,
                                                        final FeatureFlags featureFlags) {
-    return new ValidatingConfigPersistence(new DatabaseConfigPersistence(database, jsonSecretsProcessor, featureFlags));
+    return new ClassEnforcingConfigPersistence(
+        new ValidatingConfigPersistence(new DatabaseConfigPersistence(database, jsonSecretsProcessor, featureFlags)));
   }
 
   public DatabaseConfigPersistence(final Database database, final JsonSecretsProcessor jsonSecretsProcessor, final FeatureFlags featureFlags) {
@@ -1392,6 +1393,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     });
   }
 
+  // todo (cgardens) - how to protect types here?
   @Override
   public void replaceAllConfigs(final Map<AirbyteConfig, Stream<?>> configs, final boolean dryRun) throws IOException {
     if (dryRun) {

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -1393,7 +1393,6 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     });
   }
 
-  // todo (cgardens) - how to protect types here?
   @Override
   public void replaceAllConfigs(final Map<AirbyteConfig, Stream<?>> configs, final boolean dryRun) throws IOException {
     if (dryRun) {

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -85,6 +85,15 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
   private final FeatureFlags featureFlags;
   private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseConfigPersistence.class);
 
+  /**
+   * Entrypoint into DatabaseConfigPersistence. Except in testing, we should never be using it without
+   * it being decorated with validation classes.
+   *
+   * @param database - database where configs are stored
+   * @param jsonSecretsProcessor - for filtering secrets in export
+   * @param featureFlags - feature flags that govern secret export behavior
+   * @return database config persistence wrapped in validation decorators
+   */
   public static ConfigPersistence createWithValidation(final Database database,
                                                        final JsonSecretsProcessor jsonSecretsProcessor,
                                                        final FeatureFlags featureFlags) {

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ClassEnforcingConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ClassEnforcingConfigPersistenceTest.java
@@ -6,12 +6,16 @@ package io.airbyte.config.persistence;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import io.airbyte.config.AirbyteConfig;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.ConfigWithMetadata;
 import io.airbyte.config.StandardSync;
@@ -22,8 +26,11 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
 
 class ClassEnforcingConfigPersistenceTest {
 
@@ -124,6 +131,37 @@ class ClassEnforcingConfigPersistenceTest {
     assertThrows(IllegalArgumentException.class,
         () -> configPersistence.listConfigsWithMetadata(ConfigSchema.STANDARD_SYNC, StandardWorkspace.class));
     verifyNoInteractions(decoratedConfigPersistence);
+  }
+
+  @Test
+  void testReplaceAllConfigsSuccess() throws IOException, JsonValidationException {
+    consumeConfigInputStreams(decoratedConfigPersistence);
+    final Map<AirbyteConfig, Stream<?>> configs = ImmutableMap.of(ConfigSchema.STANDARD_SYNC, Stream.of(STANDARD_SYNC));
+    configPersistence.replaceAllConfigs(configs, false);
+    verify(decoratedConfigPersistence).replaceAllConfigs(any(), eq(false));
+  }
+
+  @Test
+  void testReplaceAllConfigsFailure() throws IOException {
+    consumeConfigInputStreams(decoratedConfigPersistence);
+    final Map<AirbyteConfig, Stream<?>> configs = ImmutableMap.of(ConfigSchema.STANDARD_SYNC, Stream.of(WORKSPACE));
+    assertThrows(IllegalArgumentException.class, () -> configPersistence.replaceAllConfigs(configs, false));
+    verify(decoratedConfigPersistence).replaceAllConfigs(any(), eq(false));
+  }
+
+  /**
+   * Consumes all streams input via replaceAllConfigs. This will trigger any exceptions that are
+   * thrown during processing.
+   *
+   * @param configPersistence - config persistence mock where this runs.
+   */
+  private static void consumeConfigInputStreams(final ConfigPersistence configPersistence) throws IOException {
+    doAnswer((Answer<Void>) invocation -> {
+      final Map<AirbyteConfig, Stream<?>> argument = invocation.getArgument(0);
+      // force the streams to be consumed so that we can verify the exception was thrown.
+      argument.values().forEach(entry -> entry.collect(Collectors.toList()));
+      return null;
+    }).when(configPersistence).replaceAllConfigs(any(), eq(false));
   }
 
   @SuppressWarnings("SameParameterValue")

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ClassEnforcingConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ClassEnforcingConfigPersistenceTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.config.ConfigSchema;
+import io.airbyte.config.ConfigWithMetadata;
+import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardWorkspace;
+import io.airbyte.validation.json.JsonValidationException;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ClassEnforcingConfigPersistenceTest {
+
+  public static final UUID UUID1 = UUID.randomUUID();
+  public static final Instant INSTANT = Instant.now();
+  public static final StandardWorkspace WORKSPACE = new StandardWorkspace();
+  public static final StandardSync STANDARD_SYNC = new StandardSync().withConnectionId(UUID1);
+
+  private ClassEnforcingConfigPersistence configPersistence;
+  private ConfigPersistence decoratedConfigPersistence;
+
+  @BeforeEach
+  void setUp() {
+    decoratedConfigPersistence = mock(ConfigPersistence.class);
+    configPersistence = new ClassEnforcingConfigPersistence(decoratedConfigPersistence);
+  }
+
+  @Test
+  void testWriteConfigSuccess() throws IOException, JsonValidationException {
+    configPersistence.writeConfig(ConfigSchema.STANDARD_SYNC, UUID1.toString(), STANDARD_SYNC);
+    verify(decoratedConfigPersistence).writeConfig(ConfigSchema.STANDARD_SYNC, UUID1.toString(), STANDARD_SYNC);
+  }
+
+  @Test
+  void testWriteConfigFailure() {
+    assertThrows(IllegalArgumentException.class,
+        () -> configPersistence.writeConfig(ConfigSchema.STANDARD_SYNC, UUID1.toString(), WORKSPACE));
+    verifyNoInteractions(decoratedConfigPersistence);
+  }
+
+  @Test
+  void testWriteConfigsSuccess() throws IOException, JsonValidationException {
+    final Map<String, StandardSync> configs = ImmutableMap.of(UUID1.toString(), STANDARD_SYNC);
+    configPersistence.writeConfigs(ConfigSchema.STANDARD_SYNC, configs);
+    verify(decoratedConfigPersistence).writeConfigs(ConfigSchema.STANDARD_SYNC, configs);
+  }
+
+  @Test
+  void testWriteConfigsFailure() {
+    final Map<String, StandardWorkspace> configs = ImmutableMap.of(UUID1.toString(), WORKSPACE);
+    assertThrows(IllegalArgumentException.class, () -> configPersistence.writeConfigs(ConfigSchema.STANDARD_SYNC, configs));
+    verifyNoInteractions(decoratedConfigPersistence);
+  }
+
+  @Test
+  void testGetConfigSuccess() throws IOException, JsonValidationException, ConfigNotFoundException {
+    when(decoratedConfigPersistence.getConfig(ConfigSchema.STANDARD_SYNC, UUID1.toString(), StandardSync.class))
+        .thenReturn(STANDARD_SYNC);
+    assertEquals(STANDARD_SYNC, configPersistence.getConfig(ConfigSchema.STANDARD_SYNC, UUID1.toString(), StandardSync.class));
+  }
+
+  @Test
+  void testGetConfigFailure() {
+    assertThrows(IllegalArgumentException.class,
+        () -> configPersistence.getConfig(ConfigSchema.STANDARD_SYNC, UUID1.toString(), StandardWorkspace.class));
+    verifyNoInteractions(decoratedConfigPersistence);
+  }
+
+  @Test
+  void testListConfigsSuccess() throws IOException, JsonValidationException {
+    when(decoratedConfigPersistence.listConfigs(ConfigSchema.STANDARD_SYNC, StandardSync.class)).thenReturn(List.of(STANDARD_SYNC));
+    assertEquals(List.of(STANDARD_SYNC), configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC, StandardSync.class));
+  }
+
+  @Test
+  void testListConfigsFailure() {
+    assertThrows(IllegalArgumentException.class,
+        () -> configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC, StandardWorkspace.class));
+    verifyNoInteractions(decoratedConfigPersistence);
+  }
+
+  @Test
+  void testGetConfigWithMetadataSuccess() throws IOException, JsonValidationException, ConfigNotFoundException {
+    when(decoratedConfigPersistence.getConfigWithMetadata(ConfigSchema.STANDARD_SYNC, UUID1.toString(), StandardSync.class))
+        .thenReturn(withMetadata(STANDARD_SYNC));
+    assertEquals(withMetadata(STANDARD_SYNC),
+        configPersistence.getConfigWithMetadata(ConfigSchema.STANDARD_SYNC, UUID1.toString(), StandardSync.class));
+  }
+
+  @Test
+  void testGetConfigWithMetadataFailure() {
+    assertThrows(IllegalArgumentException.class,
+        () -> configPersistence.getConfigWithMetadata(ConfigSchema.STANDARD_SYNC, UUID1.toString(), StandardWorkspace.class));
+    verifyNoInteractions(decoratedConfigPersistence);
+  }
+
+  @Test
+  void testListConfigsWithMetadataSuccess() throws IOException, JsonValidationException {
+    when(decoratedConfigPersistence.listConfigsWithMetadata(ConfigSchema.STANDARD_SYNC, StandardSync.class))
+        .thenReturn(List.of(withMetadata(STANDARD_SYNC)));
+    assertEquals(
+        List.of(withMetadata(STANDARD_SYNC)),
+        configPersistence.listConfigsWithMetadata(ConfigSchema.STANDARD_SYNC, StandardSync.class));
+  }
+
+  @Test
+  void testListConfigsWithMetadataFailure() {
+    assertThrows(IllegalArgumentException.class,
+        () -> configPersistence.listConfigsWithMetadata(ConfigSchema.STANDARD_SYNC, StandardWorkspace.class));
+    verifyNoInteractions(decoratedConfigPersistence);
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private static ConfigWithMetadata<StandardSync> withMetadata(final StandardSync actorDefinition) {
+    return new ConfigWithMetadata<>(actorDefinition.getConnectionId().toString(),
+        ConfigSchema.STANDARD_SYNC.name(),
+        INSTANT,
+        INSTANT,
+        actorDefinition);
+  }
+
+}

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ValidatingConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ValidatingConfigPersistenceTest.java
@@ -7,13 +7,17 @@ package io.airbyte.config.persistence;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import io.airbyte.config.AirbyteConfig;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.ConfigWithMetadata;
 import io.airbyte.config.StandardSourceDefinition;
@@ -26,8 +30,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
 
 class ValidatingConfigPersistenceTest {
 
@@ -203,6 +210,40 @@ class ValidatingConfigPersistenceTest {
 
     assertThrows(JsonValidationException.class, () -> configPersistence
         .listConfigsWithMetadata(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class));
+  }
+
+  @Test
+  void testReplaceAllConfigsSuccess() throws IOException, JsonValidationException {
+    consumeConfigInputStreams(decoratedConfigPersistence);
+    final Map<AirbyteConfig, Stream<?>> configs = ImmutableMap.of(ConfigSchema.STANDARD_SOURCE_DEFINITION, Stream.of(SOURCE_1));
+    configPersistence.replaceAllConfigs(configs, false);
+    verify(decoratedConfigPersistence).replaceAllConfigs(any(), eq(false));
+  }
+
+  @Test
+  void testReplaceAllConfigsFailure() throws IOException, JsonValidationException {
+    doThrow(new JsonValidationException("error")).when(schemaValidator).ensure(any(), any());
+    consumeConfigInputStreams(decoratedConfigPersistence);
+    final Map<AirbyteConfig, Stream<?>> configs = ImmutableMap.of(ConfigSchema.STANDARD_SOURCE_DEFINITION, Stream.of(SOURCE_1));
+    // because this takes place in a lambda the JsonValidationException gets rethrown as a
+    // RuntimeException.
+    assertThrows(RuntimeException.class, () -> configPersistence.replaceAllConfigs(configs, false));
+    verify(decoratedConfigPersistence).replaceAllConfigs(any(), eq(false));
+  }
+
+  /**
+   * Consumes all streams input via replaceAllConfigs. This will trigger any exceptions that are
+   * thrown during processing.
+   *
+   * @param configPersistence - config persistence mock where this runs.
+   */
+  private static void consumeConfigInputStreams(final ConfigPersistence configPersistence) throws IOException {
+    doAnswer((Answer<Void>) invocation -> {
+      final Map<AirbyteConfig, Stream<?>> argument = invocation.getArgument(0);
+      // force the streams to be consumed so that we can verify the exception was thrown.
+      argument.values().forEach(entry -> entry.collect(Collectors.toList()));
+      return null;
+    }).when(configPersistence).replaceAllConfigs(any(), eq(false));
   }
 
   private static ConfigWithMetadata<StandardSourceDefinition> withMetadata(final StandardSourceDefinition sourceDef) {

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -80,7 +80,7 @@ public class ArchiveHandlerTest {
   private JobPersistence jobPersistence;
   private SecretsRepositoryReader secretsRepositoryReader;
   private SecretsRepositoryWriter secretsRepositoryWriter;
-  private DatabaseConfigPersistence configPersistence;
+  private ConfigPersistence configPersistence;
   private ConfigPersistence seedPersistence;
   private JsonSecretsProcessor jsonSecretsProcessor;
   private FeatureFlags featureFlags;
@@ -122,7 +122,7 @@ public class ArchiveHandlerTest {
     jsonSecretsProcessor = mock(JsonSecretsProcessor.class);
     featureFlags = mock(FeatureFlags.class);
     when(featureFlags.exposeSecretsInExport()).thenReturn(true);
-    configPersistence = new DatabaseConfigPersistence(jobDatabase, jsonSecretsProcessor, featureFlags);
+    configPersistence = DatabaseConfigPersistence.createWithValidation(jobDatabase, jsonSecretsProcessor, featureFlags);
     configPersistence.replaceAllConfigs(Collections.emptyMap(), false);
     configPersistence.loadData(seedPersistence);
     configRepository = new ConfigRepository(configPersistence, configDatabase);


### PR DESCRIPTION
## What
One shortcoming of the `ConfigPersistence` iface is that it doesn't give great type safety. If you ask for a workspace object but query the sync table, it'll happily try to return this. The error handling on it isn't very clear. Sometimes it might fail because json validation will catch the mismatch. If the validation succeeds though, then you can end up with a weird, hard-to-debug output. 

This is relevant as we think about consolidating `StandardSourceDefinition` and `StandardDestinationDefinition` into a single struct `ActorDefinition`. Making that change will be safer if we check that class we are asking for matches the class declare in the enum.

## How
* Add classname to `AirbyteConfig`. Build a decorate class that compares the classname in `AirbyteConfig` to class requested in `getConfig()`, etc, and the inputs into any write methods.
