### PR TITLE
destination-s3: add a test for listObjects permission on destination bucket

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -203,7 +203,7 @@
 - name: S3
   destinationDefinitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
   dockerRepository: airbyte/destination-s3
-  dockerImageTag: 0.2.9
+  dockerImageTag: 0.2.10
   documentationUrl: https://docs.airbyte.io/integrations/destinations/s3
   icon: s3.svg
   resourceRequirements:

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -3454,7 +3454,7 @@
     supported_destination_sync_modes:
     - "append"
     - "overwrite"
-- dockerImage: "airbyte/destination-s3:0.2.9"
+- dockerImage: "airbyte/destination-s3:0.2.10"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/s3"
     connectionSpecification:

--- a/airbyte-integrations/connectors/destination-s3/Dockerfile
+++ b/airbyte-integrations/connectors/destination-s3/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-s3
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.2.9
+LABEL io.airbyte.version=0.2.10
 LABEL io.airbyte.name=airbyte/destination-s3

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3Destination.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3Destination.java
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.s3;
 import alex.mojaki.s3upload.MultiPartOutputStream;
 import alex.mojaki.s3upload.StreamTransferManager;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.integrations.BaseConnector;
@@ -33,7 +34,15 @@ import org.slf4j.LoggerFactory;
 public class S3Destination extends BaseConnector implements Destination {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(S3Destination.class);
+  private final S3DestinationConfigFactory configFactory;
 
+  public S3Destination () {
+    this.configFactory = new S3DestinationConfigFactory();
+  }
+
+  public S3Destination (final S3DestinationConfigFactory configFactory) {
+    this.configFactory = configFactory;
+  }
   public static void main(final String[] args) throws Exception {
     new IntegrationRunner(new S3Destination()).run(args);
   }
@@ -41,8 +50,11 @@ public class S3Destination extends BaseConnector implements Destination {
   @Override
   public AirbyteConnectionStatus check(final JsonNode config) {
     try {
-      final S3DestinationConfig destinationConfig = S3DestinationConfig.getS3DestinationConfig(config);
+      final S3DestinationConfig destinationConfig = this.configFactory.getS3DestinationConfig(config);
       final AmazonS3 s3Client = destinationConfig.getS3Client();
+
+      // Test for listObjects permission
+      testIAMUserHasListObjectPermission(s3Client, destinationConfig.getBucketName());
 
       // Test single upload (for small files) permissions
       testSingleUpload(s3Client, destinationConfig.getBucketName());
@@ -58,6 +70,13 @@ public class S3Destination extends BaseConnector implements Destination {
           .withMessage("Could not connect to the S3 bucket with the provided configuration. \n" + e
               .getMessage());
     }
+  }
+
+  public static void testIAMUserHasListObjectPermission(final AmazonS3 s3Client, final String bucketName) {
+    LOGGER.info("Started testing if IAM user can call listObjects on the destination bucket");
+    final ListObjectsRequest request = new ListObjectsRequest().withBucketName(bucketName).withMaxKeys(1);
+    s3Client.listObjects(request);
+    LOGGER.info("Finished checking for listObjects permission");
   }
 
   public static void testSingleUpload(final AmazonS3 s3Client, final String bucketName) {

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3Destination.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3Destination.java
@@ -36,13 +36,14 @@ public class S3Destination extends BaseConnector implements Destination {
   private static final Logger LOGGER = LoggerFactory.getLogger(S3Destination.class);
   private final S3DestinationConfigFactory configFactory;
 
-  public S3Destination () {
+  public S3Destination() {
     this.configFactory = new S3DestinationConfigFactory();
   }
 
-  public S3Destination (final S3DestinationConfigFactory configFactory) {
+  public S3Destination(final S3DestinationConfigFactory configFactory) {
     this.configFactory = configFactory;
   }
+
   public static void main(final String[] args) throws Exception {
     new IntegrationRunner(new S3Destination()).run(args);
   }

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
@@ -58,14 +58,14 @@ public class S3DestinationConfig {
   }
 
   public S3DestinationConfig(final String endpoint,
-      final String bucketName,
-      final String bucketPath,
-      final String bucketRegion,
-      final String accessKeyId,
-      final String secretAccessKey,
-      final Integer partSize,
-      final S3FormatConfig formatConfig,
-      final AmazonS3 s3Client) {
+                             final String bucketName,
+                             final String bucketPath,
+                             final String bucketRegion,
+                             final String accessKeyId,
+                             final String secretAccessKey,
+                             final Integer partSize,
+                             final S3FormatConfig formatConfig,
+                             final AmazonS3 s3Client) {
     this.endpoint = endpoint;
     this.bucketName = bucketName;
     this.bucketPath = bucketPath;
@@ -78,13 +78,13 @@ public class S3DestinationConfig {
   }
 
   public S3DestinationConfig(final String endpoint,
-      final String bucketName,
-      final String bucketPath,
-      final String bucketRegion,
-      final String accessKeyId,
-      final String secretAccessKey,
-      final Integer partSize,
-      final S3FormatConfig formatConfig) {
+                             final String bucketName,
+                             final String bucketPath,
+                             final String bucketRegion,
+                             final String accessKeyId,
+                             final String secretAccessKey,
+                             final Integer partSize,
+                             final S3FormatConfig formatConfig) {
     this(endpoint, bucketName, bucketPath, bucketRegion, accessKeyId, secretAccessKey, partSize, formatConfig, null);
   }
 

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
@@ -58,13 +58,14 @@ public class S3DestinationConfig {
   }
 
   public S3DestinationConfig(final String endpoint,
-                             final String bucketName,
-                             final String bucketPath,
-                             final String bucketRegion,
-                             final String accessKeyId,
-                             final String secretAccessKey,
-                             final Integer partSize,
-                             final S3FormatConfig formatConfig) {
+      final String bucketName,
+      final String bucketPath,
+      final String bucketRegion,
+      final String accessKeyId,
+      final String secretAccessKey,
+      final Integer partSize,
+      final S3FormatConfig formatConfig,
+      final AmazonS3 s3Client) {
     this.endpoint = endpoint;
     this.bucketName = bucketName;
     this.bucketPath = bucketPath;
@@ -73,6 +74,18 @@ public class S3DestinationConfig {
     this.secretAccessKey = secretAccessKey;
     this.formatConfig = formatConfig;
     this.partSize = partSize;
+    this.s3Client = s3Client;
+  }
+
+  public S3DestinationConfig(final String endpoint,
+      final String bucketName,
+      final String bucketPath,
+      final String bucketRegion,
+      final String accessKeyId,
+      final String secretAccessKey,
+      final Integer partSize,
+      final S3FormatConfig formatConfig) {
+    this(endpoint, bucketName, bucketPath, bucketRegion, accessKeyId, secretAccessKey, partSize, formatConfig, null);
   }
 
   public static S3DestinationConfig getS3DestinationConfig(final JsonNode config) {
@@ -166,9 +179,7 @@ public class S3DestinationConfig {
       return AmazonS3ClientBuilder.standard()
           .withCredentials(new InstanceProfileCredentialsProvider(false))
           .build();
-    }
-
-    else if (endpoint == null || endpoint.isEmpty()) {
+    } else if (endpoint == null || endpoint.isEmpty()) {
       return AmazonS3ClientBuilder.standard()
           .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
           .withRegion(bucketRegion)

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfigFactory.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfigFactory.java
@@ -1,0 +1,9 @@
+package io.airbyte.integrations.destination.s3;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class S3DestinationConfigFactory {
+  public S3DestinationConfig getS3DestinationConfig(final JsonNode config) {
+    return S3DestinationConfig.getS3DestinationConfig(config);
+  }
+}

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfigFactory.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfigFactory.java
@@ -1,9 +1,15 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.destination.s3;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class S3DestinationConfigFactory {
+
   public S3DestinationConfig getS3DestinationConfig(final JsonNode config) {
     return S3DestinationConfig.getS3DestinationConfig(config);
   }
+
 }

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/S3DestinationTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/S3DestinationTest.java
@@ -4,13 +4,27 @@
 
 package io.airbyte.integrations.destination.s3;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.protocol.models.AirbyteConnectionStatus;
+import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -20,11 +34,21 @@ import org.mockito.Mockito;
 public class S3DestinationTest {
 
   private AmazonS3 s3;
+  private AmazonS3 s3NoAccess;
   private S3DestinationConfig config;
 
   @BeforeEach
   public void setup() {
+    // S3 client mock for successful operations
     s3 = mock(AmazonS3.class);
+    final InitiateMultipartUploadResult uploadResult = mock(InitiateMultipartUploadResult.class);
+    final UploadPartResult uploadPartResult = mock(UploadPartResult.class);
+    when(s3.uploadPart(any(UploadPartRequest.class))).thenReturn(uploadPartResult);
+    when(s3.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class))).thenReturn(uploadResult);
+
+    // S3 client mock that throws Access Denied exception for listObjects operation
+    s3NoAccess = mock(AmazonS3.class);
+    doThrow(new AmazonS3Exception("Access Denied")).when(s3NoAccess).listObjects(any(ListObjectsRequest.class));
     config = new S3DestinationConfig(
         "fake-endpoint",
         "fake-bucket",
@@ -32,7 +56,44 @@ public class S3DestinationTest {
         "fake-region",
         "fake-accessKeyId",
         "fake-secretAccessKey",
-        null);
+        S3DestinationConfig.DEFAULT_PART_SIZE_MB, null, s3);
+  }
+
+  @Test
+  public void checksS3NoListObjectPermission() {
+    final S3Destination destinationFail = new S3Destination(new S3DestinationConfigFactory () {
+      public S3DestinationConfig getS3DestinationConfig(final JsonNode config) {
+        return new S3DestinationConfig(
+            "fake-endpoint",
+            "fake-bucket",
+            "fake-bucketPath",
+            "fake-region",
+            "fake-accessKeyId",
+            "fake-secretAccessKey",
+            S3DestinationConfig.DEFAULT_PART_SIZE_MB,
+            null, s3NoAccess);
+      }
+    });
+    AirbyteConnectionStatus status = destinationFail.check(null);
+    assertEquals(Status.FAILED, status.getStatus(), "Connection check should have failed");
+    assertTrue(status.getMessage().indexOf("Access Denied") > 0, "Connection check returned wrong failure message");
+
+    // Test that check succeeds when IAM user has listObjects permission
+    final S3Destination destinationSuccess = new S3Destination(new S3DestinationConfigFactory () {
+      public S3DestinationConfig getS3DestinationConfig(final JsonNode config) {
+        return new S3DestinationConfig(
+            "fake-endpoint",
+            "fake-bucket",
+            "fake-bucketPath",
+            "fake-region",
+            "fake-accessKeyId",
+            "fake-secretAccessKey",
+            S3DestinationConfig.DEFAULT_PART_SIZE_MB,
+            null, s3);
+      }
+    });
+    status = destinationSuccess.check(null);
+    assertEquals(Status.SUCCEEDED, status.getStatus(), "Connection check should have succeeded");
   }
 
   @Test

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -224,31 +224,32 @@ Under the hood, an Airbyte data stream in Json schema is first converted to an A
 
 ## CHANGELOG
 
-| Version | Date | Pull Request | Subject |
-|:--------| :--- | :--- | :--- |
-| 0.2.7 | 2022-02-14 | [\#10318](https://github.com/airbytehq/airbyte/pull/10318) | Prevented double slashes in S3 destination path |
-| 0.2.6 | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option |
-| 0.2.5 | 2022-01-13 | [\#9399](https://github.com/airbytehq/airbyte/pull/9399) | Use instance profile authentication if credentials are not provided |
-| 0.2.4   | 2022-01-12 | [\#9415](https://github.com/airbytehq/airbyte/pull/9415)   | BigQuery Destination : Fix GCS processing of Facebook data |
-| 0.2.3   | 2022-01-11 | [\#9367](https://github.com/airbytehq/airbyte/pull/9367) | Avro & Parquet: support array field with unknown item type; default any improperly typed field to string. |
-| 0.2.2   | 2021-12-21 | [\#8574](https://github.com/airbytehq/airbyte/pull/8574) | Added namespace to Avro and Parquet record types |
-| 0.2.1   | 2021-12-20 | [\#8974](https://github.com/airbytehq/airbyte/pull/8974) | Release a new version to ensure there is no excessive logging. |
+| Version | Date | Pull Request | Subject                                                                                                                    |
+|:--------| :--- | :--- |:---------------------------------------------------------------------------------------------------------------------------|
+| 0.2.8   | 2022-03-07 | [\#10856](https://github.com/airbytehq/airbyte/pull/10856) | `check` method now tests for listObjects permissions on the target bucket                                                  |
+| 0.2.7 | 2022-02-14 | [\#10318](https://github.com/airbytehq/airbyte/pull/10318) | Prevented double slashes in S3 destination path                                                                            |
+| 0.2.6 | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option                                                                               |
+| 0.2.5 | 2022-01-13 | [\#9399](https://github.com/airbytehq/airbyte/pull/9399) | Use instance profile authentication if credentials are not provided                                                        |
+| 0.2.4   | 2022-01-12 | [\#9415](https://github.com/airbytehq/airbyte/pull/9415)   | BigQuery Destination : Fix GCS processing of Facebook data                                                                 |
+| 0.2.3   | 2022-01-11 | [\#9367](https://github.com/airbytehq/airbyte/pull/9367) | Avro & Parquet: support array field with unknown item type; default any improperly typed field to string.                  |
+| 0.2.2   | 2021-12-21 | [\#8574](https://github.com/airbytehq/airbyte/pull/8574) | Added namespace to Avro and Parquet record types                                                                           |
+| 0.2.1   | 2021-12-20 | [\#8974](https://github.com/airbytehq/airbyte/pull/8974) | Release a new version to ensure there is no excessive logging.                                                             |
 | 0.2.0   | 2021-12-15 | [\#8607](https://github.com/airbytehq/airbyte/pull/8607) | Change the output filename for CSV files - it's now `bucketPath/namespace/streamName/timestamp_epochMillis_randomUuid.csv` |
-| 0.1.16  | 2021-12-10 | [\#8562](https://github.com/airbytehq/airbyte/pull/8562) | Swap dependencies with destination-jdbc. |
-| 0.1.15  | 2021-12-03 | [\#8501](https://github.com/airbytehq/airbyte/pull/8501) | Remove excessive logging for Avro and Parquet invalid date strings. |
-| 0.1.14  | 2021-11-09 | [\#7732](https://github.com/airbytehq/airbyte/pull/7732) | Support timestamp in Avro and Parquet |
-| 0.1.13  | 2021-11-03 | [\#7288](https://github.com/airbytehq/airbyte/issues/7288) | Support Json `additionalProperties`. |
-| 0.1.12  | 2021-09-13 | [\#5720](https://github.com/airbytehq/airbyte/issues/5720) | Added configurable block size for stream. Each stream is limited to 10,000 by S3 |
-| 0.1.11  | 2021-09-10 | [\#5729](https://github.com/airbytehq/airbyte/pull/5729) | For field names that start with a digit, a `_` will be appended at the beginning for the`Parquet` and `Avro` formats. |
-| 0.1.10  | 2021-08-17 | [\#4699](https://github.com/airbytehq/airbyte/pull/4699) | Added json config validator |
-| 0.1.9   | 2021-07-12 | [\#4666](https://github.com/airbytehq/airbyte/pull/4666) | Fix MinIO output for Parquet format. |
-| 0.1.8   | 2021-07-07 | [\#4613](https://github.com/airbytehq/airbyte/pull/4613) | Patched schema converter to support combined restrictions. |
-| 0.1.7   | 2021-06-23 | [\#4227](https://github.com/airbytehq/airbyte/pull/4227) | Added Avro and JSONL output. |
-| 0.1.6   | 2021-06-16 | [\#4130](https://github.com/airbytehq/airbyte/pull/4130) | Patched the check to verify prefix access instead of full-bucket access. |
-| 0.1.5   | 2021-06-14 | [\#3908](https://github.com/airbytehq/airbyte/pull/3908) | Fixed default `max_padding_size_mb` in `spec.json`. |
-| 0.1.4   | 2021-06-14 | [\#3908](https://github.com/airbytehq/airbyte/pull/3908) | Added Parquet output. |
-| 0.1.3   | 2021-06-13 | [\#4038](https://github.com/airbytehq/airbyte/pull/4038) | Added support for alternative S3. |
-| 0.1.2   | 2021-06-10 | [\#4029](https://github.com/airbytehq/airbyte/pull/4029) | Fixed `_airbyte_emitted_at` field to be a UTC instead of local timestamp for consistency. |
-| 0.1.1   | 2021-06-09 | [\#3973](https://github.com/airbytehq/airbyte/pull/3973) | Added `AIRBYTE_ENTRYPOINT` in base Docker image for Kubernetes support. |
-| 0.1.0   | 2021-06-03 | [\#3672](https://github.com/airbytehq/airbyte/pull/3672) | Initial release with CSV output. |
+| 0.1.16  | 2021-12-10 | [\#8562](https://github.com/airbytehq/airbyte/pull/8562) | Swap dependencies with destination-jdbc.                                                                                   |
+| 0.1.15  | 2021-12-03 | [\#8501](https://github.com/airbytehq/airbyte/pull/8501) | Remove excessive logging for Avro and Parquet invalid date strings.                                                        |
+| 0.1.14  | 2021-11-09 | [\#7732](https://github.com/airbytehq/airbyte/pull/7732) | Support timestamp in Avro and Parquet                                                                                      |
+| 0.1.13  | 2021-11-03 | [\#7288](https://github.com/airbytehq/airbyte/issues/7288) | Support Json `additionalProperties`.                                                                                       |
+| 0.1.12  | 2021-09-13 | [\#5720](https://github.com/airbytehq/airbyte/issues/5720) | Added configurable block size for stream. Each stream is limited to 10,000 by S3                                           |
+| 0.1.11  | 2021-09-10 | [\#5729](https://github.com/airbytehq/airbyte/pull/5729) | For field names that start with a digit, a `_` will be appended at the beginning for the`Parquet` and `Avro` formats.      |
+| 0.1.10  | 2021-08-17 | [\#4699](https://github.com/airbytehq/airbyte/pull/4699) | Added json config validator                                                                                                |
+| 0.1.9   | 2021-07-12 | [\#4666](https://github.com/airbytehq/airbyte/pull/4666) | Fix MinIO output for Parquet format.                                                                                       |
+| 0.1.8   | 2021-07-07 | [\#4613](https://github.com/airbytehq/airbyte/pull/4613) | Patched schema converter to support combined restrictions.                                                                 |
+| 0.1.7   | 2021-06-23 | [\#4227](https://github.com/airbytehq/airbyte/pull/4227) | Added Avro and JSONL output.                                                                                               |
+| 0.1.6   | 2021-06-16 | [\#4130](https://github.com/airbytehq/airbyte/pull/4130) | Patched the check to verify prefix access instead of full-bucket access.                                                   |
+| 0.1.5   | 2021-06-14 | [\#3908](https://github.com/airbytehq/airbyte/pull/3908) | Fixed default `max_padding_size_mb` in `spec.json`.                                                                        |
+| 0.1.4   | 2021-06-14 | [\#3908](https://github.com/airbytehq/airbyte/pull/3908) | Added Parquet output.                                                                                                      |
+| 0.1.3   | 2021-06-13 | [\#4038](https://github.com/airbytehq/airbyte/pull/4038) | Added support for alternative S3.                                                                                          |
+| 0.1.2   | 2021-06-10 | [\#4029](https://github.com/airbytehq/airbyte/pull/4029) | Fixed `_airbyte_emitted_at` field to be a UTC instead of local timestamp for consistency.                                  |
+| 0.1.1   | 2021-06-09 | [\#3973](https://github.com/airbytehq/airbyte/pull/3973) | Added `AIRBYTE_ENTRYPOINT` in base Docker image for Kubernetes support.                                                    |
+| 0.1.0   | 2021-06-03 | [\#3672](https://github.com/airbytehq/airbyte/pull/3672) | Initial release with CSV output.                                                                                           |
 

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -226,10 +226,10 @@ Under the hood, an Airbyte data stream in Json schema is first converted to an A
 
 | Version | Date | Pull Request | Subject                                                                                                                    |
 |:--------| :--- | :--- |:---------------------------------------------------------------------------------------------------------------------------|
-| 0.2.8   | 2022-03-07 | [\#10856](https://github.com/airbytehq/airbyte/pull/10856) | `check` method now tests for listObjects permissions on the target bucket                                                  |
-| 0.2.7 | 2022-02-14 | [\#10318](https://github.com/airbytehq/airbyte/pull/10318) | Prevented double slashes in S3 destination path                                                                            |
-| 0.2.6 | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option                                                                               |
-| 0.2.5 | 2022-01-13 | [\#9399](https://github.com/airbytehq/airbyte/pull/9399) | Use instance profile authentication if credentials are not provided                                                        |
+| 0.2.10  | 2022-03-07 | [\#10856](https://github.com/airbytehq/airbyte/pull/10856) | `check` method now tests for listObjects permissions on the target bucket                                                  |
+| 0.2.7   | 2022-02-14 | [\#10318](https://github.com/airbytehq/airbyte/pull/10318) | Prevented double slashes in S3 destination path                                                                            |
+| 0.2.6   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option                                                                               |
+| 0.2.5   | 2022-01-13 | [\#9399](https://github.com/airbytehq/airbyte/pull/9399) | Use instance profile authentication if credentials are not provided                                                        |
 | 0.2.4   | 2022-01-12 | [\#9415](https://github.com/airbytehq/airbyte/pull/9415)   | BigQuery Destination : Fix GCS processing of Facebook data                                                                 |
 | 0.2.3   | 2022-01-11 | [\#9367](https://github.com/airbytehq/airbyte/pull/9367) | Avro & Parquet: support array field with unknown item type; default any improperly typed field to string.                  |
 | 0.2.2   | 2021-12-21 | [\#8574](https://github.com/airbytehq/airbyte/pull/8574) | Added namespace to Avro and Parquet record types                                                                           |


### PR DESCRIPTION
## What
The S3 destination connector occasionally needs s3:listObjects permissions on an S3 bucket. The connector currently does not actually verify that the input IAM user has listObjects permissions on the bucket which prevents running a RESET_SCHEMA job in Airbyte. This means that a user could setup the connector only to have it fail later due to this missing permissions.

## How
* add testIAMUserHasListObjectPermission method to S3Destination
  and call this method from S3Destination::check. Method throws
  an exception if IAM user does not have listObjects permission
  on the destination bucket

* add a unit test to S3DestinationTest to verify that S3Destination::check
  fails if listObjects throws an exception

* add a unit test to S3DestinationTest to verify that S3Destination::check
  succeeds if listObjects succeeds

* Add S3DestinationConfigFactory in order to be able to mock S3 client
  used in S3Destination::check

## 🚨 User Impact 🚨
Before this change, when a user sets up an S3 destination with IAM credentials that do not have listObjects permission on the destination bucket, connection check succeeds. After this change, connection check fails if listObjects permissions are missing.


## Pre-merge Checklist
Expand the relevant checklist and delete the others.
### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [x] Code reviews completed
- [x] Documentation updated
    - [x] Connector's `README.md`
    - [x] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [x] Create a non-forked branch based on this PR and test the below items on it
- [x] Build is successful
- [x] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [x] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [x] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [x] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [x] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
## Tests

<details><summary><strong>Unit</strong></summary>

* added S3DestinationTest::checksS3NoListObjectPermission

</details>