### PR TITLE
🐛  Source MongoDB: Added support for Amazon DocumentDB with TLS

### DIFF
--- a/airbyte-db/lib/src/main/java/io/airbyte/db/mongodb/MongoUtils.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/mongodb/MongoUtils.java
@@ -292,7 +292,8 @@ public class MongoUtils {
 
     STANDALONE("standalone"),
     REPLICA("replica"),
-    ATLAS("atlas");
+    ATLAS("atlas"),
+    DOCUMENTDB("documentdb");
 
     private final String type;
 

--- a/airbyte-integrations/connectors/source-mongodb-v2/Dockerfile
+++ b/airbyte-integrations/connectors/source-mongodb-v2/Dockerfile
@@ -12,9 +12,21 @@ FROM airbyte/integration-base-java:dev
 
 WORKDIR /airbyte
 
+RUN apt-get update &&\
+    apt-get install -y --no-install-recommends 	curl	&&\
+    rm -rf /var/lib/apt/lists/*
+
+COPY build/resources/main/import-rds-cert.sh import-rds-cert.sh
+
+RUN chmod +x import-rds-cert.sh
+
+RUN ./import-rds-cert.sh
+
+RUN rm -rf import-rds-cert.sh
+
 ENV APPLICATION source-mongodb-v2
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.12
+LABEL io.airbyte.version=0.1.13
 LABEL io.airbyte.name=airbyte/source-mongodb-v2

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io.airbyte.integrations.source.mongodb/MongoDbSource.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io.airbyte.integrations.source.mongodb/MongoDbSource.java
@@ -45,6 +45,7 @@ public class MongoDbSource extends AbstractDbSource<BsonType, MongoDatabase> {
   private static final String MONGODB_SERVER_URL = "mongodb://%s%s:%s/%s?authSource=%s&ssl=%s";
   private static final String MONGODB_CLUSTER_URL = "mongodb+srv://%s%s/%s?authSource=%s&retryWrites=true&w=majority&tls=true";
   private static final String MONGODB_REPLICA_URL = "mongodb://%s%s/%s?authSource=%s&directConnection=false&ssl=true";
+  private static final String MONGODB_DOCUMENTDB_URL = "mongodb://%s%s:%s/%s?ssl=%s&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false";
   private static final String USER = "user";
   private static final String PASSWORD = "password";
   private static final String INSTANCE_TYPE = "instance_type";
@@ -236,9 +237,14 @@ public class MongoDbSource extends AbstractDbSource<BsonType, MongoDatabase> {
             String.format(MONGODB_CLUSTER_URL, credentials, instanceConfig.get(CLUSTER_URL).asText(), config.get(DATABASE).asText(),
                 config.get(AUTH_SOURCE).asText()));
       }
+      case DOCUMENTDB -> {
+        final var tls = config.has(TLS) ? config.get(TLS).asBoolean() : (instanceConfig.has(TLS) ? instanceConfig.get(TLS).asBoolean() : true);
+        connectionStrBuilder.append(
+                String.format(MONGODB_DOCUMENTDB_URL, credentials, instanceConfig.get(HOST).asText(),
+                        instanceConfig.get(PORT).asText(), config.get(DATABASE).asText(), tls));
+      }
       default -> throw new IllegalArgumentException("Unsupported instance type: " + instance);
     }
     return connectionStrBuilder.toString();
   }
-
 }

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/import-rds-cert.sh
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/import-rds-cert.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eux;
+
+# Installs the Amazon DocumentDB CA certificates into the default keystore
+# Adapted from https://docs.aws.amazon.com/documentdb/latest/developerguide/connect_programmatically.html
+
+# Default Java keystore password
+storepassword=changeit
+
+curl -sS "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem" > rds-combined-ca-bundle.pem
+
+# Break up the combined certificate into individual certificates
+# The version of csplit in the container does not seem to support the match all {*} option. Workaround is to split
+# 99 times, which is more than we need, while ignoring the return value errors.
+set +e
+csplit -f 'rds-ca-' -k rds-combined-ca-bundle.pem /-----BEGIN\ CERTIFICATE-----/ '{99}'
+set -e
+
+# Delete all empty split files
+find . -name 'rds-ca-*' -size 0 -print0 | xargs -0 rm
+
+# Import all of the individual ca certificates into the Java keystore
+for CERT in ./rds-ca-*; do
+  alias=$(openssl x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print')
+  echo "Importing $alias"
+  keytool -import -file ${CERT} -alias "${alias}" -cacerts -storepass ${storepassword} -noprompt
+  rm $CERT
+done
+
+rm rds-combined-ca-bundle.pem

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json
@@ -89,6 +89,40 @@
                 "order": 0
               }
             }
+          },
+          {
+            "title": "Amazon DocumentDB",
+            "required": ["instance", "host", "port"],
+            "properties": {
+              "instance": {
+                "type": "string",
+                "enum": ["documentdb"],
+                "default": "documentdb"
+              },
+              "host": {
+                "title": "Host",
+                "type": "string",
+                "description": "The host name of the Amazon DocumentDb cluster.",
+                "order": 0
+              },
+              "port": {
+                "title": "Port",
+                "type": "integer",
+                "description": "The port of the Amazon DocumentDb database.",
+                "minimum": 0,
+                "maximum": 65536,
+                "default": 27017,
+                "examples": ["27017"],
+                "order": 1
+              },
+              "tls": {
+                "title": "TLS Connection",
+                "type": "boolean",
+                "description": "Indicates whether TLS encryption protocol will be used to connect to Amazon DocumentDB. It is recommended to use TLS connection if possible. For more information see <a href=\"https://docs.airbyte.io/integrations/sources/mongodb-v2\">documentation</a>.",
+                "default": false,
+                "order": 2
+              }
+            }
           }
         ]
       },

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/MongoDbSourceDocumentDbAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/MongoDbSourceDocumentDbAcceptanceTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.io.airbyte.integration_tests.sources;
+
+import static io.airbyte.db.mongodb.MongoUtils.MongoInstanceType.DOCUMENTDB;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import com.mongodb.client.MongoCollection;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.db.mongodb.MongoDatabase;
+import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
+import java.util.List;
+import org.bson.BsonArray;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class MongoDbSourceDocumentDbAcceptanceTest extends MongoDbSourceAbstractAcceptanceTest {
+
+  private MongoDBContainer mongoDBContainer;
+
+  @Override
+  protected void setupEnvironment(final TestDestinationEnv environment) throws Exception {
+    mongoDBContainer = new MongoDBContainer(DockerImageName.parse("mongo:4.0.10"));
+    mongoDBContainer.start();
+
+    final JsonNode instanceConfig = Jsons.jsonNode(ImmutableMap.builder()
+        .put("instance", DOCUMENTDB.getType())
+        .put("host", mongoDBContainer.getHost())
+        .put("port", mongoDBContainer.getFirstMappedPort())
+        .put("tls", false)
+        .build());
+
+    config = Jsons.jsonNode(ImmutableMap.builder()
+        .put("instance_type", instanceConfig)
+        .put("database", DATABASE_NAME)
+        .put("auth_source", "admin")
+        .build());
+
+    final var connectionString = String.format("mongodb://%s:%s/",
+        mongoDBContainer.getHost(),
+        mongoDBContainer.getFirstMappedPort());
+
+    database = new MongoDatabase(connectionString, DATABASE_NAME);
+
+    final MongoCollection<Document> collection = database.createCollection(COLLECTION_NAME);
+    final var doc1 = new Document("id", "0001").append("name", "Test")
+        .append("test", 10).append("test_array", new BsonArray(List.of(new BsonString("test"), new BsonString("mongo"))))
+        .append("double_test", 100.12).append("int_test", 100);
+    final var doc2 = new Document("id", "0002").append("name", "Mongo").append("test", "test_value").append("int_test", 201);
+    final var doc3 = new Document("id", "0003").append("name", "Source").append("test", null)
+        .append("double_test", 212.11).append("int_test", 302);
+
+    collection.insertMany(List.of(doc1, doc2, doc3));
+  }
+
+  @Override
+  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
+    database.close();
+    mongoDBContainer.close();
+  }
+
+}


### PR DESCRIPTION
## What

Solves #10388
 
This PR adds support to the MongoDB source connector for Amazon DocumentDB when TLS is enabled. Prior to this PR, the connection could not be made because of a certificate validation error.


A new MongoDb Instance Type was added called *Amazon DocumentDB*. 
Here is a screenshot of the new *Amazon DocumentDB* MongoDb Instance Type in the MongoDB source UI.
![Screen Shot 2022-03-09 at 2 31 19 PM](https://user-images.githubusercontent.com/1019585/157517489-9e8576dc-8c28-4462-b9a2-08c5bd4fba4f.png)


## How
Installs Amazon DocumentDB CA certs on the MongoDB source docker image in the default Java keystore. Having these certs installed in the docker image allows support for Amazon DocumentDB sources with TLS enabled.

A new MongoDb Instance Type was added called *Amazon DocumentDB*. This type was added because the jdbc connection string is slightly different as recommended by Amazon. Specifically it is connecting to a replica set and should use the cluster host.


## Recommended reading order
1. `airbyte-db/lib/src/main/java/io/airbyte/db/mongodb/MongoUtils.java`
2. `airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json`
3. `airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io.airbyte.integrations.source.mongodb/MongoDbSource.java`
4. `airbyte-integrations/connectors/source-mongodb-v2/Dockerfile`

## User Impact

There should be no breaking changes. This solution extends the existing MongoDb Instance Types and adds certs to the default keystore. No changes to existing code, only addition of code.

A new MongoDb Instance Type was added called *Amazon DocumentDB* in the MongoDB source UI..

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] Credentials added to Github CI. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>


## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
