### PR TITLE
Enable reproducible archives in server and bootloader build

### DIFF
--- a/airbyte-bootloader/build.gradle
+++ b/airbyte-bootloader/build.gradle
@@ -29,6 +29,8 @@ application {
 // Publish this so Airbyte Cloud can consume and extend the classes within this jar.
 // This needs to be a shadow jar as none of the other modules are published.
 shadowJar {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
     zip64 true
     mergeServiceFiles()
     exclude 'META-INF/*.RSA'
@@ -81,3 +83,10 @@ task copyGeneratedTar(type: Copy) {
 Task dockerBuildTask = getDockerBuildTask("bootloader",  "$project.projectDir")
 dockerBuildTask.dependsOn(copyGeneratedTar)
 assemble.dependsOn(dockerBuildTask)
+
+// produce reproducible archives
+// (see https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives)
+tasks.withType(AbstractArchiveTask) {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -8,6 +8,10 @@ plugins {
 // as a delivery mechanism for the common Airbyte libraries and clients. Proper
 // publishing is blocked on some gradle work.
 shadowJar {
+    // following properties need to be set here to have reproducible shadow archives, doesn't seem to inherit from AbstractArchiveTask
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+
     zip64 true
     mergeServiceFiles()
     exclude 'META-INF/*.RSA'
@@ -141,6 +145,13 @@ task copyGeneratedTar(type: Copy) {
     into 'build/docker/bin'
 }
 
-Task dockerBuildTask = getDockerBuildTask("server",  "$project.projectDir")
+Task dockerBuildTask = getDockerBuildTask("server", "$project.projectDir")
 dockerBuildTask.dependsOn(copyGeneratedTar)
 assemble.dependsOn(dockerBuildTask)
+
+// produce reproducible archives
+// (see https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives)
+tasks.withType(AbstractArchiveTask) {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}

--- a/build.gradle
+++ b/build.gradle
@@ -150,9 +150,7 @@ def Task getDockerBuildTask(String artifactName, String projectDir) {
 allprojects {
     apply plugin: 'com.bmuschko.docker-remote-api'
 
-    task copyDocker(type: Copy) {
-        delete "build/docker"
-
+    task copyDocker(type: Sync) {
         from "${project.projectDir}/Dockerfile"
         into "build/docker/"
     }


### PR DESCRIPTION
## What
I noticed that the `:buildDockerImage-server` and `:buildDockerImage-bootloader` tasks were never up-to-date, even with no changes between builds. [Discussion on Slack](https://airbytehq-team.slack.com/archives/C02TXQ020QM/p1646853607423209) led to a few fixes to enable these tasks to be up-to-date.

Addresses #11036 


## How
Definitely read the thread for detailed context, but in short, the airbyte-server and airbyte-bootloader subprojects use the shadowJar plugin, and that plugin apparently needs to be specifically configured to produce consistent archive outputs that can be recognized by gradle as unchanged.

Also, we were deleting the `build/docker` output directory before dockerCopy tasks, which caused some task cache misses. Now, we're using a Sync command to preserve unchanged files during this copy. 

Finally, it was necessary to add the reproducible archive task block to the subprojects that use shadowJar to actually get these tasks to cache. For some reason, other subprojects that _don't_ use the shadowJar plugin apparently don't need this, but there must be some interaction between shadowJar and other archive tasks that necessitates placing this block at the end of the subproject's build.gradle file.

This is the block I'm referring to when I say "reproducible archive task block":
```
tasks.withType(AbstractArchiveTask) {
    preserveFileTimestamps = false
    reproducibleFileOrder = true
}
```

In conclusion, with all of these changes, every `:buildDockerImage-*` task is up-to-date when re-building with no changes, which can _drastically_ speed up builds in some cases. I've seen 5-10 minutes wasted on these docker image build tasks that should be up-to-date, so hopefully this change improves our local developer experience quite a bit!


## Recommended reading order
Top to bottom is fine
