### PR TITLE
migrate ConfigRepository to use ActorDefinition

### DIFF
--- a/airbyte-config/models/src/main/resources/types/ActorDefinition.yaml
+++ b/airbyte-config/models/src/main/resources/types/ActorDefinition.yaml
@@ -2,7 +2,7 @@
 "$schema": http://json-schema.org/draft-07/schema#
 "$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/ActorDefinition.yaml
 title: ActorDefinition
-description: describes a destination
+description: describes an actor definition
 type: object
 required:
   - id

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ActorDefinitionMigrationUtils.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ActorDefinitionMigrationUtils.java
@@ -24,6 +24,7 @@ public class ActorDefinitionMigrationUtils {
   // ConfigRepository to convert from ActorDefinition (used internally in the db) and
   // StandardSourceDefinition, used externally.
   public static StandardSourceDefinition mapActorDefToSourceDef(final ActorDefinition actorDefinition) {
+    System.out.println("actorDefinition.getActorType() = " + actorDefinition.getActorType());
     Preconditions.checkArgument(actorDefinition.getActorType() == ActorType.SOURCE);
     return new StandardSourceDefinition()
         .withName(actorDefinition.getName())

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryTest.java
@@ -227,25 +227,26 @@ class ConfigRepositoryTest {
   @ValueSource(ints = {0, 1, 2, 10})
   void testListStandardSourceDefinitions_handlesTombstoneSourceDefinitions(final int numSourceDefinitions)
       throws JsonValidationException, IOException {
-    final List<StandardSourceDefinition> allSourceDefinitions = new ArrayList<>();
-    final List<StandardSourceDefinition> notTombstoneSourceDefinitions = new ArrayList<>();
+    final List<ActorDefinition> allSourceDefinitions = new ArrayList<>();
+    final List<ActorDefinition> notTombstoneSourceDefinitions = new ArrayList<>();
     for (int i = 0; i < numSourceDefinitions; i++) {
       final boolean isTombstone = i % 2 == 0; // every other is tombstone
-      final StandardSourceDefinition sourceDefinition =
-          new StandardSourceDefinition().withSourceDefinitionId(UUID.randomUUID()).withTombstone(isTombstone);
+      final ActorDefinition sourceDefinition = new ActorDefinition()
+          .withId(UUID.randomUUID())
+          .withTombstone(isTombstone);
       allSourceDefinitions.add(sourceDefinition);
       if (!isTombstone) {
         notTombstoneSourceDefinitions.add(sourceDefinition);
       }
     }
     when(configPersistence.listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, ActorDefinition.class))
-        // todo (cgardens) - remove migration shim.
-        .thenReturn(allSourceDefinitions.stream().map(ActorDefinitionMigrationUtils::mapSourceDefToActorDef).collect(Collectors.toList()));
+        .thenReturn(allSourceDefinitions);
 
-    final List<StandardSourceDefinition> returnedSourceDefinitionsWithoutTombstone = configRepository.listStandardSourceDefinitions(false);
+    final List<ActorDefinition> returnedSourceDefinitionsWithoutTombstone = configRepository
+        .listStandardSourceDefinitions(false);
     assertEquals(notTombstoneSourceDefinitions, returnedSourceDefinitionsWithoutTombstone);
 
-    final List<StandardSourceDefinition> returnedSourceDefinitionsWithTombstone = configRepository.listStandardSourceDefinitions(true);
+    final List<ActorDefinition> returnedSourceDefinitionsWithTombstone = configRepository.listStandardSourceDefinitions(true);
     assertEquals(allSourceDefinitions, returnedSourceDefinitionsWithTombstone);
   }
 
@@ -285,29 +286,28 @@ class ConfigRepositoryTest {
 
   @Test
   void testDestinationDefinitionWithNullTombstone() throws JsonValidationException, ConfigNotFoundException, IOException {
-    assertReturnsDestinationDefinition(new StandardDestinationDefinition().withDestinationDefinitionId(DESTINATION_DEFINITION_ID));
+    assertReturnsDestinationDefinition(new ActorDefinition().withId(DESTINATION_DEFINITION_ID));
   }
 
   @Test
   void testDestinationDefinitionWithTrueTombstone() throws JsonValidationException, ConfigNotFoundException, IOException {
     assertReturnsDestinationDefinition(
-        new StandardDestinationDefinition().withDestinationDefinitionId(DESTINATION_DEFINITION_ID).withTombstone(true));
+        new ActorDefinition().withId(DESTINATION_DEFINITION_ID).withTombstone(true));
   }
 
   @Test
   void testDestinationDefinitionWithFalseTombstone() throws JsonValidationException, ConfigNotFoundException, IOException {
     assertReturnsDestinationDefinition(
-        new StandardDestinationDefinition().withDestinationDefinitionId(DESTINATION_DEFINITION_ID).withTombstone(false));
+        new ActorDefinition().withId(DESTINATION_DEFINITION_ID).withTombstone(false));
   }
 
-  void assertReturnsDestinationDefinition(final StandardDestinationDefinition destinationDefinition)
+  void assertReturnsDestinationDefinition(final ActorDefinition destinationDefinition)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     when(configPersistence.getConfig(
         ConfigSchema.STANDARD_DESTINATION_DEFINITION,
         DESTINATION_DEFINITION_ID.toString(),
         ActorDefinition.class))
-            // todo (cgardens) - remove migration shim.
-            .thenReturn(ActorDefinitionMigrationUtils.mapDestDefToActorDef(destinationDefinition));
+            .thenReturn(destinationDefinition);
 
     assertEquals(destinationDefinition, configRepository.getStandardDestinationDefinition(DESTINATION_DEFINITION_ID));
   }
@@ -384,11 +384,12 @@ class ConfigRepositoryTest {
         // todo (cgardens) - remove migration shim.
         .thenReturn(allDestinationDefinitions.stream().map(ActorDefinitionMigrationUtils::mapDestDefToActorDef).collect(Collectors.toList()));
 
-    final List<StandardDestinationDefinition> returnedDestinationDefinitionsWithoutTombstone =
-        configRepository.listStandardDestinationDefinitions(false);
+    final List<ActorDefinition> returnedDestinationDefinitionsWithoutTombstone = configRepository
+        .listStandardDestinationDefinitions(false);
     assertEquals(notTombstoneDestinationDefinitions, returnedDestinationDefinitionsWithoutTombstone);
 
-    final List<StandardDestinationDefinition> returnedDestinationDefinitionsWithTombstone = configRepository.listStandardDestinationDefinitions(true);
+    final List<ActorDefinition> returnedDestinationDefinitionsWithTombstone = configRepository
+        .listStandardDestinationDefinitions(true);
     assertEquals(allDestinationDefinitions, returnedDestinationDefinitionsWithTombstone);
   }
 

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/OAuthImplementationFactory.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/OAuthImplementationFactory.java
@@ -5,8 +5,7 @@
 package io.airbyte.oauth;
 
 import com.google.common.collect.ImmutableMap;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.oauth.flows.*;
 import io.airbyte.oauth.flows.facebook.FacebookMarketingOAuthFlow;
@@ -63,12 +62,8 @@ public class OAuthImplementationFactory {
         .build();
   }
 
