### PR TITLE
Update OperationHandler so that it doesn't update Connection table

### DIFF
--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
@@ -5,8 +5,11 @@
 package io.airbyte.config.persistence;
 
 import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR_CATALOG;
+import static io.airbyte.db.instance.configs.jooq.Tables.CONNECTION_OPERATION;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 
 import io.airbyte.commons.json.Jsons;
@@ -30,9 +33,12 @@ import io.airbyte.protocol.models.JsonSchemaType;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -174,6 +180,41 @@ public class ConfigRepositoryE2EReadWriteTest {
     assertTrue(retrievedTombstonedWorkspace.isPresent());
 
     assertEquals(tombstonedWorkspace, retrievedTombstonedWorkspace.get());
+  }
+
+  @Test
+  public void testUpdateConnectionOperationIds() throws Exception {
+    final StandardSync sync = MockData.standardSyncs().get(0);
+    final List<UUID> existingOperationIds = sync.getOperationIds();
+    final UUID connectionId = sync.getConnectionId();
+
+    // this test only works as intended when there are multiple operationIds
+    assertTrue(existingOperationIds.size() > 1);
+
+    // first, remove all associated operations
+    Set<UUID> expectedOperationIds = Collections.emptySet();
+    configRepository.updateConnectionOperationIds(connectionId, expectedOperationIds);
+    Set<UUID> actualOperationIds = fetchOperationIdsForConnectionId(connectionId);
+    assertEquals(expectedOperationIds, actualOperationIds);
+
+    // now, add back one operation
+    expectedOperationIds = Collections.singleton(existingOperationIds.get(0));
+    configRepository.updateConnectionOperationIds(connectionId, expectedOperationIds);
+    actualOperationIds = fetchOperationIdsForConnectionId(connectionId);
+    assertEquals(expectedOperationIds, actualOperationIds);
+
+    // finally, remove the first operation while adding back in the rest
+    expectedOperationIds = existingOperationIds.stream().skip(1).collect(Collectors.toSet());
+    configRepository.updateConnectionOperationIds(connectionId, expectedOperationIds);
+    actualOperationIds = fetchOperationIdsForConnectionId(connectionId);
+    assertEquals(expectedOperationIds, actualOperationIds);
+  }
+
+  private Set<UUID> fetchOperationIdsForConnectionId(final UUID connectionId) throws SQLException {
+    return database.query(ctx -> ctx
+        .selectFrom(CONNECTION_OPERATION)
+        .where(CONNECTION_OPERATION.CONNECTION_ID.eq(connectionId))
+        .fetchSet(CONNECTION_OPERATION.OPERATION_ID));
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/OperationsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/OperationsHandler.java
@@ -30,6 +30,7 @@ import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -183,8 +184,8 @@ public class OperationsHandler {
         removeOperation(operationId);
       }
     }
-    standardSync.withOperationIds(operationIds);
-    configRepository.writeStandardSync(standardSync);
+
+    configRepository.updateConnectionOperationIds(standardSync.getConnectionId(), new HashSet<>(operationIds));
   }
 
   public void deleteOperation(final OperationIdRequestBody operationIdRequestBody)


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte/issues/10666

## How
When a connection is deleted, [two handler methods are called](https://github.com/airbytehq/airbyte/blob/master/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java#L579-L580):
1) `operationsHandler.deleteOperationsForConnection`
2) `connectionsHandler.deleteConnection`

In (1), we identify `operation` and `connection_operation` records that can be deleted.
In (2), we update the status of the `connection` to `DEPRECATED`.

In some situations, a race condition arises where (1) may finish executing after (2). This race condition was exacerbated by two things:
- We used to call the 'deleteConnection' activity twice from the new scheduler workflow (this was fixed last week: https://github.com/airbytehq/airbyte/pull/11246)
- The UI experience for deleting a connection is poor, with delayed feedback to the user that can cause them to click the button multiple times (this will be addressed in https://github.com/airbytehq/airbyte/issues/11046)

The implementation of `operationsHandler.deleteOperationsForConnection` before this PR is to modify the `operationIds` on the `StandardSync` model, and then write the entire model to the database. This ensures that `operation` and `connection_operation` records are updated properly, but also has a side effect of writing the entire `StandardSync` model as an update to the `connection` table. The status property of the `StandardSync` model here is unchanged, so it gets persisted as `ACTIVE`.

So the race condition arises where this status update to `ACTIVE` can effectively clobber the status update to `DEPRECATED` that is supposed to happen in `connectionsHandler.deleteConnection`.

The solution in this PR is to replace the `configRepository.writeStandardSync` approach in the `operationsHandler` with a new `configRepository` method that only modifies `connection_operation` records, without touching the `connection` table at all.

## Recommended reading order
1. `airbyte-server/src/main/java/io/airbyte/server/handlers/OperationsHandler.java`
2. `airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java`
3. tests
