### PR TITLE
Airbyte CI: fix `/publish` command git action

### DIFF
--- a/.github/workflows/gke-kube-test-command.yml
+++ b/.github/workflows/gke-kube-test-command.yml
@@ -76,7 +76,7 @@ jobs:
           sudo apt-get install socat
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GKE_TEST_PROJECT_ID }}
           service_account_key: ${{ secrets.GKE_TEST_SA_KEY }}

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -51,7 +51,7 @@ jobs:
     environment: more-secrets
     steps:
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_key: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }}
           export_default_credentials: true

--- a/.github/workflows/publish-external-command.yml
+++ b/.github/workflows/publish-external-command.yml
@@ -50,7 +50,7 @@ jobs:
     environment: more-secrets
     steps:
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_key: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }}
           export_default_credentials: true


### PR DESCRIPTION
## What
According to https://github.com/google-github-actions/setup-gcloud/issues/539
We've faced with this issue already in this Workflow Run and many others: https://github.com/airbytehq/airbyte/runs/5647543616?check_suite_focus=true#step:3:55

## How
- changed the referencing of the `Set up Cloud CDK` job for the command `google-github-actions/setup-gcloud@master`
changed `@master` to `@v0` as recommended in https://github.com/google-github-actions/setup-gcloud/issues/539
