### PR TITLE
Fix react-intl upgrade

### DIFF
--- a/airbyte-webapp/src/App.tsx
+++ b/airbyte-webapp/src/App.tsx
@@ -35,7 +35,13 @@ const StyleProvider: React.FC = ({ children }) => (
 );
 
 const I18NProvider: React.FC = ({ children }) => (
-  <IntlProvider locale="en" messages={en}>
+  <IntlProvider
+    locale="en"
+    messages={en}
+    defaultRichTextElements={{
+      b: (chunk) => <strong>{chunk}</strong>,
+    }}
+  >
     {children}
   </IntlProvider>
 );

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -412,7 +412,7 @@
   "admin.documentationUrl.placeholder": "https://hub.docker.com/r/airbyte/integration-singer-postgres-source",
   "admin.learnMore": "<lnk>Learn more from our documentation</lnk> to understand how to fill these field.",
   "admin.exportConfigurationText": "Download an archive of all configuration and state data. Exported data can be upgraded to another Airbyte version or can be exported to a different Airbyte deployment. For more information visit the <lnk>configuration archive</lnk> page in our docs.",
-  "admin.importConfigurationText": "Upload an archive of all configuration and state data. <b>Warning: This will overwrite all existing configuration!</b>",
+  "admin.importConfigurationText": "Upload an archive of all configuration and state data. <warn>Warning: This will overwrite all existing configuration!</warn>",
   "admin.dropZoneTitle": "Drag 'n' drop file here, or click to select file",
   "admin.dropZoneSubtitle": "Only *.tar and *.gz files will be accepted",
   "admin.logs": "Logs",

--- a/airbyte-webapp/src/packages/cloud/App.tsx
+++ b/airbyte-webapp/src/packages/cloud/App.tsx
@@ -23,7 +23,13 @@ import { ConfigProvider } from "./services/ConfigProvider";
 const messages = Object.assign({}, en, cloudLocales);
 
 const I18NProvider: React.FC = ({ children }) => (
-  <IntlProvider locale="en" messages={messages}>
+  <IntlProvider
+    locale="en"
+    messages={messages}
+    defaultRichTextElements={{
+      b: (chunk) => <strong>{chunk}</strong>,
+    }}
+  >
     {children}
   </IntlProvider>
 );

