### PR TITLE
🐙 octavia-cli: bump with same version as Airbyte

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -42,8 +42,6 @@ serialize =
 
 [bumpversion:file:kube/overlays/stable-with-resource-limits/kustomization.yaml]
 
-[bumpversion:file:octavia-cli/publish.sh]
-
 [bumpversion:file:octavia-cli/install.sh]
 
 [bumpversion:file:octavia-cli/README.md]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -45,3 +45,5 @@ serialize =
 [bumpversion:file:octavia-cli/install.sh]
 
 [bumpversion:file:octavia-cli/README.md]
+
+[bumpversion:file:octavia-cli/Dockerfile]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -41,3 +41,9 @@ serialize =
 [bumpversion:file:kube/overlays/stable-with-resource-limits/.env]
 
 [bumpversion:file:kube/overlays/stable-with-resource-limits/kustomization.yaml]
+
+[bumpversion:file:octavia-cli/publish.sh]
+
+[bumpversion:file:octavia-cli/install.sh]
+
+[bumpversion:file:octavia-cli/README.md]

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -124,6 +124,8 @@ jobs:
           SUB_BUILD=OCTAVIA_CLI ./gradlew :octavia-cli:build javadoc --scan
 
       - name: Publish
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: ./octavia-cli/publish.sh 0.1.1
 
       - name: Slack Notification - Failure

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -124,7 +124,7 @@ jobs:
           SUB_BUILD=OCTAVIA_CLI ./gradlew :octavia-cli:build javadoc --scan
 
       - name: Publish
-        run: ./octavia-cli/publish.sh
+        run: ./octavia-cli/publish.sh 0.1.1
 
       - name: Slack Notification - Failure
         if: failure() && github.ref == 'refs/heads/master'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -123,6 +123,9 @@ jobs:
         run: |
           SUB_BUILD=OCTAVIA_CLI ./gradlew :octavia-cli:build javadoc --scan
 
+      - name: Publish
+        run: ./octavia-cli/publish.sh
+
       - name: Slack Notification - Failure
         if: failure() && github.ref == 'refs/heads/master'
         uses: rtCamp/action-slack-notify@master

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -123,11 +123,6 @@ jobs:
         run: |
           SUB_BUILD=OCTAVIA_CLI ./gradlew :octavia-cli:build javadoc --scan
 
-      - name: Publish
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: ./octavia-cli/publish.sh 0.1.1
-
       - name: Slack Notification - Failure
         if: failure() && github.ref == 'refs/heads/master'
         uses: rtCamp/action-slack-notify@master

--- a/octavia-cli/Dockerfile
+++ b/octavia-cli/Dockerfile
@@ -14,3 +14,5 @@ USER octavia-cli
 WORKDIR /home/octavia-project
 ENTRYPOINT ["octavia"]
 
+LABEL io.airbyte.version=0.35.60-alpha
+LABEL io.airbyte.name=airbyte/octavia-cli

--- a/octavia-cli/Dockerfile
+++ b/octavia-cli/Dockerfile
@@ -14,5 +14,3 @@ USER octavia-cli
 WORKDIR /home/octavia-project
 ENTRYPOINT ["octavia"]
 
-LABEL io.airbyte.version=dev
-LABEL io.airbyte.name=airbyte/octavia-cli

--- a/octavia-cli/Dockerfile
+++ b/octavia-cli/Dockerfile
@@ -14,5 +14,5 @@ USER octavia-cli
 WORKDIR /home/octavia-project
 ENTRYPOINT ["octavia"]
 
-LABEL io.airbyte.version=0.35.60-alpha
+LABEL io.airbyte.version=0.35.61-alpha
 LABEL io.airbyte.name=airbyte/octavia-cli

--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -104,7 +104,7 @@ This script:
 ```bash
 touch ~/.octavia # Create a file to store env variables that will be mapped the octavia-cli container
 mkdir my_octavia_project_directory # Create your octavia project directory where YAML configurations will be stored.
-docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:latest
+docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:0.35.60-alpha
 ```
 
 ### Using `docker-compose`

--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -104,7 +104,7 @@ This script:
 ```bash
 touch ~/.octavia # Create a file to store env variables that will be mapped the octavia-cli container
 mkdir my_octavia_project_directory # Create your octavia project directory where YAML configurations will be stored.
-docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:0.35.60-alpha
+docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:0.35.61-alpha
 ```
 
 ### Using `docker-compose`
@@ -352,4 +352,4 @@ $ octavia apply
 
 | Version | Date       | Description      | PR                                                       |
 |---------|------------|------------------|----------------------------------------------------------|
