### PR TITLE
Fix ServiceForm cyclic dependency

### DIFF
--- a/airbyte-webapp/.storybook/preview.ts
+++ b/airbyte-webapp/.storybook/preview.ts
@@ -1,7 +1,9 @@
 import { addDecorator } from "@storybook/react";
 
 import { withProviders } from "./withProvider";
+import { MockDecorator } from "./restHooksDecorator";
 
 addDecorator(withProviders);
+addDecorator(MockDecorator);
 
 export const parameters = {};

--- a/airbyte-webapp/.storybook/restHooksDecorator.tsx
+++ b/airbyte-webapp/.storybook/restHooksDecorator.tsx
@@ -1,0 +1,26 @@
+import { Fixture, MockResolver } from "@rest-hooks/test";
+import { CacheProvider } from "@rest-hooks/core";
+import { Suspense } from "react";
+import { NetworkErrorBoundary } from "rest-hooks";
+
+import WorkspaceResource from "../src/core/resources/Workspace";
+
+const fixtures: Fixture[] = [
+  {
+    request: WorkspaceResource.detailShape(),
+    params: { workspaceId: undefined },
+    result: {
+      workspaceId: "story-book",
+    },
+  },
+];
+
+export const MockDecorator = (getStory) => (
+  <CacheProvider>
+    <Suspense fallback="loading">
+      <NetworkErrorBoundary>
+        <MockResolver fixtures={fixtures}>{getStory()}</MockResolver>
+      </NetworkErrorBoundary>
+    </Suspense>
+  </CacheProvider>
+);

--- a/airbyte-webapp/.storybook/withProvider.tsx
+++ b/airbyte-webapp/.storybook/withProvider.tsx
@@ -19,7 +19,9 @@ const AnalyticsContextMock: AnalyticsServiceProviderValue = ({
   setContext: () => {},
   addContextProps: () => {},
   removeContextProps: () => {},
-  service: {},
+  service: {
+    track: () => {},
+  },
 } as unknown) as AnalyticsServiceProviderValue;
 
 export const withProviders = (getStory) => (

--- a/airbyte-webapp/.storybook/withProvider.tsx
+++ b/airbyte-webapp/.storybook/withProvider.tsx
@@ -1,5 +1,4 @@
 import { MemoryRouter } from "react-router-dom";
-import * as React from "react";
 import { IntlProvider } from "react-intl";
 import { ThemeProvider } from "styled-components";
 
@@ -10,23 +9,34 @@ import messages from "../src/locales/en.json";
 import { FeatureService } from "../src/hooks/services/Feature";
 import { ConfigServiceProvider, defaultConfig } from "../src/config";
 import { ServicesProvider } from "../src/core/servicesProvider";
+import {
+  analyticsServiceContext,
+  AnalyticsServiceProviderValue,
+} from "../src/hooks/services/Analytics";
+
+const AnalyticsContextMock: AnalyticsServiceProviderValue = ({
+  analyticsContext: {},
+  setContext: () => {},
+  addContextProps: () => {},
+  removeContextProps: () => {},
+  service: {},
+} as unknown) as AnalyticsServiceProviderValue;
 
 export const withProviders = (getStory) => (
-  <ServicesProvider>
-    <MemoryRouter>
-      <IntlProvider messages={messages} locale={"en"}>
-        <ThemeProvider theme={theme}>
-          <ConfigServiceProvider
-            defaultConfig={defaultConfig}
-            providers={[]}
-          >
-            <FeatureService>
-              <GlobalStyle />
-              {getStory()}
-            </FeatureService>
-          </ConfigServiceProvider>
-        </ThemeProvider>
-      </IntlProvider>
-    </MemoryRouter>
-  </ServicesProvider>
+  <analyticsServiceContext.Provider value={AnalyticsContextMock}>
+    <ServicesProvider>
+      <MemoryRouter>
+        <IntlProvider messages={messages} locale={"en"}>
+          <ThemeProvider theme={theme}>
+            <ConfigServiceProvider defaultConfig={defaultConfig} providers={[]}>
+              <FeatureService>
+                <GlobalStyle />
+                {getStory()}
+              </FeatureService>
+            </ConfigServiceProvider>
+          </ThemeProvider>
+        </IntlProvider>
+      </MemoryRouter>
+    </ServicesProvider>
+  </analyticsServiceContext.Provider>
 );

--- a/airbyte-webapp/src/components/EntityTable/components/ConnectionSettingsCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/ConnectionSettingsCell.tsx
@@ -3,10 +3,10 @@ import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCog } from "@fortawesome/free-solid-svg-icons";
 
