### PR TITLE
Add indices useful for listStandardSyncForWorkspace func

### DIFF
--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -80,7 +80,7 @@ public class BootloaderAppTest {
         mockedConfigs.getConfigDatabaseUrl())
             .getAndInitialize();
     val configsMigrator = new ConfigsDatabaseMigrator(configDatabase, this.getClass().getName());
-    assertEquals("0.35.32.001", configsMigrator.getLatestMigration().getVersion().getVersion());
+    assertEquals("0.35.46.001", configsMigrator.getLatestMigration().getVersion().getVersion());
 
     val jobsPersistence = new DefaultJobPersistence(jobDatabase);
     assertEquals(version, jobsPersistence.getVersion().get());

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_46_001__AddMissingIndices.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_46_001__AddMissingIndices.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class V0_35_46_001__AddMissingIndices extends BaseJavaMigration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(V0_35_46_001__AddMissingIndices.class);
+
+  @Override
+  public void migrate(final Context context) throws Exception {
+    LOGGER.info("Running migration: {}", this.getClass().getSimpleName());
+
+    final DSLContext ctx = DSL.using(context.getConnection());
+
+    ctx.createIndexIfNotExists("actor_workspace_id_idx").on("actor", "workspace_id").execute();
+    ctx.createIndexIfNotExists("connection_operation_connection_id_idx").on("connection_operation", "connection_id").execute();
+  }
+
+}

--- a/airbyte-db/lib/src/main/resources/configs_database/schema_dump.txt
+++ b/airbyte-db/lib/src/main/resources/configs_database/schema_dump.txt
@@ -206,6 +206,7 @@ alter table "public"."state"
     references "public"."connection" ("id");
 create index "actor_actor_definition_id_idx" on "public"."actor"("actor_definition_id" asc);
 create unique index "actor_pkey" on "public"."actor"("id" asc);
+create index "actor_workspace_id_idx" on "public"."actor"("workspace_id" asc);
 create index "actor_catalog_catalog_hash_id_idx" on "public"."actor_catalog"("catalog_hash" asc);
 create unique index "actor_catalog_pkey" on "public"."actor_catalog"("id" asc);
 create index "actor_catalog_fetch_event_actor_catalog_id_idx" on "public"."actor_catalog_fetch_event"("actor_catalog_id" asc);
@@ -218,6 +219,7 @@ create index "airbyte_configs_migrations_s_idx" on "public"."airbyte_configs_mig
 create index "connection_destination_id_idx" on "public"."connection"("destination_id" asc);
 create unique index "connection_pkey" on "public"."connection"("id" asc);
 create index "connection_source_id_idx" on "public"."connection"("source_id" asc);
+create index "connection_operation_connection_id_idx" on "public"."connection_operation"("connection_id" asc);
 create unique index "connection_operation_pkey" on "public"."connection_operation"(
   "id" asc, 
   "connection_id" asc, 


### PR DESCRIPTION
Some useful indices appear to be missing right now on the database. As we are changing our application queries to be more optimized, we also want to make sure the required indices are present in DB.

This add index on `actor.workspace_id` and `connection_operation.connection_id`