### PR TITLE
Fix incorrect var name and unit test from merging #11099

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -260,10 +260,10 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
           connectionUpdaterInput.getJobId(),
           "Job failed after too many retries for connection " + connectionId));
 
-      final int attemptCreationVersion =
+      final int autoDisableConnectionVersion =
           Workflow.getVersion("auto_disable_failing_connection", Workflow.DEFAULT_VERSION, AUTO_DISABLE_FAILING_CONNECTION_CHANGE_CURRENT_VERSION);
 
-      if (attemptCreationVersion != Workflow.DEFAULT_VERSION) {
+      if (autoDisableConnectionVersion != Workflow.DEFAULT_VERSION) {
         final AutoDisableConnectionActivityInput autoDisableConnectionActivityInput =
             new AutoDisableConnectionActivityInput(connectionId, Instant.ofEpochMilli(Workflow.currentTimeMillis()));
         runMandatoryActivity(autoDisableConnectionActivity::autoDisableFailingConnection, autoDisableConnectionActivityInput);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowTest.java
@@ -753,7 +753,7 @@ public class ConnectionManagerWorkflowTest {
       workflow.submitManualSync();
       testEnv.sleep(Duration.ofMinutes(1L)); // any time after no-waiting manual run
 
-      Mockito.verify(mJobCreationAndStatusUpdateActivity, atLeastOnce()).attemptFailure(Mockito.any());
+      Mockito.verify(mJobCreationAndStatusUpdateActivity, atLeastOnce()).attemptFailureWithAttemptNumber(Mockito.any());
       Mockito.verify(mJobCreationAndStatusUpdateActivity, atLeastOnce()).jobFailure(Mockito.any());
       Mockito.verify(mAutoDisableConnectionActivity)
           .autoDisableFailingConnection(new AutoDisableConnectionActivityInput(connectionId, Mockito.any()));


### PR DESCRIPTION
## What
Use correct variable name to fix build. It was incorrectly set to a var name already in use.
Also fixes a unit test.

These errors were caused by merging https://github.com/airbytehq/airbyte/pull/11099.