### PR TITLE
🐛 Normalization: Fix sync from HubSpot to MySQL fails with "Row size too large" on create table

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -28,5 +28,5 @@ WORKDIR /airbyte
 ENV AIRBYTE_ENTRYPOINT "/airbyte/entrypoint.sh"
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.67
+LABEL io.airbyte.version=0.1.68
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
@@ -538,6 +538,9 @@ where 1 = 1
                 trimmed_column_name = f"trim(BOTH '\"' from {column_name})"
                 sql_type = f"'{sql_type}'"
                 return f"nullif(accurateCastOrNull({trimmed_column_name}, {sql_type}), 'null') as {column_name}"
+            elif self.destination_type == DestinationType.MYSQL:
+                # Cast to `text` datatype. See https://github.com/airbytehq/airbyte/issues/7994
+                sql_type = f"{sql_type}(1024)"
         else:
             print(f"WARN: Unknown type {definition['type']} for column {property_name} at {self.current_json_path()}")
             return column_name

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
@@ -516,6 +516,8 @@ where 1 = 1
                 return f"parseDateTime64BestEffortOrNull(trim(BOTH '\"' from {replace_operation})) as {column_name}"
             # in all other cases
             sql_type = jinja_call("type_timestamp_with_timezone()")
+            if self.destination_type == DestinationType.MYSQL:
+                sql_type = f"{sql_type}(1024)"
             return f"cast({replace_operation} as {sql_type}) as {column_name}"
         elif is_date(definition):
             if self.destination_type.value == DestinationType.MYSQL.value:

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 public class NormalizationRunnerFactory {
 
   public static final String BASE_NORMALIZATION_IMAGE_NAME = "airbyte/normalization";
-  public static final String NORMALIZATION_VERSION = "0.1.67";
+  public static final String NORMALIZATION_VERSION = "0.1.68";
 
   static final Map<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>> NORMALIZATION_MAPPING =
       ImmutableMap.<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>>builder()

--- a/docs/understanding-airbyte/basic-normalization.md
+++ b/docs/understanding-airbyte/basic-normalization.md
@@ -350,6 +350,7 @@ Therefore, in order to "upgrade" to the desired normalization version, you need 
 
 | Airbyte Version | Normalization Version | Date | Pull Request | Subject |
 |:----------------| :--- | :--- | :--- | :--- |
+| 0.35.32-alpha   | 0.1.68 | 2022-02-20 | [\#????](https://github.com/airbytehq/airbyte/pull/????) | Fix Row size too large for table with numerous `string` fields |
 |                 | 0.1.66 | 2022-02-04 | [\#9341](https://github.com/airbytehq/airbyte/pull/9341) | Fix normalization for bigquery datasetId and tables |
 | 0.35.13-alpha   | 0.1.65 | 2021-01-28 | [\#9846](https://github.com/airbytehq/airbyte/pull/9846) | Tweak dbt multi-thread parameter down |
 | 0.35.12-alpha   | 0.1.64 | 2021-01-28 | [\#9793](https://github.com/airbytehq/airbyte/pull/9793) | Support PEM format for ssh-tunnel keys |

--- a/docs/understanding-airbyte/basic-normalization.md
+++ b/docs/understanding-airbyte/basic-normalization.md
@@ -350,7 +350,7 @@ Therefore, in order to "upgrade" to the desired normalization version, you need 
 
 | Airbyte Version | Normalization Version | Date | Pull Request | Subject |
 |:----------------| :--- | :--- | :--- | :--- |
-| 0.35.32-alpha   | 0.1.68 | 2022-02-20 | [\#????](https://github.com/airbytehq/airbyte/pull/????) | Fix Row size too large for table with numerous `string` fields |
+| 0.35.32-alpha   | 0.1.68 | 2022-02-20 | [\#10485](https://github.com/airbytehq/airbyte/pull/10485) | Fix row size too large for table with numerous `string` fields |
 |                 | 0.1.66 | 2022-02-04 | [\#9341](https://github.com/airbytehq/airbyte/pull/9341) | Fix normalization for bigquery datasetId and tables |
 | 0.35.13-alpha   | 0.1.65 | 2021-01-28 | [\#9846](https://github.com/airbytehq/airbyte/pull/9846) | Tweak dbt multi-thread parameter down |
 | 0.35.12-alpha   | 0.1.64 | 2021-01-28 | [\#9793](https://github.com/airbytehq/airbyte/pull/9793) | Support PEM format for ssh-tunnel keys |


### PR DESCRIPTION
## What
Closes #7994.
Changes default string casting from `varchar(512)` to `text`.

## How
- Found the issue is indeed possible to solve using the text fields.
- Before we casted string fields as `cast(field as char)` which leaded to field varchar(512). 
- `varchar(512)` may use as much as 512 * 4 = 2048 bytes in utf8mb4 encoding. 
- This means that it enough to have 32 sting fields to exceed InnoDB create table 65,535 bytes row size quota (for instance, hubspot `marketing_emails` has 38 of those fields).

So as a fix, I've updated the mysql create table query to cast sting fields as `cast(field as char(1024))`. 
Which leads to field text type on created table (`cast(field as text)` is not a valid statement, see https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html#function_cast). 

Experimentally found that values that is less then 1024 are converted to varchar types and values larger may lead to mediumtext or longtext, which are too large.

## Recommended reading order
1. `stream_processor.py`
2. the rest

## 🚨 User Impact 🚨
This would change `varchar` field in mysql tables to `text`.
