### PR TITLE
Implement APIs for scoped connection definitions

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -296,6 +296,11 @@ paths:
         - source_definition
       summary: List all the sourceDefinitions the current Airbyte deployment is configured to use
       operationId: listSourceDefinitions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkspaceIdRequestBody"
       responses:
         "200":
           description: Successful operation
@@ -654,6 +659,11 @@ paths:
         - destination_definition
       summary: List all the destinationDefinitions the current Airbyte deployment is configured to use
       operationId: listDestinationDefinitions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkspaceIdRequestBody"
       responses:
         "200":
           description: Successful operation

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -322,6 +322,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SourceDefinitionReadList"
+  /v1/source_definitions/list_opt_in:
+    post:
+      tags:
+        - source_definition
+      summary: List all opt-in sourceDefinitions along with the current workspace's opt-in statuses
+      operationId: listSourceDefinitionOptIns
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkspaceIdRequestBody"
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SourceDefinitionOptInReadList"
   /v1/source_definitions/get:
     post:
       tags:
@@ -2190,6 +2208,25 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/SourceDefinitionRead"
+    SourceDefinitionOptInRead:
+      type: object
+      required:
+        - sourceDefinition
+        - optIn
+      properties:
+        sourceDefinition:
+          $ref: "#/components/schemas/SourceDefinitionRead"
+        optIn:
+          type: boolean
+    SourceDefinitionOptInReadList:
+      type: object
+      required:
+        - sourceDefinitionOptIns
+      properties:
+        sourceDefinitionOptIns:
+          type: array
+          items:
+            $ref: "#/components/schemas/SourceDefinitionOptInRead"
     # SOURCE SPECIFICATION
     SourceDefinitionSpecification:
       description: The specification for what values are required to configure the sourceDefinition.

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -340,6 +340,48 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SourceDefinitionOptInReadList"
+  /v1/source_definitions/grant_definition:
+    post:
+      tags:
+        - source_definition
+      summary: Opt in to a non-public, non-custom sourceDefinition
+      operationId: createSourceDefinitionOptIn
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SourceDefinitionOptInUpdate"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SourceDefinitionOptInRead"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+        "422":
+          $ref: "#/components/responses/InvalidInputResponse"
+  /v1/source_definitions/revoke_definition:
+    post:
+      tags:
+        - source_definition
+      summary: Opt out of a non-public, non-custom sourceDefinition
+      operationId: deleteSourceDefinitionOptIn
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SourceDefinitionOptInUpdate"
+        required: true
+      responses:
+        "204":
+          description: The resource was deleted successfully.
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+        "422":
+          $ref: "#/components/responses/InvalidInputResponse"
   /v1/source_definitions/get:
     post:
       tags:
@@ -2245,6 +2287,16 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/SourceDefinitionOptInRead"
+    SourceDefinitionOptInUpdate:
+      type: object
+      required:
+        - sourceDefinitionId
+        - workspaceId
+      properties:
+        sourceDefinitionId:
+          $ref: "#/components/schemas/SourceDefinitionId"
+        workspaceId:
+          $ref: "#/components/schemas/WorkspaceId"
     # SOURCE SPECIFICATION
     SourceDefinitionSpecification:
       description: The specification for what values are required to configure the sourceDefinition.

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -763,6 +763,48 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DestinationDefinitionOptInReadList"
+  /v1/destination_definitions/grant_definition:
+    post:
+      tags:
+        - destination_definition
+      summary: Opt in to a non-public, non-custom destinationDefinition
+      operationId: createDestinationDefinitionOptIn
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DestinationDefinitionOptInUpdate"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DestinationDefinitionOptInRead"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+        "422":
+          $ref: "#/components/responses/InvalidInputResponse"
+  /v1/destination_definitions/revoke_definition:
+    post:
+      tags:
+        - destination_definition
+      summary: Opt out of a non-public, non-custom destinationDefinition
+      operationId: deleteDestinationDefinitionOptIn
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DestinationDefinitionOptInUpdate"
+        required: true
+      responses:
+        "204":
+          description: The resource was deleted successfully.
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+        "422":
+          $ref: "#/components/responses/InvalidInputResponse"
   /v1/destination_definitions/get:
     post:
       tags:
@@ -2603,6 +2645,16 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DestinationDefinitionOptInRead"
+    DestinationDefinitionOptInUpdate:
+      type: object
+      required:
+        - destinationDefinitionId
+        - workspaceId
+      properties:
+        destinationDefinitionId:
+          $ref: "#/components/schemas/DestinationDefinitionId"
+        workspaceId:
+          $ref: "#/components/schemas/WorkspaceId"
     # DESTINATION DEFINITION SPECIFICATION
     DestinationDefinitionSpecification:
       description: The specification for what values are required to configure the destinationDefinition.

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -703,6 +703,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DestinationDefinitionReadList"
+  /v1/destination_definitions/list_opt_in:
+    post:
+      tags:
+        - destination_definition
+      summary: List all opt-in destinationDefinitions along with the current workspace's opt-in statuses
+      operationId: listDestinationDefinitionOptIns
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkspaceIdRequestBody"
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DestinationDefinitionOptInReadList"
   /v1/destination_definitions/get:
     post:
       tags:
@@ -2514,6 +2532,25 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DestinationDefinitionRead"
+    DestinationDefinitionOptInRead:
+      type: object
+      required:
+        - destinationDefinition
+        - optIn
+      properties:
+        destinationDefinition:
+          $ref: "#/components/schemas/DestinationDefinitionRead"
+        optIn:
+          type: boolean
+    DestinationDefinitionOptInReadList:
+      type: object
+      required:
+        - destinationDefinitionOptIns
+      properties:
+        destinationDefinitionOptIns:
+          type: array
+          items:
+            $ref: "#/components/schemas/DestinationDefinitionOptInRead"
     # DESTINATION DEFINITION SPECIFICATION
     DestinationDefinitionSpecification:
       description: The specification for what values are required to configure the destinationDefinition.

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2118,11 +2118,14 @@ components:
     SourceDefinitionCreate:
       type: object
       required:
+        - workspaceId
         - name
         - dockerRepository
         - dockerImageTag
         - documentationUrl
       properties:
+        workspaceId:
+          $ref: "#/components/schemas/WorkspaceId"
         name:
           type: string
         dockerRepository:
@@ -2402,11 +2405,14 @@ components:
     DestinationDefinitionCreate:
       type: object
       required:
+        - workspaceId
         - name
         - dockerRepository
         - dockerImageTag
         - documentationUrl
       properties:
+        workspaceId:
+          $ref: "#/components/schemas/WorkspaceId"
         name:
           type: string
         dockerRepository:

--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -80,7 +80,7 @@ public class BootloaderAppTest {
         mockedConfigs.getConfigDatabaseUrl())
             .getAndInitialize();
     val configsMigrator = new ConfigsDatabaseMigrator(configDatabase, this.getClass().getName());
-    assertEquals("0.35.55.003", configsMigrator.getLatestMigration().getVersion().getVersion());
+    assertEquals("0.35.56.001", configsMigrator.getLatestMigration().getVersion().getVersion());
 
     val jobsPersistence = new DefaultJobPersistence(jobDatabase);
     assertEquals(version, jobsPersistence.getVersion().get());

--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -80,7 +80,7 @@ public class BootloaderAppTest {
         mockedConfigs.getConfigDatabaseUrl())
             .getAndInitialize();
     val configsMigrator = new ConfigsDatabaseMigrator(configDatabase, this.getClass().getName());
-    assertEquals("0.35.54.001", configsMigrator.getLatestMigration().getVersion().getVersion());
+    assertEquals("0.35.55.003", configsMigrator.getLatestMigration().getVersion().getVersion());
 
     val jobsPersistence = new DefaultJobPersistence(jobDatabase);
     assertEquals(version, jobsPersistence.getVersion().get());

--- a/airbyte-commons/src/main/java/io/airbyte/commons/util/MoreLists.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/util/MoreLists.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 public class MoreLists {
 
@@ -33,6 +34,18 @@ public class MoreLists {
     final ArrayList<T> reversed = new ArrayList<>(list);
     Collections.reverse(reversed);
     return reversed;
+  }
+
+  /**
+   * Concatenate multiple lists into one list.
+   *
+   * @param lists to concatenate
+   * @param <T> type
+   * @return a new concatenated list
+   */
+  @SafeVarargs
+  public static <T> List<T> concat(final List<T>... lists) {
+    return Stream.of(lists).flatMap(List::stream).toList();
   }
 
 }

--- a/airbyte-config/init/src/test/java/io/airbyte/config/init/YamlSeedConfigPersistenceTest.java
+++ b/airbyte-config/init/src/test/java/io/airbyte/config/init/YamlSeedConfigPersistenceTest.java
@@ -44,6 +44,7 @@ public class YamlSeedConfigPersistenceTest {
     assertEquals("https://docs.airbyte.io/integrations/sources/mysql", mysqlSource.getDocumentationUrl());
     assertEquals("mysql.svg", mysqlSource.getIcon());
     assertEquals(URI.create("https://docs.airbyte.io/integrations/sources/mysql"), mysqlSource.getSpec().getDocumentationUrl());
+    assertEquals(true, mysqlSource.getPublic());
 
     // destination
     final String s3DestinationId = "4816b78f-1489-44c1-9060-4b19d5fa9362";
@@ -54,6 +55,7 @@ public class YamlSeedConfigPersistenceTest {
     assertEquals("airbyte/destination-s3", s3Destination.getDockerRepository());
     assertEquals("https://docs.airbyte.io/integrations/destinations/s3", s3Destination.getDocumentationUrl());
     assertEquals(URI.create("https://docs.airbyte.io/integrations/destinations/s3"), s3Destination.getSpec().getDocumentationUrl());
+    assertEquals(true, s3Destination.getPublic());
   }
 
   @Test

--- a/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardDestinationDefinition.yaml
@@ -34,6 +34,14 @@ properties:
       if not set or false, the configuration is active. if true, then this
       configuration is permanently off.
     type: boolean
+  public:
+    description: true if this connector definition is available to all workspaces
+    type: boolean
+    default: false
+  custom:
+    description: whether this is a custom connector definition
+    type: boolean
+    default: false
   releaseStage:
     type: string
     enum:

--- a/airbyte-config/models/src/main/resources/types/StandardSourceDefinition.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSourceDefinition.yaml
@@ -41,6 +41,14 @@ properties:
       if not set or false, the configuration is active. if true, then this
       configuration is permanently off.
     type: boolean
+  public:
+    description: true if this connector definition is available to all workspaces
+    type: boolean
+    default: false
+  custom:
+    description: whether this is a custom connector definition
+    type: boolean
+    default: false
   releaseStage:
     type: string
     enum:

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -200,6 +201,18 @@ public class ConfigRepository {
         includeTombstones(ACTOR_DEFINITION.TOMBSTONE, includeTombstones));
   }
 
+  public List<Entry<StandardSourceDefinition, Boolean>> listGrantableSourceDefinitions(final UUID workspaceId,
+                                                                                       final boolean includeTombstones)
+      throws IOException {
+    return listActorDefinitionsJoinedWithGrants(
+        workspaceId,
+        JoinType.LEFT_OUTER_JOIN,
+        ActorType.source,
+        record -> actorDefinitionWithGrantStatus(record, DbConverter::buildStandardSourceDefinition),
+        ACTOR_DEFINITION.CUSTOM.eq(false),
+        includeTombstones(ACTOR_DEFINITION.TOMBSTONE, includeTombstones));
+  }
+
   public void writeStandardSourceDefinition(final StandardSourceDefinition sourceDefinition) throws JsonValidationException, IOException {
     persistence.writeConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, sourceDefinition.getSourceDefinitionId().toString(), sourceDefinition);
   }
@@ -276,6 +289,18 @@ public class ConfigRepository {
         JoinType.JOIN,
         ActorType.destination,
         DbConverter::buildStandardDestinationDefinition,
+        includeTombstones(ACTOR_DEFINITION.TOMBSTONE, includeTombstones));
+  }
+
+  public List<Entry<StandardDestinationDefinition, Boolean>> listGrantableDestinationDefinitions(final UUID workspaceId,
+                                                                                                 final boolean includeTombstones)
+      throws IOException {
+    return listActorDefinitionsJoinedWithGrants(
+        workspaceId,
+        JoinType.LEFT_OUTER_JOIN,
+        ActorType.destination,
+        record -> actorDefinitionWithGrantStatus(record, DbConverter::buildStandardDestinationDefinition),
+        ACTOR_DEFINITION.CUSTOM.eq(false),
         includeTombstones(ACTOR_DEFINITION.TOMBSTONE, includeTombstones));
   }
 
