### PR TITLE
🎉 Source Stripe: Add `Issuing_*`-like streams

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -724,7 +724,7 @@
 - name: Stripe
   sourceDefinitionId: e094cb9a-26de-4645-8761-65c0c425d1de
   dockerRepository: airbyte/source-stripe
-  dockerImageTag: 0.1.28
+  dockerImageTag: 0.1.29
   documentationUrl: https://docs.airbyte.io/integrations/sources/stripe
   icon: stripe.svg
   sourceType: api

--- a/airbyte-integrations/connectors/source-stripe/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.28
+LABEL io.airbyte.version=0.1.29
 LABEL io.airbyte.name=airbyte/source-stripe

--- a/airbyte-integrations/connectors/source-stripe/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-stripe/integration_tests/configured_catalog.json
@@ -267,6 +267,45 @@
       "sync_mode": "incremental",
       "destination_sync_mode": "overwrite",
       "cursor_field": ["created"]
+    },
+    {
+      "stream": {
+        "name": "issuing_cards",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["created"],
+        "source_defined_primary_key": [["id"]]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["created"]
+    },
+    {
+      "stream": {
+        "name": "issuing_disputes",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["created"],
+        "source_defined_primary_key": [["id"]]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["created"]
+    },
+    {
+      "stream": {
+        "name": "issuing_transactions",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["created"],
+        "source_defined_primary_key": [["id"]]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["created"]
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
@@ -34,6 +34,7 @@ from source_stripe.streams import (
     SubscriptionItems,
     Subscriptions,
     Transfers,
+    IssuingCards,
 )
 
 
@@ -74,4 +75,5 @@ class SourceStripe(AbstractSource):
             SubscriptionItems(**args),
             Subscriptions(**incremental_args),
             Transfers(**incremental_args),
+            IssuingCards(**incremental_args),
         ]

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
@@ -35,6 +35,8 @@ from source_stripe.streams import (
     Subscriptions,
     Transfers,
     IssuingCards,
+    IssuingDisputes,
+    IssuingTransactions,
 )
 
 
@@ -66,6 +68,9 @@ class SourceStripe(AbstractSource):
             InvoiceItems(**incremental_args),
             InvoiceLineItems(**args),
             Invoices(**incremental_args),
+            IssuingCards(**args),
+            IssuingDisputes(**incremental_args),
+            IssuingTransactions(**incremental_args),
             PaymentIntents(**incremental_args),
             Payouts(**incremental_args),
             Plans(**incremental_args),
@@ -75,5 +80,4 @@ class SourceStripe(AbstractSource):
             SubscriptionItems(**args),
             Subscriptions(**incremental_args),
             Transfers(**incremental_args),
-            IssuingCards(**incremental_args),
         ]

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
@@ -408,3 +408,14 @@ class PromotionCodes(IncrementalStripeStream):
 
     def path(self, **kwargs):
         return "promotion_codes"
+
+
+class IssuingCards(IncrementalStripeStream):
+    """
+    API docs: https://stripe.com/docs/api/issuing/cards/list
+    """
+
+    cursor_field = "created"
+
+    def path(self, **kwargs):
+        return "issuing/cards"

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
@@ -410,37 +410,50 @@ class PromotionCodes(IncrementalStripeStream):
         return "promotion_codes"
 
 
-class IssuingCards(IncrementalStripeStream):
+class Issuing(IncrementalStripeStream):
+    """
+    API docs: https://stripe.com/docs/api/issuing
+    This class stands for easy inheritance for [ IssuingCards, IssuingDisputes, IssuingTransactions ] streams.
+    """
+    
+    cursor_field = "created"
+    
+    def request_headers(self, **kwargs) -> Mapping[str, Any]:
+        """
+        We don't need to pass anything else, except of Authorization Header inside the params, to reach any of:
+        ::  [ IssuingCards, IssuingDisputes, IssuingTransactions ] streams.
+        """
+        return {}
+
+
+class IssuingCards(Issuing):
     """
     API docs: https://stripe.com/docs/api/issuing/cards/list
+    
+    TODO: add schemas
     """
-
-    cursor_field = "created"
-    name = "issuing_cards"
 
     def path(self, **kwargs):
         return "issuing/cards"
 
 
-class IssuingDisputes(IncrementalStripeStream):
+class IssuingDisputes(Issuing):
     """
     API docs: https://stripe.com/docs/api/issuing/disputes/list
+    
+    TODO: add schemas
     """
-
-    cursor_field = "created"
-    name = "issuing_disputes"
 
     def path(self, **kwargs):
         return "issuing/disputes"
+    
 
-
-class IssuingDisputes(IncrementalStripeStream):
+class IssuingTransactions(Issuing):
     """
     API docs: https://stripe.com/docs/api/issuing/transctions/list
+    
+    TODO: add schemas
     """
 
-    cursor_field = "created"
-    name = "issuing_transactions"
-
     def path(self, **kwargs):
-        return "issuing/transctions"
+        return "issuing/transactions"

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
@@ -416,6 +416,31 @@ class IssuingCards(IncrementalStripeStream):
     """
 
     cursor_field = "created"
+    name = "issuing_cards"
 
     def path(self, **kwargs):
         return "issuing/cards"
+
+
+class IssuingDisputes(IncrementalStripeStream):
+    """
+    API docs: https://stripe.com/docs/api/issuing/disputes/list
+    """
+
+    cursor_field = "created"
+    name = "issuing_disputes"
+
+    def path(self, **kwargs):
+        return "issuing/disputes"
+
+
+class IssuingDisputes(IncrementalStripeStream):
+    """
+    API docs: https://stripe.com/docs/api/issuing/transctions/list
+    """
+
+    cursor_field = "created"
+    name = "issuing_transactions"
+
+    def path(self, **kwargs):
+        return "issuing/transctions"


### PR DESCRIPTION
## What
Resolving Mainly: https://github.com/airbytehq/airbyte/issues/10284
Sub-Task1 : https://github.com/airbytehq/airbyte-internal-issues/issues/431
Sub-Task2: https://github.com/airbytehq/airbyte-internal-issues/issues/432

## How
- added new class for `Issuing` and inherit from it to fetch `issuing_*` streams like: `cards, disputes, transactions`

## 🚨 User Impact 🚨
User need to have the payed & bank verified account before accessing `issuing_*`-like streams, since this is the requirements from Stripe. 

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>