### PR TITLE
:bug: Fix ExternalDB settings are not passed to temporal deployment

### DIFF
--- a/charts/airbyte/templates/external-db.yaml
+++ b/charts/airbyte/templates/external-db.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.externalDatabase.enabled }}
+{{- if not .Values.postgresql.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/airbyte/templates/external-db.yaml
+++ b/charts/airbyte/templates/external-db.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.externalDatabase.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airbyte-externaldb
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-1"
+data:
+  postgresql-password: {{ .Values.externalDatabase.password | b64enc }}
+{{- end }}

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -865,7 +865,6 @@ postgresql:
 ## @param externalDatabase.port Database port number
 ##
 externalDatabase:
-  enabled: false
   host: localhost
   user: airbyte
   password: ""

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -865,6 +865,7 @@ postgresql:
 ## @param externalDatabase.port Database port number
 ##
 externalDatabase:
+  enabled: false
   host: localhost
   user: airbyte
   password: ""


### PR DESCRIPTION
## What
*Describe what the change is solving*

I tried to deploy this into EKS using the helm chart and ran into the error in [issue 7067](https://github.com/airbytehq/airbyte/issues/7067). 

After adding the secret it appeared to fix the problem in AWS EKS. 

## How

By adding a kubernetes secret for external databases. 

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

No user impact should be observed with the helm chart, everything is sensibly defaulted. 
