### PR TITLE
fix: secret not found for externaldb

### DIFF
--- a/charts/airbyte/templates/external-db.yaml
+++ b/charts/airbyte/templates/external-db.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: airbyte-externaldb
+  name: {{ .Release.Name }}-externaldb
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-1"


### PR DESCRIPTION
## What
External db secret was not named properly and was not found.

## How
Added release name into the name of externaldb secret

## 🚨 User Impact 🚨
No breaking changes
