### PR TITLE
Un-revert add /tmp emptyDir volume to connector pods

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -28,5 +28,5 @@ WORKDIR /airbyte
 ENV AIRBYTE_ENTRYPOINT "/airbyte/entrypoint.sh"
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.74
+LABEL io.airbyte.version=0.1.75
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template-clickhouse/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template-clickhouse/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template-clickhouse/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template-clickhouse/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template-mssql/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template-mssql/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template-mssql/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template-mssql/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template-mysql/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template-mysql/dbt_project.yml
@@ -4,13 +4,13 @@
 # Name your package! Package names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
-name: 'airbyte_utils'
-version: '1.0'
+name: "airbyte_utils"
+version: "1.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project. Profiles contain
 # database connection information, and should be configured in the  ~/.dbt/profiles.yml file
-profile: 'normalize'
+profile: "normalize"
 
 # These configurations specify where dbt should look for different types of files.
 # The `source-paths` config, for example, states that source models can be found
@@ -22,18 +22,18 @@ test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]
 
-target-path: "../build"  # directory which will store compiled SQL files
-log-path: "../logs"  # directory which will store DBT logs
-modules-path: "/tmp/dbt_modules"  # directory which will store external DBT dependencies
+target-path: "../build" # directory which will store compiled SQL files
+log-path: "../logs" # directory which will store DBT logs
+modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
-clean-targets:         # directories to be removed by `dbt clean`
-    - "build"
-    - "dbt_modules"
+clean-targets: # directories to be removed by `dbt clean`
+  - "build"
+  - "dbt_modules"
 
 quoting:
   database: true
-# Temporarily disabling the behavior of the ExtendedNameTransformer on table/schema names, see (issue #1785)
-# all schemas should be unquoted
+  # Temporarily disabling the behavior of the ExtendedNameTransformer on table/schema names, see (issue #1785)
+  # all schemas should be unquoted
   schema: false
   identifier: true
 
@@ -60,4 +60,4 @@ models:
         +materialized: view
 
 vars:
-  dbt_utils_dispatch_list: ['airbyte_utils']
+  dbt_utils_dispatch_list: ["airbyte_utils"]

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template-mysql/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template-mysql/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+modules-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template-oracle/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template-oracle/dbt_project.yml
@@ -4,13 +4,13 @@
 # Name your package! Package names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
-name: 'airbyte_utils'
-version: '1.0'
+name: "airbyte_utils"
+version: "1.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project. Profiles contain
 # database connection information, and should be configured in the  ~/.dbt/profiles.yml file
-profile: 'normalize'
+profile: "normalize"
 
 # These configurations specify where dbt should look for different types of files.
 # The `source-paths` config, for example, states that source models can be found
@@ -22,13 +22,13 @@ test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]
 
-target-path: "../build"  # directory which will store compiled SQL files
-log-path: "../logs"  # directory which will store DBT logs
-modules-path: "/tmp/dbt_modules"  # directory which will store external DBT dependencies
+target-path: "../build" # directory which will store compiled SQL files
+log-path: "../logs" # directory which will store DBT logs
+modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
-clean-targets:         # directories to be removed by `dbt clean`
-    - "build"
-    - "dbt_modules"
+clean-targets: # directories to be removed by `dbt clean`
+  - "build"
+  - "dbt_modules"
 
 quoting:
   database: false
@@ -58,4 +58,4 @@ models:
         +materialized: view
 
 vars:
-  dbt_utils_dispatch_list: ['airbyte_utils']
+  dbt_utils_dispatch_list: ["airbyte_utils"]

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template-oracle/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template-oracle/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+modules-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template-snowflake/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template-snowflake/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template-snowflake/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template-snowflake/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/dbt_integration_test.py
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/dbt_integration_test.py
@@ -420,7 +420,7 @@ class DbtIntegrationTest(object):
                 "-v",
                 f"{cwd}/logs:/logs",
                 "-v",
-                "/tmp:/tmp",
+                f"{cwd}/build/dbt_packages:/dbt",
                 "--network",
                 "host",
                 "--entrypoint",

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/bigquery/test_nested_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/bigquery/test_nested_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/bigquery/test_nested_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/bigquery/test_nested_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/bigquery/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/bigquery/test_simple_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/bigquery/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/bigquery/test_simple_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/bigquery/test_simple_streams/first_dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/bigquery/test_simple_streams/first_dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/bigquery/test_simple_streams/first_dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/bigquery/test_simple_streams/first_dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/dbt_project.yml
@@ -4,13 +4,13 @@
 # Name your package! Package names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
-name: 'airbyte_utils'
-version: '1.0'
+name: "airbyte_utils"
+version: "1.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project. Profiles contain
 # database connection information, and should be configured in the  ~/.dbt/profiles.yml file
-profile: 'normalize'
+profile: "normalize"
 
 # These configurations specify where dbt should look for different types of files.
 # The `source-paths` config, for example, states that source models can be found
@@ -22,18 +22,18 @@ test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]
 
