### PR TITLE
🐛   Source Shopify: Improve SubStream state handling

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -690,7 +690,7 @@
 - name: Shopify
   sourceDefinitionId: 9da77001-af33-4bcd-be46-6252bf9342b9
   dockerRepository: airbyte/source-shopify
-  dockerImageTag: 0.1.34
+  dockerImageTag: 0.1.35
   documentationUrl: https://docs.airbyte.io/integrations/sources/shopify
   icon: shopify.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -7306,7 +7306,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-shopify:0.1.34"
+- dockerImage: "airbyte/source-shopify:0.1.35"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/shopify"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-shopify/Dockerfile
+++ b/airbyte-integrations/connectors/source-shopify/Dockerfile
@@ -28,5 +28,5 @@ COPY source_shopify ./source_shopify
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.34
+LABEL io.airbyte.version=0.1.35
 LABEL io.airbyte.name=airbyte/source-shopify

--- a/airbyte-integrations/connectors/source-shopify/integration_tests/abnormal_state.json
+++ b/airbyte-integrations/connectors/source-shopify/integration_tests/abnormal_state.json
@@ -45,21 +45,21 @@
     "processed_at": "2025-03-03T03:47:45-08:00"
   },
   "pages": {
-    "updated_at": "2021-07-08T05:24:10-07:00"
+    "updated_at": "2025-07-08T05:24:10-07:00"
   },
   "price_rules": {
-    "updated_at": "2021-09-10T06:48:10-07:00"
+    "updated_at": "2025-09-10T06:48:10-07:00"
   },
   "discount_codes": {
-    "updated_at": "2021-09-10T06:48:10-07:00",
+    "updated_at": "2025-09-10T06:48:10-07:00",
     "price_rules": {
-      "updated_at": "2021-09-10T06:48:10-07:00"
+      "updated_at": "2025-09-10T06:48:10-07:00"
     }
   },
   "inventory_items": {
     "updated_at": "2025-02-22T00:40:26-08:00",
     "products": {
-      "updated_at": "2021-08-18T02:39:48-07:00"
+      "updated_at": "2025-08-18T02:39:48-07:00"
     }
   },
   "inventory_levels": {

--- a/airbyte-integrations/connectors/source-shopify/integration_tests/abnormal_state.json
+++ b/airbyte-integrations/connectors/source-shopify/integration_tests/abnormal_state.json
@@ -1,62 +1,81 @@
 {
   "customers": {
-    "updated_at": "2024-07-19T06:41:50-07:00"
+    "updated_at": "2025-07-08T05:40:38-07:00"
   },
   "orders": {
-    "updated_at": "2024-07-19T06:52:06-07:00"
+    "updated_at": "2025-07-08T05:40:38-07:00"
   },
   "draft_orders": {
-    "updated_at": "2024-07-07T08:18:59-07:00"
+    "updated_at": "2025-07-08T05:40:38-07:00"
   },
   "products": {
-    "updated_at": "2024-07-19T06:56:06-07:00"
+    "updated_at": "2025-07-08T05:40:38-07:00"
   },
   "abandoned_checkouts": {
-    "updated_at": "2024-07-08T05:41:48-07:00"
+    "updated_at": "2025-07-08T05:40:38-07:00"
   },
   "metafields": {
-    "updated_at": "2024-07-08T03:38:46-07:00"
+    "updated_at": "2025-07-08T05:40:38-07:00"
   },
   "collects": {
-    "id": 99923654213791
+    "id": 29427031703741
   },
   "custom_collections": {
-    "updated_at": "2024-07-19T07:01:37-07:00"
+    "updated_at": "2025-07-08T05:40:38-07:00"
   },
   "order_refunds": {
-    "created_at": "2024-07-19T06:41:47-07:00"
+    "created_at": "2025-03-03T03:47:46-08:00",
+    "orders": {
+      "updated_at": "2025-03-03T03:47:46-08:00"
+    }
   },
   "order_risks": {
-    "id": 9991307599038
+    "id": 6446736474301,
+    "orders": {
+      "updated_at": "2025-02-22T00:37:28-08:00"
+    }
   },
   "transactions": {
-    "created_at": "2024-07-19T06:41:46-07:00"
-  },
-  "pages": {
-    "updated_at": "2024-07-08T05:24:11-07:00"
-  },
-  "price_rules": {
-    "updated_at": "2024-07-08T05:57:05-07:00"
-  },
-  "discount_codes": {
-    "updated_at": "2024-07-08T05:40:38-07:00"
-  },
-  "locations": {
-    "updated_at": "2024-07-08T05:40:38-07:00"
-  },
-  "inventory_items": {
-    "updated_at": "2024-07-08T05:40:38-07:00"
-  },
-  "inventory_levels": {
-    "updated_at": "2024-07-08T05:40:38-07:00"
-  },
-  "fulfillment_orders": {
-    "id": 9991307599038
-  },
-  "fulfillments": {
-    "updated_at": "2024-07-08T05:40:38-07:00"
+    "created_at": "2025-03-03T03:47:45-08:00",
+    "orders": {
+      "updated_at": "2025-03-03T03:47:46-08:00"
+    }
   },
   "tender_transactions": {
-    "processed_at": "2024-07-08T05:40:38-07:00"
+    "processed_at": "2025-03-03T03:47:45-08:00"
+  },
+  "pages": {
+    "updated_at": "2021-07-08T05:24:10-07:00"
+  },
+  "price_rules": {
+    "updated_at": "2021-09-10T06:48:10-07:00"
+  },
+  "discount_codes": {
+    "updated_at": "2021-09-10T06:48:10-07:00",
+    "price_rules": {
+      "updated_at": "2021-09-10T06:48:10-07:00"
+    }
+  },
+  "inventory_items": {
+    "updated_at": "2025-02-22T00:40:26-08:00",
+    "products": {
+      "updated_at": "2021-08-18T02:39:48-07:00"
+    }
+  },
+  "inventory_levels": {
+    "updated_at": "2025-03-03T03:47:51-08:00",
+    "locations": {}
+  },
+  "fulfillment_orders": {
+    "id": 5424260808893,
+    "orders": {
+      "updated_at": "2025-03-03T03:47:46-08:00"
+    }
+  },
+  "fulfillments": {
+    "updated_at": "2025-02-27T23:49:13-08:00",
+    "orders": {
+      "updated_at": "2025-03-03T03:47:46-08:00"
+    }
   }
 }

--- a/airbyte-integrations/connectors/source-shopify/integration_tests/state.json
+++ b/airbyte-integrations/connectors/source-shopify/integration_tests/state.json
@@ -59,7 +59,7 @@
   "inventory_items": {
     "updated_at": "2022-02-22T00:40:26-08:00",
     "products": {
-      "updated_at": "2021-08-18T02:39:48-07:00"
+      "updated_at": "2022-02-18T02:39:48-07:00"
     }
   },
   "inventory_levels": {

--- a/airbyte-integrations/connectors/source-shopify/integration_tests/state.json
+++ b/airbyte-integrations/connectors/source-shopify/integration_tests/state.json
@@ -1,18 +1,18 @@
 {
   "customers": {
-    "updated_at": "2021-09-19T09:08:24-07:00"
+    "updated_at": "2022-03-02T03:23:16-08:00"
   },
   "orders": {
-    "updated_at": "2021-09-19T09:08:24-07:00"
+    "updated_at": "2022-03-03T03:47:46-08:00"
   },
   "draft_orders": {
-    "updated_at": "2021-07-07T08:18:58-07:00"
+    "updated_at": "2022-02-22T04:29:57-08:00"
   },
   "products": {
-    "updated_at": "2021-09-19T09:10:43-07:00"
+    "updated_at": "2022-03-03T03:47:51-08:00"
   },
   "abandoned_checkouts": {
-    "updated_at": "2021-07-08T05:41:47-07:00"
+    "updated_at": "2022-03-02T03:23:22-08:00"
   },
   "metafields": {
     "updated_at": "2021-07-08T03:38:45-07:00"
@@ -24,13 +24,25 @@
     "updated_at": "2021-08-18T02:39:34-07:00"
   },
   "order_refunds": {
-    "created_at": "2021-09-09T02:57:43-07:00"
+    "created_at": "2022-03-03T03:47:46-08:00",
+    "orders": {
+      "updated_at": "2022-03-03T03:47:46-08:00"
+    }
   },
-  "orders_risks": {
-    "id": 6161307599036
+  "order_risks": {
+    "id": 6446736474301,
+    "orders": {
+      "updated_at": "2022-02-22T00:37:28-08:00"
+    }
   },
   "transactions": {
-    "created_at": "2021-09-09T02:57:43-07:00"
+    "created_at": "2022-03-03T03:47:45-08:00",
+    "orders": {
+      "updated_at": "2022-03-03T03:47:46-08:00"
+    }
+  },
+  "tender_transactions": {
+    "processed_at": "2022-03-03T03:47:45-08:00"
   },
   "pages": {
     "updated_at": "2021-07-08T05:24:10-07:00"
@@ -39,24 +51,31 @@
     "updated_at": "2021-09-10T06:48:10-07:00"
   },
   "discount_codes": {
-    "updated_at": "2021-09-10T06:48:10-07:00"
-  },
-  "locations": {
-    "updated_at": "2021-09-10T06:48:10-07:00"
+    "updated_at": "2021-09-10T06:48:10-07:00",
+    "price_rules": {
+      "updated_at": "2021-09-10T06:48:10-07:00"
+    }
   },
   "inventory_items": {
-    "updated_at": "2021-09-10T06:48:10-07:00"
+    "updated_at": "2022-02-22T00:40:26-08:00",
+    "products": {
+      "updated_at": "2021-08-18T02:39:48-07:00"
+    }
   },
   "inventory_levels": {
-    "updated_at": "2021-09-10T06:48:10-07:00"
+    "updated_at": "2022-03-03T03:47:51-08:00",
+    "locations": {}
   },
   "fulfillment_orders": {
-    "id": 123
+    "id": 5424260808893,
+    "orders": {
+      "updated_at": "2022-03-03T03:47:46-08:00"
+    }
   },
   "fulfillments": {
-    "updated_at": "2021-09-10T06:48:10-07:00"
-  },
-  "tender_transactions": {
-    "processed_at": "2021-12-13T20:43:39-08:00"
+    "updated_at": "2022-02-27T23:49:13-08:00",
+    "orders": {
+      "updated_at": "2022-03-03T03:47:46-08:00"
+    }
   }
 }

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/source.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/source.py
@@ -13,7 +13,6 @@ from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http import HttpStream
 
-import airbyte_cdk.sources.utils.casing as casing
 from .auth import ShopifyAuthenticator
 from .transform import DataTypeEnforcer
 from .utils import SCOPES_MAPPING
@@ -91,15 +90,20 @@ class IncrementalShopifyStream(ShopifyStream, ABC):
 
     # Setting the default cursor field for all streams
     cursor_field = "updated_at"
-    
+
     @property
     def comparison_value(self) -> Union[int, str]:
         # certain streams are using `id` field as `cursor_field`, which requires to use `int` type,
         # but many other use `str` values for this, we determine what to use based on `cursor_field` value
         return 0 if self.cursor_field == "id" else ""
-    
+
     def get_updated_state(self, current_stream_state: MutableMapping[str, Any], latest_record: Mapping[str, Any]) -> Mapping[str, Any]:
-        return {self.cursor_field: max(latest_record.get(self.cursor_field, self.comparison_value), current_stream_state.get(self.cursor_field, self.comparison_value))}
+        return {
+            self.cursor_field: max(
+                latest_record.get(self.cursor_field, self.comparison_value),
+                current_stream_state.get(self.cursor_field, self.comparison_value),
+            )
+        }
 
     @stream_state_cache.cache_stream_state
     def request_params(self, stream_state: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None, **kwargs):
@@ -167,7 +171,7 @@ class ChildSubstream(IncrementalShopifyStream):
     nested_record: str = "id"
     nested_record_field_name: str = None
     nested_substream = None
-        
+
     @property
     def parent_stream(self) -> object:
         """
@@ -175,19 +179,19 @@ class ChildSubstream(IncrementalShopifyStream):
         """
         if self.parent_stream_class:
             return self.parent_stream_class(self.config)
-       
+
     def get_updated_state(self, current_stream_state: MutableMapping[str, Any], latest_record: Mapping[str, Any]) -> Mapping[str, Any]:
         """UPDATING THE STATE OBJECT:
-            Stream: Transactions
-            Parent Stream: Orders
-            Returns:
-                {
-                "transactions": {
-                    "created_at": "2022-03-03T03:47:45-08:00",
-                    "orders": {
-                        "updated_at": "2022-03-03T03:47:46-08:00"
-                    }
+        Stream: Transactions
+        Parent Stream: Orders
+        Returns:
+            {
+            "transactions": {
+                "created_at": "2022-03-03T03:47:45-08:00",
+                "orders": {
+                    "updated_at": "2022-03-03T03:47:46-08:00"
                 }
+            }
         """
         updated_state = super().get_updated_state(current_stream_state, latest_record)
         # populate updated_state with parent_stream_state
@@ -207,7 +211,7 @@ class ChildSubstream(IncrementalShopifyStream):
 
         Output: [ {slice_key: 123}, {slice_key: 456}, ..., {slice_key: 999} ]
         """
-        
+
         parent_stream_state = stream_state.get(self.parent_stream.name, {})
         for record in self.parent_stream.read_records(stream_state=parent_stream_state, **kwargs):
             # updating the `stream_state` with the state of it's parent stream
@@ -222,7 +226,7 @@ class ChildSubstream(IncrementalShopifyStream):
                     yield {self.slice_key: record[self.nested_record]}
             else:
                 yield {self.slice_key: record[self.nested_record]}
-                
+
     def read_records(
         self,
         stream_state: Mapping[str, Any] = None,

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/utils.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/utils.py
@@ -138,6 +138,7 @@ class EagerlyCachedStreamState:
                 state_object[stream.name] = {
                     stream.cursor_field: min(current_stream_state.get(stream.cursor_field, ""), tmp_stream_state_value)
                 }
+
         return state_object
 
     def cache_stream_state(func):

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/test_cached_stream_state.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/test_cached_stream_state.py
@@ -8,16 +8,16 @@ from source_shopify.source import OrderRefunds, Orders
 from source_shopify.utils import EagerlyCachedStreamState as stream_state_cache
 
 # Define the Stream instances for the tests
-PARENT_STREAM = Orders(config={"authenticator": None})
-CHILD_STREAM = OrderRefunds(config={"authenticator": None})
+SHOPIFY_STREAM = Orders(config={"authenticator": None})
+SHOPIFY_SUB_STREAM = OrderRefunds(config={"authenticator": None})
 
 
 @pytest.mark.parametrize(
     "stream, cur_stream_state, state_object, expected_output",
     [
         # When Full-Refresh: state_object: empty.
-        (PARENT_STREAM, {PARENT_STREAM.cursor_field: ""}, {}, {PARENT_STREAM.name: {PARENT_STREAM.cursor_field: ""}}),
-        (CHILD_STREAM, {CHILD_STREAM.cursor_field: ""}, {}, {CHILD_STREAM.name: {CHILD_STREAM.cursor_field: ""}}),
+        (SHOPIFY_STREAM, {SHOPIFY_STREAM.cursor_field: ""}, {}, {SHOPIFY_STREAM.name: {SHOPIFY_STREAM.cursor_field: ""}}),
+        (SHOPIFY_SUB_STREAM, {SHOPIFY_SUB_STREAM.cursor_field: ""}, {}, {SHOPIFY_SUB_STREAM.name: {SHOPIFY_SUB_STREAM.cursor_field: ""}}),
     ],
     ids=["Sync Started. Parent.", "Sync Started. Child."],
 )
@@ -37,29 +37,29 @@ def test_full_refresh(stream, cur_stream_state, state_object, expected_output):
     [
         # When start the incremental refresh, assuming we have the state of STREAM.
         (
-            PARENT_STREAM,
-            {PARENT_STREAM.cursor_field: "2021-01-01T01-01-01"},
+            SHOPIFY_STREAM,
+            {SHOPIFY_STREAM.cursor_field: "2021-01-01T01-01-01"},
             {},
-            {PARENT_STREAM.name: {PARENT_STREAM.cursor_field: "2021-01-01T01-01-01"}},
+            {SHOPIFY_STREAM.name: {SHOPIFY_STREAM.cursor_field: "2021-01-01T01-01-01"}},
         ),
         (
-            CHILD_STREAM,
-            {CHILD_STREAM.cursor_field: "2021-01-01T01-01-01"},
+            SHOPIFY_SUB_STREAM,
+            {SHOPIFY_SUB_STREAM.cursor_field: "2021-01-01T01-01-01"},
             {},
-            {CHILD_STREAM.name: {CHILD_STREAM.cursor_field: "2021-01-01T01-01-01"}},
+            {SHOPIFY_SUB_STREAM.name: {SHOPIFY_SUB_STREAM.cursor_field: "2021-01-01T01-01-01"}},
         ),
         # While doing the incremental refresh, we keeping the original state, even if the state is updated during the sync.
         (
-            PARENT_STREAM,
-            {PARENT_STREAM.cursor_field: "2021-01-05T02-02-02"},
+            SHOPIFY_STREAM,
+            {SHOPIFY_STREAM.cursor_field: "2021-01-05T02-02-02"},
             {},
-            {PARENT_STREAM.name: {PARENT_STREAM.cursor_field: "2021-01-05T02-02-02"}},
+            {SHOPIFY_STREAM.name: {SHOPIFY_STREAM.cursor_field: "2021-01-05T02-02-02"}},
         ),
         (
-            CHILD_STREAM,
-            {CHILD_STREAM.cursor_field: "2021-01-05T02-02-02"},
+            SHOPIFY_SUB_STREAM,
+            {SHOPIFY_SUB_STREAM.cursor_field: "2021-01-05T02-02-02"},
             {},
-            {CHILD_STREAM.name: {CHILD_STREAM.cursor_field: "2021-01-05T02-02-02"}},
+            {SHOPIFY_SUB_STREAM.name: {SHOPIFY_SUB_STREAM.cursor_field: "2021-01-05T02-02-02"}},
         ),
     ],
     ids=["Sync Started. Parent", "Sync Started. Child", "Sync in progress. Parent", "Sync in progress. Child"],

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/test_cached_stream_state.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/test_cached_stream_state.py
@@ -4,7 +4,7 @@
 
 
 import pytest
-from source_shopify.source import Orders, OrderRefunds
+from source_shopify.source import OrderRefunds, Orders
 from source_shopify.utils import EagerlyCachedStreamState as stream_state_cache
 
 # Define the Stream instances for the tests

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/test_cached_stream_state.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/test_cached_stream_state.py
@@ -4,20 +4,22 @@
 
 
 import pytest
-from source_shopify.source import Orders
+from source_shopify.source import Orders, OrderRefunds
 from source_shopify.utils import EagerlyCachedStreamState as stream_state_cache
 
-# Define the Stream class for the test
-STREAM = Orders(config={"authenticator": None})
+# Define the Stream instances for the tests
+PARENT_STREAM = Orders(config={"authenticator": None})
+CHILD_STREAM = OrderRefunds(config={"authenticator": None})
 
 
 @pytest.mark.parametrize(
     "stream, cur_stream_state, state_object, expected_output",
     [
         # When Full-Refresh: state_object: empty.
-        (STREAM, {STREAM.cursor_field: ""}, {}, {STREAM.name: {STREAM.cursor_field: ""}}),
+        (PARENT_STREAM, {PARENT_STREAM.cursor_field: ""}, {}, {PARENT_STREAM.name: {PARENT_STREAM.cursor_field: ""}}),
+        (CHILD_STREAM, {CHILD_STREAM.cursor_field: ""}, {}, {CHILD_STREAM.name: {CHILD_STREAM.cursor_field: ""}}),
     ],
-    ids=["Sync Started"],
+    ids=["Sync Started. Parent.", "Sync Started. Child."],
 )
 def test_full_refresh(stream, cur_stream_state, state_object, expected_output):
     """
@@ -35,20 +37,32 @@ def test_full_refresh(stream, cur_stream_state, state_object, expected_output):
     [
         # When start the incremental refresh, assuming we have the state of STREAM.
         (
-            STREAM,
-            {STREAM.cursor_field: "2021-01-01T01-01-01"},
+            PARENT_STREAM,
+            {PARENT_STREAM.cursor_field: "2021-01-01T01-01-01"},
             {},
-            {STREAM.name: {STREAM.cursor_field: "2021-01-01T01-01-01"}},
+            {PARENT_STREAM.name: {PARENT_STREAM.cursor_field: "2021-01-01T01-01-01"}},
+        ),
+        (
+            CHILD_STREAM,
+            {CHILD_STREAM.cursor_field: "2021-01-01T01-01-01"},
+            {},
+            {CHILD_STREAM.name: {CHILD_STREAM.cursor_field: "2021-01-01T01-01-01"}},
         ),
         # While doing the incremental refresh, we keeping the original state, even if the state is updated during the sync.
         (
-            STREAM,
-            {STREAM.cursor_field: "2021-01-05T02-02-02"},
+            PARENT_STREAM,
+            {PARENT_STREAM.cursor_field: "2021-01-05T02-02-02"},
             {},
-            {STREAM.name: {STREAM.cursor_field: "2021-01-05T02-02-02"}},
+            {PARENT_STREAM.name: {PARENT_STREAM.cursor_field: "2021-01-05T02-02-02"}},
+        ),
+        (
+            CHILD_STREAM,
+            {CHILD_STREAM.cursor_field: "2021-01-05T02-02-02"},
+            {},
+            {CHILD_STREAM.name: {CHILD_STREAM.cursor_field: "2021-01-05T02-02-02"}},
         ),
     ],
-    ids=["Sync Started", "Sync in progress"],
+    ids=["Sync Started. Parent", "Sync Started. Child", "Sync in progress. Parent", "Sync in progress. Child"],
 )
 def test_incremental_sync(stream, cur_stream_state, state_object, expected_output):
     """
@@ -58,4 +72,5 @@ def test_incremental_sync(stream, cur_stream_state, state_object, expected_outpu
     # create the fixure for *args based on input
     args = [stream]
     actual = stream_state_cache.stream_state_to_tmp(*args, state_object=state_object, stream_state=cur_stream_state)
+    print(actual)
     assert actual == expected_output

--- a/airbyte-integrations/connectors/source-shopify/unit_tests/test_cached_stream_state.py
+++ b/airbyte-integrations/connectors/source-shopify/unit_tests/test_cached_stream_state.py
@@ -72,5 +72,4 @@ def test_incremental_sync(stream, cur_stream_state, state_object, expected_outpu
     # create the fixure for *args based on input
     args = [stream]
     actual = stream_state_cache.stream_state_to_tmp(*args, state_object=state_object, stream_state=cur_stream_state)
-    print(actual)
     assert actual == expected_output

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -100,6 +100,7 @@ This is expected when the connector hits the 429 - Rate Limit Exceeded HTTP Erro
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.35 | 2022-03-07 | [10915](https://github.com/airbytehq/airbyte/pull/10915) | Implemented independent state for each ShopifySubStream |
 | 0.1.34 | 2022-03-02 | [10794](https://github.com/airbytehq/airbyte/pull/10794) | Minor specification re-order, fixed links in documentation |
 | 0.1.33 | 2022-02-17 | [10419](https://github.com/airbytehq/airbyte/pull/10419) | Fixed wrong field type for tax_exemptions for `Abandoned_checkouts` stream |
 | 0.1.32 | 2022-02-18 | [10449](https://github.com/airbytehq/airbyte/pull/10449) | Added `tender_transactions` stream |

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -100,7 +100,7 @@ This is expected when the connector hits the 429 - Rate Limit Exceeded HTTP Erro
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| 0.1.35 | 2022-03-07 | [10915](https://github.com/airbytehq/airbyte/pull/10915) | Implemented independent state for each ShopifySubStream |
+| 0.1.35 | 2022-03-07 | [10915](https://github.com/airbytehq/airbyte/pull/10915) | Fix a bug which caused `full-refresh` syncs of child REST entities configured for `incremental` |
 | 0.1.34 | 2022-03-02 | [10794](https://github.com/airbytehq/airbyte/pull/10794) | Minor specification re-order, fixed links in documentation |
 | 0.1.33 | 2022-02-17 | [10419](https://github.com/airbytehq/airbyte/pull/10419) | Fixed wrong field type for tax_exemptions for `Abandoned_checkouts` stream |
 | 0.1.32 | 2022-02-18 | [10449](https://github.com/airbytehq/airbyte/pull/10449) | Added `tender_transactions` stream |


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/airbyte/issues/10595

**Before this update:**
Now each stream could be synced independently from parent stream, for instance:
`Order_refunds` is the sub-stream of the  `Orders` stream.
To have it properly synced with the latest state of the parent, previously you have to choose the 2 streams to sync `Order_refunds` and `Orders` to have the `Orders` stream state, and based on that sync the `Order_refunds` incrementally. Sometimes this situation causes the sub-stream to sync before the parent stream is synced first, which causes to full-refresh instead of incremental one.

**WIth this update:**
You just now choose the `Order_refunds` stream alone and it would sync independently from `Orders` stream state.
Conclusion: each stream now has it's own state, and for parent-dependent streams the state object looks like:
```
{
      "order_refunds": {
          "created_at": "2022-03-03T03:47:45-08:00",
          "orders": {
              "updated_at": "2022-03-03T03:47:46-08:00"
          }
      }
}
```

## How
- re-factored the `ShopifySubStream` class to handle the parent state independently for each SubStream.
- added `unit_tests`

## 🚨 User Impact 🚨
The usual update doesn't require user actions with connector, except of the update itself. 
In case of the issues - downgrade to the previous version is possible as well.

**IMPORTANT NOTE:** 
- The very first sync after the update would be like the Initial Sync as the connector needs to update it's state up to the new state structure. 

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>