### PR TITLE
Use new AMI including cypress dependencies

### DIFF
--- a/.github/actions/start-aws-runner/action.yml
+++ b/.github/actions/start-aws-runner/action.yml
@@ -8,8 +8,8 @@ inputs:
   github-token:
     required: true
   ec2-image-id:
-    # github-self-hosted-runner-ubuntu-20-100g-disk
-    default: "ami-0ccd67e0abd945eec"
+    # github-self-hosted-runner-ubuntu-20-100g-disk-with-cypress-deps
+    default: "ami-08927c058921b27f4"
     required: true
   ec2-instance-type:
     default: "c5.2xlarge"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -543,15 +543,6 @@ jobs:
         with:
           node-version: "16.13.0"
 
-      - name: Install Cypress Test Dependencies
-        run: |
-          # wait to receive lock (see https://askubuntu.com/questions/132059/how-to-make-a-package-manager-wait-if-another-instance-of-apt-is-running)
-          while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do
-             sleep 1
-          done
-
-          sudo apt-get update && sudo apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
-
       - name: Set up CI Gradle Properties
         run: |
           mkdir -p ~/.gradle/


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/10494

Switch to a new AMI image as the default for CI, that has all dependencies for cypress installed, and thus we don't need to install them during the e2e testing job anymore.