### PR TITLE
Use ContainerRequestContext to pass requestBody between request and response filter

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/RequestLogger.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/RequestLogger.java
@@ -28,6 +28,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+/**
+ * This class implements two {@code filter()} methods that execute as part of the Jersey framework
+ * request/response chain.
+ * <p>
+ * The first {@code filter()} is the Request Filter. It takes an incoming
+ * {@link ContainerRequestContext} that contains request information, such as the request body. In
+ * this filter, we extract the request body and store it back on the request context as a custom
+ * property. We don't write any logs for requests. However, since we want to include the request
+ * body in logs for responses, we have to extract the request body in this filter.
+ * <p>
+ * The second @{code filter()} is the Response Filter. It takes an incoming
+ * {@link ContainerResponseContext} that contains response information, such as the status code.
+ * This method also has read-only access to the original {@link ContainerRequestContext}, where we
+ * set the request body as a custom property in the request filter. This is where we create and
+ * persist log lines that contain both the response status code and the original request body.
+ */
 public class RequestLogger implements ContainerRequestFilter, ContainerResponseFilter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RequestLogger.class);

--- a/airbyte-server/src/main/java/io/airbyte/server/RequestLogger.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/RequestLogger.java
@@ -48,6 +48,11 @@ public class RequestLogger implements ContainerRequestFilter, ContainerResponseF
     this.servletRequest = servletRequest;
   }
 