-target-path: "../build"  # directory which will store compiled SQL files
-log-path: "../logs"  # directory which will store DBT logs
-modules-path: "/tmp/dbt_modules"  # directory which will store external DBT dependencies
+target-path: "../build" # directory which will store compiled SQL files
+log-path: "../logs" # directory which will store DBT logs
+modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
-clean-targets:         # directories to be removed by `dbt clean`
-    - "build"
-    - "dbt_modules"
+clean-targets: # directories to be removed by `dbt clean`
+  - "build"
+  - "dbt_modules"
 
 quoting:
   database: true
-# Temporarily disabling the behavior of the ExtendedNameTransformer on table/schema names, see (issue #1785)
-# all schemas should be unquoted
+  # Temporarily disabling the behavior of the ExtendedNameTransformer on table/schema names, see (issue #1785)
+  # all schemas should be unquoted
   schema: false
   identifier: true
 
@@ -61,4 +61,4 @@ models:
 
 dispatch:
   - macro_namespace: dbt_utils
-    search_order: ['airbyte_utils', 'dbt_utils']
+    search_order: ["airbyte_utils", "dbt_utils"]

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+modules-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/dbt_project.yml
@@ -13,18 +13,18 @@ config-version: 2
 profile: "normalize"
 
 # These configurations specify where dbt should look for different types of files.
-# The `source-paths` config, for example, states that source models can be found
+# The `model-paths` config, for example, states that source models can be found
 # in the "models/" directory. You probably won't need to change these!
