### PR TITLE
🐛 octavia-cli: cross-platform builds (arm64 + amd64)

### DIFF
--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -30,7 +30,7 @@ This script:
 ## 2.b If you want to directly run the CLI without alias in your current directory:
 ```bash
 mkdir my_octavia_project_directory # Create your octavia project directory where YAML configurations will be stored.
-docker run -i --rm -v ./my_octavia_project_directory:/home/octavia-project --network host -e AIRBYTE_URL="http://localhost:8000" airbyte/octavia-cli:dev
+docker run -i --rm -v ./my_octavia_project_directory:/home/octavia-project --network host -e AIRBYTE_URL="http://localhost:8000" airbyte/octavia-cli:0.1.0
 ```
 
 

--- a/octavia-cli/publish.sh
+++ b/octavia-cli/publish.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-set -eux
+set -ux
 VERSION=$1
-docker tag airbyte/octavia-cli:dev airbyte/octavia-cli:${VERSION}
-docker push airbyte/octavia-cli:${VERSION}
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+docker buildx create --name octavia_builder > /dev/null 2>&1
+set -e
+docker buildx use octavia_builder
+docker buildx inspect --bootstrap
+docker buildx build --push --tag airbyte/octavia-cli:${VERSION} --platform=linux/arm64,linux/amd64 ${SCRIPT_DIR}


### PR DESCRIPTION
## What
The current image was built from my M1, resulting into a arm64 image. 
We need cross-platform builds to ship the CLI for arm64 and amd64 architecture.

## How
* Update the `./publish.sh` script to:
  * Use `docker buildx`
  * Run the build, tag and push in a single command for arm64 and amd64
 
* Update the README to pull 0.1.0 image and not dev
* Push the cross platform build to docker hub:
<img width="1234" alt="Screen Shot 2022-03-17 at 09 52 52" src="https://user-images.githubusercontent.com/5551758/158772790-374d8c43-5b40-4bb8-8233-8904017e66d6.png">

## 🚨 User Impact 🚨
Users that might already have pulled 0.1.0 must run to pull the cross platform image.
```bash
docker pull airbyte/octavia-cli:0.1.0
```

or run 
```bash
curl -o- https://raw.githubusercontent.com/airbytehq/airbyte/master/octavia-cli/install.sh | bash
```