### PR TITLE
🐙 octavia-cli: use yaml safe load

### DIFF
--- a/octavia-cli/integration_tests/test_generate/test_renderer.py
+++ b/octavia-cli/integration_tests/test_generate/test_renderer.py
@@ -16,9 +16,9 @@ DESTINATION_SPECS = "../airbyte-config/init/src/main/resources/seed/destination_
 
 def get_all_specs_params():
     with open(SOURCE_SPECS, "r") as f:
-        source_specs = yaml.load(f, yaml.FullLoader)
+        source_specs = yaml.safe_load(f)
     with open(DESTINATION_SPECS, "r") as f:
-        destination_specs = yaml.load(f, yaml.FullLoader)
+        destination_specs = yaml.safe_load(f)
     return [pytest.param("source", spec, id=spec["dockerImage"]) for spec in source_specs] + [
         pytest.param("destination", spec, id=spec["dockerImage"]) for spec in destination_specs
     ]
@@ -39,7 +39,7 @@ def test_render_spec(spec_type, spec, octavia_project_directory, mocker):
     )
     output_path = renderer.write_yaml(octavia_project_directory)
     with open(output_path, "r") as f:
-        parsed_yaml = yaml.load(f, yaml.FullLoader)
+        parsed_yaml = yaml.safe_load(f)
         assert all(
             [
                 expected_field in parsed_yaml
@@ -68,7 +68,7 @@ EXPECTED_RENDERED_YAML_PATH = f"{os.path.dirname(__file__)}/expected_rendered_ya
 )
 def test_expected_output(resource_name, spec_type, input_spec_path, expected_yaml_path, octavia_project_directory, mocker):
     with open(os.path.join(EXPECTED_RENDERED_YAML_PATH, input_spec_path), "r") as f:
-        input_spec = yaml.load(f, yaml.FullLoader)
+        input_spec = yaml.safe_load(f)
     renderer = ConnectionSpecificationRenderer(
         resource_name=resource_name,
         definition=mocker.Mock(

--- a/octavia-cli/octavia_cli/apply/resources.py
+++ b/octavia-cli/octavia_cli/apply/resources.py
@@ -95,7 +95,7 @@ class ResourceState:
             ResourceState: state deserialized from YAML.
         """
         with open(file_path, "r") as f:
-            raw_state = yaml.load(f, yaml.FullLoader)
+            raw_state = yaml.safe_load(f)
         return ResourceState(
             raw_state["configuration_path"],
             raw_state["resource_id"],
@@ -417,7 +417,7 @@ def factory(api_client: airbyte_api_client.ApiClient, workspace_id: str, configu
         Union[Source, Destination]: The resource object created from the YAML config.
     """
     with open(configuration_path, "r") as f:
-        local_configuration = yaml.load(f, yaml.FullLoader)
+        local_configuration = yaml.safe_load(f)
     if local_configuration["definition_type"] == "source":
         return Source(api_client, workspace_id, local_configuration, configuration_path)
     if local_configuration["definition_type"] == "destination":

--- a/octavia-cli/unit_tests/test_apply/test_resources.py
+++ b/octavia-cli/unit_tests/test_apply/test_resources.py
@@ -57,7 +57,7 @@ class TestResourceState:
 
     def test_from_file(self, mocker):
         mocker.patch.object(resources, "yaml")
-        resources.yaml.load.return_value = {
+        resources.yaml.safe_load.return_value = {
             "configuration_path": "config_path",
             "resource_id": "resource_id",
             "generation_timestamp": 0,
@@ -65,7 +65,7 @@ class TestResourceState:
         }
         with patch("builtins.open", mock_open(read_data="data")) as mock_file:
             state = resources.ResourceState.from_file("state.yaml")
-        resources.yaml.load.assert_called_with(mock_file.return_value, resources.yaml.FullLoader)
+        resources.yaml.safe_load.assert_called_with(mock_file.return_value)
         assert isinstance(state, resources.ResourceState)
         assert state.configuration_path == "config_path"
         assert state.resource_id == "resource_id"
@@ -311,7 +311,7 @@ def test_factory(mocker, mock_api_client, local_configuration, resource_to_mock,
     mocker.patch.object(resources, "yaml")
     if resource_to_mock is not None:
         mocker.patch.object(resources, resource_to_mock)
-    resources.yaml.load.return_value = local_configuration
+    resources.yaml.safe_load.return_value = local_configuration
     with patch("builtins.open", mock_open(read_data="data")) as mock_file:
         if not expected_error:
             resource = resources.factory(mock_api_client, "workspace_id", "my_config.yaml")


### PR DESCRIPTION
According to PyYaml doc:

> Warning: It is not safe to call yaml.load with any data received from an untrusted source! yaml.load is as powerful as pickle.load and so may call any Python function. Check the yaml.safe_load function though.

Use `safe_load` to open yaml file securely with the `SafeLoader`.