--- a/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/SignupPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/SignupPage.tsx
@@ -186,7 +186,7 @@ const SignupPage: React.FC = () => {
                       <FormattedMessage
                         id="login.security"
                         values={{
-                          terms: (...terms: React.ReactNode[]) => (
+                          terms: (terms: React.ReactNode) => (
                             <Link
                               $clear
                               target="_blank"
@@ -196,7 +196,7 @@ const SignupPage: React.FC = () => {
                               {terms}
                             </Link>
                           ),
-                          privacy: (...privacy: React.ReactNode[]) => (
+                          privacy: (privacy: React.ReactNode) => (
                             <Link
                               $clear
                               target="_blank"

--- a/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/components/SpecialBlock.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/components/SpecialBlock.tsx
@@ -62,11 +62,11 @@ const SpecialBlock: React.FC = () => {
         <FormattedMessage
           id="login.activateAccess.subtitle"
           values={{
-            sum: (...sum: React.ReactNode[]) => <SumBlock>{sum}</SumBlock>,
-            special: (...special: React.ReactNode[]) => (
+            sum: (sum: React.ReactNode) => <SumBlock>{sum}</SumBlock>,
+            special: (special: React.ReactNode) => (
               <HighlightBlock red>{special}</HighlightBlock>
             ),
-            free: (...free: React.ReactNode[]) => (
+            free: (free: React.ReactNode) => (
               <HighlightBlock>{free}</HighlightBlock>
             ),
           }}

--- a/airbyte-webapp/src/packages/cloud/views/users/UsersSettingsView/components/RoleToolTip.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/users/UsersSettingsView/components/RoleToolTip.tsx
@@ -37,29 +37,14 @@ const RoleToolTip: React.FC = () => {
     >
       <>
         <LineBlock>
-          <FormattedMessage
-            id="settings.accessManagement.roleViewers"
-            values={{
-              b: (...b: React.ReactNode[]) => <strong>{b}</strong>,
-            }}
-          />
+          <FormattedMessage id="settings.accessManagement.roleViewers" />
         </LineBlock>
         <LineBlock>
-          <FormattedMessage
-            id="settings.accessManagement.roleEditors"
-            values={{
-              b: (...b: React.ReactNode[]) => <strong>{b}</strong>,
-            }}
-          />
+          <FormattedMessage id="settings.accessManagement.roleEditors" />
         </LineBlock>
 
         <LineBlock>
-          <FormattedMessage
-            id="settings.accessManagement.roleAdmin"
-            values={{
-              b: (...b: React.ReactNode[]) => <strong>{b}</strong>,
-            }}
-          />
+          <FormattedMessage id="settings.accessManagement.roleAdmin" />
         </LineBlock>
       </>
     </ToolTip>

--- a/airbyte-webapp/src/pages/OnboardingPage/components/ConnectionStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/ConnectionStep.tsx
@@ -25,7 +25,7 @@ const ConnectionStep: React.FC<IProps> = ({
           <FormattedMessage
             id="onboarding.createConnection"
             values={{
-              name: (...name: React.ReactNode[]) => (
+              name: (name: React.ReactNode[]) => (
                 <HighlightedText>{name}</HighlightedText>
               ),
             }}

--- a/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
@@ -78,7 +78,7 @@ const DestinationStep: React.FC<IProps> = ({
           <FormattedMessage
             id="onboarding.createFirstDestination"
             values={{
-              name: (...name: React.ReactNode[]) => (
+              name: (name: React.ReactNode[]) => (
                 <HighlightedText>{name}</HighlightedText>
               ),
             }}

--- a/airbyte-webapp/src/pages/OnboardingPage/components/FinalStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/FinalStep.tsx
@@ -95,7 +95,7 @@ const FinalStep: React.FC<FinalStepProps> = ({ connectionId, onSync }) => {
         <FormattedMessage
           id="onboarding.useCases"
           values={{
-            name: (...name: React.ReactNode[]) => (
+            name: (name: React.ReactNode[]) => (
               <HighlightedText>{name}</HighlightedText>
             ),
           }}

--- a/airbyte-webapp/src/pages/OnboardingPage/components/ProgressBlock.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/ProgressBlock.tsx
@@ -102,18 +102,18 @@ const ProgressBlock: React.FC<ProgressBlockProps> = ({
       <FormattedMessage
         id="onboarding.synchronizationProgress"
         values={{
-          sr: (...sr: React.ReactNode[]) => (
+          sr: (sr: React.ReactNode) => (
             <>
               <Lnk to={`${RoutePaths.Source}/${connection.sourceId}`}>{sr}</Lnk>{" "}
               <FontAwesomeIcon icon={faChevronRight} />
             </>
           ),
-          ds: (...ds: React.ReactNode[]) => (
+          ds: (ds: React.ReactNode) => (
             <Lnk to={`${RoutePaths.Destination}/${connection.destinationId}`}>
               {ds}
             </Lnk>
           ),
-          sync: (...sync: React.ReactNode[]) => (
+          sync: (sync: React.ReactNode) => (
             <Lnk to={`${RoutePaths.Connections}/${connection.connectionId}`}>
               {sync}
             </Lnk>

--- a/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
@@ -73,7 +73,7 @@ const SourceStep: React.FC<IProps> = ({
           <FormattedMessage
             id="onboarding.createFirstSource"
             values={{
-              name: (...name: React.ReactNode[]) => (
+              name: (name: React.ReactNode) => (
                 <HighlightedText>{name}</HighlightedText>
               ),
             }}

--- a/airbyte-webapp/src/pages/OnboardingPage/components/WelcomeStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/WelcomeStep.tsx
@@ -44,7 +44,7 @@ const WelcomeStep: React.FC<WelcomeStepProps> = ({ userName, onSubmit }) => {
         <FormattedMessage
           id="onboarding.welcomeUser.text"
           values={{
-            b: (...b: React.ReactNode[]) => (
+            b: (b: React.ReactNode) => (
               <>
                 <b>{b}</b>
                 <br />

--- a/airbyte-webapp/src/pages/SettingsPage/pages/ConfigurationsPage/ConfigurationsPage.tsx
+++ b/airbyte-webapp/src/pages/SettingsPage/pages/ConfigurationsPage/ConfigurationsPage.tsx
@@ -105,7 +105,7 @@ const ConfigurationsPage: React.FC = () => {
             <FormattedMessage
               id="admin.exportConfigurationText"
               values={{
-                lnk: (...lnk: React.ReactNode[]) => (
+                lnk: (lnk: React.ReactNode) => (
                   <DocLink
                     target="_blank"
                     href={config.ui.configurationArchiveLink}
@@ -129,7 +129,7 @@ const ConfigurationsPage: React.FC = () => {
             <FormattedMessage
               id="admin.importConfigurationText"
               values={{
-                b: (...b: React.ReactNode[]) => <Warning>{b}</Warning>,
+                warn: (warn: React.ReactNode) => <Warning>{warn}</Warning>,
               }}
             />
           </Text>

--- a/airbyte-webapp/src/pages/SettingsPage/pages/ConnectorsPage/components/CreateConnectorModal.tsx
+++ b/airbyte-webapp/src/pages/SettingsPage/pages/ConnectorsPage/components/CreateConnectorModal.tsx
@@ -107,7 +107,7 @@ const CreateConnectorModal: React.FC<IProps> = ({
           <FormattedMessage
             id="admin.learnMore"
             values={{
-              lnk: (...lnk: React.ReactNode[]) => (
+              lnk: (lnk: React.ReactNode) => (
                 <DocLink target="_blank" href={config.ui.docsLink} as="a">
                   {lnk}
                 </DocLink>

--- a/airbyte-webapp/src/pages/SettingsPage/pages/MetricsPage/components/MetricsForm.tsx
+++ b/airbyte-webapp/src/pages/SettingsPage/pages/MetricsPage/components/MetricsForm.tsx
@@ -58,7 +58,7 @@ const MetricsForm: React.FC<MetricsFormProps> = ({
         <FormattedMessage
           id={"preferences.collectData"}
           values={{
-            docs: (...docs: React.ReactNode[]) => (
+            docs: (docs: React.ReactNode) => (
               <DocsLink target="_blank" href={config.ui.docsLink}>
                 {docs}
               </DocsLink>

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/NormalizationField.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/NormalizationField.tsx
@@ -39,7 +39,7 @@ const NormalizationField: React.FC<NormalizationBlockProps> = ({
           <FormattedMessage
             id="form.basicNormalization.message"
             values={{
-              lnk: (...lnk: React.ReactNode[]) => (
+              lnk: (lnk: React.ReactNode) => (
                 <Link target="_blank" href={config.ui.normalizationLink} as="a">
                   {lnk}
                 </Link>

--- a/airbyte-webapp/src/views/Settings/PreferencesForm/PreferencesForm.tsx
+++ b/airbyte-webapp/src/views/Settings/PreferencesForm/PreferencesForm.tsx
@@ -141,7 +141,7 @@ const PreferencesForm: React.FC<PreferencesFormProps> = ({
             <FormattedMessage
               id={"preferences.collectData"}
               values={{
-                docs: (...docs: React.ReactNode[]) => (
+                docs: (docs: React.ReactNode) => (
                   <DocsLink target="_blank" href={config.ui.docsLink}>
                     {docs}
                   </DocsLink>


### PR DESCRIPTION
## What

Fix https://github.com/airbytehq/airbyte/issues/10547

Fixes the react-intl upgrade from https://github.com/airbytehq/airbyte/pull/10507.

The format of react-intl changed and it's now no longer taking in a variadic (first time in their docs I've heard someone use that term in JS :D), but instead a single paramter: https://formatjs.io/docs/react-intl/upgrade-guide-5x

I've also enabled formatting of `<b>` in all messages.