### PR TITLE
Pin setup-gcloud to v0 instead of master

### DIFF
--- a/.github/workflows/gke-kube-test-command.yml
+++ b/.github/workflows/gke-kube-test-command.yml
@@ -76,7 +76,7 @@ jobs:
           sudo apt-get install socat
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GKE_TEST_PROJECT_ID }}
           service_account_key: ${{ secrets.GKE_TEST_SA_KEY }}
@@ -142,4 +142,3 @@ jobs:
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
           label: ${{ needs.start-gke-kube-acceptance-test-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-gke-kube-acceptance-test-runner.outputs.ec2-instance-id }}
-

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -51,7 +51,7 @@ jobs:
     environment: more-secrets
     steps:
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_key: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }}
           export_default_credentials: true

--- a/.github/workflows/publish-external-command.yml
+++ b/.github/workflows/publish-external-command.yml
@@ -50,7 +50,7 @@ jobs:
     environment: more-secrets
     steps:
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_key: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }}
           export_default_credentials: true


### PR DESCRIPTION
setup-gcloud will be updating the branch name from master to main in a future release. Even though GitHub will establish redirects, this will break any GitHub Actions workflows that pin to master. This PR updates your GitHub Actions workflows to pin to v0, which is the recommended best practice.

## 🚨 User Impact 🚨
None