### PR TITLE
parameterize jdk and nginx base images

### DIFF
--- a/airbyte-bootloader/Dockerfile
+++ b/airbyte-bootloader/Dockerfile
@@ -1,5 +1,6 @@
 ARG JDK_VERSION=17.0.1
-FROM openjdk:${JDK_VERSION}-slim
+ARG JDK_IMAGE=openjdk:${JDK_VERSION}-slim
+FROM ${JDK_IMAGE}
 
 ARG VERSION=0.36.10-alpha
 

--- a/airbyte-container-orchestrator/Dockerfile
+++ b/airbyte-container-orchestrator/Dockerfile
@@ -1,5 +1,6 @@
 ARG JDK_VERSION=17.0.1
-FROM openjdk:${JDK_VERSION}-slim AS sync-attempt
+ARG JDK_IMAGE=openjdk:${JDK_VERSION}-slim
+FROM ${JDK_IMAGE} AS sync-attempt
 
 ARG DOCKER_BUILD_ARCH=amd64
 

--- a/airbyte-metrics/reporter/Dockerfile
+++ b/airbyte-metrics/reporter/Dockerfile
@@ -1,5 +1,6 @@
 ARG JDK_VERSION=17.0.1
-FROM openjdk:${JDK_VERSION}-slim AS metrics-reporter
+ARG JDK_IMAGE=openjdk:${JDK_VERSION}-slim
+FROM ${JDK_IMAGE} AS metrics-reporter
 
 ARG VERSION=0.36.10-alpha
 

--- a/airbyte-scheduler/app/Dockerfile
+++ b/airbyte-scheduler/app/Dockerfile
@@ -1,5 +1,6 @@
 ARG JDK_VERSION=17.0.1
-FROM openjdk:${JDK_VERSION}-slim AS scheduler
+ARG JDK_IMAGE=openjdk:${JDK_VERSION}-slim
+FROM ${JDK_IMAGE} AS scheduler
 
 ARG VERSION=0.36.10-alpha
 

--- a/airbyte-server/Dockerfile
+++ b/airbyte-server/Dockerfile
@@ -1,5 +1,6 @@
 ARG JDK_VERSION=17.0.1
-FROM openjdk:${JDK_VERSION}-slim AS server
+ARG JDK_IMAGE=openjdk:${JDK_VERSION}-slim
+FROM ${JDK_IMAGE} AS server
 
 EXPOSE 8000
 

--- a/airbyte-webapp/Dockerfile
+++ b/airbyte-webapp/Dockerfile
@@ -1,4 +1,5 @@
-FROM nginx:1.19-alpine as webapp
+ARG NGINX_IMAGE=nginx:1.19-alpine
+FROM ${NGINX_IMAGE} as webapp
 
 EXPOSE 80
 

--- a/airbyte-workers/Dockerfile
+++ b/airbyte-workers/Dockerfile
@@ -1,5 +1,6 @@
 ARG JDK_VERSION=17.0.1
-FROM openjdk:${JDK_VERSION}-slim AS worker
+ARG JDK_IMAGE=openjdk:${JDK_VERSION}-slim
+FROM ${JDK_IMAGE} AS worker
 
 ARG DOCKER_BUILD_ARCH=amd64
 

--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,7 @@ def Task getDockerBuildTask(String artifactName, String projectDir, String build
 
         def buildPlatform = System.getenv('DOCKER_BUILD_PLATFORM') ?: isArm64 ? 'linux/arm64' : 'linux/amd64'
         def alpineImage = System.getenv('ALPINE_IMAGE') ?: isArm64 ? 'arm64v8/alpine:3.14' : 'amd64/alpine:3.14'
+        def nginxImage = System.getenv('NGINX_IMAGE') ?: isArm64 ? 'arm64v8/nginx:1.19-alpine' : 'amd64/nginx:1.19-alpine'
         def openjdkImage = System.getenv('JDK_IMAGE') ?: isArm64 ? "arm64v8/openjdk:${jdkVersion}-slim" : "amd64/openjdk:${jdkVersion}-slim"
         def buildArch = System.getenv('DOCKER_BUILD_ARCH') ?: isArm64 ? 'arm64' : 'amd64'
 
@@ -158,6 +159,7 @@ def Task getDockerBuildTask(String artifactName, String projectDir, String build
         buildArgs.put('JDK_VERSION', jdkVersion)
         buildArgs.put('DOCKER_BUILD_ARCH', buildArch)
         buildArgs.put('ALPINE_IMAGE', alpineImage)
+        buildArgs.put('NGINX_IMAGE', nginxImage)
         buildArgs.put('JDK_IMAGE', openjdkImage)
         buildArgs.put('VERSION', buildVersion)
     })

--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ def Task getDockerBuildTask(String artifactName, String projectDir, String build
     return task ("buildDockerImage-$artifactName"(type: DockerBuildImage) {
         def jdkVersion = System.getenv('JDK_VERSION') ?: '17.0.1'
 
-        def arch = System.getProperty("os.arch").toLowerCase()
+        def arch = System.getenv('BUILD_ARCH') ?: System.getProperty("os.arch").toLowerCase()
         def isArm64 = arch == "aarch64" || arch == "arm64"
 
         def buildPlatform = System.getenv('DOCKER_BUILD_PLATFORM') ?: isArm64 ? 'linux/arm64' : 'linux/amd64'

--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,7 @@ def Task getDockerBuildTask(String artifactName, String projectDir, String build
 
         def buildPlatform = System.getenv('DOCKER_BUILD_PLATFORM') ?: isArm64 ? 'linux/arm64' : 'linux/amd64'
         def alpineImage = System.getenv('ALPINE_IMAGE') ?: isArm64 ? 'arm64v8/alpine:3.14' : 'amd64/alpine:3.14'
+        def openjdkImage = System.getenv('JDK_IMAGE') ?: isArm64 ? "arm64v8/openjdk:${jdkVersion}-slim" : "amd64/openjdk:${jdkVersion}-slim"
         def buildArch = System.getenv('DOCKER_BUILD_ARCH') ?: isArm64 ? 'arm64' : 'amd64'
 
         inputDir = file("$projectDir/build/docker")
@@ -157,6 +158,7 @@ def Task getDockerBuildTask(String artifactName, String projectDir, String build
         buildArgs.put('JDK_VERSION', jdkVersion)
         buildArgs.put('DOCKER_BUILD_ARCH', buildArch)
         buildArgs.put('ALPINE_IMAGE', alpineImage)
+        buildArgs.put('JDK_IMAGE', openjdkImage)
         buildArgs.put('VERSION', buildVersion)
     })
 }


### PR DESCRIPTION
currently on m1 macs, switching between building for arm vs amd64
architectures is a bit cumbersome because some of the base docker images
have not been parameterized yet, so you will run into build errors unless
you untag those base images every time you switch between architectures.

This PR should allow you switch freely between the two without needing 
that manual step.

This PR also adds a single env var `BUILD_ARCH` that can be used to
switch between building for arm vs amd64.

With this PR we can build and push images for individual platform components
which is much faster than trying to redeploy everything when iterating on
changes that are limited to only a few components.

Ideally we'd have a github action that allowed us to deploy individual platform
components, but until that exists this seems like a reasonable solution for faster
iteration.