### PR TITLE
Display numbers in usage per connection table

### DIFF
--- a/airbyte-webapp/src/components/Table/Table.tsx
+++ b/airbyte-webapp/src/components/Table/Table.tsx
@@ -11,10 +11,16 @@ import {
 
 import { Card } from "components";
 
+type PaddingProps = {
+  left?: number;
+  right?: number;
+};
+
 type IHeaderProps = {
   headerHighlighted?: boolean;
   collapse?: boolean;
   customWidth?: number;
+  customPadding?: PaddingProps;
 } & ColumnInstance;
 
 type ICellProps = {
@@ -25,6 +31,7 @@ type IThProps = {
   highlighted?: boolean;
   collapse?: boolean;
   customWidth?: number;
+  customPadding?: PaddingProps;
   light?: boolean;
 } & React.ThHTMLAttributes<HTMLTableHeaderCellElement>;
 
@@ -47,8 +54,13 @@ const Tr = styled.tr<{
   cursor: ${({ hasClick }) => (hasClick ? "pointer" : "auto")};
 `;
 
-const Td = styled.td<{ collapse?: boolean; customWidth?: number }>`
-  padding: 16px 13px;
+const Td = styled.td<{
+  collapse?: boolean;
+  customWidth?: number;
+  customPadding?: PaddingProps;
+}>`
+  padding: ${({ customPadding }) =>
+    `16px ${customPadding?.right ?? 13}px 16px ${customPadding?.left ?? 13}px`};
   font-size: 12px;
   line-height: 15px;
   font-weight: normal;
@@ -75,7 +87,8 @@ const Td = styled.td<{ collapse?: boolean; customWidth?: number }>`
 
 const Th = styled.th<IThProps>`
   background: ${({ theme, light }) => (light ? "none" : theme.textColor)};
-  padding: 9px 13px 10px;
+  padding: ${({ customPadding }) =>
+    `9px ${customPadding?.right ?? 13}px 10px ${customPadding?.left ?? 13}px`};
   text-align: left;
   font-size: ${({ light }) => (light ? 11 : 10)}px;
   line-height: 12px;
@@ -157,6 +170,7 @@ const Table: React.FC<IProps> = ({
                 {...column.getHeaderProps()}
                 highlighted={column.headerHighlighted}
                 collapse={column.collapse}
+                customPadding={column.customPadding}
                 customWidth={column.customWidth}
                 key={`table-column-${key}-${columnKey}`}
                 light={light}
@@ -185,6 +199,7 @@ const Table: React.FC<IProps> = ({
                     <Td
                       {...cell.getCellProps()}
                       collapse={cell.column.collapse}
+                      customPadding={cell.column.customPadding}
                       customWidth={cell.column.customWidth}
                       key={`table-cell-${row.id}-${key}`}
                     >

--- a/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/UsageCell.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/UsageCell.tsx
@@ -2,28 +2,13 @@ import React from "react";
 import styled from "styled-components";
 
 type ConnectionCellProps = {
-  value: number;
   percent: number;
 };
-
-const Content = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-`;
-
-const Value = styled.div`
-  padding-right: 10px;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 17px;
-  flex: 1 0 0;
-  min-width: 50px;
-`;
 
 const Bar = styled.div`
   height: 10px;
   width: 100%;
+  min-width: 150px;
   background: ${({ theme }) => theme.greyColor20};
   flex: 10 0 0;
   overflow: hidden;
@@ -37,15 +22,10 @@ const Full = styled.div<{ percent: number }>`
   opacity: 0.5;
 `;
 
-const UsageCell: React.FC<ConnectionCellProps> = ({ value, percent }) => {
-  return (
-    <Content>
-      <Value>{value}</Value>
-      <Bar>
-        <Full percent={percent} />
-      </Bar>
-    </Content>
-  );
-};
+const UsageCell: React.FC<ConnectionCellProps> = ({ percent }) => (
+  <Bar>
+    <Full percent={percent} />
+  </Bar>
+);
 
 export default UsageCell;

--- a/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/UsagePerConnectionTable.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/UsagePerConnectionTable.tsx
@@ -18,6 +18,14 @@ const Content = styled.div`
   padding: 0 60px 0 15px;
 `;
 
+const UsageValue = styled.div`
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 17px;
+  padding-right: 10px;
+  min-width: 53px;
+`;
+
 type UsagePerConnectionTableProps = {
   creditConsumption: CreditConsumptionByConnector[];
 };
@@ -144,11 +152,18 @@ const UsagePerConnectionTable: React.FC<UsagePerConnectionTableProps> = ({
           </>
         ),
         accessor: "creditsConsumed",
-        Cell: ({ cell, row }: CellProps<FullTableProps>) => (
-          <UsageCell
-            value={cell.value}
-            percent={row.original.creditsConsumedPercent}
-          />
+        collapse: true,
+        customPadding: { right: 0 },
+        Cell: ({ cell }: CellProps<FullTableProps>) => (
+          <UsageValue>{cell.value}</UsageValue>
+        ),
+      },
+      {
+        Header: "",
+        accessor: "creditsConsumedPercent",
+        customPadding: { left: 0 },
+        Cell: ({ cell }: CellProps<FullTableProps>) => (
+          <UsageCell percent={cell.value} />
         ),
       },
       // TODO: Replace to Grow column


### PR DESCRIPTION
## What
Display numbers clearly and not overlap with the visual bar in "Usage per connection" table

## How
Number and Bar were divided into 2 columns. Paddings between these cells were removed so the gap between the short number and bar wouldn't be huge.
The number column width depends on the content.

_Example with short number_
<img width="1353" alt="Снимок экрана 2022-03-01 в 13 33 22" src="https://user-images.githubusercontent.com/9026944/156155784-bde91e54-feda-4c7c-8d7d-5b4deb840eb3.png">

_Example with long number_
<img width="1357" alt="Снимок экрана 2022-03-01 в 13 33 07" src="https://user-images.githubusercontent.com/9026944/156155766-ecd25dd6-0185-4f87-8a1a-e4a20107f5c8.png">


Closes #10609

