### PR TITLE
🐛 octavia-cli: [install.sh] read for user input from /dev/tty

### DIFF
--- a/octavia-cli/install.sh
+++ b/octavia-cli/install.sh
@@ -54,7 +54,7 @@ install() {
 
 update_or_install() {
     if grep -q "^alias octavia=*" ${DETECTED_PROFILE}; then
-        read -p "❓ - You already have an octavia alias in your profile. Do you want to update? (Y/n)" -n 1 -r
+        read -p "❓ - You already have an octavia alias in your profile. Do you want to update? (Y/n)" -n 1 -r </dev/tty
         echo    # (optional) move to a new line
         if [[ $REPLY =~ ^[Yy]$ ]]
         then


### PR DESCRIPTION
The current  prompt for update in `install.sh` does not work when using 
`curl -o- https://raw.githubusercontent.com/airbytehq/airbyte/master/octavia-cli/install.sh | bash` because of the pipe. We should explicitly read from `/dev/tty` to make this work.