### PR TITLE
🐛 octavia-cli: fix docker run instruction in README

### DIFF
--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -41,7 +41,7 @@ Feel free to share your use cases with the community in [#octavia-cli](https://a
 
 ## Workflow
 
-### 1. Generate local YAML files for sources or destination
+### 1. Generate local YAML files for sources or destinations
 
 1. Retrieve the *definition id* of the connector you want to use using `octavia list command`.
 2. Generate YAML configuration running `octavia generate source <DEFINITION_ID> <SOURCE_NAME>` or `octavia generate destination <DEFINITION_ID> <DESTINATION_NAME>`.
@@ -104,7 +104,7 @@ This script:
 ```bash
 touch ~/.octavia # Create a file to store env variables that will be mapped the octavia-cli container
 mkdir my_octavia_project_directory # Create your octavia project directory where YAML configurations will be stored.
-docker run --name octavia-cli -i --rm -v ./my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:latest
+docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:latest
 ```
 
 ### Using `docker-compose`


### PR DESCRIPTION
The volume path in the docker run example command is not valid and leads to the following error: 
```
Error response from daemon: create ./my_octavia_project_directory: "./my_octavia_project_directory" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
```

I remove `./` + fixed a typo in a workflow heading.