### PR TITLE
🐙 octavia-cli: create octavia env file during install

### DIFF
--- a/octavia-cli/install.sh
+++ b/octavia-cli/install.sh
@@ -4,6 +4,7 @@
 # It creates an octavia alias in your profile bound to a docker run command
 
 VERSION=dev
+OCTAVIA_ENV_FILE=${HOME}/.octavia
 
 detect_profile() {
     if [ "${SHELL#*bash}" != "$SHELL" ]; then
@@ -42,8 +43,19 @@ pull_image() {
     docker pull airbyte/octavia-cli:${VERSION} > /dev/null 2>&1
 }
 
+add_octavia_comment_to_profile() {
+    printf "\n# OCTAVIA CLI\n" >> ${DETECTED_PROFILE}
+}
+
+create_octavia_env_file() {
+    echo "OCTAVIA_ENV_FILE=${OCTAVIA_ENV_FILE}"  >> ${DETECTED_PROFILE}
+    touch ${OCTAVIA_ENV_FILE}
+    echo "🐙 - 💾 The octavia env file was created at ${OCTAVIA_ENV_FILE}"
+}
+
+
 add_alias() {
-    echo 'alias octavia="pwd | xargs -I {} docker run --rm -v {}:/home/octavia-project --network host -e AIRBYTE_URL="\${AIRBYTE_URL}" -e AIRBYTE_WORKSPACE_ID="\${AIRBYTE_WORKSPACE_ID}" airbyte/octavia-cli:'${VERSION}'"'  >> ~/.zshrc
+    echo 'alias octavia="pwd | xargs -I {} docker run --rm -v {}:/home/octavia-project --network host --env-file \${OCTAVIA_ENV_FILE} airbyte/octavia-cli:'${VERSION}'"'  >> ${DETECTED_PROFILE}
     echo "🐙 - 🎉 octavia alias was added to ${DETECTED_PROFILE} , please open a new terminal window or run source ${DETECTED_PROFILE}"
 }
 
@@ -62,6 +74,8 @@ update_or_install() {
             install
         fi
     else
+        add_octavia_comment_to_profile
+        create_octavia_env_file
         install
     fi
 }


### PR DESCRIPTION
Create a env file (`~/.octavia`) to allow usesr to map whatever env var they want to `octavia` container.
This allows them to set secret values directly in this file.

Path to this file is stored in the bash profile of the user and can be changed by changing the value of their `OCTAVIA_ENV_FILE` env var.