### PR TITLE
Consolidate StandardSourceDefinition and StandardDestinationDefinition

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2078,6 +2078,8 @@ components:
           format: uri
         icon:
           type: string
+        resourceRequirements:
+          $ref: "#/components/schemas/ActorDefinitionResourceRequirements"
     SourceDefinitionUpdate:
       type: object
       description: Update the SourceDefinition. Currently, the only allowed attribute to update is the default docker image version.
@@ -2089,6 +2091,8 @@ components:
           $ref: "#/components/schemas/SourceDefinitionId"
         dockerImageTag:
           type: string
+        resourceRequirements:
+          $ref: "#/components/schemas/ActorDefinitionResourceRequirements"
     SourceDefinitionRead:
       type: object
       required:
@@ -2116,6 +2120,8 @@ components:
           description: The date when this connector was first released, in yyyy-mm-dd format.
           type: string
           format: date
+        resourceRequirements:
+          $ref: "#/components/schemas/ActorDefinitionResourceRequirements"
     SourceDefinitionReadList:
       type: object
       required:
@@ -2347,6 +2353,8 @@ components:
           format: uri
         icon:
           type: string
+        resourceRequirements:
+          $ref: "#/components/schemas/ActorDefinitionResourceRequirements"
     DestinationDefinitionUpdate:
       type: object
       required:
@@ -2357,6 +2365,8 @@ components:
           $ref: "#/components/schemas/DestinationDefinitionId"
         dockerImageTag:
           type: string
+        resourceRequirements:
+          $ref: "#/components/schemas/ActorDefinitionResourceRequirements"
     DestinationDefinitionRead:
       type: object
       required:
@@ -2385,6 +2395,8 @@ components:
           description: The date when this connector was first released, in yyyy-mm-dd format.
           type: string
           format: date
+        resourceRequirements:
+          $ref: "#/components/schemas/ActorDefinitionResourceRequirements"
     DestinationDefinitionReadList:
       type: object
       required:
@@ -3429,6 +3441,34 @@ components:
           $ref: "#/components/schemas/ConnectionStateObject"
     ConnectionStateObject:
       type: object
+    ActorDefinitionResourceRequirements:
+      description: actor definition specific resource requirements. if default is set, these are the requirements that should be set for ALL jobs run for this actor definition. it is overriden by the job type specific configurations. if not set, the platform will use defaults. these values will be overriden by configuration at the connection level.
+      type: object
+      additionalProperties: true
+      properties:
+        default:
+          "$ref": "#/definitions/ResourceRequirements"
+        jobSpecific:
+          type: array
+          items:
+            "$ref": "#/definitions/JobTypeResourceLimit"
+    JobTypeResourceLimit:
+      description: sets resource requirements for a specific job type for an actor definition. these values override the default, if both are set.
+      type: object
+      properties:
+        jobType:
+          "$ref": "#/definitions/JobType"
+        resourceRequirements:
+          "$ref": "#/definitions/ResourceRequirements"
+    JobType:
+      description: enum that describes the different types of jobs that the platform runs.
+      type: string
+      # todo (cgardens) - sync naming with java
+      enum:
+        - sync
+        - check
+        - discover
+        - spec
     ResourceRequirements:
       description: optional resource requirements to run workers (blank for unbounded allocations)
       type: object

--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -80,7 +80,7 @@ public class BootloaderAppTest {
         mockedConfigs.getConfigDatabaseUrl())
             .getAndInitialize();
     val configsMigrator = new ConfigsDatabaseMigrator(configDatabase, this.getClass().getName());
-    assertEquals("0.35.28.001", configsMigrator.getLatestMigration().getVersion().getVersion());
+    assertEquals("0.35.32.001", configsMigrator.getLatestMigration().getVersion().getVersion());
 
     val jobsPersistence = new DefaultJobPersistence(jobDatabase);
     assertEquals(version, jobsPersistence.getVersion().get());

--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
@@ -83,6 +83,13 @@ public class Jsons {
     }
   }
 
+  /**
+   * Convert an object into JsonNode.
+   *
+   * @param object - object to convert to JsonNote
+   * @param <T> - type
+   * @return object as JsonNode
+   */
   public static <T> JsonNode jsonNode(final T object) {
     return OBJECT_MAPPER.valueToTree(object);
   }
@@ -91,6 +98,14 @@ public class Jsons {
     return jsonNode(Collections.emptyMap());
   }
 
+  /**
+   * Convert JsonNode into a typed object.
+   *
+   * @param jsonNode - json to type
+   * @param klass - type of the json will be converted to
+   * @param <T> - type
+   * @return object converted to type
+   */
   public static <T> T object(final JsonNode jsonNode, final Class<T> klass) {
     return OBJECT_MAPPER.convertValue(jsonNode, klass);
   }

--- a/airbyte-config/init/src/test/java/io/airbyte/config/init/YamlSeedConfigPersistenceTest.java
+++ b/airbyte-config/init/src/test/java/io/airbyte/config/init/YamlSeedConfigPersistenceTest.java
@@ -9,9 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.ConfigSchema;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -36,9 +35,9 @@ public class YamlSeedConfigPersistenceTest {
   public void testGetConfig() throws Exception {
     // source
     final String mySqlSourceId = "435bb9a5-7887-4809-aa58-28c27df0d7ad";
-    final StandardSourceDefinition mysqlSource = PERSISTENCE
-        .getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, mySqlSourceId, StandardSourceDefinition.class);
-    assertEquals(mySqlSourceId, mysqlSource.getSourceDefinitionId().toString());
+    final ActorDefinition mysqlSource = PERSISTENCE
+        .getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, mySqlSourceId, ActorDefinition.class);
+    assertEquals(mySqlSourceId, mysqlSource.getId().toString());
     assertEquals("MySQL", mysqlSource.getName());
     assertEquals("airbyte/source-mysql", mysqlSource.getDockerRepository());
     assertEquals("https://docs.airbyte.io/integrations/sources/mysql", mysqlSource.getDocumentationUrl());
@@ -47,9 +46,9 @@ public class YamlSeedConfigPersistenceTest {
 
     // destination
     final String s3DestinationId = "4816b78f-1489-44c1-9060-4b19d5fa9362";
-    final StandardDestinationDefinition s3Destination = PERSISTENCE
-        .getConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, s3DestinationId, StandardDestinationDefinition.class);
-    assertEquals(s3DestinationId, s3Destination.getDestinationDefinitionId().toString());
+    final ActorDefinition s3Destination = PERSISTENCE
+        .getConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, s3DestinationId, ActorDefinition.class);
+    assertEquals(s3DestinationId, s3Destination.getId().toString());
     assertEquals("S3", s3Destination.getName());
     assertEquals("airbyte/destination-s3", s3Destination.getDockerRepository());
     assertEquals("https://docs.airbyte.io/integrations/destinations/s3", s3Destination.getDocumentationUrl());

--- a/airbyte-config/models/src/main/java/io/airbyte/config/ConfigSchema.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/ConfigSchema.java
@@ -18,20 +18,20 @@ public enum ConfigSchema implements AirbyteConfig {
       "workspaceId"),
 
   // source
-  STANDARD_SOURCE_DEFINITION("StandardSourceDefinition.yaml",
-      StandardSourceDefinition.class,
-      standardSourceDefinition -> standardSourceDefinition.getSourceDefinitionId().toString(),
-      "sourceDefinitionId"),
+  STANDARD_SOURCE_DEFINITION("ActorDefinition.yaml",
+      ActorDefinition.class,
+      standardSourceDefinition -> standardSourceDefinition.getId().toString(),
+      "id"),
   SOURCE_CONNECTION("SourceConnection.yaml",
       SourceConnection.class,
       sourceConnection -> sourceConnection.getSourceId().toString(),
       "sourceId"),
 
   // destination
