### PR TITLE
exclude workers test from connectors builds on CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -112,7 +112,7 @@ jobs:
         run: SUB_BUILD=CONNECTORS_BASE ./gradlew format --scan --info --stacktrace
 
       - name: Build
-        run: SUB_BUILD=CONNECTORS_BASE ./gradlew build --scan
+        run: SUB_BUILD=CONNECTORS_BASE ./gradlew build -x :airbyte-workers:test --scan
 
       - name: Ensure no file change
         run: git --no-pager diff && test -z "$(git --no-pager diff)"


### PR DESCRIPTION
99% of the time, if platforms is causing a failure for the connectors build, it's happening with a transient failure in `:airbyte-workers:test`. The other 1% is actual breaking changes (like in terms of interface or something) which would result in a connectors build failure even after this change.

The workers tests are run for all of the other platforms-related builds so it should still be obvious to the platforms team when there is a problem with these tests. It will just make it easier to attribute the cause of the failure, especially since `--scan` [isn't available for connectors builds](https://github.com/airbytehq/airbyte/issues/10608) at the moment. 