### PR TITLE
Fix toggle styling

### DIFF
--- a/airbyte-webapp/src/components/base/Toggle/Toggle.tsx
+++ b/airbyte-webapp/src/components/base/Toggle/Toggle.tsx
@@ -41,10 +41,10 @@ const Slider = styled.span<{ small?: boolean }>`
     background: ${({ theme }) => theme.whiteColor};
     transition: 0.3s;
     border-radius: 50%;
+  }
 
-    input:checked + && {
-      transform: translateX(${({ small }) => (small ? 10 : 18)}px);
-    }
+  input:checked + &&:before {
+    transform: translateX(${({ small }) => (small ? 10 : 18)}px);
   }
 
   input:checked + & {


### PR DESCRIPTION
## What

Fixes #10678 

This was a fallout of https://github.com/airbytehq/airbyte/pull/10612, since I actually commited from the wrong local repo and commited a non-fix.

styled-components does not work properly with the `&&` operator inside pseudo elements (at least `:before`/`:after`). So we need to pull this out one level.