-source-paths: ["models"]
+model-paths: ["models"]
 docs-paths: ["docs"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-modules-path: "/dbt" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"
@@ -37,7 +37,7 @@ quoting:
   schema: false
   identifier: true
 
-# You can define configurations for models in the `source-paths` directory here.
+# You can define configurations for models in the `model-paths` directory here.
 # Using these configurations, you can enable or disable models, change how they
 # are materialized, and more!
 models:

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/first_output/airbyte_tables/test_normalization/exchange_rate.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/first_output/airbyte_tables/test_normalization/exchange_rate.sql
@@ -16,15 +16,15 @@ with __dbt__cte__exchange_rate_ab1 as (
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema
 -- depends_on: test_normalization._airbyte_raw_exchange_rate
 select
-    JSONExtractRaw(_airbyte_data, 'id') as id,
-    JSONExtractRaw(_airbyte_data, 'currency') as currency,
-    JSONExtractRaw(_airbyte_data, 'date') as date,
-    JSONExtractRaw(_airbyte_data, 'timestamp_col') as timestamp_col,
-    JSONExtractRaw(_airbyte_data, 'HKD@spéçiäl & characters') as "HKD@spéçiäl & characters",
-    JSONExtractRaw(_airbyte_data, 'HKD_special___characters') as HKD_special___characters,
-    JSONExtractRaw(_airbyte_data, 'NZD') as NZD,
-    JSONExtractRaw(_airbyte_data, 'USD') as USD,
-    JSONExtractRaw(_airbyte_data, 'column`_''with\"_quotes') as "column`_'with""_quotes",
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'id') as id,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'currency') as currency,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'date') as date,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'timestamp_col') as timestamp_col,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'HKD@spéçiäl & characters') as "HKD@spéçiäl & characters",
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'HKD_special___characters') as HKD_special___characters,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'NZD') as NZD,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'USD') as USD,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'column`_''with\"_quotes') as "column`_'with""_quotes",
     _airbyte_ab_id,
     _airbyte_emitted_at,
     now() as _airbyte_normalized_at

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/first_output/airbyte_views/test_normalization/dedup_exchange_rate_stg.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/first_output/airbyte_views/test_normalization/dedup_exchange_rate_stg.sql
@@ -9,14 +9,14 @@ with __dbt__cte__dedup_exchange_rate_ab1 as (
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema
 -- depends_on: test_normalization._airbyte_raw_dedup_exchange_rate
 select
-    JSONExtractRaw(_airbyte_data, 'id') as id,
-    JSONExtractRaw(_airbyte_data, 'currency') as currency,
-    JSONExtractRaw(_airbyte_data, 'date') as date,
-    JSONExtractRaw(_airbyte_data, 'timestamp_col') as timestamp_col,
-    JSONExtractRaw(_airbyte_data, 'HKD@spéçiäl & characters') as "HKD@spéçiäl & characters",
-    JSONExtractRaw(_airbyte_data, 'HKD_special___characters') as HKD_special___characters,
-    JSONExtractRaw(_airbyte_data, 'NZD') as NZD,
-    JSONExtractRaw(_airbyte_data, 'USD') as USD,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'id') as id,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'currency') as currency,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'date') as date,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'timestamp_col') as timestamp_col,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'HKD@spéçiäl & characters') as "HKD@spéçiäl & characters",
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'HKD_special___characters') as HKD_special___characters,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'NZD') as NZD,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'USD') as USD,
     _airbyte_ab_id,
     _airbyte_emitted_at,
     now() as _airbyte_normalized_at

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/first_output/airbyte_views/test_normalization/multiple_column_names_conflicts_stg.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/first_output/airbyte_views/test_normalization/multiple_column_names_conflicts_stg.sql
@@ -9,13 +9,13 @@ with __dbt__cte__multiple_column_names_conflicts_ab1 as (
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema
 -- depends_on: test_normalization._airbyte_raw_multiple_column_names_conflicts
 select
-    JSONExtractRaw(_airbyte_data, 'id') as id,
-    JSONExtractRaw(_airbyte_data, 'User Id') as "User Id",
-    JSONExtractRaw(_airbyte_data, 'user_id') as user_id,
-    JSONExtractRaw(_airbyte_data, 'User id') as "User id",
-    JSONExtractRaw(_airbyte_data, 'user id') as "user id",
-    JSONExtractRaw(_airbyte_data, 'User@Id') as "User@Id",
-    JSONExtractRaw(_airbyte_data, 'UserId') as UserId,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'id') as id,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'User Id') as "User Id",
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'user_id') as user_id,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'User id') as "User id",
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'user id') as "user id",
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'User@Id') as "User@Id",
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'UserId') as UserId,
     _airbyte_ab_id,
     _airbyte_emitted_at,
     now() as _airbyte_normalized_at

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/second_output/airbyte_tables/test_normalization/exchange_rate.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/second_output/airbyte_tables/test_normalization/exchange_rate.sql
@@ -16,15 +16,15 @@ with __dbt__cte__exchange_rate_ab1 as (
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema
 -- depends_on: test_normalization._airbyte_raw_exchange_rate
 select
-    JSONExtractRaw(_airbyte_data, 'id') as id,
-    JSONExtractRaw(_airbyte_data, 'currency') as currency,
-    JSONExtractRaw(_airbyte_data, 'date') as date,
-    JSONExtractRaw(_airbyte_data, 'timestamp_col') as timestamp_col,
-    JSONExtractRaw(_airbyte_data, 'HKD@spéçiäl & characters') as "HKD@spéçiäl & characters",
-    JSONExtractRaw(_airbyte_data, 'HKD_special___characters') as HKD_special___characters,
-    JSONExtractRaw(_airbyte_data, 'NZD') as NZD,
-    JSONExtractRaw(_airbyte_data, 'USD') as USD,
-    JSONExtractRaw(_airbyte_data, 'column`_''with\"_quotes') as "column`_'with""_quotes",
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'id') as id,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'currency') as currency,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'date') as date,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'timestamp_col') as timestamp_col,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'HKD@spéçiäl & characters') as "HKD@spéçiäl & characters",
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'HKD_special___characters') as HKD_special___characters,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'NZD') as NZD,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'USD') as USD,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'column`_''with\"_quotes') as "column`_'with""_quotes",
     _airbyte_ab_id,
     _airbyte_emitted_at,
     now() as _airbyte_normalized_at

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/second_output/airbyte_views/test_normalization/dedup_exchange_rate_stg.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/clickhouse/test_simple_streams/second_output/airbyte_views/test_normalization/dedup_exchange_rate_stg.sql
@@ -9,14 +9,14 @@ with __dbt__cte__dedup_exchange_rate_ab1 as (
 -- SQL model to parse JSON blob stored in a single column and extract into separated field columns as described by the JSON Schema
 -- depends_on: test_normalization._airbyte_raw_dedup_exchange_rate
 select
-    JSONExtractRaw(_airbyte_data, 'id') as id,
-    JSONExtractRaw(_airbyte_data, 'currency') as currency,
-    JSONExtractRaw(_airbyte_data, 'date') as date,
-    JSONExtractRaw(_airbyte_data, 'timestamp_col') as timestamp_col,
-    JSONExtractRaw(_airbyte_data, 'HKD@spéçiäl & characters') as "HKD@spéçiäl & characters",
-    JSONExtractRaw(_airbyte_data, 'HKD_special___characters') as HKD_special___characters,
-    JSONExtractRaw(_airbyte_data, 'NZD') as NZD,
-    JSONExtractRaw(_airbyte_data, 'USD') as USD,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'id') as id,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'currency') as currency,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'date') as date,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'timestamp_col') as timestamp_col,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'HKD@spéçiäl & characters') as "HKD@spéçiäl & characters",
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'HKD_special___characters') as HKD_special___characters,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'NZD') as NZD,
+    JSONExtractRaw(assumeNotNull(_airbyte_data), 'USD') as USD,
     _airbyte_ab_id,
     _airbyte_emitted_at,
     now() as _airbyte_normalized_at

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/dbt_project.yml
@@ -4,13 +4,13 @@
 # Name your package! Package names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
-name: 'airbyte_utils'
-version: '1.0'
+name: "airbyte_utils"
+version: "1.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project. Profiles contain
 # database connection information, and should be configured in the  ~/.dbt/profiles.yml file
