### PR TITLE
Send analytics event on opening connector selection

### DIFF
--- a/airbyte-webapp/src/hooks/services/Analytics/__mocks__/index.ts
+++ b/airbyte-webapp/src/hooks/services/Analytics/__mocks__/index.ts
@@ -1,0 +1,1 @@
+export * from "./useAnalyticsService";

--- a/airbyte-webapp/src/hooks/services/Analytics/__mocks__/useAnalyticsService.tsx
+++ b/airbyte-webapp/src/hooks/services/Analytics/__mocks__/useAnalyticsService.tsx
@@ -1,0 +1,12 @@
+import type { AnalyticsService } from "core/analytics/AnalyticsService";
+
+export const useAnalyticsService = (): AnalyticsService => {
+  return ({
+    page: jest.fn(),
+    reset: jest.fn(),
+    alias: jest.fn(),
+    track: jest.fn(),
+    identify: jest.fn(),
+    group: jest.fn(),
+  } as unknown) as AnalyticsService;
+};

--- a/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.test.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.test.tsx
@@ -88,6 +88,8 @@ const schema: AirbyteJSONSchema = {
   },
 };
 
+jest.mock("hooks/services/Analytics");
+
 describe("Service Form", () => {
   describe("should display json schema specs", () => {
     let container: HTMLElement;

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -32,7 +32,7 @@ import {
   Icon as SingleValueIcon,
   ItemView as SingleValueView,
 } from "components/base/DropDown/components/SingleValue";
-import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
+import { useAnalyticsService } from "hooks/services/Analytics";
 
 const BottomElement = styled.div`
   background: ${(props) => props.theme.greyColro0};

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -32,6 +32,7 @@ import {
   Icon as SingleValueIcon,
   ItemView as SingleValueView,
 } from "components/base/DropDown/components/SingleValue";
+import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
 
 const BottomElement = styled.div`
   background: ${(props) => props.theme.greyColro0};
@@ -167,6 +168,7 @@ const ConnectorServiceTypeControl: React.FC<{
 }) => {
   const formatMessage = useIntl().formatMessage;
   const [field, fieldMeta, { setValue }] = useField(property.path);
+  const analytics = useAnalyticsService();
 
   // TODO Begin hack
   // During the Cloud private beta, we let users pick any connector in our catalog.
@@ -219,6 +221,14 @@ const ConnectorServiceTypeControl: React.FC<{
     [setValue, onChangeServiceType]
   );
 
+  const onMenuOpen = () => {
+    const eventName =
+      formType === "source"
+        ? "Airbyte.UI.NewSource.SelectionOpened"
+        : "Airbyte.UI.NewDestination.SelectionOpened";
+    analytics.track(eventName, {});
+  };
+
   return (
     <>
       <ControlLabels
@@ -242,6 +252,7 @@ const ConnectorServiceTypeControl: React.FC<{
           })}
           options={sortedDropDownData}
           onChange={handleSelect}
+          onMenuOpen={onMenuOpen}
         />
       </ControlLabels>
       {selectedService && documentationUrl && (


### PR DESCRIPTION
## What

Fixes #11048 

Send out an analytics event as soon as the connector select box has been opened.