### PR TITLE
Add a version check in order to make sure that we avoid having a version conflict

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -520,8 +520,8 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
   private static final int CURRENT_VERSION = 1;
 
   /**
-   * This is checking if there was a version bump when the workflow is being reloaded.
-   * If so, it will set the job as fail and continue with a new run.
+   * This is checking if there was a version bump when the workflow is being reloaded. If so, it will
+   * set the job as fail and continue with a new run.
    */
   private void restartIfNewTemporalVersion(ConnectionUpdaterInput connectionUpdaterInput) {
     int version = Workflow.getVersion("connection_manager_workflow", Workflow.DEFAULT_VERSION, CURRENT_VERSION);
@@ -532,4 +532,5 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
       prepareForNextRunAndContinueAsNew(connectionUpdaterInput);
     }
   }
+
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -523,7 +523,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
    * This is checking if there was a version bump when the workflow is being reloaded. If so, it will
    * set the job as fail and continue with a new run.
    */
-  private void restartIfNewTemporalVersion(ConnectionUpdaterInput connectionUpdaterInput) {
+  private void restartIfNewTemporalVersion(final ConnectionUpdaterInput connectionUpdaterInput) {
     int version = Workflow.getVersion("connection_manager_workflow", Workflow.DEFAULT_VERSION, CURRENT_VERSION);
 
     if (version != CURRENT_VERSION) {


### PR DESCRIPTION
## What

This is adding a version check in the temporal workflow. It will make the running sync to fail and then continue a new attempt.