### PR TITLE
🐛 octavia-cli: fix write permissions in ubuntu

### DIFF
--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -90,7 +90,7 @@ We decided to package the CLI in a docker image with portability in mind.
 ### As a command available in your bash profile
 
 ```bash
-curl -o- https://raw.githubusercontent.com/airbytehq/airbyte/master/octavia-cli/install.sh | bash
+curl -s -o- https://raw.githubusercontent.com/airbytehq/airbyte/master/octavia-cli/install.sh | bash
 ```
 
 This script:
@@ -104,7 +104,7 @@ This script:
 ```bash
 touch ~/.octavia # Create a file to store env variables that will be mapped the octavia-cli container
 mkdir my_octavia_project_directory # Create your octavia project directory where YAML configurations will be stored.
-docker run --name octavia-cli -i --rm -v ./my_octavia_project_directory:/home/octavia-project --network host --env-file ~/.octavia airbyte/octavia-cli:latest
+docker run --name octavia-cli -i --rm -v ./my_octavia_project_directory:/home/octavia-project --network host  --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:latest
 ```
 
 ### Using `docker-compose`

--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -104,7 +104,7 @@ This script:
 ```bash
 touch ~/.octavia # Create a file to store env variables that will be mapped the octavia-cli container
 mkdir my_octavia_project_directory # Create your octavia project directory where YAML configurations will be stored.
-docker run --name octavia-cli -i --rm -v ./my_octavia_project_directory:/home/octavia-project --network host  --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:latest
+docker run --name octavia-cli -i --rm -v ./my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:latest
 ```
 
 ### Using `docker-compose`

--- a/octavia-cli/install.sh
+++ b/octavia-cli/install.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
 # This install scripts currently only works for ZSH and Bash profiles.
-# It creates an octavia alias in your profile bound to a docker run command
+# It creates an octavia alias in your profile bound to a docker run command and your current user.
 
 VERSION=0.1.0
 OCTAVIA_ENV_FILE=${HOME}/.octavia
+USER_ID=$(id -u)
+GROUP_ID=$(id -g)
 
 detect_profile() {
     if [ "${SHELL#*bash}" != "$SHELL" ]; then
@@ -55,7 +57,7 @@ create_octavia_env_file() {
 
 
 add_alias() {
-    echo 'alias octavia="pwd | xargs -o -I {} docker run -i --rm -v {}:/home/octavia-project --network host --env-file \${OCTAVIA_ENV_FILE} airbyte/octavia-cli:'${VERSION}'"'  >> ${DETECTED_PROFILE}
+    echo 'alias octavia="pwd | xargs -o -I {} docker run -i --rm -v {}:/home/octavia-project --network host --env-file \${OCTAVIA_ENV_FILE} --user \${USER_ID}:\${GROUP_ID} airbyte/octavia-cli:'${VERSION}'"'  >> ${DETECTED_PROFILE}
     echo "🐙 - 🎉 octavia alias was added to ${DETECTED_PROFILE}, please open a new terminal window or run source ${DETECTED_PROFILE}"
 }
 


### PR DESCRIPTION
## What
* The `octavia init` and `octavia generate` commands require write permissions to the docker host filesystem.
* Current aliased `docker run` command did not provide these permissions explicitly, it makes the `octavia init` command fails on Ubuntu with a `PermissionDenied`error.

## How
Map the current host user to the container using the `--user` option in the docker run command.

