### PR TITLE
Remove deprecated FailureReason enum values

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -3343,11 +3343,9 @@ components:
       description: Indicates where the error originated. If not set, the origin of error is not well known.
       type: string
       enum:
-        - unknown # todo (parker) remove this in favor of leaving the failureOrigin unset
         - source
         - destination
         - replication
-        - replication_worker # todo (parker) remove this in favor of replication
         - persistence
         - normalization
         - dbt
@@ -3355,7 +3353,6 @@ components:
       description: Categorizes well known errors into types for programmatic handling. If not set, the type of error is not well known.
       type: string
       enum:
-        - unknown # todo (parker) remove this in favor of leaving the failureType unset
         - config_error
         - system_error
         - manual_cancellation

--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -72,7 +72,7 @@ public class BootloaderAppTest {
         container.getPassword(),
         container.getJdbcUrl()).getInitialized();
     val jobsMigrator = new JobsDatabaseMigrator(jobDatabase, this.getClass().getName());
-    assertEquals("0.35.5.001", jobsMigrator.getLatestMigration().getVersion().getVersion());
+    assertEquals("0.35.40.001", jobsMigrator.getLatestMigration().getVersion().getVersion());
 
     val configDatabase = new ConfigsDatabaseInstance(
         mockedConfigs.getConfigDatabaseUser(),

--- a/airbyte-config/models/src/main/resources/types/FailureReason.yaml
+++ b/airbyte-config/models/src/main/resources/types/FailureReason.yaml
@@ -11,11 +11,9 @@ properties:
     description: Indicates where the error originated. If not set, the origin of error is not well known.
     type: string
     enum:
-      - unknown # todo (parker) remove this in favor of leaving the failureOrigin unset
       - source
       - destination
       - replication
-      - replicationWorker # todo (parker) remove this in favor of replication
       - persistence
       - normalization
       - dbt
@@ -23,10 +21,9 @@ properties:
     description: Categorizes well known errors into types for programmatic handling. If not set, the type of error is not well known.
     type: string
     enum:
-      - unknown # todo (parker) remove this in favor of leaving the failureType unset
-      - configError
-      - systemError
-      - manualCancellation
+      - config_error
+      - system_error
+      - manual_cancellation
   internalMessage:
     description: Human readable failure description for consumption by technical system operators, like Airbyte engineers or OSS users.
     type: string

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/jobs/migrations/V0_35_40_001__MigrateFailureReasonEnumValues.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/jobs/migrations/V0_35_40_001__MigrateFailureReasonEnumValues.java
@@ -1,11 +1,12 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.db.instance.jobs.migrations;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.config.AttemptFailureSummary;
-import io.airbyte.config.FailureReason;
 import io.airbyte.config.Metadata;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -47,23 +48,26 @@ public class V0_35_40_001__MigrateFailureReasonEnumValues extends BaseJavaMigrat
   }
 
   /**
-   * Finds all attempt record that have a failure summary containing a deprecated enum value. For each record, calls method to fix and update.
+   * Finds all attempt record that have a failure summary containing a deprecated enum value. For each
+   * record, calls method to fix and update.
    */
   static void updateRecordsWithNewEnumValues(final DSLContext ctx) {
-    final Result<Record> results = ctx.fetch(String.format("""
-        SELECT A.* FROM attempts A, jsonb_array_elements(A.failure_summary->'failures') as f
-        WHERE f->>'failureOrigin' = '%s'
-        OR f->>'failureOrigin' = '%s'
-        OR f->>'failureType' = '%s'
-        OR f->>'failureType' = '%s'
-        OR f->>'failureType' = '%s'
-        OR f->>'failureType' = '%s'
-        """, OLD_UNKNOWN, OLD_REPLICATION_ORIGIN, OLD_UNKNOWN, OLD_CONFIG_ERROR, OLD_SYSTEM_ERROR, OLD_MANUAL_CANCELLATION));
+    final Result<Record> results =
+        ctx.fetch(String.format("""
+                                SELECT A.* FROM attempts A, jsonb_array_elements(A.failure_summary->'failures') as f
+                                WHERE f->>'failureOrigin' = '%s'
+                                OR f->>'failureOrigin' = '%s'
+                                OR f->>'failureType' = '%s'
+                                OR f->>'failureType' = '%s'
+                                OR f->>'failureType' = '%s'
+                                OR f->>'failureType' = '%s'
+                                """, OLD_UNKNOWN, OLD_REPLICATION_ORIGIN, OLD_UNKNOWN, OLD_CONFIG_ERROR, OLD_SYSTEM_ERROR, OLD_MANUAL_CANCELLATION));
     results.forEach(record -> updateAttemptFailureReasons(ctx, record));
   }
 
   /**
-   * Takes in a single record from the above query and performs an UPDATE to set the failure summary to the fixed version.
+   * Takes in a single record from the above query and performs an UPDATE to set the failure summary
+   * to the fixed version.
    */
   private static void updateAttemptFailureReasons(final DSLContext ctx, final Record record) {
     final Field<Long> attemptIdField = DSL.field("id", SQLDataType.BIGINT);
@@ -72,8 +76,7 @@ public class V0_35_40_001__MigrateFailureReasonEnumValues extends BaseJavaMigrat
     final Long attemptId = record.get(attemptIdField);
     final AttemptFailureSummaryForMigration oldFailureSummary = Jsons.deserialize(
         record.get(failureSummaryField).data(),
-        AttemptFailureSummaryForMigration.class
-    );
+        AttemptFailureSummaryForMigration.class);
 
     final AttemptFailureSummaryForMigration fixedFailureSummary = getFixedAttemptFailureSummary(oldFailureSummary);
 
@@ -83,7 +86,6 @@ public class V0_35_40_001__MigrateFailureReasonEnumValues extends BaseJavaMigrat
         .execute();
   }
 
-
   /**
    * Takes in a FailureSummary and replaces deprecated enum values with their updated versions.
    */
@@ -91,12 +93,10 @@ public class V0_35_40_001__MigrateFailureReasonEnumValues extends BaseJavaMigrat
     final Map<String, String> oldFailureTypeToFixedFailureType = ImmutableMap.of(
         OLD_MANUAL_CANCELLATION, NEW_MANUAL_CANCELLATION,
         OLD_SYSTEM_ERROR, NEW_SYSTEM_ERROR,
-        OLD_CONFIG_ERROR, NEW_CONFIG_ERROR
-    );
+        OLD_CONFIG_ERROR, NEW_CONFIG_ERROR);
 
     final Map<String, String> oldFailureOriginToFixedFailureOrigin = ImmutableMap.of(
-        OLD_REPLICATION_ORIGIN, NEW_REPLICATION_ORIGIN
-    );
+        OLD_REPLICATION_ORIGIN, NEW_REPLICATION_ORIGIN);
 
     final List<FailureReasonForMigration> fixedFailureReasons = new ArrayList<>();
 