+  @VisibleForTesting
+  String getRequestBody() {
+    return MDC.get(MDC_RESPONSE_BODY_KEY);
+  }
+
   @Override
   public void filter(final ContainerRequestContext requestContext) throws IOException {
     MDC.setContextMap(mdc);

--- a/airbyte-server/src/main/java/io/airbyte/server/RequestLogger.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/RequestLogger.java
@@ -59,8 +59,6 @@ public class RequestLogger implements ContainerRequestFilter, ContainerResponseF
 
   @Override
   public void filter(final ContainerRequestContext requestContext) throws IOException {
-    MDC.setContextMap(mdc);
-
     if (requestContext.getMethod().equals("POST")) {
       // hack to refill the entity stream so it doesn't interfere with other operations
       final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -75,6 +73,8 @@ public class RequestLogger implements ContainerRequestFilter, ContainerResponseF
 
   @Override
   public void filter(final ContainerRequestContext requestContext, final ContainerResponseContext responseContext) {
+    MDC.setContextMap(mdc);
+
     final String remoteAddr = servletRequest.getRemoteAddr();
     final String method = servletRequest.getMethod();
     final String url = servletRequest.getRequestURI();

--- a/airbyte-server/src/test/java/io/airbyte/server/RequestLoggerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/RequestLoggerTest.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 import java.util.stream.Stream;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.container.ContainerRequestContext;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Nested;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -40,176 +42,194 @@ public class RequestLoggerTest {
   private static final String INVALID_JSON_OBJECT = "invalid";
   private static final String ACCEPTED_CONTENT_TYPE = "application/json";
   private static final String NON_ACCEPTED_CONTENT_TYPE = "application/gzip";
-
   private static final String METHOD = "POST";
   private static final String REMOTE_ADDR = "123.456.789.101";
   private static final String URL = "/api/v1/test";
+  private static final String REQUEST_BODY_PROPERTY = "requestBodyProperty";
 
   @Mock
   private HttpServletRequest mServletRequest;
 
+  private Path logPath;
+
   @BeforeEach
-  public void init() {
+  public void init() throws IOException {
     Mockito.when(mServletRequest.getMethod())
         .thenReturn(METHOD);
     Mockito.when(mServletRequest.getRemoteAddr())
         .thenReturn(REMOTE_ADDR);
     Mockito.when(mServletRequest.getRequestURI())
         .thenReturn(URL);
-  }
 
-  private static final int ERROR_CODE = 401;
-  private static final int SUCCESS_CODE = 200;
-
-  private static final String errorPrefix = RequestLogger
-      .createLogPrefix(REMOTE_ADDR, METHOD, ERROR_CODE, URL)
-      .toString();
-
-  private static final String successPrefix = RequestLogger
-      .createLogPrefix(REMOTE_ADDR, METHOD, SUCCESS_CODE, URL)
-      .toString();
-
-  static Stream<Arguments> logScenarios() {
-    return Stream.of(
-        Arguments.of(INVALID_JSON_OBJECT, NON_ACCEPTED_CONTENT_TYPE, ERROR_CODE, errorPrefix),
-        Arguments.of(INVALID_JSON_OBJECT, ACCEPTED_CONTENT_TYPE, ERROR_CODE, errorPrefix),
-        Arguments.of(VALID_JSON_OBJECT, NON_ACCEPTED_CONTENT_TYPE, ERROR_CODE, errorPrefix),
-        Arguments.of(VALID_JSON_OBJECT, ACCEPTED_CONTENT_TYPE, ERROR_CODE, errorPrefix + " - " + VALID_JSON_OBJECT),
-        Arguments.of(INVALID_JSON_OBJECT, NON_ACCEPTED_CONTENT_TYPE, SUCCESS_CODE, successPrefix),
-        Arguments.of(INVALID_JSON_OBJECT, ACCEPTED_CONTENT_TYPE, SUCCESS_CODE, successPrefix),
-        Arguments.of(VALID_JSON_OBJECT, NON_ACCEPTED_CONTENT_TYPE, SUCCESS_CODE, successPrefix),
-        Arguments.of(VALID_JSON_OBJECT, ACCEPTED_CONTENT_TYPE, SUCCESS_CODE, successPrefix + " - " + VALID_JSON_OBJECT));
-  }
-
-  @ParameterizedTest
-  @MethodSource("logScenarios")
-  @DisplayName("Check that the proper log is produced based on the scenario")
-  public void test(final String inputByteBuffer, final String contentType, final int status, final String expectedLog) throws IOException {
     // set up the mdc so that actually log to a file, so that we can verify that file logging captures
     // threads.
     final Path jobRoot = Files.createTempDirectory(Path.of("/tmp"), "mdc_test");
     LogClientSingleton.getInstance().setJobMdc(WorkerEnvironment.DOCKER,
         LogConfigs.EMPTY,
         jobRoot);
-
-    // We have to instanciate the logger here, because the MDC config has been changed to log in a
-    // temporary file.
-    final RequestLogger requestLogger = new RequestLogger(MDC.getCopyOfContextMap(), mServletRequest);
-
-    final ContainerRequestContext mRequestContext = Mockito.mock(ContainerRequestContext.class);
-    final ContainerResponseContext mResponseContext = Mockito.mock(ContainerResponseContext.class);
-
-    Mockito.when(mRequestContext.getMethod())
-        .thenReturn(METHOD);
-
-    Mockito.when(mRequestContext.getEntityStream())
-        .thenReturn(new ByteArrayInputStream(inputByteBuffer.getBytes()));
-    Mockito.when(mResponseContext.getStatus())
-        .thenReturn(status);
-    Mockito.when(mServletRequest.getHeader("Content-Type"))
-        .thenReturn(contentType);
-
-    // This is call to set the requestBody variable in the RequestLogger
-    requestLogger.filter(mRequestContext);
-    requestLogger.filter(mRequestContext, mResponseContext);
-
-    final String expectedLogLevel = status == SUCCESS_CODE ? "INFO" : "ERROR";
-
-    final Path logPath = jobRoot.resolve(LogClientSingleton.LOG_FILENAME);
-    final String logs = IOs.readFile(logPath);
-    final Stream<String> matchingLines = logs.lines()
-        .filter(line -> line.endsWith(expectedLog))
-        .filter(line -> line.contains(expectedLogLevel));
-
-    Assertions.assertThat(matchingLines).hasSize(1);
+    logPath = jobRoot.resolve(LogClientSingleton.LOG_FILENAME);
   }
 
-  /**
-   * This is a complex test that was written to prove that our requestLogger had a concurrency bug that caused incorrect request bodies to be logged.
-   * The RequestLogger originally used an instance variable that held the requestBody, which was written to by the request filter, and read by the
-   * response filter to generate a response log line that contained the original request body. If multiple requests were being processed at the same
-   * time, it was possible for the request filter of one request to overwrite the requestBody instance variable before the response log line was
-   * generated.
-   * <p>
-   * To cover this race condition, this test creates a single RequestLogger instance that is referenced from 100 threads. Each thread has a unique
-   * expected request body, and calls the request/response filter methods to retrieve it from a mocked context. Each thread stores its expected
-   * request body, and the actual request body that would be logged. The main thread then waits for all threads to finish, and then loops over each
-   * runnable to see if the expected request body matched the actual request body.
-   * <p>
-   * This test fails when using the instance variable approach for recording request bodies, and passes when using a ThreadLocal to store the request
-   * body between the request filter and the response filter.
-   */
-  @Test
-  public void testRequestBodyConsistency() {
-    final RequestLogger requestLogger = new RequestLogger(MDC.getCopyOfContextMap(), mServletRequest);
+  @Nested
+  @DisplayName("Formats logs correctly")
+  public class RequestLoggerFormatsLogsCorrectly {
 
-    final List<RequestResponseRunnable> testCases = new ArrayList<>();
-    final List<Thread> threads = new ArrayList<>();
+    private static final int ERROR_CODE = 401;
+    private static final int SUCCESS_CODE = 200;
+    private static final String errorPrefix = RequestLogger
+        .createLogPrefix(REMOTE_ADDR, METHOD, ERROR_CODE, URL)
+        .toString();
+    private static final String successPrefix = RequestLogger
+        .createLogPrefix(REMOTE_ADDR, METHOD, SUCCESS_CODE, URL)
+        .toString();
 
-    for (int i = 1; i < 100; i++) {
-      testCases.add(createRunnableTestCase(requestLogger, "thread" + i));
+    static Stream<Arguments> logScenarios() {
+      return Stream.of(
+          Arguments.of(INVALID_JSON_OBJECT, NON_ACCEPTED_CONTENT_TYPE, ERROR_CODE, errorPrefix),
+          Arguments.of(INVALID_JSON_OBJECT, ACCEPTED_CONTENT_TYPE, ERROR_CODE, errorPrefix),
+          Arguments.of(VALID_JSON_OBJECT, NON_ACCEPTED_CONTENT_TYPE, ERROR_CODE, errorPrefix),
+          Arguments.of(VALID_JSON_OBJECT, ACCEPTED_CONTENT_TYPE, ERROR_CODE, errorPrefix + " - " + VALID_JSON_OBJECT),
+          Arguments.of(INVALID_JSON_OBJECT, NON_ACCEPTED_CONTENT_TYPE, SUCCESS_CODE, successPrefix),
+          Arguments.of(INVALID_JSON_OBJECT, ACCEPTED_CONTENT_TYPE, SUCCESS_CODE, successPrefix),
+          Arguments.of(VALID_JSON_OBJECT, NON_ACCEPTED_CONTENT_TYPE, SUCCESS_CODE, successPrefix),
+          Arguments.of(VALID_JSON_OBJECT, ACCEPTED_CONTENT_TYPE, SUCCESS_CODE, successPrefix + " - " + VALID_JSON_OBJECT));
     }
 
-    testCases.forEach(testCase -> {
-      final Thread thread = new Thread(testCase);
-      threads.add(thread);
-      thread.start();
-    });
+    @Mock
+    private ContainerRequestContext mRequestContext;
+    @Mock
+    private ContainerResponseContext mResponseContext;
 
-    threads.forEach(thread -> {
-      try {
-        thread.join();
-      } catch (final InterruptedException e) {
-        e.printStackTrace();
-      }
-    });
+    private RequestLogger requestLogger;
 
-    testCases.forEach(testCase -> Assertions.assertThat(testCase.hadExpectedRequestBody()).isTrue());
-  }
+    @ParameterizedTest
+    @MethodSource("logScenarios")
+    @DisplayName("Check that the proper log is produced based on the scenario")
+    public void test(final String requestBody, final String contentType, final int status, final String expectedLog) throws IOException {
+      // We have to instanciate the logger here, because the MDC config has been changed to log in a
+      // temporary file.
+      requestLogger = new RequestLogger(MDC.getCopyOfContextMap(), mServletRequest);
 
-  private RequestResponseRunnable createRunnableTestCase(final RequestLogger requestLogger, final String threadIdentifier) {
-    final String expectedRequestBody = String.format("{\"thread\":\"%s\"}", threadIdentifier);
+      stubRequestContext(mRequestContext, requestBody);
 
-    // create thread-specific mocks
-    final ContainerRequestContext mRequestContext = Mockito.mock(ContainerRequestContext.class);
-    final ContainerResponseContext mResponseContext = Mockito.mock(ContainerResponseContext.class);
+      Mockito.when(mResponseContext.getStatus())
+          .thenReturn(status);
 
-    Mockito.when(mRequestContext.getMethod())
-        .thenReturn(METHOD);
-    Mockito.when(mRequestContext.getEntityStream())
-        .thenReturn(new ByteArrayInputStream(expectedRequestBody.getBytes()));
+      Mockito.when(mServletRequest.getHeader("Content-Type"))
+          .thenReturn(contentType);
 
-    return new RequestResponseRunnable(requestLogger, expectedRequestBody, mRequestContext, mResponseContext);
-  }
+      // This is call to set the requestBody variable in the RequestLogger
+      requestLogger.filter(mRequestContext);
+      requestLogger.filter(mRequestContext, mResponseContext);
 
-  @RequiredArgsConstructor
-  public class RequestResponseRunnable implements Runnable {
+      final String expectedLogLevel = status == SUCCESS_CODE ? "INFO" : "ERROR";
 
-    private final RequestLogger requestLogger;
-    private final String expectedRequestBody;
-    private final ContainerRequestContext mRequestContext;
-    private final ContainerResponseContext mResponseContext;
+      final String logs = IOs.readFile(logPath);
+      final Stream<String> matchingLines = logs.lines()
+          .filter(line -> line.endsWith(expectedLog))
+          .filter(line -> line.contains(expectedLogLevel));
 
-    String actualRequestBody;
-
-    public void run() {
-      try {
-        requestLogger.filter(mRequestContext);
-        Thread.sleep(new Random().nextInt(1000)); // random sleep to make race more likely
-        requestLogger.filter(mRequestContext, mResponseContext);
-      } catch (final IOException | InterruptedException e) {
-        e.printStackTrace();
-      }
-      actualRequestBody = requestLogger.getRequestBody();
-    }
-
-    public Boolean hadExpectedRequestBody() {
-      final Boolean result = expectedRequestBody.equals(actualRequestBody);
-      if (!result) {
-        System.out.println("unexpected result! expected " + expectedRequestBody + " but actual was " + actualRequestBody);
-      }
-      return result;
+      Assertions.assertThat(matchingLines).hasSize(1);
     }
   }
+
+  @Nested
+  @DisplayName("Logs correct requestBody")
+  public class RequestLoggerCorrectRequestBody {
+
+    /**
+     * This is a complex test that was written to prove that our requestLogger had a concurrency bug that caused incorrect request bodies to be logged.
+     * The RequestLogger originally used an instance variable that held the requestBody, which was written to by the request filter, and read by the
+     * response filter to generate a response log line that contained the original request body. If multiple requests were being processed at the same
+     * time, it was possible for the request filter of one request to overwrite the requestBody instance variable before the response log line was
+     * generated. The fixed implementation sets the requestBody as a custom property on the ContainerRequestFilter in the first filter method, and
+     * reads the custom requestBody property from the ContainerRequestFilter in the second filter method.
+     * <p>
+     * To cover this race condition, this test creates a single RequestLogger instance that is referenced from 100 threads. Each thread logs a unique
+     * request body. The main thread waits for all threads to finish, and then assures that every unique request body is included in the logs.
+     * <p>
+     * This test fails when using the instance variable approach for recording request bodies, because some request bodies are overwritten before they
+     * can be logged.
+     */
+    @Test
+    public void testRequestBodyConsistency() {
+      Mockito.when(mServletRequest.getHeader("Content-Type"))
+          .thenReturn(ACCEPTED_CONTENT_TYPE);
+
+      final RequestLogger requestLogger = new RequestLogger(MDC.getCopyOfContextMap(), mServletRequest);
+
+      final List<RequestResponseRunnable> testCases = new ArrayList<>();
+      final List<Thread> threads = new ArrayList<>();
+
+      for (int i = 1; i < 100; i++) {
+        testCases.add(createRunnableTestCase(requestLogger, UUID.randomUUID()));
+      }
+
+      testCases.forEach(testCase -> {
+        final Thread thread = new Thread(testCase);
+        threads.add(thread);
+        thread.start();
+      });
+
+      threads.forEach(thread -> {
+        try {
+          thread.join();
+        } catch (final InterruptedException e) {
+          e.printStackTrace();
+        }
+      });
+
+      testCases.forEach(testCase -> Assertions.assertThat(testCase.requestBodyWasLogged()).isTrue());
+    }
+
+    private RequestResponseRunnable createRunnableTestCase(final RequestLogger requestLogger, final UUID threadIdentifier) {
+
+      // create thread-specific context mocks
+      final ContainerRequestContext mRequestContext = Mockito.mock(ContainerRequestContext.class);
+      final ContainerResponseContext mResponseContext = Mockito.mock(ContainerResponseContext.class);
+
+      final String expectedRequestBody = String.format("{\"threadIdentifier\":\"%s\"}", threadIdentifier);
+
+      stubRequestContext(mRequestContext, expectedRequestBody);
+
+      return new RequestResponseRunnable(requestLogger, expectedRequestBody, mRequestContext, mResponseContext);
+    }
+
+    @RequiredArgsConstructor
+    public class RequestResponseRunnable implements Runnable {
+
+      private final RequestLogger requestLogger;
+      private final String expectedRequestBody;
+      private final ContainerRequestContext mRequestContext;
+      private final ContainerResponseContext mResponseContext;
+
+      public void run() {
+        try {
+          requestLogger.filter(mRequestContext);
+          Thread.sleep(new Random().nextInt(1000)); // random sleep to make race more likely
+          requestLogger.filter(mRequestContext, mResponseContext);
+        } catch (final IOException | InterruptedException e) {
+          e.printStackTrace();
+        }
+      }
+
+      // search all log lines to see if this thread's request body was logged
+      public Boolean requestBodyWasLogged() {
+        return IOs.readFile(logPath).lines().anyMatch(line -> line.contains(expectedRequestBody));
+      }
+    }
+
+  }
+
+  private void stubRequestContext(final ContainerRequestContext mockContainerRequestContext, final String requestBody) {
+    Mockito.when(mockContainerRequestContext.getMethod())
+            .thenReturn(METHOD);
+
+    Mockito.when(mockContainerRequestContext.getEntityStream())
+        .thenReturn(new ByteArrayInputStream(requestBody.getBytes()));
+
+    Mockito.when(mockContainerRequestContext.getProperty(REQUEST_BODY_PROPERTY)).thenReturn(requestBody);
+  }
+
 }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/RequestLoggerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/RequestLoggerTest.java
@@ -24,12 +24,12 @@ import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.api.Nested;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -131,6 +131,7 @@ public class RequestLoggerTest {
 
       Assertions.assertThat(matchingLines).hasSize(1);
     }
+
   }
 
   @Nested
@@ -138,18 +139,22 @@ public class RequestLoggerTest {
   public class RequestLoggerCorrectRequestBody {
 
     /**
-     * This is a complex test that was written to prove that our requestLogger had a concurrency bug that caused incorrect request bodies to be logged.
-     * The RequestLogger originally used an instance variable that held the requestBody, which was written to by the request filter, and read by the
-     * response filter to generate a response log line that contained the original request body. If multiple requests were being processed at the same
-     * time, it was possible for the request filter of one request to overwrite the requestBody instance variable before the response log line was
-     * generated. The fixed implementation sets the requestBody as a custom property on the ContainerRequestFilter in the first filter method, and
-     * reads the custom requestBody property from the ContainerRequestFilter in the second filter method.
+     * This is a complex test that was written to prove that our requestLogger had a concurrency bug
+     * that caused incorrect request bodies to be logged. The RequestLogger originally used an instance
+     * variable that held the requestBody, which was written to by the request filter, and read by the
+     * response filter to generate a response log line that contained the original request body. If
+     * multiple requests were being processed at the same time, it was possible for the request filter
+     * of one request to overwrite the requestBody instance variable before the response log line was
+     * generated. The fixed implementation sets the requestBody as a custom property on the
+     * ContainerRequestFilter in the first filter method, and reads the custom requestBody property from
+     * the ContainerRequestFilter in the second filter method.
      * <p>
-     * To cover this race condition, this test creates a single RequestLogger instance that is referenced from 100 threads. Each thread logs a unique
-     * request body. The main thread waits for all threads to finish, and then assures that every unique request body is included in the logs.
+     * To cover this race condition, this test creates a single RequestLogger instance that is
+     * referenced from 100 threads. Each thread logs a unique request body. The main thread waits for
+     * all threads to finish, and then assures that every unique request body is included in the logs.
      * <p>
-     * This test fails when using the instance variable approach for recording request bodies, because some request bodies are overwritten before they
-     * can be logged.
+     * This test fails when using the instance variable approach for recording request bodies, because
+     * some request bodies are overwritten before they can be logged.
      */
     @Test
     public void testRequestBodyConsistency() {
@@ -217,13 +222,14 @@ public class RequestLoggerTest {
       public Boolean requestBodyWasLogged() {
         return IOs.readFile(logPath).lines().anyMatch(line -> line.contains(expectedRequestBody));
       }
+
     }
 
   }
 
   private void stubRequestContext(final ContainerRequestContext mockContainerRequestContext, final String requestBody) {
     Mockito.when(mockContainerRequestContext.getMethod())
-            .thenReturn(METHOD);
+        .thenReturn(METHOD);
 
     Mockito.when(mockContainerRequestContext.getEntityStream())
         .thenReturn(new ByteArrayInputStream(requestBody.getBytes()));
@@ -232,4 +238,3 @@ public class RequestLoggerTest {
   }
 
 }
-

--- a/airbyte-server/src/test/java/io/airbyte/server/RequestLoggerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/RequestLoggerTest.java
@@ -136,8 +136,8 @@ public class RequestLoggerTest {
    * request body, and the actual request body that would be logged. The main thread then waits for all threads to finish, and then loops over each
    * runnable to see if the expected request body matched the actual request body.
    * <p>
-   * This test fails when using the instance variable approach for recording request bodies, and passes when using MDC to store the request body
-   * between the request filter and the response filter.
+   * This test fails when using the instance variable approach for recording request bodies, and passes when using a ThreadLocal to store the request
+   * body between the request filter and the response filter.
    */
   @Test
   public void testRequestBodyConsistency() {


### PR DESCRIPTION
## What

Addresses #11037 

I noticed that some of our API logs looked incorrect, with POST bodies seemingly mismatched from the route being called.

See my comment here where I first noticed this: https://github.com/airbytehq/airbyte/issues/10666#issuecomment-1059556712

My current hypothesis is that if multiple POST requests come in at the same time, it's possible to clobber the `requestBody` instance variable of the `RequestLogger` before the response filter runs, which means we construct a response log line using a `requestBody` from a different request.

~I _think_ this is the type of thing that MDC is supposed to help solve.~

~This PR does the following:~

~1. Moved the call of `MDC.setContextMap()` from the response filter to the request filter (why was it in the response filter in the first place, does anybody know?). 
2. Removed the `requestBody` instance variable, instead set it in the request filter via `MDC.put()` and read it using `MDC.get()` in the response filter.~

**UPDATE:** After discussing a bit with Charles, I don't think MDC is the right solution for this issue. I looked more for the Right Way to do this and learned that you can set a custom property on the `ContainerRequestContext` that can be read in the response `filter()`. So, this PR now uses this approach for sharing the request body from request filter to response filter.

