### PR TITLE
Adds valid PAT testing to existing ec2 pipes

### DIFF
--- a/.github/workflows/github-community-label-bot.yaml
+++ b/.github/workflows/github-community-label-bot.yaml
@@ -12,4 +12,4 @@ jobs:
       - uses: harshithmullapudi/label-actions@75686c2b3de17244526f10a22424f319d0bc134f
         with:
           github-token: ${{ secrets.OCTAVIA_PAT }}
-          github-username: ${{ secrets.LABEL_BOT_USERNAME }}
+          github-username: octavia-squidington-iii

--- a/.github/workflows/gke-kube-test-command.yml
+++ b/.github/workflows/gke-kube-test-command.yml
@@ -15,10 +15,29 @@ on:
         required: false
 
 jobs:
+  find_valid_pat:
+    name: "Find a PAT with room for actions"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    outputs:
+      pat: ${{ steps.variables.outputs.pat }}
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v2
+      - name: Check PAT rate limits
+        id: variables
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+             ${{ secrets.SUPERTOPHER_PAT }} \
+             ${{ secrets.AIRBYTEIO_PAT }} \
+             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }} \
+             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }} \
+             ${{ secrets.OCTAVIA_PAT }}
   start-gke-kube-acceptance-test-runner:
     timeout-minutes: 10
     name: Start GKE Kube Acceptance Test EC2 Runner
     runs-on: ubuntu-latest
+    needs: find_valid_pat
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -34,7 +53,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
+          github-token: ${{ needs.find_valid_pat.outputs.pat }}
   gke-kube-acceptance-test:
     # In case of self-hosted EC2 errors, removed the `needs` line and switch back to running on ubuntu-latest.
     needs: start-gke-kube-acceptance-test-runner # required to start the main job when the runner is ready
@@ -124,6 +143,7 @@ jobs:
     needs:
       - start-gke-kube-acceptance-test-runner # required to get output from the start-runner job
       - gke-kube-acceptance-test # required to wait when the main job is done
+      - find_valid_pat
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
@@ -137,6 +157,6 @@ jobs:
         uses: supertopher/ec2-github-runner@base64v1.0.5
         with:
           mode: stop
-          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
+          github-token: ${{ needs.find_valid_pat.outputs.pat }}
           label: ${{ needs.start-gke-kube-acceptance-test-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-gke-kube-acceptance-test-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/gke-kube-test-command.yml
+++ b/.github/workflows/gke-kube-test-command.yml
@@ -28,11 +28,10 @@ jobs:
         id: variables
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-             ${{ secrets.SUPERTOPHER_PAT }} \
-             ${{ secrets.AIRBYTEIO_PAT }} \
-             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }} \
-             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }} \
-             ${{ secrets.OCTAVIA_PAT }}
+            ${{ secrets.AIRBYTEIO_PAT }} \
+            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
+            ${{ secrets.SUPERTOPHER_PAT }} \
+            ${{ secrets.DAVINCHIA_PAT }}
   start-gke-kube-acceptance-test-runner:
     timeout-minutes: 10
     name: Start GKE Kube Acceptance Test EC2 Runner

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -75,11 +75,10 @@ jobs:
         id: variables
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-             ${{ secrets.SUPERTOPHER_PAT }} \
-             ${{ secrets.AIRBYTEIO_PAT }} \
-             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }} \
-             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }} \
-             ${{ secrets.OCTAVIA_PAT }}
+            ${{ secrets.AIRBYTEIO_PAT }} \
+            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
+            ${{ secrets.SUPERTOPHER_PAT }} \
+            ${{ secrets.DAVINCHIA_PAT }}
 
 
 

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -35,11 +35,10 @@ jobs:
         id: variables
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-             ${{ secrets.SUPERTOPHER_PAT }} \
-             ${{ secrets.AIRBYTEIO_PAT }} \
-             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }} \
-             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }} \
-             ${{ secrets.OCTAVIA_PAT }}
+            ${{ secrets.AIRBYTEIO_PAT }} \
+            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
+            ${{ secrets.SUPERTOPHER_PAT }} \
+            ${{ secrets.DAVINCHIA_PAT }}
   ## Gradle Build
   # In case of self-hosted EC2 errors, remove this block.
   start-publish-image-runner:

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -22,11 +22,30 @@ on:
         required: false
 
 jobs:
