### PR TITLE
Remove Postgres from local pre-requisites

### DIFF
--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -6,8 +6,7 @@ The following technologies are required to build Airbyte locally.
 2. `Node 16`
 3. `Python 3.7`
 4. `Docker`
-5. `Postgresql`
-6. `Jq`
+5. `Jq`
 
 {% hint style="info" %}
 Manually switching between different language versions can get hairy. We recommend using a version manager such as [`pyenv`](https://github.com/pyenv/pyenv) or [`jenv`](https://github.com/jenv/jenv).


### PR DESCRIPTION
Airbyte stack starts up a container with Postgres (airbyte-db) and does not need an RDBMS to be running on the host. This small change removes Postgres from the list of pre-requisites.