### PR TITLE
Build FE on FE changes

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -334,7 +334,7 @@ jobs:
       - name: Build :airbyte-webapp
         run: SUB_BUILD=PLATFORM ./gradlew --no-daemon :airbyte-webapp:build --scan
   frontend-test:
-    name: "Frontend: Run end-to-end Test"
+    name: "Frontend: Run End-to-End Tests"
     needs: frontend-build # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-frontend-test-runner.outputs.label }} # run the job on the newly created runner
     timeout-minutes: 120

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -333,10 +333,39 @@ jobs:
     name: "Frontend: Run End-to-End Tests"
     needs:
       - start-frontend-runner # required to have runner started
-      - frontend-build # start only after the actual build has passed (to not run E2E tests and build in parallel)
     runs-on: ${{ needs.start-frontend-runner.outputs.label }} # run the job on the newly created runner
     timeout-minutes: 120
     steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v2
+
+      - name: Cache Build Artifacts
+        uses: ./.github/actions/cache-build-artifacts
+        with:
+          cache-key: ${{ secrets.CACHE_VERSION }}
+          cache-python: "false"
+
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "17"
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "16.13.0"
+
+      - name: Set up CI Gradle Properties
+        run: |
+          mkdir -p ~/.gradle/
+          cat > ~/.gradle/gradle.properties <<EOF
+          org.gradle.jvmargs=-Xmx8g -Xss4m --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+            --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          org.gradle.workers.max=8
+          org.gradle.vfs.watch=false
+          EOF
+
       - name: Build Platform Docker Images
         run: SUB_BUILD=PLATFORM ./gradlew --no-daemon assemble --scan
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -293,7 +293,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }}
   frontend-build:
-    name: "Frontend: Builds"
+    name: "Frontend: Build"
     needs: start-frontend-runner
     runs-on: ${{ needs.start-frontend-runner.outputs.label }}
     steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -271,7 +271,7 @@ jobs:
   ## Frontend Test
   # In case of self-hosted EC2 errors, remove this block.
   start-frontend-test-runner:
-    name: "Frontend: Start Test EC2 Runner"
+    name: "Frontend: Start EC2 Runner"
     needs: changes
     # Because scheduled builds on master require us to skip the changes job. Use always() to force this to run on master.
     if: |
@@ -292,11 +292,10 @@ jobs:
           aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }}
-  frontend-test:
-    name: "Frontend: Run Test"
-    needs: start-frontend-test-runner # required to start the main job when the runner is ready
-    runs-on: ${{ needs.start-frontend-test-runner.outputs.label }} # run the job on the newly created runner
-    timeout-minutes: 120
+  frontend-prepare:
+    name: "Frontend: Prepare build environment"
+    needs: start-frontend-test-runner
+    runs-on: ${{ needs.start-frontend-test-runner.outputs.label }}
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
@@ -327,7 +326,19 @@ jobs:
           org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
-
+  frontend-build:
+    name: "Frontend: Build"
+    needs: frontend-prepare # required to start the main job when the runner is ready
+    runs-on: ${{ needs.start-frontend-test-runner.outputs.label }}
+    steps:
+      - name: Build :airbyte-webapp
+        run: SUB_BUILD=PLATFORM ./gradlew --no-daemon :airbyte-webapp:build --scan
+  frontend-test:
+    name: "Frontend: Run end-to-end Test"
+    needs: frontend-prepare # required to start the main job when the runner is ready
+    runs-on: ${{ needs.start-frontend-test-runner.outputs.label }} # run the job on the newly created runner
+    timeout-minutes: 120
+    steps:
       - name: Build Platform Docker Images
         run: SUB_BUILD=PLATFORM ./gradlew --no-daemon assemble --scan
 
@@ -337,11 +348,13 @@ jobs:
         run: ./tools/bin/e2e_test.sh
   # In case of self-hosted EC2 errors, remove this block.
   stop-frontend-test-runner:
-    name: "Frontend: Stop Test Runner"
+    name: "Frontend: Stop Runner"
     timeout-minutes: 10
     needs:
       - start-frontend-test-runner # required to get output from the start-runner job
-      - frontend-test # required to wait when the main job is done
+      - frontend-prepare
+      - frontend-test # required to wait when the e2e-test job is done
+      - frontend-build # required to wait when then build job is done
     runs-on: ubuntu-latest
     # Always is required to stop the runner even if the previous job has errors. However always() runs even if the previous step is skipped.
     # Thus, we check for skipped here.

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -335,7 +335,7 @@ jobs:
         run: SUB_BUILD=PLATFORM ./gradlew --no-daemon :airbyte-webapp:build --scan
   frontend-test:
     name: "Frontend: Run end-to-end Test"