-  STANDARD_DESTINATION_DEFINITION("StandardDestinationDefinition.yaml",
-      StandardDestinationDefinition.class,
-      standardDestinationDefinition -> standardDestinationDefinition.getDestinationDefinitionId().toString(),
-      "destinationDefinitionId"),
+  STANDARD_DESTINATION_DEFINITION("ActorDefinition.yaml",
+      ActorDefinition.class,
+      standardDestinationDefinition -> standardDestinationDefinition.getId().toString(),
+      "id"),
   DESTINATION_CONNECTION("DestinationConnection.yaml",
       DestinationConnection.class,
       destinationConnection -> destinationConnection.getDestinationId().toString(),
@@ -90,12 +90,13 @@ public enum ConfigSchema implements AirbyteConfig {
 
   <T> ConfigSchema(final String schemaFilename,
                    final Class<T> className) {
-    this.schemaFilename = schemaFilename;
-    this.className = className;
-    this.extractId = object -> {
-      throw new RuntimeException(className.getSimpleName() + " doesn't have an id");
-    };
-    this.idFieldName = null;
+    this(
+        schemaFilename,
+        className,
+        object -> {
+          throw new RuntimeException(className.getSimpleName() + " doesn't have an id");
+        },
+        null);
   }
 
   @Override

--- a/airbyte-config/models/src/main/resources/types/ActorDefinition.yaml
+++ b/airbyte-config/models/src/main/resources/types/ActorDefinition.yaml
@@ -1,21 +1,23 @@
 ---
 "$schema": http://json-schema.org/draft-07/schema#
-"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
-title: StandardDestinationDefinition
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/ActorDefinition.yaml
+title: ActorDefinition
 description: describes a destination
 type: object
 required:
-  - destinationDefinitionId
+  - id
+  - actorType
   - name
   - dockerRepository
   - dockerImageTag
-  - documentationUrl
   - spec
 additionalProperties: true
 properties:
-  destinationDefinitionId:
+  id:
     type: string
     format: uuid
+  actorType:
+    "$ref": ActorType.yaml
   name:
     type: string
   dockerRepository:
@@ -26,9 +28,12 @@ properties:
     type: string
   icon:
     type: string
+  # only relevant for sources
+  sourceType:
+    "$ref": SourceType.yaml
   spec:
     type: object
-    # tooooooooodoooo
+    # necessary because declaration is in another package.
     existingJavaType: io.airbyte.protocol.models.ConnectorSpecification
   tombstone:
     description:

--- a/airbyte-config/models/src/main/resources/types/ActorDefinitionReleaseStage.yaml
+++ b/airbyte-config/models/src/main/resources/types/ActorDefinitionReleaseStage.yaml
@@ -1,0 +1,11 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/ActorDefinitionReleaseStage.yaml
+title: ActorDefinitionReleaseStage
+description: releases stages for actor definitions
+type: string
+enum:
+  - alpha
+  - beta
+  - generallyAvailable
+  - custom

--- a/airbyte-config/models/src/main/resources/types/ActorDefinitionResourceRequirements.yaml
+++ b/airbyte-config/models/src/main/resources/types/ActorDefinitionResourceRequirements.yaml
@@ -1,0 +1,27 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/ActorDefinitionResourceRequirements.yaml
+title: ActorDefinitionResourceRequirements
+description: actor definition specific resource requirements
+type: object
+additionalProperties: true
+properties:
+  default:
+    description: if set, these are the requirements that should be set for ALL jobs run for this actor definition.
+    "$ref": ResourceRequirements.yaml
+  jobSpecific:
+    type: array
+    items:
+      "$ref": "#/definitions/JobTypeResourceLimit"
+definitions:
+  JobTypeResourceLimit:
+    description: sets resource requirements for a specific job type for an actor definition. these values override the default, if both are set.
+    type: object
+    required:
+      - jobtype
+      - resourceRequirements
+    properties:
+      jobType:
+        "$ref": JobType.yaml
+      resourceRequirements:
+        "$ref": ResourceRequirements.yaml

--- a/airbyte-config/models/src/main/resources/types/ActorType.yaml
+++ b/airbyte-config/models/src/main/resources/types/ActorType.yaml
@@ -1,0 +1,9 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/ActorType.yaml
+title: ActorType
+description: enum that describes different types of actors
+type: string
+enum:
+  - source
+  - destination

--- a/airbyte-config/models/src/main/resources/types/ActorType.yaml
+++ b/airbyte-config/models/src/main/resources/types/ActorType.yaml
@@ -7,3 +7,5 @@ type: string
 enum:
   - source
   - destination
+#  - mapper
+#  - runner

--- a/airbyte-config/models/src/main/resources/types/JobSyncConfig.yaml
+++ b/airbyte-config/models/src/main/resources/types/JobSyncConfig.yaml
@@ -39,6 +39,10 @@ properties:
   destinationDockerImage:
     description: Image name of the destination with tag.
     type: string
+  sourceResourceRequirements:
+    "$ref": ActorDefinitionResourceRequirements.yaml
+  destinationResourceRequirements:
+    "$ref": ActorDefinitionResourceRequirements.yaml
   operationSequence:
     description: Sequence of configurations of operations to apply as part of the sync
     type: array

--- a/airbyte-config/models/src/main/resources/types/JobType.yaml
+++ b/airbyte-config/models/src/main/resources/types/JobType.yaml
@@ -1,0 +1,12 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/JobType.yaml
+title: JobType
+description: enum that describes the different types of jobs that the platform runs.
+type: string
+# todo (cgardens) - sync naming with java
+enum:
+  - sync
+  - check
+  - discover
+  - spec

--- a/airbyte-config/models/src/main/resources/types/ResourceRequirements.yaml
+++ b/airbyte-config/models/src/main/resources/types/ResourceRequirements.yaml
@@ -1,0 +1,17 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/ResourceRequirements.yaml
+title: ResourceRequirements
+description: generic configuration for pod source requirements
+type: object
+additionalProperties: true
+properties:
+  # todo (cgardens) - should be camel case for consistency.
+  cpu_request:
+    type: string
+  cpu_limit:
+    type: string
+  memory_request:
+    type: string
+  memory_limit:
+    type: string

--- a/airbyte-config/models/src/main/resources/types/SourceType.yaml
+++ b/airbyte-config/models/src/main/resources/types/SourceType.yaml
@@ -1,0 +1,11 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/SourceType.yaml
+title: SourceType
+description: enum to describe each type of source
+type: string
+enum:
+  - api
+  - file
+  - database
+  - custom

--- a/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
@@ -28,7 +28,7 @@ properties:
     type: string
   spec:
     type: object
-    # tooooooooodoooo
+    # necessary because this type is declared in another module
     existingJavaType: io.airbyte.protocol.models.ConnectorSpecification
   tombstone:
     description:

--- a/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
@@ -45,3 +45,5 @@ properties:
     description: The date when this connector was first released, in yyyy-mm-dd format.
     type: string
     format: date
+  resourceRequirements:
+    "$ref": ActorDefinitionResourceRequirements.yaml

--- a/airbyte-config/models/src/main/resources/types/StandardSourceDefinition.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSourceDefinition.yaml
@@ -27,12 +27,7 @@ properties:
   icon:
     type: string
   sourceType:
-    type: string
-    enum:
-      - api
-      - file
-      - database
-      - custom
+    "$ref": SourceType.yaml
   spec:
     type: object
     existingJavaType: io.airbyte.protocol.models.ConnectorSpecification
@@ -42,12 +37,7 @@ properties:
       configuration is permanently off.
     type: boolean
   releaseStage:
-    type: string
-    enum:
-      - alpha
-      - beta
-      - generallyAvailable
-      - custom
+    "$ref": ActorDefinitionReleaseStage.yaml
   releaseDate:
     description: The date when this connector was first released, in yyyy-mm-dd format.
     type: string

--- a/airbyte-config/models/src/main/resources/types/StandardSourceDefinition.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSourceDefinition.yaml
@@ -52,3 +52,5 @@ properties:
     description: The date when this connector was first released, in yyyy-mm-dd format.
     type: string
     format: date
+  resourceRequirements:
+    "$ref": ActorDefinitionResourceRequirements.yaml

--- a/airbyte-config/models/src/main/resources/types/StandardSync.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSync.yaml
@@ -70,15 +70,4 @@ properties:
   manual:
     type: boolean
   resourceRequirements:
-    type: object
-    description: optional resource requirements to run sync workers
-    additionalProperties: false
-    properties:
-      cpu_request:
-        type: string
-      cpu_limit:
-        type: string
-      memory_request:
-        type: string
-      memory_limit:
-        type: string
+    "$ref": ResourceRequirements.yaml

--- a/airbyte-config/models/src/main/resources/types/StandardSyncInput.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSyncInput.yaml
@@ -35,11 +35,16 @@ properties:
   catalog:
     description: the configured airbyte catalog
     type: object
+    # necessary because the configuration declaration is in a separate package.
     existingJavaType: io.airbyte.protocol.models.ConfiguredAirbyteCatalog
   state:
     description: optional state of the previous run. this object is defined per integration.
     "$ref": State.yaml
   resourceRequirements:
-    description: optional resource requirements to run sync workers
+    description: optional resource requirements to run sync workers (confusing - overrides source and destination). takes precedence over source and destination resource requirements.
     type: object
-    existingJavaType: io.airbyte.config.ResourceRequirements
+    "$ref": ResourceRequirements.yaml
+  sourceResourceRequirements:
+    "$ref": ActorDefinitionResourceRequirements.yaml
+  destinationResourceRequirements:
+    "$ref": ActorDefinitionResourceRequirements.yaml

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ActorDefinitionMigrationUtils.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ActorDefinitionMigrationUtils.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.persistence;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition;
+import io.airbyte.config.ActorDefinition.ActorType;
+import io.airbyte.config.AirbyteConfig;
+import io.airbyte.config.ConfigSchema;
+import io.airbyte.config.StandardDestinationDefinition;
+import io.airbyte.config.StandardSourceDefinition;
+
+/**
+ * Helpers for migration of StandardSourceDefinition, StandardDefinitionDefinition to
+ * ActorDefinition. Remove after migration.
+ */
+public class ActorDefinitionMigrationUtils {
+
+  // todo (cgardens) - while we are migrating to ActorDefinitions, we have a shim layer in
+  // ConfigRepository to convert from ActorDefinition (used internally in the db) and
+  // StandardSourceDefinition, used externally.
+  public static StandardSourceDefinition mapActorDefToSourceDef(final ActorDefinition actorDefinition) {
+    Preconditions.checkArgument(actorDefinition.getActorType() == ActorType.SOURCE);
+    return new StandardSourceDefinition()
+        .withName(actorDefinition.getName())
+        .withSourceDefinitionId(actorDefinition.getId())
+        .withDockerRepository(actorDefinition.getDockerRepository())
+        .withDockerImageTag(actorDefinition.getDockerImageTag())
+        .withDocumentationUrl(actorDefinition.getDocumentationUrl())
+        .withIcon(actorDefinition.getIcon())
+        .withSpec(actorDefinition.getSpec())
+        .withSourceType(actorDefinition.getSourceType())
+        .withTombstone(actorDefinition.getTombstone())
+        .withReleaseStage(actorDefinition.getReleaseStage())
+        .withReleaseDate(actorDefinition.getReleaseDate())
+        .withResourceRequirements(actorDefinition.getResourceRequirements());
+  }
+
+  // todo (cgardens) - while we are migrating to ActorDefinitions, we have a shim layer in
+  // ConfigRepository to convert from ActorDefinition (used internally in the db) and
+  // StandardSourceDefinition, used externally.
+  public static ActorDefinition mapSourceDefToActorDef(final StandardSourceDefinition sourceDefinition) {
+    return new ActorDefinition()
+        .withName(sourceDefinition.getName())
+        .withId(sourceDefinition.getSourceDefinitionId())
+        .withActorType(ActorType.SOURCE)
+        .withDockerRepository(sourceDefinition.getDockerRepository())
+        .withDockerImageTag(sourceDefinition.getDockerImageTag())
+        .withDocumentationUrl(sourceDefinition.getDocumentationUrl())
+        .withIcon(sourceDefinition.getIcon())
+        .withSpec(sourceDefinition.getSpec())
+        .withSourceType(sourceDefinition.getSourceType())
+        .withTombstone(sourceDefinition.getTombstone())
+        .withReleaseStage(sourceDefinition.getReleaseStage())
+        .withReleaseDate(sourceDefinition.getReleaseDate())
+        .withResourceRequirements(sourceDefinition.getResourceRequirements());
+  }
+
+  // todo (cgardens) - while we are migrating to ActorDefinitions, we have a shim layer in
+  // ConfigRepository to convert from ActorDefinition (used internally in the db) and
+  // StandardDestinationDefinition, used externally.
+  public static StandardDestinationDefinition mapActorDefToDestDef(final ActorDefinition actorDefinition) {
+    Preconditions.checkArgument(actorDefinition.getActorType() == ActorType.DESTINATION);
+    return new StandardDestinationDefinition()
+        .withName(actorDefinition.getName())
+        .withDestinationDefinitionId(actorDefinition.getId())
+        .withDockerRepository(actorDefinition.getDockerRepository())
+        .withDockerImageTag(actorDefinition.getDockerImageTag())
+        .withDocumentationUrl(actorDefinition.getDocumentationUrl())
+        .withIcon(actorDefinition.getIcon())
+        .withSpec(actorDefinition.getSpec())
+        .withTombstone(actorDefinition.getTombstone())
+        .withReleaseStage(actorDefinition.getReleaseStage())
+        .withReleaseDate(actorDefinition.getReleaseDate())
+        .withResourceRequirements(actorDefinition.getResourceRequirements());
+  }
+
+  // todo (cgardens) - while we are migrating to ActorDefinitions, we have a shim layer in
+  // ConfigRepository to convert from ActorDefinition (used internally in the db) and
+  // StandardSourceDefinition, used externally.
+  public static ActorDefinition mapDestDefToActorDef(final StandardDestinationDefinition destDefinition) {
+    return new ActorDefinition()
+        .withName(destDefinition.getName())
+        .withId(destDefinition.getDestinationDefinitionId())
+        .withActorType(ActorType.DESTINATION)
+        .withDockerRepository(destDefinition.getDockerRepository())
+        .withDockerImageTag(destDefinition.getDockerImageTag())
+        .withDocumentationUrl(destDefinition.getDocumentationUrl())
+        .withIcon(destDefinition.getIcon())
+        .withSpec(destDefinition.getSpec())
+        .withTombstone(destDefinition.getTombstone())
+        .withReleaseStage(destDefinition.getReleaseStage())
+        .withReleaseDate(destDefinition.getReleaseDate())
+        .withResourceRequirements(destDefinition.getResourceRequirements());
+  }
+
+  /**
+   * If an object is stored as a StandardSourceDefinition or StandardDestinationDefinition, map it to
+   * an ActorDefinition. The ConfigPersistence iface should deal only in ActorDefinitions going
+   * forward. In all other cases, returns the original object.
+   *
+   * This is a shim until we update the yaml to match the actor definition format.
+   *
+   * @param configType - type of the config
+   * @param json - object to maybe convert
+   * @return object after conversion
+   */
+  public static JsonNode convertIfNeeded(final AirbyteConfig configType, final JsonNode json) {
+    if (configType == ConfigSchema.STANDARD_SOURCE_DEFINITION) {
+      // detect if it is using ActorDefinition or StandardSourceDefinition. If StandardSourceDefinition,
+      // normalize it to ActorDefinition.
+      if (json.has("sourceDefinitionId")) {
+        return Jsons.jsonNode(mapSourceDefToActorDef(Jsons.object(json, StandardSourceDefinition.class)));
+      } else {
+        return json;
+      }
+    } else if (configType == ConfigSchema.STANDARD_DESTINATION_DEFINITION) {
+      // detect if it is using ActorDefinition or StandardDestinationDefinition. If
+      // StandardDestinationDefinition, normalize it to ActorDefinition.
+      if (json.has("destinationDefinitionId")) {
+        return Jsons.jsonNode(mapDestDefToActorDef(Jsons.object(json, StandardDestinationDefinition.class)));
+      } else {
+        return json;
+      }
+    } else {
+      return json;
+    }
+  }
+
+}

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -27,6 +27,7 @@ import io.airbyte.commons.util.MoreIterators;
 import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.ActorCatalog;
 import io.airbyte.config.ActorCatalogFetchEvent;
+import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.AirbyteConfig;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.ConfigWithMetadata;
@@ -398,7 +399,10 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
         .withReleaseStage(record.get(ACTOR_DEFINITION.RELEASE_STAGE) == null ? null
             : Enums.toEnum(record.get(ACTOR_DEFINITION.RELEASE_STAGE, String.class), StandardSourceDefinition.ReleaseStage.class).orElseThrow())
         .withReleaseDate(record.get(ACTOR_DEFINITION.RELEASE_DATE) == null ? null
-            : record.get(ACTOR_DEFINITION.RELEASE_DATE).toString());
+            : record.get(ACTOR_DEFINITION.RELEASE_DATE).toString())
+        .withResourceRequirements(record.get(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS) == null
+            ? null
+            : Jsons.deserialize(record.get(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS).data(), ActorDefinitionResourceRequirements.class));
   }
 
   private List<ConfigWithMetadata<StandardDestinationDefinition>> listStandardDestinationDefinitionWithMetadata() throws IOException {
@@ -442,7 +446,10 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
         .withReleaseStage(record.get(ACTOR_DEFINITION.RELEASE_STAGE) == null ? null
             : Enums.toEnum(record.get(ACTOR_DEFINITION.RELEASE_STAGE, String.class), StandardDestinationDefinition.ReleaseStage.class).orElseThrow())
         .withReleaseDate(record.get(ACTOR_DEFINITION.RELEASE_DATE) == null ? null
-            : record.get(ACTOR_DEFINITION.RELEASE_DATE).toString());
+            : record.get(ACTOR_DEFINITION.RELEASE_DATE).toString())
+        .withResourceRequirements(record.get(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS) == null
+            ? null
+            : Jsons.deserialize(record.get(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS).data(), ActorDefinitionResourceRequirements.class));
   }
 
   private List<ConfigWithMetadata<SourceConnection>> listSourceConnectionWithMetadata() throws IOException {
@@ -887,6 +894,9 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                     io.airbyte.db.instance.configs.jooq.enums.ReleaseStage.class).orElseThrow())
             .set(ACTOR_DEFINITION.RELEASE_DATE, standardSourceDefinition.getReleaseDate() == null ? null
                 : LocalDate.parse(standardSourceDefinition.getReleaseDate()))
+            .set(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS,
+                standardSourceDefinition.getResourceRequirements() == null ? null
+                    : JSONB.valueOf(Jsons.serialize(standardSourceDefinition.getResourceRequirements())))
             .set(ACTOR_DEFINITION.UPDATED_AT, timestamp)
             .where(ACTOR_DEFINITION.ID.eq(standardSourceDefinition.getSourceDefinitionId()))
             .execute();
@@ -912,6 +922,9 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                         io.airbyte.db.instance.configs.jooq.enums.ReleaseStage.class).orElseThrow())
             .set(ACTOR_DEFINITION.RELEASE_DATE, standardSourceDefinition.getReleaseDate() == null ? null
                 : LocalDate.parse(standardSourceDefinition.getReleaseDate()))
+            .set(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS,
+                standardSourceDefinition.getResourceRequirements() == null ? null
+                    : JSONB.valueOf(Jsons.serialize(standardSourceDefinition.getResourceRequirements())))
             .set(ACTOR_DEFINITION.CREATED_AT, timestamp)
             .set(ACTOR_DEFINITION.UPDATED_AT, timestamp)
             .execute();
@@ -949,6 +962,9 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                     io.airbyte.db.instance.configs.jooq.enums.ReleaseStage.class).orElseThrow())
             .set(ACTOR_DEFINITION.RELEASE_DATE, standardDestinationDefinition.getReleaseDate() == null ? null
                 : LocalDate.parse(standardDestinationDefinition.getReleaseDate()))
+            .set(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS,
+                standardDestinationDefinition.getResourceRequirements() == null ? null
+                    : JSONB.valueOf(Jsons.serialize(standardDestinationDefinition.getResourceRequirements())))
             .set(ACTOR_DEFINITION.UPDATED_AT, timestamp)
             .where(ACTOR_DEFINITION.ID.eq(standardDestinationDefinition.getDestinationDefinitionId()))
             .execute();
@@ -970,6 +986,9 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                         io.airbyte.db.instance.configs.jooq.enums.ReleaseStage.class).orElseThrow())
             .set(ACTOR_DEFINITION.RELEASE_DATE, standardDestinationDefinition.getReleaseDate() == null ? null
                 : LocalDate.parse(standardDestinationDefinition.getReleaseDate()))
+            .set(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS,
+                standardDestinationDefinition.getResourceRequirements() == null ? null
+                    : JSONB.valueOf(Jsons.serialize(standardDestinationDefinition.getResourceRequirements())))
             .set(ACTOR_DEFINITION.CREATED_AT, timestamp)
             .set(ACTOR_DEFINITION.UPDATED_AT, timestamp)
             .execute();

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -1744,8 +1744,6 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
       int newConnectorCount = 0;
       int updatedConnectorCount = 0;
 
-      // todo (cgardens) you need to handle the backwards compat and conversion from old model to new
-      // somewhere. either here or upstream.
       final List<ActorDefinition> latestSources = seedConfigPersistence.listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, ActorDefinition.class);
       final ConnectorCounter sourceConnectorCounter = updateConnectorDefinitions(
           ctx,
@@ -1963,7 +1961,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
       return false;
     }
   }
-  
+
   private static class ConnectorCounter {
 
     private final int newCount;

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
@@ -96,41 +96,6 @@ public abstract class BaseDatabaseConfigPersistenceTest {
       .withDocumentationUrl("https://docs.airbyte.io/integrations/destinations/s3")
       .withTombstone(false);
 
-  // protected static final StandardSourceDefinition SOURCE_GITHUB = new StandardSourceDefinition()
-  // .withName("GitHub")
-  // .withSourceDefinitionId(UUID.fromString("ef69ef6e-aa7f-4af1-a01d-ef775033524e"))
-  // .withDockerRepository("airbyte/source-github")
-  // .withDockerImageTag("0.2.3")
-  // .withDocumentationUrl("https://docs.airbyte.io/integrations/sources/github")
-  // .withIcon("github.svg")
-  // .withSourceType(SourceType.API)
-  // .withTombstone(false);
-  // protected static final StandardSourceDefinition SOURCE_POSTGRES = new StandardSourceDefinition()
-  // .withName("Postgres")
-  // .withSourceDefinitionId(UUID.fromString("decd338e-5647-4c0b-adf4-da0e75f5a750"))
-  // .withDockerRepository("airbyte/source-postgres")
-  // .withDockerImageTag("0.3.11")
-  // .withDocumentationUrl("https://docs.airbyte.io/integrations/sources/postgres")
-  // .withIcon("postgresql.svg")
-  // .withSourceType(SourceType.DATABASE)
-  // .withTombstone(false);
-  // protected static final StandardDestinationDefinition DESTINATION_SNOWFLAKE = new
-  // StandardDestinationDefinition()
-  // .withName("Snowflake")
-  // .withDestinationDefinitionId(UUID.fromString("424892c4-daac-4491-b35d-c6688ba547ba"))
-  // .withDockerRepository("airbyte/destination-snowflake")
-  // .withDockerImageTag("0.3.16")
-  // .withDocumentationUrl("https://docs.airbyte.io/integrations/destinations/snowflake")
-  // .withTombstone(false);
-  // protected static final StandardDestinationDefinition DESTINATION_S3 = new
-  // StandardDestinationDefinition()
-  // .withName("S3")
-  // .withDestinationDefinitionId(UUID.fromString("4816b78f-1489-44c1-9060-4b19d5fa9362"))
-  // .withDockerRepository("airbyte/destination-s3")
-  // .withDockerImageTag("0.1.12")
-  // .withDocumentationUrl("https://docs.airbyte.io/integrations/destinations/s3")
-  // .withTombstone(false);
-
   protected static void writeSource(final ConfigPersistence configPersistence, final ActorDefinition source) throws Exception {
     configPersistence.writeConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, source.getId().toString(), source);
   }

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
@@ -6,14 +6,13 @@ package io.airbyte.config.persistence;
 
 import static org.jooq.impl.DSL.asterisk;
 import static org.jooq.impl.DSL.count;
-import static org.jooq.impl.DSL.table;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.config.ActorDefinition;
+import io.airbyte.config.ActorDefinition.ActorType;
+import io.airbyte.config.ActorDefinition.SourceType;
 import io.airbyte.config.ConfigSchema;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
-import io.airbyte.config.StandardSourceDefinition.SourceType;
 import io.airbyte.db.Database;
 import java.sql.SQLException;
 import java.util.List;
@@ -60,58 +59,97 @@ public abstract class BaseDatabaseConfigPersistenceTest {
             "TRUNCATE TABLE state, actor_catalog, actor_catalog_fetch_event, connection_operation, connection, operation, actor_oauth_parameter, actor, actor_definition, workspace"));
   }
 
-  protected static final StandardSourceDefinition SOURCE_GITHUB = new StandardSourceDefinition()
+  protected static final ActorDefinition SOURCE_GITHUB = new ActorDefinition()
+      .withActorType(ActorType.SOURCE)
       .withName("GitHub")
-      .withSourceDefinitionId(UUID.fromString("ef69ef6e-aa7f-4af1-a01d-ef775033524e"))
+      .withId(UUID.fromString("ef69ef6e-aa7f-4af1-a01d-ef775033524e"))
       .withDockerRepository("airbyte/source-github")
       .withDockerImageTag("0.2.3")
       .withDocumentationUrl("https://docs.airbyte.io/integrations/sources/github")
       .withIcon("github.svg")
       .withSourceType(SourceType.API)
       .withTombstone(false);
