### PR TITLE
Fix links in connection header

### DIFF
--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ConnectionPageTitle.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ConnectionPageTitle.tsx
@@ -80,12 +80,12 @@ const ConnectionPageTitle: React.FC<IProps> = ({
         <FormattedMessage id="connection.title" />
       </H6>
       <Links>
-        <ConnectorsLink to={`../../../${RoutePaths.Source}/${source.sourceId}`}>
+        <ConnectorsLink to={`../../${RoutePaths.Source}/${source.sourceId}`}>
           {source.name}
         </ConnectorsLink>
         <FontAwesomeIcon icon={faArrowRight} />
         <ConnectorsLink
-          to={`../../../${RoutePaths.Destination}/${destination.destinationId}`}
+          to={`../../${RoutePaths.Destination}/${destination.destinationId}`}
         >
           {destination.name}
         </ConnectorsLink>


### PR DESCRIPTION
## What

This will fix the links in the connection header. they currently lead one level to high and thus bring you back to the workspace selection page instead of linking you to the actual source/destination page.