+  find_valid_pat:
+    name: "Find a PAT with room for actions"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    outputs:
+      pat: ${{ steps.variables.outputs.pat }}
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v2
+      - name: Check PAT rate limits
+        id: variables
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+             ${{ secrets.SUPERTOPHER_PAT }} \
+             ${{ secrets.AIRBYTEIO_PAT }} \
+             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }} \
+             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }} \
+             ${{ secrets.OCTAVIA_PAT }}
   ## Gradle Build
   # In case of self-hosted EC2 errors, remove this block.
   start-publish-image-runner:
     name: Start Build EC2 Runner
     runs-on: ubuntu-latest
+    needs: find_valid_pat
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -42,7 +61,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
+          github-token: ${{ needs.find_valid_pat.outputs.pat }}
           # 80 gb disk
           ec2-image-id: ami-0d648081937c75a73
   publish-image:
@@ -165,6 +184,7 @@ jobs:
     needs:
       - start-publish-image-runner # required to get output from the start-runner job
       - publish-image # required to wait when the main job is done
+      - find_valid_pat
     runs-on: ubuntu-latest
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
@@ -178,6 +198,6 @@ jobs:
         uses: supertopher/ec2-github-runner@base64v1.0.5
         with:
           mode: stop
-          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
+          github-token: ${{ needs.find_valid_pat.outputs.pat }}
           label: ${{ needs.start-publish-image-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-publish-image-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/publish-external-command.yml
+++ b/.github/workflows/publish-external-command.yml
@@ -21,6 +21,24 @@ on:
         default: master
 
 jobs:
+  find_valid_pat:
+    name: "Find a PAT with room for actions"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    outputs:
+      pat: ${{ steps.variables.outputs.pat }}
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v2
+      - name: Check PAT rate limits
+        id: variables
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+             ${{ secrets.SUPERTOPHER_PAT }} \
+             ${{ secrets.AIRBYTEIO_PAT }} \
+             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }} \
+             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }} \
+             ${{ secrets.OCTAVIA_PAT }}
   ## Gradle Build
   # In case of self-hosted EC2 errors, remove this block.
   start-publish-image-runner:
@@ -105,6 +123,7 @@ jobs:
     needs:
       - start-publish-image-runner # required to get output from the start-runner job
       - publish-image # required to wait when the main job is done
+      - find_valid_pat
     runs-on: ubuntu-latest
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
@@ -118,6 +137,6 @@ jobs:
         uses: supertopher/ec2-github-runner@base64v1.0.5
         with:
           mode: stop
-          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
+          github-token: ${{ needs.find_valid_pat.outputs.pat }}
           label: ${{ needs.start-publish-image-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-publish-image-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/publish-external-command.yml
+++ b/.github/workflows/publish-external-command.yml
@@ -34,11 +34,10 @@ jobs:
         id: variables
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-             ${{ secrets.SUPERTOPHER_PAT }} \
-             ${{ secrets.AIRBYTEIO_PAT }} \
-             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }} \
-             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }} \
-             ${{ secrets.OCTAVIA_PAT }}
+            ${{ secrets.AIRBYTEIO_PAT }} \
+            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
+            ${{ secrets.SUPERTOPHER_PAT }} \
+            ${{ secrets.DAVINCHIA_PAT }}
   ## Gradle Build
   # In case of self-hosted EC2 errors, remove this block.
   start-publish-image-runner:

--- a/.github/workflows/release-airbyte-os.yml
+++ b/.github/workflows/release-airbyte-os.yml
@@ -9,6 +9,24 @@ on:
         required: true
         default: "patch"
 jobs:
+  find_valid_pat:
+    name: "Find a PAT with room for actions"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    outputs:
+      pat: ${{ steps.variables.outputs.pat }}
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v2
+      - name: Check PAT rate limits
+        id: variables
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+             ${{ secrets.SUPERTOPHER_PAT }} \
+             ${{ secrets.AIRBYTEIO_PAT }} \
+             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }} \
+             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }} \
+             ${{ secrets.OCTAVIA_PAT }}
   # In case of self-hosted EC2 errors, remove this block.
   start-release-airbyte-runner:
     name: "Release Airbyte: Start EC2 Runner"
@@ -99,6 +117,7 @@ jobs:
     needs:
       - start-release-airbyte-runner # required to get output from the start-runner job
       - releaseAirbyte # required to wait when the main job is done
+      - find_valid_pat
     runs-on: ubuntu-latest
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
@@ -112,6 +131,6 @@ jobs:
         uses: supertopher/ec2-github-runner@base64v1.0.5
         with:
           mode: stop
