### PR TITLE
Increase runner timeout to 5 minutes from 2

### DIFF
--- a/.github/actions/start-aws-runner/action.yml
+++ b/.github/actions/start-aws-runner/action.yml
@@ -41,7 +41,7 @@ runs:
         aws-region: us-east-2
     - name: Start EC2 runner
       id: start-ec2-runner
-      uses: supertopher/ec2-github-runner@base64v1.0.5
+      uses: supertopher/ec2-github-runner@base64v1.0.6
       with:
         mode: start
         github-token: ${{ inputs.github-token }}

--- a/.github/workflows/gke-kube-test-command.yml
+++ b/.github/workflows/gke-kube-test-command.yml
@@ -134,7 +134,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.6
         with:
           mode: stop
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -286,7 +286,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.6
         with:
           mode: stop
           github-token: ${{ needs.find_valid_pat.outputs.pat }}
@@ -420,7 +420,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.6
         with:
           mode: stop
           github-token: ${{ secrets.AIRBYTEIO_PAT }}
@@ -564,7 +564,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.6
         with:
           mode: stop
           github-token: ${{ secrets.AIRBYTEIO_PAT }}
@@ -688,7 +688,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.6
         with:
           mode: stop
           github-token: ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }}
@@ -854,7 +854,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.6
         with:
           mode: stop
           github-token: ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }}
@@ -987,7 +987,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.6
         with:
           mode: stop
           github-token: ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }}

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -175,7 +175,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.6
         with:
           mode: stop
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/publish-external-command.yml
+++ b/.github/workflows/publish-external-command.yml
@@ -115,7 +115,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.6
         with:
           mode: stop
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/release-airbyte-os.yml
+++ b/.github/workflows/release-airbyte-os.yml
@@ -109,7 +109,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.6
         with:
           mode: stop
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -165,7 +165,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.6
         with:
           mode: stop
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -168,7 +168,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.6
         with:
           mode: stop
           github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}


### PR DESCRIPTION
seeing failing builds from 2 and we have higher API limits now

## What
Changes ec2 runner version to have a higher timeout

## How 
changes a `2` to an upside down 2: `5`