### PR TITLE
Remove sentry flag

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
@@ -190,7 +190,6 @@ public class IntegrationRunner {
     watchForOrphanThreads(
         () -> consumeWriteStream(consumer),
         () -> System.exit(FORCED_EXIT_CODE),
-        true,
         INTERRUPT_THREAD_DELAY_MINUTES,
         TimeUnit.MINUTES,
         EXIT_THREAD_DELAY_MINUTES,
@@ -211,7 +210,6 @@ public class IntegrationRunner {
   @VisibleForTesting
   static void watchForOrphanThreads(final Procedure runMethod,
                                     final Runnable exitHook,
-                                    final boolean sentryEnabled,
                                     final int interruptTimeDelay,
                                     final TimeUnit interruptTimeUnit,
                                     final int exitTimeDelay,
@@ -249,9 +247,7 @@ public class IntegrationRunner {
           // So, we schedule an interrupt hook after a fixed time delay instead...
           scheduledExecutorService.schedule(runningThread::interrupt, interruptTimeDelay, interruptTimeUnit);
         }
-        if (!sentryEnabled) {
-          Sentry.captureMessage(sentryMessageBuilder.toString(), SentryLevel.WARNING);
-        }
+        Sentry.captureMessage(sentryMessageBuilder.toString(), SentryLevel.WARNING);
         scheduledExecutorService.schedule(() -> {
           if (ThreadUtils.getAllThreads().stream()
               .anyMatch(runningThread -> !runningThread.isDaemon() && !runningThread.getName().equals(currentThread.getName()))) {

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunnerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunnerTest.java
@@ -307,7 +307,6 @@ class IntegrationRunnerTest {
           throw new IOException("random error");
         },
         Assertions::fail,
-        false,
         3, TimeUnit.SECONDS,
         10, TimeUnit.SECONDS));
     try {
@@ -334,7 +333,6 @@ class IntegrationRunnerTest {
           throw new IOException("random error");
         },
         () -> exitCalled.set(true),
-        false,
         3, TimeUnit.SECONDS,
         10, TimeUnit.SECONDS));
     try {


### PR DESCRIPTION
- Follow up from https://github.com/airbytehq/airbyte/pull/10660#discussion_r828821586.
- When Sentry is not initialized it will just do nothing. So it is always safe to call the captureMessage method.