-profile: 'normalize'
+profile: "normalize"
 
 # These configurations specify where dbt should look for different types of files.
 # The `source-paths` config, for example, states that source models can be found
@@ -22,18 +22,18 @@ test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]
 
-target-path: "../build"  # directory which will store compiled SQL files
-log-path: "../logs"  # directory which will store DBT logs
-modules-path: "/tmp/dbt_modules"  # directory which will store external DBT dependencies
+target-path: "../build" # directory which will store compiled SQL files
+log-path: "../logs" # directory which will store DBT logs
+modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
-clean-targets:         # directories to be removed by `dbt clean`
-    - "build"
-    - "dbt_modules"
+clean-targets: # directories to be removed by `dbt clean`
+  - "build"
+  - "dbt_modules"
 
 quoting:
   database: true
-# Temporarily disabling the behavior of the ExtendedNameTransformer on table/schema names, see (issue #1785)
-# all schemas should be unquoted
+  # Temporarily disabling the behavior of the ExtendedNameTransformer on table/schema names, see (issue #1785)
+  # all schemas should be unquoted
   schema: false
   identifier: true
 
@@ -58,4 +58,4 @@ models:
         +materialized: view
 
 vars:
-  dbt_utils_dispatch_list: ['airbyte_utils']
+  dbt_utils_dispatch_list: ["airbyte_utils"]

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+modules-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/dbt_project.yml
@@ -13,18 +13,18 @@ config-version: 2
 profile: "normalize"
 
 # These configurations specify where dbt should look for different types of files.
-# The `source-paths` config, for example, states that source models can be found
+# The `model-paths` config, for example, states that source models can be found
 # in the "models/" directory. You probably won't need to change these!
