### PR TITLE
Only run slash commands on PRs

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -4,6 +4,8 @@ on:
     types: [created]
 jobs:
   slashCommandDispatch:
+    # Only allow slash commands on pull request (not on issues)
+    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
       - name: Get PR repo and ref
@@ -17,8 +19,6 @@ jobs:
         uses: peter-evans/slash-command-dispatch@v2
         with:
           token: ${{ secrets.SLASH_COMMAND_PAT }}
-          # Only allow slash commands on pull request (not on issues)
-          issue-type: pull-request
           commands: |
             test
             test-performance


### PR DESCRIPTION
## What

While we checked in the actual slash command step that it only runs on PRs, the first step trying to get PR meta data always ran on all comments and then would fail because the PR URL is not set, see e.g. https://github.com/airbytehq/airbyte/actions/runs/1958668823

This PR makes sure we only run the full job if we're on a PR. See also https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only