### PR TITLE
🐛  Source Google Ads: End date should not be in the future

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -266,7 +266,7 @@
 - name: Google Ads
   sourceDefinitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
   dockerRepository: airbyte/source-google-ads
-  dockerImageTag: 0.1.32
+  dockerImageTag: 0.1.33
   documentationUrl: https://docs.airbyte.io/integrations/sources/google-ads
   icon: google-adwords.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -2570,7 +2570,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-google-ads:0.1.32"
+- dockerImage: "airbyte/source-google-ads:0.1.33"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/google-ads"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-google-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-ads/Dockerfile
@@ -13,5 +13,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.32
+LABEL io.airbyte.version=0.1.33
 LABEL io.airbyte.name=airbyte/source-google-ads

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -11,7 +11,7 @@ from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from google.ads.googleads.errors import GoogleAdsException
-from pendulum import timezone
+from pendulum import parse, timezone, today
 from pendulum.tz.timezone import Timezone
 
 from .custom_query_stream import CustomQuery
@@ -51,12 +51,16 @@ class SourceGoogleAds(AbstractSource):
 
     @staticmethod
     def get_incremental_stream_config(google_api: GoogleAds, config: Mapping[str, Any], tz: Union[timezone, str] = "local"):
+        true_end_date = None
+        configured_end_date = config.get("end_date")
+        if configured_end_date is not None:
+            true_end_date = min(today(), parse(configured_end_date)).to_date_string()
         incremental_stream_config = dict(
             api=google_api,
             conversion_window_days=config["conversion_window_days"],
             start_date=config["start_date"],
             time_zone=tz,
-            end_date=config.get("end_date"),
+            end_date=true_end_date,
         )
         return incremental_stream_config
 

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
@@ -5,6 +5,7 @@
 import pytest
 from airbyte_cdk import AirbyteLogger
 from freezegun import freeze_time
+from pendulum import today
 from source_google_ads.custom_query_stream import CustomQuery
 from source_google_ads.google_ads import GoogleAds
 from source_google_ads.source import SourceGoogleAds
@@ -438,3 +439,11 @@ def test_check_connection_should_fail_when_api_call_fails(mocker):
     )
     assert not check_successful
     assert message.startswith("Unable to connect to Google Ads API with the provided credentials")
+
+
+def test_end_date_is_not_in_the_future():
+    source = SourceGoogleAds()
+    config = source.get_incremental_stream_config(
+        None, {"end_date": today().add(days=1).to_date_string(), "conversion_window_days": 14, "start_date": "2020-01-23"}
+    )
+    assert config.get("end_date") == today().to_date_string()

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -106,6 +106,7 @@ This source is constrained by whatever API limits are set for the Google Ads tha
 
 | Version  | Date       | Pull Request | Subject                                                                                      |
 |:---------|:-----------| :--- |:---------------------------------------------------------------------------------------------|
+| `0.1.33` | 2022-03-29 | [11513](https://github.com/airbytehq/airbyte/pull/11513) | When `end_date` is configured in the future, use today's date instead.                       |
 | `0.1.32` | 2022-03-24 | [11371](https://github.com/airbytehq/airbyte/pull/11371) | Improve how connection check returns error messages                                          |
 | `0.1.31` | 2022-03-23 | [11301](https://github.com/airbytehq/airbyte/pull/11301) | Update docs and spec to clarify usage                                                        |
 | `0.1.30` | 2022-03-23 | [11221](https://github.com/airbytehq/airbyte/pull/11221) | Add `*_labels` streams to fetch the label text rather than their IDs                         |


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/11508

If the end_date is configured in the future, just use today instead.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [x] Code reviews completed
- [x] Documentation updated
    - [x] Connector's `README.md`
    - [x] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [x] Create a non-forked branch based on this PR and test the below items on it
- [x] Build is successful
- [x] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [x] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [x] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [x] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [x] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

## Tests

<details><summary><strong>Unit</strong></summary>

```
---------- coverage: platform darwin, python 3.9.9-final-0 -----------
Name                                       Stmts   Miss  Cover
--------------------------------------------------------------
source_google_ads/__init__.py                  2      0   100%
source_google_ads/custom_query_stream.py      75      6    92%
source_google_ads/google_ads.py               68      7    90%
source_google_ads/source.py                   80      4    95%
source_google_ads/streams.py                 136     10    93%
--------------------------------------------------------------
TOTAL                                        361     27    93%
```

</details>