### PR TITLE
Fix CONNECTORS_BASE build for M1

### DIFF
--- a/airbyte-integrations/bases/base-standard-source-test-file/Dockerfile
+++ b/airbyte-integrations/bases/base-standard-source-test-file/Dockerfile
@@ -1,6 +1,8 @@
 ARG JDK_VERSION=17.0.1
 FROM openjdk:${JDK_VERSION}-slim
 
+ARG DOCKER_BUILD_ARCH=amd64
+
 # Install Docker to launch worker images. Eventually should be replaced with Docker-java.
 # See https://gitter.im/docker-java/docker-java?at=5f3eb87ba8c1780176603f4e for more information on why we are not currently using Docker-java
 RUN apt-get update && apt-get install -y \
@@ -11,7 +13,7 @@ RUN apt-get update && apt-get install -y \
                           software-properties-common
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN add-apt-repository \
-       "deb [arch=amd64] https://download.docker.com/linux/debian \
+       "deb [arch=${DOCKER_BUILD_ARCH}] https://download.docker.com/linux/debian \
        $(lsb_release -cs) \
        stable"
 RUN apt-get update && apt-get install -y docker-ce-cli jq

--- a/airbyte-integrations/bases/standard-source-test/Dockerfile
+++ b/airbyte-integrations/bases/standard-source-test/Dockerfile
@@ -1,6 +1,8 @@
 ARG JDK_VERSION=17.0.1
 FROM openjdk:${JDK_VERSION}-slim
 
+ARG DOCKER_BUILD_ARCH=amd64
+
 # Install Docker to launch worker images. Eventually should be replaced with Docker-java.
 # See https://gitter.im/docker-java/docker-java?at=5f3eb87ba8c1780176603f4e for more information on why we are not currently using Docker-java
 RUN apt-get update && apt-get install -y \
@@ -11,7 +13,7 @@ RUN apt-get update && apt-get install -y \
                           software-properties-common
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN add-apt-repository \
-       "deb [arch=amd64] https://download.docker.com/linux/debian \
+       "deb [arch=${DOCKER_BUILD_ARCH}] https://download.docker.com/linux/debian \
        $(lsb_release -cs) \
        stable"
 RUN apt-get update && apt-get install -y docker-ce-cli jq

--- a/tools/bin/build_image.sh
+++ b/tools/bin/build_image.sh
@@ -8,6 +8,7 @@ DOCKERFILE="$3"
 TAGGED_IMAGE="$4"
 ID_FILE="$5"
 FOLLOW_SYMLINKS="$6"
+DOCKER_BUILD_ARCH="${DOCKER_BUILD_ARCH:-amd64}"
 # https://docs.docker.com/develop/develop-images/build_enhancements/
 export DOCKER_BUILDKIT=1
 

--- a/tools/bin/build_image.sh
+++ b/tools/bin/build_image.sh
@@ -43,8 +43,8 @@ if [ "$FOLLOW_SYMLINKS" == "true" ]; then
 else
   JDK_VERSION="${JDK_VERSION:-17.0.1}"
   if [[ -z "${DOCKER_BUILD_PLATFORM}" ]]; then
-    docker build --build-arg JDK_VERSION="$JDK_VERSION" . "${args[@]}"
+    docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" DOCKER_BUILD_PLATFORM. "${args[@]}"
   else
-    docker build --build-arg JDK_VERSION="$JDK_VERSION" --platform="$DOCKER_BUILD_PLATFORM" . "${args[@]}"
+    docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" --platform="$DOCKER_BUILD_PLATFORM" . "${args[@]}"
   fi
 fi

--- a/tools/bin/build_image.sh
+++ b/tools/bin/build_image.sh
@@ -44,7 +44,7 @@ if [ "$FOLLOW_SYMLINKS" == "true" ]; then
 else
   JDK_VERSION="${JDK_VERSION:-17.0.1}"
   if [[ -z "${DOCKER_BUILD_PLATFORM}" ]]; then
-    docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" DOCKER_BUILD_PLATFORM. "${args[@]}"
+    docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" . "${args[@]}"
   else
     docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" --platform="$DOCKER_BUILD_PLATFORM" . "${args[@]}"
   fi


### PR DESCRIPTION
## What
Fix the `CONNECTORS_BASE` build for M1

## How
* Parameterize the apt repository based on the architecture
* Propagate the `DOCKER_BUILD_ARCH` environment variable to the dockerfiles

## Recommended reading order
1. `airbyte-integrations/bases/base-standard-source-test-file/Dockerfile`
2. `airbyte-integrations/bases/standard-source-test/Dockerfile`
3. `tools/bin/build_image.sh`