### PR TITLE
Increase 2 minute timer to 5 minutes for ec2

### DIFF
--- a/.github/actions/start-aws-runner/action.yml
+++ b/.github/actions/start-aws-runner/action.yml
@@ -41,7 +41,7 @@ runs:
         aws-region: us-east-2
     - name: Start EC2 runner
       id: start-ec2-runner
-      uses: supertopher/ec2-github-runner@base64v1.0.5
+      uses: supertopher/ec2-github-runner@base64v1.0.10
       with:
         mode: start
         github-token: ${{ inputs.github-token }}

--- a/.github/workflows/gke-kube-test-command.yml
+++ b/.github/workflows/gke-kube-test-command.yml
@@ -153,7 +153,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
           mode: stop
           github-token: ${{ needs.find_valid_pat.outputs.pat }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -291,7 +291,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
           mode: stop
           github-token: ${{ needs.find_valid_pat.outputs.pat }}
@@ -425,7 +425,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
           mode: stop
           github-token: ${{ secrets.AIRBYTEIO_PAT }}
@@ -569,7 +569,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
           mode: stop
           github-token: ${{ secrets.AIRBYTEIO_PAT }}
@@ -693,7 +693,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
           mode: stop
           github-token: ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }}
@@ -859,7 +859,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
           mode: stop
           github-token: ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }}
@@ -992,7 +992,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
           mode: stop
           github-token: ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }}

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -194,7 +194,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
           mode: stop
           github-token: ${{ needs.find_valid_pat.outputs.pat }}

--- a/.github/workflows/publish-external-command.yml
+++ b/.github/workflows/publish-external-command.yml
@@ -133,7 +133,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
           mode: stop
           github-token: ${{ needs.find_valid_pat.outputs.pat }}

--- a/.github/workflows/release-airbyte-os.yml
+++ b/.github/workflows/release-airbyte-os.yml
@@ -127,7 +127,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
           mode: stop
           github-token: ${{ needs.find_valid_pat.outputs.pat }}

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -183,7 +183,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
           mode: stop
           github-token: ${{ needs.find_valid_pat.outputs.pat }}

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -186,7 +186,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Stop EC2 runner
-        uses: supertopher/ec2-github-runner@base64v1.0.5
+        uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
           mode: stop
           github-token: ${{ needs.find_valid_pat.outputs.pat }}


### PR DESCRIPTION
same intended commit as before, i didn't tag correctly before

## What
* we are missing some builds due to the timer and can afford some wasted actions
 ## How 
* Tags a build of ec2 runner with a higher timer