-  protected static final StandardSourceDefinition SOURCE_POSTGRES = new StandardSourceDefinition()
+  protected static final ActorDefinition SOURCE_POSTGRES = new ActorDefinition()
+      .withActorType(ActorType.SOURCE)
       .withName("Postgres")
-      .withSourceDefinitionId(UUID.fromString("decd338e-5647-4c0b-adf4-da0e75f5a750"))
+      .withId(UUID.fromString("decd338e-5647-4c0b-adf4-da0e75f5a750"))
       .withDockerRepository("airbyte/source-postgres")
       .withDockerImageTag("0.3.11")
       .withDocumentationUrl("https://docs.airbyte.io/integrations/sources/postgres")
       .withIcon("postgresql.svg")
       .withSourceType(SourceType.DATABASE)
       .withTombstone(false);
-  protected static final StandardDestinationDefinition DESTINATION_SNOWFLAKE = new StandardDestinationDefinition()
+  protected static final ActorDefinition DESTINATION_SNOWFLAKE = new ActorDefinition()
+      .withActorType(ActorType.DESTINATION)
       .withName("Snowflake")
-      .withDestinationDefinitionId(UUID.fromString("424892c4-daac-4491-b35d-c6688ba547ba"))
+      .withId(UUID.fromString("424892c4-daac-4491-b35d-c6688ba547ba"))
       .withDockerRepository("airbyte/destination-snowflake")
       .withDockerImageTag("0.3.16")
       .withDocumentationUrl("https://docs.airbyte.io/integrations/destinations/snowflake")
       .withTombstone(false);
-  protected static final StandardDestinationDefinition DESTINATION_S3 = new StandardDestinationDefinition()
+  protected static final ActorDefinition DESTINATION_S3 = new ActorDefinition()
+      .withActorType(ActorType.DESTINATION)
       .withName("S3")
-      .withDestinationDefinitionId(UUID.fromString("4816b78f-1489-44c1-9060-4b19d5fa9362"))
+      .withId(UUID.fromString("4816b78f-1489-44c1-9060-4b19d5fa9362"))
       .withDockerRepository("airbyte/destination-s3")
       .withDockerImageTag("0.1.12")
       .withDocumentationUrl("https://docs.airbyte.io/integrations/destinations/s3")
       .withTombstone(false);
 
-  protected static void writeSource(final ConfigPersistence configPersistence, final StandardSourceDefinition source) throws Exception {
-    configPersistence.writeConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, source.getSourceDefinitionId().toString(), source);
+  // protected static final StandardSourceDefinition SOURCE_GITHUB = new StandardSourceDefinition()
+  // .withName("GitHub")
+  // .withSourceDefinitionId(UUID.fromString("ef69ef6e-aa7f-4af1-a01d-ef775033524e"))
+  // .withDockerRepository("airbyte/source-github")
+  // .withDockerImageTag("0.2.3")
+  // .withDocumentationUrl("https://docs.airbyte.io/integrations/sources/github")
+  // .withIcon("github.svg")
+  // .withSourceType(SourceType.API)
+  // .withTombstone(false);
+  // protected static final StandardSourceDefinition SOURCE_POSTGRES = new StandardSourceDefinition()
+  // .withName("Postgres")
+  // .withSourceDefinitionId(UUID.fromString("decd338e-5647-4c0b-adf4-da0e75f5a750"))
+  // .withDockerRepository("airbyte/source-postgres")
+  // .withDockerImageTag("0.3.11")
+  // .withDocumentationUrl("https://docs.airbyte.io/integrations/sources/postgres")
+  // .withIcon("postgresql.svg")
+  // .withSourceType(SourceType.DATABASE)
+  // .withTombstone(false);
+  // protected static final StandardDestinationDefinition DESTINATION_SNOWFLAKE = new
+  // StandardDestinationDefinition()
+  // .withName("Snowflake")
+  // .withDestinationDefinitionId(UUID.fromString("424892c4-daac-4491-b35d-c6688ba547ba"))
+  // .withDockerRepository("airbyte/destination-snowflake")
+  // .withDockerImageTag("0.3.16")
+  // .withDocumentationUrl("https://docs.airbyte.io/integrations/destinations/snowflake")
+  // .withTombstone(false);
+  // protected static final StandardDestinationDefinition DESTINATION_S3 = new
+  // StandardDestinationDefinition()
+  // .withName("S3")
+  // .withDestinationDefinitionId(UUID.fromString("4816b78f-1489-44c1-9060-4b19d5fa9362"))
+  // .withDockerRepository("airbyte/destination-s3")
+  // .withDockerImageTag("0.1.12")
+  // .withDocumentationUrl("https://docs.airbyte.io/integrations/destinations/s3")
+  // .withTombstone(false);
+
+  protected static void writeSource(final ConfigPersistence configPersistence, final ActorDefinition source) throws Exception {
+    configPersistence.writeConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, source.getId().toString(), source);
   }
 
-  protected static void writeDestination(final ConfigPersistence configPersistence, final StandardDestinationDefinition destination)
+  protected static void writeDestination(final ConfigPersistence configPersistence, final ActorDefinition destination)
       throws Exception {
-    configPersistence.writeConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destination.getDestinationDefinitionId().toString(), destination);
+    configPersistence.writeConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destination.getId().toString(), destination);
   }
 
-  protected static void writeDestinations(final ConfigPersistence configPersistence, final List<StandardDestinationDefinition> destinations)
+  protected static void writeDestinations(final ConfigPersistence configPersistence, final List<ActorDefinition> destinations)
       throws Exception {
-    final Map<String, StandardDestinationDefinition> destinationsByID = destinations.stream()
-        .collect(Collectors.toMap(destinationDefinition -> destinationDefinition.getDestinationDefinitionId().toString(), Function.identity()));
+    final Map<String, ActorDefinition> destinationsByID = destinations.stream()
+        .collect(Collectors.toMap(destinationDefinition -> destinationDefinition.getId().toString(), Function.identity()));
     configPersistence.writeConfigs(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destinationsByID);
   }
 
-  protected static void deleteDestination(final ConfigPersistence configPersistence, final StandardDestinationDefinition destination)
+  protected static void deleteDestination(final ConfigPersistence configPersistence, final ActorDefinition destination)
       throws Exception {
-    configPersistence.deleteConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destination.getDestinationDefinitionId().toString());
+    configPersistence.deleteConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destination.getId().toString());
   }
 
   protected Map<String, Set<JsonNode>> getMapWithSet(final Map<String, Stream<JsonNode>> input) {
@@ -131,16 +169,16 @@ public abstract class BaseDatabaseConfigPersistenceTest {
     assertEquals(expectedCount, recordCount.get(0).value1());
   }
 
-  protected void assertHasSource(final StandardSourceDefinition source) throws Exception {
-    assertEquals(source, configPersistence
-        .getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, source.getSourceDefinitionId().toString(),
-            StandardSourceDefinition.class));
+  protected void assertHasSource(final ActorDefinition expected) throws Exception {
+    final ActorDefinition actual = configPersistence
+        .getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, expected.getId().toString(), ActorDefinition.class);
+    assertEquals(expected, actual);
   }
 
-  protected void assertHasDestination(final StandardDestinationDefinition destination) throws Exception {
-    assertEquals(destination, configPersistence
-        .getConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, destination.getDestinationDefinitionId().toString(),
-            StandardDestinationDefinition.class));
+  protected void assertHasDestination(final ActorDefinition expected) throws Exception {
+    final ActorDefinition actual = configPersistence
+        .getConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, expected.getId().toString(), ActorDefinition.class);
+    assertEquals(expected, actual);
   }
 
 }

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceE2EReadWriteTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceE2EReadWriteTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.spy;
 
 import io.airbyte.config.ActorCatalog;
 import io.airbyte.config.ActorCatalogFetchEvent;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.DestinationOAuthParameter;
@@ -94,14 +95,14 @@ public class DatabaseConfigPersistenceE2EReadWriteTest extends BaseDatabaseConfi
     }
     assertTrue(configPersistence.listConfigs(ConfigSchema.DESTINATION_OAUTH_PARAM, DestinationOAuthParameter.class).isEmpty());
 
-    for (final StandardSourceDefinition standardSourceDefinition : MockData.standardSourceDefinitions()) {
-      configPersistence.deleteConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, standardSourceDefinition.getSourceDefinitionId().toString());
+    for (final ActorDefinition standardSourceDefinition : MockData.standardSourceDefinitions()) {
+      configPersistence.deleteConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, standardSourceDefinition.getId().toString());
     }
     assertTrue(configPersistence.listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class).isEmpty());
 
-    for (final StandardDestinationDefinition standardDestinationDefinition : MockData.standardDestinationDefinitions()) {
+    for (final ActorDefinition standardDestinationDefinition : MockData.standardDestinationDefinitions()) {
       configPersistence
-          .deleteConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, standardDestinationDefinition.getDestinationDefinitionId().toString());
+          .deleteConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, standardDestinationDefinition.getId().toString());
     }
     assertTrue(configPersistence.listConfigs(ConfigSchema.STANDARD_DESTINATION_DEFINITION, StandardDestinationDefinition.class).isEmpty());
 
@@ -225,34 +226,34 @@ public class DatabaseConfigPersistenceE2EReadWriteTest extends BaseDatabaseConfi
   }
 
   private void standardDestinationDefinition() throws JsonValidationException, IOException, ConfigNotFoundException {
-    for (final StandardDestinationDefinition standardDestinationDefinition : MockData.standardDestinationDefinitions()) {
+    for (final ActorDefinition standardDestinationDefinition : MockData.standardDestinationDefinitions()) {
       configPersistence.writeConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION,
-          standardDestinationDefinition.getDestinationDefinitionId().toString(),
+          standardDestinationDefinition.getId().toString(),
           standardDestinationDefinition);
-      final StandardDestinationDefinition standardDestinationDefinitionFromDB = configPersistence
+      final ActorDefinition standardDestinationDefinitionFromDB = configPersistence
           .getConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION,
-              standardDestinationDefinition.getDestinationDefinitionId().toString(),
-              StandardDestinationDefinition.class);
+              standardDestinationDefinition.getId().toString(),
+              ActorDefinition.class);
       assertEquals(standardDestinationDefinition, standardDestinationDefinitionFromDB);
     }
-    final List<StandardDestinationDefinition> standardDestinationDefinitions = configPersistence
-        .listConfigs(ConfigSchema.STANDARD_DESTINATION_DEFINITION, StandardDestinationDefinition.class);
+    final List<ActorDefinition> standardDestinationDefinitions = configPersistence
+        .listConfigs(ConfigSchema.STANDARD_DESTINATION_DEFINITION, ActorDefinition.class);
     assertEquals(MockData.standardDestinationDefinitions().size(), standardDestinationDefinitions.size());
     assertThat(MockData.standardDestinationDefinitions()).hasSameElementsAs(standardDestinationDefinitions);
   }
 
   private void standardSourceDefinition() throws JsonValidationException, IOException, ConfigNotFoundException {
-    for (final StandardSourceDefinition standardSourceDefinition : MockData.standardSourceDefinitions()) {
+    for (final ActorDefinition standardSourceDefinition : MockData.standardSourceDefinitions()) {
       configPersistence.writeConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION,
-          standardSourceDefinition.getSourceDefinitionId().toString(),
+          standardSourceDefinition.getId().toString(),
           standardSourceDefinition);
-      final StandardSourceDefinition standardSourceDefinitionFromDB = configPersistence.getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION,
-          standardSourceDefinition.getSourceDefinitionId().toString(),
-          StandardSourceDefinition.class);
+      final ActorDefinition standardSourceDefinitionFromDB = configPersistence.getConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION,
+          standardSourceDefinition.getId().toString(),
+          ActorDefinition.class);
       assertEquals(standardSourceDefinition, standardSourceDefinitionFromDB);
     }
-    final List<StandardSourceDefinition> standardSourceDefinitions = configPersistence
-        .listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class);
+    final List<ActorDefinition> standardSourceDefinitions = configPersistence
+        .listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, ActorDefinition.class);
     assertEquals(MockData.standardSourceDefinitions().size(), standardSourceDefinitions.size());
     assertThat(MockData.standardSourceDefinitions()).hasSameElementsAs(standardSourceDefinitions);
   }
@@ -277,7 +278,7 @@ public class DatabaseConfigPersistenceE2EReadWriteTest extends BaseDatabaseConfi
       final ActorCatalog retrievedActorCatalog = configPersistence.getConfig(
           ConfigSchema.ACTOR_CATALOG, actorCatalog.getId().toString(), ActorCatalog.class);
       assertEquals(actorCatalog, retrievedActorCatalog);
-    } ;
+    }
     final List<ActorCatalog> actorCatalogs = configPersistence
         .listConfigs(ConfigSchema.ACTOR_CATALOG, ActorCatalog.class);
     assertEquals(MockData.actorCatalogs().size(), actorCatalogs.size());

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/MockData.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/MockData.java
@@ -8,6 +8,9 @@ import com.google.common.collect.Lists;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.ActorCatalog;
 import io.airbyte.config.ActorCatalogFetchEvent;
+import io.airbyte.config.ActorDefinition;
+import io.airbyte.config.ActorDefinition.ActorType;
+import io.airbyte.config.ActorDefinition.SourceType;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.DestinationOAuthParameter;
@@ -23,9 +26,6 @@ import io.airbyte.config.Schedule.TimeUnit;
 import io.airbyte.config.SlackNotificationConfiguration;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.SourceOAuthParameter;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
-import io.airbyte.config.StandardSourceDefinition.SourceType;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSync.Status;
 import io.airbyte.config.StandardSyncOperation;
@@ -102,10 +102,11 @@ public class MockData {
         .withFeedbackDone(true);
   }
 
