### PR TITLE
Fix missing type=button

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/Instruction.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/Instruction.tsx
@@ -120,7 +120,7 @@ const Instruction: React.FC<IProps> = ({
       )}
 
       {docType === "internal" && (
-        <SideViewButton onClick={() => setIsSideViewOpen(true)}>
+        <SideViewButton type="button" onClick={() => setIsSideViewOpen(true)}>
           <FormattedMessage id="form.setupGuide" />
         </SideViewButton>
       )}


### PR DESCRIPTION
## What

Fix #10674

The button had no `type=button`, thus making it a submit button (in most browsers), and actually also triggering the click event on form submit.