### PR TITLE
List actor definitions for workspace

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/util/MoreLists.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/util/MoreLists.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 public class MoreLists {
 
@@ -33,6 +34,18 @@ public class MoreLists {
     final ArrayList<T> reversed = new ArrayList<>(list);
     Collections.reverse(reversed);
     return reversed;
+  }
+
+  /**
+   * Concatenate multiple lists into one list.
+   *
+   * @param lists to concatenate
+   * @param <T> type
+   * @return a new concatenated list
+   */
+  @SafeVarargs
+  public static <T> List<T> concat(final List<T>... lists) {
+    return Stream.of(lists).flatMap(List::stream).toList();
   }
 
 }

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -7,6 +7,7 @@ package io.airbyte.config.persistence;
 import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR;
 import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR_CATALOG;
 import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR_CATALOG_FETCH_EVENT;
+import static io.airbyte.db.instance.configs.jooq.Tables.ACTOR_DEFINITION_WORKSPACE_GRANT;
 import static io.airbyte.db.instance.configs.jooq.Tables.CONNECTION;
 import static io.airbyte.db.instance.configs.jooq.Tables.CONNECTION_OPERATION;
 import static io.airbyte.db.instance.configs.jooq.Tables.WORKSPACE;
@@ -307,6 +308,13 @@ public class ConfigRepository {
       persistence.deleteConfig(connectorType, connectorIdGetter.apply(connector).toString());
     }
     persistence.deleteConfig(definitionType, definitionId.toString());
