### PR TITLE
🎉 Source Plaid: Fix 100 record limit and added start_date

### DIFF
--- a/airbyte-integrations/connectors/source-plaid/integration_tests/sample_config.json
+++ b/airbyte-integrations/connectors/source-plaid/integration_tests/sample_config.json
@@ -2,5 +2,6 @@
   "access_token": "??",
   "api_key": "??",
   "client_id": "??",
-  "plaid_env": "sandbox"
+  "plaid_env": "sandbox",
+  "start_date": "2022-03-05"
 }

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/source.py
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/source.py
@@ -104,7 +104,8 @@ class IncrementalTransactionStream(PlaidStream):
         if date >= datetime.datetime.utcnow().date():
             return
 
-        date = max(self.start_date, date)
+        if self.start_date:
+            date = max(self.start_date, date)
 
         response = self._get_transactions_response(date)
         all_transactions.extend(response.transactions)

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/source.py
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/source.py
@@ -30,6 +30,7 @@ class PlaidStream(Stream):
         api_client = plaid.ApiClient(plaid_config)
         self.client = plaid_api.PlaidApi(api_client)
         self.access_token = config["access_token"]
+        self.start_date = datetime.datetime.strptime(config.get("start_date"), "%Y-%m-%d").date() if config.get("start_date") else None
 
 
 class BalanceStream(PlaidStream):
@@ -75,6 +76,16 @@ class IncrementalTransactionStream(PlaidStream):
     def get_updated_state(self, current_stream_state: MutableMapping[str, Any], latest_record: Mapping[str, Any]):
         return {"date": latest_record.get("date")}
 
+    def _get_transactions_response(self, start_date, end_date=datetime.datetime.utcnow().date(), offset=0):
+        from plaid.model.transactions_get_request_options import TransactionsGetRequestOptions
+
+        options = TransactionsGetRequestOptions()
+        options.offset = offset
+
+        return self.client.transactions_get(
+            TransactionsGetRequest(access_token=self.access_token, start_date=start_date, end_date=end_date, options=options)
+        )
+
     def read_records(
         self,
         sync_mode: SyncMode,
@@ -84,6 +95,8 @@ class IncrementalTransactionStream(PlaidStream):
     ) -> Iterable[Mapping[str, Any]]:
         stream_state = stream_state or {}
         date = stream_state.get("date")
+        all_transactions = []
+
         if not date:
             date = datetime.date.fromtimestamp(0)
         else:
@@ -91,11 +104,17 @@ class IncrementalTransactionStream(PlaidStream):
         if date >= datetime.datetime.utcnow().date():
             return
 
-        transaction_response = self.client.transactions_get(
-            TransactionsGetRequest(access_token=self.access_token, start_date=date, end_date=datetime.datetime.utcnow().date())
-        )
+        date = max(self.start_date, date)
 
-        yield from map(lambda x: x.to_dict(), sorted(transaction_response["transactions"], key=lambda t: t["date"]))
+        response = self._get_transactions_response(date)
+        all_transactions.extend(response.transactions)
+        num_total_transactions = response.total_transactions
+
+        while len(all_transactions) < num_total_transactions:
+            response = self._get_transactions_response(date, offset=len(all_transactions))
+            all_transactions.extend(response.transactions)
+
+        yield from map(lambda x: x.to_dict(), sorted(all_transactions, key=lambda t: t["date"]))
 
 
 class SourcePlaid(AbstractSource):

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/source.py
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/source.py
@@ -14,6 +14,7 @@ from airbyte_cdk.sources.streams import Stream
 from plaid.api import plaid_api
 from plaid.model.accounts_balance_get_request import AccountsBalanceGetRequest
 from plaid.model.transactions_get_request import TransactionsGetRequest
+from plaid.model.transactions_get_request_options import TransactionsGetRequestOptions
 
 SPEC_ENV_TO_PLAID_ENV = {
     "production": plaid.Environment.Production,
@@ -77,8 +78,6 @@ class IncrementalTransactionStream(PlaidStream):
         return {"date": latest_record.get("date")}
 
     def _get_transactions_response(self, start_date, end_date=datetime.datetime.utcnow().date(), offset=0):
-        from plaid.model.transactions_get_request_options import TransactionsGetRequestOptions
-
         options = TransactionsGetRequestOptions()
         options.offset = offset
 

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/spec.json
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/spec.json
@@ -27,6 +27,13 @@
         "type": "string",
         "enum": ["sandbox", "development", "production"],
         "description": "The Plaid environment"
+      },
+      "start_date": {
+        "title": "Start Date",
+        "type": "string",
+        "description": "The date from which you'd like to replicate data for Plaid in the format YYYY-MM-DD. All data generated after this date will be replicated.",
+        "examples": ["2021-03-01"],
+        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
       }
     }
   }

