### PR TITLE
🐛 octavia-cli: improve alias in install.sh

### DIFF
--- a/octavia-cli/install.sh
+++ b/octavia-cli/install.sh
@@ -5,8 +5,6 @@
 
 VERSION=0.1.0
 OCTAVIA_ENV_FILE=${HOME}/.octavia
-USER_ID=$(id -u)
-GROUP_ID=$(id -g)
 
 detect_profile() {
     if [ "${SHELL#*bash}" != "$SHELL" ]; then
@@ -57,7 +55,7 @@ create_octavia_env_file() {
 
 
 add_alias() {
-    echo 'alias octavia="pwd | xargs -o -I {} docker run -i --rm -v {}:/home/octavia-project --network host --env-file \${OCTAVIA_ENV_FILE} --user \${USER_ID}:\${GROUP_ID} airbyte/octavia-cli:'${VERSION}'"'  >> ${DETECTED_PROFILE}
+    echo 'alias octavia="docker run -i --rm -v \$(pwd):/home/octavia-project --network host --env-file \${OCTAVIA_ENV_FILE} --user \$(id -u):\$(id -g) airbyte/octavia-cli:'${VERSION}'"'  >> ${DETECTED_PROFILE}
     echo "🐙 - 🎉 octavia alias was added to ${DETECTED_PROFILE}, please open a new terminal window or run source ${DETECTED_PROFILE}"
 }
 


### PR DESCRIPTION
## What
* Discard the use of `xargs` to get current folder -> use `\$(pwd)` to get current directory at runtime/
* `${USER_ID)` and `${GROUP_ID)` were undefined variable, use `\$(id -u)` and `\$(id -g)` to get user and group id at runtime.