### PR TITLE
🐛  Correctly populate secrets inside nested non-combination objects

### DIFF
--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/split_secrets/JsonSecretsProcessor.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/split_secrets/JsonSecretsProcessor.java
@@ -163,19 +163,23 @@ public class JsonSecretsProcessor {
 
     final ObjectNode properties = (ObjectNode) schema.get(PROPERTIES_FIELD);
     for (final String key : Jsons.keys(properties)) {
+      // If the source object doesn't have this key then we have nothing to copy, so we should skip to the
+      // next key.
+      if (!src.has(key)) {
+        continue;
+      }
+
       final JsonNode fieldSchema = properties.get(key);
       // We only copy the original secret if the destination object isn't attempting to overwrite it
       // i.e: if the value of the secret isn't set to the mask
-      if (isSecret(fieldSchema) && src.has(key)) {
-        if (dst.has(key) && dst.get(key).asText().equals(SECRETS_MASK)) {
-          dstCopy.set(key, src.get(key));
-        }
-      }
-
-      final var combinationKey = findJsonCombinationNode(fieldSchema);
-      if (combinationKey.isPresent() && dstCopy.has(key)) {
-        var combinationCopy = dstCopy.get(key);
-        if (src.has(key)) {
+      if (isSecret(fieldSchema) && dst.has(key) && dst.get(key).asText().equals(SECRETS_MASK)) {
+        dstCopy.set(key, src.get(key));
+      } else {
+        // Check if this schema is a combination node; if it is, find a matching sub-schema and copy based
+        // on that sub-schema
+        final var combinationKey = findJsonCombinationNode(fieldSchema);
+        if (combinationKey.isPresent() && dstCopy.has(key)) {
+          var combinationCopy = dstCopy.get(key);
           final var arrayNode = (ArrayNode) fieldSchema.get(combinationKey.get());
           for (int i = 0; i < arrayNode.size(); i++) {
             final JsonNode childSchema = arrayNode.get(i);
@@ -189,8 +193,11 @@ public class JsonSecretsProcessor {
               combinationCopy = copySecrets(src.get(key), combinationCopy, childSchema);
             }
           }
+          dstCopy.set(key, combinationCopy);
+        } else {
+          final JsonNode copiedField = copySecrets(src.get(key), dst.get(key), fieldSchema);
+          dstCopy.set(key, copiedField);
         }
-        dstCopy.set(key, combinationCopy);
       }
     }
 

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/split_secrets/JsonSecretsProcessorTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/split_secrets/JsonSecretsProcessorTest.java
@@ -6,6 +6,7 @@ package io.airbyte.config.persistence.split_secrets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
@@ -322,6 +323,57 @@ public class JsonSecretsProcessorTest {
     final JsonNode actual = processor.maskSecrets(input, specs);
 
     assertEquals(expected, actual);
+  }
+
+  @Test
+  public void copiesSecrets_inNestedNonCombinationNode() throws JsonProcessingException {
+    final ObjectMapper objectMapper = new ObjectMapper();
+
+    final JsonNode source = objectMapper.readTree(
+        """
+        {
+          "top_level": {
+            "a_secret": "hunter2"
+          }
+        }
+        """);
+    final JsonNode dest = objectMapper.readTree(
+        """
+        {
+          "top_level": {
+            "a_secret": "**********"
+          }
+        }
+        """);
+    final JsonNode schema = objectMapper.readTree(
+        """
+        {
+          "type": "object",
+          "properties": {
+            "top_level": {
+              "type": "object",
+              "properties": {
+                "a_secret": {
+                  "type": "string",
+                  "airbyte_secret": true
+                }
+              }
+            }
+          }
+        }
+        """);
+
+    final JsonNode copied = processor.copySecrets(source, dest, schema);
+
+    final JsonNode expected = objectMapper.readTree(
+        """
+        {
+          "top_level": {
+            "a_secret": "hunter2"
+          }
+        }
+        """);
+    assertEquals(expected, copied);
   }
 
 }

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/split_secrets/JsonSecretsProcessorTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/split_secrets/JsonSecretsProcessorTest.java
@@ -376,4 +376,53 @@ public class JsonSecretsProcessorTest {
     assertEquals(expected, copied);
   }
 
+  @Test
+  public void doesNotCopySecrets_inNestedNonCombinationNodeWhenDestinationMissing() throws JsonProcessingException {
+    final ObjectMapper objectMapper = new ObjectMapper();
+
+    final JsonNode source = objectMapper.readTree(
+        """
+        {
+          "top_level": {
+            "a_secret": "hunter2"
+          }
+        }
+        """);
+    final JsonNode dest = objectMapper.readTree(
+        """
+        {
+          "top_level": {
+          }
+        }
+        """);
+    final JsonNode schema = objectMapper.readTree(
+        """
+        {
+          "type": "object",
+          "properties": {
+            "top_level": {
+              "type": "object",
+              "properties": {
+                "a_secret": {
+                  "type": "string",
+                  "airbyte_secret": true
+                }
+              }
+            }
+          }
+        }
+        """);
+
+    final JsonNode copied = processor.copySecrets(source, dest, schema);
+
+    final JsonNode expected = objectMapper.readTree(
+        """
+        {
+          "top_level": {
+          }
+        }
+        """);
+    assertEquals(expected, copied);
+  }
+
 }


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/9886; probably relates to https://github.com/airbytehq/airbyte/issues/6393

Built airbyte locally and verified that a GAds source can be edited without needing to re-enter the secrets.

## How
Previously `JsonSecretsProcessor#copySecrets` only recursed into combination (oneOf/anyOf/allOf) objects. Add some basic handling for normal objects.

## Recommended reading order
1. JsonSecretsProcessor.java
2. JsonSecretsProcessorTest.java

## 🚨 User Impact 🚨
none

## Tests

<details><summary><strong>Unit</strong></summary>

![Screen Shot 2022-03-07 at 2 19 24 PM](https://user-images.githubusercontent.com/5741425/157127511-66192834-2023-4623-a41c-aec45b38347a.png)


</details>