-          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
+          github-token: ${{ needs.find_valid_pat.outputs.pat }}
           label: ${{ needs.start-release-airbyte-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-release-airbyte-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/release-airbyte-os.yml
+++ b/.github/workflows/release-airbyte-os.yml
@@ -22,11 +22,10 @@ jobs:
         id: variables
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-             ${{ secrets.SUPERTOPHER_PAT }} \
-             ${{ secrets.AIRBYTEIO_PAT }} \
-             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }} \
-             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }} \
-             ${{ secrets.OCTAVIA_PAT }}
+            ${{ secrets.AIRBYTEIO_PAT }} \
+            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
+            ${{ secrets.SUPERTOPHER_PAT }} \
+            ${{ secrets.DAVINCHIA_PAT }}
   # In case of self-hosted EC2 errors, remove this block.
   start-release-airbyte-runner:
     name: "Release Airbyte: Start EC2 Runner"

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -18,6 +18,24 @@ on:
         required: false
 
 jobs:
+  find_valid_pat:
+    name: "Find a PAT with room for actions"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    outputs:
+      pat: ${{ steps.variables.outputs.pat }}
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v2
+      - name: Check PAT rate limits
+        id: variables
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+             ${{ secrets.SUPERTOPHER_PAT }} \
+             ${{ secrets.AIRBYTEIO_PAT }} \
+             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }} \
+             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }} \
+             ${{ secrets.OCTAVIA_PAT }}
   start-test-runner:
     name: Start Build EC2 Runner
     timeout-minutes: 10
@@ -155,6 +173,7 @@ jobs:
     needs:
       - start-test-runner # required to get output from the start-runner job
       - integration-test # required to wait when the main job is done
+      - find_valid_pat
     runs-on: ubuntu-latest
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
@@ -168,6 +187,6 @@ jobs:
         uses: supertopher/ec2-github-runner@base64v1.0.5
         with:
           mode: stop
-          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
+          github-token: ${{ needs.find_valid_pat.outputs.pat }}
           label: ${{ needs.start-test-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-test-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -31,11 +31,10 @@ jobs:
         id: variables
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-             ${{ secrets.SUPERTOPHER_PAT }} \
-             ${{ secrets.AIRBYTEIO_PAT }} \
-             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }} \
-             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }} \
-             ${{ secrets.OCTAVIA_PAT }}
+            ${{ secrets.AIRBYTEIO_PAT }} \
+            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
+            ${{ secrets.SUPERTOPHER_PAT }} \
+            ${{ secrets.DAVINCHIA_PAT }}
   start-test-runner:
     name: Start Build EC2 Runner
     timeout-minutes: 10

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -24,6 +24,24 @@ on:
         required: false
 
 jobs:
+  find_valid_pat:
+    name: "Find a PAT with room for actions"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    outputs:
+      pat: ${{ steps.variables.outputs.pat }}
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v2
+      - name: Check PAT rate limits
+        id: variables
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+             ${{ secrets.SUPERTOPHER_PAT }} \
+             ${{ secrets.AIRBYTEIO_PAT }} \
+             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }} \
+             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }} \
+             ${{ secrets.OCTAVIA_PAT }}
   start-test-runner:
     name: Start Build EC2 Runner
     timeout-minutes: 10
@@ -158,6 +176,7 @@ jobs:
     needs:
       - start-test-runner # required to get output from the start-runner job
       - performance-test # required to wait when the main job is done
+      - find_valid_pat
     runs-on: ubuntu-latest
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
@@ -171,6 +190,6 @@ jobs:
         uses: supertopher/ec2-github-runner@base64v1.0.5
         with:
           mode: stop
-          github-token: ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }}
+          github-token: ${{ needs.find_valid_pat.outputs.pat }}
           label: ${{ needs.start-test-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-test-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -37,11 +37,10 @@ jobs:
         id: variables
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-             ${{ secrets.SUPERTOPHER_PAT }} \
-             ${{ secrets.AIRBYTEIO_PAT }} \
-             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN }} \
-             ${{ secrets.SELF_RUNNER_GITHUB_ACCESS_TOKEN_1 }} \
-             ${{ secrets.OCTAVIA_PAT }}
+            ${{ secrets.AIRBYTEIO_PAT }} \
+            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
+            ${{ secrets.SUPERTOPHER_PAT }} \
+            ${{ secrets.DAVINCHIA_PAT }}
   start-test-runner:
     name: Start Build EC2 Runner
     timeout-minutes: 10


### PR DESCRIPTION
adds the same workflow seen in gradle.yml to other pipelines

## What
grade.yml is running through PAT keys to check for valid keys.  lets do that elsewhere

## How
adds a need before GitHub token invoking the supertopher branch