### PR TITLE
airbyte-workers: add default sidecar cpu request and limit

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -102,8 +102,11 @@ public class KubePodProcess extends Process implements KubePod {
   private static final String INIT_CONTAINER_NAME = "init";
   private static final String DEFAULT_MEMORY_REQUEST = "25Mi";
   private static final String DEFAULT_MEMORY_LIMIT = "50Mi";
+  private static final String DEFAULT_CPU_REQUEST = "0.1";
+  private static final String DEFAULT_CPU_LIMIT = "0.2";
   private static final ResourceRequirements DEFAULT_SIDECAR_RESOURCES = new ResourceRequirements()
-      .withMemoryLimit(DEFAULT_MEMORY_LIMIT).withMemoryRequest(DEFAULT_MEMORY_REQUEST);
+      .withMemoryLimit(DEFAULT_MEMORY_LIMIT).withMemoryRequest(DEFAULT_MEMORY_REQUEST)
+      .withCpuLimit(DEFAULT_CPU_LIMIT).withCpuRequest(DEFAULT_CPU_REQUEST);
 
   private static final String PIPES_DIR = "/pipes";
   private static final String STDIN_PIPE_FILE = PIPES_DIR + "/stdin";
@@ -176,6 +179,7 @@ public class KubePodProcess extends Process implements KubePod {
         .withImage(busyboxImage)
         .withWorkingDir(CONFIG_DIR)
         .withCommand("sh", "-c", initCommand)
+        .withResources(getResourceRequirementsBuilder(DEFAULT_SIDECAR_RESOURCES).build())
         .withVolumeMounts(mainVolumeMounts)
         .build();
   }


### PR DESCRIPTION
## What
Currently, only memory requests and limits are applied to the sidecar containers. In addition, no resources at all were set for the init container.
This PR ensures that all sidecar containers and the init container have both cpu and memory resources set.
This is a good practice and sometimes enforced that all containers in a pod have request and limit resources defined.

The original PR was here: https://github.com/airbytehq/airbyte/pull/9874 we decided to split it into 3 different PRs.

## How
The solution is pretty straightforward, it simply defines new default CPU request (0.1) and limit (0.2) and apply it to the sidecar containers and init container. (Default memory request (25Mi) and limit (50Mi) are already used.

It would probably be better to make these sidecar resources configurable but would require a bit more work.
Let me know what do you think, could we move on with this simple solution and make it configurable in a future PR?


## 🚨 User Impact 🚨
Setting CPU limit for the sidecar containers could have an impact.

