### PR TITLE
Python: upgrade black 22.1.0 -> 22.3.0

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -87,7 +87,7 @@ class AirbytePythonPlugin implements Plugin<Project> {
             // flake8 doesn't support pyproject.toml files
             // and thus there is the wrapper "pyproject-flake8" for this
             pip 'pyproject-flake8:0.0.1a2'
-            pip 'black:22.1.0'
+            pip 'black:22.3.0'
             pip 'mypy:0.930'
             pip 'isort:5.6.4'
             pip 'pytest:6.1.2'


### PR DESCRIPTION
Signed-off-by: Sergey Chvalyuk <grubberr@gmail.com>

## What
After [click](https://pypi.org/project/click) has upgraded from 8.0.4 -> 8.1.0, [black](https://pypi.org/project/black) 22.1.0 started to fail

```
./gradlew :airbyte-integrations:connectors:source-amazon-ads:blackFormat

Traceback (most recent call last):
  File "/home/user/.pyenv/versions/3.7.9/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/user/.pyenv/versions/3.7.9/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/user/airbyte/airbyte-integrations/connectors/source-amazon-ads/.venv/lib/python3.7/site-packages/black/__main__.py", line 3, in <module>
    patched_main()
  File "src/black/__init__.py", line 1423, in patched_main
  File "src/black/__init__.py", line 1409, in patch_click
ImportError: cannot import name '_unicodefun' from 'click' (/home/user/airbyte/airbyte-integrations/connectors/source-amazon-ads/.venv/lib/python3.7/site-packages/click/__init__.py)
```
## How
We need to upgrade [black](https://pypi.org/project/black) to the latest version [22.3.0](https://pypi.org/project/black/22.3.0/)