@@ -129,14 +129,16 @@ public class V0_35_40_001__MigrateFailureReasonEnumValues extends BaseJavaMigrat
     return failureSummary;
   }
 
-
   /**
-   * The following classes are essentially a copy of the FailureReason and AttemptFailureSummary classes at the time of this migration. They support
-   * both deprecated and new enum values and are used for record deserialization in this migration because in the future, the real FailureReason class
-   * will have those deprecated enum values removed, which would break deserialization within this migration.
+   * The following classes are essentially a copy of the FailureReason and AttemptFailureSummary
+   * classes at the time of this migration. They support both deprecated and new enum values and are
+   * used for record deserialization in this migration because in the future, the real FailureReason
+   * class will have those deprecated enum values removed, which would break deserialization within
+   * this migration.
    */
 
   static class FailureReasonForMigration implements Serializable {
+
     private String failureOrigin;
     private String failureType;
     private String internalMessage;
@@ -257,38 +259,38 @@ public class V0_35_40_001__MigrateFailureReasonEnumValues extends BaseJavaMigrat
       sb.append(FailureReasonForMigration.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
       sb.append("failureOrigin");
       sb.append('=');
-      sb.append(((this.failureOrigin == null)?"<null>":this.failureOrigin));
+      sb.append(((this.failureOrigin == null) ? "<null>" : this.failureOrigin));
       sb.append(',');
       sb.append("failureType");
       sb.append('=');
-      sb.append(((this.failureType == null)?"<null>":this.failureType));
+      sb.append(((this.failureType == null) ? "<null>" : this.failureType));
       sb.append(',');
       sb.append("internalMessage");
       sb.append('=');
-      sb.append(((this.internalMessage == null)?"<null>":this.internalMessage));
+      sb.append(((this.internalMessage == null) ? "<null>" : this.internalMessage));
       sb.append(',');
       sb.append("externalMessage");
       sb.append('=');
-      sb.append(((this.externalMessage == null)?"<null>":this.externalMessage));
+      sb.append(((this.externalMessage == null) ? "<null>" : this.externalMessage));
       sb.append(',');
       sb.append("metadata");
       sb.append('=');
-      sb.append(((this.metadata == null)?"<null>":this.metadata));
+      sb.append(((this.metadata == null) ? "<null>" : this.metadata));
       sb.append(',');
       sb.append("stacktrace");
       sb.append('=');
-      sb.append(((this.stacktrace == null)?"<null>":this.stacktrace));
+      sb.append(((this.stacktrace == null) ? "<null>" : this.stacktrace));
       sb.append(',');
       sb.append("retryable");
       sb.append('=');
-      sb.append(((this.retryable == null)?"<null>":this.retryable));
+      sb.append(((this.retryable == null) ? "<null>" : this.retryable));
       sb.append(',');
       sb.append("timestamp");
       sb.append('=');
-      sb.append(((this.timestamp == null)?"<null>":this.timestamp));
+      sb.append(((this.timestamp == null) ? "<null>" : this.timestamp));
       sb.append(',');
-      if (sb.charAt((sb.length()- 1)) == ',') {
-        sb.setCharAt((sb.length()- 1), ']');
+      if (sb.charAt((sb.length() - 1)) == ',') {
+        sb.setCharAt((sb.length() - 1), ']');
       } else {
         sb.append(']');
       }
@@ -298,14 +300,14 @@ public class V0_35_40_001__MigrateFailureReasonEnumValues extends BaseJavaMigrat
     @Override
     public int hashCode() {
       int result = 1;
-      result = ((result* 31)+((this.retryable == null)? 0 :this.retryable.hashCode()));
-      result = ((result* 31)+((this.metadata == null)? 0 :this.metadata.hashCode()));
-      result = ((result* 31)+((this.stacktrace == null)? 0 :this.stacktrace.hashCode()));
-      result = ((result* 31)+((this.failureOrigin == null)? 0 :this.failureOrigin.hashCode()));
-      result = ((result* 31)+((this.failureType == null)? 0 :this.failureType.hashCode()));
-      result = ((result* 31)+((this.internalMessage == null)? 0 :this.internalMessage.hashCode()));
-      result = ((result* 31)+((this.externalMessage == null)? 0 :this.externalMessage.hashCode()));
-      result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+      result = ((result * 31) + ((this.retryable == null) ? 0 : this.retryable.hashCode()));
+      result = ((result * 31) + ((this.metadata == null) ? 0 : this.metadata.hashCode()));
+      result = ((result * 31) + ((this.stacktrace == null) ? 0 : this.stacktrace.hashCode()));
+      result = ((result * 31) + ((this.failureOrigin == null) ? 0 : this.failureOrigin.hashCode()));
+      result = ((result * 31) + ((this.failureType == null) ? 0 : this.failureType.hashCode()));
+      result = ((result * 31) + ((this.internalMessage == null) ? 0 : this.internalMessage.hashCode()));
+      result = ((result * 31) + ((this.externalMessage == null) ? 0 : this.externalMessage.hashCode()));
+      result = ((result * 31) + ((this.timestamp == null) ? 0 : this.timestamp.hashCode()));
       return result;
     }
 
@@ -318,12 +320,20 @@ public class V0_35_40_001__MigrateFailureReasonEnumValues extends BaseJavaMigrat
         return false;
       }
       final FailureReasonForMigration rhs = ((FailureReasonForMigration) other);
-      return (((((((((this.retryable == rhs.retryable)||((this.retryable!= null)&&this.retryable.equals(rhs.retryable)))&&((this.metadata == rhs.metadata)||((this.metadata!= null)&&this.metadata.equals(rhs.metadata))))&&((this.stacktrace == rhs.stacktrace)||((this.stacktrace!= null)&&this.stacktrace.equals(rhs.stacktrace))))&&((this.failureOrigin == rhs.failureOrigin)||((this.failureOrigin!= null)&&this.failureOrigin.equals(rhs.failureOrigin))))&&((this.failureType == rhs.failureType)||((this.failureType!= null)&&this.failureType.equals(rhs.failureType))))&&((this.internalMessage == rhs.internalMessage)||((this.internalMessage!= null)&&this.internalMessage.equals(rhs.internalMessage))))&&((this.externalMessage == rhs.externalMessage)||((this.externalMessage!= null)&&this.externalMessage.equals(rhs.externalMessage))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+      return (((((((((this.retryable == rhs.retryable) || ((this.retryable != null) && this.retryable.equals(rhs.retryable)))
+          && ((this.metadata == rhs.metadata) || ((this.metadata != null) && this.metadata.equals(rhs.metadata))))
+          && ((this.stacktrace == rhs.stacktrace) || ((this.stacktrace != null) && this.stacktrace.equals(rhs.stacktrace))))
+          && ((this.failureOrigin == rhs.failureOrigin) || ((this.failureOrigin != null) && this.failureOrigin.equals(rhs.failureOrigin))))
+          && ((this.failureType == rhs.failureType) || ((this.failureType != null) && this.failureType.equals(rhs.failureType))))
+          && ((this.internalMessage == rhs.internalMessage) || ((this.internalMessage != null) && this.internalMessage.equals(rhs.internalMessage))))
+          && ((this.externalMessage == rhs.externalMessage) || ((this.externalMessage != null) && this.externalMessage.equals(rhs.externalMessage))))
+          && ((this.timestamp == rhs.timestamp) || ((this.timestamp != null) && this.timestamp.equals(rhs.timestamp))));
     }
 
   }
 
   static class AttemptFailureSummaryForMigration implements Serializable {
+
     private List<FailureReasonForMigration> failures = new ArrayList<>();
     private Boolean partialSuccess;
     private final static long serialVersionUID = -9065693637249217586L;
@@ -391,14 +401,10 @@ public class V0_35_40_001__MigrateFailureReasonEnumValues extends BaseJavaMigrat
         return false;
       }
       final AttemptFailureSummaryForMigration rhs = ((AttemptFailureSummaryForMigration) other);
-      return (((this.partialSuccess == rhs.partialSuccess) || ((this.partialSuccess != null) && this.partialSuccess.equals(rhs.partialSuccess))) && (
-          (this.failures == rhs.failures) || ((this.failures != null) && this.failures.equals(rhs.failures))));
+      return (((this.partialSuccess == rhs.partialSuccess) || ((this.partialSuccess != null) && this.partialSuccess.equals(rhs.partialSuccess)))
+          && ((this.failures == rhs.failures) || ((this.failures != null) && this.failures.equals(rhs.failures))));
     }
 
   }
 
-
 }
