### PR TITLE
Revert "add /tmp emptyDir volume to connector pods (#10761)"

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -113,7 +113,6 @@ public class KubePodProcess extends Process implements KubePod {
   private static final String STDOUT_PIPE_FILE = PIPES_DIR + "/stdout";
   private static final String STDERR_PIPE_FILE = PIPES_DIR + "/stderr";
   public static final String CONFIG_DIR = "/config";
-  public static final String TMP_DIR = "/tmp";
   private static final String TERMINATION_DIR = "/termination";
   private static final String TERMINATION_FILE_MAIN = TERMINATION_DIR + "/main";
   private static final String TERMINATION_FILE_CHECK = TERMINATION_DIR + "/check";
@@ -427,24 +426,13 @@ public class KubePodProcess extends Process implements KubePod {
         .withMountPath(TERMINATION_DIR)
         .build();
 
-    final Volume tmpVolume = new VolumeBuilder()
-        .withName("tmp")
-        .withNewEmptyDir()
-        .endEmptyDir()
-        .build();
-
-    final VolumeMount tmpVolumeMount = new VolumeMountBuilder()
-        .withName("tmp")
-        .withMountPath(TMP_DIR)
-        .build();
-
     final Container init = getInit(usesStdin, List.of(pipeVolumeMount, configVolumeMount), busyboxImage);
     final Container main = getMain(
         image,
         imagePullPolicy,
         usesStdin,
         entrypointOverride,
-        List.of(pipeVolumeMount, configVolumeMount, terminationVolumeMount, tmpVolumeMount),
+        List.of(pipeVolumeMount, configVolumeMount, terminationVolumeMount),
         resourceRequirements,
         internalToExternalPorts,
         envMap,
@@ -512,7 +500,7 @@ public class KubePodProcess extends Process implements KubePod {
         .withRestartPolicy("Never")
         .withInitContainers(init)
         .withContainers(containers)
-        .withVolumes(pipeVolume, configVolume, terminationVolume, tmpVolume)
+        .withVolumes(pipeVolume, configVolume, terminationVolume)
         .endSpec()
         .build();
 


### PR DESCRIPTION
This reverts commit 921f4a13c630ac51840cd7bfb7e9077ec630723f.

Seeing if this causes acceptance tests to pass again