-  public OAuthFlowImplementation create(final StandardSourceDefinition sourceDefinition) {
-    return create(sourceDefinition.getDockerRepository());
-  }
-
-  public OAuthFlowImplementation create(final StandardDestinationDefinition destinationDefinition) {
-    return create(destinationDefinition.getDockerRepository());
+  public OAuthFlowImplementation create(final ActorDefinition actorDefinition) {
+    return create(actorDefinition.getDockerRepository());
   }
 
   private OAuthFlowImplementation create(final String imageName) {

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobNotifier.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/JobNotifier.java
@@ -9,10 +9,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import io.airbyte.analytics.TrackingClient;
 import io.airbyte.commons.map.MoreMaps;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.Notification;
 import io.airbyte.config.Notification.NotificationType;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.notification.NotificationClient;
@@ -56,8 +55,8 @@ public class JobNotifier {
   private void notifyJob(final String reason, final String action, final Job job) {
     final UUID connectionId = UUID.fromString(job.getScope());
     try {
-      final StandardSourceDefinition sourceDefinition = configRepository.getSourceDefinitionFromConnection(connectionId);
-      final StandardDestinationDefinition destinationDefinition = configRepository.getDestinationDefinitionFromConnection(connectionId);
+      final ActorDefinition sourceDefinition = configRepository.getSourceDefinitionFromConnection(connectionId);
+      final ActorDefinition destinationDefinition = configRepository.getDestinationDefinitionFromConnection(connectionId);
       final Instant jobStartedDate = Instant.ofEpochSecond(job.getStartedAtInSecond().orElse(job.getCreatedAtInSecond()));
       final DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL).withZone(ZoneId.systemDefault());
       final Instant jobUpdatedDate = Instant.ofEpochSecond(job.getUpdatedAtInSecond());

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/DefaultSyncJobFactory.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/DefaultSyncJobFactory.java
@@ -7,10 +7,9 @@ package io.airbyte.scheduler.persistence.job_factory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.docker.DockerUtils;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -50,9 +49,9 @@ public class DefaultSyncJobFactory implements SyncJobFactory {
           destinationConnection.getWorkspaceId(),
           destinationConnection.getConfiguration());
       destinationConnection.withConfiguration(destinationConfiguration);
-      final StandardSourceDefinition sourceDefinition = configRepository
+      final ActorDefinition sourceDefinition = configRepository
           .getStandardSourceDefinition(sourceConnection.getSourceDefinitionId());
-      final StandardDestinationDefinition destinationDefinition = configRepository
+      final ActorDefinition destinationDefinition = configRepository
           .getStandardDestinationDefinition(destinationConnection.getDestinationDefinitionId());
 
       final String sourceImageName = DockerUtils.getTaggedImageName(sourceDefinition.getDockerRepository(), sourceDefinition.getDockerImageTag());

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplier.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_factory/OAuthConfigSupplier.java
@@ -14,8 +14,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airbyte.analytics.TrackingClient;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.Exceptions;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.oauth.MoreOAuthParameters;
@@ -50,7 +49,7 @@ public class OAuthConfigSupplier {
   public JsonNode injectSourceOAuthParameters(final UUID sourceDefinitionId, final UUID workspaceId, final JsonNode sourceConnectorConfig)
       throws IOException {
     try {
-      final StandardSourceDefinition sourceDefinition = configRepository.getStandardSourceDefinition(sourceDefinitionId);
+      final ActorDefinition sourceDefinition = configRepository.getStandardSourceDefinition(sourceDefinitionId);
       MoreOAuthParameters.getSourceOAuthParameter(configRepository.listSourceOAuthParam().stream(), workspaceId, sourceDefinitionId)
           .ifPresent(sourceOAuthParameter -> {
             if (injectOAuthParameters(sourceDefinition.getName(), sourceDefinition.getSpec(), sourceOAuthParameter.getConfiguration(),
@@ -70,7 +69,7 @@ public class OAuthConfigSupplier {
                                                    final JsonNode destinationConnectorConfig)
       throws IOException {
     try {
-      final StandardDestinationDefinition destinationDefinition = configRepository.getStandardDestinationDefinition(destinationDefinitionId);
+      final ActorDefinition destinationDefinition = configRepository.getStandardDestinationDefinition(destinationDefinitionId);
       MoreOAuthParameters.getDestinationOAuthParameter(configRepository.listDestinationOAuthParam().stream(), workspaceId, destinationDefinitionId)
           .ifPresent(destinationOAuthParameter -> {
             if (injectOAuthParameters(destinationDefinition.getName(), destinationDefinition.getSpec(), destinationOAuthParameter.getConfiguration(),

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -17,11 +17,10 @@ import io.airbyte.analytics.TrackingClient;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.commons.map.MoreMaps;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.JobConfig;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.StandardCheckConnectionOutput;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardWorkspace;
@@ -125,10 +124,10 @@ public class JobTracker {
       Preconditions.checkArgument(allowedJob, "Job type " + configType + " is not allowed!");
       final long jobId = job.getId();
       final UUID connectionId = UUID.fromString(job.getScope());
-      final StandardSourceDefinition sourceDefinition = configRepository.getSourceDefinitionFromConnection(connectionId);
-      final UUID sourceDefinitionId = sourceDefinition.getSourceDefinitionId();
-      final StandardDestinationDefinition destinationDefinition = configRepository.getDestinationDefinitionFromConnection(connectionId);
-      final UUID destinationDefinitionId = destinationDefinition.getDestinationDefinitionId();
+      final ActorDefinition sourceDefinition = configRepository.getSourceDefinitionFromConnection(connectionId);
+      final UUID sourceDefinitionId = sourceDefinition.getId();
+      final ActorDefinition destinationDefinition = configRepository.getDestinationDefinitionFromConnection(connectionId);
+      final UUID destinationDefinitionId = destinationDefinition.getId();
 
       final Map<String, Object> jobMetadata = generateJobMetadata(String.valueOf(jobId), configType, job.getAttemptsCount());
       final Map<String, Object> jobAttemptMetadata = generateJobAttemptMetadata(job.getId(), jobState);
@@ -319,13 +318,13 @@ public class JobTracker {
 
   private ImmutableMap<String, Object> generateDestinationDefinitionMetadata(final UUID destinationDefinitionId)
       throws ConfigNotFoundException, IOException, JsonValidationException {
-    final StandardDestinationDefinition destinationDefinition = configRepository.getStandardDestinationDefinition(destinationDefinitionId);
+    final ActorDefinition destinationDefinition = configRepository.getStandardDestinationDefinition(destinationDefinitionId);
     return TrackingMetadata.generateDestinationDefinitionMetadata(destinationDefinition);
   }
 
   private ImmutableMap<String, Object> generateSourceDefinitionMetadata(final UUID sourceDefinitionId)
       throws ConfigNotFoundException, IOException, JsonValidationException {
-    final StandardSourceDefinition sourceDefinition = configRepository.getStandardSourceDefinition(sourceDefinitionId);
+    final ActorDefinition sourceDefinition = configRepository.getStandardSourceDefinition(sourceDefinitionId);
     return TrackingMetadata.generateSourceDefinitionMetadata(sourceDefinition);
   }
 

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/TrackingMetadata.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/TrackingMetadata.java
@@ -6,10 +6,9 @@ package io.airbyte.scheduler.persistence.job_tracker;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.JobOutput;
 import io.airbyte.config.ResourceRequirements;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncSummary;
 import io.airbyte.config.helpers.ScheduleHelpers;
@@ -62,10 +61,10 @@ public class TrackingMetadata {
     return metadata.build();
   }
 
-  public static ImmutableMap<String, Object> generateDestinationDefinitionMetadata(final StandardDestinationDefinition destinationDefinition) {
+  public static ImmutableMap<String, Object> generateDestinationDefinitionMetadata(final ActorDefinition destinationDefinition) {
     final Builder<String, Object> metadata = ImmutableMap.builder();
     metadata.put("connector_destination", destinationDefinition.getName());
-    metadata.put("connector_destination_definition_id", destinationDefinition.getDestinationDefinitionId());
+    metadata.put("connector_destination_definition_id", destinationDefinition.getId());
     metadata.put("connector_destination_docker_repository", destinationDefinition.getDockerRepository());
     final String imageTag = destinationDefinition.getDockerImageTag();
     if (!Strings.isEmpty(imageTag)) {
@@ -74,10 +73,10 @@ public class TrackingMetadata {
     return metadata.build();
   }
 
-  public static ImmutableMap<String, Object> generateSourceDefinitionMetadata(final StandardSourceDefinition sourceDefinition) {
+  public static ImmutableMap<String, Object> generateSourceDefinitionMetadata(final ActorDefinition sourceDefinition) {
     final Builder<String, Object> metadata = ImmutableMap.builder();
     metadata.put("connector_source", sourceDefinition.getName());
-    metadata.put("connector_source_definition_id", sourceDefinition.getSourceDefinitionId());
+    metadata.put("connector_source_definition_id", sourceDefinition.getId());
     metadata.put("connector_source_docker_repository", sourceDefinition.getDockerRepository());
     final String imageTag = sourceDefinition.getDockerImageTag();
     if (!Strings.isEmpty(imageTag)) {

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/JobNotifierTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/JobNotifierTest.java
@@ -14,13 +14,12 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import io.airbyte.analytics.TrackingClient;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.JobConfig;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.Notification;
 import io.airbyte.config.Notification.NotificationType;
 import io.airbyte.config.SlackNotificationConfiguration;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
@@ -67,16 +66,16 @@ class JobNotifierTest {
   @Test
   void testFailJob() throws IOException, InterruptedException, JsonValidationException, ConfigNotFoundException {
     final Job job = createJob();
-    final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
+    final ActorDefinition sourceDefinition = new ActorDefinition()
         .withName("source-test")
         .withDockerRepository(TEST_DOCKER_REPO)
         .withDockerImageTag(TEST_DOCKER_TAG)
-        .withSourceDefinitionId(UUID.randomUUID());
-    final StandardDestinationDefinition destinationDefinition = new StandardDestinationDefinition()
+        .withId(UUID.randomUUID());
+    final ActorDefinition destinationDefinition = new ActorDefinition()
         .withName("destination-test")
         .withDockerRepository(TEST_DOCKER_REPO)
         .withDockerImageTag(TEST_DOCKER_TAG)
-        .withDestinationDefinitionId(UUID.randomUUID());
+        .withId(UUID.randomUUID());
     when(configRepository.getSourceDefinitionFromConnection(any())).thenReturn(sourceDefinition);
     when(configRepository.getDestinationDefinitionFromConnection(any())).thenReturn(destinationDefinition);
     when(configRepository.getStandardSourceDefinition(any())).thenReturn(sourceDefinition);
@@ -96,11 +95,11 @@ class JobNotifierTest {
 
     final Builder<String, Object> metadata = ImmutableMap.builder();
     metadata.put("connection_id", UUID.fromString(job.getScope()));
-    metadata.put("connector_source_definition_id", sourceDefinition.getSourceDefinitionId());
+    metadata.put("connector_source_definition_id", sourceDefinition.getId());
     metadata.put("connector_source", "source-test");
     metadata.put("connector_source_version", TEST_DOCKER_TAG);
     metadata.put("connector_source_docker_repository", sourceDefinition.getDockerRepository());
-    metadata.put("connector_destination_definition_id", destinationDefinition.getDestinationDefinitionId());
+    metadata.put("connector_destination_definition_id", destinationDefinition.getId());
     metadata.put("connector_destination", "destination-test");
     metadata.put("connector_destination_version", TEST_DOCKER_TAG);
     metadata.put("connector_destination_docker_repository", destinationDefinition.getDockerRepository());

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
@@ -19,6 +19,7 @@ import io.airbyte.analytics.TrackingClient;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.map.MoreMaps;
 import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.JobConfig;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.JobOutput;
@@ -28,8 +29,6 @@ import io.airbyte.config.Schedule;
 import io.airbyte.config.Schedule.TimeUnit;
 import io.airbyte.config.StandardCheckConnectionOutput;
 import io.airbyte.config.StandardCheckConnectionOutput.Status;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.StandardSyncSummary;
@@ -166,8 +165,8 @@ class JobTrackerTest {
         .build();
 
     when(configRepository.getStandardSourceDefinition(UUID1))
-        .thenReturn(new StandardSourceDefinition()
-            .withSourceDefinitionId(UUID1)
+        .thenReturn(new ActorDefinition()
+            .withId(UUID1)
             .withName(SOURCE_DEF_NAME)
             .withDockerRepository(CONNECTOR_REPOSITORY)
             .withDockerImageTag(CONNECTOR_VERSION));
@@ -196,8 +195,8 @@ class JobTrackerTest {
         .build();
 
     when(configRepository.getStandardDestinationDefinition(UUID2))
-        .thenReturn(new StandardDestinationDefinition()
-            .withDestinationDefinitionId(UUID2)
+        .thenReturn(new ActorDefinition()
+            .withId(UUID2)
             .withName(DESTINATION_DEF_NAME)
             .withDockerRepository(CONNECTOR_REPOSITORY)
             .withDockerImageTag(CONNECTOR_VERSION));
@@ -226,8 +225,8 @@ class JobTrackerTest {
         .build();
 
     when(configRepository.getStandardSourceDefinition(UUID1))
-        .thenReturn(new StandardSourceDefinition()
-            .withSourceDefinitionId(UUID1)
+        .thenReturn(new ActorDefinition()
+            .withId(UUID1)
             .withName(SOURCE_DEF_NAME)
             .withDockerRepository(CONNECTOR_REPOSITORY)
             .withDockerImageTag(CONNECTOR_VERSION));
@@ -350,30 +349,30 @@ class JobTrackerTest {
 
   private Job getJobMock(final ConfigType configType, final long jobId) throws ConfigNotFoundException, IOException, JsonValidationException {
     when(configRepository.getSourceDefinitionFromConnection(CONNECTION_ID))
-        .thenReturn(new StandardSourceDefinition()
-            .withSourceDefinitionId(UUID1)
+        .thenReturn(new ActorDefinition()
+            .withId(UUID1)
             .withName(SOURCE_DEF_NAME)
             .withDockerRepository(CONNECTOR_REPOSITORY)
             .withDockerImageTag(CONNECTOR_VERSION)
             .withSpec(SOURCE_SPEC));
     when(configRepository.getDestinationDefinitionFromConnection(CONNECTION_ID))
-        .thenReturn(new StandardDestinationDefinition()
-            .withDestinationDefinitionId(UUID2)
+        .thenReturn(new ActorDefinition()
+            .withId(UUID2)
             .withName(DESTINATION_DEF_NAME)
             .withDockerRepository(CONNECTOR_REPOSITORY)
             .withDockerImageTag(CONNECTOR_VERSION)
             .withSpec(DESTINATION_SPEC));
 
     when(configRepository.getStandardSourceDefinition(UUID1))
-        .thenReturn(new StandardSourceDefinition()
-            .withSourceDefinitionId(UUID1)
+        .thenReturn(new ActorDefinition()
+            .withId(UUID1)
             .withName(SOURCE_DEF_NAME)
             .withDockerRepository(CONNECTOR_REPOSITORY)
             .withDockerImageTag(CONNECTOR_VERSION)
             .withSpec(SOURCE_SPEC));
     when(configRepository.getStandardDestinationDefinition(UUID2))
-        .thenReturn(new StandardDestinationDefinition()
-            .withDestinationDefinitionId(UUID2)
+        .thenReturn(new ActorDefinition()
+            .withId(UUID2)
             .withName(DESTINATION_DEF_NAME)
             .withDockerRepository(CONNECTOR_REPOSITORY)
             .withDockerImageTag(CONNECTOR_VERSION)

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpExporter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpExporter.java
@@ -14,6 +14,7 @@ import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
+import io.airbyte.config.persistence.ActorDefinitionMigrationUtils;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.scheduler.persistence.JobPersistence;
@@ -180,7 +181,9 @@ public class ConfigDumpExporter {
       if (!sourceDefinitionMap.containsKey(sourceConnection.getSourceDefinitionId())) {
         sourceDefinitionMap
             .put(sourceConnection.getSourceDefinitionId(),
-                configRepository.getStandardSourceDefinition(sourceConnection.getSourceDefinitionId()));
+                // todo (cgardens) - remove migration shim.
+                ActorDefinitionMigrationUtils
+                    .mapActorDefToSourceDef(configRepository.getStandardSourceDefinition(sourceConnection.getSourceDefinitionId())));
       }
     }
     return sourceDefinitionMap.values();
@@ -193,7 +196,9 @@ public class ConfigDumpExporter {
       if (!destinationDefinitionMap.containsKey(destinationConnection.getDestinationDefinitionId())) {
         destinationDefinitionMap
             .put(destinationConnection.getDestinationDefinitionId(),
-                configRepository.getStandardDestinationDefinition(destinationConnection.getDestinationDefinitionId()));
+                // todo (cgardens) - remove migration shim.
+                ActorDefinitionMigrationUtils
+                    .mapActorDefToDestDef(configRepository.getStandardDestinationDefinition(destinationConnection.getDestinationDefinitionId())));
       }
     }
     return destinationDefinitionMap.values();

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/ConfigurationUpdate.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/ConfigurationUpdate.java
@@ -6,10 +6,9 @@ package io.airbyte.server.converters;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
@@ -38,7 +37,7 @@ public class ConfigurationUpdate {
     final SourceConnection persistedSource = configRepository.getSourceConnectionWithSecrets(sourceId);
     persistedSource.setName(sourceName);
     // get spec
-    final StandardSourceDefinition sourceDefinition = configRepository.getStandardSourceDefinition(persistedSource.getSourceDefinitionId());
+    final ActorDefinition sourceDefinition = configRepository.getStandardSourceDefinition(persistedSource.getSourceDefinitionId());
     final ConnectorSpecification spec = sourceDefinition.getSpec();
     // copy any necessary secrets from the current source to the incoming updated source
     final JsonNode updatedConfiguration = secretsProcessor.copySecrets(
@@ -55,7 +54,7 @@ public class ConfigurationUpdate {
     final DestinationConnection persistedDestination = configRepository.getDestinationConnectionWithSecrets(destinationId);
     persistedDestination.setName(destName);
     // get spec
-    final StandardDestinationDefinition destinationDefinition = configRepository
+    final ActorDefinition destinationDefinition = configRepository
         .getStandardDestinationDefinition(persistedDestination.getDestinationDefinitionId());
     final ConnectorSpecification spec = destinationDefinition.getSpec();
     // copy any necessary secrets from the current destination to the incoming updated destination

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -23,12 +23,11 @@ import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.features.FeatureFlags;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
 import io.airbyte.config.Schedule;
 import io.airbyte.config.SourceConnection;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.helpers.ScheduleHelpers;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -178,15 +177,15 @@ public class ConnectionsHandler {
     final Builder<String, Object> metadata = ImmutableMap.builder();
 
     final UUID connectionId = standardSync.getConnectionId();
-    final StandardSourceDefinition sourceDefinition = configRepository
+    final ActorDefinition sourceDefinition = configRepository
         .getSourceDefinitionFromConnection(connectionId);
-    final StandardDestinationDefinition destinationDefinition = configRepository
+    final ActorDefinition destinationDefinition = configRepository
         .getDestinationDefinitionFromConnection(connectionId);
 
     metadata.put("connector_source", sourceDefinition.getName());
-    metadata.put("connector_source_definition_id", sourceDefinition.getSourceDefinitionId());
+    metadata.put("connector_source_definition_id", sourceDefinition.getId());
     metadata.put("connector_destination", destinationDefinition.getName());
-    metadata.put("connector_destination_definition_id", destinationDefinition.getDestinationDefinitionId());
+    metadata.put("connector_destination_definition_id", destinationDefinition.getId());
 
     final String frequencyString;
     if (standardSync.getManual()) {
@@ -307,12 +306,12 @@ public class ConnectionsHandler {
       throws JsonValidationException, ConfigNotFoundException, IOException {
 
     final SourceConnection sourceConnection = configRepository.getSourceConnection(connectionRead.getSourceId());
-    final StandardSourceDefinition sourceDefinition =
+    final ActorDefinition sourceDefinition =
         configRepository.getStandardSourceDefinition(sourceConnection.getSourceDefinitionId());
     final SourceRead sourceRead = SourceHandler.toSourceRead(sourceConnection, sourceDefinition);
 
     final DestinationConnection destinationConnection = configRepository.getDestinationConnection(connectionRead.getDestinationId());
-    final StandardDestinationDefinition destinationDefinition =
+    final ActorDefinition destinationDefinition =
         configRepository.getStandardDestinationDefinition(destinationConnection.getDestinationDefinitionId());
     final DestinationRead destinationRead = DestinationHandler.toDestinationRead(destinationConnection, destinationDefinition);
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
@@ -17,8 +17,8 @@ import io.airbyte.api.model.DestinationSearch;
 import io.airbyte.api.model.DestinationUpdate;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.DestinationConnection;
-import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
@@ -244,15 +244,15 @@ public class DestinationHandler {
     final DestinationConnection dci = Jsons.clone(configRepository.getDestinationConnection(destinationId));
     dci.setConfiguration(secretsProcessor.maskSecrets(dci.getConfiguration(), spec.getConnectionSpecification()));
 
-    final StandardDestinationDefinition standardDestinationDefinition =
+    final ActorDefinition standardDestinationDefinition =
         configRepository.getStandardDestinationDefinition(dci.getDestinationDefinitionId());
     return toDestinationRead(dci, standardDestinationDefinition);
   }
 
   protected static DestinationRead toDestinationRead(final DestinationConnection destinationConnection,
-                                                     final StandardDestinationDefinition standardDestinationDefinition) {
+                                                     final ActorDefinition standardDestinationDefinition) {
     return new DestinationRead()
-        .destinationDefinitionId(standardDestinationDefinition.getDestinationDefinitionId())
+        .destinationDefinitionId(standardDestinationDefinition.getId())
         .destinationId(destinationConnection.getDestinationId())
         .workspaceId(destinationConnection.getWorkspaceId())
         .destinationDefinitionId(destinationConnection.getDestinationDefinitionId())

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/OAuthHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/OAuthHandler.java
@@ -14,10 +14,9 @@ import io.airbyte.api.model.SetInstancewideDestinationOauthParamsRequestBody;
 import io.airbyte.api.model.SetInstancewideSourceOauthParamsRequestBody;
 import io.airbyte.api.model.SourceOauthConsentRequest;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.DestinationOAuthParameter;
 import io.airbyte.config.SourceOAuthParameter;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.oauth.OAuthFlowImplementation;
@@ -51,7 +50,7 @@ public class OAuthHandler {
 
   public OAuthConsentRead getSourceOAuthConsent(final SourceOauthConsentRequest sourceDefinitionIdRequestBody)
       throws JsonValidationException, ConfigNotFoundException, IOException {
-    final StandardSourceDefinition sourceDefinition =
+    final ActorDefinition sourceDefinition =
         configRepository.getStandardSourceDefinition(sourceDefinitionIdRequestBody.getSourceDefinitionId());
     final OAuthFlowImplementation oAuthFlowImplementation = oAuthImplementationFactory.create(sourceDefinition);
     final ConnectorSpecification spec = sourceDefinition.getSpec();
@@ -80,8 +79,8 @@ public class OAuthHandler {
 
   public OAuthConsentRead getDestinationOAuthConsent(final DestinationOauthConsentRequest destinationDefinitionIdRequestBody)
       throws JsonValidationException, ConfigNotFoundException, IOException {
-    final StandardDestinationDefinition destinationDefinition =
-        configRepository.getStandardDestinationDefinition(destinationDefinitionIdRequestBody.getDestinationDefinitionId());
+    final ActorDefinition destinationDefinition = configRepository
+        .getStandardDestinationDefinition(destinationDefinitionIdRequestBody.getDestinationDefinitionId());
     final OAuthFlowImplementation oAuthFlowImplementation = oAuthImplementationFactory.create(destinationDefinition);
     final ConnectorSpecification spec = destinationDefinition.getSpec();
     final ImmutableMap<String, Object> metadata = generateDestinationMetadata(destinationDefinitionIdRequestBody.getDestinationDefinitionId());
@@ -109,8 +108,8 @@ public class OAuthHandler {
 
   public Map<String, Object> completeSourceOAuth(final CompleteSourceOauthRequest oauthSourceRequestBody)
       throws JsonValidationException, ConfigNotFoundException, IOException {
-    final StandardSourceDefinition sourceDefinition =
-        configRepository.getStandardSourceDefinition(oauthSourceRequestBody.getSourceDefinitionId());
+    final ActorDefinition sourceDefinition = configRepository
+        .getStandardSourceDefinition(oauthSourceRequestBody.getSourceDefinitionId());
     final OAuthFlowImplementation oAuthFlowImplementation = oAuthImplementationFactory.create(sourceDefinition);
     final ConnectorSpecification spec = sourceDefinition.getSpec();
     final ImmutableMap<String, Object> metadata = generateSourceMetadata(oauthSourceRequestBody.getSourceDefinitionId());
@@ -141,8 +140,8 @@ public class OAuthHandler {
 
   public Map<String, Object> completeDestinationOAuth(final CompleteDestinationOAuthRequest oauthDestinationRequestBody)
       throws JsonValidationException, ConfigNotFoundException, IOException {
-    final StandardDestinationDefinition destinationDefinition =
-        configRepository.getStandardDestinationDefinition(oauthDestinationRequestBody.getDestinationDefinitionId());
+    final ActorDefinition destinationDefinition = configRepository
+        .getStandardDestinationDefinition(oauthDestinationRequestBody.getDestinationDefinitionId());
     final OAuthFlowImplementation oAuthFlowImplementation = oAuthImplementationFactory.create(destinationDefinition);
     final ConnectorSpecification spec = destinationDefinition.getSpec();
     final ImmutableMap<String, Object> metadata = generateDestinationMetadata(oauthDestinationRequestBody.getDestinationDefinitionId());
@@ -197,13 +196,13 @@ public class OAuthHandler {
 
   private ImmutableMap<String, Object> generateSourceMetadata(final UUID sourceDefinitionId)
       throws JsonValidationException, ConfigNotFoundException, IOException {
-    final StandardSourceDefinition sourceDefinition = configRepository.getStandardSourceDefinition(sourceDefinitionId);
+    final ActorDefinition sourceDefinition = configRepository.getStandardSourceDefinition(sourceDefinitionId);
     return TrackingMetadata.generateSourceDefinitionMetadata(sourceDefinition);
   }
 
   private ImmutableMap<String, Object> generateDestinationMetadata(final UUID destinationDefinitionId)
       throws JsonValidationException, ConfigNotFoundException, IOException {
-    final StandardDestinationDefinition destinationDefinition = configRepository.getStandardDestinationDefinition(destinationDefinitionId);
+    final ActorDefinition destinationDefinition = configRepository.getStandardDestinationDefinition(destinationDefinitionId);
     return TrackingMetadata.generateDestinationDefinitionMetadata(destinationDefinition);
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -16,8 +16,8 @@ import io.airbyte.api.model.SourceSearch;
 import io.airbyte.api.model.SourceUpdate;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.lang.MoreBooleans;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.SourceConnection;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
@@ -203,7 +203,7 @@ public class SourceHandler {
   private SourceRead buildSourceRead(final UUID sourceId)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     // read configuration from db
-    final StandardSourceDefinition sourceDef = configRepository.getSourceDefinitionFromSource(sourceId);
+    final ActorDefinition sourceDef = configRepository.getSourceDefinitionFromSource(sourceId);
     final ConnectorSpecification spec = sourceDef.getSpec();
     return buildSourceRead(sourceId, spec);
   }
@@ -212,7 +212,7 @@ public class SourceHandler {
       throws ConfigNotFoundException, IOException, JsonValidationException {
     // read configuration from db
     final SourceConnection sourceConnection = configRepository.getSourceConnection(sourceId);
-    final StandardSourceDefinition standardSourceDefinition = configRepository
+    final ActorDefinition standardSourceDefinition = configRepository
         .getStandardSourceDefinition(sourceConnection.getSourceDefinitionId());
     final JsonNode sanitizedConfig = secretsProcessor.maskSecrets(
         sourceConnection.getConfiguration(), spec.getConnectionSpecification());
@@ -233,7 +233,7 @@ public class SourceHandler {
 
   private ConnectorSpecification getSpecFromSourceDefinitionId(final UUID sourceDefId)
       throws IOException, JsonValidationException, ConfigNotFoundException {
-    final StandardSourceDefinition sourceDef = configRepository.getStandardSourceDefinition(sourceDefId);
+    final ActorDefinition sourceDef = configRepository.getStandardSourceDefinition(sourceDefId);
     return sourceDef.getSpec();
   }
 
@@ -257,9 +257,9 @@ public class SourceHandler {
   }
 
   protected static SourceRead toSourceRead(final SourceConnection sourceConnection,
-                                           final StandardSourceDefinition standardSourceDefinition) {
+                                           final ActorDefinition standardSourceDefinition) {
     return new SourceRead()
-        .sourceDefinitionId(standardSourceDefinition.getSourceDefinitionId())
+        .sourceDefinitionId(standardSourceDefinition.getId())
         .sourceName(standardSourceDefinition.getName())
         .sourceId(sourceConnection.getSourceId())
         .workspaceId(sourceConnection.getWorkspaceId())

--- a/airbyte-server/src/test/java/io/airbyte/server/ConfigDumpImporterTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/ConfigDumpImporterTest.java
@@ -15,10 +15,10 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.version.AirbyteVersion;
+import io.airbyte.config.ActorDefinition;
+import io.airbyte.config.ActorDefinition.ActorType;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSync.Status;
 import io.airbyte.config.StandardSyncOperation;
@@ -71,8 +71,9 @@ class ConfigDumpImporterTest {
     workspaceId = UUID.randomUUID();
     when(jobPersistence.getVersion()).thenReturn(Optional.of(TEST_VERSION.serialize()));
 
-    final StandardSourceDefinition standardSourceDefinition = new StandardSourceDefinition()
-        .withSourceDefinitionId(UUID.randomUUID())
+    final ActorDefinition standardSourceDefinition = new ActorDefinition()
+        .withActorType(ActorType.SOURCE)
+        .withId(UUID.randomUUID())
         .withName("test-standard-source")
         .withDockerRepository("test")
         .withDocumentationUrl("http://doc")
@@ -81,20 +82,21 @@ class ConfigDumpImporterTest {
         .withSpec(emptyConnectorSpec);
     sourceConnection = new SourceConnection()
         .withSourceId(UUID.randomUUID())
-        .withSourceDefinitionId(standardSourceDefinition.getSourceDefinitionId())
+        .withSourceDefinitionId(standardSourceDefinition.getId())
         .withConfiguration(Jsons.emptyObject())
         .withName("test-source")
         .withTombstone(false)
         .withWorkspaceId(workspaceId);
     when(configRepository.listStandardSourceDefinitions(false))
         .thenReturn(List.of(standardSourceDefinition));
-    when(configRepository.getStandardSourceDefinition(standardSourceDefinition.getSourceDefinitionId()))
+    when(configRepository.getStandardSourceDefinition(standardSourceDefinition.getId()))
         .thenReturn(standardSourceDefinition);
     when(configRepository.getSourceConnection(any()))
         .thenReturn(sourceConnection);
 
-    final StandardDestinationDefinition standardDestinationDefinition = new StandardDestinationDefinition()
-        .withDestinationDefinitionId(UUID.randomUUID())
+    final ActorDefinition standardDestinationDefinition = new ActorDefinition()
+        .withActorType(ActorType.DESTINATION)
+        .withId(UUID.randomUUID())
         .withName("test-standard-destination")
         .withDockerRepository("test")
         .withDocumentationUrl("http://doc")
@@ -103,14 +105,14 @@ class ConfigDumpImporterTest {
         .withSpec(emptyConnectorSpec);
     destinationConnection = new DestinationConnection()
         .withDestinationId(UUID.randomUUID())
-        .withDestinationDefinitionId(standardDestinationDefinition.getDestinationDefinitionId())
+        .withDestinationDefinitionId(standardDestinationDefinition.getId())
         .withConfiguration(Jsons.emptyObject())
         .withName("test-source")
         .withTombstone(false)
         .withWorkspaceId(workspaceId);
     when(configRepository.listStandardDestinationDefinitions(false))
         .thenReturn(List.of(standardDestinationDefinition));
-    when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getDestinationDefinitionId()))
+    when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getId()))
         .thenReturn(standardDestinationDefinition);
     when(configRepository.getDestinationConnection(any()))
         .thenReturn(destinationConnection);

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/ConfigurationUpdateTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/ConfigurationUpdateTest.java
@@ -11,10 +11,9 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
@@ -47,7 +46,7 @@ class ConfigurationUpdateTest {
       .put("username", "airbyte")
       .put("password", "xyz")
       .build());
-  private static final StandardSourceDefinition SOURCE_DEFINITION = new StandardSourceDefinition()
+  private static final ActorDefinition SOURCE_DEFINITION = new ActorDefinition()
       .withDockerRepository(IMAGE_REPOSITORY)
       .withDockerImageTag(IMAGE_TAG)
       .withSpec(CONNECTOR_SPECIFICATION);
@@ -59,7 +58,7 @@ class ConfigurationUpdateTest {
       .withSourceId(UUID1)
       .withSourceDefinitionId(UUID2)
       .withConfiguration(NEW_CONFIGURATION);
-  private static final StandardDestinationDefinition DESTINATION_DEFINITION = new StandardDestinationDefinition()
+  private static final ActorDefinition DESTINATION_DEFINITION = new ActorDefinition()
       .withDockerRepository(IMAGE_REPOSITORY)
       .withDockerImageTag(IMAGE_TAG)
       .withSpec(CONNECTOR_SPECIFICATION);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -28,7 +28,6 @@ import io.airbyte.config.Notification;
 import io.airbyte.config.Notification.NotificationType;
 import io.airbyte.config.SlackNotificationConfiguration;
 import io.airbyte.config.SourceConnection;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.init.YamlSeedConfigPersistence;
 import io.airbyte.config.persistence.ActorDefinitionMigrationUtils;
@@ -275,8 +274,8 @@ public class ArchiveHandlerTest {
         .map(SourceConnection::getSourceId)
         .collect(Collectors.toList()).get(0);
 
-    final StandardSourceDefinition standardSourceDefinition = new StandardSourceDefinition()
-        .withSourceDefinitionId(UUID.randomUUID())
+    final ActorDefinition standardSourceDefinition = new ActorDefinition()
+        .withId(UUID.randomUUID())
         .withSourceType(SourceType.API)
         .withName("random-source-1")
         .withDockerImageTag("tag-1")
@@ -290,7 +289,7 @@ public class ArchiveHandlerTest {
         .withWorkspaceId(secondWorkspaceId)
         .withSourceId(secondSourceId)
         .withName("Some new names")
-        .withSourceDefinitionId(standardSourceDefinition.getSourceDefinitionId())
+        .withSourceDefinitionId(standardSourceDefinition.getId())
         .withTombstone(false)
         .withConfiguration(Jsons.emptyObject());
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -32,6 +32,7 @@ import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.features.FeatureFlags;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.DataType;
 import io.airbyte.config.DestinationConnection;
@@ -39,8 +40,6 @@ import io.airbyte.config.EnvConfigs;
 import io.airbyte.config.JobSyncConfig;
 import io.airbyte.config.Schedule;
 import io.airbyte.config.SourceConnection;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.helpers.LogConfigs;
@@ -179,12 +178,12 @@ class ConnectionsHandlerTest {
     @Test
     void testCreateConnection() throws JsonValidationException, ConfigNotFoundException, IOException {
       when(uuidGenerator.get()).thenReturn(standardSync.getConnectionId());
-      final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
+      final ActorDefinition sourceDefinition = new ActorDefinition()
           .withName("source-test")
-          .withSourceDefinitionId(UUID.randomUUID());
-      final StandardDestinationDefinition destinationDefinition = new StandardDestinationDefinition()
+          .withId(UUID.randomUUID());
+      final ActorDefinition destinationDefinition = new ActorDefinition()
           .withName("destination-test")
-          .withDestinationDefinitionId(UUID.randomUUID());
+          .withId(UUID.randomUUID());
       when(configRepository.getStandardSync(standardSync.getConnectionId())).thenReturn(standardSync);
       when(configRepository.getSourceDefinitionFromConnection(standardSync.getConnectionId())).thenReturn(sourceDefinition);
       when(configRepository.getDestinationDefinitionFromConnection(standardSync.getConnectionId())).thenReturn(destinationDefinition);
@@ -246,12 +245,12 @@ class ConnectionsHandlerTest {
       final UUID sourceIdBad = UUID.randomUUID();
       final UUID destinationIdBad = UUID.randomUUID();
 
-      final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
+      final ActorDefinition sourceDefinition = new ActorDefinition()
           .withName("source-test")
-          .withSourceDefinitionId(UUID.randomUUID());
-      final StandardDestinationDefinition destinationDefinition = new StandardDestinationDefinition()
+          .withId(UUID.randomUUID());
+      final ActorDefinition destinationDefinition = new ActorDefinition()
           .withName("destination-test")
-          .withDestinationDefinitionId(UUID.randomUUID());
+          .withId(UUID.randomUUID());
       when(configRepository.getStandardSync(standardSync.getConnectionId())).thenReturn(standardSync);
       when(configRepository.getSourceDefinitionFromConnection(standardSync.getConnectionId())).thenReturn(sourceDefinition);
       when(configRepository.getDestinationDefinitionFromConnection(standardSync.getConnectionId())).thenReturn(destinationDefinition);
@@ -431,12 +430,12 @@ class ConnectionsHandlerTest {
           .withManual(true)
           .withResourceRequirements(ConnectionHelpers.TESTING_RESOURCE_REQUIREMENTS);
       final ConnectionRead connectionRead2 = ConnectionHelpers.connectionReadFromStandardSync(standardSync2);
-      final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
+      final ActorDefinition sourceDefinition = new ActorDefinition()
           .withName("source-test")
-          .withSourceDefinitionId(UUID.randomUUID());
-      final StandardDestinationDefinition destinationDefinition = new StandardDestinationDefinition()
+          .withId(UUID.randomUUID());
+      final ActorDefinition destinationDefinition = new ActorDefinition()
           .withName("destination-test")
-          .withDestinationDefinitionId(UUID.randomUUID());
+          .withId(UUID.randomUUID());
 
       when(configRepository.listStandardSyncs())
           .thenReturn(Lists.newArrayList(standardSync, standardSync2));
@@ -581,12 +580,12 @@ class ConnectionsHandlerTest {
       when(workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(standardSync.getDestinationId())).thenReturn(UUID.randomUUID());
 
       when(uuidGenerator.get()).thenReturn(standardSync.getConnectionId());
-      final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
+      final ActorDefinition sourceDefinition = new ActorDefinition()
           .withName("source-test")
-          .withSourceDefinitionId(UUID.randomUUID());
-      final StandardDestinationDefinition destinationDefinition = new StandardDestinationDefinition()
+          .withId(UUID.randomUUID());
+      final ActorDefinition destinationDefinition = new ActorDefinition()
           .withName("destination-test")
-          .withDestinationDefinitionId(UUID.randomUUID());
+          .withId(UUID.randomUUID());
       when(configRepository.getStandardSync(standardSync.getConnectionId())).thenReturn(standardSync);
       when(configRepository.getSourceDefinitionFromConnection(standardSync.getConnectionId())).thenReturn(sourceDefinition);
       when(configRepository.getDestinationDefinitionFromConnection(standardSync.getConnectionId())).thenReturn(destinationDefinition);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
@@ -23,8 +23,8 @@ import io.airbyte.api.model.DestinationUpdate;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.DestinationConnection;
-import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 class DestinationHandlerTest {
 
   private ConfigRepository configRepository;
-  private StandardDestinationDefinition standardDestinationDefinition;
+  private ActorDefinition standardDestinationDefinition;
   private DestinationDefinitionSpecificationRead destinationDefinitionSpecificationRead;
   private DestinationConnection destinationConnection;
   private DestinationHandler destinationHandler;
@@ -67,8 +67,8 @@ class DestinationHandlerTest {
 
     connectorSpecification = ConnectorSpecificationHelpers.generateConnectorSpecification();
 
-    standardDestinationDefinition = new StandardDestinationDefinition()
-        .withDestinationDefinitionId(UUID.randomUUID())
+    standardDestinationDefinition = new ActorDefinition()
+        .withId(UUID.randomUUID())
         .withName("db2")
         .withDockerRepository("thebestrepo")
         .withDockerImageTag("thelatesttag")
@@ -79,16 +79,16 @@ class DestinationHandlerTest {
         DockerUtils.getTaggedImageName(standardDestinationDefinition.getDockerRepository(), standardDestinationDefinition.getDockerImageTag());
 
     final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody = new DestinationDefinitionIdRequestBody().destinationDefinitionId(
-        standardDestinationDefinition.getDestinationDefinitionId());
+        standardDestinationDefinition.getId());
 
     destinationDefinitionSpecificationRead = new DestinationDefinitionSpecificationRead()
         .connectionSpecification(connectorSpecification.getConnectionSpecification())
-        .destinationDefinitionId(standardDestinationDefinition.getDestinationDefinitionId())
+        .destinationDefinitionId(standardDestinationDefinition.getId())
         .documentationUrl(connectorSpecification.getDocumentationUrl().toString())
         .supportsDbt(connectorSpecification.getSupportsDBT())
         .supportsNormalization(connectorSpecification.getSupportsNormalization());
 
-    destinationConnection = DestinationHelpers.generateDestination(standardDestinationDefinition.getDestinationDefinitionId());
+    destinationConnection = DestinationHelpers.generateDestination(standardDestinationDefinition.getId());
 
     destinationHandler =
         new DestinationHandler(configRepository, validator, connectionsHandler, uuidGenerator, secretsProcessor, configurationUpdate);
@@ -100,7 +100,7 @@ class DestinationHandlerTest {
         .thenReturn(destinationConnection.getDestinationId());
     when(configRepository.getDestinationConnection(destinationConnection.getDestinationId()))
         .thenReturn(destinationConnection);
-    when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getDestinationDefinitionId()))
+    when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getId()))
         .thenReturn(standardDestinationDefinition);
     when(secretsProcessor.maskSecrets(destinationConnection.getConfiguration(), destinationDefinitionSpecificationRead.getConnectionSpecification()))
         .thenReturn(destinationConnection.getConfiguration());
@@ -108,7 +108,7 @@ class DestinationHandlerTest {
     final DestinationCreate destinationCreate = new DestinationCreate()
         .name(destinationConnection.getName())
         .workspaceId(destinationConnection.getWorkspaceId())
-        .destinationDefinitionId(standardDestinationDefinition.getDestinationDefinitionId())
+        .destinationDefinitionId(standardDestinationDefinition.getId())
         .connectionConfiguration(DestinationHelpers.getTestDestinationJson());
 
     final DestinationRead actualDestinationRead =
@@ -116,7 +116,7 @@ class DestinationHandlerTest {
 
     final DestinationRead expectedDestinationRead = new DestinationRead()
         .name(destinationConnection.getName())
-        .destinationDefinitionId(standardDestinationDefinition.getDestinationDefinitionId())
+        .destinationDefinitionId(standardDestinationDefinition.getId())
         .workspaceId(destinationConnection.getWorkspaceId())
         .destinationId(destinationConnection.getDestinationId())
         .connectionConfiguration(DestinationHelpers.getTestDestinationJson())
@@ -151,7 +151,7 @@ class DestinationHandlerTest {
             .thenReturn(newConfiguration);
     when(secretsProcessor.maskSecrets(newConfiguration, destinationDefinitionSpecificationRead.getConnectionSpecification()))
         .thenReturn(newConfiguration);
-    when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getDestinationDefinitionId()))
+    when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getId()))
         .thenReturn(standardDestinationDefinition);
     when(configRepository.getDestinationDefinitionFromDestination(destinationConnection.getDestinationId()))
         .thenReturn(standardDestinationDefinition);
@@ -176,7 +176,7 @@ class DestinationHandlerTest {
   void testGetDestination() throws JsonValidationException, ConfigNotFoundException, IOException {
     final DestinationRead expectedDestinationRead = new DestinationRead()
         .name(destinationConnection.getName())
-        .destinationDefinitionId(standardDestinationDefinition.getDestinationDefinitionId())
+        .destinationDefinitionId(standardDestinationDefinition.getId())
         .workspaceId(destinationConnection.getWorkspaceId())
         .destinationId(destinationConnection.getDestinationId())
         .connectionConfiguration(destinationConnection.getConfiguration())
@@ -187,7 +187,7 @@ class DestinationHandlerTest {
     when(secretsProcessor.maskSecrets(destinationConnection.getConfiguration(), destinationDefinitionSpecificationRead.getConnectionSpecification()))
         .thenReturn(destinationConnection.getConfiguration());
     when(configRepository.getDestinationConnection(destinationConnection.getDestinationId())).thenReturn(destinationConnection);
-    when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getDestinationDefinitionId()))
+    when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getId()))
         .thenReturn(standardDestinationDefinition);
 
     final DestinationRead actualDestinationRead = destinationHandler.getDestination(destinationIdRequestBody);
@@ -201,7 +201,7 @@ class DestinationHandlerTest {
   void testListDestinationForWorkspace() throws JsonValidationException, ConfigNotFoundException, IOException {
     final DestinationRead expectedDestinationRead = new DestinationRead()
         .name(destinationConnection.getName())
-        .destinationDefinitionId(standardDestinationDefinition.getDestinationDefinitionId())
+        .destinationDefinitionId(standardDestinationDefinition.getId())
         .workspaceId(destinationConnection.getWorkspaceId())
         .destinationId(destinationConnection.getDestinationId())
         .connectionConfiguration(destinationConnection.getConfiguration())
@@ -210,7 +210,7 @@ class DestinationHandlerTest {
 
     when(configRepository.getDestinationConnection(destinationConnection.getDestinationId())).thenReturn(destinationConnection);
     when(configRepository.listDestinationConnection()).thenReturn(Lists.newArrayList(destinationConnection));
-    when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getDestinationDefinitionId()))
+    when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getId()))
         .thenReturn(standardDestinationDefinition);
     when(secretsProcessor.maskSecrets(destinationConnection.getConfiguration(), destinationDefinitionSpecificationRead.getConnectionSpecification()))
         .thenReturn(destinationConnection.getConfiguration());
@@ -226,7 +226,7 @@ class DestinationHandlerTest {
   void testSearchDestinations() throws JsonValidationException, ConfigNotFoundException, IOException {
     final DestinationRead expectedDestinationRead = new DestinationRead()
         .name(destinationConnection.getName())
-        .destinationDefinitionId(standardDestinationDefinition.getDestinationDefinitionId())
+        .destinationDefinitionId(standardDestinationDefinition.getId())
         .workspaceId(destinationConnection.getWorkspaceId())
         .destinationId(destinationConnection.getDestinationId())
         .connectionConfiguration(destinationConnection.getConfiguration())
@@ -234,7 +234,7 @@ class DestinationHandlerTest {
 
     when(configRepository.getDestinationConnection(destinationConnection.getDestinationId())).thenReturn(destinationConnection);
     when(configRepository.listDestinationConnection()).thenReturn(Lists.newArrayList(destinationConnection));
-    when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getDestinationDefinitionId()))
+    when(configRepository.getStandardDestinationDefinition(standardDestinationDefinition.getId()))
         .thenReturn(standardDestinationDefinition);
     when(secretsProcessor.maskSecrets(destinationConnection.getConfiguration(), destinationDefinitionSpecificationRead.getConnectionSpecification()))
         .thenReturn(destinationConnection.getConfiguration());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/JobHistoryHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/JobHistoryHandlerTest.java
@@ -64,8 +64,8 @@ public class JobHistoryHandlerTest {
   private DestinationHandler destinationHandler;
   private SourceDefinitionsHandler sourceDefinitionsHandler;
   private DestinationDefinitionsHandler destinationDefinitionsHandler;
-  private StandardDestinationDefinition standardDestinationDefinition;
-  private StandardSourceDefinition standardSourceDefinition;
+  private ActorDefinition standardDestinationDefinition;
+  private ActorDefinition standardSourceDefinition;
   private AirbyteVersion airbyteVersion;
   private Job testJob;
   private Attempt testJobAttempt;

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
@@ -37,6 +37,7 @@ import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.Exceptions;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.JobConfig;
@@ -45,8 +46,6 @@ import io.airbyte.config.OperatorNormalization;
 import io.airbyte.config.OperatorNormalization.Option;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardCheckConnectionOutput;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncOperation.OperatorType;
@@ -168,10 +167,10 @@ class SchedulerHandlerTest {
     final SourceIdRequestBody request = new SourceIdRequestBody().sourceId(source.getSourceId());
 
     when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId()))
-        .thenReturn(new StandardSourceDefinition()
+        .thenReturn(new ActorDefinition()
             .withDockerRepository(SOURCE_DOCKER_REPO)
             .withDockerImageTag(SOURCE_DOCKER_TAG)
-            .withSourceDefinitionId(source.getSourceDefinitionId()));
+            .withId(source.getSourceDefinitionId()));
     when(configRepository.getSourceConnection(source.getSourceId())).thenReturn(source);
     when(synchronousSchedulerClient.createSourceCheckConnectionJob(source, SOURCE_DOCKER_IMAGE))
         .thenReturn((SynchronousResponse<StandardCheckConnectionOutput>) jobResponse);
@@ -193,10 +192,10 @@ class SchedulerHandlerTest {
         .connectionConfiguration(source.getConfiguration());
 
     when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId()))
-        .thenReturn(new StandardSourceDefinition()
+        .thenReturn(new ActorDefinition()
             .withDockerRepository(SOURCE_DOCKER_REPO)
             .withDockerImageTag(SOURCE_DOCKER_TAG)
-            .withSourceDefinitionId(source.getSourceDefinitionId()));
+            .withId(source.getSourceDefinitionId()));
     when(configRepository.statefulSplitEphemeralSecrets(
         eq(source.getConfiguration()),
         any())).thenReturn(source.getConfiguration());
@@ -215,10 +214,10 @@ class SchedulerHandlerTest {
         .name(source.getName())
         .sourceId(source.getSourceId())
         .connectionConfiguration(source.getConfiguration());
-    final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
+    final ActorDefinition sourceDefinition = new ActorDefinition()
         .withDockerRepository(DESTINATION_DOCKER_REPO)
         .withDockerImageTag(DESTINATION_DOCKER_TAG)
-        .withSourceDefinitionId(source.getSourceDefinitionId())
+        .withId(source.getSourceDefinitionId())
         .withSpec(CONNECTOR_SPECIFICATION);
     when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId()))
         .thenReturn(sourceDefinition);
@@ -243,11 +242,11 @@ class SchedulerHandlerTest {
     final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody = new SourceDefinitionIdRequestBody().sourceDefinitionId(UUID.randomUUID());
 
     final SynchronousResponse<ConnectorSpecification> specResponse = (SynchronousResponse<ConnectorSpecification>) jobResponse;
-    final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
+    final ActorDefinition sourceDefinition = new ActorDefinition()
         .withName("name")
         .withDockerRepository(SOURCE_DOCKER_REPO)
         .withDockerImageTag(SOURCE_DOCKER_TAG)
-        .withSourceDefinitionId(sourceDefinitionIdRequestBody.getSourceDefinitionId())
+        .withId(sourceDefinitionIdRequestBody.getSourceDefinitionId())
         .withSpec(CONNECTOR_SPECIFICATION);
     when(configRepository.getStandardSourceDefinition(sourceDefinitionIdRequestBody.getSourceDefinitionId()))
         .thenReturn(sourceDefinition);
@@ -263,11 +262,11 @@ class SchedulerHandlerTest {
     final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody =
         new DestinationDefinitionIdRequestBody().destinationDefinitionId(UUID.randomUUID());
 
-    final StandardDestinationDefinition destinationDefinition = new StandardDestinationDefinition()
+    final ActorDefinition destinationDefinition = new ActorDefinition()
         .withName("name")
         .withDockerRepository(DESTINATION_DOCKER_REPO)
         .withDockerImageTag(DESTINATION_DOCKER_TAG)
-        .withDestinationDefinitionId(destinationDefinitionIdRequestBody.getDestinationDefinitionId())
+        .withId(destinationDefinitionIdRequestBody.getDestinationDefinitionId())
         .withSpec(CONNECTOR_SPECIFICATION);
     when(configRepository.getStandardDestinationDefinition(destinationDefinitionIdRequestBody.getDestinationDefinitionId()))
         .thenReturn(destinationDefinition);
@@ -284,10 +283,10 @@ class SchedulerHandlerTest {
     final DestinationIdRequestBody request = new DestinationIdRequestBody().destinationId(destination.getDestinationId());
 
     when(configRepository.getStandardDestinationDefinition(destination.getDestinationDefinitionId()))
-        .thenReturn(new StandardDestinationDefinition()
+        .thenReturn(new ActorDefinition()
             .withDockerRepository(DESTINATION_DOCKER_REPO)
             .withDockerImageTag(DESTINATION_DOCKER_TAG)
-            .withDestinationDefinitionId(destination.getDestinationDefinitionId()));
+            .withId(destination.getDestinationDefinitionId()));
     when(configRepository.getDestinationConnection(destination.getDestinationId())).thenReturn(destination);
     when(synchronousSchedulerClient.createDestinationCheckConnectionJob(destination, DESTINATION_DOCKER_IMAGE))
         .thenReturn((SynchronousResponse<StandardCheckConnectionOutput>) jobResponse);
@@ -309,10 +308,10 @@ class SchedulerHandlerTest {
         .connectionConfiguration(destination.getConfiguration());
 
     when(configRepository.getStandardDestinationDefinition(destination.getDestinationDefinitionId()))
-        .thenReturn(new StandardDestinationDefinition()
+        .thenReturn(new ActorDefinition()
             .withDockerRepository(DESTINATION_DOCKER_REPO)
             .withDockerImageTag(DESTINATION_DOCKER_TAG)
-            .withDestinationDefinitionId(destination.getDestinationDefinitionId()));
+            .withId(destination.getDestinationDefinitionId()));
 
     when(synchronousSchedulerClient.createDestinationCheckConnectionJob(destination, DESTINATION_DOCKER_IMAGE))
         .thenReturn((SynchronousResponse<StandardCheckConnectionOutput>) jobResponse);
@@ -331,10 +330,10 @@ class SchedulerHandlerTest {
         .name(destination.getName())
         .destinationId(destination.getDestinationId())
         .connectionConfiguration(destination.getConfiguration());
-    final StandardDestinationDefinition destinationDefinition = new StandardDestinationDefinition()
+    final ActorDefinition destinationDefinition = new ActorDefinition()
         .withDockerRepository(DESTINATION_DOCKER_REPO)
         .withDockerImageTag(DESTINATION_DOCKER_TAG)
-        .withDestinationDefinitionId(destination.getDestinationDefinitionId())
+        .withId(destination.getDestinationDefinitionId())
         .withSpec(CONNECTOR_SPECIFICATION);
     when(configRepository.getStandardDestinationDefinition(destination.getDestinationDefinitionId()))
         .thenReturn(destinationDefinition);
@@ -368,10 +367,10 @@ class SchedulerHandlerTest {
     when(metadata.isSucceeded()).thenReturn(true);
 
     when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId()))
-        .thenReturn(new StandardSourceDefinition()
+        .thenReturn(new ActorDefinition()
             .withDockerRepository(SOURCE_DOCKER_REPO)
             .withDockerImageTag(SOURCE_DOCKER_TAG)
-            .withSourceDefinitionId(source.getSourceDefinitionId()));
+            .withId(source.getSourceDefinitionId()));
     when(configRepository.getSourceConnection(source.getSourceId())).thenReturn(source);
     when(synchronousSchedulerClient.createDiscoverSchemaJob(source, SOURCE_DOCKER_IMAGE))
         .thenReturn(discoverResponse);
@@ -391,10 +390,10 @@ class SchedulerHandlerTest {
     final SourceIdRequestBody request = new SourceIdRequestBody().sourceId(source.getSourceId());
 
     when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId()))
-        .thenReturn(new StandardSourceDefinition()
+        .thenReturn(new ActorDefinition()
             .withDockerRepository(SOURCE_DOCKER_REPO)
             .withDockerImageTag(SOURCE_DOCKER_TAG)
-            .withSourceDefinitionId(source.getSourceDefinitionId()));
+            .withId(source.getSourceDefinitionId()));
     when(configRepository.getSourceConnection(source.getSourceId())).thenReturn(source);
     when(synchronousSchedulerClient.createDiscoverSchemaJob(source, SOURCE_DOCKER_IMAGE))
         .thenReturn((SynchronousResponse<AirbyteCatalog>) jobResponse);
@@ -428,10 +427,10 @@ class SchedulerHandlerTest {
         .connectionConfiguration(source.getConfiguration());
 
     when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId()))
-        .thenReturn(new StandardSourceDefinition()
+        .thenReturn(new ActorDefinition()
             .withDockerRepository(SOURCE_DOCKER_REPO)
             .withDockerImageTag(SOURCE_DOCKER_TAG)
-            .withSourceDefinitionId(source.getSourceDefinitionId()));
+            .withId(source.getSourceDefinitionId()));
     when(synchronousSchedulerClient.createDiscoverSchemaJob(source, SOURCE_DOCKER_IMAGE))
         .thenReturn(discoverResponse);
     when(configRepository.statefulSplitEphemeralSecrets(
@@ -457,10 +456,10 @@ class SchedulerHandlerTest {
         .connectionConfiguration(source.getConfiguration());
 
     when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId()))
-        .thenReturn(new StandardSourceDefinition()
+        .thenReturn(new ActorDefinition()
             .withDockerRepository(SOURCE_DOCKER_REPO)
             .withDockerImageTag(SOURCE_DOCKER_TAG)
-            .withSourceDefinitionId(source.getSourceDefinitionId()));
+            .withId(source.getSourceDefinitionId()));
     when(synchronousSchedulerClient.createDiscoverSchemaJob(source, SOURCE_DOCKER_IMAGE))
         .thenReturn((SynchronousResponse<AirbyteCatalog>) jobResponse);
     when(configRepository.statefulSplitEphemeralSecrets(
@@ -488,15 +487,15 @@ class SchedulerHandlerTest {
     final List<StandardSyncOperation> operations = getOperations(standardSync);
 
     when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId()))
-        .thenReturn(new StandardSourceDefinition()
+        .thenReturn(new ActorDefinition()
             .withDockerRepository(SOURCE_DOCKER_REPO)
             .withDockerImageTag(SOURCE_DOCKER_TAG)
-            .withSourceDefinitionId(source.getSourceDefinitionId()));
+            .withId(source.getSourceDefinitionId()));
     when(configRepository.getStandardDestinationDefinition(destination.getDestinationDefinitionId()))
-        .thenReturn(new StandardDestinationDefinition()
+        .thenReturn(new ActorDefinition()
             .withDockerRepository(DESTINATION_DOCKER_REPO)
             .withDockerImageTag(DESTINATION_DOCKER_TAG)
-            .withDestinationDefinitionId(destination.getDestinationDefinitionId()));
+            .withId(destination.getDestinationDefinitionId()));
     when(configRepository.getStandardSync(standardSync.getConnectionId())).thenReturn(standardSync);
     when(configRepository.getSourceConnection(source.getSourceId())).thenReturn(source);
     when(configRepository.getDestinationConnection(destination.getDestinationId())).thenReturn(destination);
@@ -544,15 +543,15 @@ class SchedulerHandlerTest {
     final List<StandardSyncOperation> operations = getOperations(standardSync);
 
     when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId()))
-        .thenReturn(new StandardSourceDefinition()
+        .thenReturn(new ActorDefinition()
             .withDockerRepository(SOURCE_DOCKER_REPO)
             .withDockerImageTag(SOURCE_DOCKER_TAG)
-            .withSourceDefinitionId(source.getSourceDefinitionId()));
+            .withId(source.getSourceDefinitionId()));
     when(configRepository.getStandardDestinationDefinition(destination.getDestinationDefinitionId()))
-        .thenReturn(new StandardDestinationDefinition()
+        .thenReturn(new ActorDefinition()
             .withDockerRepository(DESTINATION_DOCKER_REPO)
             .withDockerImageTag(DESTINATION_DOCKER_TAG)
-            .withDestinationDefinitionId(destination.getDestinationDefinitionId()));
+            .withId(destination.getDestinationDefinitionId()));
     when(configRepository.getStandardSync(standardSync.getConnectionId())).thenReturn(standardSync);
     when(configRepository.getSourceConnection(source.getSourceId())).thenReturn(source);
     when(configRepository.getDestinationConnection(destination.getDestinationId())).thenReturn(destination);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
@@ -26,8 +26,8 @@ import io.airbyte.api.model.SourceUpdate;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.SourceConnection;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.Test;
 class SourceHandlerTest {
 
   private ConfigRepository configRepository;
-  private StandardSourceDefinition standardSourceDefinition;
+  private ActorDefinition standardSourceDefinition;
   private SourceDefinitionSpecificationRead sourceDefinitionSpecificationRead;
   private SourceConnection sourceConnection;
   private SourceHandler sourceHandler;
@@ -73,8 +73,8 @@ class SourceHandlerTest {
 
     connectorSpecification = ConnectorSpecificationHelpers.generateConnectorSpecification();
 
-    standardSourceDefinition = new StandardSourceDefinition()
-        .withSourceDefinitionId(UUID.randomUUID())
+    standardSourceDefinition = new ActorDefinition()
+        .withId(UUID.randomUUID())
         .withName("marketo")
         .withDockerRepository("thebestrepo")
         .withDockerImageTag("thelatesttag")
@@ -84,11 +84,11 @@ class SourceHandlerTest {
     imageName = DockerUtils.getTaggedImageName(standardSourceDefinition.getDockerRepository(), standardSourceDefinition.getDockerImageTag());
 
     sourceDefinitionSpecificationRead = new SourceDefinitionSpecificationRead()
-        .sourceDefinitionId(standardSourceDefinition.getSourceDefinitionId())
+        .sourceDefinitionId(standardSourceDefinition.getId())
         .connectionSpecification(connectorSpecification.getConnectionSpecification())
         .documentationUrl(connectorSpecification.getDocumentationUrl().toString());
 
-    sourceConnection = SourceHelpers.generateSource(standardSourceDefinition.getSourceDefinitionId());
+    sourceConnection = SourceHelpers.generateSource(standardSourceDefinition.getId());
 
     sourceHandler = new SourceHandler(configRepository, validator, connectionsHandler, uuidGenerator, secretsProcessor, configurationUpdate);
   }
@@ -98,7 +98,7 @@ class SourceHandlerTest {
     final SourceCreate sourceCreate = new SourceCreate()
         .name(sourceConnection.getName())
         .workspaceId(sourceConnection.getWorkspaceId())
-        .sourceDefinitionId(standardSourceDefinition.getSourceDefinitionId())
+        .sourceDefinitionId(standardSourceDefinition.getId())
         .connectionConfiguration(sourceConnection.getConfiguration());
 
     when(uuidGenerator.get()).thenReturn(sourceConnection.getSourceId());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -56,10 +56,9 @@ import io.airbyte.api.model.WebBackendOperationCreateOrUpdate;
 import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.features.FeatureFlags;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.protocol.models.CatalogHelpers;
@@ -122,11 +121,11 @@ class WebBackendConnectionsHandlerTest {
         featureFlags,
         temporalWorkerRunFactory);
 
-    final StandardSourceDefinition standardSourceDefinition = SourceDefinitionHelpers.generateSourceDefinition();
+    final ActorDefinition standardSourceDefinition = SourceDefinitionHelpers.generateSourceDefinition();
     final SourceConnection source = SourceHelpers.generateSource(UUID.randomUUID());
     sourceRead = SourceHelpers.getSourceRead(source, standardSourceDefinition);
 
-    final StandardDestinationDefinition destinationDefinition = DestinationDefinitionHelpers.generateDestination();
+    final ActorDefinition destinationDefinition = DestinationDefinitionHelpers.generateDestination();
     final DestinationConnection destination = DestinationHelpers.generateDestination(UUID.randomUUID());
     final DestinationRead destinationRead = DestinationHelpers.getDestinationRead(destination, destinationDefinition);
 

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/DestinationDefinitionHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/DestinationDefinitionHelpers.java
@@ -4,14 +4,14 @@
 
 package io.airbyte.server.helpers;
 
-import io.airbyte.config.StandardDestinationDefinition;
+import io.airbyte.config.ActorDefinition;
 import java.util.UUID;
 
 public class DestinationDefinitionHelpers {
 
-  public static StandardDestinationDefinition generateDestination() {
-    return new StandardDestinationDefinition()
-        .withDestinationDefinitionId(UUID.randomUUID())
+  public static ActorDefinition generateDestination() {
+    return new ActorDefinition()
+        .withId(UUID.randomUUID())
         .withName("db2")
         .withDockerRepository("thebestrepo")
         .withDockerImageTag("thelatesttag")

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/DestinationHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/DestinationHelpers.java
@@ -7,8 +7,8 @@ package io.airbyte.server.helpers;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.api.model.DestinationRead;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.DestinationConnection;
-import io.airbyte.config.StandardDestinationDefinition;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -53,9 +53,9 @@ public class DestinationHelpers {
   }
 
   public static DestinationRead getDestinationRead(final DestinationConnection destination,
-                                                   final StandardDestinationDefinition standardDestinationDefinition) {
+                                                   final ActorDefinition standardDestinationDefinition) {
     return new DestinationRead()
-        .destinationDefinitionId(standardDestinationDefinition.getDestinationDefinitionId())
+        .destinationDefinitionId(standardDestinationDefinition.getId())
         .workspaceId(destination.getWorkspaceId())
         .destinationDefinitionId(destination.getDestinationDefinitionId())
         .destinationId(destination.getDestinationId())

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/SourceDefinitionHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/SourceDefinitionHelpers.java
@@ -4,14 +4,14 @@
 
 package io.airbyte.server.helpers;
 
-import io.airbyte.config.StandardSourceDefinition;
+import io.airbyte.config.ActorDefinition;
 import java.util.UUID;
 
 public class SourceDefinitionHelpers {
 
-  public static StandardSourceDefinition generateSourceDefinition() {
-    return new StandardSourceDefinition()
-        .withSourceDefinitionId(UUID.randomUUID())
+  public static ActorDefinition generateSourceDefinition() {
+    return new ActorDefinition()
+        .withId(UUID.randomUUID())
         .withName("marketo")
         .withDockerRepository("thebestrepo")
         .withDockerImageTag("thelatesttag")

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/SourceHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/SourceHelpers.java
@@ -7,8 +7,8 @@ package io.airbyte.server.helpers;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.api.model.SourceRead;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.SourceConnection;
-import io.airbyte.config.StandardSourceDefinition;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -49,10 +49,10 @@ public class SourceHelpers {
     return Jsons.deserialize(Files.readString(path));
   }
 
-  public static SourceRead getSourceRead(final SourceConnection source, final StandardSourceDefinition standardSourceDefinition) {
+  public static SourceRead getSourceRead(final SourceConnection source, final ActorDefinition standardSourceDefinition) {
 
     return new SourceRead()
-        .sourceDefinitionId(standardSourceDefinition.getSourceDefinitionId())
+        .sourceDefinitionId(standardSourceDefinition.getId())
         .workspaceId(source.getWorkspaceId())
         .sourceDefinitionId(source.getSourceDefinitionId())
         .sourceId(source.getSourceId())

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -7,10 +7,10 @@ package io.airbyte.workers.temporal.scheduling.activities;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.enums.Enums;
+import io.airbyte.config.ActorDefinition;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.JobOutput;
-import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.helpers.LogClientSingleton;
@@ -58,8 +58,8 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
 
         final DestinationConnection destination = configRepository.getDestinationConnection(standardSync.getDestinationId());
 
-        final StandardDestinationDefinition destinationDef =
-            configRepository.getStandardDestinationDefinition(destination.getDestinationDefinitionId());
+        final ActorDefinition destinationDef = configRepository
+            .getStandardDestinationDefinition(destination.getDestinationDefinitionId());
         final String destinationImageName = DockerUtils.getTaggedImageName(destinationDef.getDockerRepository(), destinationDef.getDockerImageTag());
 
         final List<StandardSyncOperation> standardSyncOperations = Lists.newArrayList();


### PR DESCRIPTION
Relates to https://github.com/airbytehq/airbyte-internal-issues/issues/428

This just changes all types that ConfigRepository has in a public iface to use `ActorDefinition` instead of `StandardSourceDefinition` and `StandardDestinationDefinition`.