### PR TITLE
Set default values as current values in editMode

### DIFF
--- a/airbyte-webapp/src/core/form/uiWidget.test.ts
+++ b/airbyte-webapp/src/core/form/uiWidget.test.ts
@@ -156,14 +156,19 @@ test("should select correct key for enum", () => {
   );
   expect(uiWidgetState).toEqual({
     "key.dataset_name": {},
-    "key.format": {},
+    "key.format": {
+      default: "csv",
+    },
     "key.provider": {
       selectedItem: "GCS: Google Cloud Storage",
     },
-    "key.provider.reader_impl": {},
+    "key.provider.reader_impl": {
+      default: "gcsfs",
+    },
     "key.provider.service_account_json": {},
     "key.provider.storage": {
       const: "GCS",
+      default: "GCS",
     },
     "key.reader_options": {},
     "key.url": {},

--- a/airbyte-webapp/src/core/form/uiWidget.ts
+++ b/airbyte-webapp/src/core/form/uiWidget.ts
@@ -23,6 +23,10 @@ export const buildPathInitialState = (
           resultObject.const = formItem.const;
         }
 
+        if (isDefined(formItem.default)) {
+          resultObject.default = formItem.default;
+        }
+
         widgetStateBuilder[formItem.path] = resultObject;
         return widgetStateBuilder;
       }


### PR DESCRIPTION
## What
Closes #6791

## How
As initial patch, always set fields that are defined as defaults into form values. As a result, form values will be assumed dirty and could be updated correctly.