### PR TITLE
Exclude package.json from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 # Frontend code
-/airbyte-webapp/  @airbytehq/frontend
 /airbyte-webapp-e2e-tests/  @airbytehq/frontend
+/airbyte-webapp/  @airbytehq/frontend
+## Exclude the package(-lock).json from code ownership to prevent version bump PRs from triggering codeowners review
+/airbyte-webapp/package.json
+/airbyte-webapp/package-lock.json


### PR DESCRIPTION
## What

Exclude the package.json and package-lock.json from the code ownership of the frontend team. This will prevent our version bump automatically generated PRs to trigger a codeownership review, which is a noise for the FE team + the person creating the version bump PR.

We unfortunately can't disable codeownership for specific PRs which would be the better way, since this will also disable codeownership triggering on PRs that purely touch package.json otherwise, but that's a small enough concern for now.