### PR TITLE
🐛  octavia-cli: rollback build and publish of octavia

### DIFF
--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -42,6 +42,3 @@ VERSION=$NEW_VERSION SUB_BUILD=PLATFORM ./gradlew clean build
 SUB_BUILD=PLATFORM ./gradlew publish
 VERSION=$NEW_VERSION GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml push
 echo "Completed building and publishing..."
-
-VERSION=$NEW_VERSION SUB_BUILD=OCTAVIA_CLI ./gradlew clean build
-./octavia-cli/publish.sh ${NEW_VERSION} ${GIT_REVISION}


### PR DESCRIPTION
## What
Do not publish octavia because the runner is not able to build it.
