### PR TITLE
Add missing auth error messages

### DIFF
--- a/airbyte-webapp/src/packages/cloud/lib/auth/GoogleAuthService.ts
+++ b/airbyte-webapp/src/packages/cloud/lib/auth/GoogleAuthService.ts
@@ -61,6 +61,7 @@ export class GoogleAuthService implements AuthService {
           case AuthErrorCodes.INVALID_EMAIL:
             throw new FieldError("email", ErrorCodes.Invalid);
           case AuthErrorCodes.USER_CANCELLED:
+          case AuthErrorCodes.USER_DISABLED:
             throw new FieldError("email", "disabled");
           case AuthErrorCodes.USER_DELETED:
             throw new FieldError("email", "notfound");
@@ -125,11 +126,11 @@ export class GoogleAuthService implements AuthService {
         await updateEmail(user, email);
       } catch (e) {
         switch (e.code) {
-          case "auth/invalid-email":
+          case AuthErrorCodes.INVALID_EMAIL:
             throw new FieldError("email", ErrorCodes.Invalid);
-          case "auth/email-already-in-use":
+          case AuthErrorCodes.EMAIL_EXISTS:
             throw new FieldError("email", ErrorCodes.Duplicate);
-          case "auth/requires-recent-login":
+          case AuthErrorCodes.CREDENTIAL_TOO_OLD_LOGIN_AGAIN:
             throw new Error("auth/requires-recent-login");
         }
       }

--- a/airbyte-webapp/src/packages/cloud/locales/en.json
+++ b/airbyte-webapp/src/packages/cloud/locales/en.json
@@ -114,6 +114,8 @@
 
   "signup.password.minLength": "Password should be at least 6 characters",
   "email.duplicate": "Email already exists",
+  "email.notfound": "Email not found",
+  "email.disabled": "Your account is disabled",
   "password.validation": "Your password is too weak",
   "password.invalid": "Invalid password"
 }


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/11165

Adds error messages for non existing mails as well as deactivated accounts. Also replaces some hard coded strings with the correlating enum.