-    needs: frontend-prepare # required to start the main job when the runner is ready
+    needs: frontend-build # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-frontend-test-runner.outputs.label }} # run the job on the newly created runner
     timeout-minutes: 120
     steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -292,8 +292,8 @@ jobs:
           aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }}
-  frontend-prepare:
-    name: "Frontend: Prepare build environment"
+  frontend-build:
+    name: "Frontend: Builds"
     needs: start-frontend-runner
     runs-on: ${{ needs.start-frontend-runner.outputs.label }}
     steps:
@@ -326,13 +326,7 @@ jobs:
           org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
-  frontend-build:
-    name: "Frontend: Build"
-    needs: 
-      - start-frontend-runner # required to have runner started
-      - frontend-prepare # required to start the main job after preparation is done
-    runs-on: ${{ needs.start-frontend-runner.outputs.label }}
-    steps:
+
       - name: Build :airbyte-webapp
         run: SUB_BUILD=PLATFORM ./gradlew --no-daemon :airbyte-webapp:build --scan
   frontend-test:
@@ -356,7 +350,6 @@ jobs:
     timeout-minutes: 10
     needs:
       - start-frontend-runner # required to get output from the start-runner job
-      - frontend-prepare
       - frontend-test # required to wait when the e2e-test job is done
       - frontend-build # required to wait when then build job is done
     runs-on: ubuntu-latest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -270,7 +270,7 @@ jobs:
 
   ## Frontend Test
   # In case of self-hosted EC2 errors, remove this block.
-  start-frontend-test-runner:
+  start-frontend-runner:
     name: "Frontend: Start EC2 Runner"
     needs: changes
     # Because scheduled builds on master require us to skip the changes job. Use always() to force this to run on master.
@@ -294,8 +294,8 @@ jobs:
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }}
   frontend-prepare:
     name: "Frontend: Prepare build environment"
-    needs: start-frontend-test-runner
-    runs-on: ${{ needs.start-frontend-test-runner.outputs.label }}
+    needs: start-frontend-runner
+    runs-on: ${{ needs.start-frontend-runner.outputs.label }}
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
@@ -328,15 +328,19 @@ jobs:
           EOF
   frontend-build:
     name: "Frontend: Build"
-    needs: frontend-prepare # required to start the main job when the runner is ready
-    runs-on: ${{ needs.start-frontend-test-runner.outputs.label }}
+    needs: 
+      - start-frontend-runner # required to have runner started
+      - frontend-prepare # required to start the main job after preparation is done
+    runs-on: ${{ needs.start-frontend-runner.outputs.label }}
     steps:
       - name: Build :airbyte-webapp
         run: SUB_BUILD=PLATFORM ./gradlew --no-daemon :airbyte-webapp:build --scan
   frontend-test:
     name: "Frontend: Run End-to-End Tests"
-    needs: frontend-build # required to start the main job when the runner is ready
-    runs-on: ${{ needs.start-frontend-test-runner.outputs.label }} # run the job on the newly created runner
+    needs:
+      - start-frontend-runner # required to have runner started
+      - frontend-build # start only after the actual build has passed (to not run E2E tests and build in parallel)
+    runs-on: ${{ needs.start-frontend-runner.outputs.label }} # run the job on the newly created runner
     timeout-minutes: 120
     steps:
       - name: Build Platform Docker Images
@@ -347,18 +351,18 @@ jobs:
           CYPRESS_WEBAPP_KEY: ${{ secrets.CYPRESS_WEBAPP_KEY }}
         run: ./tools/bin/e2e_test.sh
   # In case of self-hosted EC2 errors, remove this block.
-  stop-frontend-test-runner:
+  stop-frontend-runner:
     name: "Frontend: Stop Runner"
     timeout-minutes: 10
     needs:
-      - start-frontend-test-runner # required to get output from the start-runner job
+      - start-frontend-runner # required to get output from the start-runner job
       - frontend-prepare
       - frontend-test # required to wait when the e2e-test job is done
       - frontend-build # required to wait when then build job is done
     runs-on: ubuntu-latest
     # Always is required to stop the runner even if the previous job has errors. However always() runs even if the previous step is skipped.
     # Thus, we check for skipped here.
-    if: ${{ always() && needs.start-frontend-test-runner.result != 'skipped'}}
+    if: ${{ always() && needs.start-frontend-runner.result != 'skipped'}}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -371,8 +375,8 @@ jobs:
         with:
           mode: stop
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }}
-          label: ${{ needs.start-frontend-test-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-frontend-test-runner.outputs.ec2-instance-id }}
+          label: ${{ needs.start-frontend-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-frontend-runner.outputs.ec2-instance-id }}
 
   ## FOLLOWING BUILDS ARE ALL PLATFORM BUILDS.
 


### PR DESCRIPTION
## What

Builds the :airbyte-webapp project (via gradle), when FE code changes. This was not happening since we split the builds and thus accidentally the FE unit tests (jest) was never running on any PR.