### PR TITLE
Source Hubspot: cast timestamp to date/datetime

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -328,7 +328,7 @@
 - name: HubSpot
   sourceDefinitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
   dockerRepository: airbyte/source-hubspot
-  dockerImageTag: 0.1.42
+  dockerImageTag: 0.1.43
   documentationUrl: https://docs.airbyte.io/integrations/sources/hubspot
   icon: hubspot.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -3148,7 +3148,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-hubspot:0.1.42"
+- dockerImage: "airbyte/source-hubspot:0.1.43"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/hubspot"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-hubspot/Dockerfile
+++ b/airbyte-integrations/connectors/source-hubspot/Dockerfile
@@ -34,5 +34,5 @@ COPY source_hubspot ./source_hubspot
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.42
+LABEL io.airbyte.version=0.1.43
 LABEL io.airbyte.name=airbyte/source-hubspot

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
@@ -366,9 +366,9 @@ class Stream(HttpStream, ABC):
             return dt.to_datetime_string()
 
     @classmethod
-    def _cast_timestamp_to_date(cls, field_name: str, field_value: Any, declared_format: str = None) -> Any:
+    def _cast_datetime(cls, field_name: str, field_value: Any, declared_format: str = None) -> Any:
         """
-        Convert timestamp to date / datetime string
+        If format is date/date-time, but actual value is timestamp, convert timestamp to date/date-time string.
         """
         if not field_value:
             return field_value
@@ -409,7 +409,7 @@ class Stream(HttpStream, ABC):
                 return None
 
         if declared_format in ["date", "date-time"]:
-            field_value = cls._cast_timestamp_to_date(field_name, field_value, declared_format=declared_format)
+            field_value = cls._cast_datetime(field_name, field_value, declared_format=declared_format)
 
         actual_field_type = type(field_value)
         actual_field_type_name = CUSTOM_FIELD_TYPE_TO_VALUE.get(actual_field_type)

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
@@ -360,9 +360,9 @@ class Stream(HttpStream, ABC):
 
     @staticmethod
     def _convert_datetime_to_string(dt: pendulum.datetime, declared_format: str = None):
-        if declared_format == 'date':
+        if declared_format == "date":
             return dt.to_date_string()
-        elif declared_format == 'date-time':
+        elif declared_format == "date-time":
             return dt.to_datetime_string()
 
     @classmethod
@@ -384,10 +384,8 @@ class Stream(HttpStream, ABC):
         try:
             dt = pendulum.from_timestamp(int(field_value) / 1000)
             return cls._convert_datetime_to_string(dt, declared_format=declared_format)
-        except (ValueError, TypeError):
-            logger.warning(
-                f"Couldn't parse timestamp in {field_name}. Field value: {field_value}. Ex: {ex}"
-            )
+        except (ValueError, TypeError) as ex:
+            logger.warning(f"Couldn't parse timestamp in {field_name}. Field value: {field_value}. Ex: {ex}")
 
         return field_value
 

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
@@ -359,7 +359,7 @@ class Stream(HttpStream, ABC):
             yield from []
 
     @staticmethod
-    def _convert_datetime_to_string(dt: pendulum.datetime, declared_format: str = None):
+    def _convert_datetime_to_string(dt: pendulum.datetime, declared_format: str = None) -> str:
         if declared_format == "date":
             return dt.to_date_string()
         elif declared_format == "date-time":

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
@@ -359,22 +359,33 @@ class Stream(HttpStream, ABC):
             yield from []
 
     @staticmethod
-    def _cast_timestamp_to_date(field_name: str, field_value: Any, declared_format: str = None) -> Any:  # TODO
+    def _cast_timestamp_to_date(field_name: str, field_value: Any, declared_format: str = None) -> Any:
         """
         Convert timestamp to date / datetime string
         """
+        if not field_value:
+            return field_value
+
         try:
             pendulum.parse(field_value)
-        except ValueError:
-            logger.warning(f"Couldn't parse date/datetime string in {field_name}, trying to parse timestamp... Field value: {field_value}")
+            return field_value
+        except (ValueError, TypeError) as ex:
+            logger.warning(
+                f"Couldn't parse date/datetime string in {field_name}, trying to parse timestamp... Field value: {field_value}. Ex: {ex}"
+            )
 
+        try:
             dt = pendulum.from_timestamp(int(field_value) / 1000)
