### PR TITLE
Pin the Google Sheet connector to the top

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -6,13 +6,7 @@ import { MenuListComponentProps } from "react-select/src/components/Menu";
 import styled from "styled-components";
 import { WarningMessage } from "../WarningMessage";
 
-import {
-  ControlLabels,
-  defaultDataItemSort,
-  DropDown,
-  DropDownRow,
-  ImageBlock,
-} from "components";
+import { ControlLabels, DropDown, DropDownRow, ImageBlock } from "components";
 
 import { FormBaseItem } from "core/form/types";
 import {
@@ -33,6 +27,7 @@ import {
   ItemView as SingleValueView,
 } from "components/base/DropDown/components/SingleValue";
 import { useAnalyticsService } from "hooks/services/Analytics";
+import { naturalComparator } from "utils/objects";
 
 const BottomElement = styled.div`
   background: ${(props) => props.theme.greyColro0};
@@ -86,6 +81,16 @@ const SingleValueContent = styled(components.SingleValue)`
 `;
 
 type MenuWithRequestButtonProps = MenuListComponentProps<IDataItem, false>;
+
+/**
+ * Can be used to overwrite the alphabetical order of connectors in the select.
+ * A higher positive number will put the given connector to the top of the list
+ * a low negative number to the end of it.
+ */
+const ORDER_OVERWRITE: Record<string, number> = {
+  // Push Google Sheets connector to top
+  "71607ba1-c0ac-4799-8049-7f4b90dd50f7": 1,
+};
 
 const ConnectorList: React.FC<MenuWithRequestButtonProps> = ({
   children,
@@ -199,7 +204,14 @@ const ConnectorServiceTypeControl: React.FC<{
           img: <ImageBlock img={item.icon} />,
           releaseStage: item.releaseStage,
         }))
-        .sort(defaultDataItemSort),
+        .sort((a, b) => {
+          const priorityA = ORDER_OVERWRITE[a.value] ?? 0;
+          const priorityB = ORDER_OVERWRITE[b.value] ?? 0;
+          // If they have different priority use the higher priority first, otherwise use the label
+          return priorityA !== priorityB
+            ? priorityB - priorityA
+            : naturalComparator(a.label, b.label);
+        }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [availableServices]
   );


### PR DESCRIPTION
## What

Fixes #11045 

This will pin the Google Sheets connector to the top of the source dropdown, and allows specifying a custom order overwrite for any connector.