### PR TITLE
Fix the toggle design

### DIFF
--- a/airbyte-webapp/src/components/base/Toggle/Toggle.tsx
+++ b/airbyte-webapp/src/components/base/Toggle/Toggle.tsx
@@ -42,7 +42,7 @@ const Slider = styled.span<{ small?: boolean }>`
     transition: 0.3s;
     border-radius: 50%;
 
-    input:checked + & {
+    input:checked + && {
       transform: translateX(${({ small }) => (small ? 10 : 18)}px);
     }
   }


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/10610

This was happening whenever a small Toggle and a large one would be loaded, e.g. by navigating from the Replication page to the connection or overview page.

The `&` in styled components refer to **all** instances of the parent element, while `&&` refers to an instance of the component (https://styled-components.com/docs/basics#pseudoelements-pseudoselectors-and-nesting). Thus the `&` was causing to apply the `small` styles to all `:before` elements of this component.