### PR TITLE
Avoid double-calling the deleteConnection activity

### DIFF
--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -289,20 +289,22 @@ public class AcceptanceTests {
       destinationPsql.stop();
     }
 
-    for (final UUID sourceId : sourceIds) {
-      deleteSource(sourceId);
+    for (final UUID operationId : operationIds) {
+      deleteOperation(operationId);
     }
 
     for (final UUID connectionId : connectionIds) {
       disableConnection(connectionId);
     }
 
+    for (final UUID sourceId : sourceIds) {
+      deleteSource(sourceId);
+    }
+
     for (final UUID destinationId : destinationIds) {
       deleteDestination(destinationId);
     }
-    for (final UUID operationId : operationIds) {
-      deleteOperation(operationId);
-    }
+
   }
 
   @Test

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -96,6 +96,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
       }
 
       if (workflowState.isDeleted()) {
+        log.info("Workflow deletion was requested. Calling deleteConnection activity before terminating the workflow.");
         deleteConnectionBeforeTerminatingTheWorkflow();
         return;
       }
@@ -138,7 +139,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
           () -> skipScheduling() || connectionUpdaterInput.isFromFailure());
 
       if (workflowState.isDeleted()) {
-        deleteConnectionBeforeTerminatingTheWorkflow();
+        log.info("Returning from workflow cancellation scope because workflow deletion was requested.");
         return;
       }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowTest.java
@@ -399,7 +399,7 @@ public class ConnectionManagerWorkflowTest {
                   && changedStateEvent.isValue())
           .isEmpty();
 
-      Mockito.verify(mConnectionDeletionActivity, Mockito.atLeast(1)).deleteConnection(Mockito.any());
+      Mockito.verify(mConnectionDeletionActivity, Mockito.times(1)).deleteConnection(Mockito.any());
     }
 
   }


### PR DESCRIPTION
## What
While investigating https://github.com/airbytehq/airbyte/issues/10666, I noticed that every 'delete connection' request issued to a waiting workflow seems to spawn two deleteConnection activity tasks. This seems to be due to the fact that we call the `deleteConnection` activity both inside the cancellationScope AND by the parent as soon as the cancellation scope returns.

## How
Instead of calling the 'deleteConnection' activity from both within the cancellationScope and also outside of the cancellationScope, this PR changes the behavior of the cancellationScope to just return early if the workflow state becomes 'deleted' during the `Workflow.await` step.

The parent of the cancellation scope is already responsible for calling the `deleteConnection` activity, so the cancellationScope's return is effectively delegating the responsibility of running the cancel activity to the parent. I added log statements to make this extra clear.

The ConnectionManagerWorkflowTests all pass with this change but we'll see how acceptance tests do.

## Recommended reading order
- top to bottom