-| 0.1.0   | 2022-04-07 | Alpha release    | [EPIC](https://github.com/airbytehq/airbyte/issues/10704)|
+| 0.35.61 | 2022-04-07 | Alpha release    | [EPIC](https://github.com/airbytehq/airbyte/issues/10704)|

--- a/octavia-cli/install.sh
+++ b/octavia-cli/install.sh
@@ -3,7 +3,7 @@
 # This install scripts currently only works for ZSH and Bash profiles.
 # It creates an octavia alias in your profile bound to a docker run command and your current user.
 
-VERSION=0.35.60-alpha
+VERSION=0.35.61-alpha
 OCTAVIA_ENV_FILE=${HOME}/.octavia
 
 detect_profile() {

--- a/octavia-cli/install.sh
+++ b/octavia-cli/install.sh
@@ -3,7 +3,7 @@
 # This install scripts currently only works for ZSH and Bash profiles.
 # It creates an octavia alias in your profile bound to a docker run command and your current user.
 
-VERSION=0.1.0
+VERSION=0.35.60-alpha
 OCTAVIA_ENV_FILE=${HOME}/.octavia
 
 detect_profile() {

--- a/octavia-cli/publish.sh
+++ b/octavia-cli/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ux
-VERSION=0.35.60-alpha
+VERSION=$1
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 docker buildx create --name octavia_builder > /dev/null 2>&1

--- a/octavia-cli/publish.sh
+++ b/octavia-cli/publish.sh
@@ -3,7 +3,8 @@
 set -ux
 VERSION=$1
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
+docker run --privileged --rm tonistiigi/binfmt --install all
+docker build --push --tag airbyte/octavia-cli:${VERSION} ${SCRIPT_DIR}
 docker buildx create --name octavia_builder > /dev/null 2>&1
 set -e
 docker buildx use octavia_builder

--- a/octavia-cli/publish.sh
+++ b/octavia-cli/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ux
-VERSION=$1
+VERSION=0.35.60-alpha
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 docker buildx create --name octavia_builder > /dev/null 2>&1

--- a/octavia-cli/publish.sh
+++ b/octavia-cli/publish.sh
@@ -3,12 +3,7 @@
 set -ux
 VERSION=$1
 
-if [[ -z "${DOCKER_PASSWORD}" ]]; then
-  echo 'DOCKER_PASSWORD for airbytebot not set.';
-  exit 1;
-fi
 docker login -u airbytebot -p "${DOCKER_PASSWORD}"
-
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 docker run --privileged --rm tonistiigi/binfmt --install all
 docker build --push --tag airbyte/octavia-cli:${VERSION} ${SCRIPT_DIR}

--- a/octavia-cli/publish.sh
+++ b/octavia-cli/publish.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-set -ux
+set -uxe
 VERSION=$1
-
-docker login -u airbytebot -p "${DOCKER_PASSWORD}"
+GIT_REVISION=$2
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-docker run --privileged --rm tonistiigi/binfmt --install all
-docker build --push --tag airbyte/octavia-cli:${VERSION} ${SCRIPT_DIR}
+
+docker run --privileged --rm tonistiigi/binfmt --install all # This installs the emulator to build multi-arch images
+set +e # Disable exit if the next command fails if the builder already exist.
 docker buildx create --name octavia_builder > /dev/null 2>&1
-set -e
+set -e # The previous command can fail safely if
 docker buildx use octavia_builder
 docker buildx inspect --bootstrap
-docker buildx build --push --tag airbyte/octavia-cli:${VERSION} --platform=linux/arm64,linux/amd64 ${SCRIPT_DIR}
+docker buildx build --push --tag airbyte/octavia-cli:${VERSION} --platform=linux/arm64,linux/amd64 --label "io.airbyte.git-revision=${GIT_REVISION}" ${SCRIPT_DIR}

--- a/octavia-cli/publish.sh
+++ b/octavia-cli/publish.sh
@@ -2,6 +2,13 @@
 
 set -ux
 VERSION=$1
+
+if [[ -z "${DOCKER_PASSWORD}" ]]; then
+  echo 'DOCKER_PASSWORD for airbytebot not set.';
+  exit 1;
+fi
+docker login -u airbytebot -p "${DOCKER_PASSWORD}"
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 docker run --privileged --rm tonistiigi/binfmt --install all
 docker build --push --tag airbyte/octavia-cli:${VERSION} ${SCRIPT_DIR}

--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -46,4 +46,4 @@ echo "Completed building and publishing..."
 # TODO alafanechere: does SUB_BUILD=OCTAVIA_CLI ./gradlew publish would work?
 echo "Build and publish octavia-cli..."
 VERSION=$NEW_VERSION SUB_BUILD=OCTAVIA_CLI ./gradlew clean build
-./octavia-cli/publish.sh
+./octavia-cli/publish.sh ${NEW_VERSION}

--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -43,7 +43,5 @@ SUB_BUILD=PLATFORM ./gradlew publish
 VERSION=$NEW_VERSION GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml push
 echo "Completed building and publishing..."
 
-# TODO alafanechere: does SUB_BUILD=OCTAVIA_CLI ./gradlew publish would work?
-echo "Build and publish octavia-cli..."
 VERSION=$NEW_VERSION SUB_BUILD=OCTAVIA_CLI ./gradlew clean build
-./octavia-cli/publish.sh ${NEW_VERSION}
+./octavia-cli/publish.sh ${NEW_VERSION} ${GIT_REVISION}

--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -42,3 +42,8 @@ VERSION=$NEW_VERSION SUB_BUILD=PLATFORM ./gradlew clean build
 SUB_BUILD=PLATFORM ./gradlew publish
 VERSION=$NEW_VERSION GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml push
 echo "Completed building and publishing..."
+
+# TODO alafanechere: does SUB_BUILD=OCTAVIA_CLI ./gradlew publish would work?
+echo "Build and publish octavia-cli..."
+VERSION=$NEW_VERSION SUB_BUILD=OCTAVIA_CLI ./gradlew clean build
+./octavia-cli/publish.sh


### PR DESCRIPTION
## What
Airbyte's API is the core dependency of `octavia-cli`.
As Airbyte API is versioned with the Airbyte platform we should version `octavia-cli` with the Airbyte platform to guarantee compatibility and avoid regressions.


## How
* Add octavia-cli version files to `.bumpversion.cfg`
* Update octavia-cli version to the latest Airbyte version
* Run the octavia-cli publish script from `release_version.sh`
