### PR TITLE
Fix Sonar check for non-python based connectors

### DIFF
--- a/.github/actions/ci-tests-runner/action.yml
+++ b/.github/actions/ci-tests-runner/action.yml
@@ -113,8 +113,11 @@ runs:
 
           [ -f ${{ steps.ci-py-tests.outputs.coverage-paths }} ] && OPTIONS+=("-Dsonar.python.coverage.reportPaths=${{ steps.ci-py-tests.outputs.coverage-paths }}")
           [ -f ${{ steps.ci-py-tests.outputs.flake8-logs }} ] && OPTIONS+=("-Dsonar.python.flake8.reportPaths=${{ steps.ci-py-tests.outputs.flake8-logs }}")
+          # TODO: figure out how to make this check work for Java-based connectors
+          # See more in https://github.com/airbytehq/airbyte/issues/10924
+          cat ${REPORT_FOLDER}/*
         fi
-        cat ${REPORT_FOLDER}/*
+
         if [ ${{ inputs.module-lang }} == 'java' ]; then
              [ -d "./src/main/java" ] && OPTIONS+=("-Dsonar.sources=./src/main/java")
              [ -d "./src/test/java" ] && OPTIONS+=("-Dsonar.tests=./src/test/java")


### PR DESCRIPTION
## What
This is a quick fix that moves `cat ${REPORT_FOLDER}/*`
inside if block for python-based connectors.

## How
The temporary fix is to move `cat ${REPORT_FOLDER}/*` inside the if block for python-based connectors. This will unbreak Sonar checks for java-based connectors. However, the remaining work that is still TBD is to make sure that Sonar generates reports correctly for Java-based connectors as well as for python-based ones.
