### PR TITLE
Put getState() and isRunning() call within same try/catch block

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -239,7 +239,7 @@ public class TemporalClient {
         try {
           do {
             Thread.sleep(DELAY_BETWEEN_QUERY_MS);
-          } while (!isWorkflowRunning(getConnectionManagerName(connectionId)));
+          } while (!isWorkflowReachable(getConnectionManagerName(connectionId)));
         } catch (final InterruptedException e) {}
 
         return null;
@@ -274,11 +274,11 @@ public class TemporalClient {
 
   public ManualSyncSubmissionResult startNewManualSync(final UUID connectionId) {
     log.info("Manual sync request");
-    final boolean isWorflowRunning = isWorkflowRunning(getConnectionManagerName(connectionId));
+    final boolean workflowReachable = isWorkflowReachable(getConnectionManagerName(connectionId));
 
-    if (!isWorflowRunning) {
+    if (!workflowReachable) {
       return new ManualSyncSubmissionResult(
-          Optional.of("No scheduler workflow is running for: " + connectionId),
+          Optional.of("No scheduler workflow is reachable for: " + connectionId),
           Optional.empty());
     }
 
@@ -325,12 +325,12 @@ public class TemporalClient {
   public ManualSyncSubmissionResult startNewCancelation(final UUID connectionId) {
     log.info("Manual sync request");
 
-    final boolean isWorflowRunning = isWorkflowRunning(getConnectionManagerName(connectionId));
+    final boolean workflowReachable = isWorkflowReachable(getConnectionManagerName(connectionId));
 
-    if (!isWorflowRunning) {
+    if (!workflowReachable) {
       log.error("Can't cancel a non running workflow");
       return new ManualSyncSubmissionResult(
-          Optional.of("No scheduler workflow is running for: " + connectionId),
+          Optional.of("No scheduler workflow is reachable for: " + connectionId),
           Optional.empty());
     }
 
@@ -347,7 +347,7 @@ public class TemporalClient {
             Optional.of("Didn't manage cancel a sync for: " + connectionId),
             Optional.empty());
       }
-    } while (connectionManagerWorkflow.getState().isRunning());
+    } while (isWorkflowStateRunning(getConnectionManagerName(connectionId)));
 
     log.info("end of manual cancellation");
 
@@ -361,12 +361,12 @@ public class TemporalClient {
   public ManualSyncSubmissionResult resetConnection(final UUID connectionId) {
     log.info("reset sync request");
 
-    final boolean isWorflowRunning = isWorkflowRunning(getConnectionManagerName(connectionId));
+    final boolean workflowReachable = isWorkflowReachable(getConnectionManagerName(connectionId));
 
-    if (!isWorflowRunning) {
-      log.error("Can't reset a non running workflow");
+    if (!workflowReachable) {
+      log.error("Can't reset a non-reachable workflow");
       return new ManualSyncSubmissionResult(
-          Optional.of("No scheduler workflow is running for: " + connectionId),
+          Optional.of("No scheduler workflow is reachable for: " + connectionId),
           Optional.empty());
     }
 
@@ -445,10 +445,10 @@ public class TemporalClient {
   }
 
   private ConnectionManagerWorkflow getConnectionUpdateWorkflow(final UUID connectionId) {
-    final boolean isWorflowRunning = isWorkflowRunning(getConnectionManagerName(connectionId));
+    final boolean workflowReachable = isWorkflowReachable(getConnectionManagerName(connectionId));
 
-    if (!isWorflowRunning) {
-      throw new IllegalStateException("No running workflow for the connection {} while trying to delete it");
+    if (!workflowReachable) {
+      throw new IllegalStateException("No reachable workflow for the connection {} while trying to delete it");
     }
 
     final ConnectionManagerWorkflow connectionManagerWorkflow =
@@ -476,10 +476,10 @@ public class TemporalClient {
   }
 
   /**
-   * Check if a workflow is currently running. Running means that it is query-able, thus we check that
-   * we can properly launch a query
+   * Check if a workflow is reachable for signal calls by attempting to query for current state. If the query succeeds, the workflow is reachable.
    */
-  public boolean isWorkflowRunning(final String workflowName) {
+  @VisibleForTesting
+  boolean isWorkflowReachable(final String workflowName) {
     try {
       final ConnectionManagerWorkflow connectionManagerWorkflow = getExistingWorkflow(ConnectionManagerWorkflow.class, workflowName);
       connectionManagerWorkflow.getState();
@@ -490,8 +490,22 @@ public class TemporalClient {
     }
   }
 
+  /**
+   * Check if a workflow is reachable and has state {@link WorkflowState#isRunning()}
+   */
   @VisibleForTesting
-  public static String getConnectionManagerName(final UUID connectionId) {
+  boolean isWorkflowStateRunning(final String workflowName) {
+    try {
+      final ConnectionManagerWorkflow connectionManagerWorkflow = getExistingWorkflow(ConnectionManagerWorkflow.class, workflowName);
+
+      return connectionManagerWorkflow.getState().isRunning();
+    } catch (final Exception e) {
+      return false;
+    }
+  }
+
+  @VisibleForTesting
+  static String getConnectionManagerName(final UUID connectionId) {
     return "connection_manager_" + connectionId;
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -476,7 +476,8 @@ public class TemporalClient {
   }
 
   /**
-   * Check if a workflow is reachable for signal calls by attempting to query for current state. If the query succeeds, the workflow is reachable.
+   * Check if a workflow is reachable for signal calls by attempting to query for current state. If
+   * the query succeeds, the workflow is reachable.
    */
   @VisibleForTesting
   boolean isWorkflowReachable(final String workflowName) {

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
@@ -203,7 +203,7 @@ class TemporalClientTest {
 
     @Test
     public void testSynchronousResetConnection() {
-      ConnectionManagerWorkflow mConnectionManagerWorkflow = mock(ConnectionManagerWorkflow.class);
+      final ConnectionManagerWorkflow mConnectionManagerWorkflow = mock(ConnectionManagerWorkflow.class);
       final long jobId1 = 1L;
       final long jobId2 = 2L;
       final long jobId3 = 3L;
@@ -216,11 +216,11 @@ class TemporalClientTest {
           new JobInformation(jobId3, 0),
           new JobInformation(jobId3, 0));
 
-      doReturn(true).when(temporalClient).isWorkflowRunning(anyString());
+      doReturn(true).when(temporalClient).isWorkflowReachable(anyString());
 
       when(workflowClient.newWorkflowStub(any(Class.class), anyString())).thenReturn(mConnectionManagerWorkflow);
 
-      ManualSyncSubmissionResult manualSyncSubmissionResult = temporalClient.synchronousResetConnection(CONNECTION_ID);
+      final ManualSyncSubmissionResult manualSyncSubmissionResult = temporalClient.synchronousResetConnection(CONNECTION_ID);
 
       verify(mConnectionManagerWorkflow).resetConnection();
 


### PR DESCRIPTION
## What
Addresses #9627 

The cancelSync acceptance test flakiness seemed to be caused by a race condition where `workflow.getState()` was called when the workflow is not queryable. When we check for whether or not a workflow is reachable, we call `workflow.getState()` and return false if an exception is thrown. For cancellation, we didn't wrap the `workflow.getState()` call in a similar try/catch,  which meant acceptance tests could throw internal errors if called at the wrong time.

## How
This PR renames the existing `isWorkflowRunning()` method to `isWorkflowReachable()`, and adds a new method called `isWorkflowStateRunning()`. The new method calls `.getState()` and `isRunning()` inside a try/catch so that we simply return false if the workflow is not reachable when this method is called.