-  public static List<StandardSourceDefinition> standardSourceDefinitions() {
+  public static List<ActorDefinition> standardSourceDefinitions() {
     final ConnectorSpecification connectorSpecification = connectorSpecification();
-    final StandardSourceDefinition standardSourceDefinition1 = new StandardSourceDefinition()
-        .withSourceDefinitionId(SOURCE_DEFINITION_ID_1)
+    final ActorDefinition standardSourceDefinition1 = new ActorDefinition()
+        .withId(SOURCE_DEFINITION_ID_1)
+        .withActorType(ActorType.SOURCE)
         .withSourceType(SourceType.API)
         .withName("random-source-1")
         .withDockerImageTag("tag-1")
@@ -115,8 +116,9 @@ public class MockData {
         .withSpec(connectorSpecification)
         .withTombstone(false)
         .withResourceRequirements(new ActorDefinitionResourceRequirements().withDefault(new ResourceRequirements().withCpuRequest("2")));
-    final StandardSourceDefinition standardSourceDefinition2 = new StandardSourceDefinition()
-        .withSourceDefinitionId(SOURCE_DEFINITION_ID_2)
+    final ActorDefinition standardSourceDefinition2 = new ActorDefinition()
+        .withId(SOURCE_DEFINITION_ID_2)
+        .withActorType(ActorType.SOURCE)
         .withSourceType(SourceType.DATABASE)
         .withName("random-source-2")
         .withDockerImageTag("tag-2")
@@ -140,10 +142,11 @@ public class MockData {
         .withSupportsNormalization(true);
   }
 
-  public static List<StandardDestinationDefinition> standardDestinationDefinitions() {
+  public static List<ActorDefinition> standardDestinationDefinitions() {
     final ConnectorSpecification connectorSpecification = connectorSpecification();
-    final StandardDestinationDefinition standardDestinationDefinition1 = new StandardDestinationDefinition()
-        .withDestinationDefinitionId(DESTINATION_DEFINITION_ID_1)
+    final ActorDefinition standardDestinationDefinition1 = new ActorDefinition()
+        .withId(DESTINATION_DEFINITION_ID_1)
+        .withActorType(ActorType.DESTINATION)
         .withName("random-destination-1")
         .withDockerImageTag("tag-3")
         .withDockerRepository("repository-3")
@@ -152,8 +155,9 @@ public class MockData {
         .withSpec(connectorSpecification)
         .withTombstone(false)
         .withResourceRequirements(new ActorDefinitionResourceRequirements().withDefault(new ResourceRequirements().withCpuRequest("2")));
-    final StandardDestinationDefinition standardDestinationDefinition2 = new StandardDestinationDefinition()
-        .withDestinationDefinitionId(DESTINATION_DEFINITION_ID_2)
+    final ActorDefinition standardDestinationDefinition2 = new ActorDefinition()
+        .withId(DESTINATION_DEFINITION_ID_2)
+        .withActorType(ActorType.DESTINATION)
         .withName("random-destination-2")
         .withDockerImageTag("tag-4")
         .withDockerRepository("repository-4")

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/MockData.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/MockData.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Lists;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.ActorCatalog;
 import io.airbyte.config.ActorCatalogFetchEvent;
+import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.DestinationOAuthParameter;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
@@ -112,7 +113,8 @@ public class MockData {
         .withDocumentationUrl("documentation-url-1")
         .withIcon("icon-1")
         .withSpec(connectorSpecification)
-        .withTombstone(false);
+        .withTombstone(false)
+        .withResourceRequirements(new ActorDefinitionResourceRequirements().withDefault(new ResourceRequirements().withCpuRequest("2")));
     final StandardSourceDefinition standardSourceDefinition2 = new StandardSourceDefinition()
         .withSourceDefinitionId(SOURCE_DEFINITION_ID_2)
         .withSourceType(SourceType.DATABASE)
@@ -148,7 +150,8 @@ public class MockData {
         .withDocumentationUrl("documentation-url-3")
         .withIcon("icon-3")
         .withSpec(connectorSpecification)
-        .withTombstone(false);
+        .withTombstone(false)
+        .withResourceRequirements(new ActorDefinitionResourceRequirements().withDefault(new ResourceRequirements().withCpuRequest("2")));
     final StandardDestinationDefinition standardDestinationDefinition2 = new StandardDestinationDefinition()
         .withDestinationDefinitionId(DESTINATION_DEFINITION_ID_2)
         .withName("random-destination-2")

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_32_001__AddConnectorDefinitionResourceLimits.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_32_001__AddConnectorDefinitionResourceLimits.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class V0_35_32_001__AddConnectorDefinitionResourceLimits extends BaseJavaMigration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(V0_35_32_001__AddConnectorDefinitionResourceLimits.class);
+
+  @Override
+  public void migrate(final Context context) throws Exception {
+    LOGGER.info("Running migration: {}", this.getClass().getSimpleName());
+
+    final DSLContext ctx = DSL.using(context.getConnection());
+    addTombstoneColumn(ctx);
+  }
+
+  public static void addTombstoneColumn(final DSLContext ctx) {
+    ctx.alterTable("actor_definition")
+        .addColumnIfNotExists(DSL.field("resource_requirements", SQLDataType.JSONB.nullable(true)))
+        .execute();
+  }
+
+}

--- a/airbyte-db/lib/src/main/resources/configs_database/schema_dump.txt
+++ b/airbyte-db/lib/src/main/resources/configs_database/schema_dump.txt
@@ -50,6 +50,7 @@ create table "public"."actor_definition"(
   "tombstone" bool not null default false,
   "release_stage" release_stage null,
   "release_date" date null,
+  "resource_requirements" jsonb null,
   constraint "actor_definition_pkey"
     primary key ("id")
 );

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_32_8_001__AirbyteConfigDatabaseDenormalization_Test.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_32_8_001__AirbyteConfigDatabaseDenormalization_Test.java
@@ -4,17 +4,18 @@
 
 package io.airbyte.db.instance.configs.migrations;
 
-import static io.airbyte.db.instance.configs.migrations.SetupForNormalizedTablesTest.*;
-import static io.airbyte.db.instance.configs.migrations.SetupForNormalizedTablesTest.destinationOauthParameters;
-import static io.airbyte.db.instance.configs.migrations.SetupForNormalizedTablesTest.standardSyncOperations;
-import static io.airbyte.db.instance.configs.migrations.SetupForNormalizedTablesTest.standardSyncStates;
-import static io.airbyte.db.instance.configs.migrations.SetupForNormalizedTablesTest.standardSyncs;
-import static io.airbyte.db.instance.configs.migrations.SetupForNormalizedTablesTest.standardWorkspace;
+import static io.airbyte.db.instance.configs.migrations.V0_32_8_001__SetupForNormalizedTablesTest.*;
+import static io.airbyte.db.instance.configs.migrations.V0_32_8_001__SetupForNormalizedTablesTest.destinationOauthParameters;
+import static io.airbyte.db.instance.configs.migrations.V0_32_8_001__SetupForNormalizedTablesTest.standardSyncOperations;
+import static io.airbyte.db.instance.configs.migrations.V0_32_8_001__SetupForNormalizedTablesTest.standardSyncStates;
+import static io.airbyte.db.instance.configs.migrations.V0_32_8_001__SetupForNormalizedTablesTest.standardSyncs;
+import static io.airbyte.db.instance.configs.migrations.V0_32_8_001__SetupForNormalizedTablesTest.standardWorkspace;
 import static org.jooq.impl.DSL.asterisk;
 import static org.jooq.impl.DSL.table;
 
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.DestinationOAuthParameter;
 import io.airbyte.config.Notification;
@@ -62,7 +63,7 @@ public class V0_32_8_001__AirbyteConfigDatabaseDenormalization_Test extends Abst
   public void testCompleteMigration() throws IOException, SQLException {
     final Database database = getDatabase();
     final DSLContext context = DSL.using(database.getDataSource().getConnection());
-    SetupForNormalizedTablesTest.setup(context);
+    V0_32_8_001__SetupForNormalizedTablesTest.setup(context);
 
     V0_32_8_001__AirbyteConfigDatabaseDenormalization.migrate(context);
 
@@ -79,7 +80,7 @@ public class V0_32_8_001__AirbyteConfigDatabaseDenormalization_Test extends Abst
   }
 
   private void assertDataForWorkspace(final DSLContext context) {
-    Result<Record> workspaces = context.select(asterisk())
+    final Result<Record> workspaces = context.select(asterisk())
         .from(table("workspace"))
         .fetch();
     Assertions.assertEquals(1, workspaces.size());
@@ -105,7 +106,7 @@ public class V0_32_8_001__AirbyteConfigDatabaseDenormalization_Test extends Abst
 
     final List<Notification> notificationList = new ArrayList<>();
     final List fetchedNotifications = Jsons.deserialize(workspace.get(notifications).data(), List.class);
-    for (Object notification : fetchedNotifications) {
+    for (final Object notification : fetchedNotifications) {
       notificationList.add(Jsons.convertValue(notification, Notification.class));
     }
     final StandardWorkspace workspaceFromNewTable = new StandardWorkspace()
@@ -158,7 +159,7 @@ public class V0_32_8_001__AirbyteConfigDatabaseDenormalization_Test extends Abst
           .withDockerRepository(sourceDefinition.get(dockerRepository))
           .withDocumentationUrl(sourceDefinition.get(documentationUrl))
           .withName(sourceDefinition.get(name))
-          .withSourceType(Enums.toEnum(sourceDefinition.get(sourceType, String.class), StandardSourceDefinition.SourceType.class).orElseThrow())
+          .withSourceType(Enums.toEnum(sourceDefinition.get(sourceType, String.class), ActorDefinition.SourceType.class).orElseThrow())
           .withSpec(Jsons.deserialize(sourceDefinition.get(spec).data(), ConnectorSpecification.class));
       Assertions.assertTrue(expectedDefinitions.contains(standardSourceDefinition));
       Assertions.assertEquals(now(), sourceDefinition.get(createdAt).toInstant());
@@ -428,7 +429,7 @@ public class V0_32_8_001__AirbyteConfigDatabaseDenormalization_Test extends Abst
 
     final List<UUID> ids = new ArrayList<>();
 
-    for (Record record : connectionOperations) {
+    for (final Record record : connectionOperations) {
       ids.add(record.get(operationId));
       Assertions.assertNotNull(record.get(id));
       Assertions.assertEquals(now(), record.get(createdAt).toInstant());

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_32_8_001__SetupForNormalizedTablesTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_32_8_001__SetupForNormalizedTablesTest.java
@@ -10,8 +10,7 @@ import static org.jooq.impl.DSL.table;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.config.AirbyteConfig;
-import io.airbyte.config.ConfigSchema;
+import io.airbyte.config.ActorDefinition.SourceType;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.DestinationOAuthParameter;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
@@ -28,7 +27,6 @@ import io.airbyte.config.SourceConnection;
 import io.airbyte.config.SourceOAuthParameter;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
-import io.airbyte.config.StandardSourceDefinition.SourceType;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSync.Status;
 import io.airbyte.config.StandardSyncOperation;
@@ -60,7 +58,7 @@ import org.jooq.JSONB;
 import org.jooq.Record;
 import org.jooq.Table;
 
-public class SetupForNormalizedTablesTest {
+public class V0_32_8_001__SetupForNormalizedTablesTest {
 
   private static final UUID WORKSPACE_ID = UUID.randomUUID();
   private static final UUID WORKSPACE_CUSTOMER_ID = UUID.randomUUID();
@@ -91,45 +89,45 @@ public class SetupForNormalizedTablesTest {
   private static final Instant NOW = Instant.parse("2021-12-15T20:30:40.00Z");
 
   public static void setup(final DSLContext context) {
-    createConfigInOldTable(context, standardWorkspace(), ConfigSchema.STANDARD_WORKSPACE);
+    createConfigInOldTable(context, standardWorkspace(), ConfigSchemaAt0_32_8_001.STANDARD_WORKSPACE);
 
     for (final StandardSourceDefinition standardSourceDefinition : standardSourceDefinitions()) {
-      createConfigInOldTable(context, standardSourceDefinition, ConfigSchema.STANDARD_SOURCE_DEFINITION);
+      createConfigInOldTable(context, standardSourceDefinition, ConfigSchemaAt0_32_8_001.STANDARD_SOURCE_DEFINITION);
     }
 
     for (final StandardDestinationDefinition standardDestinationDefinition : standardDestinationDefinitions()) {
-      createConfigInOldTable(context, standardDestinationDefinition, ConfigSchema.STANDARD_DESTINATION_DEFINITION);
+      createConfigInOldTable(context, standardDestinationDefinition, ConfigSchemaAt0_32_8_001.STANDARD_DESTINATION_DEFINITION);
     }
 
     for (final SourceConnection sourceConnection : sourceConnections()) {
-      createConfigInOldTable(context, sourceConnection, ConfigSchema.SOURCE_CONNECTION);
+      createConfigInOldTable(context, sourceConnection, ConfigSchemaAt0_32_8_001.SOURCE_CONNECTION);
     }
 
     for (final DestinationConnection destinationConnection : destinationConnections()) {
-      createConfigInOldTable(context, destinationConnection, ConfigSchema.DESTINATION_CONNECTION);
+      createConfigInOldTable(context, destinationConnection, ConfigSchemaAt0_32_8_001.DESTINATION_CONNECTION);
     }
 
     for (final SourceOAuthParameter sourceOAuthParameter : sourceOauthParameters()) {
-      createConfigInOldTable(context, sourceOAuthParameter, ConfigSchema.SOURCE_OAUTH_PARAM);
+      createConfigInOldTable(context, sourceOAuthParameter, ConfigSchemaAt0_32_8_001.SOURCE_OAUTH_PARAM);
     }
 
     for (final DestinationOAuthParameter destinationOAuthParameter : destinationOauthParameters()) {
-      createConfigInOldTable(context, destinationOAuthParameter, ConfigSchema.DESTINATION_OAUTH_PARAM);
+      createConfigInOldTable(context, destinationOAuthParameter, ConfigSchemaAt0_32_8_001.DESTINATION_OAUTH_PARAM);
     }
 
     for (final StandardSyncOperation standardSyncOperation : standardSyncOperations()) {
-      createConfigInOldTable(context, standardSyncOperation, ConfigSchema.STANDARD_SYNC_OPERATION);
+      createConfigInOldTable(context, standardSyncOperation, ConfigSchemaAt0_32_8_001.STANDARD_SYNC_OPERATION);
     }
 
     for (final StandardSync standardSync : standardSyncs()) {
-      createConfigInOldTable(context, standardSync, ConfigSchema.STANDARD_SYNC);
+      createConfigInOldTable(context, standardSync, ConfigSchemaAt0_32_8_001.STANDARD_SYNC);
     }
     for (final StandardSyncState standardSyncState : standardSyncStates()) {
-      createConfigInOldTable(context, standardSyncState, ConfigSchema.STANDARD_SYNC_STATE);
+      createConfigInOldTable(context, standardSyncState, ConfigSchemaAt0_32_8_001.STANDARD_SYNC_STATE);
     }
   }
 
-  private static <T> void createConfigInOldTable(final DSLContext context, final T config, final AirbyteConfig configType) {
+  private static <T> void createConfigInOldTable(final DSLContext context, final T config, final ConfigSchemaAt0_32_8_001 configType) {
     insertConfigRecord(
         context,
         configType.name(),
@@ -423,6 +421,44 @@ public class SetupForNormalizedTablesTest {
 
   public static Instant now() {
     return NOW;
+  }
+
+  /**
+   * This is the ConfigSchema as it existed at the time of migration v0.32.8-alpha. We have preseved
+   * it (pruning out unneeded functionality), so that these helper methods work as they did when the
+   * migration was written.
+   */
+  public enum ConfigSchemaAt0_32_8_001 {
+
+    // workspace
+    STANDARD_WORKSPACE("workspaceId"),
+
+    // source
+    STANDARD_SOURCE_DEFINITION("sourceDefinitionId"),
+    SOURCE_CONNECTION("sourceId"),
+
+    // destination
+    STANDARD_DESTINATION_DEFINITION("destinationDefinitionId"),
+    DESTINATION_CONNECTION("destinationId"),
+
+    // sync (i.e. connection)
+    STANDARD_SYNC("connectionId"),
+    STANDARD_SYNC_OPERATION("operationId"),
+    STANDARD_SYNC_STATE("connectionId"),
+
+    SOURCE_OAUTH_PARAM("oauthParameterId"),
+    DESTINATION_OAUTH_PARAM("oauthParameterId");
+
+    private final String idFieldName;
+
+    <T> ConfigSchemaAt0_32_8_001(final String idFieldName) {
+      this.idFieldName = idFieldName;
+    }
+
+    public String getIdFieldName() {
+      return idFieldName;
+    }
+
   }
 
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_32_8_001__SetupForNormalizedTablesTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_32_8_001__SetupForNormalizedTablesTest.java
@@ -58,6 +58,9 @@ import org.jooq.JSONB;
 import org.jooq.Record;
 import org.jooq.Table;
 
+/**
+ * This should only be used for testing migration V0_32_8_001. It preserves state from then.
+ */
 public class V0_32_8_001__SetupForNormalizedTablesTest {
 
   private static final UUID WORKSPACE_ID = UUID.randomUUID();

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_1_001__RemoveForeignKeyFromActorOauth_Test.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_1_001__RemoveForeignKeyFromActorOauth_Test.java
@@ -4,9 +4,9 @@
 
 package io.airbyte.db.instance.configs.migrations;
 
-import static io.airbyte.db.instance.configs.migrations.SetupForNormalizedTablesTest.destinationOauthParameters;
-import static io.airbyte.db.instance.configs.migrations.SetupForNormalizedTablesTest.now;
-import static io.airbyte.db.instance.configs.migrations.SetupForNormalizedTablesTest.sourceOauthParameters;
+import static io.airbyte.db.instance.configs.migrations.V0_32_8_001__SetupForNormalizedTablesTest.destinationOauthParameters;
+import static io.airbyte.db.instance.configs.migrations.V0_32_8_001__SetupForNormalizedTablesTest.now;
+import static io.airbyte.db.instance.configs.migrations.V0_32_8_001__SetupForNormalizedTablesTest.sourceOauthParameters;
 import static org.jooq.impl.DSL.asterisk;
 import static org.jooq.impl.DSL.table;
 
@@ -37,7 +37,9 @@ public class V0_35_1_001__RemoveForeignKeyFromActorOauth_Test extends AbstractCo
   public void testCompleteMigration() throws IOException, SQLException {
     final Database database = getDatabase();
     final DSLContext context = DSL.using(database.getDataSource().getConnection());
-    SetupForNormalizedTablesTest.setup(context);
+    // todo (cgardens) - we should not be using V0_32_8_001__SetupForNormalizedTablesTest outside of
+    // their intended migration.
+    V0_32_8_001__SetupForNormalizedTablesTest.setup(context);
 
     V0_32_8_001__AirbyteConfigDatabaseDenormalization.migrate(context);
     V0_35_1_001__RemoveForeignKeyFromActorOauth.migrate(context);

--- a/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/DefaultSchedulerJobClient.java
+++ b/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/DefaultSchedulerJobClient.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.scheduler.client;
 
+import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSync;
@@ -35,7 +36,9 @@ public class DefaultSchedulerJobClient implements SchedulerJobClient {
                                       final StandardSync standardSync,
                                       final String sourceDockerImage,
                                       final String destinationDockerImage,
-                                      final List<StandardSyncOperation> standardSyncOperations)
+                                      final List<StandardSyncOperation> standardSyncOperations,
+                                      final ActorDefinitionResourceRequirements sourceResourceRequirements,
+                                      final ActorDefinitionResourceRequirements destinationResourceRequirements)
       throws IOException {
     final Optional<Long> jobIdOptional = jobCreator.createSyncJob(
         source,
@@ -43,7 +46,9 @@ public class DefaultSchedulerJobClient implements SchedulerJobClient {
         standardSync,
         sourceDockerImage,
         destinationDockerImage,
-        standardSyncOperations);
+        standardSyncOperations,
+        sourceResourceRequirements,
+        destinationResourceRequirements);
 
     final long jobId = jobIdOptional.isEmpty()
         ? jobPersistence.getLastReplicationJob(standardSync.getConnectionId()).orElseThrow(() -> new RuntimeException("No job available")).getId()

--- a/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/SchedulerJobClient.java
+++ b/airbyte-scheduler/client/src/main/java/io/airbyte/scheduler/client/SchedulerJobClient.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.scheduler.client;
 
+import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSync;
@@ -24,7 +25,9 @@ public interface SchedulerJobClient {
                                StandardSync standardSync,
                                String sourceDockerImage,
                                String destinationDockerImage,
-                               List<StandardSyncOperation> standardSyncOperations)
+                               List<StandardSyncOperation> standardSyncOperations,
+                               ActorDefinitionResourceRequirements sourceResourceRequirements,
+                               ActorDefinitionResourceRequirements destinationResourceRequirements)
       throws IOException;
 
   Job createOrGetActiveResetConnectionJob(DestinationConnection destination,

--- a/airbyte-scheduler/client/src/test/java/io/airbyte/scheduler/client/DefaultSchedulerJobClientTest.java
+++ b/airbyte-scheduler/client/src/test/java/io/airbyte/scheduler/client/DefaultSchedulerJobClientTest.java
@@ -46,11 +46,13 @@ class DefaultSchedulerJobClientTest {
     final DestinationConnection destination = mock(DestinationConnection.class);
     final StandardSync standardSync = mock(StandardSync.class);
     final String destinationDockerImage = "airbyte/spaceport";
-    when(jobCreator.createSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage, List.of()))
+    when(jobCreator.createSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage, List.of(), null, null))
         .thenReturn(Optional.of(JOB_ID));
     when(jobPersistence.getJob(JOB_ID)).thenReturn(job);
 
-    assertEquals(job, client.createOrGetActiveSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage, List.of()));
+    assertEquals(
+        job,
+        client.createOrGetActiveSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage, List.of(), null, null));
   }
 
   @Test
@@ -61,14 +63,23 @@ class DefaultSchedulerJobClientTest {
     final UUID connectionUuid = UUID.randomUUID();
     when(standardSync.getConnectionId()).thenReturn(connectionUuid);
     final String destinationDockerImage = "airbyte/spaceport";
-    when(jobCreator.createSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage, List.of())).thenReturn(Optional.empty());
+    when(jobCreator.createSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage, List.of(), null, null))
+        .thenReturn(Optional.empty());
 
     final Job currentJob = mock(Job.class);
     when(currentJob.getId()).thenReturn(42L);
     when(jobPersistence.getLastReplicationJob(connectionUuid)).thenReturn(Optional.of(currentJob));
     when(jobPersistence.getJob(42L)).thenReturn(currentJob);
 
-    assertEquals(currentJob, client.createOrGetActiveSyncJob(source, destination, standardSync, DOCKER_IMAGE, destinationDockerImage, List.of()));
+    assertEquals(currentJob, client.createOrGetActiveSyncJob(
+        source,
+        destination,
+        standardSync,
+        DOCKER_IMAGE,
+        destinationDockerImage,
+        List.of(),
+        null,
+        null));
   }
 
   @Test

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.scheduler.persistence;
 
+import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.JobConfig;
 import io.airbyte.config.JobConfig.ConfigType;
@@ -41,7 +42,9 @@ public class DefaultJobCreator implements JobCreator {
                                       final StandardSync standardSync,
                                       final String sourceDockerImageName,
                                       final String destinationDockerImageName,
-                                      final List<StandardSyncOperation> standardSyncOperations)
+                                      final List<StandardSyncOperation> standardSyncOperations,
+                                      final ActorDefinitionResourceRequirements sourceResourceReqs,
+                                      final ActorDefinitionResourceRequirements destinationResourceReqs)
       throws IOException {
     // reusing this isn't going to quite work.
     final JobSyncConfig jobSyncConfig = new JobSyncConfig()
@@ -55,7 +58,9 @@ public class DefaultJobCreator implements JobCreator {
         .withOperationSequence(standardSyncOperations)
         .withConfiguredAirbyteCatalog(standardSync.getCatalog())
         .withState(null)
-        .withResourceRequirements(getJobResourceRequirements(standardSync));
+        .withResourceRequirements(getJobResourceRequirements(standardSync))
+        .withSourceResourceRequirements(sourceResourceReqs)
+        .withDestinationResourceRequirements(destinationResourceReqs);
 
     configRepository.getConnectionState(standardSync.getConnectionId()).ifPresent(jobSyncConfig::withState);
 

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobCreator.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobCreator.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.scheduler.persistence;
 
+import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSync;
@@ -29,7 +30,9 @@ public interface JobCreator {
                                StandardSync standardSync,
                                String sourceDockerImage,
                                String destinationDockerImage,
-                               List<StandardSyncOperation> standardSyncOperations)
+                               List<StandardSyncOperation> standardSyncOperations,
+                               ActorDefinitionResourceRequirements sourceResourceReqs,
+                               ActorDefinitionResourceRequirements destinationResourceReqs)
       throws IOException;
 
   /**

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/DefaultSyncJobFactory.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/DefaultSyncJobFactory.java
@@ -50,9 +50,10 @@ public class DefaultSyncJobFactory implements SyncJobFactory {
           destinationConnection.getWorkspaceId(),
           destinationConnection.getConfiguration());
       destinationConnection.withConfiguration(destinationConfiguration);
-      final StandardSourceDefinition sourceDefinition = configRepository.getStandardSourceDefinition(sourceConnection.getSourceDefinitionId());
-      final StandardDestinationDefinition destinationDefinition =
-          configRepository.getStandardDestinationDefinition(destinationConnection.getDestinationDefinitionId());
+      final StandardSourceDefinition sourceDefinition = configRepository
+          .getStandardSourceDefinition(sourceConnection.getSourceDefinitionId());
+      final StandardDestinationDefinition destinationDefinition = configRepository
+          .getStandardDestinationDefinition(destinationConnection.getDestinationDefinitionId());
 
       final String sourceImageName = DockerUtils.getTaggedImageName(sourceDefinition.getDockerRepository(), sourceDefinition.getDockerImageTag());
       final String destinationImageName =
@@ -70,7 +71,9 @@ public class DefaultSyncJobFactory implements SyncJobFactory {
           standardSync,
           sourceImageName,
           destinationImageName,
-          standardSyncOperations)
+          standardSyncOperations,
+          sourceDefinition.getResourceRequirements(),
+          destinationDefinition.getResourceRequirements())
           .orElseThrow(() -> new IllegalStateException("We shouldn't be trying to create a new sync job if there is one running already."));
 
     } catch (final IOException | JsonValidationException | ConfigNotFoundException e) {

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
@@ -151,7 +151,9 @@ public class DefaultJobCreatorTest {
         STANDARD_SYNC,
         SOURCE_IMAGE_NAME,
         DESTINATION_IMAGE_NAME,
-        List.of(STANDARD_SYNC_OPERATION)).orElseThrow();
+        List.of(STANDARD_SYNC_OPERATION),
+        null,
+        null).orElseThrow();
     assertEquals(JOB_ID, jobId);
   }
 
@@ -182,7 +184,9 @@ public class DefaultJobCreatorTest {
         STANDARD_SYNC,
         SOURCE_IMAGE_NAME,
         DESTINATION_IMAGE_NAME,
-        List.of(STANDARD_SYNC_OPERATION)).isEmpty());
+        List.of(STANDARD_SYNC_OPERATION),
+        null,
+        null).isEmpty());
   }
 
   @Test

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_factory/DefaultSyncJobFactoryTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_factory/DefaultSyncJobFactoryTest.java
@@ -62,7 +62,7 @@ class DefaultSyncJobFactoryTest {
     when(configRepository.getSourceConnection(sourceId)).thenReturn(sourceConnection);
     when(configRepository.getDestinationConnection(destinationId)).thenReturn(destinationConnection);
     when(configRepository.getStandardSyncOperation(operationId)).thenReturn(operation);
-    when(jobCreator.createSyncJob(sourceConnection, destinationConnection, standardSync, srcDockerImage, dstDockerImage, operations))
+    when(jobCreator.createSyncJob(sourceConnection, destinationConnection, standardSync, srcDockerImage, dstDockerImage, operations, null, null))
         .thenReturn(Optional.of(jobId));
     when(configRepository.getStandardSourceDefinition(sourceDefinitionId))
         .thenReturn(new StandardSourceDefinition().withSourceDefinitionId(sourceDefinitionId).withDockerRepository(srcDockerRepo)
@@ -77,7 +77,7 @@ class DefaultSyncJobFactoryTest {
     assertEquals(jobId, actualJobId);
 
     verify(jobCreator)
-        .createSyncJob(sourceConnection, destinationConnection, standardSync, srcDockerImage, dstDockerImage, operations);
+        .createSyncJob(sourceConnection, destinationConnection, standardSync, srcDockerImage, dstDockerImage, operations, null, null);
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -119,7 +119,6 @@ import io.airbyte.server.handlers.WorkspacesHandler;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.WorkerConfigs;
-import io.airbyte.workers.helper.ConnectionHelper;
 import io.airbyte.workers.worker_run.TemporalWorkerRunFactory;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.io.File;
@@ -192,14 +191,12 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
         jobNotifier,
         temporalService,
         new OAuthConfigSupplier(configRepository, trackingClient), workerEnvironment, logConfigs, temporalWorkerRunFactory);
-    final ConnectionHelper connectionHelper = new ConnectionHelper(configRepository, workspaceHelper, workerConfigs);
     connectionsHandler = new ConnectionsHandler(
         configRepository,
         workspaceHelper,
         trackingClient,
         temporalWorkerRunFactory,
         featureFlags,
-        connectionHelper,
         workerConfigs);
     sourceHandler = new SourceHandler(configRepository, schemaValidator, connectionsHandler);
     sourceDefinitionsHandler = new SourceDefinitionsHandler(configRepository, synchronousSchedulerClient, sourceHandler);
@@ -218,8 +215,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
         schedulerHandler,
         operationsHandler,
         featureFlags,
-        temporalWorkerRunFactory,
-        connectionHelper);
+        temporalWorkerRunFactory);
     healthCheckHandler = new HealthCheckHandler();
     archiveHandler = new ArchiveHandler(
         airbyteVersion,

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/ApiPojoConverters.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/ApiPojoConverters.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.server.converters;
+
+import io.airbyte.api.model.ConnectionRead;
+import io.airbyte.api.model.ConnectionSchedule;
+import io.airbyte.api.model.ConnectionStatus;
+import io.airbyte.api.model.ConnectionUpdate;
+import io.airbyte.api.model.ResourceRequirements;
+import io.airbyte.commons.enums.Enums;
+import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
+import io.airbyte.config.Schedule;
+import io.airbyte.config.StandardSync;
+import io.airbyte.workers.helper.CatalogConverter;
+
+public class ApiPojoConverters {
+
+  public static io.airbyte.config.ResourceRequirements resourceRequirementsToInternal(final ResourceRequirements resourceRequirements) {
+    return new io.airbyte.config.ResourceRequirements()
+        .withCpuRequest(resourceRequirements.getCpuRequest())
+        .withCpuLimit(resourceRequirements.getCpuLimit())
+        .withMemoryRequest(resourceRequirements.getMemoryRequest())
+        .withMemoryLimit(resourceRequirements.getMemoryLimit());
+  }
+
+  public static ResourceRequirements resourceRequirementsToApi(final io.airbyte.config.ResourceRequirements resourceRequirements) {
+    return new ResourceRequirements()
+        .cpuRequest(resourceRequirements.getCpuRequest())
+        .cpuLimit(resourceRequirements.getCpuLimit())
+        .memoryRequest(resourceRequirements.getMemoryRequest())
+        .memoryLimit(resourceRequirements.getMemoryLimit());
+  }
+
+  public static io.airbyte.config.StandardSync connectionUpdateToInternal(final ConnectionUpdate update) {
+
+    final StandardSync newConnection = new StandardSync()
+        .withNamespaceDefinition(Enums.convertTo(update.getNamespaceDefinition(), NamespaceDefinitionType.class))
+        .withNamespaceFormat(update.getNamespaceFormat())
+        .withPrefix(update.getPrefix())
+        .withOperationIds(update.getOperationIds())
+        .withCatalog(CatalogConverter.toProtocol(update.getSyncCatalog()))
+        .withStatus(toPersistenceStatus(update.getStatus()));
+
+    // update Resource Requirements
+    if (update.getResourceRequirements() != null) {
+      newConnection.withResourceRequirements(new io.airbyte.config.ResourceRequirements()
+          .withCpuRequest(update.getResourceRequirements().getCpuRequest())
+          .withCpuLimit(update.getResourceRequirements().getCpuLimit())
+          .withMemoryRequest(update.getResourceRequirements().getMemoryRequest())
+          .withMemoryLimit(update.getResourceRequirements().getMemoryLimit()));
+    }
+
+    // update sync schedule
+    if (update.getSchedule() != null) {
+      final Schedule newSchedule = new Schedule()
+          .withTimeUnit(toPersistenceTimeUnit(update.getSchedule().getTimeUnit()))
+          .withUnits(update.getSchedule().getUnits());
+      newConnection.withManual(false).withSchedule(newSchedule);
+    } else {
+      newConnection.withManual(true).withSchedule(null);
+    }
+
+    return newConnection;
+  }
+
+  public static ConnectionRead internalToConnectionRead(final StandardSync standardSync) {
+    ConnectionSchedule apiSchedule = null;
+
+    if (!standardSync.getManual()) {
+      apiSchedule = new ConnectionSchedule()
+          .timeUnit(toApiTimeUnit(standardSync.getSchedule().getTimeUnit()))
+          .units(standardSync.getSchedule().getUnits());
+    }
+
+    final ConnectionRead connectionRead = new ConnectionRead()
+        .connectionId(standardSync.getConnectionId())
+        .sourceId(standardSync.getSourceId())
+        .destinationId(standardSync.getDestinationId())
+        .operationIds(standardSync.getOperationIds())
+        .status(toApiStatus(standardSync.getStatus()))
+        .schedule(apiSchedule)
+        .name(standardSync.getName())
+        .namespaceDefinition(Enums.convertTo(standardSync.getNamespaceDefinition(), io.airbyte.api.model.NamespaceDefinitionType.class))
+        .namespaceFormat(standardSync.getNamespaceFormat())
+        .prefix(standardSync.getPrefix())
+        .syncCatalog(CatalogConverter.toApi(standardSync.getCatalog()));
+
+    if (standardSync.getResourceRequirements() != null) {
+      connectionRead.resourceRequirements(resourceRequirementsToApi(standardSync.getResourceRequirements()));
+    }
+
+    return connectionRead;
+  }
+
+  public static ConnectionSchedule.TimeUnitEnum toApiTimeUnit(final Schedule.TimeUnit apiTimeUnit) {
+    return Enums.convertTo(apiTimeUnit, ConnectionSchedule.TimeUnitEnum.class);
+  }
+
+  public static ConnectionStatus toApiStatus(final StandardSync.Status status) {
+    return Enums.convertTo(status, ConnectionStatus.class);
+  }
+
+  public static StandardSync.Status toPersistenceStatus(final ConnectionStatus apiStatus) {
+    return Enums.convertTo(apiStatus, StandardSync.Status.class);
+  }
+
+  public static Schedule.TimeUnit toPersistenceTimeUnit(final ConnectionSchedule.TimeUnitEnum apiTimeUnit) {
+    return Enums.convertTo(apiTimeUnit, Schedule.TimeUnit.class);
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/ApiPojoConverters.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/ApiPojoConverters.java
@@ -4,33 +4,77 @@
 
 package io.airbyte.server.converters;
 
+import io.airbyte.api.model.ActorDefinitionResourceRequirements;
 import io.airbyte.api.model.ConnectionRead;
 import io.airbyte.api.model.ConnectionSchedule;
 import io.airbyte.api.model.ConnectionStatus;
 import io.airbyte.api.model.ConnectionUpdate;
+import io.airbyte.api.model.JobType;
+import io.airbyte.api.model.JobTypeResourceLimit;
 import io.airbyte.api.model.ResourceRequirements;
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
 import io.airbyte.config.Schedule;
 import io.airbyte.config.StandardSync;
 import io.airbyte.workers.helper.CatalogConverter;
+import java.util.stream.Collectors;
 
 public class ApiPojoConverters {
 
-  public static io.airbyte.config.ResourceRequirements resourceRequirementsToInternal(final ResourceRequirements resourceRequirements) {
-    return new io.airbyte.config.ResourceRequirements()
-        .withCpuRequest(resourceRequirements.getCpuRequest())
-        .withCpuLimit(resourceRequirements.getCpuLimit())
-        .withMemoryRequest(resourceRequirements.getMemoryRequest())
-        .withMemoryLimit(resourceRequirements.getMemoryLimit());
+  public static io.airbyte.config.ActorDefinitionResourceRequirements actorDefResourceReqsToInternal(final ActorDefinitionResourceRequirements actorDefResourceReqs) {
+    if (actorDefResourceReqs == null) {
+      return null;
+    }
+
+    return new io.airbyte.config.ActorDefinitionResourceRequirements()
+        .withDefault(actorDefResourceReqs.getDefault() == null ? null : resourceRequirementsToInternal(actorDefResourceReqs.getDefault()))
+        .withJobSpecific(actorDefResourceReqs.getJobSpecific() == null ? null
+            : actorDefResourceReqs.getJobSpecific()
+                .stream()
+                .map(jobSpecific -> new io.airbyte.config.JobTypeResourceLimit()
+                    .withJobType(toInternalJobType(jobSpecific.getJobType()))
+                    .withResourceRequirements(resourceRequirementsToInternal(jobSpecific.getResourceRequirements())))
+                .collect(Collectors.toList()));
   }
 
-  public static ResourceRequirements resourceRequirementsToApi(final io.airbyte.config.ResourceRequirements resourceRequirements) {
+  public static ActorDefinitionResourceRequirements actorDefResourceReqsToApi(final io.airbyte.config.ActorDefinitionResourceRequirements actorDefResourceReqs) {
+    if (actorDefResourceReqs == null) {
+      return null;
+    }
+
+    return new ActorDefinitionResourceRequirements()
+        ._default(actorDefResourceReqs.getDefault() == null ? null : resourceRequirementsToApi(actorDefResourceReqs.getDefault()))
+        .jobSpecific(actorDefResourceReqs.getJobSpecific() == null ? null
+            : actorDefResourceReqs.getJobSpecific()
+                .stream()
+                .map(jobSpecific -> new JobTypeResourceLimit()
+                    .jobType(toApiJobType(jobSpecific.getJobType()))
+                    .resourceRequirements(resourceRequirementsToApi(jobSpecific.getResourceRequirements())))
+                .collect(Collectors.toList()));
+  }
+
+  public static io.airbyte.config.ResourceRequirements resourceRequirementsToInternal(final ResourceRequirements resourceReqs) {
+    if (resourceReqs == null) {
+      return null;
+    }
+
+    return new io.airbyte.config.ResourceRequirements()
+        .withCpuRequest(resourceReqs.getCpuRequest())
+        .withCpuLimit(resourceReqs.getCpuLimit())
+        .withMemoryRequest(resourceReqs.getMemoryRequest())
+        .withMemoryLimit(resourceReqs.getMemoryLimit());
+  }
+
+  public static ResourceRequirements resourceRequirementsToApi(final io.airbyte.config.ResourceRequirements resourceReqs) {
+    if (resourceReqs == null) {
+      return null;
+    }
+
     return new ResourceRequirements()
-        .cpuRequest(resourceRequirements.getCpuRequest())
-        .cpuLimit(resourceRequirements.getCpuLimit())
-        .memoryRequest(resourceRequirements.getMemoryRequest())
-        .memoryLimit(resourceRequirements.getMemoryLimit());
+        .cpuRequest(resourceReqs.getCpuRequest())
+        .cpuLimit(resourceReqs.getCpuLimit())
+        .memoryRequest(resourceReqs.getMemoryRequest())
+        .memoryLimit(resourceReqs.getMemoryLimit());
   }
 
   public static io.airbyte.config.StandardSync connectionUpdateToInternal(final ConnectionUpdate update) {
@@ -92,6 +136,14 @@ public class ApiPojoConverters {
     }
 
     return connectionRead;
+  }
+
+  public static JobType toApiJobType(final io.airbyte.config.JobTypeResourceLimit.JobType jobType) {
+    return Enums.convertTo(jobType, JobType.class);
+  }
+
+  public static io.airbyte.config.JobTypeResourceLimit.JobType toInternalJobType(final JobType jobType) {
+    return Enums.convertTo(jobType, io.airbyte.config.JobTypeResourceLimit.JobType.class);
   }
 
   public static ConnectionSchedule.TimeUnitEnum toApiTimeUnit(final Schedule.TimeUnit apiTimeUnit) {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -12,7 +12,6 @@ import io.airbyte.analytics.TrackingClient;
 import io.airbyte.api.model.ConnectionCreate;
 import io.airbyte.api.model.ConnectionRead;
 import io.airbyte.api.model.ConnectionReadList;
-import io.airbyte.api.model.ConnectionSchedule;
 import io.airbyte.api.model.ConnectionSearch;
 import io.airbyte.api.model.ConnectionStatus;
 import io.airbyte.api.model.ConnectionUpdate;
@@ -23,6 +22,7 @@ import io.airbyte.api.model.SourceSearch;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.features.FeatureFlags;
+import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
 import io.airbyte.config.Schedule;
@@ -35,6 +35,7 @@ import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.scheduler.persistence.WorkspaceHelper;
+import io.airbyte.server.converters.ApiPojoConverters;
 import io.airbyte.server.handlers.helpers.ConnectionMatcher;
 import io.airbyte.server.handlers.helpers.DestinationMatcher;
 import io.airbyte.server.handlers.helpers.SourceMatcher;
@@ -63,7 +64,6 @@ public class ConnectionsHandler {
   private final TrackingClient trackingClient;
   private final TemporalWorkerRunFactory temporalWorkerRunFactory;
   private final FeatureFlags featureFlags;
-  private final ConnectionHelper connectionHelper;
   private final WorkerConfigs workerConfigs;
 
   @VisibleForTesting
@@ -73,7 +73,6 @@ public class ConnectionsHandler {
                      final TrackingClient trackingClient,
                      final TemporalWorkerRunFactory temporalWorkerRunFactory,
                      final FeatureFlags featureFlags,
-                     final ConnectionHelper connectionHelper,
                      final WorkerConfigs workerConfigs) {
     this.configRepository = configRepository;
     this.uuidGenerator = uuidGenerator;
@@ -81,26 +80,21 @@ public class ConnectionsHandler {
     this.trackingClient = trackingClient;
     this.temporalWorkerRunFactory = temporalWorkerRunFactory;
     this.featureFlags = featureFlags;
-    this.connectionHelper = connectionHelper;
     this.workerConfigs = workerConfigs;
   }
 
-  public ConnectionsHandler(
-                            final ConfigRepository configRepository,
+  public ConnectionsHandler(final ConfigRepository configRepository,
                             final WorkspaceHelper workspaceHelper,
                             final TrackingClient trackingClient,
                             final TemporalWorkerRunFactory temporalWorkerRunFactory,
                             final FeatureFlags featureFlags,
-                            final ConnectionHelper connectionHelper,
                             final WorkerConfigs workerConfigs) {
-    this(
-        configRepository,
+    this(configRepository,
         UUID::randomUUID,
         workspaceHelper,
         trackingClient,
         temporalWorkerRunFactory,
         featureFlags,
-        connectionHelper,
         workerConfigs);
 
   }
@@ -110,7 +104,9 @@ public class ConnectionsHandler {
     // Validate source and destination
     configRepository.getSourceConnection(connectionCreate.getSourceId());
     configRepository.getDestinationConnection(connectionCreate.getDestinationId());
-    connectionHelper.validateWorkspace(connectionCreate.getSourceId(), connectionCreate.getDestinationId(),
+    ConnectionHelper.validateWorkspace(workspaceHelper,
+        connectionCreate.getSourceId(),
+        connectionCreate.getDestinationId(),
         new HashSet<>(connectionCreate.getOperationIds()));
 
     final UUID connectionId = uuidGenerator.get();
@@ -125,13 +121,9 @@ public class ConnectionsHandler {
         .withSourceId(connectionCreate.getSourceId())
         .withDestinationId(connectionCreate.getDestinationId())
         .withOperationIds(connectionCreate.getOperationIds())
-        .withStatus(toPersistenceStatus(connectionCreate.getStatus()));
+        .withStatus(ApiPojoConverters.toPersistenceStatus(connectionCreate.getStatus()));
     if (connectionCreate.getResourceRequirements() != null) {
-      standardSync.withResourceRequirements(new io.airbyte.config.ResourceRequirements()
-          .withCpuRequest(connectionCreate.getResourceRequirements().getCpuRequest())
-          .withCpuLimit(connectionCreate.getResourceRequirements().getCpuLimit())
-          .withMemoryRequest(connectionCreate.getResourceRequirements().getMemoryRequest())
-          .withMemoryLimit(connectionCreate.getResourceRequirements().getMemoryLimit()));
+      standardSync.withResourceRequirements(ApiPojoConverters.resourceRequirementsToInternal(connectionCreate.getResourceRequirements()));
     } else {
       standardSync.withResourceRequirements(workerConfigs.getResourceRequirements());
     }
@@ -145,7 +137,7 @@ public class ConnectionsHandler {
 
     if (connectionCreate.getSchedule() != null) {
       final Schedule schedule = new Schedule()
-          .withTimeUnit(toPersistenceTimeUnit(connectionCreate.getSchedule().getTimeUnit()))
+          .withTimeUnit(ApiPojoConverters.toPersistenceTimeUnit(connectionCreate.getSchedule().getTimeUnit()))
           .withUnits(connectionCreate.getSchedule().getUnits());
       standardSync
           .withManual(false)
@@ -169,7 +161,7 @@ public class ConnectionsHandler {
       }
     }
 
-    return connectionHelper.buildConnectionRead(connectionId);
+    return buildConnectionRead(connectionId);
   }
 
   private void trackNewConnection(final StandardSync standardSync) {
@@ -209,21 +201,45 @@ public class ConnectionsHandler {
 
   public ConnectionRead updateConnection(final ConnectionUpdate connectionUpdate)
       throws ConfigNotFoundException, IOException, JsonValidationException {
-    return updateConnection(connectionUpdate, false);
-  }
+    // retrieve and update sync
+    // retrieve and update sync
+    final StandardSync persistedSync = configRepository.getStandardSync(connectionUpdate.getConnectionId());
 
-  public ConnectionRead updateConnection(final ConnectionUpdate connectionUpdate, boolean isAReset)
-      throws ConfigNotFoundException, IOException, JsonValidationException {
-    if (featureFlags.usesNewScheduler()) {
-      connectionHelper.updateConnection(connectionUpdate);
+    ConnectionHelper.updateConnectionObject(workspaceHelper, persistedSync, ApiPojoConverters.connectionUpdateToInternal(connectionUpdate));
+    ConnectionHelper.validateWorkspace(workspaceHelper, persistedSync.getSourceId(), persistedSync.getDestinationId(),
+        new HashSet<>(connectionUpdate.getOperationIds()));
 
-      if (!isAReset) {
-        temporalWorkerRunFactory.update(connectionUpdate);
-      }
+    final StandardSync newConnection = Jsons.clone(persistedSync)
+        .withNamespaceDefinition(Enums.convertTo(connectionUpdate.getNamespaceDefinition(), NamespaceDefinitionType.class))
+        .withNamespaceFormat(connectionUpdate.getNamespaceFormat())
+        .withPrefix(connectionUpdate.getPrefix())
+        .withOperationIds(connectionUpdate.getOperationIds())
+        .withCatalog(CatalogConverter.toProtocol(connectionUpdate.getSyncCatalog()))
+        .withStatus(ApiPojoConverters.toPersistenceStatus(connectionUpdate.getStatus()));
 
-      return connectionHelper.buildConnectionRead(connectionUpdate.getConnectionId());
+    // update Resource Requirements
+    if (connectionUpdate.getResourceRequirements() != null) {
+      newConnection.withResourceRequirements(new io.airbyte.config.ResourceRequirements()
+          .withCpuRequest(connectionUpdate.getResourceRequirements().getCpuRequest())
+          .withCpuLimit(connectionUpdate.getResourceRequirements().getCpuLimit())
+          .withMemoryRequest(connectionUpdate.getResourceRequirements().getMemoryRequest())
+          .withMemoryLimit(connectionUpdate.getResourceRequirements().getMemoryLimit()));
+    } else {
+      newConnection.withResourceRequirements(persistedSync.getResourceRequirements());
     }
-    return connectionHelper.updateConnection(connectionUpdate);
+
+    // update sync schedule
+    if (connectionUpdate.getSchedule() != null) {
+      final Schedule newSchedule = new Schedule()
+          .withTimeUnit(ApiPojoConverters.toPersistenceTimeUnit(connectionUpdate.getSchedule().getTimeUnit()))
+          .withUnits(connectionUpdate.getSchedule().getUnits());
+      newConnection.withManual(false).withSchedule(newSchedule);
+    } else {
+      newConnection.withManual(true).withSchedule(null);
+    }
+
+    configRepository.writeStandardSync(newConnection);
+    return buildConnectionRead(connectionUpdate.getConnectionId());
   }
 
   public ConnectionReadList listConnectionsForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody)
@@ -248,7 +264,7 @@ public class ConnectionsHandler {
         continue;
       }
 
-      connectionReads.add(connectionHelper.buildConnectionRead(standardSync.getConnectionId()));
+      connectionReads.add(buildConnectionRead(standardSync.getConnectionId()));
     }
 
     return new ConnectionReadList().connections(connectionReads);
@@ -261,7 +277,7 @@ public class ConnectionsHandler {
       if (standardSync.getStatus() == StandardSync.Status.DEPRECATED) {
         continue;
       }
-      connectionReads.add(connectionHelper.buildConnectionRead(standardSync.getConnectionId()));
+      connectionReads.add(buildConnectionRead(standardSync.getConnectionId()));
     }
 
     return new ConnectionReadList().connections(connectionReads);
@@ -269,7 +285,7 @@ public class ConnectionsHandler {
 
   public ConnectionRead getConnection(final UUID connectionId)
       throws JsonValidationException, IOException, ConfigNotFoundException {
-    return connectionHelper.buildConnectionRead(connectionId);
+    return buildConnectionRead(connectionId);
   }
 
   public ConnectionReadList searchConnections(final ConnectionSearch connectionSearch)
@@ -277,7 +293,7 @@ public class ConnectionsHandler {
     final List<ConnectionRead> reads = Lists.newArrayList();
     for (final StandardSync standardSync : configRepository.listStandardSyncs()) {
       if (standardSync.getStatus() != StandardSync.Status.DEPRECATED) {
-        final ConnectionRead connectionRead = connectionHelper.buildConnectionRead(standardSync.getConnectionId());
+        final ConnectionRead connectionRead = buildConnectionRead(standardSync.getConnectionId());
         if (matchSearch(connectionSearch, connectionRead)) {
           reads.add(connectionRead);
         }
@@ -308,6 +324,7 @@ public class ConnectionsHandler {
         matchSearch(connectionSearch.getDestination(), destinationRead);
   }
 
+  // todo (cgardens) - make this static. requires removing one bad dependence in SourceHandlerTest
   public boolean matchSearch(final SourceSearch sourceSearch, final SourceRead sourceRead) {
     final SourceMatcher sourceMatcher = new SourceMatcher(sourceSearch);
     final SourceRead sourceReadFromSearch = sourceMatcher.match(sourceRead);
@@ -315,6 +332,8 @@ public class ConnectionsHandler {
     return (sourceReadFromSearch == null || sourceReadFromSearch.equals(sourceRead));
   }
 
+  // todo (cgardens) - make this static. requires removing one bad dependence in
+  // DestinationHandlerTest
   public boolean matchSearch(final DestinationSearch destinationSearch, final DestinationRead destinationRead) {
     final DestinationMatcher destinationMatcher = new DestinationMatcher(destinationSearch);
     final DestinationRead destinationReadFromSearch = destinationMatcher.match(destinationRead);
@@ -325,6 +344,7 @@ public class ConnectionsHandler {
   public void deleteConnection(final UUID connectionId)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     if (featureFlags.usesNewScheduler()) {
+      // todo (cgardens) - need an interface over this.
       temporalWorkerRunFactory.deleteConnection(connectionId);
     } else {
       final ConnectionRead connectionRead = getConnection(connectionId);
@@ -353,12 +373,10 @@ public class ConnectionsHandler {
     return configRepository.getSourceConnection(standardSync.getSourceId()).getWorkspaceId().equals(workspaceId);
   }
 
-  private StandardSync.Status toPersistenceStatus(final ConnectionStatus apiStatus) {
-    return Enums.convertTo(apiStatus, StandardSync.Status.class);
-  }
-
-  private Schedule.TimeUnit toPersistenceTimeUnit(final ConnectionSchedule.TimeUnitEnum apiTimeUnit) {
-    return Enums.convertTo(apiTimeUnit, Schedule.TimeUnit.class);
+  private ConnectionRead buildConnectionRead(final UUID connectionId)
+      throws ConfigNotFoundException, IOException, JsonValidationException {
+    final StandardSync standardSync = configRepository.getStandardSync(connectionId);
+    return ApiPojoConverters.internalToConnectionRead(standardSync);
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -16,6 +16,7 @@ import io.airbyte.api.model.DestinationRead;
 import io.airbyte.api.model.ReleaseStage;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.config.ActorDefinition.ActorDefinitionReleaseStage;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -146,7 +147,7 @@ public class DestinationDefinitionsHandler {
         .withIcon(destinationDefCreate.getIcon())
         .withSpec(spec)
         .withTombstone(false)
-        .withReleaseStage(StandardDestinationDefinition.ReleaseStage.CUSTOM)
+        .withReleaseStage(ActorDefinitionReleaseStage.CUSTOM)
         .withResourceRequirements(ApiPojoConverters.actorDefResourceReqsToInternal(destinationDefCreate.getResourceRequirements()));
 
     configRepository.writeStandardDestinationDefinition(destinationDefinition);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -342,7 +342,9 @@ public class SchedulerHandler {
         standardSync,
         sourceImageName,
         destinationImageName,
-        standardSyncOperations);
+        standardSyncOperations,
+        sourceDef.getResourceRequirements(),
+        destinationDef.getResourceRequirements());
 
     return jobConverter.getJobInfoRead(job);
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -16,6 +16,7 @@ import io.airbyte.api.model.SourceDefinitionUpdate;
 import io.airbyte.api.model.SourceRead;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.config.ActorDefinition.ActorDefinitionReleaseStage;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -139,7 +140,7 @@ public class SourceDefinitionsHandler {
         .withIcon(sourceDefinitionCreate.getIcon())
         .withSpec(spec)
         .withTombstone(false)
-        .withReleaseStage(StandardSourceDefinition.ReleaseStage.CUSTOM)
+        .withReleaseStage(ActorDefinitionReleaseStage.CUSTOM)
         .withResourceRequirements(ApiPojoConverters.actorDefResourceReqsToInternal(sourceDefinitionCreate.getResourceRequirements()));
 
     configRepository.writeStandardSourceDefinition(sourceDefinition);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
@@ -54,7 +53,7 @@ import io.airbyte.scheduler.persistence.job_factory.SyncJobFactory;
 import io.airbyte.server.helpers.ConnectionHelpers;
 import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.WorkerConfigs;
-import io.airbyte.workers.helper.ConnectionHelper;
+import io.airbyte.workers.helper.CatalogConverter;
 import io.airbyte.workers.worker_run.TemporalWorkerRunFactory;
 import java.io.IOException;
 import java.util.Collections;
@@ -162,60 +161,11 @@ class ConnectionsHandlerTest {
     when(featureFlags.usesNewScheduler()).thenReturn(false);
   }
 
-  // TODO: bmoric move to a mock
-  private ConnectionHelper connectionHelper;
-
-  @Nested
-  class MockedConnectionHelper {
-
-    @BeforeEach
-    void setUp() {
-      connectionHelper = mock(ConnectionHelper.class);
-
-      connectionsHandler = new ConnectionsHandler(
-          configRepository,
-          uuidGenerator,
-          workspaceHelper,
-          trackingClient,
-          temporalWorkflowHandler,
-          featureFlags,
-          connectionHelper,
-          workerConfigs);
-    }
-
-    @Test
-    void testUpdateConnectionWithNewScheduler() throws JsonValidationException, ConfigNotFoundException, IOException {
-      final ConnectionUpdate connectionUpdate = new ConnectionUpdate()
-          .connectionId(standardSync.getConnectionId());
-
-      when(featureFlags.usesNewScheduler()).thenReturn(true);
-      connectionsHandler.updateConnection(connectionUpdate, false);
-
-      verify(connectionHelper).updateConnection(connectionUpdate);
-      verify(temporalWorkflowHandler).update(connectionUpdate);
-    }
-
-    @Test
-    void testUpdateConnectionWithNewSchedulerForReset() throws JsonValidationException, ConfigNotFoundException, IOException {
-      final ConnectionUpdate connectionUpdate = new ConnectionUpdate()
-          .connectionId(standardSync.getConnectionId());
-
-      when(featureFlags.usesNewScheduler()).thenReturn(true);
-      connectionsHandler.updateConnection(connectionUpdate, true);
-
-      verify(connectionHelper).updateConnection(connectionUpdate);
-      verifyNoInteractions(temporalWorkflowHandler);
-    }
-
-  }
-
   @Nested
   class UnMockedConnectionHelper {
 
     @BeforeEach
     void setUp() {
-      connectionHelper = new ConnectionHelper(configRepository, workspaceHelper, workerConfigs);
-
       connectionsHandler = new ConnectionsHandler(
           configRepository,
           uuidGenerator,
@@ -223,7 +173,6 @@ class ConnectionsHandlerTest {
           trackingClient,
           temporalWorkflowHandler,
           featureFlags,
-          connectionHelper,
           workerConfigs);
     }
 
@@ -409,7 +358,8 @@ class ConnectionsHandlerTest {
 
       final ConnectionUpdate connectionUpdate = new ConnectionUpdate()
           .connectionId(standardSync.getConnectionId())
-          .operationIds(Collections.singletonList(operationId));
+          .operationIds(Collections.singletonList(operationId))
+          .syncCatalog(CatalogConverter.toApi(standardSync.getCatalog()));
 
       assertThrows(IllegalArgumentException.class, () -> connectionsHandler.updateConnection(connectionUpdate));
     }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
@@ -24,6 +24,7 @@ import io.airbyte.api.model.DestinationReadList;
 import io.airbyte.api.model.ReleaseStage;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition.ActorDefinitionReleaseStage;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.ResourceRequirements;
@@ -91,7 +92,7 @@ class DestinationDefinitionsHandlerTest {
         .withIcon("http.svg")
         .withSpec(spec)
         .withTombstone(false)
-        .withReleaseStage(StandardDestinationDefinition.ReleaseStage.ALPHA)
+        .withReleaseStage(ActorDefinitionReleaseStage.ALPHA)
         .withReleaseDate(TODAY_DATE_STRING)
         .withResourceRequirements(new ActorDefinitionResourceRequirements().withDefault(new ResourceRequirements().withCpuRequest("2")));
   }
@@ -203,7 +204,7 @@ class DestinationDefinitionsHandlerTest {
     verify(schedulerSynchronousClient).createGetSpecJob(imageName);
     verify(configRepository).writeStandardDestinationDefinition(destination
         .withReleaseDate(null)
-        .withReleaseStage(StandardDestinationDefinition.ReleaseStage.CUSTOM));
+        .withReleaseStage(ActorDefinitionReleaseStage.CUSTOM));
   }
 
   @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
@@ -501,8 +501,16 @@ class SchedulerHandlerTest {
     when(configRepository.getSourceConnection(source.getSourceId())).thenReturn(source);
     when(configRepository.getDestinationConnection(destination.getDestinationId())).thenReturn(destination);
     when(configRepository.getStandardSyncOperation(operationId)).thenReturn(getOperation(operationId));
-    when(schedulerJobClient.createOrGetActiveSyncJob(source, destination, standardSync, SOURCE_DOCKER_IMAGE, DESTINATION_DOCKER_IMAGE, operations))
-        .thenReturn(completedJob);
+    when(schedulerJobClient.createOrGetActiveSyncJob(
+        source,
+        destination,
+        standardSync,
+        SOURCE_DOCKER_IMAGE,
+        DESTINATION_DOCKER_IMAGE,
+        operations,
+        null,
+        null))
+            .thenReturn(completedJob);
     when(completedJob.getScope()).thenReturn("cat:12");
     final JobConfig jobConfig = mock(JobConfig.class);
     when(completedJob.getConfig()).thenReturn(jobConfig);
@@ -514,7 +522,15 @@ class SchedulerHandlerTest {
     verify(configRepository).getStandardSync(standardSync.getConnectionId());
     verify(configRepository).getSourceConnection(standardSync.getSourceId());
     verify(configRepository).getDestinationConnection(standardSync.getDestinationId());
-    verify(schedulerJobClient).createOrGetActiveSyncJob(source, destination, standardSync, SOURCE_DOCKER_IMAGE, DESTINATION_DOCKER_IMAGE, operations);
+    verify(schedulerJobClient).createOrGetActiveSyncJob(
+        source,
+        destination,
+        standardSync,
+        SOURCE_DOCKER_IMAGE,
+        DESTINATION_DOCKER_IMAGE,
+        operations,
+        null,
+        null);
   }
 
   @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -25,7 +25,9 @@ import io.airbyte.api.model.SourceRead;
 import io.airbyte.api.model.SourceReadList;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.JobConfig.ConfigType;
+import io.airbyte.config.ResourceRequirements;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
@@ -88,7 +90,9 @@ class SourceDefinitionsHandlerTest {
         .withSpec(spec)
         .withTombstone(false)
         .withReleaseStage(StandardSourceDefinition.ReleaseStage.ALPHA)
-        .withReleaseDate(TODAY_DATE_STRING);
+        .withReleaseDate(TODAY_DATE_STRING)
+        .withResourceRequirements(new ActorDefinitionResourceRequirements().withDefault(new ResourceRequirements().withCpuRequest("2")));
+
   }
 
   @Test
@@ -106,7 +110,10 @@ class SourceDefinitionsHandlerTest {
         .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
-        .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()));
+        .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
+        .resourceRequirements(new io.airbyte.api.model.ActorDefinitionResourceRequirements()
+            ._default(new io.airbyte.api.model.ResourceRequirements()
+                .cpuRequest(sourceDefinition.getResourceRequirements().getDefault().getCpuRequest())));
 
     final SourceDefinitionRead expectedSourceDefinitionRead2 = new SourceDefinitionRead()
         .sourceDefinitionId(sourceDefinition2.getSourceDefinitionId())
@@ -116,7 +123,10 @@ class SourceDefinitionsHandlerTest {
         .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
-        .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()));
+        .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
+        .resourceRequirements(new io.airbyte.api.model.ActorDefinitionResourceRequirements()
+            ._default(new io.airbyte.api.model.ResourceRequirements()
+                .cpuRequest(sourceDefinition2.getResourceRequirements().getDefault().getCpuRequest())));
 
     final SourceDefinitionReadList actualSourceDefinitionReadList = sourceDefinitionsHandler.listSourceDefinitions();
 
@@ -139,7 +149,10 @@ class SourceDefinitionsHandlerTest {
         .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
-        .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()));
+        .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
+        .resourceRequirements(new io.airbyte.api.model.ActorDefinitionResourceRequirements()
+            ._default(new io.airbyte.api.model.ResourceRequirements()
+                .cpuRequest(sourceDefinition.getResourceRequirements().getDefault().getCpuRequest())));
 
     final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody =
         new SourceDefinitionIdRequestBody().sourceDefinitionId(sourceDefinition.getSourceDefinitionId());
@@ -165,7 +178,10 @@ class SourceDefinitionsHandlerTest {
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
         .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
-        .icon(sourceDefinition.getIcon());
+        .icon(sourceDefinition.getIcon())
+        .resourceRequirements(new io.airbyte.api.model.ActorDefinitionResourceRequirements()
+            ._default(new io.airbyte.api.model.ResourceRequirements()
+                .cpuRequest(sourceDefinition.getResourceRequirements().getDefault().getCpuRequest())));
 
     final SourceDefinitionRead expectedRead = new SourceDefinitionRead()
         .name(sourceDefinition.getName())
@@ -174,7 +190,10 @@ class SourceDefinitionsHandlerTest {
         .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
         .sourceDefinitionId(sourceDefinition.getSourceDefinitionId())
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
-        .releaseStage(ReleaseStage.CUSTOM);
+        .releaseStage(ReleaseStage.CUSTOM)
+        .resourceRequirements(new io.airbyte.api.model.ActorDefinitionResourceRequirements()
+            ._default(new io.airbyte.api.model.ResourceRequirements()
+                .cpuRequest(sourceDefinition.getResourceRequirements().getDefault().getCpuRequest())));
 
     final SourceDefinitionRead actualRead = sourceDefinitionsHandler.createCustomSourceDefinition(create);
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -25,6 +25,7 @@ import io.airbyte.api.model.SourceRead;
 import io.airbyte.api.model.SourceReadList;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition.ActorDefinitionReleaseStage;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.ResourceRequirements;
@@ -89,7 +90,7 @@ class SourceDefinitionsHandlerTest {
         .withIcon("http.svg")
         .withSpec(spec)
         .withTombstone(false)
-        .withReleaseStage(StandardSourceDefinition.ReleaseStage.ALPHA)
+        .withReleaseStage(ActorDefinitionReleaseStage.ALPHA)
         .withReleaseDate(TODAY_DATE_STRING)
         .withResourceRequirements(new ActorDefinitionResourceRequirements().withDefault(new ResourceRequirements().withCpuRequest("2")));
 
@@ -200,7 +201,7 @@ class SourceDefinitionsHandlerTest {
     assertEquals(expectedRead, actualRead);
     verify(schedulerSynchronousClient).createGetSpecJob(imageName);
     verify(configRepository)
-        .writeStandardSourceDefinition(sourceDefinition.withReleaseDate(null).withReleaseStage(StandardSourceDefinition.ReleaseStage.CUSTOM));
+        .writeStandardSourceDefinition(sourceDefinition.withReleaseDate(null).withReleaseStage(ActorDefinitionReleaseStage.CUSTOM));
   }
 
   @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -113,8 +113,14 @@ class WebBackendConnectionsHandlerTest {
     featureFlags = mock(FeatureFlags.class);
     temporalWorkerRunFactory = mock(TemporalWorkerRunFactory.class);
     connectionHelper = mock(ConnectionHelper.class);
-    wbHandler = new WebBackendConnectionsHandler(connectionsHandler, sourceHandler, destinationHandler, jobHistoryHandler, schedulerHandler,
-        operationsHandler, featureFlags, temporalWorkerRunFactory, connectionHelper);
+    wbHandler = new WebBackendConnectionsHandler(connectionsHandler,
+        sourceHandler,
+        destinationHandler,
+        jobHistoryHandler,
+        schedulerHandler,
+        operationsHandler,
+        featureFlags,
+        temporalWorkerRunFactory);
 
     final StandardSourceDefinition standardSourceDefinition = SourceDefinitionHelpers.generateSourceDefinition();
     final SourceConnection source = SourceHelpers.generateSource(UUID.randomUUID());
@@ -573,7 +579,7 @@ class WebBackendConnectionsHandlerTest {
         .status(expected.getStatus())
         .schedule(expected.getSchedule());
     when(connectionsHandler.updateConnection(any())).thenReturn(connectionRead);
-    when(connectionHelper.buildConnectionRead(any())).thenReturn(connectionRead);
+    when(connectionsHandler.getConnection(expected.getConnectionId())).thenReturn(connectionRead);
     when(featureFlags.usesNewScheduler()).thenReturn(true);
 
     final WebBackendConnectionRead result = wbHandler.webBackendUpdateConnection(updateBody);
@@ -583,7 +589,7 @@ class WebBackendConnectionsHandlerTest {
     final ConnectionIdRequestBody connectionId = new ConnectionIdRequestBody().connectionId(result.getConnectionId());
     verify(schedulerHandler, times(0)).resetConnection(connectionId);
     verify(schedulerHandler, times(0)).syncConnection(connectionId);
-    InOrder orderVerifier = inOrder(temporalWorkerRunFactory);
+    final InOrder orderVerifier = inOrder(temporalWorkerRunFactory);
     orderVerifier.verify(temporalWorkerRunFactory, times(1)).synchronousResetConnection(connectionId.getConnectionId());
     orderVerifier.verify(temporalWorkerRunFactory, times(1)).startNewManualSync(connectionId.getConnectionId());
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -378,10 +378,7 @@ public class WorkerApp {
         configRepository,
         jobPersistence);
 
-    final ConnectionHelper connectionHelper = new ConnectionHelper(
-        configRepository,
-        workspaceHelper,
-        defaultWorkerConfigs);
+    final ConnectionHelper connectionHelper = new ConnectionHelper(configRepository, workspaceHelper);
 
     final Optional<ContainerOrchestratorConfig> containerOrchestratorConfig = getContainerOrchestratorConfig(configs);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/ConnectionHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/ConnectionHelper.java
@@ -5,11 +5,6 @@
 package io.airbyte.workers.helper;
 
 import com.google.common.base.Preconditions;
-import io.airbyte.api.model.ConnectionRead;
-import io.airbyte.api.model.ConnectionSchedule;
-import io.airbyte.api.model.ConnectionStatus;
-import io.airbyte.api.model.ConnectionUpdate;
-import io.airbyte.api.model.ResourceRequirements;
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
@@ -19,85 +14,90 @@ import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.scheduler.persistence.WorkspaceHelper;
 import io.airbyte.validation.json.JsonValidationException;
-import io.airbyte.workers.WorkerConfigs;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 
+// todo (cgardens) - we are not getting any value out of instantiating this class. we should just
+// use it as statics. not doing it now, because already in the middle of another refactor.
 @AllArgsConstructor
 public class ConnectionHelper {
 
   private final ConfigRepository configRepository;
   private final WorkspaceHelper workspaceHelper;
-  private final WorkerConfigs workerConfigs;
 
   public void deleteConnection(final UUID connectionId) throws JsonValidationException, ConfigNotFoundException, IOException {
-    final ConnectionRead connectionRead = buildConnectionRead(connectionId);
-
-    final ConnectionUpdate connectionUpdate = new ConnectionUpdate()
-        .namespaceDefinition(connectionRead.getNamespaceDefinition())
-        .namespaceFormat(connectionRead.getNamespaceFormat())
-        .prefix(connectionRead.getPrefix())
-        .connectionId(connectionRead.getConnectionId())
-        .operationIds(connectionRead.getOperationIds())
-        .syncCatalog(connectionRead.getSyncCatalog())
-        .schedule(connectionRead.getSchedule())
-        .status(ConnectionStatus.DEPRECATED)
-        .resourceRequirements(connectionRead.getResourceRequirements());
-
-    updateConnection(connectionUpdate);
+    final StandardSync update = Jsons.clone(configRepository.getStandardSync(connectionId));
+    updateConnection(update);
   }
 
-  public ConnectionRead updateConnection(final ConnectionUpdate connectionUpdate)
-      throws ConfigNotFoundException, IOException, JsonValidationException {
-    // retrieve and update sync
-    // retrieve and update sync
-    final StandardSync persistedSync = configRepository.getStandardSync(connectionUpdate.getConnectionId());
+  /**
+   * Given a connection update, fetches an existing connection, applies the update, and then persists
+   * the update.
+   *
+   * @param update - updated sync info to be merged with original sync.
+   * @return new sync object
+   * @throws JsonValidationException - if provided object is invalid
+   * @throws ConfigNotFoundException - if there is no sync already persisted
+   * @throws IOException - you never know when you io
+   */
+  public StandardSync updateConnection(final StandardSync update)
+      throws JsonValidationException, ConfigNotFoundException, IOException {
+    final StandardSync original = configRepository.getStandardSync(update.getConnectionId());
+    final StandardSync newConnection = updateConnectionObject(workspaceHelper, original, update);
+    configRepository.writeStandardSync(newConnection);
+    return newConnection;
+  }
 
-    validateWorkspace(persistedSync.getSourceId(), persistedSync.getDestinationId(), new HashSet<>(connectionUpdate.getOperationIds()));
+  /**
+   * Core logic for merging an existing connection configuration with an update.
+   *
+   * @param workspaceHelper - helper class
+   * @param original - already persisted sync
+   * @param update - updated sync info to be merged with original sync.
+   * @return new sync object
+   */
+  public static StandardSync updateConnectionObject(final WorkspaceHelper workspaceHelper, final StandardSync original, final StandardSync update) {
+    validateWorkspace(workspaceHelper, original.getSourceId(), original.getDestinationId(), new HashSet<>(update.getOperationIds()));
 
-    final StandardSync newConnection = Jsons.clone(persistedSync)
-        .withNamespaceDefinition(Enums.convertTo(connectionUpdate.getNamespaceDefinition(), NamespaceDefinitionType.class))
-        .withNamespaceFormat(connectionUpdate.getNamespaceFormat())
-        .withPrefix(connectionUpdate.getPrefix())
-        .withOperationIds(connectionUpdate.getOperationIds())
-        .withCatalog(CatalogConverter.toProtocol(connectionUpdate.getSyncCatalog()))
-        .withStatus(toPersistenceStatus(connectionUpdate.getStatus()));
+    final StandardSync newConnection = Jsons.clone(original)
+        .withNamespaceDefinition(Enums.convertTo(update.getNamespaceDefinition(), NamespaceDefinitionType.class))
+        .withNamespaceFormat(update.getNamespaceFormat())
+        .withPrefix(update.getPrefix())
+        .withOperationIds(update.getOperationIds())
+        .withCatalog(update.getCatalog())
+        .withStatus(update.getStatus());
 
     // update Resource Requirements
-    if (connectionUpdate.getResourceRequirements() != null) {
+    if (update.getResourceRequirements() != null) {
       newConnection.withResourceRequirements(new io.airbyte.config.ResourceRequirements()
-          .withCpuRequest(connectionUpdate.getResourceRequirements().getCpuRequest())
-          .withCpuLimit(connectionUpdate.getResourceRequirements().getCpuLimit())
-          .withMemoryRequest(connectionUpdate.getResourceRequirements().getMemoryRequest())
-          .withMemoryLimit(connectionUpdate.getResourceRequirements().getMemoryLimit()));
+          .withCpuRequest(update.getResourceRequirements().getCpuRequest())
+          .withCpuLimit(update.getResourceRequirements().getCpuLimit())
+          .withMemoryRequest(update.getResourceRequirements().getMemoryRequest())
+          .withMemoryLimit(update.getResourceRequirements().getMemoryLimit()));
     } else {
-      newConnection.withResourceRequirements(persistedSync.getResourceRequirements());
+      newConnection.withResourceRequirements(original.getResourceRequirements());
     }
 
     // update sync schedule
-    if (connectionUpdate.getSchedule() != null) {
+    if (update.getSchedule() != null) {
       final Schedule newSchedule = new Schedule()
-          .withTimeUnit(toPersistenceTimeUnit(connectionUpdate.getSchedule().getTimeUnit()))
-          .withUnits(connectionUpdate.getSchedule().getUnits());
+          .withTimeUnit(update.getSchedule().getTimeUnit())
+          .withUnits(update.getSchedule().getUnits());
       newConnection.withManual(false).withSchedule(newSchedule);
     } else {
       newConnection.withManual(true).withSchedule(null);
     }
 
-    configRepository.writeStandardSync(newConnection);
-    return buildConnectionRead(connectionUpdate.getConnectionId());
+    return newConnection;
   }
 
-  public ConnectionRead buildConnectionRead(final UUID connectionId)
-      throws ConfigNotFoundException, IOException, JsonValidationException {
-    final StandardSync standardSync = configRepository.getStandardSync(connectionId);
-    return buildConnectionRead(standardSync);
-  }
-
-  public void validateWorkspace(final UUID sourceId, final UUID destinationId, final Set<UUID> operationIds) {
+  public static void validateWorkspace(final WorkspaceHelper workspaceHelper,
+                                       final UUID sourceId,
+                                       final UUID destinationId,
+                                       final Set<UUID> operationIds) {
     final UUID sourceWorkspace = workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(sourceId);
     final UUID destinationWorkspace = workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(destinationId);
 
@@ -120,61 +120,6 @@ public class ConnectionHelper {
               operationId,
               operationWorkspace));
     }
-  }
-
-  private ConnectionRead buildConnectionRead(final StandardSync standardSync) {
-    ConnectionSchedule apiSchedule = null;
-
-    if (!standardSync.getManual()) {
-      apiSchedule = new ConnectionSchedule()
-          .timeUnit(toApiTimeUnit(standardSync.getSchedule().getTimeUnit()))
-          .units(standardSync.getSchedule().getUnits());
-    }
-
-    final ConnectionRead connectionRead = new ConnectionRead()
-        .connectionId(standardSync.getConnectionId())
-        .sourceId(standardSync.getSourceId())
-        .destinationId(standardSync.getDestinationId())
-        .operationIds(standardSync.getOperationIds())
-        .status(toApiStatus(standardSync.getStatus()))
-        .schedule(apiSchedule)
-        .name(standardSync.getName())
-        .namespaceDefinition(Enums.convertTo(standardSync.getNamespaceDefinition(), io.airbyte.api.model.NamespaceDefinitionType.class))
-        .namespaceFormat(standardSync.getNamespaceFormat())
-        .prefix(standardSync.getPrefix())
-        .syncCatalog(CatalogConverter.toApi(standardSync.getCatalog()));
-
-    if (standardSync.getResourceRequirements() != null) {
-      connectionRead.resourceRequirements(new ResourceRequirements()
-          .cpuRequest(standardSync.getResourceRequirements().getCpuRequest())
-          .cpuLimit(standardSync.getResourceRequirements().getCpuLimit())
-          .memoryRequest(standardSync.getResourceRequirements().getMemoryRequest())
-          .memoryLimit(standardSync.getResourceRequirements().getMemoryLimit()));
-    } else {
-      final io.airbyte.config.ResourceRequirements resourceRequirements = workerConfigs.getResourceRequirements();
-      connectionRead.resourceRequirements(new ResourceRequirements()
-          .cpuRequest(resourceRequirements.getCpuRequest())
-          .cpuLimit(resourceRequirements.getCpuLimit())
-          .memoryRequest(resourceRequirements.getMemoryRequest())
-          .memoryLimit(resourceRequirements.getMemoryLimit()));
-    }
-    return connectionRead;
-  }
-
-  private ConnectionSchedule.TimeUnitEnum toApiTimeUnit(final Schedule.TimeUnit apiTimeUnit) {
-    return Enums.convertTo(apiTimeUnit, ConnectionSchedule.TimeUnitEnum.class);
-  }
-
-  private ConnectionStatus toApiStatus(final StandardSync.Status status) {
-    return Enums.convertTo(status, ConnectionStatus.class);
-  }
-
-  private StandardSync.Status toPersistenceStatus(final ConnectionStatus apiStatus) {
-    return Enums.convertTo(apiStatus, StandardSync.Status.class);
-  }
-
-  private Schedule.TimeUnit toPersistenceTimeUnit(final ConnectionSchedule.TimeUnitEnum apiTimeUnit) {
-    return Enums.convertTo(apiTimeUnit, Schedule.TimeUnit.class);
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/ResourceRequirementsUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/ResourceRequirementsUtils.java
@@ -5,8 +5,8 @@
 package io.airbyte.workers.helper;
 
 import com.google.common.base.Preconditions;
+import io.airbyte.config.ActorDefinition.ActorType;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
-import io.airbyte.config.ActorType;
 import io.airbyte.config.JobTypeResourceLimit;
 import io.airbyte.config.JobTypeResourceLimit.JobType;
 import io.airbyte.config.ResourceRequirements;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/ResourceRequirementsUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/ResourceRequirementsUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.helper;
+
+import com.google.common.base.Preconditions;
+import io.airbyte.config.ActorDefinitionResourceRequirements;
+import io.airbyte.config.ActorType;
+import io.airbyte.config.JobTypeResourceLimit;
+import io.airbyte.config.JobTypeResourceLimit.JobType;
+import io.airbyte.config.ResourceRequirements;
+import io.airbyte.config.StandardSyncInput;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class ResourceRequirementsUtils {
+
+  /**
+   * Given an actor type and job type, returns resource requirements, if present. Otherwise, null.
+   * Sync-level resource requirements, take precedence over connector definition level ones.
+   *
+   * @param input - sync input
+   * @param actorType - type of actor to extract resource requirements for
+   * @param jobType - toe of job to extract resource requirements for
+   * @return resource requirements, if present, otherwise null.
+   */
+  public static ResourceRequirements getResourceRequirements(final StandardSyncInput input, final ActorType actorType, final JobType jobType) {
+    final ActorDefinitionResourceRequirements actorDefResourceReqs = getResourceRequirementsForActorType(input, actorType);
+    if (input.getResourceRequirements() != null) {
+      return input.getResourceRequirements();
+    } else if (actorDefResourceReqs != null) {
+      final Optional<ResourceRequirements> resourceRequirementsForJobType = getResourceRequirementsForJobType(actorDefResourceReqs, jobType);
+      return resourceRequirementsForJobType.orElse(actorDefResourceReqs.getDefault()); // default can return null.
+    } else {
+      return null;
+    }
+
+  }
+
+  private static Optional<ResourceRequirements> getResourceRequirementsForJobType(final ActorDefinitionResourceRequirements actorDefResourceReqs,
+                                                                                  final JobType jobType) {
+    final List<ResourceRequirements> jobTypeResourceRequirement = actorDefResourceReqs.getJobSpecific()
+        .stream()
+        .filter(jobSpecific -> jobSpecific.getJobType() == jobType).map(JobTypeResourceLimit::getResourceRequirements).collect(
+            Collectors.toList());
+
+    Preconditions.checkArgument(jobTypeResourceRequirement.size() <= 1, "Should only have one resource requirement per job type.");
+    return jobTypeResourceRequirement.isEmpty() ? Optional.empty() : Optional.of(jobTypeResourceRequirement.get(0));
+  }
+
+  private static ActorDefinitionResourceRequirements getResourceRequirementsForActorType(final StandardSyncInput input, final ActorType actorType) {
+    switch (actorType) {
+      case SOURCE -> {
+        return input.getSourceResourceRequirements();
+      }
+      case DESTINATION -> {
+        return input.getDestinationResourceRequirements();
+      }
+      default -> {
+        throw new IllegalArgumentException("Unrecognized actor type.");
+      }
+    }
+  }
+
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/GenerateInputActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/GenerateInputActivityImpl.java
@@ -65,7 +65,9 @@ public class GenerateInputActivityImpl implements GenerateInputActivity {
           .withOperationSequence(config.getOperationSequence())
           .withCatalog(config.getConfiguredAirbyteCatalog())
           .withState(config.getState())
-          .withResourceRequirements(config.getResourceRequirements());
+          .withResourceRequirements(config.getResourceRequirements())
+          .withSourceResourceRequirements(config.getSourceResourceRequirements())
+          .withDestinationResourceRequirements(config.getDestinationResourceRequirements());
 
       return new GeneratedJobInput(jobRunConfig, sourceLauncherConfig, destinationLauncherConfig, syncInput);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationActivityImpl.java
@@ -7,9 +7,11 @@ package io.airbyte.workers.temporal.sync;
 import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.commons.functional.CheckedSupplier;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorType;
 import io.airbyte.config.AirbyteConfigValidator;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.Configs.WorkerEnvironment;
+import io.airbyte.config.JobTypeResourceLimit.JobType;
 import io.airbyte.config.ReplicationOutput;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardSyncOutput;
@@ -24,6 +26,7 @@ import io.airbyte.workers.Worker;
 import io.airbyte.workers.WorkerApp;
 import io.airbyte.workers.WorkerConfigs;
 import io.airbyte.workers.WorkerConstants;
+import io.airbyte.workers.helper.ResourceRequirementsUtils;
 import io.airbyte.workers.process.AirbyteIntegrationLauncher;
 import io.airbyte.workers.process.IntegrationLauncher;
 import io.airbyte.workers.process.ProcessFactory;
@@ -180,13 +183,13 @@ public class ReplicationActivityImpl implements ReplicationActivity {
           Math.toIntExact(sourceLauncherConfig.getAttemptId()),
           sourceLauncherConfig.getDockerImage(),
           processFactory,
-          syncInput.getResourceRequirements());
+          ResourceRequirementsUtils.getResourceRequirements(syncInput, ActorType.SOURCE, JobType.SYNC));
       final IntegrationLauncher destinationLauncher = new AirbyteIntegrationLauncher(
           destinationLauncherConfig.getJobId(),
           Math.toIntExact(destinationLauncherConfig.getAttemptId()),
           destinationLauncherConfig.getDockerImage(),
           processFactory,
-          syncInput.getResourceRequirements());
+          ResourceRequirementsUtils.getResourceRequirements(syncInput, ActorType.DESTINATION, JobType.SYNC));
 
       // reset jobs use an empty source to induce resetting all data in destination.
       final AirbyteSource airbyteSource =

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationActivityImpl.java
@@ -7,7 +7,7 @@ package io.airbyte.workers.temporal.sync;
 import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.commons.functional.CheckedSupplier;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.config.ActorType;
+import io.airbyte.config.ActorDefinition.ActorType;
 import io.airbyte.config.AirbyteConfigValidator;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.Configs.WorkerEnvironment;


### PR DESCRIPTION
Relates to: https://github.com/airbytehq/airbyte-internal-issues/issues/428
## What
This is the first step in https://github.com/airbytehq/airbyte-internal-issues/issues/428

>  Convert ConfigPersistence to work on ActorDefinitions instead of StandardSourceDefinition and StandardDestinationDefinition. This includes all underlying persistence layers. i.e. db will store ActorDefinition

## How
Convert everything in `ConfigPersistence` and below.

Does it by doing the following:
* Creating and `ActorDefinition` struct.
* Creates some temporary conversion utils
* Change `DatabaseConfigPersistence` to use `ActorDefinition` instead
* Fix all usages that assume something different. Mostly ConfigRepository.

## Reading Order
* `ActorDefinition.yaml`
* `ActorDefinitionMigrationUtils.java`
* `DatabaseConfigPersistence.java`
* `ConfigRepository.java`

## Todo
- [ ] tests for `ActorDefinitionMigrationUtils.java`