-            if declared_format == 'date':
-                return dt.to_date_string()
-            elif declared_format == 'date-time':
-                return dt.to_datetime_string()
+        except (ValueError, TypeError):
+            logger.warning(
+                f"Couldn't parse timestamp in {field_name}. Field value: {field_value}. Ex: {ex}"
+            )
+            return field_value
 
-        return field_value
+        if declared_format == 'date':
+            return dt.to_date_string()
+        elif declared_format == 'date-time':
+            return dt.to_datetime_string()
 
     @classmethod
     def _cast_value(cls, declared_field_types: List, field_name: str, field_value: Any, declared_format: str = None) -> Any:

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_field_type_converting.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_field_type_converting.py
@@ -87,8 +87,12 @@ def test_cast_type_if_needed(declared_field_types, field_name, field_value, form
 @pytest.mark.parametrize("field_value, declared_format, expected_casted_value",
                          [('1653696000000', 'date', '2022-05-28'),
                           ('1645608465000', 'date-time', '2022-02-23 09:27:45'),
+                          (1645608465000, 'date-time', '2022-02-23 09:27:45'),
                           ('2022-05-28', 'date', '2022-05-28'),
-                          ('2022-02-23 09:27:45', 'date-time', '2022-02-23 09:27:45')],)
+                          ('2022-02-23 09:27:45', 'date-time', '2022-02-23 09:27:45'),
+                          ('', 'date', ''),
+                          (None, 'date', None)
+                          ],)
 def test_cast_timestamp_to_date(field_value, declared_format, expected_casted_value):
     casted_value = Stream._cast_timestamp_to_date("hs_recurring_billing_end_date", field_value, declared_format=declared_format)
     assert casted_value == expected_casted_value

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_field_type_converting.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_field_type_converting.py
@@ -72,7 +72,7 @@ def test_bad_field_type_converting(field_type, expected, caplog, capsys):
         # Test casting fields with format specified
         (["null", "string"], "some_field", "", "date-time", None),
         (["string"], "some_field", "", "date-time", ""),
-        (["null", "string"], "some_field", "2020", "date-time", "2020"),
+        (["null", "string"], "some_field", "2020", "date-time", "2020-01-01 00:00:00"),
     ],
 )
 def test_cast_type_if_needed(declared_field_types, field_name, field_value, format, casted_value):
@@ -99,5 +99,5 @@ def test_cast_type_if_needed(declared_field_types, field_name, field_value, form
     ],
 )
 def test_cast_timestamp_to_date(field_value, declared_format, expected_casted_value):
-    casted_value = Stream._cast_timestamp_to_date("hs_recurring_billing_end_date", field_value, declared_format=declared_format)
+    casted_value = Stream._cast_datetime("hs_recurring_billing_end_date", field_value, declared_format=declared_format)
     assert casted_value == expected_casted_value

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_field_type_converting.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_field_type_converting.py
@@ -89,6 +89,6 @@ def test_cast_type_if_needed(declared_field_types, field_name, field_value, form
                           ('1645608465000', 'date-time', '2022-02-23 09:27:45'),
                           ('2022-05-28', 'date', '2022-05-28'),
                           ('2022-02-23 09:27:45', 'date-time', '2022-02-23 09:27:45')],)
-def test_cast_timestamp_to_date_should_convert_to_date(field_value, declared_format, expected_casted_value):
+def test_cast_timestamp_to_date(field_value, declared_format, expected_casted_value):
     casted_value = Stream._cast_timestamp_to_date("hs_recurring_billing_end_date", field_value, declared_format=declared_format)
     assert casted_value == expected_casted_value

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_field_type_converting.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_field_type_converting.py
@@ -82,3 +82,13 @@ def test_cast_type_if_needed(declared_field_types, field_name, field_value, form
         )
         == casted_value
     )
