### PR TITLE
Fix breaking the app with fragment links in docs

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/Instruction.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/Instruction.tsx
@@ -71,8 +71,8 @@ const DocumentationPanel: React.FC<{ onClose: () => void } & IProps> = ({
   const config = useConfig();
   const { data: docs, isLoading } = useDocumentation(documentationUrl);
 
-  const removeBaseUrl = (url: { path: string }) => {
-    if (url.path.startsWith("../../")) {
+  const removeBaseUrl = (url: { path?: string }) => {
+    if (url.path?.startsWith("../../")) {
       return url.path.replace("../../", `${config.integrationUrl}/`);
     }
     return url.path;


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/11304

This is a quick fix, to fixes documentations that contain fragment-only URLs like the Salesforce documentation. Fixing this method properly is tracked via https://github.com/airbytehq/airbyte/issues/11313