### PR TITLE
🎉  Server logging S3 credentials: switch to DefaultCredentialsProvider

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -203,8 +203,6 @@ public class EnvConfigs implements Configs {
     } else if (getEnv(LogClientSingleton.S3_LOG_BUCKET_REGION) != null && !getEnv(LogClientSingleton.S3_LOG_BUCKET_REGION).isBlank()) {
       return Optional.of(CloudStorageConfigs.s3(new S3Config(
           getEnvOrDefault(LogClientSingleton.S3_LOG_BUCKET, ""),
-          getEnvOrDefault(LogClientSingleton.AWS_ACCESS_KEY_ID, ""),
-          getEnvOrDefault(LogClientSingleton.AWS_SECRET_ACCESS_KEY, ""),
           getEnvOrDefault(LogClientSingleton.S3_LOG_BUCKET_REGION, ""))));
     } else {
       return Optional.empty();
@@ -225,8 +223,6 @@ public class EnvConfigs implements Configs {
     } else if (getEnv(STATE_STORAGE_S3_REGION) != null) {
       return Optional.of(CloudStorageConfigs.s3(new S3Config(
           getEnvOrDefault(STATE_STORAGE_S3_BUCKET_NAME, ""),
-          getEnvOrDefault(STATE_STORAGE_S3_ACCESS_KEY, ""),
-          getEnvOrDefault(STATE_STORAGE_S3_SECRET_ACCESS_KEY, ""),
           getEnvOrDefault(STATE_STORAGE_S3_REGION, ""))));
     } else {
       return Optional.empty();

--- a/airbyte-config/models/src/main/java/io/airbyte/config/storage/CloudStorageConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/storage/CloudStorageConfigs.java
@@ -131,6 +131,16 @@ public class CloudStorageConfigs {
       return region;
     }
 
+    @Override
+    public String getAwsAccessKey() {
+      throw new IllegalArgumentException("Should not call getAwsAccessKey for AWS S3");
+    }
+
+    @Override
+    public String getAwsSecretAccessKey() {
+      throw new IllegalArgumentException("Should not call getAwsSecretAccessKey for AWS S3");
+    }
+
   }
 
   public static class MinioConfig extends S3ApiWorkerStorageConfig {

--- a/airbyte-config/models/src/main/java/io/airbyte/config/storage/CloudStorageConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/storage/CloudStorageConfigs.java
@@ -94,6 +94,10 @@ public class CloudStorageConfigs {
     private final String awsAccessKey;
     private final String awsSecretAccessKey;
 
+    protected S3ApiWorkerStorageConfig(final String bucketName) {
+      this(bucketName, null, null);
+    }
+
     protected S3ApiWorkerStorageConfig(final String bucketName, final String awsAccessKey, final String awsSecretAccessKey) {
       this.bucketName = bucketName;
       this.awsAccessKey = awsAccessKey;
@@ -118,8 +122,8 @@ public class CloudStorageConfigs {
 
     private final String region;
 
-    public S3Config(final String bucketName, final String awsAccessKey, final String awsSecretAccessKey, final String region) {
-      super(bucketName, awsAccessKey, awsSecretAccessKey);
+    public S3Config(final String bucketName, final String region) {
+      super(bucketName, null, null);
       this.region = region;
     }
 

--- a/airbyte-config/models/src/main/java/io/airbyte/config/storage/DefaultS3ClientFactory.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/storage/DefaultS3ClientFactory.java
@@ -8,7 +8,7 @@ import com.google.common.base.Preconditions;
 import io.airbyte.config.storage.CloudStorageConfigs.S3ApiWorkerStorageConfig;
 import io.airbyte.config.storage.CloudStorageConfigs.S3Config;
 import java.util.function.Supplier;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -33,16 +33,13 @@ public class DefaultS3ClientFactory implements Supplier<S3Client> {
   }
 
   static void validateBase(final S3ApiWorkerStorageConfig s3BaseConfig) {
-    Preconditions.checkArgument(!s3BaseConfig.getAwsAccessKey().isBlank());
-    Preconditions.checkArgument(!s3BaseConfig.getAwsSecretAccessKey().isBlank());
-    Preconditions.checkArgument(!s3BaseConfig.getBucketName().isBlank());
     Preconditions.checkArgument(!s3BaseConfig.getBucketName().isBlank());
   }
 
   @Override
   public S3Client get() {
     final var builder = S3Client.builder();
-    builder.credentialsProvider(() -> AwsBasicCredentials.create(s3Config.getAwsAccessKey(), s3Config.getAwsSecretAccessKey()));
+    builder.credentialsProvider(DefaultCredentialsProvider.builder().build());
     builder.region(Region.of(s3Config.getRegion()));
     return builder.build();
   }

--- a/airbyte-config/models/src/test/java/io/airbyte/config/helpers/CloudLogsClientTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/helpers/CloudLogsClientTest.java
@@ -29,8 +29,6 @@ public class CloudLogsClientTest {
   public void createCloudLogClientTestAws() {
     final var configs = new LogConfigs(CloudStorageConfigs.s3(new S3Config(
         "test-bucket",
-        "access-key",
-        "access-key-secret",
         "us-east-1")));
 
     assertEquals(S3Logs.class, CloudLogs.createCloudLogClient(configs).getClass());

--- a/airbyte-config/models/src/test/java/io/airbyte/config/helpers/S3LogsTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/helpers/S3LogsTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -29,15 +30,13 @@ public class S3LogsTest {
 
   private static final LogConfigs logConfigs = new LogConfigs(CloudStorageConfigs.s3(new CloudStorageConfigs.S3Config(
       System.getenv(LogClientSingleton.S3_LOG_BUCKET),
-      System.getenv(LogClientSingleton.AWS_ACCESS_KEY_ID),
-      System.getenv(LogClientSingleton.AWS_SECRET_ACCESS_KEY),
       System.getenv(LogClientSingleton.S3_LOG_BUCKET_REGION))));
 
   private S3Client s3Client;
 
   @BeforeEach
   void setup() {
-    s3Client = S3Client.builder().region(REGION).build();
+    s3Client = S3Client.builder().region(REGION).credentialsProvider(DefaultCredentialsProvider.create()).build();
     generatePaginateTestFiles();
   }
 

--- a/airbyte-config/models/src/test/java/io/airbyte/config/storage/DefaultS3ClientFactoryTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/storage/DefaultS3ClientFactoryTest.java
@@ -15,11 +15,8 @@ public class DefaultS3ClientFactoryTest {
   @Test
   public void testS3() {
     final var s3Config = Mockito.mock(S3Config.class);
-    Mockito.when(s3Config.getAwsAccessKey()).thenReturn("access-key");
-    Mockito.when(s3Config.getAwsSecretAccessKey()).thenReturn("access-key-secret");
     Mockito.when(s3Config.getBucketName()).thenReturn("test-bucket");
     Mockito.when(s3Config.getRegion()).thenReturn("us-east-1");
-
     new DefaultS3ClientFactory(s3Config).get();
   }
 
@@ -27,12 +24,20 @@ public class DefaultS3ClientFactoryTest {
   public void testS3RegionNotSet() {
     final var s3Config = Mockito.mock(S3Config.class);
     // Missing bucket and access key.
-    Mockito.when(s3Config.getAwsAccessKey()).thenReturn("");
-    Mockito.when(s3Config.getAwsSecretAccessKey()).thenReturn("access-key-secret");
     Mockito.when(s3Config.getBucketName()).thenReturn("");
     Mockito.when(s3Config.getRegion()).thenReturn("");
 
     assertThrows(IllegalArgumentException.class, () -> new DefaultS3ClientFactory(s3Config));
+  }
+
+  @Test
+  public void testIAMPropertiesFail() {
+    final var s3Config = new S3Config("test-bucket", "us-east-1");
+
+    // Calling these properties should intentionally fail for AWS S3. These should be fetched
+    // via DefaultCredentialsProvider.
+    assertThrows(IllegalArgumentException.class, () -> s3Config.getAwsAccessKey());
+    assertThrows(IllegalArgumentException.class, () -> s3Config.getAwsSecretAccessKey());
   }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -256,6 +256,7 @@ subprojects {
 
         implementation(platform("com.fasterxml.jackson:jackson-bom:2.13.0"))
         implementation(platform("org.glassfish.jersey:jersey-bom:2.31"))
+        implementation(platform("software.amazon.awssdk:bom:2.17.136"))
 
 
         // version is handled by "com.fasterxml.jackson:jackson-bom:2.10.4", so we do not explicitly set it here.
@@ -287,10 +288,12 @@ subprojects {
 
         // Dependencies for logging to cloud storage, as well as the various clients used to do so.
         implementation 'com.therealvan:appender-log4j2:3.6.0'
-        implementation 'com.amazonaws:aws-java-sdk-s3:1.12.6'
         implementation 'com.google.cloud:google-cloud-storage:2.2.2'
 
-        implementation 'software.amazon.awssdk:s3:2.16.84'
+        implementation 'software.amazon.awssdk:s3'
+        implementation 'software.amazon.awssdk:sts'
+        implementation 'software.amazon.awssdk:auth'
+        implementation 'software.amazon.awssdk:iam'
 
         // Lombok dependencies
         compileOnly 'org.projectlombok:lombok:1.18.22'

--- a/docs/operator-guides/configuring-airbyte.md
+++ b/docs/operator-guides/configuring-airbyte.md
@@ -73,7 +73,20 @@ The following variables are relevant to both Docker and Kubernetes.
 6. `JOB_MAIN_CONTAINER_MEMORY_LIMIT` - Define the job container's maximum RAM usage. Units follow either Docker or Kubernetes, depending on the deployment. Defaults to none.
 
 #### Logging
+
+Note that Airbyte does not support logging to separate Cloud Storage providers.
+
+Please see [here](https://docs.airbyte.com/deploying-airbyte/on-kubernetes#configure-logs) for more information on configuring Kuberentes logging.
+
 1. `LOG_LEVEL` - Define log levels. Defaults to INFO. This value is expected to be one of the various Log4J log levels.
+2. `GCS_LOG_BUCKET` - Define the GCS bucket to store logs.
+3. `GOOGLE_APPLICATION_CREDENTIALS` - Define the GCS credentials to use to write to the GCS bucket.
+4. `S3_LOG_BUCKET` - Define the S3 bucket to store logs.
+5. `S3_LOG_BUCKET_REGION` - Define the S3 region the S3 log bucket is in.
+6. `S3_MINIO_ENDPOINT` - Define the url Minio is hosted at so Airbyte can use Minio to store logs. Set to empty string if logging to S3.
+7. `S3_PATH_STYLE_ACCESS` - Set to `true` if using Minio to store logs. Empty otherwise.
+
+See **AWS** below for information on providing AWS credentials for access to S3.
 
 #### Worker
 1. `MAX_SPEC_WORKERS` - Define the maximum number of Spec workers each Airbyte Worker container can support. Defaults to 5.
@@ -87,6 +100,25 @@ The following variables are relevant to both Docker and Kubernetes.
 2. `MINIMUM_WORKSPACE_RETENTION_DAYS` - Defines the minimum configuration file age for sweeping. The Scheduler will do it's best to now sweep files younger than this. Defaults to 1 day.
 3. `MAXIMUM_WORKSPACE_RETENTION_DAYS` - Defines the oldest un-swept configuration file age. Files older than this will definitely be swept. Defaults to 60 days.
 4. `MAXIMUM_WORKSPACE_SIZE_MB` - Defines the workspace size sweeping will continue until. Defaults to 5GB.
+
+### AWS
+
+The Airbyte server makes use of the AWS Java SDK's [DefaultCredentialsProvider](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html) to utilise AWS credentials.
+
+From the [AWS documentation](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html):
+
+> AWS credentials provider chain that looks for credentials in this order:
+> * Java System Properties - aws.accessKeyId and aws.secretAccessKey
+> * Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+> * Web Identity Token credentials from system properties or environment variables
+> * Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs and the AWS CLI
+> * Credentials delivered through the Amazon EC2 container service if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" environment variable is set and security manager has permission to access the variable,
+> * Instance profile credentials delivered through the Amazon EC2 metadata service
+
+**NOTE**
+
+This applies ONLY to the server at the moment. There are a number of AWS connectors that need to be updated use this credential provider.
+In the meantime, those components and services must be configured to use the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.
 
 ### Docker-Only
 1. `WORKSPACE_DOCKER_MOUNT` - Defines the name of the Airbyte docker volume.
@@ -106,16 +138,3 @@ The following variables are relevant to both Docker and Kubernetes.
 
 #### Worker
 1. `TEMPORAL_WORKER_PORTS` - Define the local ports the Airbyte Worker pod uses to connect to the various Job pods. Port 9001 - 9040 are exposed by default in the Kustomize deployments.
-
-#### Logging
-Note that Airbyte does not support logging to separate Cloud Storage providers.
-
-Please see [here](https://docs.airbyte.com/deploying-airbyte/on-kubernetes#configure-logs) for more information on configuring Kuberentes logging.
-
-1. `GCS_LOG_BUCKET` - Define the GCS bucket to store logs.
-2. `S3_BUCKET` - Define the S3 bucket to store logs.
-3. `S3_RREGION` - Define the S3 region the S3 log bucket is in.
-4. `S3_AWS_KEY` - Define the key used to access the S3 log bucket.
-5. `S3_AWS_SECRET` - Define the secret used to access the S3 log bucket.
-6. `S3_MINIO_ENDPOINT` - Define the url Minio is hosted at so Airbyte can use Minio to store logs.
-7. `S3_PATH_STYLE_ACCESS` - Set to `true` if using Minio to store logs. Empty otherwise.


### PR DESCRIPTION
## What

Resolves #10570: Switches the means by which the AWS credentials for setting up the logging S3 client are collected on startup.

## How

For AWS S3 specifically (Minio and GCP are unaffected by this change), the way that we now fetch the AWS credentials switches from `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables to `software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider`. This gives the platform and operators greater flexibility in terms of how the platform is run on AWS, and enables AWS EKS/IRSA deployments.

This change is transparent to how current implementations (and tests) run the Airbyte services. By switching to `DefaultCredentialsProvider`, there is a _chain_ of discovering credentials in addition to the existing usage of environment variables.

Additional AWS dependencies have been added to the root `build.gradle` to support the default provider chain.

**Note:** There are a lot of connectors in the solution where this same change needs to be applied. This change is focused _just_ on the server component.

## Recommended reading order
1. `airbyte-config/models/src/main/java/io/airbyte/config/storage/DefaultS3ClientFactory.java`
2. `airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java`

## 🚨 User Impact 🚨

No user-facing change.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

### Community member or Airbyter

- [x] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

## Tests

<details><summary><strong>Unit</strong></summary>

```
> Task :buildSrc:extractPluginRequests UP-TO-DATE
> Task :buildSrc:generatePluginAdapters UP-TO-DATE
> Task :buildSrc:compileJava UP-TO-DATE
> Task :buildSrc:compileGroovy UP-TO-DATE
> Task :buildSrc:compileGroovyPlugins UP-TO-DATE
> Task :buildSrc:pluginDescriptors UP-TO-DATE
> Task :buildSrc:processResources UP-TO-DATE
> Task :buildSrc:classes UP-TO-DATE
> Task :buildSrc:jar UP-TO-DATE
> Task :buildSrc:assemble UP-TO-DATE
> Task :buildSrc:pluginUnderTestMetadata UP-TO-DATE
> Task :buildSrc:compileTestJava NO-SOURCE
> Task :buildSrc:compileTestGroovy NO-SOURCE
> Task :buildSrc:processTestResources NO-SOURCE
> Task :buildSrc:testClasses UP-TO-DATE
> Task :buildSrc:test NO-SOURCE
> Task :buildSrc:validatePlugins UP-TO-DATE
> Task :buildSrc:check UP-TO-DATE
> Task :buildSrc:build UP-TO-DATE
> Task :airbyte-json-validation:processResources NO-SOURCE
> Task :airbyte-protocol:models:processResources UP-TO-DATE
> Task :airbyte-protocol:models:generateJsonSchema2Pojo UP-TO-DATE
> Task :airbyte-config:models:processResources UP-TO-DATE
> Task :airbyte-config:models:generateJsonSchema2Pojo UP-TO-DATE
> Task :airbyte-config:models:processTestResources NO-SOURCE
> Task :airbyte-commons:compileJava UP-TO-DATE
> Task :airbyte-commons:processResources UP-TO-DATE
> Task :airbyte-commons:classes UP-TO-DATE
> Task :airbyte-commons:jar UP-TO-DATE
> Task :airbyte-json-validation:compileJava UP-TO-DATE
> Task :airbyte-json-validation:classes UP-TO-DATE
> Task :airbyte-json-validation:jar UP-TO-DATE
> Task :airbyte-protocol:models:compileJava UP-TO-DATE
> Task :airbyte-protocol:models:classes UP-TO-DATE
> Task :airbyte-protocol:models:jar UP-TO-DATE
> Task :airbyte-config:models:compileJava UP-TO-DATE
> Task :airbyte-config:models:classes UP-TO-DATE
> Task :airbyte-config:models:compileTestJava UP-TO-DATE
> Task :airbyte-config:models:testClasses UP-TO-DATE
> Task :airbyte-config:models:test
Mar 02, 2022 10:24:08 PM org.junit.platform.launcher.core.EngineDiscoveryOrchestrator lambda$logTestDescriptorExclusionReasons$7
INFO: 0 containers and 5 tests were excluded because tags match tag expression(s): [log4j2-config,logger-client]
ConfigSchemaTest > testFile() PASSED
ConfigSchemaTest > testPrepareKnownSchemas() PASSED
DataTypeEnumTest > testConversionFromJsonSchemaPrimitiveToDataType() PASSED
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable JOB_KUBE_NODE_SELECTORS: ''
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable DISCOVER_JOB_KUBE_NODE_SELECTORS: ''
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable PUBLISH_METRICS: 'false'
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable PUBLISH_METRICS: 'false'
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable SPEC_JOB_KUBE_NODE_SELECTORS: ''
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable CHECK_JOB_KUBE_NODE_SELECTORS: ''
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable TRACKING_STRATEGY: 'LOGGING'
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(lambda$getTrackingStrategy$17):680 - abc not recognized, defaulting to LOGGING
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable WORKSPACE_DOCKER_MOUNT: 'abc/def'
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable DOCKER_NETWORK: 'host'
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable LOCAL_DOCKER_MOUNT: 'abc/def'
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable JOB_KUBE_TOLERATIONS: ''
2022-03-02 11:24:10 WARN i.a.c.EnvConfigs(parseToleration):454 - Ignoring toleration key=k,value=v, missing one of key,effect or operator
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable CHECK_JOB_MAIN_CONTAINER_MEMORY_REQUEST: '1'
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable CHECK_JOB_MAIN_CONTAINER_CPU_REQUEST: '1'
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable CHECK_JOB_MAIN_CONTAINER_CPU_LIMIT: '1'
2022-03-02 11:24:10 INFO i.a.c.EnvConfigs(getEnvOrDefault):827 - Using default value for environment variable CHECK_JOB_MAIN_CONTAINER_MEMORY_LIMIT: '1'
EnvConfigsTest > testAirbyteVersion() PASSED
EnvConfigsTest > testGetDatabaseUrl() PASSED
EnvConfigsTest > testEmptyEnvMapRetrieval() PASSED
EnvConfigsTest > testJobKubeNodeSelectors() PASSED
EnvConfigsTest > testWorkspaceRoot() PASSED
EnvConfigsTest > ensureGetEnvBehavior() PASSED
EnvConfigsTest > testLocalRoot() PASSED
EnvConfigsTest > testDiscoverKubeNodeSelectors() PASSED
EnvConfigsTest > testPublishMetrics() PASSED
EnvConfigsTest > testConfigRoot() PASSED
EnvConfigsTest > testGetDatabasePassword() PASSED
EnvConfigsTest > testSpecKubeNodeSelectors() PASSED
EnvConfigsTest > testAirbyteRole() PASSED
EnvConfigsTest > testCheckKubeNodeSelectors() PASSED
EnvConfigsTest > testTrackingStrategy() PASSED
EnvConfigsTest > testGetWorkspaceDockerMount() PASSED
EnvConfigsTest > testDockerNetwork() PASSED
EnvConfigsTest > testGetLocalDockerMount() PASSED
EnvConfigsTest > testGetDatabaseUser() PASSED
EnvConfigsTest > testEnvMapRetrieval() PASSED
EnvConfigsTest > testworkerKubeTolerations() PASSED
EnvConfigsTest > CheckJobResourceSettings > checkJobCpuRequest should take precedent if set PASSED
EnvConfigsTest > CheckJobResourceSettings > checkJobMemoryLimit should take precedent if set PASSED
EnvConfigsTest > CheckJobResourceSettings > checkJobMemoryRequest should take precedent if set PASSED
EnvConfigsTest > CheckJobResourceSettings > should default to JobMainMemoryRequest if not set PASSED
EnvConfigsTest > CheckJobResourceSettings > should default to JobMainCpuRequest if not set PASSED
EnvConfigsTest > CheckJobResourceSettings > checkJobCpuLimit should take precedent if set PASSED
EnvConfigsTest > CheckJobResourceSettings > should default to JobMainCpuLimit if not set PASSED
EnvConfigsTest > CheckJobResourceSettings > should default to JobMainMemoryLimit if not set PASSED
CloudLogsClientTest > createCloudLogClientTestAws() PASSED
CloudLogsClientTest > createCloudLogClientTestGcs() PASSED
CloudLogsClientTest > createCloudLogClientTestMinio() PASSED
LogClientSingletonTest > testGetJobLogFileNullPath() PASSED
LogClientSingletonTest > testGetJobLogFileEmptyPath() PASSED
LogClientSingletonTest > testGetJobLogFileK8s() PASSED
ScheduleHelpersTest > testGetSecondsInUnit() PASSED
ScheduleHelpersTest > testAllOfTimeUnitEnumValues() PASSED
YamlListToStandardDefinitionsTest > verifyAndConvertToModelList > should error out on bad data PASSED
YamlListToStandardDefinitionsTest > verifyAndConvertToModelList > should error out on duplicate name PASSED
YamlListToStandardDefinitionsTest > verifyAndConvertToModelList > should correctly read yaml file PASSED
YamlListToStandardDefinitionsTest > verifyAndConvertToModelList > should error out on duplicate id PASSED
YamlListToStandardDefinitionsTest > verifyAndConvertToModelList > should error out on empty file PASSED
YamlListToStandardDefinitionsTest > vertifyAndConvertToJsonNode > should error out on bad data PASSED
YamlListToStandardDefinitionsTest > vertifyAndConvertToJsonNode > should error out on duplicate name PASSED
YamlListToStandardDefinitionsTest > vertifyAndConvertToJsonNode > should correctly read yaml file PASSED
YamlListToStandardDefinitionsTest > vertifyAndConvertToJsonNode > should error out on duplicate id PASSED
YamlListToStandardDefinitionsTest > vertifyAndConvertToJsonNode > should error out on empty file PASSED
CloudLogsClientTest > testGcs() PASSED
CloudLogsClientTest > testGcsMissingBucket() PASSED
DefaultS3ClientFactoryTest > testS3() PASSED
DefaultS3ClientFactoryTest > testIAMPropertiesFail() PASSED
DefaultS3ClientFactoryTest > testS3RegionNotSet() PASSED
MinioS3ClientFactoryTest > testMinio() PASSED
MinioS3ClientFactoryTest > testMinioEndpointMissing() PASSED
> Task :airbyte-config:models:jacocoTestReport
Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
See https://docs.gradle.org/7.4/userguide/command_line_interface.html#sec:command_line_warnings
BUILD SUCCESSFUL in 29s
```
</details>