-
-
-

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/jobs/migrations/V0_35_40_001__MigrateFailureReasonEnumValues.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/jobs/migrations/V0_35_40_001__MigrateFailureReasonEnumValues.java
@@ -1,0 +1,557 @@
+package io.airbyte.db.instance.jobs.migrations;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.Metadata;
+import io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.FailureReasonForMigration.FailureOrigin;
+import io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.FailureReasonForMigration.FailureType;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.JSONB;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class V0_35_40_001__MigrateFailureReasonEnumValues extends BaseJavaMigration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(V0_35_40_001__MigrateFailureReasonEnumValues.class);
+
+  @Override
+  public void migrate(final Context context) throws Exception {
+    LOGGER.info("Running migration: {}", this.getClass().getSimpleName());
+
+    final DSLContext ctx = DSL.using(context.getConnection());
+    updateRecordsWithNewEnumValues(ctx);
+  }
+
+  /**
+   * Finds all attempt record that have a failure summary containing a deprecated enum value. For each record, calls method to fix and update.
+   */
+  static void updateRecordsWithNewEnumValues(final DSLContext ctx) {
+    final Result<Record> results = ctx.fetch("""
+        SELECT A.* FROM attempts A, jsonb_array_elements(A.failure_summary->'failures') as f
+        WHERE f->>'failureOrigin' = 'unknown'
+        OR f->>'failureOrigin' = 'replicationWorker'
+        OR f->>'failureType' = 'unknown'
+        OR f->>'failureType' = 'configError'
+        OR f->>'failureType' = 'systemError'
+        OR f->>'failureType' = 'manualCancellation'
+        """);
+    results.forEach(record -> updateAttemptFailureReasons(ctx, record));
+  }
+
+  /**
+   * Takes in a single record from the above query and performs an UPDATE to set the failure summary to the fixed version.
+   */
+  private static void updateAttemptFailureReasons(final DSLContext ctx, final Record record) {
+    final Field<Long> attemptIdField = DSL.field("id", SQLDataType.BIGINT);
+    final Field<JSONB> failureSummaryField = DSL.field("failure_summary", SQLDataType.JSONB.nullable(true));
+
+    final Long attemptId = record.get(attemptIdField);
+    final AttemptFailureSummaryForMigration oldFailureSummary = Jsons.deserialize(
+        record.get(failureSummaryField).data(),
+        AttemptFailureSummaryForMigration.class
+    );
+
+    final AttemptFailureSummaryForMigration fixedFailureSummary = getFixedAttemptFailureSummary(oldFailureSummary);
+
+    ctx.update(DSL.table("attempts"))
+        .set(failureSummaryField, JSONB.valueOf(Jsons.serialize(fixedFailureSummary)))
+        .where(attemptIdField.eq(attemptId))
+        .execute();
+  }
+
+
+  /**
+   * Takes in a FailureSummary and replaces deprecated enum values with their updated versions.
+   */
+  private static AttemptFailureSummaryForMigration getFixedAttemptFailureSummary(final AttemptFailureSummaryForMigration failureSummary) {
+    final Map<FailureType, FailureType> oldFailureTypeToFixedFailureType = ImmutableMap.of(
+        FailureType.MANUAL_CANCELLATION_OLD, FailureType.MANUAL_CANCELLATION,
+        FailureType.SYSTEM_ERROR_OLD, FailureType.SYSTEM_ERROR,
+        FailureType.CONFIG_ERROR_OLD, FailureType.CONFIG_ERROR
+    );
+
+    final Map<FailureOrigin, FailureOrigin> oldFailureOriginToFixedFailureOrigin = ImmutableMap.of(
+        FailureOrigin.REPLICATION_WORKER, FailureOrigin.REPLICATION
+    );
+
+    final List<FailureReasonForMigration> fixedFailureReasons = new ArrayList<>();
+
+    failureSummary.getFailures().stream().forEach(failureReason -> {
+      final FailureType failureType = failureReason.getFailureType();
+      final FailureOrigin failureOrigin = failureReason.getFailureOrigin();
+
+      // null failureType is valid and doesn't need correction
+      if (failureType != null) {
+        if (oldFailureTypeToFixedFailureType.containsKey(failureType)) {
+          failureReason.setFailureType(oldFailureTypeToFixedFailureType.get(failureType));
+        } else if (failureType.equals(FailureType.UNKNOWN)) {
+          failureReason.setFailureType(null);
+        }
+      }
+
+      // null failureOrigin is valid and doesn't need correction
+      if (failureOrigin != null) {
+        if (oldFailureOriginToFixedFailureOrigin.containsKey(failureOrigin)) {
+          failureReason.setFailureOrigin(oldFailureOriginToFixedFailureOrigin.get(failureOrigin));
+        } else if (failureOrigin.equals(FailureOrigin.UNKNOWN)) {
+          failureReason.setFailureOrigin(null);
+        }
+      }
+
+      fixedFailureReasons.add(failureReason);
+    });
+
+    failureSummary.setFailures(fixedFailureReasons);
+    return failureSummary;
+  }
+
+
+  /**
+   * The following classes are essentially a copy of the FailureReason and AttemptFailureSummary classes at the time of this migration. They support
+   * both deprecated and new enum values and are used for record deserialization in this migration because in the future, the real FailureReason class
+   * will have those deprecated enum values removed, which would break deserialization within this migration.
+   */
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonPropertyOrder({
+      "failureOrigin",
+      "failureType",
+      "internalMessage",
+      "externalMessage",
+      "metadata",
+      "stacktrace",
+      "retryable",
+      "timestamp"
+  })
+  static
+  class FailureReasonForMigration {
+
+    @JsonProperty("failureOrigin")
+    @JsonPropertyDescription("Indicates where the error originated. If not set, the origin of error is not well known.")
+    private FailureReasonForMigration.FailureOrigin failureOrigin;
+    @JsonProperty("failureType")
+    @JsonPropertyDescription("Categorizes well known errors into types for programmatic handling. If not set, the type of error is not well known.")
+    private FailureReasonForMigration.FailureType failureType;
+    @JsonProperty("internalMessage")
+    @JsonPropertyDescription("Human readable failure description for consumption by technical system operators, like Airbyte engineers or OSS users.")
+    private String internalMessage;
+    @JsonProperty("externalMessage")
+    @JsonPropertyDescription("Human readable failure description for presentation in the UI to non-technical users.")
+    private String externalMessage;
+    @JsonProperty("metadata")
+    @JsonPropertyDescription("Key-value pairs of relevant data")
+    private Metadata metadata;
+    @JsonProperty("stacktrace")
+    @JsonPropertyDescription("Raw stacktrace associated with the failure.")
+    private String stacktrace;
+    @JsonProperty("retryable")
+    @JsonPropertyDescription("True if it is known that retrying may succeed, e.g. for a transient failure. False if it is known that a retry will not succeed, e.g. for a configuration issue. If not set, retryable status is not well known.")
+    private Boolean retryable;
+    @JsonProperty("timestamp")
+    private Long timestamp;
+    private final static long serialVersionUID = -1485119682657564218L;
+
+    @JsonProperty("failureOrigin")
+    public FailureReasonForMigration.FailureOrigin getFailureOrigin() {
+      return failureOrigin;
+    }
+
+    @JsonProperty("failureOrigin")
+    public void setFailureOrigin(final FailureReasonForMigration.FailureOrigin failureOrigin) {
+      this.failureOrigin = failureOrigin;
+    }
+
+    public FailureReasonForMigration withFailureOrigin(final FailureReasonForMigration.FailureOrigin failureOrigin) {
+      this.failureOrigin = failureOrigin;
+      return this;
+    }
+
+    @JsonProperty("failureType")
+    public FailureReasonForMigration.FailureType getFailureType() {
+      return failureType;
+    }
+
+    @JsonProperty("failureType")
+    public void setFailureType(final FailureReasonForMigration.FailureType failureType) {
+      this.failureType = failureType;
+    }
+
+    public FailureReasonForMigration withFailureType(final FailureReasonForMigration.FailureType failureType) {
+      this.failureType = failureType;
+      return this;
+    }
+
+    @JsonProperty("internalMessage")
+    public String getInternalMessage() {
+      return internalMessage;
+    }
+
+    @JsonProperty("internalMessage")
+    public void setInternalMessage(final String internalMessage) {
+      this.internalMessage = internalMessage;
+    }
+
+    public FailureReasonForMigration withInternalMessage(final String internalMessage) {
+      this.internalMessage = internalMessage;
+      return this;
+    }
+
+    @JsonProperty("externalMessage")
+    public String getExternalMessage() {
+      return externalMessage;
+    }
+
+    @JsonProperty("externalMessage")
+    public void setExternalMessage(final String externalMessage) {
+      this.externalMessage = externalMessage;
+    }
+
+    public FailureReasonForMigration withExternalMessage(final String externalMessage) {
+      this.externalMessage = externalMessage;
+      return this;
+    }
+
+    @JsonProperty("metadata")
+    public Metadata getMetadata() {
+      return metadata;
+    }
+
+    @JsonProperty("metadata")
+    public void setMetadata(final Metadata metadata) {
+      this.metadata = metadata;
+    }
+
+    public FailureReasonForMigration withMetadata(final Metadata metadata) {
+      this.metadata = metadata;
+      return this;
+    }
+
+    @JsonProperty("stacktrace")
+    public String getStacktrace() {
+      return stacktrace;
+    }
+
+    @JsonProperty("stacktrace")
+    public void setStacktrace(final String stacktrace) {
+      this.stacktrace = stacktrace;
+    }
+
+    public FailureReasonForMigration withStacktrace(final String stacktrace) {
+      this.stacktrace = stacktrace;
+      return this;
+    }
+
+    @JsonProperty("retryable")
+    public Boolean getRetryable() {
+      return retryable;
+    }
+
+    @JsonProperty("retryable")
+    public void setRetryable(final Boolean retryable) {
+      this.retryable = retryable;
+    }
+
+    public FailureReasonForMigration withRetryable(final Boolean retryable) {
+      this.retryable = retryable;
+      return this;
+    }
+
+    @JsonProperty("timestamp")
+    public Long getTimestamp() {
+      return timestamp;
+    }
+
+    @JsonProperty("timestamp")
+    public void setTimestamp(final Long timestamp) {
+      this.timestamp = timestamp;
+    }
+
+    public FailureReasonForMigration withTimestamp(final Long timestamp) {
+      this.timestamp = timestamp;
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      final StringBuilder sb = new StringBuilder();
+      sb.append(FailureReasonForMigration.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+      sb.append("failureOrigin");
+      sb.append('=');
+      sb.append(((this.failureOrigin == null)?"<null>":this.failureOrigin));
+      sb.append(',');
+      sb.append("failureType");
+      sb.append('=');
+      sb.append(((this.failureType == null)?"<null>":this.failureType));
+      sb.append(',');
+      sb.append("internalMessage");
+      sb.append('=');
+      sb.append(((this.internalMessage == null)?"<null>":this.internalMessage));
+      sb.append(',');
+      sb.append("externalMessage");
+      sb.append('=');
+      sb.append(((this.externalMessage == null)?"<null>":this.externalMessage));
+      sb.append(',');
+      sb.append("metadata");
+      sb.append('=');
+      sb.append(((this.metadata == null)?"<null>":this.metadata));
+      sb.append(',');
+      sb.append("stacktrace");
+      sb.append('=');
+      sb.append(((this.stacktrace == null)?"<null>":this.stacktrace));
+      sb.append(',');
+      sb.append("retryable");
+      sb.append('=');
+      sb.append(((this.retryable == null)?"<null>":this.retryable));
+      sb.append(',');
+      sb.append("timestamp");
+      sb.append('=');
+      sb.append(((this.timestamp == null)?"<null>":this.timestamp));
+      sb.append(',');
+      if (sb.charAt((sb.length()- 1)) == ',') {
+        sb.setCharAt((sb.length()- 1), ']');
+      } else {
+        sb.append(']');
+      }
+      return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+      int result = 1;
+      result = ((result* 31)+((this.retryable == null)? 0 :this.retryable.hashCode()));
+      result = ((result* 31)+((this.metadata == null)? 0 :this.metadata.hashCode()));
+      result = ((result* 31)+((this.stacktrace == null)? 0 :this.stacktrace.hashCode()));
+      result = ((result* 31)+((this.failureOrigin == null)? 0 :this.failureOrigin.hashCode()));
+      result = ((result* 31)+((this.failureType == null)? 0 :this.failureType.hashCode()));
+      result = ((result* 31)+((this.internalMessage == null)? 0 :this.internalMessage.hashCode()));
+      result = ((result* 31)+((this.externalMessage == null)? 0 :this.externalMessage.hashCode()));
+      result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+      return result;
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+      if (other == this) {
+        return true;
+      }
+      if ((other instanceof FailureReasonForMigration) == false) {
+        return false;
+      }
+      final FailureReasonForMigration rhs = ((FailureReasonForMigration) other);
+      return (((((((((this.retryable == rhs.retryable)||((this.retryable!= null)&&this.retryable.equals(rhs.retryable)))&&((this.metadata == rhs.metadata)||((this.metadata!= null)&&this.metadata.equals(rhs.metadata))))&&((this.stacktrace == rhs.stacktrace)||((this.stacktrace!= null)&&this.stacktrace.equals(rhs.stacktrace))))&&((this.failureOrigin == rhs.failureOrigin)||((this.failureOrigin!= null)&&this.failureOrigin.equals(rhs.failureOrigin))))&&((this.failureType == rhs.failureType)||((this.failureType!= null)&&this.failureType.equals(rhs.failureType))))&&((this.internalMessage == rhs.internalMessage)||((this.internalMessage!= null)&&this.internalMessage.equals(rhs.internalMessage))))&&((this.externalMessage == rhs.externalMessage)||((this.externalMessage!= null)&&this.externalMessage.equals(rhs.externalMessage))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
+    public enum FailureOrigin {
+
+      UNKNOWN("unknown"),
+      SOURCE("source"),
+      DESTINATION("destination"),
+      REPLICATION("replication"),
+      REPLICATION_WORKER("replicationWorker"),
+      PERSISTENCE("persistence"),
+      NORMALIZATION("normalization"),
+      DBT("dbt");
+      private final String value;
+      private final static Map<String, FailureReasonForMigration.FailureOrigin> CONSTANTS = new HashMap<String, FailureReasonForMigration.FailureOrigin>();
+
+      static {
+        for (final FailureReasonForMigration.FailureOrigin c: values()) {
+          CONSTANTS.put(c.value, c);
+        }
+      }
+
+      private FailureOrigin(final String value) {
+        this.value = value;
+      }
+
+      @Override
+      public String toString() {
+        return this.value;
+      }
+
+      @JsonValue
+      public String value() {
+        return this.value;
+      }
+
+      @JsonCreator
+      public static FailureReasonForMigration.FailureOrigin fromValue(final String value) {
+        final FailureReasonForMigration.FailureOrigin constant = CONSTANTS.get(value);
+        if (constant == null) {
+          throw new IllegalArgumentException(value);
+        } else {
+          return constant;
+        }
+      }
+
+    }
+
+
+    public enum FailureType {
+
+      UNKNOWN("unknown"),
+      CONFIG_ERROR_OLD("configError"),
+      SYSTEM_ERROR_OLD("systemError"),
+      MANUAL_CANCELLATION_OLD("manualCancellation"),
+      CONFIG_ERROR("config_error"),
+      SYSTEM_ERROR("system_error"),
+      MANUAL_CANCELLATION("manual_cancellation");
+      private final String value;
+      private final static Map<String, FailureReasonForMigration.FailureType> CONSTANTS = new HashMap<String, FailureReasonForMigration.FailureType>();
+
+      static {
+        for (final FailureReasonForMigration.FailureType c : values()) {
+          CONSTANTS.put(c.value, c);
+        }
+      }
+
+      private FailureType(final String value) {
+        this.value = value;
+      }
+
+      @Override
+      public String toString() {
+        return this.value;
+      }
+
+      @JsonValue
+      public String value() {
+        return this.value;
+      }
+
+      @JsonCreator
+      public static FailureReasonForMigration.FailureType fromValue(final String value) {
+        final FailureReasonForMigration.FailureType constant = CONSTANTS.get(value);
+        if (constant == null) {
+          throw new IllegalArgumentException(value);
+        } else {
+          return constant;
+        }
+      }
+
+    }
+
+  }
+
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonPropertyOrder({
+      "failures",
+      "partialSuccess"
+  })
+  static
+  class AttemptFailureSummaryForMigration implements Serializable {
+
+    @JsonProperty("failures")
+    @JsonPropertyDescription("Ordered list of failures that occurred during the attempt.")
+    private List<FailureReasonForMigration> failures = new ArrayList<FailureReasonForMigration>();
+
+    @JsonProperty("partialSuccess")
+    @JsonPropertyDescription("True if the number of committed records for this attempt was greater than 0. False if 0 records were committed. Blank if number of committed records is unknown.")
+    private Boolean partialSuccess;
+    private final static long serialVersionUID = -9065693637249217586L;
+
+    @JsonProperty("failures")
+    public List<FailureReasonForMigration> getFailures() {
+      return failures;
+    }
+
+    @JsonProperty("failures")
+    public void setFailures(final List<FailureReasonForMigration> failures) {
+      this.failures = failures;
+    }
+
+    public AttemptFailureSummaryForMigration withFailures(final List<FailureReasonForMigration> failures) {
+      this.failures = failures;
+      return this;
+    }
+
+    /**
+     * True if the number of committed records for this attempt was greater than 0. False if 0 records were committed. Blank if number of committed
+     * records is unknown.
+     */
+    @JsonProperty("partialSuccess")
+    public Boolean getPartialSuccess() {
+      return partialSuccess;
+    }
+
+    /**
+     * True if the number of committed records for this attempt was greater than 0. False if 0 records were committed. Blank if number of committed
+     * records is unknown.
+     */
+    @JsonProperty("partialSuccess")
+    public void setPartialSuccess(final Boolean partialSuccess) {
+      this.partialSuccess = partialSuccess;
+    }
+
+    public AttemptFailureSummaryForMigration withPartialSuccess(final Boolean partialSuccess) {
+      this.partialSuccess = partialSuccess;
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      final StringBuilder sb = new StringBuilder();
+      sb.append(AttemptFailureSummaryForMigration.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+      sb.append("failures");
+      sb.append('=');
+      sb.append(((this.failures == null) ? "<null>" : this.failures));
+      sb.append(',');
+      sb.append("partialSuccess");
+      sb.append('=');
+      sb.append(((this.partialSuccess == null) ? "<null>" : this.partialSuccess));
+      sb.append(',');
+      if (sb.charAt((sb.length() - 1)) == ',') {
+        sb.setCharAt((sb.length() - 1), ']');
+      } else {
+        sb.append(']');
+      }
+      return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+      int result = 1;
+      result = ((result * 31) + ((this.partialSuccess == null) ? 0 : this.partialSuccess.hashCode()));
+      result = ((result * 31) + ((this.failures == null) ? 0 : this.failures.hashCode()));
+      return result;
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+      if (other == this) {
+        return true;
+      }
+      if ((other instanceof AttemptFailureSummaryForMigration) == false) {
+        return false;
+      }
+      final AttemptFailureSummaryForMigration rhs = ((AttemptFailureSummaryForMigration) other);
+      return (((this.partialSuccess == rhs.partialSuccess) || ((this.partialSuccess != null) && this.partialSuccess.equals(rhs.partialSuccess))) && (
+          (this.failures == rhs.failures) || ((this.failures != null) && this.failures.equals(rhs.failures))));
+    }
+
+  }
+
+
+}
+
+
+

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/jobs/migrations/V0_35_5_001__Add_failureSummary_col_to_Attempts.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/jobs/migrations/V0_35_5_001__Add_failureSummary_col_to_Attempts.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.db.instance.jobs.migrations;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
 import org.jooq.DSLContext;
@@ -21,6 +22,11 @@ public class V0_35_5_001__Add_failureSummary_col_to_Attempts extends BaseJavaMig
     LOGGER.info("Running migration: {}", this.getClass().getSimpleName());
 
     final DSLContext ctx = DSL.using(context.getConnection());
+    migrate(ctx);
+  }
+
+  @VisibleForTesting
+  public static void migrate(final DSLContext ctx) {
     addFailureSummaryColumn(ctx);
   }
 

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/jobs/migrations/V0_35_40_001_MigrateFailureReasonEnumValues_Test.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/jobs/migrations/V0_35_40_001_MigrateFailureReasonEnumValues_Test.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.db.instance.jobs.migrations;
 
 import static io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.NEW_CONFIG_ERROR;
@@ -5,10 +9,10 @@ import static io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailur
 import static io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.NEW_REPLICATION_ORIGIN;
 import static io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.NEW_SYSTEM_ERROR;
 import static io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.OLD_CONFIG_ERROR;
+import static io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.OLD_MANUAL_CANCELLATION;
 import static io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.OLD_REPLICATION_ORIGIN;
 import static io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.OLD_SYSTEM_ERROR;
 import static io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.OLD_UNKNOWN;
-import static io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.OLD_MANUAL_CANCELLATION;
 import static org.jooq.impl.DSL.asterisk;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -55,16 +59,19 @@ public class V0_35_40_001_MigrateFailureReasonEnumValues_Test extends AbstractJo
   private static final FailureReasonForMigration noChangeNeeded = baseFailureReason().withFailureOrigin(ORIGIN_SOURCE);
   private static final FailureReasonForMigration unrecognizedValue = baseFailureReason().withFailureType("someUnrecognizedValue");
 
-
   // create failure summaries containing failure reasons that need fixing.
-  // mixing in noChangeNeeded reasons in different spots to make sure the migration properly leaves those untouched.
+  // mixing in noChangeNeeded reasons in different spots to make sure the migration properly leaves
+  // those untouched.
   private static final AttemptFailureSummaryForMigration summaryFixReplicationOrigin = getFailureSummary(noChangeNeeded, originReplicationWorker);
-  private static final AttemptFailureSummaryForMigration summaryFixReplicationOriginAndManualCancellationType = getFailureSummary(originReplicationWorker, typeManualCancellation, noChangeNeeded);
-  private static final AttemptFailureSummaryForMigration summaryFixUnknownOriginAndUnknownType = getFailureSummary(originUnknown, noChangeNeeded, typeUnknown);
+  private static final AttemptFailureSummaryForMigration summaryFixReplicationOriginAndManualCancellationType =
+      getFailureSummary(originReplicationWorker, typeManualCancellation, noChangeNeeded);
+  private static final AttemptFailureSummaryForMigration summaryFixUnknownOriginAndUnknownType =
+      getFailureSummary(originUnknown, noChangeNeeded, typeUnknown);
   private static final AttemptFailureSummaryForMigration summaryFixMultipleSystemErrorType = getFailureSummary(typeSystemError, typeSystemError);
   private static final AttemptFailureSummaryForMigration summaryFixConfigErrorType = getFailureSummary(typeConfigError);
   private static final AttemptFailureSummaryForMigration summaryNoChangeNeeded = getFailureSummary(noChangeNeeded, noChangeNeeded);
-  private static final AttemptFailureSummaryForMigration summaryFixOriginAndLeaveUnrecognizedValue = getFailureSummary(originReplicationWorker, unrecognizedValue);
+  private static final AttemptFailureSummaryForMigration summaryFixOriginAndLeaveUnrecognizedValue =
+      getFailureSummary(originReplicationWorker, unrecognizedValue);
 
   // define attempt ids corresponding to each summary above
   private static final Long attemptIdForFixReplicationOrigin = 1L;
@@ -105,7 +112,6 @@ public class V0_35_40_001_MigrateFailureReasonEnumValues_Test extends AbstractJo
     verifyEnumValuesFixed(ctx);
   }
 
-
   private static void addRecordsWithOldEnumValues(final DSLContext ctx) {
     insertAttemptWithSummary(ctx, attemptIdForFixReplicationOrigin, summaryFixReplicationOrigin);
     insertAttemptWithSummary(ctx, attemptIdForFixReplicationOriginAndManualCancellationType, summaryFixReplicationOriginAndManualCancellationType);
@@ -118,7 +124,8 @@ public class V0_35_40_001_MigrateFailureReasonEnumValues_Test extends AbstractJo
 
   private static void verifyEnumValuesFixed(final DSLContext ctx) {
     assertEquals(expectedSummaryFixReplicationOrigin, fetchFailureSummary(ctx, attemptIdForFixReplicationOrigin));
-    assertEquals(expectedSummaryFixReplicationOriginAndManualCancellationType, fetchFailureSummary(ctx, attemptIdForFixReplicationOriginAndManualCancellationType));
+    assertEquals(expectedSummaryFixReplicationOriginAndManualCancellationType,
+        fetchFailureSummary(ctx, attemptIdForFixReplicationOriginAndManualCancellationType));
     assertEquals(expectedSummaryFixUnknownOriginAndUnknownType, fetchFailureSummary(ctx, attemptIdForFixUnknownOriginAndUnknownType));
     assertEquals(expectedSummaryFixMultipleSystemErrorType, fetchFailureSummary(ctx, attemptIdForFixMultipleSystemErrorType));
     assertEquals(expectedSummaryFixConfigErrorType, fetchFailureSummary(ctx, attemptIdForFixConfigErrorType));
@@ -137,8 +144,8 @@ public class V0_35_40_001_MigrateFailureReasonEnumValues_Test extends AbstractJo
             attemptId,
             JSONB.valueOf(Jsons.serialize(summary)),
             currJobId,
-            1
-        ).execute();
+            1)
+        .execute();
 
     currJobId++;
   }
@@ -146,8 +153,7 @@ public class V0_35_40_001_MigrateFailureReasonEnumValues_Test extends AbstractJo
   private static AttemptFailureSummaryForMigration fetchFailureSummary(final DSLContext ctx, final Long attemptId) {
     final Record record = ctx.fetchOne(DSL.select(asterisk())
         .from(DSL.table("attempts"))
-        .where(DSL.field("id").eq(attemptId))
-    );
+        .where(DSL.field("id").eq(attemptId)));
 
     return Jsons.deserialize(
         record.get(DSL.field("failure_summary", SQLDataType.JSONB.nullable(true))).data(),
@@ -165,9 +171,10 @@ public class V0_35_40_001_MigrateFailureReasonEnumValues_Test extends AbstractJo
         .withMetadata(new Metadata().withAdditionalProperty("key1", "value1"));
   }
 
-  private static AttemptFailureSummaryForMigration getFailureSummary(final FailureReasonForMigration ...failureReasons) {
+  private static AttemptFailureSummaryForMigration getFailureSummary(final FailureReasonForMigration... failureReasons) {
     return new AttemptFailureSummaryForMigration()
         .withPartialSuccess(false)
         .withFailures(List.of(failureReasons));
   }
+
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/jobs/migrations/V0_35_40_001_MigrateFailureReasonEnumValues_Test.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/jobs/migrations/V0_35_40_001_MigrateFailureReasonEnumValues_Test.java
@@ -1,0 +1,157 @@
+package io.airbyte.db.instance.jobs.migrations;
+
+import static org.jooq.impl.DSL.asterisk;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.Metadata;
+import io.airbyte.db.Database;
+import io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.AttemptFailureSummaryForMigration;
+import io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.FailureReasonForMigration;
+import io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.FailureReasonForMigration.FailureOrigin;
+import io.airbyte.db.instance.jobs.migrations.V0_35_40_001__MigrateFailureReasonEnumValues.FailureReasonForMigration.FailureType;
+import io.airbyte.db.instance.jobs.AbstractJobsDatabaseTest;
+import java.util.List;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.junit.jupiter.api.Test;
+
+public class V0_35_40_001_MigrateFailureReasonEnumValues_Test extends AbstractJobsDatabaseTest {
+
+  private static int currJobId = 1;
+  private static final long timeNowMillis = System.currentTimeMillis();
+
+  // create pairs of old failure reasons and their fixed versions.
+  private static final FailureReasonForMigration originReplicationWorker = baseFailureReason().withFailureOrigin(FailureOrigin.REPLICATION_WORKER);
+  private static final FailureReasonForMigration fixedOriginReplicationWorker = baseFailureReason().withFailureOrigin(FailureOrigin.REPLICATION);
+
+  private static final FailureReasonForMigration originUnknown = baseFailureReason().withFailureOrigin(FailureOrigin.UNKNOWN);
+  private static final FailureReasonForMigration fixedOriginUnknown = baseFailureReason().withFailureOrigin(null);
+
+  private static final FailureReasonForMigration typeManualCancellation = baseFailureReason().withFailureType(FailureType.MANUAL_CANCELLATION_OLD);
+  private static final FailureReasonForMigration fixedTypeManualCancellation = baseFailureReason().withFailureType(FailureType.MANUAL_CANCELLATION);
+
+  private static final FailureReasonForMigration typeSystemError = baseFailureReason().withFailureType(FailureType.SYSTEM_ERROR_OLD);
+  private static final FailureReasonForMigration fixedTypeSystemError = baseFailureReason().withFailureType(FailureType.SYSTEM_ERROR);
+
+  private static final FailureReasonForMigration typeConfigError = baseFailureReason().withFailureType(FailureType.CONFIG_ERROR_OLD);
+  private static final FailureReasonForMigration fixedTypeConfigError = baseFailureReason().withFailureType(FailureType.CONFIG_ERROR);
+
+  private static final FailureReasonForMigration typeUnknown = baseFailureReason().withFailureType(FailureType.UNKNOWN);
+  private static final FailureReasonForMigration fixedTypeUnknown = baseFailureReason().withFailureType(null);
+
+  private static final FailureReasonForMigration noChangeNeeded = baseFailureReason().withFailureOrigin(FailureOrigin.SOURCE);
+
+  // create failure summaries containing failure reasons that need fixing.
+  // mixing in noChangeNeeded reasons in different spots to make sure the migration properly leaves those untouched.
+  private static final AttemptFailureSummaryForMigration summaryFixReplicationOrigin = getFailureSummary(noChangeNeeded, originReplicationWorker);
+  private static final AttemptFailureSummaryForMigration summaryFixReplicationOriginAndManualCancellationType = getFailureSummary(originReplicationWorker, typeManualCancellation, noChangeNeeded);
+  private static final AttemptFailureSummaryForMigration summaryFixUnknownOriginAndUnknownType = getFailureSummary(originUnknown, noChangeNeeded, typeUnknown);
+  private static final AttemptFailureSummaryForMigration summaryFixMultipleSystemErrorType = getFailureSummary(typeSystemError, typeSystemError);
+  private static final AttemptFailureSummaryForMigration summaryFixConfigErrorType = getFailureSummary(typeConfigError);
+  private static final AttemptFailureSummaryForMigration summaryNoChangeNeeded = getFailureSummary(noChangeNeeded, noChangeNeeded);
+
+  // define attempt ids corresponding to each summary above
+  private static final Long attemptIdForFixReplicationOrigin = 1L;
+  private static final Long attemptIdForFixReplicationOriginAndManualCancellationType = 2L;
+  private static final Long attemptIdForFixUnknownOriginAndUnknownType = 3L;
+  private static final Long attemptIdForFixMultipleSystemErrorType = 4L;
+  private static final Long attemptIdForFixConfigErrorType = 5L;
+  private static final Long attemptIdForNoChangeNeeded = 6L;
+
+  // create expected fixed failure summaries after migration.
+  private static final AttemptFailureSummaryForMigration expectedSummaryFixReplicationOrigin =
+      getFailureSummary(noChangeNeeded, fixedOriginReplicationWorker);
+  private static final AttemptFailureSummaryForMigration expectedSummaryFixReplicationOriginAndManualCancellationType =
+      getFailureSummary(fixedOriginReplicationWorker, fixedTypeManualCancellation, noChangeNeeded);
+  private static final AttemptFailureSummaryForMigration expectedSummaryFixUnknownOriginAndUnknownType =
+      getFailureSummary(fixedOriginUnknown, noChangeNeeded, fixedTypeUnknown);
+  private static final AttemptFailureSummaryForMigration expectedSummaryFixMultipleSystemErrorType =
+      getFailureSummary(fixedTypeSystemError, fixedTypeSystemError);
+  private static final AttemptFailureSummaryForMigration expectedSummaryFixConfigErrorType =
+      getFailureSummary(fixedTypeConfigError);
+  private static final AttemptFailureSummaryForMigration expectedSummaryNoChangeNeeded =
+      getFailureSummary(noChangeNeeded, noChangeNeeded);
+
+  @Test
+  public void test() throws Exception {
+    final Database database = getDatabase();
+    final DSLContext ctx = DSL.using(database.getDataSource().getConnection());
+
+    V0_35_5_001__Add_failureSummary_col_to_Attempts.migrate(ctx);
+
+    addRecordsWithOldEnumValues(ctx);
+
+    V0_35_40_001__MigrateFailureReasonEnumValues.updateRecordsWithNewEnumValues(ctx);
+
+    verifyEnumValuesFixed(ctx);
+  }
+
+
+  private static void addRecordsWithOldEnumValues(final DSLContext ctx) {
+    insertAttemptWithSummary(ctx, attemptIdForFixReplicationOrigin, summaryFixReplicationOrigin);
+    insertAttemptWithSummary(ctx, attemptIdForFixReplicationOriginAndManualCancellationType, summaryFixReplicationOriginAndManualCancellationType);
+    insertAttemptWithSummary(ctx, attemptIdForFixUnknownOriginAndUnknownType, summaryFixUnknownOriginAndUnknownType);
+    insertAttemptWithSummary(ctx, attemptIdForFixMultipleSystemErrorType, summaryFixMultipleSystemErrorType);
+    insertAttemptWithSummary(ctx, attemptIdForFixConfigErrorType, summaryFixConfigErrorType);
+    insertAttemptWithSummary(ctx, attemptIdForNoChangeNeeded, summaryNoChangeNeeded);
+  }
+
+  private static void verifyEnumValuesFixed(final DSLContext ctx) {
+    assertEquals(expectedSummaryFixReplicationOrigin, fetchFailureSummary(ctx, attemptIdForFixReplicationOrigin));
+    assertEquals(expectedSummaryFixReplicationOriginAndManualCancellationType, fetchFailureSummary(ctx, attemptIdForFixReplicationOriginAndManualCancellationType));
+    assertEquals(expectedSummaryFixUnknownOriginAndUnknownType, fetchFailureSummary(ctx, attemptIdForFixUnknownOriginAndUnknownType));
+    assertEquals(expectedSummaryFixMultipleSystemErrorType, fetchFailureSummary(ctx, attemptIdForFixMultipleSystemErrorType));
+    assertEquals(expectedSummaryFixConfigErrorType, fetchFailureSummary(ctx, attemptIdForFixConfigErrorType));
+    assertEquals(expectedSummaryNoChangeNeeded, fetchFailureSummary(ctx, attemptIdForNoChangeNeeded));
+
+  }
+
+  private static void insertAttemptWithSummary(final DSLContext ctx, final Long attemptId, final AttemptFailureSummaryForMigration summary) {
+    ctx.insertInto(DSL.table("attempts"))
+        .columns(
+            DSL.field("id"),
+            DSL.field("failure_summary"),
+            DSL.field("job_id"),
+            DSL.field("attempt_number"))
+        .values(
+            attemptId,
+            JSONB.valueOf(Jsons.serialize(summary)),
+            currJobId,
+            1
+        ).execute();
+
+    currJobId++;
+  }
+
+  private static AttemptFailureSummaryForMigration fetchFailureSummary(final DSLContext ctx, final Long attemptId) {
+    final Record record = ctx.fetchOne(DSL.select(asterisk())
+        .from(DSL.table("attempts"))
+        .where(DSL.field("id").eq(attemptId))
+    );
+
+    return Jsons.deserialize(
+        record.get(DSL.field("failure_summary", SQLDataType.JSONB.nullable(true))).data(),
+        AttemptFailureSummaryForMigration.class);
+
+  }
+
+  private static FailureReasonForMigration baseFailureReason() {
+    return new FailureReasonForMigration()
+        .withInternalMessage("some internal message")
+        .withExternalMessage("some external message")
+        .withRetryable(false)
+        .withTimestamp(timeNowMillis)
+        .withStacktrace("some stacktrace")
+        .withMetadata(new Metadata().withAdditionalProperty("key1", "value1"));
+  }
+
+  private static AttemptFailureSummaryForMigration getFailureSummary(final FailureReasonForMigration ...failureReasons) {
+    return new AttemptFailureSummaryForMigration()
+        .withPartialSuccess(false)
+        .withFailures(List.of(failureReasons));
+  }
+}

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
@@ -346,7 +346,7 @@ class JobTrackerTest {
 
       {
         put("failureOrigin", "source");
-        put("failureType", "configError");
+        put("failureType", "config_error");
         put("internalMessage", "Internal config error error msg");
         put("externalMessage", "Config error related msg");
         put("metadata", ImmutableMap.of("some", "metadata"));
@@ -360,7 +360,7 @@ class JobTrackerTest {
 
       {
         put("failureOrigin", "replication");
-        put("failureType", "systemError");
+        put("failureType", "system_error");
         put("internalMessage", "Internal system error error msg");
         put("externalMessage", "System error related msg");
         put("metadata", ImmutableMap.of("some", "metadata"));


### PR DESCRIPTION
### Overview

The current FailureReason schema has a few issues:

1. We decided to replace `replicationWorker` origin with `replication`, but when I made this change initially, I neglected to consider records that had already been written to databases with `replicationWorker` set as the value. When we added failure origins to the UI, any workspace that had a `replicationWorker` enum value set would crash due to deserialization failure. In order to get us back online quickly, I re-added `replicationWorker` to the enum.

2. We decided that having an 'unknown' value for a nullable field was confusing since 'unknown' and 'null' mean the same thing. We don't actually set 'unknown' anywhere in code, so this PR just removes it from the enum to avoid confusion.

3. There is a lurking snake_case vs camelCase discrepancy in the `failureType` enum that could cause a deserialization failure in the future. The API schema uses snake_case while the json schema uses camelCase. Right now we don't have any code that depends on this enum but this will likely change in the near future. This PR updates the enum values to snake_case so that we're consistent between what we store in the DB and what the API expects.

Basically, there were some pitfalls around working with json schemas, jsonb columns, and serialization that I fell into during this project, and now that I've learned what those pitfalls are and how to avoid them, I'm writing this PR to clean up the mess and get us back into a solid state.

### Implementation Details

- The migration queries the `attempts` table to find all records that contain a failure summary that contains an enum value that needs correcting.
- The migration class defines its own version of the AttemptFailureSummary and FailureReason class that are essentially copies of the real thing, except for the fact that they support both the old and new versions of the enum values. This is important because we need this migration to be able to deserialize records whenever it is run, no matter what version of Airbyte it's being run against. I can't use the real version of these classes as deserialization targets because we're removing the deprecated enum values from them.
- The migration test should cover every bad enum value and the update from 'unknown' to null.