### PR TITLE
Create ActorDefinitionHandler to dedupe *DefinitionHandler logic

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ActorDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ActorDefinitionsHandler.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.server.handlers;
+
+import static io.airbyte.server.ServerConstants.DEV_IMAGE_TAG;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airbyte.api.model.DestinationDefinitionIdRequestBody;
+import io.airbyte.api.model.DestinationRead;
+import io.airbyte.api.model.ReleaseStage;
+import io.airbyte.api.model.SourceDefinitionIdRequestBody;
+import io.airbyte.api.model.SourceRead;
+import io.airbyte.commons.docker.DockerUtils;
+import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.config.ActorDefinition;
+import io.airbyte.config.ActorDefinition.ActorDefinitionReleaseStage;
+import io.airbyte.config.ActorDefinition.ActorType;
+import io.airbyte.config.ActorDefinitionResourceRequirements;
+import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.protocol.models.ConnectorSpecification;
+import io.airbyte.scheduler.client.SynchronousResponse;
+import io.airbyte.scheduler.client.SynchronousSchedulerClient;
+import io.airbyte.server.converters.SpecFetcher;
+import io.airbyte.server.errors.InternalServerKnownException;
+import io.airbyte.server.services.AirbyteGithubStore;
+import io.airbyte.validation.json.JsonValidationException;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class ActorDefinitionsHandler<READ, LIST, CREATE, UPDATE, ID> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ActorDefinitionsHandler.class);
+
+  private final ConfigRepository configRepository;
+  private final Supplier<UUID> uuidSupplier;
+  private final SynchronousSchedulerClient schedulerSynchronousClient;
+  private final AirbyteGithubStore githubStore;
+  private final SourceHandler sourceHandler;
+  private final DestinationHandler destinationHandler;
+  private final ActorType actorType;
+
+  public ActorDefinitionsHandler(final ConfigRepository configRepository,
+                                 final SynchronousSchedulerClient schedulerSynchronousClient,
+                                 final SourceHandler sourceHandler,
+                                 final DestinationHandler destinationHandler,
+                                 final ActorType actorType) {
+    this(configRepository,
+        UUID::randomUUID,
+        schedulerSynchronousClient,
+        AirbyteGithubStore.production(),
+        sourceHandler,
+        destinationHandler,
+        actorType);
+  }
+
+  @VisibleForTesting
+  public ActorDefinitionsHandler(final ConfigRepository configRepository,
+                                 final Supplier<UUID> uuidSupplier,
+                                 final SynchronousSchedulerClient schedulerSynchronousClient,
+                                 final AirbyteGithubStore githubStore,
+                                 final SourceHandler sourceHandler,
+                                 final DestinationHandler destinationHandler,
+                                 final ActorType actorType) {
+    this.configRepository = configRepository;
+    this.uuidSupplier = uuidSupplier;
+    this.schedulerSynchronousClient = schedulerSynchronousClient;
+    this.githubStore = githubStore;
+    this.sourceHandler = sourceHandler;
+    this.destinationHandler = destinationHandler;
+    this.actorType = actorType;
+  }
+
+  abstract READ toRead(ActorDefinition actorDefinition);
+
+  abstract ActorDefinition fromRead(READ read);
+
+  abstract LIST toList(List<READ> reads);
+
+  abstract ActorDefinition fromCreate(CREATE create);
+
+  abstract ActorDefinition fromUpdate(UPDATE update);
+
+  abstract UUID fromId(ID idRequest);
+
+  public READ getActorDefinition(final ID idRequestBody) throws ConfigNotFoundException, IOException, JsonValidationException {
+    return toRead(configRepository.getActorDefinition(fromId(idRequestBody), actorType));
+  }
+
+  public LIST listActorDefinitions() throws IOException, JsonValidationException {
+    return toList(configRepository.listActorDefinitions(actorType, false)
+        .stream()
+        .map(this::toRead)
+        .collect(Collectors.toList()));
+  }
+
+  public READ createCustomActorDefinition(final CREATE create) throws JsonValidationException, IOException {
+    final ActorDefinition actorDefinition = fromCreate(create);
+
+    final ConnectorSpecification spec = getSpecForImage(
+        actorDefinition.getDockerRepository(),
+        actorDefinition.getDockerImageTag());
+
+    final UUID id = uuidSupplier.get();
+    actorDefinition
+        .withId(id)
+        .withSpec(spec)
+        .withTombstone(false)
+        .withReleaseStage(ActorDefinitionReleaseStage.CUSTOM);
+
+    configRepository.writeActorDefinition(actorDefinition);
+
+    return toRead(actorDefinition);
+  }
+
+  public READ updateActorDefinition(final UPDATE update) throws ConfigNotFoundException, IOException, JsonValidationException {
+    final ActorDefinition updateActorDefinition = fromUpdate(update);
+    final ActorDefinition currentActorDefinition = configRepository.getActorDefinition(updateActorDefinition.getId(), actorType);
+
+    // specs are re-fetched from the container if the image tag has changed, or if the tag is "dev",
+    // to allow for easier iteration of dev images
+    final boolean specNeedsUpdate = !currentActorDefinition.getDockerImageTag().equals(updateActorDefinition.getDockerImageTag())
+        || updateActorDefinition.getDockerImageTag().equals(DEV_IMAGE_TAG);
+    final ConnectorSpecification spec = specNeedsUpdate
+        ? getSpecForImage(currentActorDefinition.getDockerRepository(), updateActorDefinition.getDockerImageTag())
+        : currentActorDefinition.getSpec();
+    final ActorDefinitionResourceRequirements updatedResourceReqs = updateActorDefinition.getResourceRequirements() != null
+        ? updateActorDefinition.getResourceRequirements()
+        : currentActorDefinition.getResourceRequirements();
+
+    final ActorDefinition newActorDefinition = new ActorDefinition()
+        .withId(currentActorDefinition.getId())
+        .withDockerImageTag(updateActorDefinition.getDockerImageTag())
+        .withDockerRepository(currentActorDefinition.getDockerRepository())
+        .withName(currentActorDefinition.getName())
+        .withDocumentationUrl(currentActorDefinition.getDocumentationUrl())
+        .withIcon(currentActorDefinition.getIcon())
+        .withSpec(spec)
+        .withTombstone(currentActorDefinition.getTombstone())
+        .withReleaseStage(currentActorDefinition.getReleaseStage())
+        .withReleaseDate(currentActorDefinition.getReleaseDate())
+        .withResourceRequirements(updatedResourceReqs);
+
+    configRepository.writeActorDefinition(newActorDefinition);
+    return toRead(newActorDefinition);
+  }
+
+  public void deleteActorDefinition(final ID idRequestBody) throws JsonValidationException, ConfigNotFoundException, IOException {
+    /*
+     * "delete" all destinations associated with the destination definition as well. This will cascade
+     * to connections that depend on any deleted destinations. Delete destinations first in case a
+     * failure occurs mid-operation.
+     */
+    final UUID actorDefinitionId = fromId(idRequestBody);
+    final ActorDefinition persistedActorDefinition = configRepository.getActorDefinition(actorDefinitionId, actorType);
+
+    // todo (cgardens) - remove when we consolidate SourceHandler and DestinationHandler
+    if (actorType == ActorType.SOURCE) {
+      final SourceDefinitionIdRequestBody destDefRequest = new SourceDefinitionIdRequestBody().sourceDefinitionId(actorDefinitionId);
+      for (final SourceRead sourceRead : sourceHandler.listSourcesForSourceDefinition(destDefRequest).getSources()) {
+        sourceHandler.deleteSource(sourceRead);
+      }
+    } else if (actorType == ActorType.DESTINATION) {
+      final DestinationDefinitionIdRequestBody destDefRequest = new DestinationDefinitionIdRequestBody().destinationDefinitionId(actorDefinitionId);
+      for (final DestinationRead destinationRead : destinationHandler.listDestinationsForDestinationDefinition(destDefRequest).getDestinations()) {
+        destinationHandler.deleteDestination(destinationRead);
+      }
+    } else {
+      throw new IllegalArgumentException("Unrecognized actor type");
+    }
+
+    persistedActorDefinition.withTombstone(true);
+    configRepository.writeActorDefinition(persistedActorDefinition);
+  }
+
+  public LIST listLatestActorDefinitions() {
+    if (actorType == ActorType.SOURCE) {
+      return toList(getLatestSources()
+          .stream()
+          .map(this::toRead)
+          .collect(Collectors.toList()));
+    } else if (actorType == ActorType.DESTINATION) {
+      return toList(getLatestDestinations()
+          .stream()
+          .map(this::toRead)
+          .collect(Collectors.toList()));
+    } else {
+      throw new IllegalArgumentException("Unrecognized actor type");
+    }
+  }
+
+  static URI getDocumentUri(final String documentationUrl) {
+    try {
+      return new URI(documentationUrl);
+    } catch (final URISyntaxException | NullPointerException e) {
+      throw new InternalServerKnownException("Unable to process retrieved latest source definitions list", e);
+    }
+  }
+
+  static ReleaseStage getReleaseStage(final ActorDefinition actorDefinition) {
+    if (actorDefinition.getReleaseStage() == null) {
+      return null;
+    }
+    return ReleaseStage.fromValue(actorDefinition.getReleaseStage().value());
+  }
+
+  static LocalDate getReleaseDate(final ActorDefinition actorDefinition) {
+    if (actorDefinition.getReleaseDate() == null || actorDefinition.getReleaseDate().isBlank()) {
+      return null;
+    }
+
+    return LocalDate.parse(actorDefinition.getReleaseDate());
+  }
+
+  private List<ActorDefinition> getLatestSources() {
+    try {
+      return githubStore.getLatestSources();
+    } catch (final InterruptedException e) {
+      throw new InternalServerKnownException("Request to retrieve latest destination definitions failed", e);
+    }
+  }
+
+  private List<ActorDefinition> getLatestDestinations() {
+    try {
+      return githubStore.getLatestDestinations();
+    } catch (final InterruptedException e) {
+      throw new InternalServerKnownException("Request to retrieve latest destination definitions failed", e);
+    }
+  }
+
+  private ConnectorSpecification getSpecForImage(final String dockerRepository, final String imageTag) throws IOException {
+    final String imageName = DockerUtils.getTaggedImageName(dockerRepository, imageTag);
+    final SynchronousResponse<ConnectorSpecification> getSpecResponse = schedulerSynchronousClient.createGetSpecJob(imageName);
+    return SpecFetcher.getSpecFromJob(getSpecResponse);
+  }
+
+  public static String loadIcon(final String name) {
+    try {
+      return name == null ? null : MoreResources.readResource("icons/" + name);
+    } catch (final Exception e) {
+      return null;
+    }
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler2.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler2.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.server.handlers;
+
+import io.airbyte.api.model.DestinationDefinitionCreate;
+import io.airbyte.api.model.DestinationDefinitionIdRequestBody;
+import io.airbyte.api.model.DestinationDefinitionRead;
+import io.airbyte.api.model.DestinationDefinitionReadList;
+import io.airbyte.api.model.DestinationDefinitionUpdate;
+import io.airbyte.api.model.DestinationRead;
+import io.airbyte.config.ActorDefinition;
+import io.airbyte.config.ActorDefinition.ActorDefinitionReleaseStage;
+import io.airbyte.config.ActorDefinition.ActorType;
+import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.scheduler.client.SynchronousSchedulerClient;
+import io.airbyte.server.converters.ApiPojoConverters;
+import io.airbyte.server.services.AirbyteGithubStore;
+import io.airbyte.validation.json.JsonValidationException;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+public class DestinationDefinitionsHandler2 extends
+    ActorDefinitionsHandler<DestinationDefinitionRead, DestinationDefinitionReadList, DestinationDefinitionCreate, DestinationDefinitionUpdate, DestinationDefinitionIdRequestBody> {
+
+  private final DestinationHandler destinationHandler;
+
+  public DestinationDefinitionsHandler2(final ConfigRepository configRepository,
+                                        final SynchronousSchedulerClient schedulerSynchronousClient,
+                                        final DestinationHandler destinationHandler) {
+    this(configRepository, UUID::randomUUID, schedulerSynchronousClient, AirbyteGithubStore.production(), destinationHandler);
+  }
+
+  public DestinationDefinitionsHandler2(final ConfigRepository configRepository,
+                                        final Supplier<UUID> uuidSupplier,
+                                        final SynchronousSchedulerClient schedulerSynchronousClient,
+                                        final AirbyteGithubStore githubStore,
+                                        final DestinationHandler destinationHandler) {
+    super(configRepository,
+        uuidSupplier,
+        schedulerSynchronousClient,
+        githubStore,
+        ActorType.DESTINATION);
+    this.destinationHandler = destinationHandler;
+  }
+
+  @Override
+  DestinationDefinitionRead toRead(final ActorDefinition actorDefinition) {
+    return new DestinationDefinitionRead()
+        .destinationDefinitionId(actorDefinition.getId())
+        .name(actorDefinition.getName())
+        .dockerRepository(actorDefinition.getDockerRepository())
+        .dockerImageTag(actorDefinition.getDockerImageTag())
+        .documentationUrl(getDocumentUri(actorDefinition.getDocumentationUrl()))
+        .icon(loadIcon(actorDefinition.getIcon()))
+        .releaseStage(getReleaseStage(actorDefinition))
+        .releaseDate(getReleaseDate(actorDefinition))
+        .resourceRequirements(ApiPojoConverters.actorDefResourceReqsToApi(actorDefinition.getResourceRequirements()));
+  }
+
+  @Override
+  DestinationDefinitionReadList toList(final List<DestinationDefinitionRead> reads) {
+    return new DestinationDefinitionReadList().destinationDefinitions(reads);
+  }
+
+  @Override
+  ActorDefinition fromCreate(final DestinationDefinitionCreate create) {
+    return new ActorDefinition()
+        .withActorType(actorType)
+        .withId(null) // will get populated internally.
+        .withDockerRepository(create.getDockerRepository())
+        .withDockerImageTag(create.getDockerImageTag())
+        .withDocumentationUrl(create.getDocumentationUrl().toString())
+        .withName(create.getName())
+        .withIcon(create.getIcon())
+        .withSpec(null) // will get populated internally.
+        .withTombstone(false)
+        .withReleaseStage(ActorDefinitionReleaseStage.CUSTOM)
+        .withResourceRequirements(ApiPojoConverters.actorDefResourceReqsToInternal(create.getResourceRequirements()));
+  }
+
+  @Override
+  ActorDefinition fromUpdate(final DestinationDefinitionUpdate update) {
+    return new ActorDefinition()
+        .withActorType(actorType)
+        .withId(update.getDestinationDefinitionId())
+        .withDockerImageTag(update.getDockerImageTag())
+        .withResourceRequirements(ApiPojoConverters.actorDefResourceReqsToInternal(update.getResourceRequirements()));
+  }
+
+  @Override
+  UUID fromId(final DestinationDefinitionIdRequestBody idRequest) {
+    return idRequest.getDestinationDefinitionId();
+  }
+
+  @Override
+  void deleteChildren(final UUID definitionId) throws JsonValidationException, ConfigNotFoundException, IOException {
+    final DestinationDefinitionIdRequestBody destDefRequest = new DestinationDefinitionIdRequestBody().destinationDefinitionId(definitionId);
+    for (final DestinationRead destinationRead : destinationHandler.listDestinationsForDestinationDefinition(destDefRequest).getDestinations()) {
+      destinationHandler.deleteDestination(destinationRead);
+    }
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler2.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler2.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.server.handlers;
+
+import io.airbyte.api.model.SourceDefinitionCreate;
+import io.airbyte.api.model.SourceDefinitionIdRequestBody;
+import io.airbyte.api.model.SourceDefinitionRead;
+import io.airbyte.api.model.SourceDefinitionReadList;
+import io.airbyte.api.model.SourceDefinitionUpdate;
+import io.airbyte.config.ActorDefinition;
+import io.airbyte.config.ActorDefinition.ActorDefinitionReleaseStage;
+import io.airbyte.config.ActorDefinition.ActorType;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.scheduler.client.SynchronousSchedulerClient;
+import io.airbyte.server.converters.ApiPojoConverters;
+import io.airbyte.server.services.AirbyteGithubStore;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+public class SourceDefinitionsHandler2 extends
+    ActorDefinitionsHandler<SourceDefinitionRead, SourceDefinitionReadList, SourceDefinitionCreate, SourceDefinitionUpdate, SourceDefinitionIdRequestBody> {
+
+  public SourceDefinitionsHandler2(final ConfigRepository configRepository,
+                                   final SynchronousSchedulerClient schedulerSynchronousClient,
+                                   final SourceHandler sourceHandler) {
+    this(configRepository, UUID::randomUUID, schedulerSynchronousClient, AirbyteGithubStore.production(), sourceHandler);
+  }
+
+  public SourceDefinitionsHandler2(final ConfigRepository configRepository,
+                                   final Supplier<UUID> uuidSupplier,
+                                   final SynchronousSchedulerClient schedulerSynchronousClient,
+                                   final AirbyteGithubStore githubStore,
+                                   final SourceHandler sourceHandler) {
+    super(configRepository,
+        uuidSupplier,
+        schedulerSynchronousClient,
+        githubStore,
+        sourceHandler,
+        null, // will never use destination handler since this is the source version.
+        ActorType.SOURCE);
+  }
+
+  @Override
+  SourceDefinitionRead toRead(final ActorDefinition actorDefinition) {
+    return new SourceDefinitionRead()
+        .sourceDefinitionId(actorDefinition.getId())
+        .name(actorDefinition.getName())
+        .dockerRepository(actorDefinition.getDockerRepository())
+        .dockerImageTag(actorDefinition.getDockerImageTag())
+        .documentationUrl(getDocumentUri(actorDefinition.getDocumentationUrl()))
+        .icon(loadIcon(actorDefinition.getIcon()))
+        .releaseStage(getReleaseStage(actorDefinition))
+        .releaseDate(getReleaseDate(actorDefinition))
+        .resourceRequirements(ApiPojoConverters.actorDefResourceReqsToApi(actorDefinition.getResourceRequirements()));
+  }
+
+  @Override
+  ActorDefinition fromRead(final SourceDefinitionRead sourceDefinitionRead) {
+    return null;
+  }
+
+  @Override
+  SourceDefinitionReadList toList(final List<SourceDefinitionRead> reads) {
+    return new SourceDefinitionReadList().sourceDefinitions(reads);
+  }
+
+  @Override
+  ActorDefinition fromCreate(final SourceDefinitionCreate create) {
+    return new ActorDefinition()
+        .withId(null) // will get populated internally.
+        .withDockerRepository(create.getDockerRepository())
+        .withDockerImageTag(create.getDockerImageTag())
+        .withDocumentationUrl(create.getDocumentationUrl().toString())
+        .withName(create.getName())
+        .withIcon(create.getIcon())
+        .withSpec(null) // will get populated internally.
+        .withTombstone(false)
+        .withReleaseStage(ActorDefinitionReleaseStage.CUSTOM)
+        .withResourceRequirements(ApiPojoConverters.actorDefResourceReqsToInternal(create.getResourceRequirements()));
+  }
+
+  @Override
+  ActorDefinition fromUpdate(final SourceDefinitionUpdate update) {
+    return new ActorDefinition()
+        .withId(update.getSourceDefinitionId())
+        .withDockerImageTag(update.getDockerImageTag())
+        .withResourceRequirements(ApiPojoConverters.actorDefResourceReqsToInternal(update.getResourceRequirements()));
+  }
+
+  @Override
+  UUID fromId(final SourceDefinitionIdRequestBody idRequest) {
+    return idRequest.getSourceDefinitionId();
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/services/AirbyteGithubStore.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/services/AirbyteGithubStore.java
@@ -6,6 +6,7 @@ package io.airbyte.server.services;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.config.ActorDefinition;
+import io.airbyte.config.ActorDefinition.ActorType;
 import io.airbyte.config.helpers.YamlListToStandardDefinitions;
 import io.airbyte.config.persistence.ActorDefinitionMigrationUtils;
 import java.io.IOException;
@@ -51,6 +52,17 @@ public class AirbyteGithubStore {
     this.timeout = timeout;
   }
 
+  public List<ActorDefinition> getLatestDefinitions(final ActorType actorType) throws InterruptedException {
+    if (actorType == ActorType.SOURCE) {
+      return getLatestSources();
+    } else if (actorType == ActorType.DESTINATION) {
+      return getLatestDestinations();
+    } else {
+      throw new IllegalArgumentException("Unrecognized actor type");
+    }
+  }
+
+  // todo (cgardens) - make private
   public List<ActorDefinition> getLatestDestinations() throws InterruptedException {
     try {
       // todo (cgardens) - remove migration shim
@@ -66,6 +78,7 @@ public class AirbyteGithubStore {
     }
   }
 
+  // todo (cgardens) - make private
   public List<ActorDefinition> getLatestSources() throws InterruptedException {
     try {
       // todo (cgardens) - remove migration shim

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandler2Test.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandler2Test.java
@@ -83,6 +83,7 @@ class SourceDefinitionsHandler2Test {
         Jsons.jsonNode(ImmutableMap.of("foo", "bar")));
 
     return new ActorDefinition()
+        .withActorType(ActorType.SOURCE)
         .withId(sourceDefinitionId)
         .withName("presto")
         .withDocumentationUrl("https://netflix.com")
@@ -263,7 +264,7 @@ class SourceDefinitionsHandler2Test {
     @DisplayName("should return the latest list")
     void testCorrect() throws InterruptedException {
       final ActorDefinition sourceDefinition = generateSourceDefinition();
-      when(githubStore.getLatestSources()).thenReturn(Collections.singletonList(sourceDefinition));
+      when(githubStore.getLatestDefinitions(ActorType.SOURCE)).thenReturn(Collections.singletonList(sourceDefinition));
 
       final var sourceDefinitionReadList = sourceDefinitionsHandler.listLatestActorDefinitions().getSourceDefinitions();
       assertEquals(1, sourceDefinitionReadList.size());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandler2Test.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandler2Test.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.server.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import io.airbyte.api.model.ReleaseStage;
+import io.airbyte.api.model.SourceDefinitionCreate;
+import io.airbyte.api.model.SourceDefinitionIdRequestBody;
+import io.airbyte.api.model.SourceDefinitionRead;
+import io.airbyte.api.model.SourceDefinitionReadList;
+import io.airbyte.api.model.SourceDefinitionUpdate;
+import io.airbyte.api.model.SourceRead;
+import io.airbyte.api.model.SourceReadList;
+import io.airbyte.commons.docker.DockerUtils;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinition;
+import io.airbyte.config.ActorDefinition.ActorDefinitionReleaseStage;
+import io.airbyte.config.ActorDefinition.ActorType;
+import io.airbyte.config.ActorDefinitionResourceRequirements;
+import io.airbyte.config.JobConfig.ConfigType;
+import io.airbyte.config.ResourceRequirements;
+import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.protocol.models.ConnectorSpecification;
+import io.airbyte.scheduler.client.SynchronousJobMetadata;
+import io.airbyte.scheduler.client.SynchronousResponse;
+import io.airbyte.scheduler.client.SynchronousSchedulerClient;
+import io.airbyte.server.services.AirbyteGithubStore;
+import io.airbyte.validation.json.JsonValidationException;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SourceDefinitionsHandler2Test {
+
+  private static final String TODAY_DATE_STRING = LocalDate.now().toString();
+
+  private ConfigRepository configRepository;
+  private ActorDefinition sourceDefinition;
+  private SourceDefinitionsHandler2 sourceDefinitionsHandler;
+  private Supplier<UUID> uuidSupplier;
+  private SynchronousSchedulerClient schedulerSynchronousClient;
+  private AirbyteGithubStore githubStore;
+  private SourceHandler sourceHandler;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() {
+    configRepository = mock(ConfigRepository.class);
+    uuidSupplier = mock(Supplier.class);
+    schedulerSynchronousClient = spy(SynchronousSchedulerClient.class);
+    githubStore = mock(AirbyteGithubStore.class);
+    sourceHandler = mock(SourceHandler.class);
+
+    sourceDefinition = generateSourceDefinition();
+
+    sourceDefinitionsHandler = new SourceDefinitionsHandler2(configRepository, uuidSupplier, schedulerSynchronousClient, githubStore, sourceHandler);
+  }
+
+  private ActorDefinition generateSourceDefinition() {
+    final UUID sourceDefinitionId = UUID.randomUUID();
+    final ConnectorSpecification spec = new ConnectorSpecification().withConnectionSpecification(
+        Jsons.jsonNode(ImmutableMap.of("foo", "bar")));
+
+    return new ActorDefinition()
+        .withId(sourceDefinitionId)
+        .withName("presto")
+        .withDocumentationUrl("https://netflix.com")
+        .withDockerRepository("dockerstuff")
+        .withDockerImageTag("12.3")
+        .withIcon("http.svg")
+        .withSpec(spec)
+        .withTombstone(false)
+        .withReleaseStage(ActorDefinitionReleaseStage.ALPHA)
+        .withReleaseDate(TODAY_DATE_STRING)
+        .withResourceRequirements(new ActorDefinitionResourceRequirements().withDefault(new ResourceRequirements().withCpuRequest("2")));
+
+  }
+
+  @Test
+  @DisplayName("listSourceDefinition should return the right list")
+  void testListSourceDefinitions() throws JsonValidationException, IOException, URISyntaxException {
+    final ActorDefinition sourceDefinition2 = generateSourceDefinition();
+
+    when(configRepository.listActorDefinitions(ActorType.SOURCE, false))
+        .thenReturn(Lists.newArrayList(sourceDefinition, sourceDefinition2));
+
+    final SourceDefinitionRead expectedSourceDefinitionRead1 = new SourceDefinitionRead()
+        .sourceDefinitionId(sourceDefinition.getId())
+        .name(sourceDefinition.getName())
+        .dockerRepository(sourceDefinition.getDockerRepository())
+        .dockerImageTag(sourceDefinition.getDockerImageTag())
+        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
+        .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
+        .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
+        .resourceRequirements(new io.airbyte.api.model.ActorDefinitionResourceRequirements()
+            ._default(new io.airbyte.api.model.ResourceRequirements()
+                .cpuRequest(sourceDefinition.getResourceRequirements().getDefault().getCpuRequest())));
+
+    final SourceDefinitionRead expectedSourceDefinitionRead2 = new SourceDefinitionRead()
+        .sourceDefinitionId(sourceDefinition2.getId())
+        .name(sourceDefinition2.getName())
+        .dockerRepository(sourceDefinition.getDockerRepository())
+        .dockerImageTag(sourceDefinition.getDockerImageTag())
+        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
+        .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
+        .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
+        .resourceRequirements(new io.airbyte.api.model.ActorDefinitionResourceRequirements()
+            ._default(new io.airbyte.api.model.ResourceRequirements()
+                .cpuRequest(sourceDefinition2.getResourceRequirements().getDefault().getCpuRequest())));
+
+    final SourceDefinitionReadList actualSourceDefinitionReadList = sourceDefinitionsHandler.listActorDefinitions();
+
+    assertEquals(
+        Lists.newArrayList(expectedSourceDefinitionRead1, expectedSourceDefinitionRead2),
+        actualSourceDefinitionReadList.getSourceDefinitions());
+  }
+
+  @Test
+  @DisplayName("getSourceDefinition should return the right source")
+  void testGetSourceDefinition() throws JsonValidationException, ConfigNotFoundException, IOException, URISyntaxException {
+    when(configRepository.getActorDefinition(sourceDefinition.getId(), ActorType.SOURCE))
+        .thenReturn(sourceDefinition);
+
+    final SourceDefinitionRead expectedSourceDefinitionRead = new SourceDefinitionRead()
+        .sourceDefinitionId(sourceDefinition.getId())
+        .name(sourceDefinition.getName())
+        .dockerRepository(sourceDefinition.getDockerRepository())
+        .dockerImageTag(sourceDefinition.getDockerImageTag())
+        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
+        .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
+        .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
+        .resourceRequirements(new io.airbyte.api.model.ActorDefinitionResourceRequirements()
+            ._default(new io.airbyte.api.model.ResourceRequirements()
+                .cpuRequest(sourceDefinition.getResourceRequirements().getDefault().getCpuRequest())));
+
+    final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody =
+        new SourceDefinitionIdRequestBody().sourceDefinitionId(sourceDefinition.getId());
+
+    final SourceDefinitionRead actualSourceDefinitionRead = sourceDefinitionsHandler.getActorDefinition(sourceDefinitionIdRequestBody);
+
+    assertEquals(expectedSourceDefinitionRead, actualSourceDefinitionRead);
+  }
+
+  @Test
+  @DisplayName("createSourceDefinition should correctly create a sourceDefinition")
+  void testCreateSourceDefinition() throws URISyntaxException, IOException, JsonValidationException {
+    final ActorDefinition sourceDefinition = generateSourceDefinition();
+    final String imageName = DockerUtils.getTaggedImageName(sourceDefinition.getDockerRepository(), sourceDefinition.getDockerImageTag());
+
+    when(uuidSupplier.get()).thenReturn(sourceDefinition.getId());
+    when(schedulerSynchronousClient.createGetSpecJob(imageName)).thenReturn(new SynchronousResponse<>(
+        sourceDefinition.getSpec(),
+        SynchronousJobMetadata.mock(ConfigType.GET_SPEC)));
+
+    final SourceDefinitionCreate create = new SourceDefinitionCreate()
+        .name(sourceDefinition.getName())
+        .dockerRepository(sourceDefinition.getDockerRepository())
+        .dockerImageTag(sourceDefinition.getDockerImageTag())
+        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .icon(sourceDefinition.getIcon())
+        .resourceRequirements(new io.airbyte.api.model.ActorDefinitionResourceRequirements()
+            ._default(new io.airbyte.api.model.ResourceRequirements()
+                .cpuRequest(sourceDefinition.getResourceRequirements().getDefault().getCpuRequest())));
+
+    final SourceDefinitionRead expectedRead = new SourceDefinitionRead()
+        .name(sourceDefinition.getName())
+        .dockerRepository(sourceDefinition.getDockerRepository())
+        .dockerImageTag(sourceDefinition.getDockerImageTag())
+        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .sourceDefinitionId(sourceDefinition.getId())
+        .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
+        .releaseStage(ReleaseStage.CUSTOM)
+        .resourceRequirements(new io.airbyte.api.model.ActorDefinitionResourceRequirements()
+            ._default(new io.airbyte.api.model.ResourceRequirements()
+                .cpuRequest(sourceDefinition.getResourceRequirements().getDefault().getCpuRequest())));
+
+    final SourceDefinitionRead actualRead = sourceDefinitionsHandler.createCustomActorDefinition(create);
+
+    assertEquals(expectedRead, actualRead);
+    verify(schedulerSynchronousClient).createGetSpecJob(imageName);
+    verify(configRepository)
+        .writeActorDefinition(sourceDefinition.withReleaseDate(null).withReleaseStage(ActorDefinitionReleaseStage.CUSTOM));
+  }
+
+  @Test
+  @DisplayName("updateSourceDefinition should correctly update a sourceDefinition")
+  void testUpdateSourceDefinition() throws ConfigNotFoundException, IOException, JsonValidationException, URISyntaxException {
+    when(configRepository.getActorDefinition(sourceDefinition.getId(), ActorType.SOURCE)).thenReturn(sourceDefinition);
+    final String newDockerImageTag = "averydifferenttag";
+    final SourceDefinitionRead sourceDefinition = sourceDefinitionsHandler
+        .getActorDefinition(new SourceDefinitionIdRequestBody().sourceDefinitionId(this.sourceDefinition.getId()));
+    final String dockerRepository = sourceDefinition.getDockerRepository();
+    final String currentTag = sourceDefinition.getDockerImageTag();
+    assertNotEquals(newDockerImageTag, currentTag);
+
+    final String newImageName = DockerUtils.getTaggedImageName(this.sourceDefinition.getDockerRepository(), newDockerImageTag);
+    final ConnectorSpecification newSpec = new ConnectorSpecification().withConnectionSpecification(
+        Jsons.jsonNode(ImmutableMap.of("foo2", "bar2")));
+    when(schedulerSynchronousClient.createGetSpecJob(newImageName)).thenReturn(new SynchronousResponse<>(
+        newSpec,
+        SynchronousJobMetadata.mock(ConfigType.GET_SPEC)));
+
+    final ActorDefinition updatedSource = Jsons.clone(this.sourceDefinition).withDockerImageTag(newDockerImageTag).withSpec(newSpec);
+
+    final SourceDefinitionRead sourceDefinitionRead = sourceDefinitionsHandler
+        .updateActorDefinition(new SourceDefinitionUpdate().sourceDefinitionId(this.sourceDefinition.getId()).dockerImageTag(newDockerImageTag));
+
+    assertEquals(newDockerImageTag, sourceDefinitionRead.getDockerImageTag());
+    verify(schedulerSynchronousClient).createGetSpecJob(newImageName);
+    verify(configRepository).writeActorDefinition(updatedSource);
+  }
+
+  @Test
+  @DisplayName("deleteSourceDefinition should correctly delete a sourceDefinition")
+  void testDeleteSourceDefinition() throws ConfigNotFoundException, IOException, JsonValidationException {
+    final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody =
+        new SourceDefinitionIdRequestBody().sourceDefinitionId(sourceDefinition.getId());
+    final ActorDefinition updatedSourceDefinition = Jsons.clone(this.sourceDefinition).withTombstone(true);
+    final SourceRead source = new SourceRead();
+
+    when(configRepository.getActorDefinition(sourceDefinition.getId(), ActorType.SOURCE))
+        .thenReturn(sourceDefinition);
+    when(sourceHandler.listSourcesForSourceDefinition(sourceDefinitionIdRequestBody))
+        .thenReturn(new SourceReadList().sources(Collections.singletonList(source)));
+
+    assertFalse(sourceDefinition.getTombstone());
+
+    sourceDefinitionsHandler.deleteActorDefinition(sourceDefinitionIdRequestBody);
+
+    verify(sourceHandler).deleteSource(source);
+    verify(configRepository).writeActorDefinition(updatedSourceDefinition);
+  }
+
+  @Nested
+  @DisplayName("listLatest")
+  class listLatest {
+
+    @Test
+    @DisplayName("should return the latest list")
+    void testCorrect() throws InterruptedException {
+      final ActorDefinition sourceDefinition = generateSourceDefinition();
+      when(githubStore.getLatestSources()).thenReturn(Collections.singletonList(sourceDefinition));
+
+      final var sourceDefinitionReadList = sourceDefinitionsHandler.listLatestActorDefinitions().getSourceDefinitions();
+      assertEquals(1, sourceDefinitionReadList.size());
+
+      final var sourceDefinitionRead = sourceDefinitionReadList.get(0);
+      assertEquals(SourceDefinitionsHandler.buildSourceDefinitionRead(sourceDefinition), sourceDefinitionRead);
+    }
+
+    @Test
+    @DisplayName("returns empty collection if cannot find latest definitions")
+    void testHttpTimeout() {
+      assertEquals(0, sourceDefinitionsHandler.listLatestActorDefinitions().getSourceDefinitions().size());
+    }
+
+    @Test
+    @DisplayName("Icon should contain data")
+    void testIconHoldsData() {
+      final String icon = SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon());
+      assertNotNull(icon);
+      assert (icon.length() > 3000);
+      assert (icon.length() < 6000);
+    }
+
+  }
+
+}


### PR DESCRIPTION
relates to https://github.com/airbytehq/airbyte-internal-issues/issues/428

## What
The classes `StandardSourceDefinitionHandler` and `ActorDefinitionHandler` are logically identical. They are only separate because in the old data model (pre-actor definition), it was very hard to consolidate them because of how the types worked. Now that we have a common internal data model for source and destination definitions, this is feasible.

First half of this step in this [issue](https://github.com/airbytehq/airbyte-internal-issues/issues/428):
> Replace SourceDefinitionHandler and DestinationDefinitionHandler with ActorDefinitionHandler.

## How
* Create an abstract class called `ActorDefinitionHandler`. It handles all of the logic for CRUD operations on an ActorDefinition. When extending this class, the extender just adds in mappings from `ActorDefinition` to the API structs specific to the sources (e.g. `SourceDefinitionRead`). 
* If in the future we decide to consolidate the API structs, even that can be remove then. Decided to stop short of making API changes for this refactor.
* I copy and pasted the existing tests that we have for the definition handlers and hooked them up to the new handlers to verify that behavior is the same. All I changed where the mocked db calls as necessary since the new handler makes slightly different db queries.
* Note: This is just to demonstrate the new code. It doesn't actually hook it up to the API. I have separate it this way, because it makes it easier to see what this new abstraction is doing.
