### PR TITLE
Allow for deleting connection in an unexpected state

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -466,7 +466,8 @@ public class TemporalClient {
     return client.newWorkflowStub(workflowClass, TemporalUtils.getWorkflowOptionsWithWorkflowId(jobType, name));
   }
 
-  private <T> T getExistingWorkflow(final Class<T> workflowClass, final String name) {
+  @VisibleForTesting
+  public <T> T getExistingWorkflow(final Class<T> workflowClass, final String name) {
     return client.newWorkflowStub(workflowClass, name);
   }
 
@@ -533,7 +534,7 @@ public class TemporalClient {
   }
 
   @VisibleForTesting
-  static String getConnectionManagerName(final UUID connectionId) {
+  public static String getConnectionManagerName(final UUID connectionId) {
     return "connection_manager_" + connectionId;
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -28,7 +28,6 @@ import io.airbyte.workers.temporal.scheduling.ConnectionUpdaterInput;
 import io.airbyte.workers.temporal.scheduling.state.WorkflowState;
 import io.airbyte.workers.temporal.spec.SpecWorkflow;
 import io.airbyte.workers.temporal.sync.SyncWorkflow;
-import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.workflowservice.v1.ListOpenWorkflowExecutionsRequest;
 import io.temporal.api.workflowservice.v1.ListOpenWorkflowExecutionsResponse;
 import io.temporal.client.BatchRequest;
@@ -464,12 +463,10 @@ public class TemporalClient {
     return client.newWorkflowStub(workflowClass, TemporalUtils.getWorkflowOptionsWithWorkflowId(jobType, name));
   }
 
-  @VisibleForTesting
-  public <T> T getExistingWorkflow(final Class<T> workflowClass, final String name) {
+  private <T> T getExistingWorkflow(final Class<T> workflowClass, final String name) {
     return client.newWorkflowStub(workflowClass, name);
   }
 
-  @VisibleForTesting
   ConnectionManagerWorkflow getConnectionUpdateWorkflow(final UUID connectionId) {
     final boolean workflowReachable = isWorkflowReachable(getConnectionManagerName(connectionId));
 
@@ -531,8 +528,7 @@ public class TemporalClient {
     }
   }
 
-  @VisibleForTesting
-  public static String getConnectionManagerName(final UUID connectionId) {
+  static String getConnectionManagerName(final UUID connectionId) {
     return "connection_manager_" + connectionId;
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -274,12 +274,10 @@ public class TemporalClient {
           .build();
 
       final BatchRequest signalRequest = client.newSignalWithStartRequest();
-      signalRequest.add(connectionManagerWorkflow::run, input); // todo: check if this is necessary
+      signalRequest.add(connectionManagerWorkflow::run, input);
       signalRequest.add(connectionManagerWorkflow::deleteConnection);
-      final WorkflowExecution workflowExecution = client.signalWithStart(signalRequest);
-
-      // todo add logging about workflow execution? do i need to sleep to confirm connection has started
-      // and received signal?
+      client.signalWithStart(signalRequest);
+      log.info("New start request and delete signal submitted");
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -272,7 +272,7 @@ public class TemporalClient {
           .build();
 
       final BatchRequest signalRequest = client.newSignalWithStartRequest();
-      signalRequest.add(connectionManagerWorkflow::run, input);
+      signalRequest.add(connectionManagerWorkflow::run, input); // todo: check if this is necessary
       signalRequest.add(connectionManagerWorkflow::deleteConnection);
       final WorkflowExecution workflowExecution = client.signalWithStart(signalRequest);
       // todo add logging about workflow execution? do i need to sleep to confirm connection has started

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -260,7 +260,6 @@ public class TemporalClient {
       log.info("Create new workflow and sent delete signal", e); // todo make better logging message
       final ConnectionManagerWorkflow connectionManagerWorkflow =
           getExistingWorkflow(ConnectionManagerWorkflow.class, getConnectionManagerName(connectionId));
-      final BatchRequest signalRequest = client.newSignalWithStartRequest();
       final ConnectionUpdaterInput input = ConnectionUpdaterInput.builder()
           .connectionId(connectionId)
           .jobId(null)
@@ -272,6 +271,7 @@ public class TemporalClient {
           .fromJobResetFailure(false)
           .build();
 
+      final BatchRequest signalRequest = client.newSignalWithStartRequest();
       signalRequest.add(connectionManagerWorkflow::run, input);
       signalRequest.add(connectionManagerWorkflow::deleteConnection);
       final WorkflowExecution workflowExecution = client.signalWithStart(signalRequest);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -467,7 +467,8 @@ public class TemporalClient {
     return client.newWorkflowStub(workflowClass, name);
   }
 
-  private ConnectionManagerWorkflow getConnectionUpdateWorkflow(final UUID connectionId) {
+  @VisibleForTesting
+  ConnectionManagerWorkflow getConnectionUpdateWorkflow(final UUID connectionId) {
     final boolean workflowReachable = isWorkflowReachable(getConnectionManagerName(connectionId));
 
     if (!workflowReachable) {

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
@@ -54,7 +54,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.mockito.stubbing.OngoingStubbing;
 
 class TemporalClientTest {
 
@@ -304,7 +303,6 @@ class TemporalClientTest {
       temporalClient.deleteConnection(CONNECTION_ID);
 
       verify(workflowClient).newSignalWithStartRequest();
-//      verify(mBatchRequest).add(mConnectionManagerWorkflow::deleteConnection);
       verify(workflowClient).signalWithStart(mBatchRequest);
     }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
@@ -299,7 +299,7 @@ class TemporalClientTest {
 
       when(workflowClient.newWorkflowStub(any(Class.class), anyString())).thenReturn(mConnectionManagerWorkflow);
       when(workflowClient.newSignalWithStartRequest()).thenReturn(mBatchRequest);
-      doThrow(new IllegalStateException("Force illegal state")).when(mConnectionManagerWorkflow).deleteConnection();
+      doThrow(new IllegalStateException("Force illegal state")).when(temporalClient).getConnectionUpdateWorkflow(CONNECTION_ID);
 
       temporalClient.deleteConnection(CONNECTION_ID);
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowTest.java
@@ -4,10 +4,6 @@
 
 package io.airbyte.workers.temporal.scheduling;
 
-import static io.airbyte.workers.temporal.TemporalClient.getConnectionManagerName;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atLeastOnce;
 
 import io.airbyte.config.FailureReason.FailureOrigin;
@@ -15,7 +11,6 @@ import io.airbyte.config.FailureReason.FailureType;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
-import io.airbyte.workers.temporal.TemporalClient;
 import io.airbyte.workers.temporal.TemporalJobType;
 import io.airbyte.workers.temporal.scheduling.activities.AutoDisableConnectionActivity;
 import io.airbyte.workers.temporal.scheduling.activities.AutoDisableConnectionActivity.AutoDisableConnectionActivityInput;
@@ -47,14 +42,10 @@ import io.airbyte.workers.temporal.scheduling.testsyncworkflow.SyncWorkflowFaili
 import io.airbyte.workers.temporal.scheduling.testsyncworkflow.SyncWorkflowWithActivityFailureException;
 import io.airbyte.workers.temporal.sync.SyncWorkflow;
 import io.temporal.client.WorkflowClient;
-import io.temporal.client.WorkflowNotFoundException;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -416,55 +407,6 @@ public class ConnectionManagerWorkflowTest {
           .isEmpty();
 
       Mockito.verify(mConnectionDeletionActivity, Mockito.times(1)).deleteConnection(Mockito.any());
-    }
-
-    @Test
-    @Timeout(value = 2,
-             unit = TimeUnit.SECONDS)
-    @DisplayName("Test that the connection is properly deleted even if the temporal workflow is in a bad state")
-    public void deleteConnectionInUnexpectedState() throws IOException {
-
-      final UUID connectionId = UUID.randomUUID();
-      final Path workspaceRoot = Files.createTempDirectory(Path.of("/tmp"), "temporal_client_test");
-      final TemporalClient temporalClient = new TemporalClient(client, workspaceRoot, testEnv.getWorkflowService(), null);
-
-      // assert that we cannot reach the existing workflow
-      ConnectionManagerWorkflow connectionManagerWorkflow =
-          temporalClient.getExistingWorkflow(ConnectionManagerWorkflow.class, getConnectionManagerName(connectionId));
-      assertThrows(WorkflowNotFoundException.class, connectionManagerWorkflow::getState);
-
-      temporalClient.deleteConnection(connectionId);
-      testEnv.sleep(Duration.ofMinutes(1L));
-
-      // assert that we spin up a new workflow and delete the connection
-      connectionManagerWorkflow = temporalClient.getExistingWorkflow(ConnectionManagerWorkflow.class, getConnectionManagerName(connectionId));
-      assertTrue(connectionManagerWorkflow.getState().isDeleted());
-    }
-
-    @Test
-    @Timeout(value = 2,
-             unit = TimeUnit.SECONDS)
-    @DisplayName("Test that the connection is properly deleted")
-    public void deleteConnection() throws IOException {
-
-      final UUID connectionId = UUID.randomUUID();
-      final Path workspaceRoot = Files.createTempDirectory(Path.of("/tmp"), "temporal_client_test");
-      final TemporalClient temporalClient = new TemporalClient(client, workspaceRoot, testEnv.getWorkflowService(), null);
-
-      temporalClient.submitConnectionUpdaterAsync(connectionId);
-      testEnv.sleep(Duration.ofMinutes(1L));
-
-      // assert connection is not deleted
-      ConnectionManagerWorkflow connectionManagerWorkflow =
-          temporalClient.getExistingWorkflow(ConnectionManagerWorkflow.class, getConnectionManagerName(connectionId));
-      assertFalse(connectionManagerWorkflow.getState().isDeleted());
-
-      temporalClient.deleteConnection(connectionId);
-      testEnv.sleep(Duration.ofMinutes(1L));
-
-      // assert that it is deleted
-      connectionManagerWorkflow = temporalClient.getExistingWorkflow(ConnectionManagerWorkflow.class, getConnectionManagerName(connectionId));
-      assertTrue(connectionManagerWorkflow.getState().isDeleted());
     }
 
   }


### PR DESCRIPTION
## What
When a temporal workflow is in an unexpected state, there is no way to delete a connection unless you interact with temporal directly. This PR will make it so that the deletion occurs even if the temporal state is in an unexpected state and addresses issue #11214.

## How
If the temporal workflow is in an unexpected state, we spin up a new workflow and send a signal to delete the connection.

## Tests
In addition to unit tests, this was tested locally by terminating a temporal workflow with the command `docker run --rm -it --entrypoint tctl --env TEMPORAL_CLI_ADDRESS=host.docker.internal:7233 temporalio/admin-tools:1.14.0 wf terminate --wid <workflow_id>` and then attempting to delete the connection through the UI.

