### PR TITLE
remove --cpu-shares flag

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
@@ -138,9 +138,6 @@ public class DockerProcessFactory implements ProcessFactory {
         cmd.add(entrypoint);
       }
       if (resourceRequirements != null) {
-        if (!Strings.isNullOrEmpty(resourceRequirements.getCpuRequest())) {
-          cmd.add(String.format("--cpu-shares=%s", resourceRequirements.getCpuRequest()));
-        }
         if (!Strings.isNullOrEmpty(resourceRequirements.getCpuLimit())) {
           cmd.add(String.format("--cpus=%s", resourceRequirements.getCpuLimit()));
         }


### PR DESCRIPTION
see https://github.com/airbytehq/airbyte/pull/10483#issuecomment-1054726677

Since the cpu-shares aren't 1:1 with the types of resources we're specifying for kubernetes, and cpu-limit does most of what we want anyways, we should probably just drop this.

Separately we need to figure out if we want to drop resource requirements for docker-compose entirely or not (Airbyte engineers can refer to [this internal Slack thread](https://airbytehq-team.slack.com/archives/C02TXQ020QM/p1646087983818549)). 