### PR TITLE
Log pod state if init pod wait condition times out (for debugging transient test issue)

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -32,6 +32,7 @@ import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import java.io.IOException;
 import java.io.InputStream;
@@ -300,8 +301,18 @@ public class KubePodProcess extends Process implements KubePod {
    */
   private static void waitForInitPodToRun(final KubernetesClient client, final Pod podDefinition) throws InterruptedException {
     LOGGER.info("Waiting for init container to be ready before copying files...");
-    client.pods().inNamespace(podDefinition.getMetadata().getNamespace()).withName(podDefinition.getMetadata().getName())
-        .waitUntilCondition(p -> p.getStatus().getInitContainerStatuses().size() != 0, 5, TimeUnit.MINUTES);
+    final PodResource<Pod> pod = client.pods().inNamespace(podDefinition.getMetadata().getNamespace()).withName(podDefinition.getMetadata().getName());
+    try {
+      pod.waitUntilCondition(p -> p.getStatus().getInitContainerStatuses().size() != 0, 5, TimeUnit.MINUTES);
+    } catch (InterruptedException e) {
+      LOGGER.error("Init pod not found after 5 minutes");
+      LOGGER.error("Pod search executed in namespace {} for pod name {} resulted in: {}",
+          podDefinition.getMetadata().getNamespace(),
+          podDefinition.getMetadata().getName(),
+          pod.get().toString()
+          );
+      throw e;
+    }
     LOGGER.info("Init container present..");
     client.pods().inNamespace(podDefinition.getMetadata().getNamespace()).withName(podDefinition.getMetadata().getName())
         .waitUntilCondition(p -> p.getStatus().getInitContainerStatuses().get(0).getState().getRunning() != null, 5, TimeUnit.MINUTES);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -301,7 +301,8 @@ public class KubePodProcess extends Process implements KubePod {
    */
   private static void waitForInitPodToRun(final KubernetesClient client, final Pod podDefinition) throws InterruptedException {
     LOGGER.info("Waiting for init container to be ready before copying files...");
-    final PodResource<Pod> pod = client.pods().inNamespace(podDefinition.getMetadata().getNamespace()).withName(podDefinition.getMetadata().getName());
+    final PodResource<Pod> pod =
+        client.pods().inNamespace(podDefinition.getMetadata().getNamespace()).withName(podDefinition.getMetadata().getName());
     try {
       pod.waitUntilCondition(p -> p.getStatus().getInitContainerStatuses().size() != 0, 5, TimeUnit.MINUTES);
     } catch (InterruptedException e) {
@@ -309,8 +310,7 @@ public class KubePodProcess extends Process implements KubePod {
       LOGGER.error("Pod search executed in namespace {} for pod name {} resulted in: {}",
           podDefinition.getMetadata().getNamespace(),
           podDefinition.getMetadata().getName(),
-          pod.get().toString()
-          );
+          pod.get().toString());
       throw e;
     }
     LOGGER.info("Init container present..");

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Timeout;
 // requires kube running locally to run. If using Minikube it requires MINIKUBE=true
 // Must have a timeout on this class because it tests child processes that may misbehave; otherwise
 // this can hang forever during failures.
-@Timeout(value = 5,
+@Timeout(value = 6,
          unit = TimeUnit.MINUTES)
 public class KubePodProcessIntegrationTest {
 


### PR DESCRIPTION
I was running into transient timeouts in the KubePodProcessIntegrationTests in [this CI build](https://github.com/airbytehq/airbyte/runs/5312880637?check_suite_focus=true). This PR should log detailed pod state to aid with debugging these transient issues (and also increases the test timeout from 5 to 6 minutes so that the test doesn't terminate before the pod wait timeout occurs)

Probably won't actually merge this, just want to see if I can reproduce the timeout and get some logs