+  }
+
+  public void writeActorDefinitionWorkspaceGrant(final UUID actorDefinitionId, final UUID workspaceId) throws IOException {
+    database.query(ctx -> ctx.insertInto(ACTOR_DEFINITION_WORKSPACE_GRANT)
+        .set(ACTOR_DEFINITION_WORKSPACE_GRANT.ACTOR_DEFINITION_ID, actorDefinitionId)
+        .set(ACTOR_DEFINITION_WORKSPACE_GRANT.WORKSPACE_ID, workspaceId)
+        .execute());
   }
 
   /**

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -60,6 +60,7 @@ import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Field;
 import org.jooq.JSONB;
+import org.jooq.JoinType;
 import org.jooq.Record;
 import org.jooq.Record1;
 import org.jooq.Record2;
@@ -196,6 +197,16 @@ public class ConfigRepository {
         ACTOR_DEFINITION.PUBLIC.eq(true));
   }
 
+  public List<StandardSourceDefinition> listGrantedSourceDefinitions(final UUID workspaceId, final boolean includeTombstones)
+      throws IOException {
+    return listActorDefinitionsJoinedWithGrants(
+        workspaceId,
+        JoinType.JOIN,
+        ActorType.source,
+        DbConverter::buildStandardSourceDefinition,
+        includeTombstones(ACTOR_DEFINITION.TOMBSTONE, includeTombstones));
+  }
+
   public void writeStandardSourceDefinition(final StandardSourceDefinition sourceDefinition) throws JsonValidationException, IOException {
     persistence.writeConfig(ConfigSchema.STANDARD_SOURCE_DEFINITION, sourceDefinition.getSourceDefinitionId().toString(), sourceDefinition);
   }
@@ -263,6 +274,16 @@ public class ConfigRepository {
         DbConverter::buildStandardDestinationDefinition,
         includeTombstones(ACTOR_DEFINITION.TOMBSTONE, includeTombstone),
         ACTOR_DEFINITION.PUBLIC.eq(true));
+  }
+
+  public List<StandardDestinationDefinition> listGrantedDestinationDefinitions(final UUID workspaceId, final boolean includeTombstones)
+      throws IOException {
+    return listActorDefinitionsJoinedWithGrants(
+        workspaceId,
+        JoinType.JOIN,
+        ActorType.destination,
+        DbConverter::buildStandardDestinationDefinition,
+        includeTombstones(ACTOR_DEFINITION.TOMBSTONE, includeTombstones));
   }
 
   public void writeStandardDestinationDefinition(final StandardDestinationDefinition destinationDefinition)
@@ -345,6 +366,26 @@ public class ConfigRepository {
 
     return records.stream()
         .map(recordToActorDefinition)
+        .toList();
+  }
+
+  private <T> List<T> listActorDefinitionsJoinedWithGrants(final UUID workspaceId,
+                                                           final JoinType joinType,
+                                                           final ActorType actorType,
+                                                           final Function<Record, T> recordToReturnType,
+                                                           final Condition... conditions)
+      throws IOException {
+    final Result<Record> records = database.query(ctx -> ctx.select(asterisk()).from(ACTOR_DEFINITION)
+        .join(ACTOR_DEFINITION_WORKSPACE_GRANT, joinType)
+        .on(ACTOR_DEFINITION.ID.eq(ACTOR_DEFINITION_WORKSPACE_GRANT.ACTOR_DEFINITION_ID),
+            ACTOR_DEFINITION_WORKSPACE_GRANT.WORKSPACE_ID.eq(workspaceId))
+        .where(conditions)
+        .and(ACTOR_DEFINITION.ACTOR_TYPE.eq(actorType))
+        .and(ACTOR_DEFINITION.PUBLIC.eq(false))
+        .fetch());
+
+    return records.stream()
+        .map(recordToReturnType)
         .toList();
   }
 

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
@@ -231,9 +231,35 @@ public class ConfigRepositoryE2EReadWriteTest {
   }
 
   @Test
+  public void testSourceDefinitionGrants() throws IOException {
+    final UUID workspaceId = MockData.standardWorkspaces().get(0).getWorkspaceId();
+    final StandardSourceDefinition grantableDefinition1 = MockData.standardSourceDefinitions().get(1);
+    final StandardSourceDefinition customDefinition = MockData.standardSourceDefinitions().get(3);
+
+    configRepository.writeActorDefinitionWorkspaceGrant(customDefinition.getSourceDefinitionId(), workspaceId);
+    configRepository.writeActorDefinitionWorkspaceGrant(grantableDefinition1.getSourceDefinitionId(), workspaceId);
+    final List<StandardSourceDefinition> actualGrantedDefinitions = configRepository
+        .listGrantedSourceDefinitions(workspaceId, false);
+    assertThat(actualGrantedDefinitions).hasSameElementsAs(List.of(grantableDefinition1, customDefinition));
+  }
+
+  @Test
   public void testListPublicDestinationDefinitions() throws IOException {
     final List<StandardDestinationDefinition> actualDefinitions = configRepository.listPublicDestinationDefinitions(false);
     assertEquals(List.of(MockData.standardDestinationDefinitions().get(0)), actualDefinitions);
+  }
+
+  @Test
+  public void testDestinationDefinitionGrants() throws IOException {
+    final UUID workspaceId = MockData.standardWorkspaces().get(0).getWorkspaceId();
+    final StandardDestinationDefinition grantableDefinition1 = MockData.standardDestinationDefinitions().get(1);
+    final StandardDestinationDefinition customDefinition = MockData.standardDestinationDefinitions().get(3);
+
+    configRepository.writeActorDefinitionWorkspaceGrant(customDefinition.getDestinationDefinitionId(), workspaceId);
+    configRepository.writeActorDefinitionWorkspaceGrant(grantableDefinition1.getDestinationDefinitionId(), workspaceId);
+    final List<StandardDestinationDefinition> actualGrantedDefinitions = configRepository
+        .listGrantedDestinationDefinitions(workspaceId, false);
+    assertThat(actualGrantedDefinitions).hasSameElementsAs(List.of(grantableDefinition1, customDefinition));
   }
 
 }

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
@@ -224,4 +224,16 @@ public class ConfigRepositoryE2EReadWriteTest {
         .fetchSet(CONNECTION_OPERATION.OPERATION_ID));
   }
 
+  @Test
+  public void testListPublicSourceDefinitions() throws IOException {
+    final List<StandardSourceDefinition> actualDefinitions = configRepository.listPublicSourceDefinitions(false);
+    assertEquals(List.of(MockData.standardSourceDefinitions().get(0)), actualDefinitions);
+  }
+
+  @Test
+  public void testListPublicDestinationDefinitions() throws IOException {
+    final List<StandardDestinationDefinition> actualDefinitions = configRepository.listPublicDestinationDefinitions(false);
+    assertEquals(List.of(MockData.standardDestinationDefinitions().get(0)), actualDefinitions);
+  }
+
 }

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
@@ -227,14 +227,14 @@ public class ConfigRepositoryE2EReadWriteTest {
   @Test
   public void testListPublicSourceDefinitions() throws IOException {
     final List<StandardSourceDefinition> actualDefinitions = configRepository.listPublicSourceDefinitions(false);
-    assertEquals(List.of(MockData.standardSourceDefinitions().get(0)), actualDefinitions);
+    assertEquals(List.of(MockData.publicSourceDefinition()), actualDefinitions);
   }
 
   @Test
   public void testSourceDefinitionGrants() throws IOException {
     final UUID workspaceId = MockData.standardWorkspaces().get(0).getWorkspaceId();
-    final StandardSourceDefinition grantableDefinition1 = MockData.standardSourceDefinitions().get(1);
-    final StandardSourceDefinition customDefinition = MockData.standardSourceDefinitions().get(3);
+    final StandardSourceDefinition grantableDefinition1 = MockData.grantableSourceDefinition1();
+    final StandardSourceDefinition customDefinition = MockData.customSourceDefinition();
 
     configRepository.writeActorDefinitionWorkspaceGrant(customDefinition.getSourceDefinitionId(), workspaceId);
     configRepository.writeActorDefinitionWorkspaceGrant(grantableDefinition1.getSourceDefinitionId(), workspaceId);
@@ -246,14 +246,14 @@ public class ConfigRepositoryE2EReadWriteTest {
   @Test
   public void testListPublicDestinationDefinitions() throws IOException {
     final List<StandardDestinationDefinition> actualDefinitions = configRepository.listPublicDestinationDefinitions(false);
-    assertEquals(List.of(MockData.standardDestinationDefinitions().get(0)), actualDefinitions);
+    assertEquals(List.of(MockData.publicDestinationDefinition()), actualDefinitions);
   }
 
   @Test
   public void testDestinationDefinitionGrants() throws IOException {
     final UUID workspaceId = MockData.standardWorkspaces().get(0).getWorkspaceId();
-    final StandardDestinationDefinition grantableDefinition1 = MockData.standardDestinationDefinitions().get(1);
-    final StandardDestinationDefinition customDefinition = MockData.standardDestinationDefinitions().get(3);
+    final StandardDestinationDefinition grantableDefinition1 = MockData.grantableDestinationDefinition1();
+    final StandardDestinationDefinition customDefinition = MockData.cusstomDestinationDefinition();
 
     configRepository.writeActorDefinitionWorkspaceGrant(customDefinition.getDestinationDefinitionId(), workspaceId);
     configRepository.writeActorDefinitionWorkspaceGrant(grantableDefinition1.getDestinationDefinitionId(), workspaceId);

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/MockData.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/MockData.java
@@ -57,8 +57,12 @@ public class MockData {
   private static final UUID WORKSPACE_CUSTOMER_ID = UUID.randomUUID();
   private static final UUID SOURCE_DEFINITION_ID_1 = UUID.randomUUID();
   private static final UUID SOURCE_DEFINITION_ID_2 = UUID.randomUUID();
+  private static final UUID SOURCE_DEFINITION_ID_3 = UUID.randomUUID();
+  private static final UUID SOURCE_DEFINITION_ID_4 = UUID.randomUUID();
   private static final UUID DESTINATION_DEFINITION_ID_1 = UUID.randomUUID();
   private static final UUID DESTINATION_DEFINITION_ID_2 = UUID.randomUUID();
+  private static final UUID DESTINATION_DEFINITION_ID_3 = UUID.randomUUID();
+  private static final UUID DESTINATION_DEFINITION_ID_4 = UUID.randomUUID();
   private static final UUID SOURCE_ID_1 = UUID.randomUUID();
   private static final UUID SOURCE_ID_2 = UUID.randomUUID();
   private static final UUID SOURCE_ID_3 = UUID.randomUUID();
@@ -148,8 +152,32 @@ public class MockData {
         .withDockerRepository("repository-2")
         .withDocumentationUrl("documentation-url-2")
         .withIcon("icon-2")
-        .withTombstone(false);
-    return Arrays.asList(standardSourceDefinition1, standardSourceDefinition2);
+        .withTombstone(false)
+        .withPublic(false)
+        .withCustom(false);
+    final StandardSourceDefinition standardSourceDefinition3 = new StandardSourceDefinition()
+        .withSourceDefinitionId(SOURCE_DEFINITION_ID_3)
+        .withSourceType(SourceType.DATABASE)
+        .withName("random-source-3")
+        .withDockerImageTag("tag-3")
+        .withDockerRepository("repository-3")
+        .withDocumentationUrl("documentation-url-3")
+        .withIcon("icon-3")
+        .withTombstone(false)
+        .withPublic(false)
+        .withCustom(false);
+    final StandardSourceDefinition standardSourceDefinition4 = new StandardSourceDefinition()
+        .withSourceDefinitionId(SOURCE_DEFINITION_ID_4)
+        .withSourceType(SourceType.DATABASE)
+        .withName("random-source-4")
+        .withDockerImageTag("tag-4")
+        .withDockerRepository("repository-4")
+        .withDocumentationUrl("documentation-url-4")
+        .withIcon("icon-4")
+        .withTombstone(false)
+        .withPublic(false)
+        .withCustom(true);
+    return Arrays.asList(standardSourceDefinition1, standardSourceDefinition2, standardSourceDefinition3, standardSourceDefinition4);
   }
 
   private static ConnectorSpecification connectorSpecification() {
@@ -187,8 +215,33 @@ public class MockData {
         .withDocumentationUrl("documentation-url-4")
         .withIcon("icon-4")
         .withSpec(connectorSpecification)
-        .withTombstone(false);
-    return Arrays.asList(standardDestinationDefinition1, standardDestinationDefinition2);
+        .withTombstone(false)
+        .withPublic(false)
+        .withCustom(false);
+    final StandardDestinationDefinition standardDestinationDefinition3 = new StandardDestinationDefinition()
+        .withDestinationDefinitionId(DESTINATION_DEFINITION_ID_3)
+        .withName("random-destination-3")
+        .withDockerImageTag("tag-33")
+        .withDockerRepository("repository-33")
+        .withDocumentationUrl("documentation-url-33")
+        .withIcon("icon-3")
+        .withSpec(connectorSpecification)
+        .withTombstone(false)
+        .withPublic(false)
+        .withCustom(false);
+    final StandardDestinationDefinition standardDestinationDefinition4 = new StandardDestinationDefinition()
+        .withDestinationDefinitionId(DESTINATION_DEFINITION_ID_4)
+        .withName("random-destination-4")
+        .withDockerImageTag("tag-44")
+        .withDockerRepository("repository-44")
+        .withDocumentationUrl("documentation-url-44")
+        .withIcon("icon-4")
+        .withSpec(connectorSpecification)
+        .withTombstone(false)
+        .withPublic(false)
+        .withCustom(true);
+    return Arrays.asList(standardDestinationDefinition1, standardDestinationDefinition2, standardDestinationDefinition3,
+        standardDestinationDefinition4);
   }
 
   public static List<SourceConnection> sourceConnections() {

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/MockData.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/MockData.java
@@ -137,6 +137,8 @@ public class MockData {
         .withIcon("icon-1")
         .withSpec(connectorSpecification)
         .withTombstone(false)
+        .withPublic(true)
+        .withCustom(false)
         .withResourceRequirements(new ActorDefinitionResourceRequirements().withDefault(new ResourceRequirements().withCpuRequest("2")));
     final StandardSourceDefinition standardSourceDefinition2 = new StandardSourceDefinition()
         .withSourceDefinitionId(SOURCE_DEFINITION_ID_2)
@@ -174,6 +176,8 @@ public class MockData {
         .withIcon("icon-3")
         .withSpec(connectorSpecification)
         .withTombstone(false)
+        .withPublic(true)
+        .withCustom(false)
         .withResourceRequirements(new ActorDefinitionResourceRequirements().withDefault(new ResourceRequirements().withCpuRequest("2")));
     final StandardDestinationDefinition standardDestinationDefinition2 = new StandardDestinationDefinition()
         .withDestinationDefinitionId(DESTINATION_DEFINITION_ID_2)

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/MockData.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/MockData.java
@@ -129,9 +129,8 @@ public class MockData {
     return Arrays.asList(workspace1, workspace2, workspace3);
   }
 
-  public static List<StandardSourceDefinition> standardSourceDefinitions() {
-    final ConnectorSpecification connectorSpecification = connectorSpecification();
-    final StandardSourceDefinition standardSourceDefinition1 = new StandardSourceDefinition()
+  public static StandardSourceDefinition publicSourceDefinition() {
+    return new StandardSourceDefinition()
         .withSourceDefinitionId(SOURCE_DEFINITION_ID_1)
         .withSourceType(SourceType.API)
         .withName("random-source-1")
@@ -139,12 +138,15 @@ public class MockData {
         .withDockerRepository("repository-1")
         .withDocumentationUrl("documentation-url-1")
         .withIcon("icon-1")
-        .withSpec(connectorSpecification)
+        .withSpec(connectorSpecification())
         .withTombstone(false)
         .withPublic(true)
         .withCustom(false)
         .withResourceRequirements(new ActorDefinitionResourceRequirements().withDefault(new ResourceRequirements().withCpuRequest("2")));
-    final StandardSourceDefinition standardSourceDefinition2 = new StandardSourceDefinition()
+  }
+
+  public static StandardSourceDefinition grantableSourceDefinition1() {
+    return new StandardSourceDefinition()
         .withSourceDefinitionId(SOURCE_DEFINITION_ID_2)
         .withSourceType(SourceType.DATABASE)
         .withName("random-source-2")
@@ -155,7 +157,10 @@ public class MockData {
         .withTombstone(false)
         .withPublic(false)
         .withCustom(false);
-    final StandardSourceDefinition standardSourceDefinition3 = new StandardSourceDefinition()
+  }
+
+  public static StandardSourceDefinition grantableSourceDefinition2() {
+    return new StandardSourceDefinition()
         .withSourceDefinitionId(SOURCE_DEFINITION_ID_3)
         .withSourceType(SourceType.DATABASE)
         .withName("random-source-3")
@@ -166,7 +171,10 @@ public class MockData {
         .withTombstone(false)
         .withPublic(false)
         .withCustom(false);
-    final StandardSourceDefinition standardSourceDefinition4 = new StandardSourceDefinition()
+  }
+
+  public static StandardSourceDefinition customSourceDefinition() {
+    return new StandardSourceDefinition()
         .withSourceDefinitionId(SOURCE_DEFINITION_ID_4)
         .withSourceType(SourceType.DATABASE)
         .withName("random-source-4")
@@ -177,7 +185,14 @@ public class MockData {
         .withTombstone(false)
         .withPublic(false)
         .withCustom(true);
-    return Arrays.asList(standardSourceDefinition1, standardSourceDefinition2, standardSourceDefinition3, standardSourceDefinition4);
+  }
+
+  public static List<StandardSourceDefinition> standardSourceDefinitions() {
+    return Arrays.asList(
+        publicSourceDefinition(),
+        grantableSourceDefinition1(),
+        grantableSourceDefinition2(),
+        customSourceDefinition());
   }
 
   private static ConnectorSpecification connectorSpecification() {
@@ -193,55 +208,69 @@ public class MockData {
         .withSupportsNormalization(true);
   }
 
-  public static List<StandardDestinationDefinition> standardDestinationDefinitions() {
-    final ConnectorSpecification connectorSpecification = connectorSpecification();
-    final StandardDestinationDefinition standardDestinationDefinition1 = new StandardDestinationDefinition()
+  public static StandardDestinationDefinition publicDestinationDefinition() {
+    return new StandardDestinationDefinition()
         .withDestinationDefinitionId(DESTINATION_DEFINITION_ID_1)
         .withName("random-destination-1")
         .withDockerImageTag("tag-3")
         .withDockerRepository("repository-3")
         .withDocumentationUrl("documentation-url-3")
         .withIcon("icon-3")
-        .withSpec(connectorSpecification)
+        .withSpec(connectorSpecification())
         .withTombstone(false)
         .withPublic(true)
         .withCustom(false)
         .withResourceRequirements(new ActorDefinitionResourceRequirements().withDefault(new ResourceRequirements().withCpuRequest("2")));
-    final StandardDestinationDefinition standardDestinationDefinition2 = new StandardDestinationDefinition()
+  }
+
+  public static StandardDestinationDefinition grantableDestinationDefinition1() {
+    return new StandardDestinationDefinition()
         .withDestinationDefinitionId(DESTINATION_DEFINITION_ID_2)
         .withName("random-destination-2")
         .withDockerImageTag("tag-4")
         .withDockerRepository("repository-4")
         .withDocumentationUrl("documentation-url-4")
         .withIcon("icon-4")
-        .withSpec(connectorSpecification)
+        .withSpec(connectorSpecification())
         .withTombstone(false)
         .withPublic(false)
         .withCustom(false);
-    final StandardDestinationDefinition standardDestinationDefinition3 = new StandardDestinationDefinition()
+  }
+
+  public static StandardDestinationDefinition grantableDestinationDefinition2() {
+    return new StandardDestinationDefinition()
         .withDestinationDefinitionId(DESTINATION_DEFINITION_ID_3)
         .withName("random-destination-3")
         .withDockerImageTag("tag-33")
         .withDockerRepository("repository-33")
         .withDocumentationUrl("documentation-url-33")
         .withIcon("icon-3")
-        .withSpec(connectorSpecification)
+        .withSpec(connectorSpecification())
         .withTombstone(false)
         .withPublic(false)
         .withCustom(false);
-    final StandardDestinationDefinition standardDestinationDefinition4 = new StandardDestinationDefinition()
+  }
+
+  public static StandardDestinationDefinition cusstomDestinationDefinition() {
+    return new StandardDestinationDefinition()
         .withDestinationDefinitionId(DESTINATION_DEFINITION_ID_4)
         .withName("random-destination-4")
         .withDockerImageTag("tag-44")
         .withDockerRepository("repository-44")
         .withDocumentationUrl("documentation-url-44")
         .withIcon("icon-4")
-        .withSpec(connectorSpecification)
+        .withSpec(connectorSpecification())
         .withTombstone(false)
         .withPublic(false)
         .withCustom(true);
-    return Arrays.asList(standardDestinationDefinition1, standardDestinationDefinition2, standardDestinationDefinition3,
-        standardDestinationDefinition4);
+  }
+
+  public static List<StandardDestinationDefinition> standardDestinationDefinitions() {
+    return Arrays.asList(
+        publicDestinationDefinition(),
+        grantableDestinationDefinition1(),
+        grantableDestinationDefinition2(),
+        cusstomDestinationDefinition());
   }
 
   public static List<SourceConnection> sourceConnections() {

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -321,7 +321,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
 
   @Override
   public SourceDefinitionReadList listSourceDefinitionsForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody) {
-    return null;
+    return execute(() -> sourceDefinitionsHandler.listSourceDefinitionsForWorkspace(workspaceIdRequestBody));
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -508,7 +508,7 @@ public class ConfigurationApi implements io.airbyte.api.V1Api {
 
   @Override
   public DestinationDefinitionReadList listDestinationDefinitionsForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody) {
-    return null;
+    return execute(() -> destinationDefinitionsHandler.listDestinationDefinitionsForWorkspace(workspaceIdRequestBody));
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -14,8 +14,10 @@ import io.airbyte.api.model.DestinationDefinitionReadList;
 import io.airbyte.api.model.DestinationDefinitionUpdate;
 import io.airbyte.api.model.DestinationRead;
 import io.airbyte.api.model.ReleaseStage;
+import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.commons.util.MoreLists;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -122,6 +124,14 @@ public class DestinationDefinitionsHandler {
     } catch (final InterruptedException e) {
       throw new InternalServerKnownException("Request to retrieve latest destination definitions failed", e);
     }
+  }
+
+  public DestinationDefinitionReadList listDestinationDefinitionsForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody)
+      throws IOException {
+    return toDestinationDefinitionReadList(MoreLists.concat(
+        configRepository.listPublicDestinationDefinitions(false),
+        configRepository.listGrantedDestinationDefinitions(
+            workspaceIdRequestBody.getWorkspaceId(), false)));
   }
 
   public DestinationDefinitionRead getDestinationDefinition(final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody)

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -130,8 +130,7 @@ public class DestinationDefinitionsHandler {
       throws IOException {
     return toDestinationDefinitionReadList(MoreLists.concat(
         configRepository.listPublicDestinationDefinitions(false),
-        configRepository.listGrantedDestinationDefinitions(
-            workspaceIdRequestBody.getWorkspaceId(), false)));
+        configRepository.listGrantedDestinationDefinitions(workspaceIdRequestBody.getWorkspaceId(), false)));
   }
 
   public DestinationDefinitionRead getDestinationDefinition(final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody)

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -14,8 +14,10 @@ import io.airbyte.api.model.SourceDefinitionRead;
 import io.airbyte.api.model.SourceDefinitionReadList;
 import io.airbyte.api.model.SourceDefinitionUpdate;
 import io.airbyte.api.model.SourceRead;
+import io.airbyte.api.model.WorkspaceIdRequestBody;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.commons.util.MoreLists;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -118,6 +120,14 @@ public class SourceDefinitionsHandler {
     } catch (final InterruptedException e) {
       throw new InternalServerKnownException("Request to retrieve latest destination definitions failed", e);
     }
+  }
+
+  public SourceDefinitionReadList listSourceDefinitionsForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody)
+      throws IOException {
+    return toSourceDefinitionReadList(MoreLists.concat(
+        configRepository.listPublicSourceDefinitions(false),
+        configRepository.listGrantedSourceDefinitions(
+            workspaceIdRequestBody.getWorkspaceId(), false)));
   }
 
   public SourceDefinitionRead getSourceDefinition(final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody)

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -126,8 +126,7 @@ public class SourceDefinitionsHandler {
       throws IOException {
     return toSourceDefinitionReadList(MoreLists.concat(
         configRepository.listPublicSourceDefinitions(false),
-        configRepository.listGrantedSourceDefinitions(
-            workspaceIdRequestBody.getWorkspaceId(), false)));
+        configRepository.listGrantedSourceDefinitions(workspaceIdRequestBody.getWorkspaceId(), false)));
   }
 
   public SourceDefinitionRead getSourceDefinition(final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody)


### PR DESCRIPTION
## What
Part of https://github.com/airbytehq/airbyte/issues/9652
[Tech Spec](https://docs.google.com/document/d/1KfJiTKZnBIUr1CFHUbi-8LjByRh03bheX6TQnuWlZyY/edit?usp=sharing)

Implements routes to list all actor definitions a given workspace is configured to use. Depends on https://github.com/airbytehq/airbyte/pull/11305

## Recommended reading order
Easiest to view by commit

## User Impact
Doesn't change the behavior of existing routes
