### PR TITLE
Use Segment token from window if available

### DIFF
--- a/airbyte-webapp/src/config/configProviders.ts
+++ b/airbyte-webapp/src/config/configProviders.ts
@@ -8,6 +8,7 @@ const windowConfigProvider: ConfigProvider = async () => {
       enabled: isDefined(window.TRACKING_STRATEGY)
         ? window.TRACKING_STRATEGY === "segment"
         : undefined,
+      token: window.SEGMENT_TOKEN,
     },
     apiUrl: window.API_URL,
     version: window.AIRBYTE_VERSION,

--- a/airbyte-webapp/src/config/types.ts
+++ b/airbyte-webapp/src/config/types.ts
@@ -13,6 +13,7 @@ declare global {
     REACT_APP_WEBAPP_TAG?: string;
     REACT_APP_INTERCOM_APP_ID?: string;
     REACT_APP_INTEGRATION_DOCS_URLS?: string;
+    SEGMENT_TOKEN?: string;
     analytics: SegmentAnalytics;
 
     // API_URL to hack rest-hooks resources

--- a/airbyte-webapp/src/packages/cloud/services/ConfigProvider.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/ConfigProvider.tsx
@@ -19,8 +19,8 @@ const configProviders: ValueProvider<Config> = [
   // fileConfigProvider,
   cloudEnvConfigProvider,
   cloudWindowConfigProvider,
-  windowConfigProvider,
   envConfigProvider,
+  windowConfigProvider,
 ];
 
 /**


### PR DESCRIPTION
## What

Closes https://github.com/airbytehq/airbyte/issues/10450

This will enable usage of the `window.SEGMENT_TOKEN` to overwrite the build in REACT_APP_SEGMENT_TOKEN if available. Those token are already set on our cloud environments.