### PR TITLE
upgrade temporal sdk to 1.8.1

### DIFF
--- a/airbyte-bootloader/build.gradle
+++ b/airbyte-bootloader/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(':airbyte-scheduler:persistence')
     implementation project(':airbyte-scheduler:models')
 
-    implementation 'io.temporal:temporal-sdk:1.6.0'
+    implementation 'io.temporal:temporal-sdk:1.8.1'
     implementation "org.flywaydb:flyway-core:7.14.0"
 
     testImplementation "org.testcontainers:postgresql:1.15.3"

--- a/airbyte-config/persistence/build.gradle
+++ b/airbyte-config/persistence/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(':airbyte-protocol:models')
     implementation project(':airbyte-config:models')
     implementation project(':airbyte-json-validation')
-    implementation 'com.google.cloud:google-cloud-secretmanager:2.0.5'
+    implementation 'com.google.cloud:google-cloud-secretmanager:2.1.1'
     testImplementation "org.testcontainers:postgresql:1.15.3"
     testImplementation project(':airbyte-test-utils')
     integrationTestJavaImplementation project(':airbyte-config:persistence')

--- a/airbyte-config/persistence/build.gradle
+++ b/airbyte-config/persistence/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(':airbyte-protocol:models')
     implementation project(':airbyte-config:models')
     implementation project(':airbyte-json-validation')
-    implementation 'com.google.cloud:google-cloud-secretmanager:2.1.1'
+    implementation 'com.google.cloud:google-cloud-secretmanager:2.0.5'
     testImplementation "org.testcontainers:postgresql:1.15.3"
     testImplementation project(':airbyte-test-utils')
     integrationTestJavaImplementation project(':airbyte-config:persistence')

--- a/airbyte-container-orchestrator/build.gradle
+++ b/airbyte-container-orchestrator/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 dependencies {
     implementation 'io.fabric8:kubernetes-client:5.3.1'
-    implementation 'io.temporal:temporal-sdk:1.0.4'
     implementation 'org.apache.commons:commons-lang3:3.11'
     implementation 'org.apache.commons:commons-text:1.9'
     implementation 'org.eclipse.jetty:jetty-server:9.4.31.v20200723'

--- a/airbyte-scheduler/app/build.gradle
+++ b/airbyte-scheduler/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation 'io.fabric8:kubernetes-client:5.9.0'
-    implementation 'io.temporal:temporal-sdk:1.6.0'
+    implementation 'io.temporal:temporal-sdk:1.8.1'
 
     implementation project(':airbyte-analytics')
     implementation project(':airbyte-api')

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -47,7 +47,7 @@ publishing {
 }
 
 dependencies {
-    implementation 'io.temporal:temporal-sdk:1.6.0'
+    implementation 'io.temporal:temporal-sdk:1.8.1'
 
     implementation 'org.apache.cxf:cxf-core:3.4.2'
 

--- a/airbyte-tests/build.gradle
+++ b/airbyte-tests/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
     acceptanceTestsImplementation 'com.fasterxml.jackson.core:jackson-databind'
     acceptanceTestsImplementation 'io.github.cdimascio:java-dotenv:3.0.0'
-    acceptanceTestsImplementation 'io.temporal:temporal-sdk:1.6.0'
+    acceptanceTestsImplementation 'io.temporal:temporal-sdk:1.8.1'
     acceptanceTestsImplementation 'org.apache.commons:commons-csv:1.4'
     acceptanceTestsImplementation 'org.testcontainers:postgresql:1.15.3'
     acceptanceTestsImplementation 'org.postgresql:postgresql:42.2.18'

--- a/airbyte-workers/build.gradle
+++ b/airbyte-workers/build.gradle
@@ -31,8 +31,8 @@ dependencies {
     implementation project(':airbyte-scheduler:persistence')
     implementation project(':airbyte-scheduler:models')
 
-    testImplementation 'io.temporal:temporal-testing:1.6.0'
-    testImplementation 'io.temporal:temporal-testing-junit5:1.5.0'
+    testImplementation 'io.temporal:temporal-testing:1.8.1'
+    testImplementation 'io.temporal:temporal-testing-junit5:1.8.1'
     testImplementation "org.flywaydb:flyway-core:7.14.0"
     testImplementation 'org.mockito:mockito-inline:4.0.0'
     testImplementation 'org.postgresql:postgresql:42.2.18'

--- a/airbyte-workers/build.gradle
+++ b/airbyte-workers/build.gradle
@@ -12,7 +12,7 @@ configurations {
 
 dependencies {
     implementation 'io.fabric8:kubernetes-client:5.3.1'
-    implementation 'io.temporal:temporal-sdk:1.6.0'
+    implementation 'io.temporal:temporal-sdk:1.8.1'
     implementation 'org.apache.ant:ant:1.10.10'
     implementation 'org.apache.commons:commons-lang3:3.11'
     implementation 'org.apache.commons:commons-text:1.9'

--- a/airbyte-workers/build.gradle
+++ b/airbyte-workers/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation project(':airbyte-scheduler:models')
 
     testImplementation 'io.temporal:temporal-testing:1.8.1'
-    testImplementation 'io.temporal:temporal-testing-junit5:1.8.1'
+    testImplementation 'io.temporal:temporal-testing-junit5:1.5.0' // versioned separately from rest of temporal
     testImplementation "org.flywaydb:flyway-core:7.14.0"
     testImplementation 'org.mockito:mockito-inline:4.0.0'
     testImplementation 'org.postgresql:postgresql:42.2.18'


### PR DESCRIPTION
Commits: https://github.com/temporalio/sdk-java/compare/v1.6.0...v1.8.1

Nothing critical here, just want to make sure we aren't getting too far behind.