### PR TITLE
Snowflake s3 memory usage investigation

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
@@ -184,6 +184,7 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
       for (final Map.Entry<AirbyteStreamNameNamespacePair, List<AirbyteRecordMessage>> entry : streamBuffer.entrySet()) {
         LOGGER.info("Flushing {}: {} records", entry.getKey().getName(), entry.getValue().size());
         recordWriter.accept(entry.getKey(), entry.getValue());
+
         if (checkAndRemoveRecordWriter != null) {
           fileName = checkAndRemoveRecordWriter.apply(entry.getKey(), fileName);
         }

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/CopyConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/CopyConsumerFactory.java
@@ -106,6 +106,8 @@ public class CopyConsumerFactory {
   private static CheckAndRemoveRecordWriter removeStagingFilePrinter(final Map<AirbyteStreamNameNamespacePair, StreamCopier> pairToCopier) {
     return (AirbyteStreamNameNamespacePair pair, String stagingFileName) -> {
       String currentFileName = pairToCopier.get(pair).getCurrentFile();
+      LOGGER.info("Checking writer removal for stream {} (staging file: {}, current file: {})",
+          pair.getName(), stagingFileName, currentFileName);
       if (stagingFileName != null && currentFileName != null && !stagingFileName.equals(currentFileName)) {
         pairToCopier.get(pair).closeNonCurrentStagingFileWriters();
       }

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3StreamCopier.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/s3/S3StreamCopier.java
@@ -36,7 +36,9 @@ public abstract class S3StreamCopier implements StreamCopier {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(S3StreamCopier.class);
 
-  private static final int DEFAULT_UPLOAD_THREADS = 10; // The S3 cli uses 10 threads by default.
+  // The S3 cli uses 10 threads by default, but each thread will hold
+  // upto partSize amount of memory. So we cannot set it to very high.
+  private static final int DEFAULT_UPLOAD_THREADS = 2;
   private static final int DEFAULT_QUEUE_CAPACITY = DEFAULT_UPLOAD_THREADS;
 
   protected final AmazonS3 s3Client;

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/S3CsvWriter.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/S3CsvWriter.java
@@ -20,6 +20,7 @@ import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.QuoteMode;
@@ -36,6 +37,7 @@ public class S3CsvWriter extends BaseS3Writer implements DestinationFileWriter {
   private final CSVPrinter csvPrinter;
   private final String objectKey;
   private final String gcsFileLocation;
+  private static final AtomicInteger ID_GENERATOR = new AtomicInteger(0);
 
   private S3CsvWriter(final S3DestinationConfig config,
                       final AmazonS3 s3Client,
@@ -51,7 +53,7 @@ public class S3CsvWriter extends BaseS3Writer implements DestinationFileWriter {
 
     this.csvSheetGenerator = csvSheetGenerator;
 
-    final String fileSuffix = "_" + UUID.randomUUID();
+    final String fileSuffix = "_" + ID_GENERATOR.incrementAndGet();
     final String outputFilename = BaseS3Writer.getOutputFilename(uploadTimestamp, fileSuffix, S3Format.CSV);
     this.objectKey = String.join("/", outputPrefix, outputFilename);
 

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/StagingDatabaseCsvSheetGenerator.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/StagingDatabaseCsvSheetGenerator.java
@@ -24,6 +24,8 @@ import java.util.UUID;
  */
 public class StagingDatabaseCsvSheetGenerator implements CsvSheetGenerator {
 
+  public static final StagingDatabaseCsvSheetGenerator INSTANCE = new StagingDatabaseCsvSheetGenerator();
+
   /**
    * This method is implemented for clarity, but not actually used. S3StreamCopier disables headers on
    * S3CsvWriter.

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/csv/S3CsvWriterTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/csv/S3CsvWriterTest.java
@@ -266,7 +266,7 @@ class S3CsvWriterTest {
             .queueCapacity(QUEUE_CAPACITY)
             .withHeader(false)
             .csvSettings(CSVFormat.DEFAULT)
-            .csvSheetGenerator(new StagingDatabaseCsvSheetGenerator())
+            .csvSheetGenerator(StagingDatabaseCsvSheetGenerator.INSTANCE)
             .build();
 
     writer.write(

--- a/airbyte-integrations/connectors/destination-snowflake/Dockerfile
+++ b/airbyte-integrations/connectors/destination-snowflake/Dockerfile
@@ -10,12 +10,14 @@ FROM airbyte/integration-base-java:dev
 WORKDIR /airbyte
 
 ENV APPLICATION destination-snowflake
+RUN apt-get update && apt-get install -y procps && rm -rf /var/lib/apt/lists/*
 
 # Needed for JDK17 (in turn, needed on M1 macs) - see https://github.com/snowflakedb/snowflake-jdbc/issues/589#issuecomment-983944767
 ENV DESTINATION_SNOWFLAKE_OPTS "--add-opens java.base/java.nio=ALL-UNNAMED"
 
 COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
+EXPOSE 6000
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
 ENV APPLICATION_VERSION 0.4.17

--- a/airbyte-integrations/connectors/destination-snowflake/build.gradle
+++ b/airbyte-integrations/connectors/destination-snowflake/build.gradle
@@ -10,14 +10,15 @@ application {
     applicationDefaultJvmArgs = [
             '-XX:+ExitOnOutOfMemoryError',
             '-XX:MaxRAMPercentage=75.0',
-//            '-XX:NativeMemoryTracking=detail',
-//            "-Djava.rmi.server.hostname=localhost",
-//            '-Dcom.sun.management.jmxremote=true',
-//            '-Dcom.sun.management.jmxremote.port=6000',
-//            "-Dcom.sun.management.jmxremote.rmi.port=6000",
-//            '-Dcom.sun.management.jmxremote.local.only=false',
-//            '-Dcom.sun.management.jmxremote.authenticate=false',
-//            '-Dcom.sun.management.jmxremote.ssl=false',
+            '-Xmx1000m',
+            '-XX:NativeMemoryTracking=detail',
+            "-Djava.rmi.server.hostname=localhost",
+            '-Dcom.sun.management.jmxremote=true',
+            '-Dcom.sun.management.jmxremote.port=6000',
+            "-Dcom.sun.management.jmxremote.rmi.port=6000",
+            '-Dcom.sun.management.jmxremote.local.only=false',
+            '-Dcom.sun.management.jmxremote.authenticate=false',
+            '-Dcom.sun.management.jmxremote.ssl=false',
 //            '-agentpath:/usr/local/YourKit-JavaProfiler-2021.3/bin/linux-x86-64/libyjpagent.so=port=10001,listen=all'
     ]
 

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeParallelCopyStreamCopier.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeParallelCopyStreamCopier.java
@@ -13,6 +13,8 @@ import java.util.stream.Collectors;
 
 interface SnowflakeParallelCopyStreamCopier {
 
+  int STAGE_COPY_THREAD_SIZE = 5;
+
   /**
    * Generates list of staging files. See more
    * https://docs.snowflake.com/en/user-guide/data-load-considerations-load.html#lists-of-files
@@ -28,7 +30,7 @@ interface SnowflakeParallelCopyStreamCopier {
    * completed.
    */
   default void copyFilesInParallel(List<List<String>> partitions) {
-    ExecutorService executorService = Executors.newFixedThreadPool(5);
+    ExecutorService executorService = Executors.newFixedThreadPool(STAGE_COPY_THREAD_SIZE);
     List<CompletableFuture<Void>> futures = partitions.stream()
         .map(partition -> CompletableFuture.runAsync(() -> copyIntoStage(partition), executorService))
         .toList();

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeParallelCopyStreamCopier.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeParallelCopyStreamCopier.java
@@ -31,7 +31,7 @@ interface SnowflakeParallelCopyStreamCopier {
     ExecutorService executorService = Executors.newFixedThreadPool(5);
     List<CompletableFuture<Void>> futures = partitions.stream()
         .map(partition -> CompletableFuture.runAsync(() -> copyIntoStage(partition), executorService))
-        .collect(Collectors.toList());
+        .toList();
 
     try {
       // wait until all futures ready

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/DockerProcessFactory.java
@@ -113,9 +113,10 @@ public class DockerProcessFactory implements ProcessFactory {
           "--log-driver",
           "none");
 
-      if (networkName != null) {
-        cmd.add("--network");
-        cmd.add(networkName);
+      if (imageName.startsWith("airbyte/destination-snowflake")) {
+        LOGGER.info("Exposing image {} port 6000", imageName);
+        cmd.add("-p");
+        cmd.add("6000:6000");
       }
 
       if (workspaceMountSource != null) {


### PR DESCRIPTION
- Relate to https://github.com/airbytehq/airbyte/issues/10591.

## Findings
- We are using 10 upload thread per stream, which is costly.
- We always keep N number of stream uploader. We can potentially close them more aggressively.
- We always open a new S3 connection pool for each stream. This is wasteful, but not the root cause of high memory usage.
