### PR TITLE
Source Google Ads: Add unit test for check_connection

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/common.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/common.py
@@ -1,8 +1,10 @@
 #
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
+import json
 
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v8 import GoogleAdsFailure
 
 
 class MockSearchRequest:
@@ -35,12 +37,25 @@ class MockGoogleAdsClient:
 
 class MockErroringGoogleAdsService:
     def search(self, search_request):
-        raise GoogleAdsException("This mocked class always returns an error")
+        raise make_google_ads_exception(1)
+
+
+def make_google_ads_exception(failure_code: int):
+    # There is no easy way I could find to mock a GoogleAdsException without doing something heinous like this
+    # Following the definition of the object here
+    # https://developers.google.com/google-ads/api/reference/rpc/v10/GoogleAdsFailure
+    protobuf_as_json = json.dumps({"errors": [{"error_code": {"request_error": failure_code}, "message": "it failed"}], "request_id": "1"})
+    failure = type(GoogleAdsFailure).from_json(GoogleAdsFailure, protobuf_as_json)
+    return GoogleAdsException(None, None, failure, 1)
 
 
 class MockErroringGoogleAdsClient:
-    def __init__(self, config):
-        self.config = config
+    def __init__(self, credentials, **kwargs):
+        self.config = credentials
+        self.customer_ids = ["1"]
+
+    def send_request(self, query, customer_id):
+        raise make_google_ads_exception(1)
 
     def get_type(self, type):
         return MockSearchRequest()

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/common.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/common.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
 
+from google.ads.googleads.errors import GoogleAdsException
+
 
 class MockSearchRequest:
     customer_id = "12345"
@@ -29,3 +31,23 @@ class MockGoogleAdsClient:
     @staticmethod
     def load_from_dict(config):
         return MockGoogleAdsClient(config)
+
+
+class MockErroringGoogleAdsService:
+    def search(self, search_request):
+        raise GoogleAdsException("This mocked class always returns an error")
+
+
+class MockErroringGoogleAdsClient:
+    def __init__(self, config):
+        self.config = config
+
+    def get_type(self, type):
+        return MockSearchRequest()
+
+    def get_service(self, service):
+        return MockErroringGoogleAdsService()
+
+    @staticmethod
+    def load_from_dict(config):
+        return MockErroringGoogleAdsClient(config)

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/common.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/common.py
@@ -21,8 +21,9 @@ class MockGoogleAdsService:
 
 
 class MockGoogleAdsClient:
-    def __init__(self, config):
-        self.config = config
+    def __init__(self, credentials, **kwargs):
+        self.config = credentials
+        self.customer_ids = ["1"]
 
     def get_type(self, type):
         return MockSearchRequest()
@@ -33,6 +34,9 @@ class MockGoogleAdsClient:
     @staticmethod
     def load_from_dict(config):
         return MockGoogleAdsClient(config)
+
+    def send_request(self, query, customer_id):
+        yield from ()
 
 
 class MockErroringGoogleAdsService:

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
@@ -398,7 +398,9 @@ def test_checkConnection_should_pass_when_configValid(mocker):
 
 
 def test_checkConnection_should_fail_when_apiCallFails(mocker):
-    mocker.patch("source_google_ads.google_ads.GoogleAdsClient", return_value=MockErroringGoogleAdsClient)
+    # We patch the object inside source.py because that's the calling context
+    # https://docs.python.org/3/library/unittest.mock.html#where-to-patch
+    mocker.patch("source_google_ads.source.GoogleAds", MockErroringGoogleAdsClient)
     source = SourceGoogleAds()
     check_successful, message = source.check_connection(
         AirbyteLogger(),

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
@@ -356,7 +356,7 @@ def test_google_type_conversion(config):
         assert desired_mapping[prop] == value.get("type"), f"{prop} should be {value}"
 
 
-def test_checkConnection_should_pass_when_configValid(mocker):
+def test_check_connection_should_pass_when_config_valid(mocker):
     mocker.patch("source_google_ads.source.GoogleAds", MockGoogleAdsClient)
     source = SourceGoogleAds()
     check_successful, message = source.check_connection(
@@ -397,7 +397,7 @@ def test_checkConnection_should_pass_when_configValid(mocker):
     assert message is None
 
 
-def test_checkConnection_should_fail_when_apiCallFails(mocker):
+def test_check_connection_should_fail_when_api_call_fails(mocker):
     # We patch the object inside source.py because that's the calling context
     # https://docs.python.org/3/library/unittest.mock.html#where-to-patch
     mocker.patch("source_google_ads.source.GoogleAds", MockErroringGoogleAdsClient)

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
@@ -357,7 +357,7 @@ def test_google_type_conversion(config):
 
 
 def test_checkConnection_should_pass_when_configValid(mocker):
-    mocker.patch("source_google_ads.google_ads.GoogleAdsClient", return_value=MockGoogleAdsClient)
+    mocker.patch("source_google_ads.source.GoogleAds", MockGoogleAdsClient)
     source = SourceGoogleAds()
     check_successful, message = source.check_connection(
         AirbyteLogger(),


### PR DESCRIPTION
## What
This seems like a reasonable test to have - validate the happy path (good config, GAds API returns success) and the obvious error path (GAds API throws an error).

test coverage:
```
---------- coverage: platform darwin, python 3.9.9-final-0 -----------
Name                                       Stmts   Miss  Cover
--------------------------------------------------------------
source_google_ads/__init__.py                  2      0   100%
source_google_ads/custom_query_stream.py      75      6    92%
source_google_ads/google_ads.py               68      7    90%
source_google_ads/source.py                   73      4    95%
source_google_ads/streams.py                 130     10    92%
--------------------------------------------------------------
TOTAL                                        348     27    92%


Results (6.82s):
      35 passed
```