### PR TITLE
Fix connection UI regressions

### DIFF
--- a/airbyte-webapp/src/views/Connection/ConnectionForm/TransferFormCard.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/TransferFormCard.tsx
@@ -44,9 +44,11 @@ const TransferFormCard: React.FC<TransferFormProps> = ({ connection }) => {
         schedule: values.schedule,
         connectionId: connection.connectionId,
         namespaceDefinition: connection.namespaceDefinition,
+        namespaceFormat: connection.namespaceFormat,
         status: connection.status,
         prefix: connection.prefix,
         syncCatalog: connection.syncCatalog,
+        operations: connection.operations,
       });
     }
 


### PR DESCRIPTION
## What
Fixes a problem that form was reinitialized when values of sync was changed Closes #10671 

## How
As the form is not split into 2 separate subforms - they shouldn't be reinitialized when values from some forms are changed. The problem was that not all values were sent to backend from sync form - as a result, some values were changed in the background and catalog form was reinitialized.