+
+
+@pytest.mark.parametrize("field_value, declared_format, expected_casted_value",
+                         [('1653696000000', 'date', '2022-05-28'),
+                          ('1645608465000', 'date-time', '2022-02-23 09:27:45'),
+                          ('2022-05-28', 'date', '2022-05-28'),
+                          ('2022-02-23 09:27:45', 'date-time', '2022-02-23 09:27:45')],)
+def test_cast_timestamp_to_date_should_convert_to_date(field_value, declared_format, expected_casted_value):
+    casted_value = Stream._cast_timestamp_to_date("hs_recurring_billing_end_date", field_value, declared_format=declared_format)
+    assert casted_value == expected_casted_value

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_field_type_converting.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_field_type_converting.py
@@ -91,7 +91,9 @@ def test_cast_type_if_needed(declared_field_types, field_name, field_value, form
                           ('2022-05-28', 'date', '2022-05-28'),
                           ('2022-02-23 09:27:45', 'date-time', '2022-02-23 09:27:45'),
                           ('', 'date', ''),
-                          (None, 'date', None)
+                          (None, 'date', None),
+                          ('2022-02-23 09:27:45', 'date', '2022-02-23'),
+                          ('2022-05-28', 'date-time', '2022-05-28 00:00:00')
                           ],)
 def test_cast_timestamp_to_date(field_value, declared_format, expected_casted_value):
     casted_value = Stream._cast_timestamp_to_date("hs_recurring_billing_end_date", field_value, declared_format=declared_format)

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_field_type_converting.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_field_type_converting.py
@@ -84,17 +84,20 @@ def test_cast_type_if_needed(declared_field_types, field_name, field_value, form
     )
 
 
-@pytest.mark.parametrize("field_value, declared_format, expected_casted_value",
-                         [('1653696000000', 'date', '2022-05-28'),
-                          ('1645608465000', 'date-time', '2022-02-23 09:27:45'),
-                          (1645608465000, 'date-time', '2022-02-23 09:27:45'),
-                          ('2022-05-28', 'date', '2022-05-28'),
-                          ('2022-02-23 09:27:45', 'date-time', '2022-02-23 09:27:45'),
-                          ('', 'date', ''),
-                          (None, 'date', None),
-                          ('2022-02-23 09:27:45', 'date', '2022-02-23'),
-                          ('2022-05-28', 'date-time', '2022-05-28 00:00:00')
-                          ],)
+@pytest.mark.parametrize(
+    "field_value, declared_format, expected_casted_value",
+    [
+        ("1653696000000", "date", "2022-05-28"),
+        ("1645608465000", "date-time", "2022-02-23 09:27:45"),
+        (1645608465000, "date-time", "2022-02-23 09:27:45"),
+        ("2022-05-28", "date", "2022-05-28"),
+        ("2022-02-23 09:27:45", "date-time", "2022-02-23 09:27:45"),
+        ("", "date", ""),
+        (None, "date", None),
+        ("2022-02-23 09:27:45", "date", "2022-02-23"),
+        ("2022-05-28", "date-time", "2022-05-28 00:00:00"),
+    ],
+)
 def test_cast_timestamp_to_date(field_value, declared_format, expected_casted_value):
     casted_value = Stream._cast_timestamp_to_date("hs_recurring_billing_end_date", field_value, declared_format=declared_format)
     assert casted_value == expected_casted_value

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -112,6 +112,7 @@ If you are using Oauth, most of the streams require the appropriate [scopes](htt
 
 | Version | Date       | Pull Request | Subject                                                                                                                                        |
 |:--------|:-----------| :--- |:-----------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.1.43  | 2022-02-24 | [10576](https://github.com/airbytehq/airbyte/pull/10576) | Cast timestamp to date/datetime|
 | 0.1.42  | 2022-02-22 | [10492](https://github.com/airbytehq/airbyte/pull/10492) | Add `date-time` format to datetime fields|
 | 0.1.41  | 2022-02-21 | [10177](https://github.com/airbytehq/airbyte/pull/10177) | Migrate to CDK |
 | 0.1.40  | 2022-02-10 | [10142](https://github.com/airbytehq/airbyte/pull/10142) | Add associations to ticket stream |


### PR DESCRIPTION
## What
Resolves #9264 and #9014

The field format is `"format": "date"`, but the API returns timestamp in milliseconds. That's why normalization fails. 
`"hs_recurring_billing_end_date": "1653696000000"`

![image](https://user-images.githubusercontent.com/93112548/155150271-92ba9262-f323-45ca-b70b-dddcd369db4f.png)

Schema in discovered catalog
![image](https://user-images.githubusercontent.com/93112548/155269855-57a63b03-be57-443e-9044-3e1325c26853.png)

Hubspot properties API response  (`properties/v2/line_item/properties`): 
![image](https://user-images.githubusercontent.com/93112548/155269942-683000e1-9e77-40c6-8fef-e9783cc2abeb.png)

## How

As there can be mismatch in field type (format) and its value in Hubscpot's properties API, we can fix this issue by checking field format (in airbyte stream schema) and if it's date-time or date, but actual value is timestamp, convert timestamp to appropriate format (date or date-time in string).

## Recommended reading order
1. `source-hubspot/source_hubspot/streams.py`
2. `source-hubspot/unit_tests/test_field_type_converting.py`