-source-paths: ["models"]
+model-paths: ["models"]
 docs-paths: ["docs"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-modules-path: "/dbt" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"
@@ -37,7 +37,7 @@ quoting:
   schema: false
   identifier: true
 
-# You can define configurations for models in the `source-paths` directory here.
+# You can define configurations for models in the `model-paths` directory here.
 # Using these configurations, you can enable or disable models, change how they
 # are materialized, and more!
 models:

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/second_output/airbyte_incremental/scd/test_normalization/nested_stream_with_co__lting_into_long_names_scd.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/second_output/airbyte_incremental/scd/test_normalization/nested_stream_with_co__lting_into_long_names_scd.sql
@@ -1,14 +1,17 @@
 
-      delete
-    from "test_normalization".test_normalization."nested_stream_with_co__lting_into_long_names_scd"
+      
+  
+    delete from "test_normalization".test_normalization."nested_stream_with_co__lting_into_long_names_scd"
     where (_airbyte_unique_key_scd) in (
         select (_airbyte_unique_key_scd)
         from "test_normalization".test_normalization."#nested_stream_with_co__lting_into_long_names_scd__dbt_tmp"
     );
+    
 
     insert into "test_normalization".test_normalization."nested_stream_with_co__lting_into_long_names_scd" ("_airbyte_unique_key", "_airbyte_unique_key_scd", "id", "date", "partition", "_airbyte_start_at", "_airbyte_end_at", "_airbyte_active_row", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_nested_strea__nto_long_names_hashid")
     (
-       select "_airbyte_unique_key", "_airbyte_unique_key_scd", "id", "date", "partition", "_airbyte_start_at", "_airbyte_end_at", "_airbyte_active_row", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_nested_strea__nto_long_names_hashid"
-       from "test_normalization".test_normalization."#nested_stream_with_co__lting_into_long_names_scd__dbt_tmp"
+        select "_airbyte_unique_key", "_airbyte_unique_key_scd", "id", "date", "partition", "_airbyte_start_at", "_airbyte_end_at", "_airbyte_active_row", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_nested_strea__nto_long_names_hashid"
+        from "test_normalization".test_normalization."#nested_stream_with_co__lting_into_long_names_scd__dbt_tmp"
     );
+
   

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/second_output/airbyte_incremental/test_normalization/nested_stream_with_co___long_names_partition.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/second_output/airbyte_incremental/test_normalization/nested_stream_with_co___long_names_partition.sql
@@ -1,9 +1,11 @@
 
       
+  
 
     insert into "test_normalization".test_normalization."nested_stream_with_co___long_names_partition" ("_airbyte_nested_strea__nto_long_names_hashid", "double_array_data", "DATA", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_partition_hashid")
     (
-       select "_airbyte_nested_strea__nto_long_names_hashid", "double_array_data", "DATA", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_partition_hashid"
-       from "test_normalization".test_normalization."#nested_stream_with_co___long_names_partition__dbt_tmp"
+        select "_airbyte_nested_strea__nto_long_names_hashid", "double_array_data", "DATA", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_partition_hashid"
+        from "test_normalization".test_normalization."#nested_stream_with_co___long_names_partition__dbt_tmp"
     );
+
   

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/second_output/airbyte_incremental/test_normalization/nested_stream_with_co___names_partition_data.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/second_output/airbyte_incremental/test_normalization/nested_stream_with_co___names_partition_data.sql
@@ -1,9 +1,11 @@
 
       
+  
 
     insert into "test_normalization".test_normalization."nested_stream_with_co___names_partition_data" ("_airbyte_partition_hashid", "currency", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_data_hashid")
     (
-       select "_airbyte_partition_hashid", "currency", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_data_hashid"
-       from "test_normalization".test_normalization."#nested_stream_with_co___names_partition_data__dbt_tmp"
+        select "_airbyte_partition_hashid", "currency", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_data_hashid"
+        from "test_normalization".test_normalization."#nested_stream_with_co___names_partition_data__dbt_tmp"
     );
+
   

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/second_output/airbyte_incremental/test_normalization/nested_stream_with_co__ion_double_array_data.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/second_output/airbyte_incremental/test_normalization/nested_stream_with_co__ion_double_array_data.sql
@@ -1,9 +1,11 @@
 
       
+  
 
     insert into "test_normalization".test_normalization."nested_stream_with_co__ion_double_array_data" ("_airbyte_partition_hashid", "id", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_double_array_data_hashid")
     (
-       select "_airbyte_partition_hashid", "id", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_double_array_data_hashid"
-       from "test_normalization".test_normalization."#nested_stream_with_co__ion_double_array_data__dbt_tmp"
+        select "_airbyte_partition_hashid", "id", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_double_array_data_hashid"
+        from "test_normalization".test_normalization."#nested_stream_with_co__ion_double_array_data__dbt_tmp"
     );
+
   

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/second_output/airbyte_incremental/test_normalization/nested_stream_with_co__lting_into_long_names.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_nested_streams/second_output/airbyte_incremental/test_normalization/nested_stream_with_co__lting_into_long_names.sql
@@ -1,14 +1,17 @@
 
-      delete
-    from "test_normalization".test_normalization."nested_stream_with_co__lting_into_long_names"
+      
+  
+    delete from "test_normalization".test_normalization."nested_stream_with_co__lting_into_long_names"
     where (_airbyte_unique_key) in (
         select (_airbyte_unique_key)
         from "test_normalization".test_normalization."#nested_stream_with_co__lting_into_long_names__dbt_tmp"
     );
+    
 
     insert into "test_normalization".test_normalization."nested_stream_with_co__lting_into_long_names" ("_airbyte_unique_key", "id", "date", "partition", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_nested_strea__nto_long_names_hashid")
     (
-       select "_airbyte_unique_key", "id", "date", "partition", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_nested_strea__nto_long_names_hashid"
-       from "test_normalization".test_normalization."#nested_stream_with_co__lting_into_long_names__dbt_tmp"
+        select "_airbyte_unique_key", "id", "date", "partition", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_nested_strea__nto_long_names_hashid"
+        from "test_normalization".test_normalization."#nested_stream_with_co__lting_into_long_names__dbt_tmp"
     );
+
   

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_simple_streams/dbt_project.yml
@@ -4,13 +4,13 @@
 # Name your package! Package names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
-name: 'airbyte_utils'
-version: '1.0'
+name: "airbyte_utils"
+version: "1.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project. Profiles contain
 # database connection information, and should be configured in the  ~/.dbt/profiles.yml file
-profile: 'normalize'
+profile: "normalize"
 
 # These configurations specify where dbt should look for different types of files.
 # The `source-paths` config, for example, states that source models can be found
@@ -22,18 +22,18 @@ test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]
 
-target-path: "../build"  # directory which will store compiled SQL files
-log-path: "../logs"  # directory which will store DBT logs
-modules-path: "/tmp/dbt_modules"  # directory which will store external DBT dependencies
+target-path: "../build" # directory which will store compiled SQL files
+log-path: "../logs" # directory which will store DBT logs
+modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
-clean-targets:         # directories to be removed by `dbt clean`
-    - "build"
-    - "dbt_modules"
+clean-targets: # directories to be removed by `dbt clean`
+  - "build"
+  - "dbt_modules"
 
 quoting:
   database: true
-# Temporarily disabling the behavior of the ExtendedNameTransformer on table/schema names, see (issue #1785)
-# all schemas should be unquoted
+  # Temporarily disabling the behavior of the ExtendedNameTransformer on table/schema names, see (issue #1785)
+  # all schemas should be unquoted
   schema: false
   identifier: true
 
@@ -58,4 +58,4 @@ models:
         +materialized: view
 
 vars:
-  dbt_utils_dispatch_list: ['airbyte_utils']
+  dbt_utils_dispatch_list: ["airbyte_utils"]

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_simple_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+modules-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_simple_streams/dbt_project.yml
@@ -13,18 +13,18 @@ config-version: 2
 profile: "normalize"
 
 # These configurations specify where dbt should look for different types of files.
-# The `source-paths` config, for example, states that source models can be found
+# The `model-paths` config, for example, states that source models can be found
 # in the "models/" directory. You probably won't need to change these!
-source-paths: ["models"]
+model-paths: ["models"]
 docs-paths: ["docs"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-modules-path: "/dbt" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"
@@ -37,7 +37,7 @@ quoting:
   schema: false
   identifier: true
 
-# You can define configurations for models in the `source-paths` directory here.
+# You can define configurations for models in the `model-paths` directory here.
 # Using these configurations, you can enable or disable models, change how they
 # are materialized, and more!
 models:

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_simple_streams/second_output/airbyte_incremental/scd/test_normalization/dedup_exchange_rate_scd.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_simple_streams/second_output/airbyte_incremental/scd/test_normalization/dedup_exchange_rate_scd.sql
@@ -1,14 +1,17 @@
 
-      delete
-    from "test_normalization".test_normalization."dedup_exchange_rate_scd"
+      
+  
+    delete from "test_normalization".test_normalization."dedup_exchange_rate_scd"
     where (_airbyte_unique_key_scd) in (
         select (_airbyte_unique_key_scd)
         from "test_normalization".test_normalization."#dedup_exchange_rate_scd__dbt_tmp"
     );
+    
 
     insert into "test_normalization".test_normalization."dedup_exchange_rate_scd" ("_airbyte_unique_key", "_airbyte_unique_key_scd", "id", "currency", "date", "timestamp_col", "HKD@spéçiäl & characters", "hkd_special___characters", "nzd", "usd", "_airbyte_start_at", "_airbyte_end_at", "_airbyte_active_row", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_dedup_exchange_rate_hashid")
     (
-       select "_airbyte_unique_key", "_airbyte_unique_key_scd", "id", "currency", "date", "timestamp_col", "HKD@spéçiäl & characters", "hkd_special___characters", "nzd", "usd", "_airbyte_start_at", "_airbyte_end_at", "_airbyte_active_row", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_dedup_exchange_rate_hashid"
-       from "test_normalization".test_normalization."#dedup_exchange_rate_scd__dbt_tmp"
+        select "_airbyte_unique_key", "_airbyte_unique_key_scd", "id", "currency", "date", "timestamp_col", "HKD@spéçiäl & characters", "hkd_special___characters", "nzd", "usd", "_airbyte_start_at", "_airbyte_end_at", "_airbyte_active_row", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_dedup_exchange_rate_hashid"
+        from "test_normalization".test_normalization."#dedup_exchange_rate_scd__dbt_tmp"
     );
+
   

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_simple_streams/second_output/airbyte_incremental/test_normalization/dedup_exchange_rate.sql
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mssql/test_simple_streams/second_output/airbyte_incremental/test_normalization/dedup_exchange_rate.sql
@@ -1,14 +1,17 @@
 
-      delete
-    from "test_normalization".test_normalization."dedup_exchange_rate"
+      
+  
+    delete from "test_normalization".test_normalization."dedup_exchange_rate"
     where (_airbyte_unique_key) in (
         select (_airbyte_unique_key)
         from "test_normalization".test_normalization."#dedup_exchange_rate__dbt_tmp"
     );
+    
 
     insert into "test_normalization".test_normalization."dedup_exchange_rate" ("_airbyte_unique_key", "id", "currency", "date", "timestamp_col", "HKD@spéçiäl & characters", "hkd_special___characters", "nzd", "usd", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_dedup_exchange_rate_hashid")
     (
-       select "_airbyte_unique_key", "id", "currency", "date", "timestamp_col", "HKD@spéçiäl & characters", "hkd_special___characters", "nzd", "usd", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_dedup_exchange_rate_hashid"
-       from "test_normalization".test_normalization."#dedup_exchange_rate__dbt_tmp"
+        select "_airbyte_unique_key", "id", "currency", "date", "timestamp_col", "HKD@spéçiäl & characters", "hkd_special___characters", "nzd", "usd", "_airbyte_ab_id", "_airbyte_emitted_at", "_airbyte_normalized_at", "_airbyte_dedup_exchange_rate_hashid"
+        from "test_normalization".test_normalization."#dedup_exchange_rate__dbt_tmp"
     );
+
   

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mysql/test_nested_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mysql/test_nested_streams/dbt_project.yml
@@ -4,13 +4,13 @@
 # Name your package! Package names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
-name: 'airbyte_utils'
-version: '1.0'
+name: "airbyte_utils"
+version: "1.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project. Profiles contain
 # database connection information, and should be configured in the  ~/.dbt/profiles.yml file
-profile: 'normalize'
+profile: "normalize"
 
 # These configurations specify where dbt should look for different types of files.
 # The `source-paths` config, for example, states that source models can be found
@@ -22,18 +22,18 @@ test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]
 
-target-path: "../build"  # directory which will store compiled SQL files
-log-path: "../logs"  # directory which will store DBT logs
-modules-path: "/tmp/dbt_modules"  # directory which will store external DBT dependencies
+target-path: "../build" # directory which will store compiled SQL files
+log-path: "../logs" # directory which will store DBT logs
+modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
-clean-targets:         # directories to be removed by `dbt clean`
-    - "build"
-    - "dbt_modules"
+clean-targets: # directories to be removed by `dbt clean`
+  - "build"
+  - "dbt_modules"
 
 quoting:
   database: true
-# Temporarily disabling the behavior of the ExtendedNameTransformer on table/schema names, see (issue #1785)
-# all schemas should be unquoted
+  # Temporarily disabling the behavior of the ExtendedNameTransformer on table/schema names, see (issue #1785)
+  # all schemas should be unquoted
   schema: false
   identifier: true
 
@@ -60,4 +60,4 @@ models:
         +materialized: view
 
 vars:
-  dbt_utils_dispatch_list: ['airbyte_utils']
+  dbt_utils_dispatch_list: ["airbyte_utils"]

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mysql/test_nested_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mysql/test_nested_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+modules-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mysql/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mysql/test_simple_streams/dbt_project.yml
@@ -4,13 +4,13 @@
 # Name your package! Package names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
-name: 'airbyte_utils'
-version: '1.0'
+name: "airbyte_utils"
+version: "1.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project. Profiles contain
 # database connection information, and should be configured in the  ~/.dbt/profiles.yml file
-profile: 'normalize'
+profile: "normalize"
 
 # These configurations specify where dbt should look for different types of files.
 # The `source-paths` config, for example, states that source models can be found
@@ -22,18 +22,18 @@ test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]
 
-target-path: "../build"  # directory which will store compiled SQL files
-log-path: "../logs"  # directory which will store DBT logs
-modules-path: "/tmp/dbt_modules"  # directory which will store external DBT dependencies
+target-path: "../build" # directory which will store compiled SQL files
+log-path: "../logs" # directory which will store DBT logs
+modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
-clean-targets:         # directories to be removed by `dbt clean`
-    - "build"
-    - "dbt_modules"
+clean-targets: # directories to be removed by `dbt clean`
+  - "build"
+  - "dbt_modules"
 
 quoting:
   database: true
-# Temporarily disabling the behavior of the ExtendedNameTransformer on table/schema names, see (issue #1785)
-# all schemas should be unquoted
+  # Temporarily disabling the behavior of the ExtendedNameTransformer on table/schema names, see (issue #1785)
+  # all schemas should be unquoted
   schema: false
   identifier: true
 
@@ -60,4 +60,4 @@ models:
         +materialized: view
 
 vars:
-  dbt_utils_dispatch_list: ['airbyte_utils']
+  dbt_utils_dispatch_list: ["airbyte_utils"]

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mysql/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/mysql/test_simple_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+modules-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/oracle/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/oracle/test_simple_streams/dbt_project.yml
@@ -4,13 +4,13 @@
 # Name your package! Package names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
-name: 'airbyte_utils'
-version: '1.0'
+name: "airbyte_utils"
+version: "1.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project. Profiles contain
 # database connection information, and should be configured in the  ~/.dbt/profiles.yml file
-profile: 'normalize'
+profile: "normalize"
 
 # These configurations specify where dbt should look for different types of files.
 # The `source-paths` config, for example, states that source models can be found
@@ -22,13 +22,13 @@ test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]
 
-target-path: "../build"  # directory which will store compiled SQL files
-log-path: "../logs"  # directory which will store DBT logs
-modules-path: "/tmp/dbt_modules"  # directory which will store external DBT dependencies
+target-path: "../build" # directory which will store compiled SQL files
+log-path: "../logs" # directory which will store DBT logs
+modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
-clean-targets:         # directories to be removed by `dbt clean`
-    - "build"
-    - "dbt_modules"
+clean-targets: # directories to be removed by `dbt clean`
+  - "build"
+  - "dbt_modules"
 
 quoting:
   database: false
@@ -58,4 +58,4 @@ models:
         +materialized: view
 
 vars:
-  dbt_utils_dispatch_list: ['airbyte_utils']
+  dbt_utils_dispatch_list: ["airbyte_utils"]

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/oracle/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/oracle/test_simple_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-modules-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+modules-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/postgres/test_nested_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/postgres/test_nested_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/postgres/test_nested_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/postgres/test_nested_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/postgres/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/postgres/test_simple_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/postgres/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/postgres/test_simple_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/postgres/test_simple_streams/first_dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/postgres/test_simple_streams/first_dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/postgres/test_simple_streams/first_dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/postgres/test_simple_streams/first_dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/redshift/test_nested_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/redshift/test_nested_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/redshift/test_nested_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/redshift/test_nested_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/redshift/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/redshift/test_simple_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/redshift/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/redshift/test_simple_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/redshift/test_simple_streams/first_dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/redshift/test_simple_streams/first_dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/redshift/test_simple_streams/first_dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/redshift/test_simple_streams/first_dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/snowflake/test_nested_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/snowflake/test_nested_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/snowflake/test_nested_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/snowflake/test_nested_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/snowflake/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/snowflake/test_simple_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/snowflake/test_simple_streams/dbt_project.yml
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output/snowflake/test_simple_streams/dbt_project.yml
@@ -24,7 +24,7 @@ macro-paths: ["macros"]
 
 target-path: "../build" # directory which will store compiled SQL files
 log-path: "../logs" # directory which will store DBT logs
-packages-install-path: "/dbt-tmp/dbt_modules" # directory which will store external DBT dependencies
+packages-install-path: "/dbt" # directory which will store external DBT dependencies
 
 clean-targets: # directories to be removed by `dbt clean`
   - "build"

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 public class NormalizationRunnerFactory {
 
   public static final String BASE_NORMALIZATION_IMAGE_NAME = "airbyte/normalization";
-  public static final String NORMALIZATION_VERSION = "0.1.74";
+  public static final String NORMALIZATION_VERSION = "0.1.75";
 
   static final Map<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>> NORMALIZATION_MAPPING =
       ImmutableMap.<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>>builder()

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -114,6 +114,7 @@ public class KubePodProcess extends Process implements KubePod {
   private static final String STDOUT_PIPE_FILE = PIPES_DIR + "/stdout";
   private static final String STDERR_PIPE_FILE = PIPES_DIR + "/stderr";
   public static final String CONFIG_DIR = "/config";
+  public static final String TMP_DIR = "/tmp";
   private static final String TERMINATION_DIR = "/termination";
   private static final String TERMINATION_FILE_MAIN = TERMINATION_DIR + "/main";
   private static final String TERMINATION_FILE_CHECK = TERMINATION_DIR + "/check";
@@ -422,13 +423,24 @@ public class KubePodProcess extends Process implements KubePod {
         .withMountPath(TERMINATION_DIR)
         .build();
 
+    final Volume tmpVolume = new VolumeBuilder()
+        .withName("tmp")
+        .withNewEmptyDir()
+        .endEmptyDir()
+        .build();
+
+    final VolumeMount tmpVolumeMount = new VolumeMountBuilder()
+        .withName("tmp")
+        .withMountPath(TMP_DIR)
+        .build();
+
     final Container init = getInit(usesStdin, List.of(pipeVolumeMount, configVolumeMount), busyboxImage);
     final Container main = getMain(
         image,
         imagePullPolicy,
         usesStdin,
         entrypointOverride,
-        List.of(pipeVolumeMount, configVolumeMount, terminationVolumeMount),
+        List.of(pipeVolumeMount, configVolumeMount, terminationVolumeMount, tmpVolumeMount),
         resourceRequirements,
         internalToExternalPorts,
         envMap,
@@ -497,7 +509,7 @@ public class KubePodProcess extends Process implements KubePod {
         .withRestartPolicy("Never")
         .withInitContainers(init)
         .withContainers(containers)
-        .withVolumes(pipeVolume, configVolume, terminationVolume)
+        .withVolumes(pipeVolume, configVolume, terminationVolume, tmpVolume)
         .endSpec()
         .build();
 

--- a/docs/understanding-airbyte/basic-normalization.md
+++ b/docs/understanding-airbyte/basic-normalization.md
@@ -350,6 +350,7 @@ Therefore, in order to "upgrade" to the desired normalization version, you need 
 
 | Airbyte Version | Normalization Version | Date | Pull Request | Subject |
 |:----------------| :--- | :--- | :--- | :--- |
+| 0.35.65-alpha   | 0.1.74 | 2022-04-09 | [\#11511](https://github.com/airbytehq/airbyte/pull/11511) | Move DBT modules from `/tmp/dbt_modules` to `/dbt` |
 | 0.35.61-alpha   | 0.1.74 | 2022-03-24 | [\#10905](https://github.com/airbytehq/airbyte/pull/10905) | Update clickhouse dbt version |
 | 0.35.60-alpha   | 0.1.73 | 2022-03-25 | [\#11267](https://github.com/airbytehq/airbyte/pull/11267) | Set `--event-buffer-size` to reduce memory usage |
 | 0.35.59-alpha   | 0.1.72 | 2022-03-24 | [\#11093](https://github.com/airbytehq/airbyte/pull/11093) | Added Snowflake OAuth2.0 support |


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte/issues/11163

Context: in https://github.com/airbytehq/airbyte/pull/10761, a kube volume mount at `/tmp` was added for connector pods that need to write temporary data to disk. This was reverted because kube acceptance tests were consistently failing after this change. 

After some digging, I found that normalization was failing due to an empty `/tmp/dbt_modules` directory, and this made sense as the new volume mount at `/tmp` was clearly overwriting the compile-time dbt modules that were stored there.

Slack thread with some context/convo: https://airbytehq-team.slack.com/archives/C02TXQ020QM/p1648763773988619

## How
This PR updates our dbt project templates to store dbt_modules at `/dbt-tmp` instead of `/tmp` so that the volume mount no longer conflicts. It also un-reverts the original PR to re-introduce the `/tmp` volume mount.


## Misc Questions
- Is this the correct way to make a change to `base-normalization`? I'll need a `/publish` command at some point right? (I haven't ever had to use `publish` so this is the first time I'm running into this process).