-import { RoutePaths } from "pages/routes";
 import { useCurrentWorkspace } from "hooks/services/useWorkspace";
 import { Link } from "components";
 import { ConnectionSettingsRoutes } from "pages/ConnectionPage/pages/ConnectionItemPage/ConnectionSettingsRoutes";
+import { RoutePaths } from "../../../pages/routePaths";
 
 type IProps = {
   id: string;

--- a/airbyte-webapp/src/hooks/services/Analytics/pageNameUtils.tsx
+++ b/airbyte-webapp/src/hooks/services/Analytics/pageNameUtils.tsx
@@ -1,5 +1,5 @@
-import { RoutePaths } from "pages/routes";
 import { SettingsRoute } from "pages/SettingsPage/SettingsPage";
+import { RoutePaths } from "../../../pages/routePaths";
 
 const getPageName = (pathname: string): string => {
   const itemSourcePageRegex = new RegExp(`${RoutePaths.Source}/.*`);

--- a/airbyte-webapp/src/hooks/services/Analytics/useAnalyticsService.tsx
+++ b/airbyte-webapp/src/hooks/services/Analytics/useAnalyticsService.tsx
@@ -13,7 +13,7 @@ export type AnalyticsServiceProviderValue = {
   service: AnalyticsService;
 };
 
-const analyticsServiceContext = React.createContext<AnalyticsServiceProviderValue | null>(
+export const analyticsServiceContext = React.createContext<AnalyticsServiceProviderValue | null>(
   null
 );
 

--- a/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
@@ -14,7 +14,6 @@ import ConnectionResource, {
   ScheduleProperties,
 } from "core/resources/Connection";
 import { SyncSchema } from "core/domain/catalog";
-import { RoutePaths } from "pages/routes";
 import useWorkspace from "./useWorkspace";
 import { Operation } from "core/domain/connection/operation";
 import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
@@ -24,6 +23,7 @@ import { RequestMiddleware } from "core/request/RequestMiddleware";
 
 import { equal } from "utils/objects";
 import { Destination, Source, SourceDefinition } from "core/domain/connector";
+import { RoutePaths } from "../../pages/routePaths";
 
 export type ValuesProps = {
   schedule: ScheduleProperties | null;

--- a/airbyte-webapp/src/hooks/services/useDestinationHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useDestinationHook.tsx
@@ -3,13 +3,13 @@ import { useFetcher, useResource } from "rest-hooks";
 
 import DestinationResource from "core/resources/Destination";
 import ConnectionResource, { Connection } from "core/resources/Connection";
-import { RoutePaths } from "pages/routes";
 import useRouter from "../useRouter";
 import SchedulerResource, { Scheduler } from "core/resources/Scheduler";
 import { ConnectionConfiguration } from "core/domain/connection";
 import useWorkspace from "./useWorkspace";
 import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
 import { Destination } from "core/domain/connector";
+import { RoutePaths } from "../../pages/routePaths";
 
 type ValuesProps = {
   name: string;

--- a/airbyte-webapp/src/hooks/services/useSourceHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useSourceHook.tsx
@@ -2,7 +2,6 @@ import { useCallback } from "react";
 import { useFetcher, useResource } from "rest-hooks";
 
 import SourceResource from "core/resources/Source";
-import { RoutePaths } from "pages/routes";
 import ConnectionResource, { Connection } from "core/resources/Connection";
 import SchedulerResource, { Scheduler } from "core/resources/Scheduler";
 import { ConnectionConfiguration } from "core/domain/connection";
@@ -11,6 +10,7 @@ import useWorkspace from "./useWorkspace";
 import useRouter from "hooks/useRouter";
 import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
 import { Source } from "core/domain/connector";
+import { RoutePaths } from "../../pages/routePaths";
 
 type ValuesProps = {
   name: string;

--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -31,11 +31,11 @@ import {
 } from "hooks/services/Analytics/useAnalyticsService";
 import { CloudSettingsPage } from "./views/settings/CloudSettingsPage";
 import { VerifyEmailAction } from "./views/FirebaseActionRoute";
-import { RoutePaths } from "pages/routes";
 import useRouter from "hooks/useRouter";
 import { storeUtmFromQuery } from "utils/utmStorage";
 import { DefaultView } from "./views/DefaultView";
 import { hasFromState } from "utils/stateUtils";
+import { RoutePaths } from "../../pages/routePaths";
 
 export const CloudRoutes = {
   Root: "/",

--- a/airbyte-webapp/src/packages/cloud/views/DefaultView.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/DefaultView.tsx
@@ -1,7 +1,7 @@
-import { RoutePaths } from "pages/routes";
 import { Navigate } from "react-router-dom";
 import { CloudRoutes } from "../cloudRoutes";
 import { useListCloudWorkspaces } from "../services/workspaces/WorkspacesService";
+import { RoutePaths } from "../../../pages/routePaths";
 
 export const DefaultView: React.FC = () => {
   const workspaces = useListCloudWorkspaces();

--- a/airbyte-webapp/src/packages/cloud/views/layout/SideBar/SideBar.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/layout/SideBar/SideBar.tsx
@@ -26,8 +26,8 @@ import ResourcesPopup, {
   Icon,
   Item,
 } from "views/layout/SideBar/components/ResourcesPopup";
-import { RoutePaths } from "pages/routes";
 import { FeatureItem, WithFeature } from "hooks/services/Feature";
+import { RoutePaths } from "../../../../../pages/routePaths";
 
 const CreditsIcon = styled(FontAwesomeIcon)`
   font-size: 21px;

--- a/airbyte-webapp/src/pages/ConnectionPage/ConnectionPage.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/ConnectionPage.tsx
@@ -3,13 +3,13 @@ import { Route, Routes } from "react-router-dom";
 
 import { LoadingPage } from "components";
 
-import { RoutePaths } from "../routes";
 import ConnectionItemPage from "./pages/ConnectionItemPage";
 import CreationFormPage from "./pages/CreationFormPage";
 import AllConnectionsPage from "./pages/AllConnectionsPage";
 
 import { StartOverErrorView } from "views/common/StartOverErrorView";
 import { ResourceNotFoundErrorBoundary } from "views/common/ResorceNotFoundErrorBoundary";
+import { RoutePaths } from "../routePaths";
 
 const ConnectionPage: React.FC = () => (
   <Suspense fallback={<LoadingPage />}>

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/AllConnectionsPage/AllConnectionsPage.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/AllConnectionsPage/AllConnectionsPage.tsx
@@ -5,11 +5,11 @@ import { useResource } from "rest-hooks";
 import { Button, MainPageWithScroll, PageTitle, LoadingPage } from "components";
 import ConnectionResource from "core/resources/Connection";
 import ConnectionsTable from "./components/ConnectionsTable";
-import { RoutePaths } from "pages/routes";
 import useRouter from "hooks/useRouter";
 import HeadTitle from "components/HeadTitle";
 import Placeholder, { ResourceTypes } from "components/Placeholder";
 import useWorkspace from "hooks/services/useWorkspace";
+import { RoutePaths } from "../../../routePaths";
 
 const AllConnectionsPage: React.FC = () => {
   const { push } = useRouter();

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ConnectionPageTitle.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ConnectionPageTitle.tsx
@@ -6,11 +6,11 @@ import { FormattedMessage } from "react-intl";
 
 import { Source, Destination } from "core/domain/connector/types";
 import { H6, Link } from "components";
-import { RoutePaths } from "pages/routes";
 import StepsMenu from "components/StepsMenu";
 import useRouter from "hooks/useRouter";
 
 import { ConnectionSettingsRoutes } from "../ConnectionSettingsRoutes";
+import { RoutePaths } from "../../../../routePaths";
 
 type IProps = {
   source: Source;

--- a/airbyte-webapp/src/pages/DestinationPage/DestinationPage.tsx
+++ b/airbyte-webapp/src/pages/DestinationPage/DestinationPage.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { Route, Routes } from "react-router-dom";
 
-import { RoutePaths } from "../routes";
 import AllDestinationsPage from "./pages/AllDestinationsPage";
 import DestinationItemPage from "./pages/DestinationItemPage";
 import CreateDestinationPage from "./pages/CreateDestinationPage";
 import CreationFormPage from "../ConnectionPage/pages/CreationFormPage";
 import { ResourceNotFoundErrorBoundary } from "views/common/ResorceNotFoundErrorBoundary";
 import { StartOverErrorView } from "views/common/StartOverErrorView";
+import { RoutePaths } from "../routePaths";
 
 const DestinationsPage: React.FC = () => {
   return (

--- a/airbyte-webapp/src/pages/DestinationPage/pages/AllDestinationsPage/AllDestinationsPage.tsx
+++ b/airbyte-webapp/src/pages/DestinationPage/pages/AllDestinationsPage/AllDestinationsPage.tsx
@@ -3,7 +3,6 @@ import { FormattedMessage } from "react-intl";
 import { useResource } from "rest-hooks";
 
 import { Button, MainPageWithScroll } from "components";
-import { RoutePaths } from "pages/routes";
 import PageTitle from "components/PageTitle";
 import useRouter from "hooks/useRouter";
 import DestinationsTable from "./components/DestinationsTable";
@@ -11,6 +10,7 @@ import DestinationResource from "core/resources/Destination";
 import HeadTitle from "components/HeadTitle";
 import Placeholder, { ResourceTypes } from "components/Placeholder";
 import useWorkspace from "hooks/services/useWorkspace";
+import { RoutePaths } from "../../../routePaths";
 
 const AllDestinationsPage: React.FC = () => {
   const { push } = useRouter();

--- a/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/DestinationItemPage.tsx
+++ b/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/DestinationItemPage.tsx
@@ -6,7 +6,6 @@ import PageTitle from "components/PageTitle";
 import useRouter from "hooks/useRouter";
 import Placeholder, { ResourceTypes } from "components/Placeholder";
 import ConnectionResource from "core/resources/Connection";
-import { RoutePaths } from "pages/routes";
 import Breadcrumbs from "components/Breadcrumbs";
 import DestinationConnectionTable from "./components/DestinationConnectionTable";
 import DestinationResource from "core/resources/Destination";
@@ -26,6 +25,7 @@ import SourceDefinitionResource from "core/resources/SourceDefinition";
 import HeadTitle from "components/HeadTitle";
 import useWorkspace from "hooks/services/useWorkspace";
 import { DropDownRow } from "components";
+import { RoutePaths } from "../../../routePaths";
 
 const DestinationItemPage: React.FC = () => {
   const { params, push } = useRouter<unknown, { id: string }>();

--- a/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/components/DestinationConnectionTable.tsx
+++ b/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/components/DestinationConnectionTable.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from "react";
 import { useResource } from "rest-hooks";
 
 import { ConnectionTable } from "components/EntityTable";
-import { RoutePaths } from "pages/routes";
 import useRouter from "hooks/useRouter";
 import { Connection } from "core/resources/Connection";
 import useSyncActions from "components/EntityTable/hooks";
@@ -11,6 +10,7 @@ import { ITableDataItem } from "components/EntityTable/types";
 import SourceDefinitionResource from "core/resources/SourceDefinition";
 import DestinationDefinitionResource from "core/resources/DestinationDefinition";
 import useWorkspace from "hooks/services/useWorkspace";
+import { RoutePaths } from "../../../../routePaths";
 
 type IProps = {
   connections: Connection[];

--- a/airbyte-webapp/src/pages/OnboardingPage/OnboardingPage.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/OnboardingPage.tsx
@@ -28,8 +28,8 @@ import StepsCounter from "./components/StepsCounter";
 import LoadingPage from "components/LoadingPage";
 import useWorkspace from "hooks/services/useWorkspace";
 import useRouterHook from "hooks/useRouter";
-import { RoutePaths } from "pages/routes";
 import { JobInfo } from "../../core/domain/job/Job";
+import { RoutePaths } from "../routePaths";
 
 const Content = styled.div<{ big?: boolean; medium?: boolean }>`
   width: 100%;

--- a/airbyte-webapp/src/pages/OnboardingPage/components/ProgressBlock.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/ProgressBlock.tsx
@@ -7,8 +7,8 @@ import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
 import { Connection } from "core/domain/connection";
 import Link from "components/Link";
 import { Button, H1 } from "components/base";
-import { RoutePaths } from "pages/routes";
 import Status from "core/statuses";
+import { RoutePaths } from "../../routePaths";
 
 const run = keyframes`
   from {

--- a/airbyte-webapp/src/pages/SettingsPage/pages/ConnectorsPage/components/CreateConnector.tsx
+++ b/airbyte-webapp/src/pages/SettingsPage/pages/ConnectorsPage/components/CreateConnector.tsx
@@ -5,11 +5,11 @@ import { useFetcher } from "rest-hooks";
 import { Button } from "components";
 import SourceDefinitionResource from "core/resources/SourceDefinition";
 import useRouter from "hooks/useRouter";
-import { RoutePaths } from "pages/routes";
 import DestinationDefinitionResource from "core/resources/DestinationDefinition";
 
 import CreateConnectorModal from "./CreateConnectorModal";
 import useWorkspace from "hooks/services/useWorkspace";
+import { RoutePaths } from "../../../../routePaths";
 
 type IProps = {
   type: string;

--- a/airbyte-webapp/src/pages/SourcesPage/SourcesPage.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/SourcesPage.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 
-import { RoutePaths } from "pages/routes";
 import AllSourcesPage from "./pages/AllSourcesPage";
 import CreateSourcePage from "./pages/CreateSourcePage";
 import SourceItemPage from "./pages/SourceItemPage";
 import CreationFormPage from "pages/ConnectionPage/pages/CreationFormPage";
 import { StartOverErrorView } from "views/common/StartOverErrorView";
 import { ResourceNotFoundErrorBoundary } from "views/common/ResorceNotFoundErrorBoundary";
+import { RoutePaths } from "../routePaths";
 
 const SourcesPage: React.FC = () => (
   <Routes>

--- a/airbyte-webapp/src/pages/SourcesPage/pages/AllSourcesPage/AllSourcesPage.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/AllSourcesPage/AllSourcesPage.tsx
@@ -3,7 +3,6 @@ import { FormattedMessage } from "react-intl";
 import { useResource } from "rest-hooks";
 
 import { Button, MainPageWithScroll } from "components";
-import { RoutePaths } from "pages/routes";
 import PageTitle from "components/PageTitle";
 import useRouter from "hooks/useRouter";
 import SourcesTable from "./components/SourcesTable";
@@ -11,6 +10,7 @@ import SourceResource from "core/resources/Source";
 import HeadTitle from "components/HeadTitle";
 import Placeholder, { ResourceTypes } from "components/Placeholder";
 import useWorkspace from "hooks/services/useWorkspace";
+import { RoutePaths } from "../../../routePaths";
 
 const AllSourcesPage: React.FC = () => {
   const { push } = useRouter();

--- a/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/SourceItemPage.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/SourceItemPage.tsx
@@ -2,7 +2,6 @@ import React, { Suspense, useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { useResource } from "rest-hooks";
 
-import { RoutePaths } from "pages/routes";
 import { DropDownRow, ImageBlock } from "components";
 import PageTitle from "components/PageTitle";
 import useRouter from "hooks/useRouter";
@@ -28,6 +27,7 @@ import { getIcon } from "utils/imageUtils";
 import HeadTitle from "components/HeadTitle";
 import Placeholder, { ResourceTypes } from "components/Placeholder";
 import useWorkspace from "hooks/services/useWorkspace";
+import { RoutePaths } from "../../../routePaths";
 
 const SourceItemPage: React.FC = () => {
   const { query, push } = useRouter<{ id: string }>();

--- a/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/components/SourceConnectionTable.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/components/SourceConnectionTable.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from "react";
 import { useResource } from "rest-hooks";
 
 import { ConnectionTable } from "components/EntityTable";
-import { RoutePaths } from "pages/routes";
 import useRouter from "hooks/useRouter";
 import { Connection } from "core/resources/Connection";
 import useSyncActions from "components/EntityTable/hooks";
@@ -11,6 +10,7 @@ import { ITableDataItem } from "components/EntityTable/types";
 import SourceDefinitionResource from "core/resources/SourceDefinition";
 import DestinationDefinitionResource from "core/resources/DestinationDefinition";
 import useWorkspace from "hooks/services/useWorkspace";
+import { RoutePaths } from "../../../../routePaths";
 
 type IProps = {
   connections: Connection[];

--- a/airbyte-webapp/src/pages/routePaths.tsx
+++ b/airbyte-webapp/src/pages/routePaths.tsx
@@ -1,0 +1,17 @@
+export enum RoutePaths {
+  AuthFlow = "/auth_flow",
+  Root = "/",
+
+  Workspaces = "workspaces",
+  Preferences = "preferences",
+  Onboarding = "onboarding",
+  Connections = "connections",
+  Destination = "destination",
+  Source = "source",
+  Settings = "settings",
+
+  Connection = "connection",
+  ConnectionNew = "new-connection",
+  SourceNew = "new-source",
+  DestinationNew = "new-destination",
+}

--- a/airbyte-webapp/src/pages/routes.tsx
+++ b/airbyte-webapp/src/pages/routes.tsx
@@ -1,8 +1,7 @@
 import React, { useMemo } from "react";
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useIntl } from "react-intl";
 import { useEffectOnce } from "react-use";
-import { useLocation } from "react-router-dom";
 
 import { useConfig } from "config";
 
@@ -27,24 +26,7 @@ import { OnboardingServiceProvider } from "hooks/services/Onboarding";
 import { useCurrentWorkspace } from "hooks/services/useWorkspace";
 import { Workspace } from "core/domain/workspace/Workspace";
 import { storeUtmFromQuery } from "utils/utmStorage";
-
-export enum RoutePaths {
-  AuthFlow = "/auth_flow",
-  Root = "/",
-
-  Workspaces = "workspaces",
-  Preferences = "preferences",
-  Onboarding = "onboarding",
-  Connections = "connections",
-  Destination = "destination",
-  Source = "source",
-  Settings = "settings",
-
-  Connection = "connection",
-  ConnectionNew = "new-connection",
-  SourceNew = "new-source",
-  DestinationNew = "new-destination",
-}
+import { RoutePaths } from "./routePaths";
 
 function useDemo() {
   const { formatMessage } = useIntl();

--- a/airbyte-webapp/src/services/workspaces/WorkspacesService.tsx
+++ b/airbyte-webapp/src/services/workspaces/WorkspacesService.tsx
@@ -5,7 +5,7 @@ import { useResetter, useResource } from "rest-hooks";
 import WorkspaceResource from "core/resources/Workspace";
 import useRouter from "hooks/useRouter";
 import { Workspace } from "core/domain/workspace/Workspace";
-import { RoutePaths } from "pages/routes";
+import { RoutePaths } from "../../pages/routePaths";
 
 type Context = {
   selectWorkspace: (workspaceId?: string | null | Workspace) => void;

--- a/airbyte-webapp/src/views/layout/SideBar/SideBar.tsx
+++ b/airbyte-webapp/src/views/layout/SideBar/SideBar.tsx
@@ -5,7 +5,6 @@ import { faRocket } from "@fortawesome/free-solid-svg-icons";
 import { FormattedMessage } from "react-intl";
 import { NavLink } from "react-router-dom";
 
-import { RoutePaths } from "pages/routes";
 import { useConfig } from "config";
 import { useCurrentWorkspace } from "hooks/services/useWorkspace";
 
@@ -20,6 +19,7 @@ import SettingsIcon from "./components/SettingsIcon";
 import SourceIcon from "./components/SourceIcon";
 import ResourcesPopup from "./components/ResourcesPopup";
 import { NotificationIndicator } from "./NotificationIndicator";
+import { RoutePaths } from "../../../pages/routePaths";
 
 const Bar = styled.nav`
   width: 100px;


### PR DESCRIPTION
## What
Fixes Cyclic dependency issue from Closes #10685
Also adds analytics context provider and mock provider for workspaceId that is now required to make `<ConnectorServiceTypeControl />` work properly.

## How
Add `restHooksDecorator` for StoryBook in `preview.tsx`.
Extract `RoutePaths` to separate file.
