### PR TITLE
Fix doc links/loading

### DIFF
--- a/airbyte-webapp/src/hooks/services/useDocumentation.ts
+++ b/airbyte-webapp/src/hooks/services/useDocumentation.ts
@@ -9,9 +9,20 @@ export const documentationKeys = {
   text: (integrationUrl: string) => ["document", integrationUrl] as const,
 };
 
-const DOCS_URL = "https://docs.airbyte.io";
+const DOCS_URL = /^https:\/\/docs\.airbyte\.(io|com)/;
 
-const useDocumentation = (documentationUrl: string): UseDocumentationResult => {
+export const getDocumentationType = (
+  documentationUrl: string
+): "external" | "internal" | "none" => {
+  if (!documentationUrl) {
+    return "none";
+  }
+  return DOCS_URL.test(documentationUrl) ? "internal" : "external";
+};
+
+export const useDocumentation = (
+  documentationUrl: string
+): UseDocumentationResult => {
   const { integrationUrl } = useConfig();
   const url = documentationUrl.replace(DOCS_URL, integrationUrl) + ".md";
 
@@ -27,5 +38,3 @@ const useDocumentation = (documentationUrl: string): UseDocumentationResult => {
     }
   );
 };
-
-export default useDocumentation;


### PR DESCRIPTION
## What

Fix #10412

This will now make sure we treat the old `docs.airbyte.io` and the new `docs.airbyte.com` URL as internal URLs and try to load those as markdown files internally. Since we have some connectors having full external documentations, those will now not try to open the sideview but instead directly link to the documentation.

As a bonus this PR also fixes the link being a `span` so far and make it a proper button/a element.