### PR TITLE
Fix incorrect path selection for oneOf cases in jsonschema

### DIFF
--- a/airbyte-webapp/src/core/jsonSchema/schemaToYup.test.ts
+++ b/airbyte-webapp/src/core/jsonSchema/schemaToYup.test.ts
@@ -138,9 +138,10 @@ test("should build schema for conditional case with inner schema and selected ui
         },
       },
     },
-    { "key.credentials": { selectedItem: "oauth" } },
+    { "topKey.subKey.credentials": { selectedItem: "oauth" } },
     undefined,
-    "key"
+    "topKey",
+    "topKey.subKey"
   );
 
   const expectedSchema = yup.object().shape({

--- a/airbyte-webapp/src/core/jsonSchema/schemaToYup.ts
+++ b/airbyte-webapp/src/core/jsonSchema/schemaToYup.ts
@@ -34,20 +34,22 @@ export const buildYupFormForJsonSchema = (
     | null = null;
 
   if (jsonSchema.oneOf && uiConfig && propertyPath) {
-    const selectedSchema =
-      jsonSchema.oneOf.find((condition) => {
-        if (typeof condition !== "boolean") {
-          return uiConfig[propertyPath]?.selectedItem === condition.title;
-        }
-        return false;
-      }) ?? jsonSchema.oneOf[0];
+    let selectedSchema = jsonSchema.oneOf.find(
+      (condition) =>
+        typeof condition !== "boolean" &&
+        uiConfig[propertyPath]?.selectedItem === condition.title
+    );
+
+    // Select first oneOf path if no item selected
+    selectedSchema = selectedSchema ?? jsonSchema.oneOf[0];
+
     if (selectedSchema && typeof selectedSchema !== "boolean") {
       return buildYupFormForJsonSchema(
         { type: jsonSchema.type, ...selectedSchema },
         uiConfig,
         jsonSchema,
         propertyKey,
-        propertyPath ? `${propertyPath}.${propertyKey}` : propertyKey
+        propertyPath
       );
     }
   }


### PR DESCRIPTION
## What
Fixes a problem, when wrong validation schema path was selected for oneOf field. Closes #9980

## How
For some reason when we were building validationSchema we were combining current path with property key ( so in oneOf case, instead of `format.compression_codec` it was `format.format.compression_codec`, as a result always first entry in oneOf was selected.