### PR TITLE
Hide shopify in cloud

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -182,6 +182,7 @@ const ConnectorServiceTypeControl: React.FC<{
       ? [
           "200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b", // Snapchat
           "2470e835-feaf-4db6-96f3-70fd645acc77", // Salesforce Singer
+          "9da77001-af33-4bcd-be46-6252bf9342b9", // Shopify
         ]
       : [];
   const sortedDropDownData = useMemo(


### PR DESCRIPTION
## What
IDK exactly why shopify was added back to Cloud but given that our oauth application is not ready yet, it should not be available for customers to pick. 

cc @bazarnov hiding it from Cloud for the time being. 