### PR TITLE
Docs: Fix Incorrect Year on January 2022 Changelog Updates

### DIFF
--- a/docs/project-overview/changelog/README.md
+++ b/docs/project-overview/changelog/README.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1/28/2021 Summary
+## 1/28/2022 Summary
 
 * New Source: Chartmogul (contributyed by Titas Skrebė)
 * New Source: Hellobaton (contributed by Daniel Luftspring)
@@ -20,7 +20,7 @@
 * 🐛 Postgres Source: Now supports handling of the Java SQL date type.
 * 🐛 Salesforce Source: No longer fails during schema generation.
 
-## 1/13/2021 Summary
+## 1/13/2022 Summary
 
 ⚠️ WARNING ⚠️
 
@@ -40,7 +40,7 @@ Snowflake Source: Normalization with Snowflake now produces permanent tables. [I
 * 🐛 Recurly Source: Now does not load all accounts when importing account coupon redemptions.
 * 🐛 Salesforce Source: Now properly handles 400 when streams don't support query or queryAll.
 
-## 1/6/2021 Summary
+## 1/6/2022 Summary
 
 * New Source: 3PL Central (contributed by Juozas)
 * New Source: My Hours (contributed by Wisse Jelgersma)


### PR DESCRIPTION
## What
The year on the date headings for the most recently added changelog summaries are listed incorrectly as 2021 (instead of the correct 2022), making the documentation appear significantly out of date and potentially leading to confusion as to when different features were added or changed.

## How
Corrected the dates to read correctly.

## 🚨 User Impact 🚨
N/A