@@ -381,6 +406,13 @@ public class ConfigRepository {
     return records.stream()
         .map(recordToReturnType)
         .toList();
+  }
+
+  private <T> Entry<T, Boolean> actorDefinitionWithGrantStatus(final Record outerJoinRecord,
+                                                               final Function<Record, T> recordToActorDefinition) {
+    final T actorDefinition = recordToActorDefinition.apply(outerJoinRecord);
+    final boolean granted = outerJoinRecord.get(ACTOR_DEFINITION_WORKSPACE_GRANT.WORKSPACE_ID) != null;
+    return Map.entry(actorDefinition, granted);
   }
 
   /**

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -415,6 +415,20 @@ public class ConfigRepository {
     return Map.entry(actorDefinition, granted);
   }
 
+  public void writeActorDefinitionWorkspaceGrant(final UUID actorDefinitionId, final UUID workspaceId) throws IOException {
+    database.query(ctx -> ctx.insertInto(ACTOR_DEFINITION_WORKSPACE_GRANT)
+        .set(ACTOR_DEFINITION_WORKSPACE_GRANT.ACTOR_DEFINITION_ID, actorDefinitionId)
+        .set(ACTOR_DEFINITION_WORKSPACE_GRANT.WORKSPACE_ID, workspaceId)
+        .execute());
+  }
+
+  public void deleteActorDefinitionWorkspaceGrant(final UUID actorDefinitionId, final UUID workspaceId) throws IOException {
+    database.query(ctx -> ctx.deleteFrom(ACTOR_DEFINITION_WORKSPACE_GRANT)
+        .where(ACTOR_DEFINITION_WORKSPACE_GRANT.ACTOR_DEFINITION_ID.eq(actorDefinitionId))
+        .and(ACTOR_DEFINITION_WORKSPACE_GRANT.WORKSPACE_ID.eq(workspaceId))
+        .execute());
+  }
+
   /**
    * Returns source with a given id. Does not contain secrets. To hydrate with secrets see { @link
    * SecretsRepositoryReader#getSourceConnectionWithSecrets(final UUID sourceId) }.

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -8,6 +8,7 @@ import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR;
 import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR_CATALOG;
 import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR_CATALOG_FETCH_EVENT;
 import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR_DEFINITION;
+import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR_DEFINITION_WORKSPACE_GRANT;
 import static io.airbyte.db.instance.configs.jooq.Tables.CONNECTION;
 import static io.airbyte.db.instance.configs.jooq.Tables.CONNECTION_OPERATION;
 import static org.jooq.impl.DSL.asterisk;
@@ -55,6 +56,7 @@ import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Field;
 import org.jooq.JSONB;
+import org.jooq.JoinType;
 import org.jooq.Record;
 import org.jooq.Record1;
 import org.jooq.Record2;
@@ -188,6 +190,16 @@ public class ConfigRepository {
         ACTOR_DEFINITION.PUBLIC.eq(true));
   }
 
+  public List<StandardSourceDefinition> listGrantedSourceDefinitions(final UUID workspaceId, final boolean includeTombstones)
+      throws IOException {
+    return listActorDefinitionsJoinedWithGrants(
+        workspaceId,
+        JoinType.JOIN,
+        ActorType.source,
+        DbConverter::buildStandardSourceDefinition,
+        includeTombstones(ACTOR_DEFINITION.TOMBSTONE, includeTombstones));
+  }
+
   public void writeStandardSourceDefinition(final StandardSourceDefinition sourceDefinition) throws JsonValidationException, IOException {
     persistence.writeConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, sourceDefinition.getSourceDefinitionId().toString(), sourceDefinition);
   }
@@ -255,6 +267,16 @@ public class ConfigRepository {
         DbConverter::buildStandardDestinationDefinition,
         includeTombstones(ACTOR_DEFINITION.TOMBSTONE, includeTombstone),
         ACTOR_DEFINITION.PUBLIC.eq(true));
+  }
+
+  public List<StandardDestinationDefinition> listGrantedDestinationDefinitions(final UUID workspaceId, final boolean includeTombstones)
+      throws IOException {
+    return listActorDefinitionsJoinedWithGrants(
+        workspaceId,
+        JoinType.JOIN,
+        ActorType.destination,
+        DbConverter::buildStandardDestinationDefinition,
+        includeTombstones(ACTOR_DEFINITION.TOMBSTONE, includeTombstones));
   }
 
   public void writeStandardDestinationDefinition(final StandardDestinationDefinition destinationDefinition)
@@ -338,6 +360,26 @@ public class ConfigRepository {
 
     return records.stream()
         .map(recordToActorDefinition)
+        .toList();
+  }
+
+  private <T> List<T> listActorDefinitionsJoinedWithGrants(final UUID workspaceId,
+                                                           final JoinType joinType,
+                                                           final ActorType actorType,
+                                                           final Function<Record, T> recordToReturnType,
+                                                           final Condition... conditions)
+      throws IOException {
+    final Result<Record> records = database.query(ctx -> ctx.select(asterisk()).from(ACTOR_DEFINITION)
+        .join(ACTOR_DEFINITION_WORKSPACE_GRANT, joinType)
+        .on(ACTOR_DEFINITION.ID.eq(ACTOR_DEFINITION_WORKSPACE_GRANT.ACTOR_DEFINITION_ID),
+            ACTOR_DEFINITION_WORKSPACE_GRANT.WORKSPACE_ID.eq(workspaceId))
+        .where(conditions)
+        .and(ACTOR_DEFINITION.ACTOR_TYPE.eq(actorType))
+        .and(ACTOR_DEFINITION.PUBLIC.eq(false))
+        .fetch());
+
+    return records.stream()
+        .map(recordToReturnType)
         .toList();
   }
 

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -27,7 +27,6 @@ import io.airbyte.commons.util.MoreIterators;
 import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.ActorCatalog;
 import io.airbyte.config.ActorCatalogFetchEvent;
-import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.AirbyteConfig;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.ConfigWithMetadata;
@@ -368,7 +367,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     final List<ConfigWithMetadata<StandardSourceDefinition>> standardSourceDefinitions = new ArrayList<>();
 
     for (final Record record : result) {
-      final StandardSourceDefinition standardSourceDefinition = buildStandardSourceDefinition(record);
+      final StandardSourceDefinition standardSourceDefinition = DbConverter.buildStandardSourceDefinition(record);
       standardSourceDefinitions.add(new ConfigWithMetadata<>(
           record.get(ACTOR_DEFINITION.ID).toString(),
           ConfigSchema.STANDARD_SOURCE_DEFINITION.name(),
@@ -377,29 +376,6 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
           standardSourceDefinition));
     }
     return standardSourceDefinitions;
-  }
-
-  private StandardSourceDefinition buildStandardSourceDefinition(final Record record) {
-    return new StandardSourceDefinition()
-        .withSourceDefinitionId(record.get(ACTOR_DEFINITION.ID))
-        .withDockerImageTag(record.get(ACTOR_DEFINITION.DOCKER_IMAGE_TAG))
-        .withIcon(record.get(ACTOR_DEFINITION.ICON))
-        .withDockerRepository(record.get(ACTOR_DEFINITION.DOCKER_REPOSITORY))
-        .withDocumentationUrl(record.get(ACTOR_DEFINITION.DOCUMENTATION_URL))
-        .withName(record.get(ACTOR_DEFINITION.NAME))
-        .withSourceType(record.get(ACTOR_DEFINITION.SOURCE_TYPE) == null ? null
-            : Enums.toEnum(record.get(ACTOR_DEFINITION.SOURCE_TYPE, String.class), SourceType.class).orElseThrow())
-        .withSpec(Jsons.deserialize(record.get(ACTOR_DEFINITION.SPEC).data(), ConnectorSpecification.class))
-        .withTombstone(record.get(ACTOR_DEFINITION.TOMBSTONE))
-        .withPublic(record.get(ACTOR_DEFINITION.PUBLIC))
-        .withCustom(record.get(ACTOR_DEFINITION.CUSTOM))
-        .withReleaseStage(record.get(ACTOR_DEFINITION.RELEASE_STAGE) == null ? null
-            : Enums.toEnum(record.get(ACTOR_DEFINITION.RELEASE_STAGE, String.class), StandardSourceDefinition.ReleaseStage.class).orElseThrow())
-        .withReleaseDate(record.get(ACTOR_DEFINITION.RELEASE_DATE) == null ? null
-            : record.get(ACTOR_DEFINITION.RELEASE_DATE).toString())
-        .withResourceRequirements(record.get(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS) == null
-            ? null
-            : Jsons.deserialize(record.get(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS).data(), ActorDefinitionResourceRequirements.class));
   }
 
   private List<ConfigWithMetadata<StandardDestinationDefinition>> listStandardDestinationDefinitionWithMetadata() throws IOException {
@@ -419,7 +395,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     final List<ConfigWithMetadata<StandardDestinationDefinition>> standardDestinationDefinitions = new ArrayList<>();
 
     for (final Record record : result) {
-      final StandardDestinationDefinition standardDestinationDefinition = buildStandardDestinationDefinition(record);
+      final StandardDestinationDefinition standardDestinationDefinition = DbConverter.buildStandardDestinationDefinition(record);
       standardDestinationDefinitions.add(new ConfigWithMetadata<>(
           record.get(ACTOR_DEFINITION.ID).toString(),
           ConfigSchema.STANDARD_DESTINATION_DEFINITION.name(),
@@ -428,27 +404,6 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
           standardDestinationDefinition));
     }
     return standardDestinationDefinitions;
-  }
-
-  private StandardDestinationDefinition buildStandardDestinationDefinition(final Record record) {
-    return new StandardDestinationDefinition()
-        .withDestinationDefinitionId(record.get(ACTOR_DEFINITION.ID))
-        .withDockerImageTag(record.get(ACTOR_DEFINITION.DOCKER_IMAGE_TAG))
-        .withIcon(record.get(ACTOR_DEFINITION.ICON))
-        .withDockerRepository(record.get(ACTOR_DEFINITION.DOCKER_REPOSITORY))
-        .withDocumentationUrl(record.get(ACTOR_DEFINITION.DOCUMENTATION_URL))
-        .withName(record.get(ACTOR_DEFINITION.NAME))
-        .withSpec(Jsons.deserialize(record.get(ACTOR_DEFINITION.SPEC).data(), ConnectorSpecification.class))
-        .withTombstone(record.get(ACTOR_DEFINITION.TOMBSTONE))
-        .withPublic(record.get(ACTOR_DEFINITION.PUBLIC))
-        .withCustom(record.get(ACTOR_DEFINITION.CUSTOM))
-        .withReleaseStage(record.get(ACTOR_DEFINITION.RELEASE_STAGE) == null ? null
-            : Enums.toEnum(record.get(ACTOR_DEFINITION.RELEASE_STAGE, String.class), StandardDestinationDefinition.ReleaseStage.class).orElseThrow())
-        .withReleaseDate(record.get(ACTOR_DEFINITION.RELEASE_DATE) == null ? null
-            : record.get(ACTOR_DEFINITION.RELEASE_DATE).toString())
-        .withResourceRequirements(record.get(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS) == null
-            ? null
-            : Jsons.deserialize(record.get(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS).data(), ActorDefinitionResourceRequirements.class));
   }
 
   private List<ConfigWithMetadata<SourceConnection>> listSourceConnectionWithMetadata() throws IOException {

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -391,6 +391,8 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
             : Enums.toEnum(record.get(ACTOR_DEFINITION.SOURCE_TYPE, String.class), SourceType.class).orElseThrow())
         .withSpec(Jsons.deserialize(record.get(ACTOR_DEFINITION.SPEC).data(), ConnectorSpecification.class))
         .withTombstone(record.get(ACTOR_DEFINITION.TOMBSTONE))
+        .withPublic(record.get(ACTOR_DEFINITION.PUBLIC))
+        .withCustom(record.get(ACTOR_DEFINITION.CUSTOM))
         .withReleaseStage(record.get(ACTOR_DEFINITION.RELEASE_STAGE) == null ? null
             : Enums.toEnum(record.get(ACTOR_DEFINITION.RELEASE_STAGE, String.class), StandardSourceDefinition.ReleaseStage.class).orElseThrow())
         .withReleaseDate(record.get(ACTOR_DEFINITION.RELEASE_DATE) == null ? null
@@ -438,6 +440,8 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
         .withName(record.get(ACTOR_DEFINITION.NAME))
         .withSpec(Jsons.deserialize(record.get(ACTOR_DEFINITION.SPEC).data(), ConnectorSpecification.class))
         .withTombstone(record.get(ACTOR_DEFINITION.TOMBSTONE))
+        .withPublic(record.get(ACTOR_DEFINITION.PUBLIC))
+        .withCustom(record.get(ACTOR_DEFINITION.CUSTOM))
         .withReleaseStage(record.get(ACTOR_DEFINITION.RELEASE_STAGE) == null ? null
             : Enums.toEnum(record.get(ACTOR_DEFINITION.RELEASE_STAGE, String.class), StandardDestinationDefinition.ReleaseStage.class).orElseThrow())
         .withReleaseDate(record.get(ACTOR_DEFINITION.RELEASE_DATE) == null ? null
@@ -864,6 +868,8 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                         io.airbyte.db.instance.configs.jooq.enums.SourceType.class).orElseThrow())
             .set(ACTOR_DEFINITION.SPEC, JSONB.valueOf(Jsons.serialize(standardSourceDefinition.getSpec())))
             .set(ACTOR_DEFINITION.TOMBSTONE, standardSourceDefinition.getTombstone())
+            .set(ACTOR_DEFINITION.PUBLIC, standardSourceDefinition.getPublic())
+            .set(ACTOR_DEFINITION.CUSTOM, standardSourceDefinition.getCustom())
             .set(ACTOR_DEFINITION.RELEASE_STAGE, standardSourceDefinition.getReleaseStage() == null ? null
                 : Enums.toEnum(standardSourceDefinition.getReleaseStage().value(),
                     io.airbyte.db.instance.configs.jooq.enums.ReleaseStage.class).orElseThrow())
@@ -891,6 +897,8 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                         io.airbyte.db.instance.configs.jooq.enums.SourceType.class).orElseThrow())
             .set(ACTOR_DEFINITION.SPEC, JSONB.valueOf(Jsons.serialize(standardSourceDefinition.getSpec())))
             .set(ACTOR_DEFINITION.TOMBSTONE, standardSourceDefinition.getTombstone() != null && standardSourceDefinition.getTombstone())
+            .set(ACTOR_DEFINITION.PUBLIC, standardSourceDefinition.getPublic())
+            .set(ACTOR_DEFINITION.CUSTOM, standardSourceDefinition.getCustom())
             .set(ACTOR_DEFINITION.RELEASE_STAGE,
                 standardSourceDefinition.getReleaseStage() == null ? null
                     : Enums.toEnum(standardSourceDefinition.getReleaseStage().value(),
@@ -932,6 +940,8 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
             .set(ACTOR_DEFINITION.ACTOR_TYPE, ActorType.destination)
             .set(ACTOR_DEFINITION.SPEC, JSONB.valueOf(Jsons.serialize(standardDestinationDefinition.getSpec())))
             .set(ACTOR_DEFINITION.TOMBSTONE, standardDestinationDefinition.getTombstone())
+            .set(ACTOR_DEFINITION.PUBLIC, standardDestinationDefinition.getPublic())
+            .set(ACTOR_DEFINITION.CUSTOM, standardDestinationDefinition.getCustom())
             .set(ACTOR_DEFINITION.RELEASE_STAGE, standardDestinationDefinition.getReleaseStage() == null ? null
                 : Enums.toEnum(standardDestinationDefinition.getReleaseStage().value(),
                     io.airbyte.db.instance.configs.jooq.enums.ReleaseStage.class).orElseThrow())
@@ -955,6 +965,8 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
             .set(ACTOR_DEFINITION.ACTOR_TYPE, ActorType.destination)
             .set(ACTOR_DEFINITION.SPEC, JSONB.valueOf(Jsons.serialize(standardDestinationDefinition.getSpec())))
             .set(ACTOR_DEFINITION.TOMBSTONE, standardDestinationDefinition.getTombstone() != null && standardDestinationDefinition.getTombstone())
+            .set(ACTOR_DEFINITION.PUBLIC, standardDestinationDefinition.getPublic())
+            .set(ACTOR_DEFINITION.CUSTOM, standardDestinationDefinition.getCustom())
             .set(ACTOR_DEFINITION.RELEASE_STAGE,
                 standardDestinationDefinition.getReleaseStage() == null ? null
                     : Enums.toEnum(standardDestinationDefinition.getReleaseStage().value(),
@@ -1776,6 +1788,8 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                     .withDockerRepository(row.get(ACTOR_DEFINITION.DOCKER_REPOSITORY))
                     .withDocumentationUrl(row.get(ACTOR_DEFINITION.DOCUMENTATION_URL))
                     .withName(row.get(ACTOR_DEFINITION.NAME))
+                    .withPublic(row.get(ACTOR_DEFINITION.PUBLIC))
+                    .withCustom(row.get(ACTOR_DEFINITION.CUSTOM))
                     .withSourceType(row.get(ACTOR_DEFINITION.SOURCE_TYPE) == null ? null
                         : Enums.toEnum(row.get(ACTOR_DEFINITION.SOURCE_TYPE, String.class), SourceType.class).orElseThrow())
                     .withSpec(Jsons.deserialize(row.get(ACTOR_DEFINITION.SPEC).data(), ConnectorSpecification.class)));
@@ -1787,6 +1801,8 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                     .withDockerRepository(row.get(ACTOR_DEFINITION.DOCKER_REPOSITORY))
                     .withDocumentationUrl(row.get(ACTOR_DEFINITION.DOCUMENTATION_URL))
                     .withName(row.get(ACTOR_DEFINITION.NAME))
+                    .withPublic(row.get(ACTOR_DEFINITION.PUBLIC))
+                    .withCustom(row.get(ACTOR_DEFINITION.CUSTOM))
                     .withSpec(Jsons.deserialize(row.get(ACTOR_DEFINITION.SPEC).data(), ConnectorSpecification.class)));
               } else {
                 throw new RuntimeException("Unknown Actor Type " + row.get(ACTOR_DEFINITION.ACTOR_TYPE));

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
@@ -4,16 +4,22 @@
 
 package io.airbyte.config.persistence;
 
+import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR_DEFINITION;
 import static io.airbyte.db.instance.configs.jooq.Tables.CONNECTION;
 
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
 import io.airbyte.config.ResourceRequirements;
 import io.airbyte.config.Schedule;
+import io.airbyte.config.StandardDestinationDefinition;
+import io.airbyte.config.StandardSourceDefinition;
+import io.airbyte.config.StandardSourceDefinition.SourceType;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSync.Status;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.ConnectorSpecification;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
@@ -40,6 +46,50 @@ public class DbConverter {
         .withManual(record.get(CONNECTION.MANUAL))
         .withOperationIds(connectionOperationId)
         .withResourceRequirements(Jsons.deserialize(record.get(CONNECTION.RESOURCE_REQUIREMENTS).data(), ResourceRequirements.class));
+  }
+
+  public static StandardSourceDefinition buildStandardSourceDefinition(final Record record) {
+    return new StandardSourceDefinition()
+        .withSourceDefinitionId(record.get(ACTOR_DEFINITION.ID))
+        .withDockerImageTag(record.get(ACTOR_DEFINITION.DOCKER_IMAGE_TAG))
+        .withIcon(record.get(ACTOR_DEFINITION.ICON))
+        .withDockerRepository(record.get(ACTOR_DEFINITION.DOCKER_REPOSITORY))
+        .withDocumentationUrl(record.get(ACTOR_DEFINITION.DOCUMENTATION_URL))
+        .withName(record.get(ACTOR_DEFINITION.NAME))
+        .withSourceType(record.get(ACTOR_DEFINITION.SOURCE_TYPE) == null ? null
+            : Enums.toEnum(record.get(ACTOR_DEFINITION.SOURCE_TYPE, String.class), SourceType.class).orElseThrow())
+        .withSpec(Jsons.deserialize(record.get(ACTOR_DEFINITION.SPEC).data(), ConnectorSpecification.class))
+        .withTombstone(record.get(ACTOR_DEFINITION.TOMBSTONE))
+        .withPublic(record.get(ACTOR_DEFINITION.PUBLIC))
+        .withCustom(record.get(ACTOR_DEFINITION.CUSTOM))
+        .withReleaseStage(record.get(ACTOR_DEFINITION.RELEASE_STAGE) == null ? null
+            : Enums.toEnum(record.get(ACTOR_DEFINITION.RELEASE_STAGE, String.class), StandardSourceDefinition.ReleaseStage.class).orElseThrow())
+        .withReleaseDate(record.get(ACTOR_DEFINITION.RELEASE_DATE) == null ? null
+            : record.get(ACTOR_DEFINITION.RELEASE_DATE).toString())
+        .withResourceRequirements(record.get(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS) == null
+            ? null
+            : Jsons.deserialize(record.get(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS).data(), ActorDefinitionResourceRequirements.class));
+  }
+
+  public static StandardDestinationDefinition buildStandardDestinationDefinition(final Record record) {
+    return new StandardDestinationDefinition()
+        .withDestinationDefinitionId(record.get(ACTOR_DEFINITION.ID))
+        .withDockerImageTag(record.get(ACTOR_DEFINITION.DOCKER_IMAGE_TAG))
+        .withIcon(record.get(ACTOR_DEFINITION.ICON))
+        .withDockerRepository(record.get(ACTOR_DEFINITION.DOCKER_REPOSITORY))
+        .withDocumentationUrl(record.get(ACTOR_DEFINITION.DOCUMENTATION_URL))
+        .withName(record.get(ACTOR_DEFINITION.NAME))
+        .withSpec(Jsons.deserialize(record.get(ACTOR_DEFINITION.SPEC).data(), ConnectorSpecification.class))
+        .withTombstone(record.get(ACTOR_DEFINITION.TOMBSTONE))
+        .withPublic(record.get(ACTOR_DEFINITION.PUBLIC))
+        .withCustom(record.get(ACTOR_DEFINITION.CUSTOM))
+        .withReleaseStage(record.get(ACTOR_DEFINITION.RELEASE_STAGE) == null ? null
+            : Enums.toEnum(record.get(ACTOR_DEFINITION.RELEASE_STAGE, String.class), StandardDestinationDefinition.ReleaseStage.class).orElseThrow())
+        .withReleaseDate(record.get(ACTOR_DEFINITION.RELEASE_DATE) == null ? null
+            : record.get(ACTOR_DEFINITION.RELEASE_DATE).toString())
+        .withResourceRequirements(record.get(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS) == null
+            ? null
+            : Jsons.deserialize(record.get(ACTOR_DEFINITION.RESOURCE_REQUIREMENTS).data(), ActorDefinitionResourceRequirements.class));
   }
 
 }

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
@@ -6,7 +6,6 @@ package io.airbyte.config.persistence;
 
 import static org.jooq.impl.DSL.asterisk;
 import static org.jooq.impl.DSL.count;
-import static org.jooq.impl.DSL.table;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -57,7 +56,8 @@ public abstract class BaseDatabaseConfigPersistenceTest {
   protected static void truncateAllTables() throws SQLException {
     database.query(ctx -> ctx
         .execute(
-            "TRUNCATE TABLE state, actor_catalog, actor_catalog_fetch_event, connection_operation, connection, operation, actor_oauth_parameter, actor, actor_definition, workspace"));
+            "TRUNCATE TABLE state, actor_catalog, actor_catalog_fetch_event, connection_operation, connection, operation, actor_oauth_parameter, "
+                + "actor, actor_definition, actor_definition_workspace_grant, workspace"));
   }
 
   protected static final StandardSourceDefinition SOURCE_GITHUB = new StandardSourceDefinition()

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
@@ -156,4 +156,16 @@ public class ConfigRepositoryE2EReadWriteTest {
     assertThat(MockData.standardSyncs().subList(0, 4)).hasSameElementsAs(syncs);
   }
 
+  @Test
+  public void testListPublicSourceDefinitions() throws IOException {
+    final List<StandardSourceDefinition> actualDefinitions = configRepository.listPublicSourceDefinitions(false);
+    assertEquals(List.of(MockData.standardSourceDefinitions().get(0)), actualDefinitions);
+  }
+
+  @Test
+  public void testListPublicDestinationDefinitions() throws IOException {
+    final List<StandardDestinationDefinition> actualDefinitions = configRepository.listPublicDestinationDefinitions(false);
+    assertEquals(List.of(MockData.standardDestinationDefinitions().get(0)), actualDefinitions);
+  }
+
 }

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
@@ -6,7 +6,9 @@ package io.airbyte.config.persistence;
 
 import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR_CATALOG;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 
 import io.airbyte.commons.json.Jsons;
@@ -31,6 +33,8 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
@@ -163,9 +167,59 @@ public class ConfigRepositoryE2EReadWriteTest {
   }
 
   @Test
+  public void testSourceDefinitionGrants() throws IOException {
+    final UUID workspaceId = MockData.standardWorkspaces().get(0).getWorkspaceId();
+    final StandardSourceDefinition grantableDefinition1 = MockData.standardSourceDefinitions().get(1);
+    final StandardSourceDefinition grantableDefinition2 = MockData.standardSourceDefinitions().get(2);
+    final StandardSourceDefinition customDefinition = MockData.standardSourceDefinitions().get(3);
+
+    configRepository.writeActorDefinitionWorkspaceGrant(customDefinition.getSourceDefinitionId(), workspaceId);
+    configRepository.writeActorDefinitionWorkspaceGrant(grantableDefinition1.getSourceDefinitionId(), workspaceId);
+    final List<StandardSourceDefinition> actualGrantedDefinitions = configRepository
+        .listGrantedSourceDefinitions(workspaceId, false);
+    assertThat(actualGrantedDefinitions).hasSameElementsAs(List.of(grantableDefinition1, customDefinition));
+
+    final List<Entry<StandardSourceDefinition, Boolean>> actualGrantableDefinitions = configRepository
+        .listGrantableSourceDefinitions(workspaceId, false);
+    assertThat(actualGrantableDefinitions).hasSameElementsAs(List.of(
+        Map.entry(grantableDefinition1, true),
+        Map.entry(grantableDefinition2, false)));
+
+    configRepository.deleteActorDefinitionWorkspaceGrant(customDefinition.getSourceDefinitionId(), workspaceId);
+    final List<StandardSourceDefinition> actualGrantedDefinitions2 = configRepository
+        .listGrantedSourceDefinitions(workspaceId, false);
+    assertEquals(List.of(grantableDefinition1), actualGrantedDefinitions2);
+  }
+
+  @Test
   public void testListPublicDestinationDefinitions() throws IOException {
     final List<StandardDestinationDefinition> actualDefinitions = configRepository.listPublicDestinationDefinitions(false);
     assertEquals(List.of(MockData.standardDestinationDefinitions().get(0)), actualDefinitions);
+  }
+
+  @Test
+  public void testDestinationDefinitionGrants() throws IOException {
+    final UUID workspaceId = MockData.standardWorkspaces().get(0).getWorkspaceId();
+    final StandardDestinationDefinition grantableDefinition1 = MockData.standardDestinationDefinitions().get(1);
+    final StandardDestinationDefinition grantableDefinition2 = MockData.standardDestinationDefinitions().get(2);
+    final StandardDestinationDefinition customDefinition = MockData.standardDestinationDefinitions().get(3);
+
+    configRepository.writeActorDefinitionWorkspaceGrant(customDefinition.getDestinationDefinitionId(), workspaceId);
+    configRepository.writeActorDefinitionWorkspaceGrant(grantableDefinition1.getDestinationDefinitionId(), workspaceId);
+    final List<StandardDestinationDefinition> actualGrantedDefinitions = configRepository
+        .listGrantedDestinationDefinitions(workspaceId, false);
+    assertThat(actualGrantedDefinitions).hasSameElementsAs(List.of(grantableDefinition1, customDefinition));
+
+    final List<Entry<StandardDestinationDefinition, Boolean>> actualGrantableDefinitions = configRepository
+        .listGrantableDestinationDefinitions(workspaceId, false);
+    assertThat(actualGrantableDefinitions).hasSameElementsAs(List.of(
+        Map.entry(grantableDefinition1, true),
+        Map.entry(grantableDefinition2, false)));
+
+    configRepository.deleteActorDefinitionWorkspaceGrant(customDefinition.getDestinationDefinitionId(), workspaceId);
+    final List<StandardDestinationDefinition> actualGrantedDefinitions2 = configRepository
+        .listGrantedDestinationDefinitions(workspaceId, false);
+    assertEquals(List.of(grantableDefinition1), actualGrantedDefinitions2);
   }
 
 }

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/MockData.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/MockData.java
@@ -56,8 +56,12 @@ public class MockData {
   private static final UUID WORKSPACE_CUSTOMER_ID = UUID.randomUUID();
   private static final UUID SOURCE_DEFINITION_ID_1 = UUID.randomUUID();
   private static final UUID SOURCE_DEFINITION_ID_2 = UUID.randomUUID();
+  private static final UUID SOURCE_DEFINITION_ID_3 = UUID.randomUUID();
+  private static final UUID SOURCE_DEFINITION_ID_4 = UUID.randomUUID();
   private static final UUID DESTINATION_DEFINITION_ID_1 = UUID.randomUUID();
   private static final UUID DESTINATION_DEFINITION_ID_2 = UUID.randomUUID();
+  private static final UUID DESTINATION_DEFINITION_ID_3 = UUID.randomUUID();
+  private static final UUID DESTINATION_DEFINITION_ID_4 = UUID.randomUUID();
   private static final UUID SOURCE_ID_1 = UUID.randomUUID();
   private static final UUID SOURCE_ID_2 = UUID.randomUUID();
   private static final UUID SOURCE_ID_3 = UUID.randomUUID();
@@ -129,6 +133,8 @@ public class MockData {
         .withIcon("icon-1")
         .withSpec(connectorSpecification)
         .withTombstone(false)
+        .withPublic(true)
+        .withCustom(false)
         .withResourceRequirements(new ActorDefinitionResourceRequirements().withDefault(new ResourceRequirements().withCpuRequest("2")));
     final StandardSourceDefinition standardSourceDefinition2 = new StandardSourceDefinition()
         .withSourceDefinitionId(SOURCE_DEFINITION_ID_2)
@@ -138,8 +144,32 @@ public class MockData {
         .withDockerRepository("repository-2")
         .withDocumentationUrl("documentation-url-2")
         .withIcon("icon-2")
-        .withTombstone(false);
-    return Arrays.asList(standardSourceDefinition1, standardSourceDefinition2);
+        .withTombstone(false)
+        .withPublic(false)
+        .withCustom(false);
+    final StandardSourceDefinition standardSourceDefinition3 = new StandardSourceDefinition()
+        .withSourceDefinitionId(SOURCE_DEFINITION_ID_3)
+        .withSourceType(SourceType.DATABASE)
+        .withName("random-source-3")
+        .withDockerImageTag("tag-3")
+        .withDockerRepository("repository-3")
+        .withDocumentationUrl("documentation-url-3")
+        .withIcon("icon-3")
+        .withTombstone(false)
+        .withPublic(false)
+        .withCustom(false);
+    final StandardSourceDefinition standardSourceDefinition4 = new StandardSourceDefinition()
+        .withSourceDefinitionId(SOURCE_DEFINITION_ID_4)
+        .withSourceType(SourceType.DATABASE)
+        .withName("random-source-4")
+        .withDockerImageTag("tag-4")
+        .withDockerRepository("repository-4")
+        .withDocumentationUrl("documentation-url-4")
+        .withIcon("icon-4")
+        .withTombstone(false)
+        .withPublic(false)
+        .withCustom(true);
+    return Arrays.asList(standardSourceDefinition1, standardSourceDefinition2, standardSourceDefinition3, standardSourceDefinition4);
   }
 
   private static ConnectorSpecification connectorSpecification() {
@@ -166,6 +196,8 @@ public class MockData {
         .withIcon("icon-3")
         .withSpec(connectorSpecification)
         .withTombstone(false)
+        .withPublic(true)
+        .withCustom(false)
         .withResourceRequirements(new ActorDefinitionResourceRequirements().withDefault(new ResourceRequirements().withCpuRequest("2")));
     final StandardDestinationDefinition standardDestinationDefinition2 = new StandardDestinationDefinition()
         .withDestinationDefinitionId(DESTINATION_DEFINITION_ID_2)
@@ -175,8 +207,33 @@ public class MockData {
         .withDocumentationUrl("documentation-url-4")
         .withIcon("icon-4")
         .withSpec(connectorSpecification)
-        .withTombstone(false);
-    return Arrays.asList(standardDestinationDefinition1, standardDestinationDefinition2);
+        .withTombstone(false)
+        .withPublic(false)
+        .withCustom(false);
+    final StandardDestinationDefinition standardDestinationDefinition3 = new StandardDestinationDefinition()
+        .withDestinationDefinitionId(DESTINATION_DEFINITION_ID_3)
+        .withName("random-destination-3")
+        .withDockerImageTag("tag-33")
+        .withDockerRepository("repository-33")
+        .withDocumentationUrl("documentation-url-33")
+        .withIcon("icon-3")
+        .withSpec(connectorSpecification)
+        .withTombstone(false)
+        .withPublic(false)
+        .withCustom(false);
+    final StandardDestinationDefinition standardDestinationDefinition4 = new StandardDestinationDefinition()
+        .withDestinationDefinitionId(DESTINATION_DEFINITION_ID_4)
+        .withName("random-destination-4")
+        .withDockerImageTag("tag-44")
+        .withDockerRepository("repository-44")
+        .withDocumentationUrl("documentation-url-44")
+        .withIcon("icon-4")
+        .withSpec(connectorSpecification)
+        .withTombstone(false)
+        .withPublic(false)
+        .withCustom(true);
+    return Arrays.asList(standardDestinationDefinition1, standardDestinationDefinition2, standardDestinationDefinition3,
+        standardDestinationDefinition4);
   }
 
   public static List<SourceConnection> sourceConnections() {

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_55_001__AddPublicToActorDefinition.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_55_001__AddPublicToActorDefinition.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// TODO: update migration description in the class name
+public class V0_35_55_001__AddPublicToActorDefinition extends BaseJavaMigration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(V0_35_55_001__AddPublicToActorDefinition.class);
+
+  @Override
+  public void migrate(final Context context) throws Exception {
+    LOGGER.info("Running migration: {}", this.getClass().getSimpleName());
+
+    // Warning: please do not use any jOOQ generated code to write a migration.
+    // As database schema changes, the generated jOOQ code can be deprecated. So
+    // old migration may not compile if there is any generated code.
+    final DSLContext ctx = DSL.using(context.getConnection());
+    addPublicColumn(ctx);
+  }
+
+  public static void addPublicColumn(final DSLContext ctx) {
+    ctx.alterTable("actor_definition")
+        .addColumnIfNotExists(DSL.field("public", SQLDataType.BOOLEAN.nullable(false).defaultValue(false)))
+        .execute();
+  }
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_55_002__AddActorDefinitionWorkspaceGrantTable.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_55_002__AddActorDefinitionWorkspaceGrantTable.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import static org.jooq.impl.DSL.foreignKey;
+import static org.jooq.impl.DSL.unique;
+
+import java.util.UUID;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// TODO: update migration description in the class name
+public class V0_35_55_002__AddActorDefinitionWorkspaceGrantTable extends BaseJavaMigration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(V0_35_55_002__AddActorDefinitionWorkspaceGrantTable.class);
+
+  @Override
+  public void migrate(final Context context) throws Exception {
+    LOGGER.info("Running migration: {}", this.getClass().getSimpleName());
+
+    // Warning: please do not use any jOOQ generated code to write a migration.
+    // As database schema changes, the generated jOOQ code can be deprecated. So
+    // old migration may not compile if there is any generated code.
+    final DSLContext ctx = DSL.using(context.getConnection());
+    createActorDefinitionWorkspaceGrant(ctx);
+  }
+
+  public static void createActorDefinitionWorkspaceGrant(final DSLContext ctx) {
+    final Field<UUID> actorDefinitionId = DSL.field("actor_definition_id", SQLDataType.UUID.nullable(false));
+    final Field<UUID> workspaceId = DSL.field("workspace_id", SQLDataType.UUID.nullable(false));
+    ctx.createTableIfNotExists("actor_definition_workspace_grant")
+        .columns(
+            actorDefinitionId,
+            workspaceId)
+        .constraints(
+            unique(workspaceId, actorDefinitionId),
+            foreignKey(actorDefinitionId).references("actor_definition", "id").onDeleteCascade(),
+            foreignKey(workspaceId).references("workspace", "id").onDeleteCascade())
+        .execute();
+    LOGGER.info("actor_definition_workspace_grant table created");
+  }
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_55_003__AddCustomToActorDefinition.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_55_003__AddCustomToActorDefinition.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// TODO: update migration description in the class name
+public class V0_35_55_003__AddCustomToActorDefinition extends BaseJavaMigration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(V0_35_55_003__AddCustomToActorDefinition.class);
+
+  @Override
+  public void migrate(final Context context) throws Exception {
+    LOGGER.info("Running migration: {}", this.getClass().getSimpleName());
+
+    // Warning: please do not use any jOOQ generated code to write a migration.
+    // As database schema changes, the generated jOOQ code can be deprecated. So
+    // old migration may not compile if there is any generated code.
+    final DSLContext ctx = DSL.using(context.getConnection());
+    addCustomColumn(ctx);
+  }
+
+  public static void addCustomColumn(final DSLContext ctx) {
+    ctx.alterTable("actor_definition")
+        .addColumnIfNotExists(DSL.field("custom", SQLDataType.BOOLEAN.nullable(false).defaultValue(false)))
+        .execute();
+  }
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_56_001__SetAllExistingActorDefinitionsToPublic.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_35_56_001__SetAllExistingActorDefinitionsToPublic.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// Set all existing actor definitions to public
+// This is to ensure that any existing custom actor definitions will continue to be usable by all
+// workspaces
+public class V0_35_56_001__SetAllExistingActorDefinitionsToPublic extends BaseJavaMigration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(V0_35_56_001__SetAllExistingActorDefinitionsToPublic.class);
+
+  @Override
+  public void migrate(final Context context) throws Exception {
+    LOGGER.info("Running migration: {}", this.getClass().getSimpleName());
+
+    // Warning: please do not use any jOOQ generated code to write a migration.
+    // As database schema changes, the generated jOOQ code can be deprecated. So
+    // old migration may not compile if there is any generated code.
+    final DSLContext ctx = DSL.using(context.getConnection());
+    setPublic(ctx);
+  }
+
+  public static void setPublic(final DSLContext ctx) {
+    ctx.update(DSL.table("actor_definition"))
+        .set(DSL.field("public"), true)
+        .execute();
+  }
+
+}

--- a/airbyte-db/lib/src/main/resources/configs_database/schema_dump.txt
+++ b/airbyte-db/lib/src/main/resources/configs_database/schema_dump.txt
@@ -51,8 +51,14 @@ create table "public"."actor_definition"(
   "release_stage" release_stage null,
   "release_date" date null,
   "resource_requirements" jsonb null,
+  "public" bool not null default false,
+  "custom" bool not null default false,
   constraint "actor_definition_pkey"
     primary key ("id")
+);
+create table "public"."actor_definition_workspace_grant"(
+  "actor_definition_id" uuid not null,
+  "workspace_id" uuid not null
 );
 create table "public"."actor_oauth_parameter"(
   "id" uuid not null,
@@ -172,6 +178,14 @@ alter table "public"."actor_catalog_fetch_event"
   add constraint "actor_catalog_fetch_event_actor_id_fkey"
     foreign key ("actor_id")
     references "public"."actor" ("id");
+alter table "public"."actor_definition_workspace_grant"
+  add constraint "actor_definition_workspace_grant_actor_definition_id_fkey"
+    foreign key ("actor_definition_id")
+    references "public"."actor_definition" ("id");
+alter table "public"."actor_definition_workspace_grant"
+  add constraint "actor_definition_workspace_grant_workspace_id_fkey"
+    foreign key ("workspace_id")
+    references "public"."workspace" ("id");
 alter table "public"."actor_oauth_parameter"
   add constraint "actor_oauth_parameter_actor_definition_id_fkey"
     foreign key ("actor_definition_id")
@@ -213,6 +227,10 @@ create index "actor_catalog_fetch_event_actor_catalog_id_idx" on "public"."actor
 create index "actor_catalog_fetch_event_actor_id_idx" on "public"."actor_catalog_fetch_event"("actor_id" asc);
 create unique index "actor_catalog_fetch_event_pkey" on "public"."actor_catalog_fetch_event"("id" asc);
 create unique index "actor_definition_pkey" on "public"."actor_definition"("id" asc);
+create unique index "actor_definition_workspace_gr_workspace_id_actor_definition_key" on "public"."actor_definition_workspace_grant"(
+  "workspace_id" asc, 
+  "actor_definition_id" asc
+);
 create unique index "actor_oauth_parameter_pkey" on "public"."actor_oauth_parameter"("id" asc);
 create unique index "airbyte_configs_migrations_pk" on "public"."airbyte_configs_migrations"("installed_rank" asc);
 create index "airbyte_configs_migrations_s_idx" on "public"."airbyte_configs_migrations"("success" asc);

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_55_001__AddPublicToActorDefinitionTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_55_001__AddPublicToActorDefinitionTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import io.airbyte.db.Database;
+import io.airbyte.db.instance.configs.AbstractConfigsDatabaseTest;
+import io.airbyte.db.instance.configs.migrations.V0_32_8_001__AirbyteConfigDatabaseDenormalization.ActorType;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.UUID;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class V0_35_55_001__AddPublicToActorDefinitionTest extends AbstractConfigsDatabaseTest {
+
+  @Test
+  public void test() throws SQLException, IOException {
+
+    final Database database = getDatabase();
+    final DSLContext context = DSL.using(database.getDataSource().getConnection());
+
+    // necessary to add actor_definition table
+    V0_32_8_001__AirbyteConfigDatabaseDenormalization.migrate(context);
+
+    Assertions.assertFalse(publicColumnExists(context));
+
+    final UUID id = UUID.randomUUID();
+    context.insertInto(DSL.table("actor_definition"))
+        .columns(
+            DSL.field("id"),
+            DSL.field("name"),
+            DSL.field("docker_repository"),
+            DSL.field("docker_image_tag"),
+            DSL.field("actor_type"),
+            DSL.field("spec"))
+        .values(
+            id,
+            "name",
+            "repo",
+            "1.0.0",
+            ActorType.source,
+            JSONB.valueOf("{}"))
+        .execute();
+
+    V0_35_55_001__AddPublicToActorDefinition.addPublicColumn(context);
+
+    Assertions.assertTrue(publicColumnExists(context));
+    Assertions.assertTrue(publicDefaultsToFalse(context, id));
+  }
+
+  protected static boolean publicColumnExists(final DSLContext ctx) {
+    return ctx.fetchExists(DSL.select()
+        .from("information_schema.columns")
+        .where(DSL.field("table_name").eq("actor_definition")
+            .and(DSL.field("column_name").eq("public"))));
+  }
+
+  protected static boolean publicDefaultsToFalse(final DSLContext ctx, final UUID id) {
+    final Record record = ctx.fetchOne(DSL.select()
+        .from("actor_definition")
+        .where(DSL.field("id").eq(id)));
+
+    return record.get("public").equals(false);
+  }
+
+}

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_55_002__AddActorDefinitionWorkspaceGrantTableTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_55_002__AddActorDefinitionWorkspaceGrantTableTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import io.airbyte.db.Database;
+import io.airbyte.db.instance.configs.AbstractConfigsDatabaseTest;
+import io.airbyte.db.instance.configs.migrations.V0_32_8_001__AirbyteConfigDatabaseDenormalization.ActorType;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.UUID;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.jooq.exception.DataAccessException;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class V0_35_55_002__AddActorDefinitionWorkspaceGrantTableTest extends AbstractConfigsDatabaseTest {
+
+  @Test
+  public void test() throws SQLException, IOException {
+
+    final Database database = getDatabase();
+    final DSLContext context = DSL.using(database.getDataSource().getConnection());
+    V0_32_8_001__AirbyteConfigDatabaseDenormalization.migrate(context);
+
+    final UUID actorDefinitionId = new UUID(0L, 1L);
+    context.insertInto(DSL.table("actor_definition"))
+        .columns(
+            DSL.field("id"),
+            DSL.field("name"),
+            DSL.field("docker_repository"),
+            DSL.field("docker_image_tag"),
+            DSL.field("actor_type"),
+            DSL.field("spec"))
+        .values(
+            actorDefinitionId,
+            "name",
+            "repo",
+            "1.0.0",
+            ActorType.source,
+            JSONB.valueOf("{}"))
+        .execute();
+
+    final UUID workspaceId = new UUID(0L, 2L);
+    context.insertInto(DSL.table("workspace"))
+        .columns(
+            DSL.field("id"),
+            DSL.field("name"),
+            DSL.field("slug"),
+            DSL.field("initial_setup_complete"))
+        .values(
+            workspaceId,
+            "default",
+            "default",
+            true)
+        .execute();
+
+    V0_35_55_002__AddActorDefinitionWorkspaceGrantTable.createActorDefinitionWorkspaceGrant(context);
+    assertCanInsertActorDefinitionWorkspaceGrant(context, actorDefinitionId, workspaceId);
+    assertActorDefinitionWorkspaceGrantConstraints(context);
+  }
+
+  private void assertCanInsertActorDefinitionWorkspaceGrant(
+                                                            final DSLContext context,
+                                                            final UUID actorDefinitionId,
+                                                            final UUID workspaceId) {
+    Assertions.assertDoesNotThrow(() -> {
+      context.insertInto(DSL.table("actor_definition_workspace_grant"))
+          .columns(
+              DSL.field("actor_definition_id"),
+              DSL.field("workspace_id"))
+          .values(
+              actorDefinitionId,
+              workspaceId)
+          .execute();
+    });
+  }
+
+  private void assertActorDefinitionWorkspaceGrantConstraints(final DSLContext context) {
+    final Exception e = Assertions.assertThrows(DataAccessException.class, () -> {
+      context.insertInto(DSL.table("actor_definition_workspace_grant"))
+          .columns(
+              DSL.field("actor_definition_id"),
+              DSL.field("workspace_id"))
+          .values(
+              new UUID(0L, 3L),
+              new UUID(0L, 4L))
+          .execute();
+    });
+    Assertions.assertTrue(e.getMessage().contains("violates foreign key constraint"));
+  }
+
+}

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_55_003__AddCustomToActorDefinitionTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_55_003__AddCustomToActorDefinitionTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import io.airbyte.db.Database;
+import io.airbyte.db.instance.configs.AbstractConfigsDatabaseTest;
+import io.airbyte.db.instance.configs.migrations.V0_32_8_001__AirbyteConfigDatabaseDenormalization.ActorType;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.UUID;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class V0_35_55_003__AddCustomToActorDefinitionTest extends AbstractConfigsDatabaseTest {
+
+  @Test
+  public void test() throws SQLException, IOException {
+
+    final Database database = getDatabase();
+    final DSLContext context = DSL.using(database.getDataSource().getConnection());
+
+    // necessary to add actor_definition table
+    V0_32_8_001__AirbyteConfigDatabaseDenormalization.migrate(context);
+
+    Assertions.assertFalse(customColumnExists(context));
+
+    final UUID id = UUID.randomUUID();
+    context.insertInto(DSL.table("actor_definition"))
+        .columns(
+            DSL.field("id"),
+            DSL.field("name"),
+            DSL.field("docker_repository"),
+            DSL.field("docker_image_tag"),
+            DSL.field("actor_type"),
+            DSL.field("spec"))
+        .values(
+            id,
+            "name",
+            "repo",
+            "1.0.0",
+            ActorType.source,
+            JSONB.valueOf("{}"))
+        .execute();
+
+    V0_35_55_003__AddCustomToActorDefinition.addCustomColumn(context);
+
+    Assertions.assertTrue(customColumnExists(context));
+    Assertions.assertTrue(customDefaultsToFalse(context, id));
+  }
+
+  protected static boolean customColumnExists(final DSLContext ctx) {
+    return ctx.fetchExists(DSL.select()
+        .from("information_schema.columns")
+        .where(DSL.field("table_name").eq("actor_definition")
+            .and(DSL.field("column_name").eq("custom"))));
+  }
+
+  protected static boolean customDefaultsToFalse(final DSLContext ctx, final UUID id) {
+    final Record record = ctx.fetchOne(DSL.select()
+        .from("actor_definition")
+        .where(DSL.field("id").eq(id)));
+
+    return record.get("custom").equals(false);
+  }
+
+}

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_56_001__SetAllExistingActorDefinitionsToPublicTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_35_56_001__SetAllExistingActorDefinitionsToPublicTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import io.airbyte.db.Database;
+import io.airbyte.db.instance.configs.AbstractConfigsDatabaseTest;
+import io.airbyte.db.instance.configs.migrations.V0_32_8_001__AirbyteConfigDatabaseDenormalization.ActorType;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.UUID;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class V0_35_56_001__SetAllExistingActorDefinitionsToPublicTest extends AbstractConfigsDatabaseTest {
+
+  @Test
+  public void test() throws SQLException, IOException {
+
+    final Database database = getDatabase();
+    final DSLContext context = DSL.using(database.getDataSource().getConnection());
+
+    // necessary to add actor_definition table
+    V0_32_8_001__AirbyteConfigDatabaseDenormalization.migrate(context);
+    V0_35_55_001__AddPublicToActorDefinition.addPublicColumn(context);
+
+    final UUID id = UUID.randomUUID();
+    context.insertInto(DSL.table("actor_definition"))
+        .columns(
+            DSL.field("id"),
+            DSL.field("name"),
+            DSL.field("docker_repository"),
+            DSL.field("docker_image_tag"),
+            DSL.field("actor_type"),
+            DSL.field("spec"))
+        .values(
+            id,
+            "name",
+            "repo",
+            "1.0.0",
+            ActorType.source,
+            JSONB.valueOf("{}"))
+        .execute();
+    Assertions.assertFalse(publicColumnValue(context, id));
+
+    V0_35_56_001__SetAllExistingActorDefinitionsToPublic.setPublic(context);
+    Assertions.assertTrue(publicColumnValue(context, id));
+  }
+
+  protected static boolean publicColumnValue(final DSLContext ctx, final UUID id) {
+    final Record record = ctx.fetchOne(DSL.select()
+        .from("actor_definition")
+        .where(DSL.field("id").eq(id)));
+
+    return record.get("public").equals(true);
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -23,7 +23,9 @@ import io.airbyte.api.model.DestinationCoreConfig;
 import io.airbyte.api.model.DestinationCreate;
 import io.airbyte.api.model.DestinationDefinitionCreate;
 import io.airbyte.api.model.DestinationDefinitionIdRequestBody;
+import io.airbyte.api.model.DestinationDefinitionOptInRead;
 import io.airbyte.api.model.DestinationDefinitionOptInReadList;
+import io.airbyte.api.model.DestinationDefinitionOptInUpdate;
 import io.airbyte.api.model.DestinationDefinitionRead;
 import io.airbyte.api.model.DestinationDefinitionReadList;
 import io.airbyte.api.model.DestinationDefinitionSpecificationRead;
@@ -496,6 +498,11 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   }
 
   @Override
+  public DestinationDefinitionOptInRead createDestinationDefinitionOptIn(final DestinationDefinitionOptInUpdate destinationDefinitionOptInUpdate) {
+    return null;
+  }
+
+  @Override
   public DestinationDefinitionRead updateDestinationDefinition(final DestinationDefinitionUpdate destinationDefinitionUpdate) {
     return execute(() -> destinationDefinitionsHandler.updateDestinationDefinition(destinationDefinitionUpdate));
   }
@@ -506,6 +513,11 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
       destinationDefinitionsHandler.deleteDestinationDefinition(destinationDefinitionIdRequestBody);
       return null;
     });
+  }
+
+  @Override
+  public void deleteDestinationDefinitionOptIn(final DestinationDefinitionOptInUpdate destinationDefinitionOptInUpdate) {
+
   }
 
   // DESTINATION SPECIFICATION

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -305,7 +305,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   // SOURCE
 
   @Override
-  public SourceDefinitionReadList listSourceDefinitions() {
+  public SourceDefinitionReadList listSourceDefinitions(final WorkspaceIdRequestBody workspaceIdRequestBody) {
     return execute(sourceDefinitionsHandler::listSourceDefinitions);
   }
 
@@ -452,7 +452,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   // DESTINATION
 
   @Override
-  public DestinationDefinitionReadList listDestinationDefinitions() {
+  public DestinationDefinitionReadList listDestinationDefinitions(final WorkspaceIdRequestBody workspaceIdRequestBody) {
     return execute(destinationDefinitionsHandler::listDestinationDefinitions);
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -312,7 +312,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
 
   @Override
   public SourceDefinitionReadList listSourceDefinitions(final WorkspaceIdRequestBody workspaceIdRequestBody) {
-    return execute(sourceDefinitionsHandler::listSourceDefinitions);
+    return execute(() -> sourceDefinitionsHandler.listSourceDefinitions(workspaceIdRequestBody));
   }
 
   @Override
@@ -474,7 +474,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
 
   @Override
   public DestinationDefinitionReadList listDestinationDefinitions(final WorkspaceIdRequestBody workspaceIdRequestBody) {
-    return execute(destinationDefinitionsHandler::listDestinationDefinitions);
+    return execute(() -> destinationDefinitionsHandler.listDestinationDefinitions(workspaceIdRequestBody));
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -322,7 +322,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
 
   @Override
   public SourceDefinitionOptInReadList listSourceDefinitionOptIns(final WorkspaceIdRequestBody workspaceIdRequestBody) {
-    return null;
+    return execute(() -> sourceDefinitionsHandler.listSourceDefinitionOptIns(workspaceIdRequestBody));
   }
 
   @Override
@@ -484,7 +484,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
 
   @Override
   public DestinationDefinitionOptInReadList listDestinationDefinitionOptIns(final WorkspaceIdRequestBody workspaceIdRequestBody) {
-    return null;
+    return execute(() -> destinationDefinitionsHandler.listDestinationDefinitionOptIns(workspaceIdRequestBody));
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -337,7 +337,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
 
   @Override
   public SourceDefinitionOptInRead createSourceDefinitionOptIn(final SourceDefinitionOptInUpdate sourceDefinitionOptInUpdate) {
-    return null;
+    return execute(() -> sourceDefinitionsHandler.createSourceDefinitionOptIn(sourceDefinitionOptInUpdate));
   }
 
   @Override
@@ -499,7 +499,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
 
   @Override
   public DestinationDefinitionOptInRead createDestinationDefinitionOptIn(final DestinationDefinitionOptInUpdate destinationDefinitionOptInUpdate) {
-    return null;
+    return execute(() -> destinationDefinitionsHandler.createDestinationDefinitionOptIn(destinationDefinitionOptInUpdate));
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -58,6 +58,7 @@ import io.airbyte.api.model.SourceCoreConfig;
 import io.airbyte.api.model.SourceCreate;
 import io.airbyte.api.model.SourceDefinitionCreate;
 import io.airbyte.api.model.SourceDefinitionIdRequestBody;
+import io.airbyte.api.model.SourceDefinitionOptInReadList;
 import io.airbyte.api.model.SourceDefinitionRead;
 import io.airbyte.api.model.SourceDefinitionReadList;
 import io.airbyte.api.model.SourceDefinitionSpecificationRead;
@@ -312,6 +313,11 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   @Override
   public SourceDefinitionReadList listLatestSourceDefinitions() {
     return execute(sourceDefinitionsHandler::listLatestSourceDefinitions);
+  }
+
+  @Override
+  public SourceDefinitionOptInReadList listSourceDefinitionOptIns(final WorkspaceIdRequestBody workspaceIdRequestBody) {
+    return null;
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -355,7 +355,10 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
 
   @Override
   public void deleteSourceDefinitionOptIn(final SourceDefinitionOptInUpdate sourceDefinitionOptInUpdate) {
-
+    execute(() -> {
+      sourceDefinitionsHandler.deleteSourceDefinitionOptIn(sourceDefinitionOptInUpdate);
+      return null;
+    });
   }
 
   // SOURCE SPECIFICATION
@@ -517,7 +520,10 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
 
   @Override
   public void deleteDestinationDefinitionOptIn(final DestinationDefinitionOptInUpdate destinationDefinitionOptInUpdate) {
-
+    execute(() -> {
+      destinationDefinitionsHandler.deleteDestinationDefinitionOptIn(destinationDefinitionOptInUpdate);
+      return null;
+    });
   }
 
   // DESTINATION SPECIFICATION

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -59,7 +59,9 @@ import io.airbyte.api.model.SourceCoreConfig;
 import io.airbyte.api.model.SourceCreate;
 import io.airbyte.api.model.SourceDefinitionCreate;
 import io.airbyte.api.model.SourceDefinitionIdRequestBody;
+import io.airbyte.api.model.SourceDefinitionOptInRead;
 import io.airbyte.api.model.SourceDefinitionOptInReadList;
+import io.airbyte.api.model.SourceDefinitionOptInUpdate;
 import io.airbyte.api.model.SourceDefinitionRead;
 import io.airbyte.api.model.SourceDefinitionReadList;
 import io.airbyte.api.model.SourceDefinitionSpecificationRead;
@@ -332,6 +334,11 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   }
 
   @Override
+  public SourceDefinitionOptInRead createSourceDefinitionOptIn(final SourceDefinitionOptInUpdate sourceDefinitionOptInUpdate) {
+    return null;
+  }
+
+  @Override
   public SourceDefinitionRead updateSourceDefinition(final SourceDefinitionUpdate sourceDefinitionUpdate) {
     return execute(() -> sourceDefinitionsHandler.updateSourceDefinition(sourceDefinitionUpdate));
   }
@@ -342,6 +349,11 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
       sourceDefinitionsHandler.deleteSourceDefinition(sourceDefinitionIdRequestBody);
       return null;
     });
+  }
+
+  @Override
+  public void deleteSourceDefinitionOptIn(final SourceDefinitionOptInUpdate sourceDefinitionOptInUpdate) {
+
   }
 
   // SOURCE SPECIFICATION

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -23,6 +23,7 @@ import io.airbyte.api.model.DestinationCoreConfig;
 import io.airbyte.api.model.DestinationCreate;
 import io.airbyte.api.model.DestinationDefinitionCreate;
 import io.airbyte.api.model.DestinationDefinitionIdRequestBody;
+import io.airbyte.api.model.DestinationDefinitionOptInReadList;
 import io.airbyte.api.model.DestinationDefinitionRead;
 import io.airbyte.api.model.DestinationDefinitionReadList;
 import io.airbyte.api.model.DestinationDefinitionSpecificationRead;
@@ -465,6 +466,11 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
   @Override
   public DestinationDefinitionReadList listLatestDestinationDefinitions() {
     return execute(destinationDefinitionsHandler::listLatestDestinationDefinitions);
+  }
+
+  @Override
+  public DestinationDefinitionOptInReadList listDestinationDefinitionOptIns(final WorkspaceIdRequestBody workspaceIdRequestBody) {
+    return null;
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -156,6 +156,13 @@ public class DestinationDefinitionsHandler {
         .optIn(true);
   }
 
+  public void deleteDestinationDefinitionOptIn(final DestinationDefinitionOptInUpdate destinationDefinitionOptInUpdate)
+      throws IOException {
+    configRepository.deleteActorDefinitionWorkspaceGrant(
+        destinationDefinitionOptInUpdate.getWorkspaceId(),
+        destinationDefinitionOptInUpdate.getDestinationDefinitionId());
+  }
+
   private List<StandardDestinationDefinition> getLatestDestinations() {
     try {
       return githubStore.getLatestDestinations();

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -14,8 +14,10 @@ import io.airbyte.api.model.DestinationDefinitionReadList;
 import io.airbyte.api.model.DestinationDefinitionUpdate;
 import io.airbyte.api.model.DestinationRead;
 import io.airbyte.api.model.ReleaseStage;
+import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.commons.util.MoreLists;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -101,8 +103,12 @@ public class DestinationDefinitionsHandler {
     return LocalDate.parse(standardDestinationDefinition.getReleaseDate());
   }
 
-  public DestinationDefinitionReadList listDestinationDefinitions() throws IOException, JsonValidationException {
-    return toDestinationDefinitionReadList(configRepository.listStandardDestinationDefinitions(false));
+  public DestinationDefinitionReadList listDestinationDefinitions(final WorkspaceIdRequestBody workspaceIdRequestBody)
+      throws IOException {
+    return toDestinationDefinitionReadList(MoreLists.concat(
+        configRepository.listPublicDestinationDefinitions(false),
+        configRepository.listGrantedDestinationDefinitions(
+            workspaceIdRequestBody.getWorkspaceId(), false)));
   }
 
   private static DestinationDefinitionReadList toDestinationDefinitionReadList(final List<StandardDestinationDefinition> defs) {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -9,7 +9,9 @@ import static io.airbyte.server.ServerConstants.DEV_IMAGE_TAG;
 import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.api.model.DestinationDefinitionCreate;
 import io.airbyte.api.model.DestinationDefinitionIdRequestBody;
+import io.airbyte.api.model.DestinationDefinitionOptInRead;
 import io.airbyte.api.model.DestinationDefinitionOptInReadList;
+import io.airbyte.api.model.DestinationDefinitionOptInUpdate;
 import io.airbyte.api.model.DestinationDefinitionRead;
 import io.airbyte.api.model.DestinationDefinitionReadList;
 import io.airbyte.api.model.DestinationDefinitionUpdate;
@@ -139,6 +141,19 @@ public class DestinationDefinitionsHandler {
             .optIn(entry.getValue()))
         .collect(Collectors.toList());
     return new DestinationDefinitionOptInReadList().destinationDefinitionOptIns(reads);
+  }
+
+  public DestinationDefinitionOptInRead createDestinationDefinitionOptIn(
+                                                                         final DestinationDefinitionOptInUpdate destinationDefinitionOptInUpdate)
+      throws JsonValidationException, ConfigNotFoundException, IOException {
+    final StandardDestinationDefinition standardDestinationDefinition =
+        configRepository.getStandardDestinationDefinition(destinationDefinitionOptInUpdate.getDestinationDefinitionId());
+    configRepository.writeActorDefinitionWorkspaceGrant(
+        destinationDefinitionOptInUpdate.getWorkspaceId(),
+        destinationDefinitionOptInUpdate.getDestinationDefinitionId());
+    return new DestinationDefinitionOptInRead()
+        .destinationDefinition(buildDestinationDefinitionRead(standardDestinationDefinition))
+        .optIn(true);
   }
 
   private List<StandardDestinationDefinition> getLatestDestinations() {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -152,10 +152,13 @@ public class DestinationDefinitionsHandler {
         .withIcon(destinationDefCreate.getIcon())
         .withSpec(spec)
         .withTombstone(false)
+        .withPublic(false)
+        .withCustom(true)
         .withReleaseStage(StandardDestinationDefinition.ReleaseStage.CUSTOM)
         .withResourceRequirements(ApiPojoConverters.actorDefResourceReqsToInternal(destinationDefCreate.getResourceRequirements()));
 
     configRepository.writeStandardDestinationDefinition(destinationDefinition);
+    configRepository.writeActorDefinitionWorkspaceGrant(id, destinationDefCreate.getWorkspaceId());
 
     return buildDestinationDefinitionRead(destinationDefinition);
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -152,6 +152,13 @@ public class SourceDefinitionsHandler {
         .optIn(true);
   }
 
+  public void deleteSourceDefinitionOptIn(final SourceDefinitionOptInUpdate sourceDefinitionOptInUpdate)
+      throws IOException {
+    configRepository.deleteActorDefinitionWorkspaceGrant(
+        sourceDefinitionOptInUpdate.getWorkspaceId(),
+        sourceDefinitionOptInUpdate.getSourceDefinitionId());
+  }
+
   private List<StandardSourceDefinition> getLatestSources() {
     try {
       return githubStore.getLatestSources();

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -145,10 +145,13 @@ public class SourceDefinitionsHandler {
         .withIcon(sourceDefinitionCreate.getIcon())
         .withSpec(spec)
         .withTombstone(false)
+        .withPublic(false)
+        .withCustom(true)
         .withReleaseStage(StandardSourceDefinition.ReleaseStage.CUSTOM)
         .withResourceRequirements(ApiPojoConverters.actorDefResourceReqsToInternal(sourceDefinitionCreate.getResourceRequirements()));
 
     configRepository.writeStandardSourceDefinition(sourceDefinition);
+    configRepository.writeActorDefinitionWorkspaceGrant(id, sourceDefinitionCreate.getWorkspaceId());
 
     return buildSourceDefinitionRead(sourceDefinition);
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -10,7 +10,9 @@ import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.api.model.ReleaseStage;
 import io.airbyte.api.model.SourceDefinitionCreate;
 import io.airbyte.api.model.SourceDefinitionIdRequestBody;
+import io.airbyte.api.model.SourceDefinitionOptInRead;
 import io.airbyte.api.model.SourceDefinitionOptInReadList;
+import io.airbyte.api.model.SourceDefinitionOptInUpdate;
 import io.airbyte.api.model.SourceDefinitionRead;
 import io.airbyte.api.model.SourceDefinitionReadList;
 import io.airbyte.api.model.SourceDefinitionUpdate;
@@ -135,6 +137,19 @@ public class SourceDefinitionsHandler {
             .optIn(entry.getValue()))
         .collect(Collectors.toList());
     return new SourceDefinitionOptInReadList().sourceDefinitionOptIns(reads);
+  }
+
+  public SourceDefinitionOptInRead createSourceDefinitionOptIn(
+                                                               final SourceDefinitionOptInUpdate sourceDefinitionOptInUpdate)
+      throws JsonValidationException, ConfigNotFoundException, IOException {
+    final StandardSourceDefinition standardSourceDefinition =
+        configRepository.getStandardSourceDefinition(sourceDefinitionOptInUpdate.getSourceDefinitionId());
+    configRepository.writeActorDefinitionWorkspaceGrant(
+        sourceDefinitionOptInUpdate.getWorkspaceId(),
+        sourceDefinitionOptInUpdate.getSourceDefinitionId());
+    return new SourceDefinitionOptInRead()
+        .sourceDefinition(buildSourceDefinitionRead(standardSourceDefinition))
+        .optIn(true);
   }
 
   private List<StandardSourceDefinition> getLatestSources() {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -14,8 +14,10 @@ import io.airbyte.api.model.SourceDefinitionRead;
 import io.airbyte.api.model.SourceDefinitionReadList;
 import io.airbyte.api.model.SourceDefinitionUpdate;
 import io.airbyte.api.model.SourceRead;
+import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.commons.util.MoreLists;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -97,8 +99,12 @@ public class SourceDefinitionsHandler {
     return LocalDate.parse(standardSourceDefinition.getReleaseDate());
   }
 
-  public SourceDefinitionReadList listSourceDefinitions() throws IOException, JsonValidationException {
-    return toSourceDefinitionReadList(configRepository.listStandardSourceDefinitions(false));
+  public SourceDefinitionReadList listSourceDefinitions(final WorkspaceIdRequestBody workspaceIdRequestBody)
+      throws IOException {
+    return toSourceDefinitionReadList(MoreLists.concat(
+        configRepository.listPublicSourceDefinitions(false),
+        configRepository.listGrantedSourceDefinitions(
+            workspaceIdRequestBody.getWorkspaceId(), false)));
   }
 
   private static SourceDefinitionReadList toSourceDefinitionReadList(final List<StandardSourceDefinition> defs) {

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
@@ -186,6 +186,7 @@ class DestinationDefinitionsHandlerTest {
         .dockerImageTag(destination.getDockerImageTag())
         .documentationUrl(new URI(destination.getDocumentationUrl()))
         .icon(destination.getIcon())
+        .workspaceId(workspaceId)
         .resourceRequirements(new io.airbyte.api.model.ActorDefinitionResourceRequirements()
             ._default(new io.airbyte.api.model.ResourceRequirements()
                 .cpuRequest(destination.getResourceRequirements().getDefault().getCpuRequest())));
@@ -208,7 +209,11 @@ class DestinationDefinitionsHandlerTest {
     verify(schedulerSynchronousClient).createGetSpecJob(imageName);
     verify(configRepository).writeStandardDestinationDefinition(destination
         .withReleaseDate(null)
-        .withReleaseStage(StandardDestinationDefinition.ReleaseStage.CUSTOM));
+        .withReleaseStage(StandardDestinationDefinition.ReleaseStage.CUSTOM)
+        .withCustom(true));
+    verify(configRepository).writeActorDefinitionWorkspaceGrant(
+        destination.getDestinationDefinitionId(),
+        workspaceId);
   }
 
   @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
@@ -229,6 +229,17 @@ class DestinationDefinitionsHandlerTest {
   }
 
   @Test
+  @DisplayName("deleteDestinationDefinitionOptIn should attempt to delete a ActorDefinitionWorkspaceGrant")
+  void testDeleteDestinationDefinitionOptIn() throws IOException {
+    destinationDefinitionsHandler.deleteDestinationDefinitionOptIn(new DestinationDefinitionOptInUpdate()
+        .destinationDefinitionId(destinationDefinition.getDestinationDefinitionId())
+        .workspaceId(workspaceId));
+    verify(configRepository).deleteActorDefinitionWorkspaceGrant(
+        workspaceId,
+        destinationDefinition.getDestinationDefinitionId());
+  }
+
+  @Test
   @DisplayName("getDestinationDefinition should return the right destination")
   void testGetDestination() throws JsonValidationException, ConfigNotFoundException, IOException, URISyntaxException {
     when(configRepository.getStandardDestinationDefinition(destinationDefinition.getDestinationDefinitionId()))

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -228,6 +228,17 @@ class SourceDefinitionsHandlerTest {
   }
 
   @Test
+  @DisplayName("deleteSourceDefinitionOptIn should attempt to delete a ActorDefinitionWorkspaceGrant")
+  void testDeleteSourceDefinitionOptIn() throws IOException {
+    sourceDefinitionsHandler.deleteSourceDefinitionOptIn(new SourceDefinitionOptInUpdate()
+        .sourceDefinitionId(sourceDefinition.getSourceDefinitionId())
+        .workspaceId(workspaceId));
+    verify(configRepository).deleteActorDefinitionWorkspaceGrant(
+        workspaceId,
+        sourceDefinition.getSourceDefinitionId());
+  }
+
+  @Test
   @DisplayName("getSourceDefinition should return the right source")
   void testGetSourceDefinition() throws JsonValidationException, ConfigNotFoundException, IOException, URISyntaxException {
     when(configRepository.getStandardSourceDefinition(sourceDefinition.getSourceDefinitionId()))

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -184,6 +184,7 @@ class SourceDefinitionsHandlerTest {
         .dockerImageTag(sourceDefinition.getDockerImageTag())
         .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
         .icon(sourceDefinition.getIcon())
+        .workspaceId(workspaceId)
         .resourceRequirements(new io.airbyte.api.model.ActorDefinitionResourceRequirements()
             ._default(new io.airbyte.api.model.ResourceRequirements()
                 .cpuRequest(sourceDefinition.getResourceRequirements().getDefault().getCpuRequest())));
@@ -204,8 +205,13 @@ class SourceDefinitionsHandlerTest {
 
     assertEquals(expectedRead, actualRead);
     verify(schedulerSynchronousClient).createGetSpecJob(imageName);
-    verify(configRepository)
-        .writeStandardSourceDefinition(sourceDefinition.withReleaseDate(null).withReleaseStage(StandardSourceDefinition.ReleaseStage.CUSTOM));
+    verify(configRepository).writeStandardSourceDefinition(sourceDefinition
+        .withReleaseDate(null)
+        .withReleaseStage(StandardSourceDefinition.ReleaseStage.CUSTOM)
+        .withCustom(true));
+    verify(configRepository).writeActorDefinitionWorkspaceGrant(
+        sourceDefinition.getSourceDefinitionId(),
+        workspaceId);
   }
 
   @Test

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1407,7 +1407,8 @@ public class AcceptanceTests {
         .name("E2E Test Source")
         .dockerRepository("airbyte/source-e2e-test")
         .dockerImageTag(SOURCE_E2E_TEST_CONNECTOR_VERSION)
-        .documentationUrl(URI.create("https://example.com")));
+        .documentationUrl(URI.create("https://example.com"))
+        .workspaceId(workspaceId));
   }
 
   private DestinationDefinitionRead createE2eDestinationDefinition() throws ApiException {
@@ -1415,7 +1416,8 @@ public class AcceptanceTests {
         .name("E2E Test Destination")
         .dockerRepository("airbyte/destination-e2e-test")
         .dockerImageTag(DESTINATION_E2E_TEST_CONNECTOR_VERSION)
-        .documentationUrl(URI.create("https://example.com")));
+        .documentationUrl(URI.create("https://example.com"))
+        .workspaceId(workspaceId));
   }
 
   private SourceRead createPostgresSource() throws ApiException {

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -69,6 +69,7 @@ import io.airbyte.api.client.model.SourceDiscoverSchemaRequestBody;
 import io.airbyte.api.client.model.SourceIdRequestBody;
 import io.airbyte.api.client.model.SourceRead;
 import io.airbyte.api.client.model.SyncMode;
+import io.airbyte.api.client.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.features.EnvVariableFeatureFlags;
 import io.airbyte.commons.features.FeatureFlags;
 import io.airbyte.commons.json.Jsons;
@@ -782,7 +783,7 @@ public class AcceptanceTests {
     // now cancel it so that we freeze state!
     try {
       apiClient.getJobsApi().cancelJob(new JobIdRequestBody().id(connectionSyncRead1.getJob().getId()));
-    } catch (Exception e) {}
+    } catch (final Exception e) {}
 
     final ConnectionState connectionState = waitForConnectionState(apiClient, connectionId);
 
@@ -1306,7 +1307,8 @@ public class AcceptanceTests {
   }
 
   private UUID getDestinationDefId() throws ApiException {
-    return apiClient.getDestinationDefinitionApi().listDestinationDefinitions().getDestinationDefinitions()
+    return apiClient.getDestinationDefinitionApi().listDestinationDefinitions(
+        new WorkspaceIdRequestBody().workspaceId(workspaceId)).getDestinationDefinitions()
         .stream()
         .filter(dr -> dr.getName().toLowerCase().contains("postgres"))
         .findFirst()
@@ -1436,7 +1438,8 @@ public class AcceptanceTests {
   }
 
   private UUID getPostgresSourceDefinitionId() throws ApiException {
-    return apiClient.getSourceDefinitionApi().listSourceDefinitions().getSourceDefinitions()
+    return apiClient.getSourceDefinitionApi().listSourceDefinitions(
+        new WorkspaceIdRequestBody().workspaceId(workspaceId)).getSourceDefinitions()
         .stream()
         .filter(sourceRead -> sourceRead.getName().equalsIgnoreCase("postgres"))
         .findFirst()

--- a/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
+++ b/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
@@ -190,14 +190,15 @@ public class MigrationAcceptanceTest {
 
   private static void assertDataFromApi(final ApiClient apiClient) throws ApiException {
     final WorkspaceIdRequestBody workspaceIdRequestBody = assertWorkspaceInformation(apiClient);
-    assertSourceDefinitionInformation(apiClient);
-    assertDestinationDefinitionInformation(apiClient);
+    assertSourceDefinitionInformation(apiClient, workspaceIdRequestBody);
+    assertDestinationDefinitionInformation(apiClient, workspaceIdRequestBody);
     assertConnectionInformation(apiClient, workspaceIdRequestBody);
   }
 
-  private static void assertSourceDefinitionInformation(final ApiClient apiClient) throws ApiException {
+  private static void assertSourceDefinitionInformation(final ApiClient apiClient, final WorkspaceIdRequestBody workspaceIdRequestBody)
+      throws ApiException {
     final SourceDefinitionApi sourceDefinitionApi = new SourceDefinitionApi(apiClient);
-    final List<SourceDefinitionRead> sourceDefinitions = sourceDefinitionApi.listSourceDefinitions().getSourceDefinitions();
+    final List<SourceDefinitionRead> sourceDefinitions = sourceDefinitionApi.listSourceDefinitions(workspaceIdRequestBody).getSourceDefinitions();
     assertTrue(sourceDefinitions.size() >= 58);
     boolean foundMysqlSourceDefinition = false;
     boolean foundPostgresSourceDefinition = false;
@@ -224,9 +225,11 @@ public class MigrationAcceptanceTest {
     assertTrue(foundPostgresSourceDefinition);
   }
 
-  private static void assertDestinationDefinitionInformation(final ApiClient apiClient) throws ApiException {
+  private static void assertDestinationDefinitionInformation(final ApiClient apiClient, final WorkspaceIdRequestBody workspaceIdRequestBody)
+      throws ApiException {
     final DestinationDefinitionApi destinationDefinitionApi = new DestinationDefinitionApi(apiClient);
-    final List<DestinationDefinitionRead> destinationDefinitions = destinationDefinitionApi.listDestinationDefinitions().getDestinationDefinitions();
+    final List<DestinationDefinitionRead> destinationDefinitions =
+        destinationDefinitionApi.listDestinationDefinitions(workspaceIdRequestBody).getDestinationDefinitions();
     assertTrue(destinationDefinitions.size() >= 10);
     boolean foundPostgresDestinationDefinition = false;
     boolean foundLocalCSVDestinationDefinition = false;

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -336,6 +336,7 @@ font-style: italic;
   <li><a href="#deleteSourceDefinition"><code><span class="http-method">post</span> /v1/source_definitions/delete</code></a></li>
   <li><a href="#getSourceDefinition"><code><span class="http-method">post</span> /v1/source_definitions/get</code></a></li>
   <li><a href="#listLatestSourceDefinitions"><code><span class="http-method">post</span> /v1/source_definitions/list_latest</code></a></li>
+  <li><a href="#listSourceDefinitionOptIns"><code><span class="http-method">post</span> /v1/source_definitions/list_opt_in</code></a></li>
   <li><a href="#listSourceDefinitions"><code><span class="http-method">post</span> /v1/source_definitions/list</code></a></li>
   <li><a href="#updateSourceDefinition"><code><span class="http-method">post</span> /v1/source_definitions/update</code></a></li>
   </ul>
@@ -6140,6 +6141,126 @@ font-style: italic;
         <a href="#SourceDefinitionReadList">SourceDefinitionReadList</a>
   </div> <!-- method -->
   <hr/>
+  <div class="method"><a name="listSourceDefinitionOptIns"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/source_definitions/list_opt_in</code></pre></div>
+    <div class="method-summary">List all opt-in sourceDefinitions along with the current workspace's opt-in statuses (<span class="nickname">listSourceDefinitionOptIns</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">WorkspaceIdRequestBody <a href="#WorkspaceIdRequestBody">WorkspaceIdRequestBody</a> (optional)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#SourceDefinitionOptInReadList">SourceDefinitionOptInReadList</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "sourceDefinitionOptIns" : [ {
+    "sourceDefinition" : {
+      "resourceRequirements" : {
+        "default" : {
+          "cpu_limit" : "cpu_limit",
+          "memory_request" : "memory_request",
+          "memory_limit" : "memory_limit",
+          "cpu_request" : "cpu_request"
+        },
+        "jobSpecific" : [ {
+          "resourceRequirements" : {
+            "cpu_limit" : "cpu_limit",
+            "memory_request" : "memory_request",
+            "memory_limit" : "memory_limit",
+            "cpu_request" : "cpu_request"
+          }
+        }, {
+          "resourceRequirements" : {
+            "cpu_limit" : "cpu_limit",
+            "memory_request" : "memory_request",
+            "memory_limit" : "memory_limit",
+            "cpu_request" : "cpu_request"
+          }
+        } ]
+      },
+      "documentationUrl" : "https://openapi-generator.tech",
+      "dockerImageTag" : "dockerImageTag",
+      "releaseDate" : "2000-01-23",
+      "dockerRepository" : "dockerRepository",
+      "name" : "name",
+      "icon" : "icon",
+      "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
+    },
+    "optIn" : true
+  }, {
+    "sourceDefinition" : {
+      "resourceRequirements" : {
+        "default" : {
+          "cpu_limit" : "cpu_limit",
+          "memory_request" : "memory_request",
+          "memory_limit" : "memory_limit",
+          "cpu_request" : "cpu_request"
+        },
+        "jobSpecific" : [ {
+          "resourceRequirements" : {
+            "cpu_limit" : "cpu_limit",
+            "memory_request" : "memory_request",
+            "memory_limit" : "memory_limit",
+            "cpu_request" : "cpu_request"
+          }
+        }, {
+          "resourceRequirements" : {
+            "cpu_limit" : "cpu_limit",
+            "memory_request" : "memory_request",
+            "memory_limit" : "memory_limit",
+            "cpu_request" : "cpu_request"
+          }
+        } ]
+      },
+      "documentationUrl" : "https://openapi-generator.tech",
+      "dockerImageTag" : "dockerImageTag",
+      "releaseDate" : "2000-01-23",
+      "dockerRepository" : "dockerRepository",
+      "name" : "name",
+      "icon" : "icon",
+      "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
+    },
+    "optIn" : true
+  } ]
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#SourceDefinitionOptInReadList">SourceDefinitionOptInReadList</a>
+  </div> <!-- method -->
+  <hr/>
   <div class="method"><a name="listSourceDefinitions"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -8398,6 +8519,8 @@ font-style: italic;
     <li><a href="#SourceCreate"><code>SourceCreate</code> - </a></li>
     <li><a href="#SourceDefinitionCreate"><code>SourceDefinitionCreate</code> - </a></li>
     <li><a href="#SourceDefinitionIdRequestBody"><code>SourceDefinitionIdRequestBody</code> - </a></li>
+    <li><a href="#SourceDefinitionOptInRead"><code>SourceDefinitionOptInRead</code> - </a></li>
+    <li><a href="#SourceDefinitionOptInReadList"><code>SourceDefinitionOptInReadList</code> - </a></li>
     <li><a href="#SourceDefinitionRead"><code>SourceDefinitionRead</code> - </a></li>
     <li><a href="#SourceDefinitionReadList"><code>SourceDefinitionReadList</code> - </a></li>
     <li><a href="#SourceDefinitionSpecificationRead"><code>SourceDefinitionSpecificationRead</code> - </a></li>
@@ -9334,6 +9457,21 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">sourceDefinitionId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="SourceDefinitionOptInRead"><code>SourceDefinitionOptInRead</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">sourceDefinition </div><div class="param-desc"><span class="param-type"><a href="#SourceDefinitionRead">SourceDefinitionRead</a></span>  </div>
+<div class="param">optIn </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="SourceDefinitionOptInReadList"><code>SourceDefinitionOptInReadList</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">sourceDefinitionOptIns </div><div class="param-desc"><span class="param-type"><a href="#SourceDefinitionOptInRead">array[SourceDefinitionOptInRead]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -8798,7 +8798,8 @@ font-style: italic;
     <h3><a name="DestinationDefinitionCreate"><code>DestinationDefinitionCreate</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+      <div class="param">workspaceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dockerRepository </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dockerImageTag </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">documentationUrl </div><div class="param-desc"><span class="param-type"><a href="#URI">URI</a></span>  format: uri</div>
@@ -9319,7 +9320,8 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
     <h3><a name="SourceDefinitionCreate"><code>SourceDefinitionCreate</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+      <div class="param">workspaceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dockerRepository </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dockerImageTag </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">documentationUrl </div><div class="param-desc"><span class="param-type"><a href="#URI">URI</a></span>  format: uri</div>

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -2797,7 +2797,19 @@ font-style: italic;
     <div class="method-notes"></div>
 
 
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
 
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">WorkspaceIdRequestBody <a href="#WorkspaceIdRequestBody">WorkspaceIdRequestBody</a> (optional)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
 
 
 
@@ -6136,7 +6148,19 @@ font-style: italic;
     <div class="method-notes"></div>
 
 
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
 
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">WorkspaceIdRequestBody <a href="#WorkspaceIdRequestBody">WorkspaceIdRequestBody</a> (optional)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
 
 
 

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -262,6 +262,7 @@ font-style: italic;
   <li><a href="#createDestinationDefinition"><code><span class="http-method">post</span> /v1/destination_definitions/create</code></a></li>
   <li><a href="#deleteDestinationDefinition"><code><span class="http-method">post</span> /v1/destination_definitions/delete</code></a></li>
   <li><a href="#getDestinationDefinition"><code><span class="http-method">post</span> /v1/destination_definitions/get</code></a></li>
+  <li><a href="#listDestinationDefinitionOptIns"><code><span class="http-method">post</span> /v1/destination_definitions/list_opt_in</code></a></li>
   <li><a href="#listDestinationDefinitions"><code><span class="http-method">post</span> /v1/destination_definitions/list</code></a></li>
   <li><a href="#listLatestDestinationDefinitions"><code><span class="http-method">post</span> /v1/destination_definitions/list_latest</code></a></li>
   <li><a href="#updateDestinationDefinition"><code><span class="http-method">post</span> /v1/destination_definitions/update</code></a></li>
@@ -2788,6 +2789,126 @@ font-style: italic;
     <h4 class="field-label">422</h4>
     Input failed validation
         <a href="#InvalidInputExceptionInfo">InvalidInputExceptionInfo</a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="listDestinationDefinitionOptIns"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/destination_definitions/list_opt_in</code></pre></div>
+    <div class="method-summary">List all opt-in destinationDefinitions along with the current workspace's opt-in statuses (<span class="nickname">listDestinationDefinitionOptIns</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">WorkspaceIdRequestBody <a href="#WorkspaceIdRequestBody">WorkspaceIdRequestBody</a> (optional)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#DestinationDefinitionOptInReadList">DestinationDefinitionOptInReadList</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "destinationDefinitionOptIns" : [ {
+    "optIn" : true,
+    "destinationDefinition" : {
+      "resourceRequirements" : {
+        "default" : {
+          "cpu_limit" : "cpu_limit",
+          "memory_request" : "memory_request",
+          "memory_limit" : "memory_limit",
+          "cpu_request" : "cpu_request"
+        },
+        "jobSpecific" : [ {
+          "resourceRequirements" : {
+            "cpu_limit" : "cpu_limit",
+            "memory_request" : "memory_request",
+            "memory_limit" : "memory_limit",
+            "cpu_request" : "cpu_request"
+          }
+        }, {
+          "resourceRequirements" : {
+            "cpu_limit" : "cpu_limit",
+            "memory_request" : "memory_request",
+            "memory_limit" : "memory_limit",
+            "cpu_request" : "cpu_request"
+          }
+        } ]
+      },
+      "documentationUrl" : "https://openapi-generator.tech",
+      "dockerImageTag" : "dockerImageTag",
+      "releaseDate" : "2000-01-23",
+      "dockerRepository" : "dockerRepository",
+      "name" : "name",
+      "icon" : "icon",
+      "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
+    }
+  }, {
+    "optIn" : true,
+    "destinationDefinition" : {
+      "resourceRequirements" : {
+        "default" : {
+          "cpu_limit" : "cpu_limit",
+          "memory_request" : "memory_request",
+          "memory_limit" : "memory_limit",
+          "cpu_request" : "cpu_request"
+        },
+        "jobSpecific" : [ {
+          "resourceRequirements" : {
+            "cpu_limit" : "cpu_limit",
+            "memory_request" : "memory_request",
+            "memory_limit" : "memory_limit",
+            "cpu_request" : "cpu_request"
+          }
+        }, {
+          "resourceRequirements" : {
+            "cpu_limit" : "cpu_limit",
+            "memory_request" : "memory_request",
+            "memory_limit" : "memory_limit",
+            "cpu_request" : "cpu_request"
+          }
+        } ]
+      },
+      "documentationUrl" : "https://openapi-generator.tech",
+      "dockerImageTag" : "dockerImageTag",
+      "releaseDate" : "2000-01-23",
+      "dockerRepository" : "dockerRepository",
+      "name" : "name",
+      "icon" : "icon",
+      "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
+    }
+  } ]
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#DestinationDefinitionOptInReadList">DestinationDefinitionOptInReadList</a>
   </div> <!-- method -->
   <hr/>
   <div class="method"><a name="listDestinationDefinitions"/>
@@ -8459,6 +8580,8 @@ font-style: italic;
     <li><a href="#DestinationCreate"><code>DestinationCreate</code> - </a></li>
     <li><a href="#DestinationDefinitionCreate"><code>DestinationDefinitionCreate</code> - </a></li>
     <li><a href="#DestinationDefinitionIdRequestBody"><code>DestinationDefinitionIdRequestBody</code> - </a></li>
+    <li><a href="#DestinationDefinitionOptInRead"><code>DestinationDefinitionOptInRead</code> - </a></li>
+    <li><a href="#DestinationDefinitionOptInReadList"><code>DestinationDefinitionOptInReadList</code> - </a></li>
     <li><a href="#DestinationDefinitionRead"><code>DestinationDefinitionRead</code> - </a></li>
     <li><a href="#DestinationDefinitionReadList"><code>DestinationDefinitionReadList</code> - </a></li>
     <li><a href="#DestinationDefinitionSpecificationRead"><code>DestinationDefinitionSpecificationRead</code> - </a></li>
@@ -8935,6 +9058,21 @@ font-style: italic;
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">destinationDefinitionId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="DestinationDefinitionOptInRead"><code>DestinationDefinitionOptInRead</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">destinationDefinition </div><div class="param-desc"><span class="param-type"><a href="#DestinationDefinitionRead">DestinationDefinitionRead</a></span>  </div>
+<div class="param">optIn </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="DestinationDefinitionOptInReadList"><code>DestinationDefinitionOptInReadList</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">destinationDefinitionOptIns </div><div class="param-desc"><span class="param-type"><a href="#DestinationDefinitionOptInRead">array[DestinationDefinitionOptInRead]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -260,7 +260,9 @@ font-style: italic;
   <h4><a href="#DestinationDefinition">DestinationDefinition</a></h4>
   <ul>
   <li><a href="#createDestinationDefinition"><code><span class="http-method">post</span> /v1/destination_definitions/create</code></a></li>
+  <li><a href="#createDestinationDefinitionOptIn"><code><span class="http-method">post</span> /v1/destination_definitions/grant_definition</code></a></li>
   <li><a href="#deleteDestinationDefinition"><code><span class="http-method">post</span> /v1/destination_definitions/delete</code></a></li>
+  <li><a href="#deleteDestinationDefinitionOptIn"><code><span class="http-method">post</span> /v1/destination_definitions/revoke_definition</code></a></li>
   <li><a href="#getDestinationDefinition"><code><span class="http-method">post</span> /v1/destination_definitions/get</code></a></li>
   <li><a href="#listDestinationDefinitionOptIns"><code><span class="http-method">post</span> /v1/destination_definitions/list_opt_in</code></a></li>
   <li><a href="#listDestinationDefinitions"><code><span class="http-method">post</span> /v1/destination_definitions/list</code></a></li>
@@ -2658,6 +2660,96 @@ font-style: italic;
         <a href="#InvalidInputExceptionInfo">InvalidInputExceptionInfo</a>
   </div> <!-- method -->
   <hr/>
+  <div class="method"><a name="createDestinationDefinitionOptIn"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/destination_definitions/grant_definition</code></pre></div>
+    <div class="method-summary">Opt in to a non-public, non-custom destinationDefinition (<span class="nickname">createDestinationDefinitionOptIn</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">DestinationDefinitionOptInUpdate <a href="#DestinationDefinitionOptInUpdate">DestinationDefinitionOptInUpdate</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#DestinationDefinitionOptInRead">DestinationDefinitionOptInRead</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "optIn" : true,
+  "destinationDefinition" : {
+    "resourceRequirements" : {
+      "default" : {
+        "cpu_limit" : "cpu_limit",
+        "memory_request" : "memory_request",
+        "memory_limit" : "memory_limit",
+        "cpu_request" : "cpu_request"
+      },
+      "jobSpecific" : [ {
+        "resourceRequirements" : {
+          "cpu_limit" : "cpu_limit",
+          "memory_request" : "memory_request",
+          "memory_limit" : "memory_limit",
+          "cpu_request" : "cpu_request"
+        }
+      }, {
+        "resourceRequirements" : {
+          "cpu_limit" : "cpu_limit",
+          "memory_request" : "memory_request",
+          "memory_limit" : "memory_limit",
+          "cpu_request" : "cpu_request"
+        }
+      } ]
+    },
+    "documentationUrl" : "https://openapi-generator.tech",
+    "dockerImageTag" : "dockerImageTag",
+    "releaseDate" : "2000-01-23",
+    "dockerRepository" : "dockerRepository",
+    "name" : "name",
+    "icon" : "icon",
+    "destinationDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
+  }
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#DestinationDefinitionOptInRead">DestinationDefinitionOptInRead</a>
+    <h4 class="field-label">404</h4>
+    Object with given id was not found.
+        <a href="#NotFoundKnownExceptionInfo">NotFoundKnownExceptionInfo</a>
+    <h4 class="field-label">422</h4>
+    Input failed validation
+        <a href="#InvalidInputExceptionInfo">InvalidInputExceptionInfo</a>
+  </div> <!-- method -->
+  <hr/>
   <div class="method"><a name="deleteDestinationDefinition"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -2675,6 +2767,54 @@ font-style: italic;
     <h3 class="field-label">Request body</h3>
     <div class="field-items">
       <div class="param">DestinationDefinitionIdRequestBody <a href="#DestinationDefinitionIdRequestBody">DestinationDefinitionIdRequestBody</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">204</h4>
+    The resource was deleted successfully.
+        <a href="#"></a>
+    <h4 class="field-label">404</h4>
+    Object with given id was not found.
+        <a href="#NotFoundKnownExceptionInfo">NotFoundKnownExceptionInfo</a>
+    <h4 class="field-label">422</h4>
+    Input failed validation
+        <a href="#InvalidInputExceptionInfo">InvalidInputExceptionInfo</a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="deleteDestinationDefinitionOptIn"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/destination_definitions/revoke_definition</code></pre></div>
+    <div class="method-summary">Opt out of a non-public, non-custom destinationDefinition (<span class="nickname">deleteDestinationDefinitionOptIn</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">DestinationDefinitionOptInUpdate <a href="#DestinationDefinitionOptInUpdate">DestinationDefinitionOptInUpdate</a> (required)</div>
 
       <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
 
@@ -8722,6 +8862,7 @@ font-style: italic;
     <li><a href="#DestinationDefinitionIdRequestBody"><code>DestinationDefinitionIdRequestBody</code> - </a></li>
     <li><a href="#DestinationDefinitionOptInRead"><code>DestinationDefinitionOptInRead</code> - </a></li>
     <li><a href="#DestinationDefinitionOptInReadList"><code>DestinationDefinitionOptInReadList</code> - </a></li>
+    <li><a href="#DestinationDefinitionOptInUpdate"><code>DestinationDefinitionOptInUpdate</code> - </a></li>
     <li><a href="#DestinationDefinitionRead"><code>DestinationDefinitionRead</code> - </a></li>
     <li><a href="#DestinationDefinitionReadList"><code>DestinationDefinitionReadList</code> - </a></li>
     <li><a href="#DestinationDefinitionSpecificationRead"><code>DestinationDefinitionSpecificationRead</code> - </a></li>
@@ -9214,6 +9355,14 @@ font-style: italic;
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">destinationDefinitionOptIns </div><div class="param-desc"><span class="param-type"><a href="#DestinationDefinitionOptInRead">array[DestinationDefinitionOptInRead]</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="DestinationDefinitionOptInUpdate"><code>DestinationDefinitionOptInUpdate</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">destinationDefinitionId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">workspaceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -334,7 +334,9 @@ font-style: italic;
   <h4><a href="#SourceDefinition">SourceDefinition</a></h4>
   <ul>
   <li><a href="#createSourceDefinition"><code><span class="http-method">post</span> /v1/source_definitions/create</code></a></li>
+  <li><a href="#createSourceDefinitionOptIn"><code><span class="http-method">post</span> /v1/source_definitions/grant_definition</code></a></li>
   <li><a href="#deleteSourceDefinition"><code><span class="http-method">post</span> /v1/source_definitions/delete</code></a></li>
+  <li><a href="#deleteSourceDefinitionOptIn"><code><span class="http-method">post</span> /v1/source_definitions/revoke_definition</code></a></li>
   <li><a href="#getSourceDefinition"><code><span class="http-method">post</span> /v1/source_definitions/get</code></a></li>
   <li><a href="#listLatestSourceDefinitions"><code><span class="http-method">post</span> /v1/source_definitions/list_latest</code></a></li>
   <li><a href="#listSourceDefinitionOptIns"><code><span class="http-method">post</span> /v1/source_definitions/list_opt_in</code></a></li>
@@ -6025,6 +6027,96 @@ font-style: italic;
         <a href="#InvalidInputExceptionInfo">InvalidInputExceptionInfo</a>
   </div> <!-- method -->
   <hr/>
+  <div class="method"><a name="createSourceDefinitionOptIn"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/source_definitions/grant_definition</code></pre></div>
+    <div class="method-summary">Opt in to a non-public, non-custom sourceDefinition (<span class="nickname">createSourceDefinitionOptIn</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">SourceDefinitionOptInUpdate <a href="#SourceDefinitionOptInUpdate">SourceDefinitionOptInUpdate</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#SourceDefinitionOptInRead">SourceDefinitionOptInRead</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "sourceDefinition" : {
+    "resourceRequirements" : {
+      "default" : {
+        "cpu_limit" : "cpu_limit",
+        "memory_request" : "memory_request",
+        "memory_limit" : "memory_limit",
+        "cpu_request" : "cpu_request"
+      },
+      "jobSpecific" : [ {
+        "resourceRequirements" : {
+          "cpu_limit" : "cpu_limit",
+          "memory_request" : "memory_request",
+          "memory_limit" : "memory_limit",
+          "cpu_request" : "cpu_request"
+        }
+      }, {
+        "resourceRequirements" : {
+          "cpu_limit" : "cpu_limit",
+          "memory_request" : "memory_request",
+          "memory_limit" : "memory_limit",
+          "cpu_request" : "cpu_request"
+        }
+      } ]
+    },
+    "documentationUrl" : "https://openapi-generator.tech",
+    "dockerImageTag" : "dockerImageTag",
+    "releaseDate" : "2000-01-23",
+    "dockerRepository" : "dockerRepository",
+    "name" : "name",
+    "icon" : "icon",
+    "sourceDefinitionId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
+  },
+  "optIn" : true
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#SourceDefinitionOptInRead">SourceDefinitionOptInRead</a>
+    <h4 class="field-label">404</h4>
+    Object with given id was not found.
+        <a href="#NotFoundKnownExceptionInfo">NotFoundKnownExceptionInfo</a>
+    <h4 class="field-label">422</h4>
+    Input failed validation
+        <a href="#InvalidInputExceptionInfo">InvalidInputExceptionInfo</a>
+  </div> <!-- method -->
+  <hr/>
   <div class="method"><a name="deleteSourceDefinition"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -6042,6 +6134,54 @@ font-style: italic;
     <h3 class="field-label">Request body</h3>
     <div class="field-items">
       <div class="param">SourceDefinitionIdRequestBody <a href="#SourceDefinitionIdRequestBody">SourceDefinitionIdRequestBody</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">204</h4>
+    The resource was deleted successfully.
+        <a href="#"></a>
+    <h4 class="field-label">404</h4>
+    Object with given id was not found.
+        <a href="#NotFoundKnownExceptionInfo">NotFoundKnownExceptionInfo</a>
+    <h4 class="field-label">422</h4>
+    Input failed validation
+        <a href="#InvalidInputExceptionInfo">InvalidInputExceptionInfo</a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="deleteSourceDefinitionOptIn"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/source_definitions/revoke_definition</code></pre></div>
+    <div class="method-summary">Opt out of a non-public, non-custom sourceDefinition (<span class="nickname">deleteSourceDefinitionOptIn</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">SourceDefinitionOptInUpdate <a href="#SourceDefinitionOptInUpdate">SourceDefinitionOptInUpdate</a> (required)</div>
 
       <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
 
@@ -8644,6 +8784,7 @@ font-style: italic;
     <li><a href="#SourceDefinitionIdRequestBody"><code>SourceDefinitionIdRequestBody</code> - </a></li>
     <li><a href="#SourceDefinitionOptInRead"><code>SourceDefinitionOptInRead</code> - </a></li>
     <li><a href="#SourceDefinitionOptInReadList"><code>SourceDefinitionOptInReadList</code> - </a></li>
+    <li><a href="#SourceDefinitionOptInUpdate"><code>SourceDefinitionOptInUpdate</code> - </a></li>
     <li><a href="#SourceDefinitionRead"><code>SourceDefinitionRead</code> - </a></li>
     <li><a href="#SourceDefinitionReadList"><code>SourceDefinitionReadList</code> - </a></li>
     <li><a href="#SourceDefinitionSpecificationRead"><code>SourceDefinitionSpecificationRead</code> - </a></li>
@@ -9610,6 +9751,14 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">sourceDefinitionOptIns </div><div class="param-desc"><span class="param-type"><a href="#SourceDefinitionOptInRead">array[SourceDefinitionOptInRead]</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="SourceDefinitionOptInUpdate"><code>SourceDefinitionOptInUpdate</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">sourceDefinitionId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">workspaceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What
Part of https://github.com/airbytehq/airbyte/issues/9652
[Tech Spec](https://docs.google.com/document/d/1KfJiTKZnBIUr1CFHUbi-8LjByRh03bheX6TQnuWlZyY/edit?usp=sharing)

This PR implements the APIs defined in https://github.com/airbytehq/airbyte/pull/11244 using the DB queries from https://github.com/airbytehq/airbyte/pull/11245.

## Recommended reading order
Probably easiest to review by commit.

## 🚨 User Impact 🚨
With this PR, custom connector definitions will now be scoped to one workspace only (as opposed to always being available to all workspaces), and there is no user visible functionality at current to change this behavior.

This PR includes a migration to mark all existing connector definitions as public so that they continue to be available to all workspaces as before, but newly created connector definitions will follow the new behavior.
