### PR TITLE
Use cypress dashboard and stabilize e2e tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -440,6 +440,8 @@ jobs:
         run: SUB_BUILD=PLATFORM ./gradlew --no-daemon assemble --scan
 
       - name: Run End-to-End Frontend Tests
+        env:
+          CYPRESS_WEBAPP_KEY: ${{ secrets.CYPRESS_WEBAPP_KEY }}
         run: ./tools/bin/e2e_test.sh
   # In case of self-hosted EC2 errors, remove this block.
   stop-frontend-test-runner:

--- a/airbyte-webapp-e2e-tests/build.gradle
+++ b/airbyte-webapp-e2e-tests/build.gradle
@@ -13,8 +13,15 @@ node {
 
 task e2etest(type: NpmTask) {
     dependsOn npmInstall
-
-    args = ['run', 'cypress:ci']
+    // If the cypressWebappKey property has been set from the outside (see tools/bin/e2e_test.sh)
+    // we'll record the cypress session, otherwise we're not recording
+    def recordCypress = project.hasProperty('cypressWebappKey') && project.getProperty('cypressWebappKey')
+    if (recordCypress) {
+        environment = [CYPRESS_KEY: project.getProperty('cypressWebappKey')]
+        args = ['run', 'cypress:ci:record']
+    } else {
+        args = ['run', 'cypress:ci']
+    }
     inputs.files fileTree('cypress')
     inputs.file 'package.json'
     inputs.file 'package-lock.json'

--- a/airbyte-webapp-e2e-tests/cypress.json
+++ b/airbyte-webapp-e2e-tests/cypress.json
@@ -1,4 +1,5 @@
 {
+  "projectId": "916nvw",
   "baseUrl": "http://localhost:3000",
   "testFiles": [
     "base.spec.js",

--- a/airbyte-webapp-e2e-tests/cypress.json
+++ b/airbyte-webapp-e2e-tests/cypress.json
@@ -1,6 +1,6 @@
 {
   "projectId": "916nvw",
-  "baseUrl": "http://localhost:3000",
+  "baseUrl": "http://localhost:8000",
   "testFiles": [
     "base.spec.js",
     "onboarding.spec.js",

--- a/airbyte-webapp-e2e-tests/cypress.json
+++ b/airbyte-webapp-e2e-tests/cypress.json
@@ -1,6 +1,6 @@
 {
   "projectId": "916nvw",
-  "baseUrl": "http://localhost:8000",
+  "baseUrl": "http://localhost:3000",
   "testFiles": [
     "base.spec.js",
     "onboarding.spec.js",

--- a/airbyte-webapp-e2e-tests/cypress/integration/connection.spec.js
+++ b/airbyte-webapp-e2e-tests/cypress/integration/connection.spec.js
@@ -1,4 +1,8 @@
 describe("Connection main actions", () => {
+  beforeEach(() => {
+    cy.initialSetupCompleted();
+  });
+
   it("Create new connection", () => {
     cy.createTestConnection("Test connection source cypress", "Test destination cypress");
 
@@ -6,7 +10,7 @@ describe("Connection main actions", () => {
     cy.get("div").contains("Test destination cypress").should("exist");
   });
 
-  it.only("Update connection", () => {
+  it("Update connection", () => {
     cy.intercept("/api/v1/web_backend/connections/update").as("updateConnection");
 
     cy.createTestConnection("Test update connection source cypress", "Test update connection destination cypress");

--- a/airbyte-webapp-e2e-tests/cypress/integration/destination.spec.js
+++ b/airbyte-webapp-e2e-tests/cypress/integration/destination.spec.js
@@ -1,4 +1,8 @@
 describe("Destination main actions", () => {
+  beforeEach(() => {
+    cy.initialSetupCompleted();
+  });
+
   it("Create new destination", () => {
     cy.createTestDestination("Test destination cypress");
 

--- a/airbyte-webapp-e2e-tests/cypress/integration/onboarding.spec.js
+++ b/airbyte-webapp-e2e-tests/cypress/integration/onboarding.spec.js
@@ -1,4 +1,8 @@
 describe("Preferences actions", () => {
+  beforeEach(() => {
+    cy.initialSetupCompleted(false);
+  });
+
   it("Should redirect to onboarding after email is entered", () => {
     cy.visit("/preferences");
     cy.url().should("include", `/preferences`);

--- a/airbyte-webapp-e2e-tests/cypress/integration/source.spec.js
+++ b/airbyte-webapp-e2e-tests/cypress/integration/source.spec.js
@@ -1,4 +1,8 @@
 describe("Source main actions", () => {
+  beforeEach(() => {
+    cy.initialSetupCompleted();
+  });
+
   it("Create new source", () => {
     cy.createTestSource("Test source cypress");
 

--- a/airbyte-webapp-e2e-tests/cypress/support/commands/index.ts
+++ b/airbyte-webapp-e2e-tests/cypress/support/commands/index.ts
@@ -3,3 +3,4 @@ import "./sidebar";
 import "./source";
 import "./destination";
 import "./connection";
+import "./workspaces";

--- a/airbyte-webapp-e2e-tests/cypress/support/commands/workspaces.js
+++ b/airbyte-webapp-e2e-tests/cypress/support/commands/workspaces.js
@@ -1,9 +1,9 @@
-Cypress.Commands.add("initialSetupCompleted", () => {
+Cypress.Commands.add("initialSetupCompleted", (completed = true) => {
   // Modify the workspaces/list response to mark every workspace as "initialSetupComplete" to ensure we're not showing
   // the setup/preference page for any workspace if this method got called.
   cy.intercept("POST", "/api/v1/workspaces/list", (req) => {
     req.continue(res => {
-      res.body.workspaces = res.body.workspaces.map(ws => ({ ...ws, initialSetupComplete: true }));
+      res.body.workspaces = res.body.workspaces.map(ws => ({ ...ws, initialSetupComplete: completed }));
       res.send(res.body);
     });
   });

--- a/airbyte-webapp-e2e-tests/cypress/support/commands/workspaces.js
+++ b/airbyte-webapp-e2e-tests/cypress/support/commands/workspaces.js
@@ -1,0 +1,10 @@
+Cypress.Commands.add("initialSetupCompleted", () => {
+  // Modify the workspaces/list response to mark every workspace as "initialSetupComplete" to ensure we're not showing
+  // the setup/preference page for any workspace if this method got called.
+  cy.intercept("POST", "/api/v1/workspaces/list", (req) => {
+    req.continue(res => {
+      res.body.workspaces = res.body.workspaces.map(ws => ({ ...ws, initialSetupComplete: true }));
+      res.send(res.body);
+    });
+  });
+});

--- a/airbyte-webapp-e2e-tests/package.json
+++ b/airbyte-webapp-e2e-tests/package.json
@@ -4,7 +4,8 @@
   "description": "Airbyte e2e testing",
   "scripts": {
     "cypress:open": "cypress open",
-    "cypress:ci": "CYPRESS_BASE_URL=http://localhost:8000 cypress run"
+    "cypress:ci": "CYPRESS_BASE_URL=http://localhost:8000 cypress run",
+    "cypress:ci:record": "CYPRESS_BASE_URL=http://localhost:8000 cypress run --record --key $CYPRESS_KEY"
   },
   "eslintConfig": {
     "env": {

--- a/tools/bin/e2e_test.sh
+++ b/tools/bin/e2e_test.sh
@@ -16,9 +16,9 @@ mkdir -p /tmp/airbyte_local
 
 # Detach so we can run subsequent commands
 VERSION=dev TRACKING_STRATEGY=logging docker-compose up -d
-trap 'echo "docker-compose logs:" && docker-compose logs -t --tail 1000 && docker-compose down && docker rm -f $(docker ps -q --filter name=airbyte_ci_pg)' EXIT
+trap 'echo "docker-compose logs:" && docker-compose logs -t --tail 1000 && docker-compose down && docker stop airbyte_ci_pg' EXIT
 
-docker run -d -p 5433:5432 -e POSTGRES_PASSWORD=secret_password -e POSTGRES_DB=airbyte_ci --name airbyte_ci_pg postgres
+docker run --rm -d -p 5433:5432 -e POSTGRES_PASSWORD=secret_password -e POSTGRES_DB=airbyte_ci --name airbyte_ci_pg postgres
 echo "Waiting for services to begin"
 sleep 30 # TODO need a better way to wait
 

--- a/tools/bin/e2e_test.sh
+++ b/tools/bin/e2e_test.sh
@@ -23,4 +23,4 @@ echo "Waiting for services to begin"
 sleep 30 # TODO need a better way to wait
 
 echo "Running e2e tests via gradle"
-SUB_BUILD=PLATFORM ./gradlew --no-daemon :airbyte-webapp-e2e-tests:e2etest
+SUB_BUILD=PLATFORM ./gradlew --no-daemon :airbyte-webapp-e2e-tests:e2etest -PcypressWebappKey=$CYPRESS_WEBAPP_KEY


### PR DESCRIPTION
## What
Use Cypress dashboard to record all e2e test runs. We're passing in the cypress key from the `e2e_test.sh` explicitly as a property, since gradle build files won't have access to all environment variables by default.

Also our test suites currently relied that they are running in a specific order, so that the onboarding test handles the preferences screen that should then be gone for other tests. This is an [anti-pattern](https://docs.cypress.io/guides/references/best-practices#Organizing-Tests-Logging-In-Controlling-State) and test order actually differs when using `--record`, since it's enabling paralellization. Thus I properly made sure the test suites are handling their setup state internally, so the test order execution won't matter anymore.

Also the e2e test script will now properly wait on the airbyte-server to be available before starting the test run (so far it just waited 30s).

I've also added integration from cypress dashboards with GitHub checks, so that the link to the test run will be easier accessible directly as a check:

![screenshot-20220303-124934](https://user-images.githubusercontent.com/877229/156559561-fb11c807-f0ed-4d32-89df-a299ddc5a4f2.png)
