### PR TITLE
Helm: Add missing hooks for serviceaccount

### DIFF
--- a/charts/airbyte/templates/_helpers.tpl
+++ b/charts/airbyte/templates/_helpers.tpl
@@ -113,21 +113,6 @@ Add environment variables to configure database values
 {{/*
 Add environment variables to configure database values
 */}}
-{{- define "airbyte.database.password" -}}
-{{- if .Values.postgresql.enabled -}}
-    {{- printf "%s" .Values.postgresql.postgresqlPassword -}}
-{{- else -}}
-    {{- if eq "" .Values.externalDatabase.existingSecret -}}
-        {{- printf "%s" .Values.externalDatabase.password -}}      
-    {{- else -}}
-        {{- printf "%s" "postgresql-password" -}}
-    {{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Add environment variables to configure database values
-*/}}
 {{- define "airbyte.database.existingsecret.key" -}}
 {{- if .Values.postgresql.enabled -}}
     {{- printf "%s" "postgresql-password" -}}

--- a/charts/airbyte/templates/_helpers.tpl
+++ b/charts/airbyte/templates/_helpers.tpl
@@ -113,6 +113,21 @@ Add environment variables to configure database values
 {{/*
 Add environment variables to configure database values
 */}}
+{{- define "airbyte.database.password" -}}
+{{- if .Values.postgresql.enabled -}}
+    {{- printf "%s" .Values.postgresql.postgresqlPassword -}}
+{{- else -}}
+    {{- if eq "" .Values.externalDatabase.existingSecret -}}
+        {{- printf "%s" .Values.externalDatabase.password -}}      
+    {{- else -}}
+        {{- printf "%s" "postgresql-password" -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Add environment variables to configure database values
+*/}}
 {{- define "airbyte.database.existingsecret.key" -}}
 {{- if .Values.postgresql.enabled -}}
     {{- printf "%s" "postgresql-password" -}}

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -24,7 +24,9 @@ fullnameOverride: ""
 ##
 serviceAccount:
   create: true
-  annotations: {}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
   name: airbyte-admin
 
 ## @param version Sets the AIRBYTE_VERSION environment variable. Defaults to Chart.AppVersion.


### PR DESCRIPTION
## What
This add the missing helm hooks to create the serviceaccount before the bootloader is created. Issue was described in #10336

## How
Updated default helm values

## 🚨 User Impact 🚨
No breaking changes.

## Tests
Tested on my EKS cluster using argocd for deployment