--- a/docs/integrations/sources/plaid.md
+++ b/docs/integrations/sources/plaid.md
@@ -67,3 +67,4 @@ This guide will walk through how to create the credentials you need to run this 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
 | 0.3.0 | 2022-01-05 | [7977](https://github.com/airbytehq/airbyte/pull/7977) | Migrate to Python CDK + add transaction stream |
+| 0.3.1 | 2022-xx-xx | [7977](https://github.com/airbytehq/airbyte/pull/11104) | Fix 100 record limit and added start_date |


### PR DESCRIPTION
## What
Fixes #10252

Added Start Date to Plaid connector
<img width="830" alt="Screenshot 2022-03-14 at 4 04 49 PM" src="https://user-images.githubusercontent.com/10597112/158163764-cd53e116-d2b7-4379-b4ad-6d94ba8a3f50.png">


## How
1. Fetched the total records count from Plaid in the first API call. If the current results are lesser than total count, keep fetching with the updated offset.
2. Added `start_date` to `spec.json` and used it to fetch limited records.

## Recommended reading order
1. `airbyte-integrations/connectors/source-plaid/source_plaid/spec.json`
2. `airbyte-integrations/connectors/source-plaid/source_plaid/source.py`

## 🚨 User Impact 🚨
No breaking changes

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [x] Documentation updated
    - [x] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

No Unit tests

</details>

<details><summary><strong>Integration</strong></summary>

```
Test session starts (platform: darwin, Python 3.9.4, pytest 6.1.2, pytest-sugar 0.9.4)
cachedir: .pytest_cache
rootdir: /Users/ehmadzubair/Documents/cogent-labs/upwork/airbyte-project/airbyte-fork/airbyte, configfile: pytest.ini
plugins: sugar-0.9.4, timeout-1.4.2
collecting ... 

Results (0.02s):
```

</details>

<details><summary><strong>Acceptance</strong></summary>

```
Test session starts (platform: darwin, Python 3.9.4, pytest 6.1.2, pytest-sugar 0.9.4)
cachedir: .pytest_cache
rootdir: /Users/ehmadzubair/Documents/cogent-labs/upwork/airbyte-project/airbyte-fork/airbyte, configfile: pytest.ini
plugins: sugar-0.9.4, timeout-1.4.2
collecting ... 
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_config_match_spec[inputs0] ✓                                                                                                                                                                   5% ▌         
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_match_expected[inputs0] ✓                                                                                                                                                                      9% ▉         
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_docker_env[inputs0] ✓                                                                                                                                                                         14% █▍        
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_oneof_usage[inputs0] ✓                                                                                                                                                                        18% █▊        
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_required[inputs0] ✓                                                                                                                                                                           23% ██▍       
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_optional[inputs0] ✓                                                                                                                                                                           27% ██▊       
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_has_secret[inputs0] ✓                                                                                                                                                                         32% ███▎      
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_secret_never_in_the_output[inputs0] ✓                                                                                                                                                         36% ███▋      
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_defined_refs_exist_in_json_spec_file[inputs0] ✓                                                                                                                                               41% ████▏     
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_oauth_flow_parameters[inputs0] ✓                                                                                                                                                              45% ████▋     
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestConnection.test_check[inputs0] ✓                                                                                                                                                                        50% █████     
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestConnection.test_check[inputs1] ✓                                                                                                                                                                        55% █████▌    
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_discover[inputs0] ✓                                                                                                                                                                      59% █████▉    
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_defined_cursors_exist_in_schema[inputs0] ✓                                                                                                                                               64% ██████▍   
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_defined_refs_exist_in_schema[inputs0] ✓                                                                                                                                                  68% ██████▊   
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_defined_keyword_exist_in_schema[inputs0-allOf] ✓                                                                                                                                         73% ███████▍  
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_defined_keyword_exist_in_schema[inputs0-not] ✓                                                                                                                                           77% ███████▊  
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_primary_keys_exist_in_schema[inputs0] ✓                                                                                                                                                  82% ████████▎ 
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestBasicRead.test_read[inputs0] ✓                                                                                                                                                                          86% ████████▋ 
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_full_refresh.py::TestFullRefresh.test_sequential_reads[inputs0] ✓                                                                                                                                                    91% █████████▏
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py::TestIncremental.test_two_sequential_reads[inputs0] ✓                                                                                                                                                 95% █████████▋
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py::TestIncremental.test_state_with_abnormally_large_values[inputs0] ✓                                                                                                                                  100% ██████████
=================================================================================================================================================== warnings summary ===================================================================================================================================================
airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py: 16 warnings
airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_full_refresh.py: 1 warning
airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py: 2 warnings
  /Users/ehmadzubair/Documents/cogent-labs/upwork/airbyte-project/airbyte-fork/airbyte/airbyte-integrations/connectors/source-plaid/.venv/lib/python3.9/site-packages/docker/utils/utils.py:52: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    s1 = StrictVersion(v1)

airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py: 16 warnings
airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_full_refresh.py: 1 warning
airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py: 2 warnings
  /Users/ehmadzubair/Documents/cogent-labs/upwork/airbyte-project/airbyte-fork/airbyte/airbyte-integrations/connectors/source-plaid/.venv/lib/python3.9/site-packages/docker/utils/utils.py:53: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    s2 = StrictVersion(v2)

-- Docs: https://docs.pytest.org/en/stable/warnings.html

Results (42.39s):
      22 passed
```

</details>
