### PR TITLE
remove language about admin users from the ui

### DIFF
--- a/airbyte-webapp/src/packages/cloud/views/users/InviteUsersModal/InviteUsersModal.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/users/InviteUsersModal/InviteUsersModal.tsx
@@ -54,7 +54,8 @@ export const InviteUsersModal: React.FC<{
   const roleOptions = [
     {
       value: "admin",
-      label: "admin",
+      // todo (cgardens) - internally we call them admins, but since there is only one level, externally we don't show that distinction to avoid confusing users.
+      label: "user",
     },
   ];
   return (

--- a/airbyte-webapp/src/packages/cloud/views/users/UsersSettingsView/UsersSettingsView.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/users/UsersSettingsView/UsersSettingsView.tsx
@@ -71,7 +71,8 @@ export const UsersSettingsView: React.FC = () => {
         ),
         headerHighlighted: true,
         accessor: "userId",
-        Cell: (_: CellProps<User>) => "admin",
+        // todo (cgardens) - internally we call them admins, but since there is only one level, externally we don't show that distinction to avoid confusing users.
+        Cell: (_: CellProps<User>) => "user",
       },
       {
         Header: <FormattedMessage id="userSettings.table.column.action" />,


### PR DESCRIPTION
In reference to this comment: https://docs.google.com/document/d/1aS7A8eN96qjYrin9GF1B__myBRA-bfIxp5S62HJxWCI/edit?disco=AAAAXBQ3M-o

Idea being removing the word admin from the UI will remove questions. There's some debate on this, so we may decide to just not do this. Leaving as draft for now.