### PR TITLE
Rename jdbc db methods that require manual closure

### DIFF
--- a/airbyte-db/lib/src/main/java/io/airbyte/db/SqlDatabase.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/SqlDatabase.java
@@ -11,6 +11,6 @@ public abstract class SqlDatabase extends AbstractDatabase {
 
   public abstract void execute(String sql) throws Exception;
 
-  public abstract Stream<JsonNode> query(String sql, String... params) throws Exception;
+  public abstract Stream<JsonNode> unsafeQuery(String sql, String... params) throws Exception;
 
 }

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/bigquery/BigQueryDatabase.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/bigquery/BigQueryDatabase.java
@@ -91,7 +91,7 @@ public class BigQueryDatabase extends SqlDatabase {
   }
 
   @Override
-  public Stream<JsonNode> query(final String sql, final String... params) throws Exception {
+  public Stream<JsonNode> unsafeQuery(final String sql, final String... params) throws Exception {
     final List<QueryParameterValue> parameterValueList;
     if (params == null)
       parameterValueList = Collections.emptyList();

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/jdbc/DefaultJdbcDatabase.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/jdbc/DefaultJdbcDatabase.java
@@ -51,18 +51,18 @@ public class DefaultJdbcDatabase extends JdbcDatabase {
                                             final CheckedFunction<ResultSet, T, SQLException> recordTransform)
       throws SQLException {
     try (final Connection connection = dataSource.getConnection();
-        final Stream<T> results = toStream(query.apply(connection), recordTransform)) {
+        final Stream<T> results = toUnsafeStream(query.apply(connection), recordTransform)) {
       return results.collect(Collectors.toList());
     }
   }
 
   @Override
   @MustBeClosed
-  public <T> Stream<T> resultSetQuery(final CheckedFunction<Connection, ResultSet, SQLException> query,
-                                      final CheckedFunction<ResultSet, T, SQLException> recordTransform)
+  public <T> Stream<T> unsafeResultSetQuery(final CheckedFunction<Connection, ResultSet, SQLException> query,
+                                            final CheckedFunction<ResultSet, T, SQLException> recordTransform)
       throws SQLException {
     final Connection connection = dataSource.getConnection();
-    return toStream(query.apply(connection), recordTransform)
+    return toUnsafeStream(query.apply(connection), recordTransform)
         .onClose(() -> {
           try {
             connection.close();
@@ -96,11 +96,11 @@ public class DefaultJdbcDatabase extends JdbcDatabase {
    */
   @Override
   @MustBeClosed
-  public <T> Stream<T> query(final CheckedFunction<Connection, PreparedStatement, SQLException> statementCreator,
-                             final CheckedFunction<ResultSet, T, SQLException> recordTransform)
+  public <T> Stream<T> unsafeQuery(final CheckedFunction<Connection, PreparedStatement, SQLException> statementCreator,
+                                   final CheckedFunction<ResultSet, T, SQLException> recordTransform)
       throws SQLException {
     final Connection connection = dataSource.getConnection();
-    return toStream(statementCreator.apply(connection).executeQuery(), recordTransform)
+    return toUnsafeStream(statementCreator.apply(connection).executeQuery(), recordTransform)
         .onClose(() -> {
           try {
             LOGGER.info("closing connection");

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/jdbc/JdbcDatabase.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/jdbc/JdbcDatabase.java
@@ -59,7 +59,8 @@ public abstract class JdbcDatabase extends SqlDatabase {
   }
 
   /**
-   * Map records returned in a result set.
+   * Map records returned in a result set. It is an "unsafe" stream because the stream
+   * must be manually closed. Otherwise, there will be a database connection leak.
    *
    * @param resultSet the result set
    * @param mapper function to make each record of the result set
@@ -67,7 +68,7 @@ public abstract class JdbcDatabase extends SqlDatabase {
    * @return stream of records that the result set is mapped to.
    */
   @MustBeClosed
-  protected static <T> Stream<T> toStream(final ResultSet resultSet, final CheckedFunction<ResultSet, T, SQLException> mapper) {
+  protected static <T> Stream<T> toUnsafeStream(final ResultSet resultSet, final CheckedFunction<ResultSet, T, SQLException> mapper) {
     return StreamSupport.stream(new Spliterators.AbstractSpliterator<>(Long.MAX_VALUE, Spliterator.ORDERED) {
 
       @Override
@@ -108,8 +109,8 @@ public abstract class JdbcDatabase extends SqlDatabase {
    * Use a connection to create a {@link ResultSet} and map it into a stream. You CANNOT assume that
    * data will be returned from this method before the entire {@link ResultSet} is buffered in memory.
    * Review the implementation of the database's JDBC driver or use the StreamingJdbcDriver if you
-   * need this guarantee. The caller should close the returned stream to release the database
-   * connection.
+   * need this guarantee. It is "unsafe" because the caller should close the returned stream to
+   * release the database connection. Otherwise, there will be a connection leak.
    *
    * @param query execute a query using a {@link Connection} to get a {@link ResultSet}.
    * @param recordTransform transform each record of that result set into the desired type. do NOT
@@ -120,16 +121,17 @@ public abstract class JdbcDatabase extends SqlDatabase {
    * @throws SQLException SQL related exceptions.
    */
   @MustBeClosed
-  public abstract <T> Stream<T> resultSetQuery(CheckedFunction<Connection, ResultSet, SQLException> query,
-                                               CheckedFunction<ResultSet, T, SQLException> recordTransform)
+  public abstract <T> Stream<T> unsafeResultSetQuery(CheckedFunction<Connection, ResultSet, SQLException> query,
+                                                     CheckedFunction<ResultSet, T, SQLException> recordTransform)
       throws SQLException;
 
   /**
    * Use a connection to create a {@link PreparedStatement} and map it into a stream. You CANNOT
    * assume that data will be returned from this method before the entire {@link ResultSet} is
    * buffered in memory. Review the implementation of the database's JDBC driver or use the
-   * StreamingJdbcDriver if you need this guarantee. The caller should close the returned stream to
-   * release the database connection.
+   * StreamingJdbcDriver if you need this guarantee. It is "unsafe" because the caller should
+   * close the returned stream to release the database connection. Otherwise, there will be a
+   * connection leak.
    *
    * @param statementCreator create a {@link PreparedStatement} from a {@link Connection}.
    * @param recordTransform transform each record of that result set into the desired type. do NOT
@@ -140,12 +142,12 @@ public abstract class JdbcDatabase extends SqlDatabase {
    * @throws SQLException SQL related exceptions.
    */
   @MustBeClosed
-  public abstract <T> Stream<T> query(CheckedFunction<Connection, PreparedStatement, SQLException> statementCreator,
-                                      CheckedFunction<ResultSet, T, SQLException> recordTransform)
+  public abstract <T> Stream<T> unsafeQuery(CheckedFunction<Connection, PreparedStatement, SQLException> statementCreator,
+                                            CheckedFunction<ResultSet, T, SQLException> recordTransform)
       throws SQLException;
 
   public int queryInt(final String sql, final String... params) throws SQLException {
-    try (final Stream<Integer> q = query(c -> {
+    try (final Stream<Integer> q = unsafeQuery(c -> {
       PreparedStatement statement = c.prepareStatement(sql);
       int i = 1;
       for (String param : params) {
@@ -159,10 +161,14 @@ public abstract class JdbcDatabase extends SqlDatabase {
     }
   }
 
+  /**
+   * It is "unsafe" because the caller must manually close the returned stream. Otherwise,
+   * there will be a database connection leak.
+   */
   @MustBeClosed
   @Override
-  public Stream<JsonNode> query(final String sql, final String... params) throws SQLException {
-    return query(connection -> {
+  public Stream<JsonNode> unsafeQuery(final String sql, final String... params) throws SQLException {
+    return unsafeQuery(connection -> {
       final PreparedStatement statement = connection.prepareStatement(sql);
       int i = 1;
       for (final String param : params) {
@@ -174,7 +180,7 @@ public abstract class JdbcDatabase extends SqlDatabase {
   }
 
   public ResultSetMetaData queryMetadata(final String sql, final String... params) throws SQLException {
-    try (final Stream<ResultSetMetaData> q = query(c -> {
+    try (final Stream<ResultSetMetaData> q = unsafeQuery(c -> {
       PreparedStatement statement = c.prepareStatement(sql);
       int i = 1;
       for (String param : params) {

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/jdbc/JdbcDatabase.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/jdbc/JdbcDatabase.java
@@ -59,8 +59,8 @@ public abstract class JdbcDatabase extends SqlDatabase {
   }
 
   /**
-   * Map records returned in a result set. It is an "unsafe" stream because the stream
-   * must be manually closed. Otherwise, there will be a database connection leak.
+   * Map records returned in a result set. It is an "unsafe" stream because the stream must be
+   * manually closed. Otherwise, there will be a database connection leak.
    *
    * @param resultSet the result set
    * @param mapper function to make each record of the result set
@@ -129,9 +129,9 @@ public abstract class JdbcDatabase extends SqlDatabase {
    * Use a connection to create a {@link PreparedStatement} and map it into a stream. You CANNOT
    * assume that data will be returned from this method before the entire {@link ResultSet} is
    * buffered in memory. Review the implementation of the database's JDBC driver or use the
-   * StreamingJdbcDriver if you need this guarantee. It is "unsafe" because the caller should
-   * close the returned stream to release the database connection. Otherwise, there will be a
-   * connection leak.
+   * StreamingJdbcDriver if you need this guarantee. It is "unsafe" because the caller should close
+   * the returned stream to release the database connection. Otherwise, there will be a connection
+   * leak.
    *
    * @param statementCreator create a {@link PreparedStatement} from a {@link Connection}.
    * @param recordTransform transform each record of that result set into the desired type. do NOT
@@ -162,8 +162,8 @@ public abstract class JdbcDatabase extends SqlDatabase {
   }
 
   /**
-   * It is "unsafe" because the caller must manually close the returned stream. Otherwise,
-   * there will be a database connection leak.
+   * It is "unsafe" because the caller must manually close the returned stream. Otherwise, there will
+   * be a database connection leak.
    */
   @MustBeClosed
   @Override

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/jdbc/StreamingJdbcDatabase.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/jdbc/StreamingJdbcDatabase.java
@@ -48,15 +48,15 @@ public class StreamingJdbcDatabase extends DefaultJdbcDatabase {
    */
   @Override
   @MustBeClosed
-  public <T> Stream<T> query(final CheckedFunction<Connection, PreparedStatement, SQLException> statementCreator,
-                             final CheckedFunction<ResultSet, T, SQLException> recordTransform)
+  public <T> Stream<T> unsafeQuery(final CheckedFunction<Connection, PreparedStatement, SQLException> statementCreator,
+                                   final CheckedFunction<ResultSet, T, SQLException> recordTransform)
       throws SQLException {
     try {
       final Connection connection = dataSource.getConnection();
       final PreparedStatement ps = statementCreator.apply(connection);
       // allow configuration of connection and prepared statement to make streaming possible.
       jdbcStreamingQueryConfiguration.accept(connection, ps);
-      return toStream(ps.executeQuery(), recordTransform)
+      return toUnsafeStream(ps.executeQuery(), recordTransform)
           .onClose(() -> {
             try {
               connection.setAutoCommit(true);

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/jdbc/TestDefaultJdbcDatabase.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/jdbc/TestDefaultJdbcDatabase.java
@@ -81,7 +81,7 @@ public class TestDefaultJdbcDatabase {
 
   @Test
   void testResultSetQuery() throws SQLException {
-    final Stream<JsonNode> actual = database.resultSetQuery(
+    final Stream<JsonNode> actual = database.unsafeResultSetQuery(
         connection -> connection.createStatement().executeQuery("SELECT * FROM id_and_name;"),
         sourceOperations::rowToJson);
     final List<JsonNode> actualAsList = actual.collect(Collectors.toList());
@@ -92,7 +92,7 @@ public class TestDefaultJdbcDatabase {
 
   @Test
   void testQuery() throws SQLException {
-    final Stream<JsonNode> actual = database.query(
+    final Stream<JsonNode> actual = database.unsafeQuery(
         connection -> connection.prepareStatement("SELECT * FROM id_and_name;"),
         sourceOperations::rowToJson);
 

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/jdbc/TestJdbcUtils.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/jdbc/TestJdbcUtils.java
@@ -106,7 +106,7 @@ public class TestJdbcUtils {
   void testToStream() throws SQLException {
     try (final Connection connection = dataSource.getConnection()) {
       final ResultSet rs = connection.createStatement().executeQuery("SELECT * FROM id_and_name;");
-      final List<JsonNode> actual = JdbcDatabase.toStream(rs, sourceOperations::rowToJson).collect(Collectors.toList());
+      final List<JsonNode> actual = JdbcDatabase.toUnsafeStream(rs, sourceOperations::rowToJson).collect(Collectors.toList());
       assertEquals(RECORDS_AS_JSON, actual);
     }
   }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/jdbc/TestStreamingJdbcDatabase.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/jdbc/TestStreamingJdbcDatabase.java
@@ -93,7 +93,7 @@ public class TestStreamingJdbcDatabase {
     // invoked.
     final AtomicReference<Connection> connection1 = new AtomicReference<>();
     final AtomicReference<PreparedStatement> ps1 = new AtomicReference<>();
-    final Stream<JsonNode> actual = streamingJdbcDatabase.query(
+    final Stream<JsonNode> actual = streamingJdbcDatabase.unsafeQuery(
         connection -> {
           connection1.set(connection);
           final PreparedStatement ps = connection.prepareStatement("SELECT * FROM id_and_name;");

--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationStrictEncryptAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationStrictEncryptAcceptanceTest.java
@@ -110,7 +110,7 @@ public class ClickhouseDestinationStrictEncryptAcceptanceTest extends Destinatio
 
   private List<JsonNode> retrieveRecordsFromTable(final String tableName, final String schemaName) throws SQLException {
     final JdbcDatabase jdbcDB = getDatabase(getConfig());
-    return jdbcDB.query(String.format("SELECT * FROM %s.%s ORDER BY %s ASC", schemaName, tableName,
+    return jdbcDB.unsafeQuery(String.format("SELECT * FROM %s.%s ORDER BY %s ASC", schemaName, tableName,
         JavaBaseConstants.COLUMN_NAME_EMITTED_AT))
         .collect(Collectors.toList());
   }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationAcceptanceTest.java
@@ -101,7 +101,7 @@ public class ClickhouseDestinationAcceptanceTest extends DestinationAcceptanceTe
 
   private List<JsonNode> retrieveRecordsFromTable(final String tableName, final String schemaName) throws SQLException {
     final JdbcDatabase jdbcDB = getDatabase(getConfig());
-    return jdbcDB.query(String.format("SELECT * FROM %s.%s ORDER BY %s ASC", schemaName, tableName,
+    return jdbcDB.unsafeQuery(String.format("SELECT * FROM %s.%s ORDER BY %s ASC", schemaName, tableName,
         JavaBaseConstants.COLUMN_NAME_EMITTED_AT))
         .collect(Collectors.toList());
   }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/java/io/airbyte/integrations/destination/clickhouse/SshClickhouseDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/java/io/airbyte/integrations/destination/clickhouse/SshClickhouseDestinationAcceptanceTest.java
@@ -103,7 +103,7 @@ public abstract class SshClickhouseDestinationAcceptanceTest extends Destination
         ClickhouseDestination.HOST_KEY,
         ClickhouseDestination.PORT_KEY,
         (CheckedFunction<JsonNode, List<JsonNode>, Exception>) mangledConfig -> getDatabase(mangledConfig)
-            .query(String.format("SELECT * FROM %s.%s ORDER BY %s ASC", schemaName, tableName,
+            .unsafeQuery(String.format("SELECT * FROM %s.%s ORDER BY %s ASC", schemaName, tableName,
                 JavaBaseConstants.COLUMN_NAME_EMITTED_AT))
             .collect(Collectors.toList()));
   }

--- a/airbyte-integrations/connectors/destination-mariadb-columnstore/src/main/java/io/airbyte/integrations/destination/mariadb_columnstore/MariadbColumnstoreSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-mariadb-columnstore/src/main/java/io/airbyte/integrations/destination/mariadb_columnstore/MariadbColumnstoreSqlOperations.java
@@ -103,7 +103,7 @@ public class MariadbColumnstoreSqlOperations extends JdbcSqlOperations {
   }
 
   private Semver getVersion(final JdbcDatabase database) throws SQLException {
-    final List<String> value = database.resultSetQuery(connection -> connection.createStatement().executeQuery("SELECT version()"),
+    final List<String> value = database.unsafeResultSetQuery(connection -> connection.createStatement().executeQuery("SELECT version()"),
         resultSet -> resultSet.getString("version()")).collect(Collectors.toList());
     Matcher matcher = VERSION_PATTERN.matcher(value.get(0));
     if (matcher.find()) {
@@ -123,7 +123,7 @@ public class MariadbColumnstoreSqlOperations extends JdbcSqlOperations {
 
   private boolean checkIfLocalFileIsEnabled(final JdbcDatabase database) throws SQLException {
     final List<String> value =
-        database.resultSetQuery(connection -> connection.createStatement().executeQuery("SHOW GLOBAL VARIABLES LIKE 'local_infile'"),
+        database.unsafeResultSetQuery(connection -> connection.createStatement().executeQuery("SHOW GLOBAL VARIABLES LIKE 'local_infile'"),
             resultSet -> resultSet.getString("Value")).collect(Collectors.toList());
 
     return value.get(0).equalsIgnoreCase("on");

--- a/airbyte-integrations/connectors/destination-mariadb-columnstore/src/test-integration/java/io/airbyte/integrations/destination/mariadb_columnstore/MariadbColumnstoreDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mariadb-columnstore/src/test-integration/java/io/airbyte/integrations/destination/mariadb_columnstore/MariadbColumnstoreDestinationAcceptanceTest.java
@@ -82,7 +82,7 @@ public class MariadbColumnstoreDestinationAcceptanceTest extends DestinationAcce
 
   private List<JsonNode> retrieveRecordsFromTable(final String tableName, final String schemaName) throws SQLException {
     JdbcDatabase database = getDatabase(getConfig());
-    return database.query(String.format("SELECT * FROM %s.%s ORDER BY %s ASC;", schemaName, tableName,
+    return database.unsafeQuery(String.format("SELECT * FROM %s.%s ORDER BY %s ASC;", schemaName, tableName,
         JavaBaseConstants.COLUMN_NAME_EMITTED_AT))
         .collect(Collectors.toList());
   }

--- a/airbyte-integrations/connectors/destination-mysql/src/main/java/io/airbyte/integrations/destination/mysql/MySQLSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-mysql/src/main/java/io/airbyte/integrations/destination/mysql/MySQLSqlOperations.java
@@ -100,7 +100,7 @@ public class MySQLSqlOperations extends JdbcSqlOperations {
   }
 
   private double getVersion(final JdbcDatabase database) throws SQLException {
-    final List<String> value = database.resultSetQuery(connection -> connection.createStatement().executeQuery("select version()"),
+    final List<String> value = database.unsafeResultSetQuery(connection -> connection.createStatement().executeQuery("select version()"),
         resultSet -> resultSet.getString("version()")).collect(Collectors.toList());
     return Double.parseDouble(value.get(0).substring(0, 3));
   }
@@ -117,7 +117,7 @@ public class MySQLSqlOperations extends JdbcSqlOperations {
 
   private boolean checkIfLocalFileIsEnabled(final JdbcDatabase database) throws SQLException {
     final List<String> value =
-        database.resultSetQuery(connection -> connection.createStatement().executeQuery("SHOW GLOBAL VARIABLES LIKE 'local_infile'"),
+        database.unsafeResultSetQuery(connection -> connection.createStatement().executeQuery("SHOW GLOBAL VARIABLES LIKE 'local_infile'"),
             resultSet -> resultSet.getString("Value")).collect(Collectors.toList());
 
     return value.get(0).equalsIgnoreCase("on");

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/oracle_strict_encrypt/OracleStrictEncryptDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/oracle_strict_encrypt/OracleStrictEncryptDestinationAcceptanceTest.java
@@ -183,7 +183,7 @@ public class OracleStrictEncryptDestinationAcceptanceTest extends DestinationAcc
 
     final String network_service_banner =
         "select network_service_banner from v$session_connect_info where sid in (select distinct sid from v$mystat)";
-    final List<JsonNode> collect = database.query(network_service_banner).collect(Collectors.toList());
+    final List<JsonNode> collect = database.unsafeQuery(network_service_banner).collect(Collectors.toList());
 
     assertThat(collect.get(2).get("NETWORK_SERVICE_BANNER").asText(),
         equals("Oracle Advanced Security: " + algorithm + " encryption"));
@@ -208,7 +208,7 @@ public class OracleStrictEncryptDestinationAcceptanceTest extends DestinationAcc
             + algorithm + " )"));
 
     final String network_service_banner = "SELECT sys_context('USERENV', 'NETWORK_PROTOCOL') as network_protocol FROM dual";
-    final List<JsonNode> collect = database.query(network_service_banner).collect(Collectors.toList());
+    final List<JsonNode> collect = database.unsafeQuery(network_service_banner).collect(Collectors.toList());
 
     assertEquals("tcp", collect.get(0).get("NETWORK_PROTOCOL").asText());
   }

--- a/airbyte-integrations/connectors/destination-oracle/src/test-integration/java/io/airbyte/integrations/destination/oracle/NneOracleDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-oracle/src/test-integration/java/io/airbyte/integrations/destination/oracle/NneOracleDestinationAcceptanceTest.java
@@ -42,7 +42,7 @@ public class NneOracleDestinationAcceptanceTest extends UnencryptedOracleDestina
 
     final String network_service_banner =
         "select network_service_banner from v$session_connect_info where sid in (select distinct sid from v$mystat)";
-    final List<JsonNode> collect = database.query(network_service_banner).toList();
+    final List<JsonNode> collect = database.unsafeQuery(network_service_banner).toList();
 
     assertThat(collect.get(2).get("NETWORK_SERVICE_BANNER").asText(),
         equals("Oracle Advanced Security: " + algorithm + " encryption"));
@@ -74,7 +74,7 @@ public class NneOracleDestinationAcceptanceTest extends UnencryptedOracleDestina
         getAdditionalProperties(algorithm));
 
     final String network_service_banner = "SELECT sys_context('USERENV', 'NETWORK_PROTOCOL') as network_protocol FROM dual";
-    final List<JsonNode> collect = database.query(network_service_banner).collect(Collectors.toList());
+    final List<JsonNode> collect = database.unsafeQuery(network_service_banner).collect(Collectors.toList());
 
     assertEquals("tcp", collect.get(0).get("NETWORK_PROTOCOL").asText());
   }

--- a/airbyte-integrations/connectors/destination-oracle/src/test-integration/java/io/airbyte/integrations/destination/oracle/UnencryptedOracleDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-oracle/src/test-integration/java/io/airbyte/integrations/destination/oracle/UnencryptedOracleDestinationAcceptanceTest.java
@@ -175,7 +175,7 @@ public class UnencryptedOracleDestinationAcceptanceTest extends DestinationAccep
 
     final String network_service_banner =
         "select network_service_banner from v$session_connect_info where sid in (select distinct sid from v$mystat)";
-    final List<JsonNode> collect = database.query(network_service_banner).collect(Collectors.toList());
+    final List<JsonNode> collect = database.unsafeQuery(network_service_banner).collect(Collectors.toList());
 
     assertTrue(collect.get(1).get("NETWORK_SERVICE_BANNER").asText()
         .contains("Oracle Advanced Security: encryption"));

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingSqlOperations.java
@@ -112,7 +112,7 @@ public class SnowflakeInternalStagingSqlOperations extends SnowflakeSqlOperation
     final String query = getListQuery(stageName, stagingPath, filename);
     LOGGER.debug("Executing query: {}", query);
     final boolean result;
-    try (final Stream<JsonNode> stream = database.query(query)) {
+    try (final Stream<JsonNode> stream = database.unsafeQuery(query)) {
       result = stream.findAny().isPresent();
     }
     return result;

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeSqlOperations.java
@@ -36,7 +36,7 @@ class SnowflakeSqlOperations extends JdbcSqlOperations implements SqlOperations 
 
   @Override
   public boolean isSchemaExists(final JdbcDatabase database, final String outputSchema) throws Exception {
-    try (final Stream<JsonNode> results = database.query(SHOW_SCHEMAS)) {
+    try (final Stream<JsonNode> results = database.unsafeQuery(SHOW_SCHEMAS)) {
       return results.map(schemas -> schemas.get(NAME).asText()).anyMatch(outputSchema::equalsIgnoreCase);
     }
   }

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/java/io/airbyte/integrations/destination/snowflake/SnowflakeSqlOperationsTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/java/io/airbyte/integrations/destination/snowflake/SnowflakeSqlOperationsTest.java
@@ -44,7 +44,7 @@ class SnowflakeSqlOperationsTest {
   @Test
   void isSchemaExists() throws Exception {
     snowflakeSqlOperations.isSchemaExists(db, SCHEMA_NAME);
-    verify(db, times(1)).query(anyString());
+    verify(db, times(1)).unsafeQuery(anyString());
   }
 
   @Test

--- a/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
@@ -50,7 +50,7 @@ public class ClickHouseSource extends AbstractJdbcSource<JDBCType> implements So
                 .getFullyQualifiedTableName(tableInfo.getNameSpace(), tableInfo.getName()),
             tableInfo -> {
               try {
-                return database.resultSetQuery(connection -> {
+                return database.unsafeResultSetQuery(connection -> {
                   final String sql = "SELECT name FROM system.columns WHERE database = ? AND table = ? AND is_in_primary_key = 1";
                   final PreparedStatement preparedStatement = connection.prepareStatement(sql);
                   preparedStatement.setString(1, tableInfo.getNameSpace());

--- a/airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSource.java
+++ b/airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSource.java
@@ -101,7 +101,7 @@ public class CockroachDbSource extends AbstractJdbcSource<JDBCType> {
   @Override
   public Set<JdbcPrivilegeDto> getPrivilegesTableForCurrentUser(final JdbcDatabase database, final String schema) throws SQLException {
     return database
-        .query(getPrivileges(database), sourceOperations::rowToJson)
+        .unsafeQuery(getPrivileges(database), sourceOperations::rowToJson)
         .map(this::getPrivilegeDto)
         .collect(Collectors.toSet());
   }

--- a/airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachJdbcDatabase.java
+++ b/airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachJdbcDatabase.java
@@ -54,21 +54,21 @@ public class CockroachJdbcDatabase
   }
 
   @Override
-  public <T> Stream<T> resultSetQuery(final CheckedFunction<Connection, ResultSet, SQLException> query,
-                                      final CheckedFunction<ResultSet, T, SQLException> recordTransform)
+  public <T> Stream<T> unsafeResultSetQuery(final CheckedFunction<Connection, ResultSet, SQLException> query,
+                                            final CheckedFunction<ResultSet, T, SQLException> recordTransform)
       throws SQLException {
-    return database.resultSetQuery(query, recordTransform);
+    return database.unsafeResultSetQuery(query, recordTransform);
   }
 
   @Override
-  public <T> Stream<T> query(final CheckedFunction<Connection, PreparedStatement, SQLException> statementCreator,
-                             final CheckedFunction<ResultSet, T, SQLException> recordTransform)
+  public <T> Stream<T> unsafeQuery(final CheckedFunction<Connection, PreparedStatement, SQLException> statementCreator,
+                                   final CheckedFunction<ResultSet, T, SQLException> recordTransform)
       throws SQLException {
-    return database.query(statementCreator, recordTransform);
+    return database.unsafeQuery(statementCreator, recordTransform);
   }
 
   @Override
-  public Stream<JsonNode> query(final String sql, final String... params) throws SQLException {
+  public Stream<JsonNode> unsafeQuery(final String sql, final String... params) throws SQLException {
     return bufferedResultSetQuery(connection -> {
       final PreparedStatement statement = connection.prepareStatement(sql);
       int i = 1;

--- a/airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2Source.java
+++ b/airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2Source.java
@@ -90,7 +90,7 @@ public class Db2Source extends AbstractJdbcSource<JDBCType> implements Source {
   @Override
   public Set<JdbcPrivilegeDto> getPrivilegesTableForCurrentUser(final JdbcDatabase database, final String schema) throws SQLException {
     return database
-        .query(getPrivileges(), sourceOperations::rowToJson)
+        .unsafeQuery(getPrivileges(), sourceOperations::rowToJson)
         .map(this::getPrivilegeDto)
         .collect(Collectors.toSet());
   }

--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -262,7 +262,7 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractRelationalDbS
     LOGGER.info("Queueing query for table: {}", tableName);
     return AutoCloseableIterators.lazyIterator(() -> {
       try {
-        final Stream<JsonNode> stream = database.query(
+        final Stream<JsonNode> stream = database.unsafeQuery(
             connection -> {
               LOGGER.info("Preparing query for table: {}", tableName);
               final String sql = String.format("SELECT %s FROM %s WHERE %s > ?",

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
@@ -94,7 +94,7 @@ public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source 
     LOGGER.info("Queueing query for table: {}", tableName);
     return AutoCloseableIterators.lazyIterator(() -> {
       try {
-        final Stream<JsonNode> stream = database.query(
+        final Stream<JsonNode> stream = database.unsafeQuery(
             connection -> {
               LOGGER.info("Preparing query for table: {}", tableName);
 
@@ -244,7 +244,7 @@ public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source 
 
   protected void assertCdcEnabledInDb(final JsonNode config, final JdbcDatabase database)
       throws SQLException {
-    final List<JsonNode> queryResponse = database.query(connection -> {
+    final List<JsonNode> queryResponse = database.unsafeQuery(connection -> {
       final String sql = "SELECT name, is_cdc_enabled FROM sys.databases WHERE name = ?";
       final PreparedStatement ps = connection.prepareStatement(sql);
       ps.setString(1, config.get("database").asText());
@@ -267,7 +267,7 @@ public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source 
 
   protected void assertCdcSchemaQueryable(final JsonNode config, final JdbcDatabase database)
       throws SQLException {
-    final List<JsonNode> queryResponse = database.query(connection -> {
+    final List<JsonNode> queryResponse = database.unsafeQuery(connection -> {
       final String sql =
           "USE " + config.get("database").asText() + "; SELECT * FROM cdc.change_tables";
       final PreparedStatement ps = connection.prepareStatement(sql);
@@ -286,7 +286,7 @@ public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source 
   // todo: ensure this works for Azure managed SQL (since it uses different sql server agent)
   protected void assertSqlServerAgentRunning(final JdbcDatabase database) throws SQLException {
     try {
-      final List<JsonNode> queryResponse = database.query(connection -> {
+      final List<JsonNode> queryResponse = database.unsafeQuery(connection -> {
         final String sql = "SELECT status_desc FROM sys.dm_server_services WHERE [servicename] LIKE 'SQL Server Agent%'";
         final PreparedStatement ps = connection.prepareStatement(sql);
         LOGGER.info(String
@@ -312,7 +312,7 @@ public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source 
 
   protected void assertSnapshotIsolationAllowed(final JsonNode config, final JdbcDatabase database)
       throws SQLException {
-    final List<JsonNode> queryResponse = database.query(connection -> {
+    final List<JsonNode> queryResponse = database.unsafeQuery(connection -> {
       final String sql = "SELECT name, snapshot_isolation_state FROM sys.databases WHERE name = ?";
       final PreparedStatement ps = connection.prepareStatement(sql);
       ps.setString(1, config.get("database").asText());

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcTargetPosition.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlCdcTargetPosition.java
@@ -47,7 +47,7 @@ public class MySqlCdcTargetPosition implements CdcTargetPosition {
 
   public static MySqlCdcTargetPosition targetPosition(final JdbcDatabase database) {
     try {
-      final List<MySqlCdcTargetPosition> masterStatus = database.resultSetQuery(
+      final List<MySqlCdcTargetPosition> masterStatus = database.unsafeResultSetQuery(
           connection -> connection.createStatement().executeQuery("SHOW MASTER STATUS"),
           resultSet -> {
             final String file = resultSet.getString("File");

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/helpers/CdcConfigurationHelper.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/helpers/CdcConfigurationHelper.java
@@ -75,7 +75,7 @@ public class CdcConfigurationHelper {
 
   private static boolean isBinlogAvailable(String binlog, JdbcDatabase database) {
     try {
-      List<String> binlogs = database.resultSetQuery(connection -> connection.createStatement().executeQuery("SHOW BINARY LOGS"),
+      List<String> binlogs = database.unsafeResultSetQuery(connection -> connection.createStatement().executeQuery("SHOW BINARY LOGS"),
           resultSet -> resultSet.getString("Log_name")).collect(Collectors.toList());
 
       return !binlog.isEmpty() && binlogs.stream().anyMatch(e -> e.equals(binlog));
@@ -97,7 +97,7 @@ public class CdcConfigurationHelper {
 
   private static CheckedConsumer<JdbcDatabase, Exception> getCheckOperation(String name, String value) {
     return database -> {
-      final List<String> result = database.resultSetQuery(connection -> {
+      final List<String> result = database.unsafeResultSetQuery(connection -> {
         final String sql = """
                            show variables where Variable_name = '%s'""".formatted(name);
 

--- a/airbyte-integrations/connectors/source-oracle-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/oracle_strict_encrypt/OracleSourceNneAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-oracle-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/oracle_strict_encrypt/OracleSourceNneAcceptanceTest.java
@@ -45,7 +45,7 @@ public class OracleSourceNneAcceptanceTest extends OracleStrictEncryptSourceAcce
 
     final String network_service_banner =
         "select network_service_banner from v$session_connect_info where sid in (select distinct sid from v$mystat)";
-    final List<JsonNode> collect = database.query(network_service_banner).collect(Collectors.toList());
+    final List<JsonNode> collect = database.unsafeQuery(network_service_banner).collect(Collectors.toList());
 
     assertTrue(collect.get(2).get("NETWORK_SERVICE_BANNER").asText()
         .contains(algorithm + " Encryption"));
@@ -74,7 +74,7 @@ public class OracleSourceNneAcceptanceTest extends OracleStrictEncryptSourceAcce
             + algorithm + " )"));
 
     final String network_service_banner = "SELECT sys_context('USERENV', 'NETWORK_PROTOCOL') as network_protocol FROM dual";
-    final List<JsonNode> collect = database.query(network_service_banner).collect(Collectors.toList());
+    final List<JsonNode> collect = database.unsafeQuery(network_service_banner).collect(Collectors.toList());
 
     assertEquals("tcp", collect.get(0).get("NETWORK_PROTOCOL").asText());
   }

--- a/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/OracleSourceNneAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/OracleSourceNneAcceptanceTest.java
@@ -45,7 +45,7 @@ public class OracleSourceNneAcceptanceTest extends OracleSourceAcceptanceTest {
 
     final String network_service_banner =
         "select network_service_banner from v$session_connect_info where sid in (select distinct sid from v$mystat)";
-    final List<JsonNode> collect = database.query(network_service_banner).collect(Collectors.toList());
+    final List<JsonNode> collect = database.unsafeQuery(network_service_banner).collect(Collectors.toList());
 
     assertTrue(collect.get(2).get("NETWORK_SERVICE_BANNER").asText()
         .contains(algorithm + " Encryption"));
@@ -64,7 +64,7 @@ public class OracleSourceNneAcceptanceTest extends OracleSourceAcceptanceTest {
 
     final String network_service_banner =
         "select network_service_banner from v$session_connect_info where sid in (select distinct sid from v$mystat)";
-    final List<JsonNode> collect = database.query(network_service_banner).collect(Collectors.toList());
+    final List<JsonNode> collect = database.unsafeQuery(network_service_banner).collect(Collectors.toList());
 
     assertTrue(collect.get(1).get("NETWORK_SERVICE_BANNER").asText()
         .contains("Encryption service"));
@@ -93,7 +93,7 @@ public class OracleSourceNneAcceptanceTest extends OracleSourceAcceptanceTest {
             + algorithm + " )"));
 
     final String network_service_banner = "SELECT sys_context('USERENV', 'NETWORK_PROTOCOL') as network_protocol FROM dual";
-    final List<JsonNode> collect = database.query(network_service_banner).collect(Collectors.toList());
+    final List<JsonNode> collect = database.unsafeQuery(network_service_banner).collect(Collectors.toList());
 
     assertEquals("tcp", collect.get(0).get("NETWORK_PROTOCOL").asText());
   }

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -155,7 +155,7 @@ public class PostgresSource extends AbstractJdbcSource<JDBCType> implements Sour
 
     if (isCdc(config)) {
       checkOperations.add(database -> {
-        final List<JsonNode> matchingSlots = database.query(connection -> {
+        final List<JsonNode> matchingSlots = database.unsafeQuery(connection -> {
           final String sql = "SELECT * FROM pg_replication_slots WHERE slot_name = ? AND plugin = ? AND database = ?";
           final PreparedStatement ps = connection.prepareStatement(sql);
           ps.setString(1, config.get("replication_method").get("replication_slot").asText());
@@ -177,7 +177,7 @@ public class PostgresSource extends AbstractJdbcSource<JDBCType> implements Sour
       });
 
       checkOperations.add(database -> {
-        final List<JsonNode> matchingPublications = database.query(connection -> {
+        final List<JsonNode> matchingPublications = database.unsafeQuery(connection -> {
           final PreparedStatement ps = connection
               .prepareStatement("SELECT * FROM pg_publication WHERE pubname = ?");
           ps.setString(1, config.get("replication_method").get("publication").asText());
@@ -274,7 +274,7 @@ public class PostgresSource extends AbstractJdbcSource<JDBCType> implements Sour
   public Set<JdbcPrivilegeDto> getPrivilegesTableForCurrentUser(final JdbcDatabase database,
                                                                 final String schema)
       throws SQLException {
-    return database.query(connection -> {
+    return database.unsafeQuery(connection -> {
       final PreparedStatement ps = connection.prepareStatement(
           """
                  SELECT DISTINCT table_catalog,

--- a/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/AbstractRelationalDbSource.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/AbstractRelationalDbSource.java
@@ -58,7 +58,7 @@ public abstract class AbstractRelationalDbSource<DataType, Database extends SqlD
   protected AutoCloseableIterator<JsonNode> queryTable(final Database database, final String sqlQuery) {
     return AutoCloseableIterators.lazyIterator(() -> {
       try {
-        final Stream<JsonNode> stream = database.query(sqlQuery);
+        final Stream<JsonNode> stream = database.unsafeQuery(sqlQuery);
         return AutoCloseableIterators.fromStream(stream);
       } catch (final Exception e) {
         throw new RuntimeException(e);


### PR DESCRIPTION
## Summary
- This relates to https://github.com/airbytehq/airbyte/issues/10386.
- A few methods in `JdbcDatabase` is not safe because the returned streams need to be closed manually, otherwise there will be database connection leaks.
- This PR renames those methods to make this issue more visible.

## Review order
- The only real changes are all in `JdbcDatabase.java`.

