### PR TITLE
🎉 Source Orb: enrich credits ledger entries with cost basis data, description, and update expiration date fields

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -536,7 +536,7 @@
 - name: Orb
   sourceDefinitionId: 7f0455fb-4518-4ec0-b7a3-d808bf8081cc
   dockerRepository: airbyte/source-orb
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   documentationUrl: https://docs.airbyte.io/integrations/sources/orb
   icon: orb.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -5909,7 +5909,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-orb:0.1.1"
+- dockerImage: "airbyte/source-orb:0.1.2"
   spec:
     documentationUrl: "https://docs.withorb.com/"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-orb/Dockerfile
+++ b/airbyte-integrations/connectors/source-orb/Dockerfile
@@ -34,5 +34,5 @@ COPY source_orb ./source_orb
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/source-orb

--- a/airbyte-integrations/connectors/source-orb/integration_tests/catalog.json
+++ b/airbyte-integrations/connectors/source-orb/integration_tests/catalog.json
@@ -111,10 +111,6 @@
             "starting_balance": { "type": "number" },
             "ending_balance": { "type": "number" },
             "amount": { "type": ["null", "number"] },
-            "block_expiry_date": {
-              "type": ["null", "string"],
-              "format": "date-time"
-            },
             "created_at": { "type": ["null", "string"], "format": "date-time" },
             "entry_type": { "type": "string" },
             "expiry_date": {
@@ -130,6 +126,14 @@
               "properties": {
                 "id": { "type": "string" },
                 "external_customer_id": { "type": ["null", "string"] }
+              }
+            },
+            "credit_block": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "expiry_date": { "type": ["null", "string"] },
+                "per_unit_cost_basis": { "type": ["null", "string"] }
               }
             }
           }

--- a/airbyte-integrations/connectors/source-orb/source_orb/schemas/credits_ledger_entries.json
+++ b/airbyte-integrations/connectors/source-orb/source_orb/schemas/credits_ledger_entries.json
@@ -32,7 +32,7 @@
     "customer_id": {
       "type": "string"
     },
-    "per_unit_cost_basis": {
+    "credit_block_per_unit_cost_basis": {
       "type": ["null", "string"]
     },
     "description": {
@@ -47,7 +47,7 @@
     "created_at",
     "customer_id",
     "entry_type",
-    "per_unit_cost_basis",
+    "credit_block_per_unit_cost_basis",
     "description"
   ]
 }

--- a/airbyte-integrations/connectors/source-orb/source_orb/schemas/credits_ledger_entries.json
+++ b/airbyte-integrations/connectors/source-orb/source_orb/schemas/credits_ledger_entries.json
@@ -31,6 +31,12 @@
     },
     "customer_id": {
       "type": "string"
+    },
+    "per_unit_cost_basis": {
+      "type": ["null", "string"]
+    },
+    "description": {
+      "type": ["null", "string"]
     }
   },
   "required": [
@@ -40,6 +46,8 @@
     "amount",
     "created_at",
     "customer_id",
-    "entry_type"
+    "entry_type",
+    "per_unit_cost_basis",
+    "description"
   ]
 }

--- a/airbyte-integrations/connectors/source-orb/source_orb/source.py
+++ b/airbyte-integrations/connectors/source-orb/source_orb/source.py
@@ -235,6 +235,11 @@ class CreditsLedgerEntries(IncrementalOrbStream):
         Request params are based on the specific slice (i.e. customer_id) we are requesting for,
         and so we need to pull out relevant slice state from the stream state.
 
+        Ledger entries can either be `pending` or `committed`.
+        We're filtering to only return `committed` ledger entries, which are entries that are older than the
+        reporting grace period (12 hours) and are considered finalized.
+        `pending` entries can change during the reporting grace period, so we don't want to export those entries.
+
         Note that the user of super() here implies that the state for a specific slice of this stream
         is of the same format as the stream_state of a regular incremental stream.
         """
@@ -275,7 +280,7 @@ class CreditsLedgerEntries(IncrementalOrbStream):
         nested_per_unit_cost_basis = ledger_entry_record["credit_block"]["per_unit_cost_basis"]
         del ledger_entry_record["credit_block"]
         ledger_entry_record["block_expiry_date"] = nested_expiry_date
-        ledger_entry_record["per_unit_cost_basis"] = nested_per_unit_cost_basis
+        ledger_entry_record["credit_block_per_unit_cost_basis"] = nested_per_unit_cost_basis
 
         return ledger_entry_record
 

--- a/airbyte-integrations/connectors/source-orb/source_orb/source.py
+++ b/airbyte-integrations/connectors/source-orb/source_orb/source.py
@@ -326,7 +326,7 @@ class CreditsLedgerEntries(IncrementalOrbStream):
 
         # Prepare request with self._session, which should
         # automatically deal with the authentication header.
-        args = {"method": "POST", "url": self.url_base + "events", "params": {"limit": self.page_size}, "json": request_filter_json}
+        args = {"method": "POST", "url": self.url_base + "events", "params": {"limit": self.page_size, "entry_status": "committed"}, "json": request_filter_json}
         prepared_request = self._session.prepare_request(requests.Request(**args))
         events_response: requests.Response = self._session.send(prepared_request)
         # Error for invalid responses

--- a/airbyte-integrations/connectors/source-orb/source_orb/source.py
+++ b/airbyte-integrations/connectors/source-orb/source_orb/source.py
@@ -268,7 +268,7 @@ class CreditsLedgerEntries(IncrementalOrbStream):
         del ledger_entry_record["customer"]
         ledger_entry_record["customer_id"] = nested_customer_id
 
-        # Un-next credit_block -> expiry_date into block_expiry_date and per_unit_cost_basis
+        # Un-nest credit_block -> expiry_date into block_expiry_date and per_unit_cost_basis
         nested_expiry_date = ledger_entry_record["credit_block"]["expiry_date"]
         nested_per_unit_cost_basis = ledger_entry_record["credit_block"]["per_unit_cost_basis"]
         del ledger_entry_record["credit_block"]

--- a/airbyte-integrations/connectors/source-orb/source_orb/source.py
+++ b/airbyte-integrations/connectors/source-orb/source_orb/source.py
@@ -239,7 +239,9 @@ class CreditsLedgerEntries(IncrementalOrbStream):
         is of the same format as the stream_state of a regular incremental stream.
         """
         current_customer_state = stream_state.get(stream_slice["customer_id"], {})
-        return super().request_params(current_customer_state, **kwargs)
+        params = super().request_params(current_customer_state, **kwargs)
+        params["entry_status"] = "committed"
+        return params
 
     def path(self, stream_slice: Mapping[str, Any] = None, **kwargs):
         """
@@ -326,7 +328,7 @@ class CreditsLedgerEntries(IncrementalOrbStream):
 
         # Prepare request with self._session, which should
         # automatically deal with the authentication header.
-        args = {"method": "POST", "url": self.url_base + "events", "params": {"limit": self.page_size, "entry_status": "committed"}, "json": request_filter_json}
+        args = {"method": "POST", "url": self.url_base + "events", "params": {"limit": self.page_size}, "json": request_filter_json}
         prepared_request = self._session.prepare_request(requests.Request(**args))
         events_response: requests.Response = self._session.send(prepared_request)
         # Error for invalid responses

--- a/airbyte-integrations/connectors/source-orb/source_orb/source.py
+++ b/airbyte-integrations/connectors/source-orb/source_orb/source.py
@@ -268,6 +268,13 @@ class CreditsLedgerEntries(IncrementalOrbStream):
         del ledger_entry_record["customer"]
         ledger_entry_record["customer_id"] = nested_customer_id
 
+        # Un-next credit_block -> expiry_date into block_expiry_date and per_unit_cost_basis
+        nested_expiry_date = ledger_entry_record["credit_block"]["expiry_date"]
+        nested_per_unit_cost_basis = ledger_entry_record["credit_block"]["per_unit_cost_basis"]
+        del ledger_entry_record["credit_block"]
+        ledger_entry_record["block_expiry_date"] = nested_expiry_date
+        ledger_entry_record["per_unit_cost_basis"] = nested_per_unit_cost_basis
+
         return ledger_entry_record
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:

--- a/airbyte-integrations/connectors/source-orb/unit_tests/test_incremental_streams.py
+++ b/airbyte-integrations/connectors/source-orb/unit_tests/test_incremental_streams.py
@@ -160,7 +160,7 @@ def test_credits_ledger_entries_stream_slices(mocker):
 def test_credits_ledger_entries_request_params(mocker, current_stream_state, current_stream_slice, next_page_token):
     stream = CreditsLedgerEntries()
     inputs = {"stream_state": current_stream_state, "stream_slice": current_stream_slice, "next_page_token": next_page_token}
-    expected_params = dict(limit=CreditsLedgerEntries.page_size)
+    expected_params = dict(limit=CreditsLedgerEntries.page_size, entry_status="committed")
     current_slice_state = current_stream_state.get(current_stream_slice["customer_id"], {})
     if current_slice_state.get("created_at"):
         expected_params["created_at[gte]"] = current_slice_state["created_at"]

--- a/airbyte-integrations/connectors/source-orb/unit_tests/test_incremental_streams.py
+++ b/airbyte-integrations/connectors/source-orb/unit_tests/test_incremental_streams.py
@@ -178,20 +178,17 @@ def test_credits_ledger_entries_transform_record(mocker):
         "customer": {
             "id": "foo-customer-id",
         },
-        "credit_block": {
-            "expiry_date": "2023-01-25T12:00:00+00:00",
-            "per_unit_cost_basis": "2.50"
-        }
+        "credit_block": {"expiry_date": "2023-01-25T12:00:00+00:00", "per_unit_cost_basis": "2.50"},
     }
 
     # Validate that calling transform record unwraps nested customer and credit block fields.
     assert stream.transform_record(ledger_entry_record) == {
-            "event_id": "foo-event-id",
-            "entry_type": "decrement",
-            "customer_id": "foo-customer-id",
-            "block_expiry_date": "2023-01-25T12:00:00+00:00",
-            "credit_block_per_unit_cost_basis": "2.50"
-        }
+        "event_id": "foo-event-id",
+        "entry_type": "decrement",
+        "customer_id": "foo-customer-id",
+        "block_expiry_date": "2023-01-25T12:00:00+00:00",
+        "credit_block_per_unit_cost_basis": "2.50",
+    }
 
 
 @responses.activate

--- a/airbyte-integrations/connectors/source-orb/unit_tests/test_incremental_streams.py
+++ b/airbyte-integrations/connectors/source-orb/unit_tests/test_incremental_streams.py
@@ -170,6 +170,30 @@ def test_credits_ledger_entries_request_params(mocker, current_stream_state, cur
     assert stream.request_params(**inputs) == expected_params
 
 
+def test_credits_ledger_entries_transform_record(mocker):
+    stream = CreditsLedgerEntries()
+    ledger_entry_record = {
+        "event_id": "foo-event-id",
+        "entry_type": "decrement",
+        "customer": {
+            "id": "foo-customer-id",
+        },
+        "credit_block": {
+            "expiry_date": "2023-01-25T12:00:00+00:00",
+            "per_unit_cost_basis": "2.50"
+        }
+    }
+
+    # Validate that calling transform record unwraps nested customer and credit block fields.
+    assert stream.transform_record(ledger_entry_record) == {
+            "event_id": "foo-event-id",
+            "entry_type": "decrement",
+            "customer_id": "foo-customer-id",
+            "block_expiry_date": "2023-01-25T12:00:00+00:00",
+            "credit_block_per_unit_cost_basis": "2.50"
+        }
+
+
 @responses.activate
 def test_credits_ledger_entries_no_matching_events(mocker):
     stream = CreditsLedgerEntries(string_event_properties_keys=["ping"])

--- a/docs/integrations/sources/orb.md
+++ b/docs/integrations/sources/orb.md
@@ -52,7 +52,7 @@ an Orb Account and API Key.
 
 | Version | Date | Pull Request | Subject |
 | --- | --- | --- | --- |
-| 0.1.2 | 2022-03-30 | [10839](https://github.com/airbytehq/airbyte/pull/10839) | Add cost basis to ledger entries + update expiration date
+| 0.1.2 | 2022-03-30 | [11528](https://github.com/airbytehq/airbyte/pull/11528) | Add cost basis to ledger entries + update expiration date
 | 0.1.1 | 2022-03-03 | [10839](https://github.com/airbytehq/airbyte/pull/10839) | Support ledger entries with numeric properties + schema fixes
 | 0.1.0 | 2022-02-01 | | New Source: Orb
 | :--- | :--- | :--- | :--- |

--- a/docs/integrations/sources/orb.md
+++ b/docs/integrations/sources/orb.md
@@ -52,7 +52,7 @@ an Orb Account and API Key.
 
 | Version | Date | Pull Request | Subject |
 | --- | --- | --- | --- |
-| 0.1.2 | 2022-03-30 | [11528](https://github.com/airbytehq/airbyte/pull/11528) | Add cost basis to ledger entries + update expiration date
+| 0.1.2 | 2022-04-20 | [11528](https://github.com/airbytehq/airbyte/pull/11528) | Add cost basis to ledger entries, update expiration date, sync only committed entries
 | 0.1.1 | 2022-03-03 | [10839](https://github.com/airbytehq/airbyte/pull/10839) | Support ledger entries with numeric properties + schema fixes
 | 0.1.0 | 2022-02-01 | | New Source: Orb
 | :--- | :--- | :--- | :--- |

--- a/docs/integrations/sources/orb.md
+++ b/docs/integrations/sources/orb.md
@@ -51,6 +51,8 @@ an Orb Account and API Key.
 ## Changelog
 
 | Version | Date | Pull Request | Subject |
+| --- | --- | --- | --- |
+| 0.1.2 | 2022-03-30 | [10839](https://github.com/airbytehq/airbyte/pull/10839) | Add cost basis to ledger entries + update expiration date
 | 0.1.1 | 2022-03-03 | [10839](https://github.com/airbytehq/airbyte/pull/10839) | Support ledger entries with numeric properties + schema fixes
 | 0.1.0 | 2022-02-01 | | New Source: Orb
 | :--- | :--- | :--- | :--- |


### PR DESCRIPTION
## What
This PR enriches the Orb source connector's credits ledger entries with newly added cost basis data and description fields. 
We also pull the `block_expiry_date` from a serialized `credit_block` object now, instead of pulling it off the `credit_ledger_entry` object itself. 
We also filter to only return ledger entries that have a status of `committed`. 
 
## How
We've added the new cost basis and description fields to the underlying Orb API, and we now parse those fields in the connector. The Orb source API has also been updated to return `expiry_date` as part of a nested `credit_block` object, which we now unwrap and map to `block_expiry_date` in the connector.

The Orb source API has also been updated to filter ledger entries based on status.

## Recommended reading order
1. `credits_ledger_entries.json`
2. `source.py`
3. All remaining files

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

Changes are all additive, so do not expect any user impact.
## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the new connector version is published, connector version bumped in the seed directory as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

<img width="1920" alt="image" src="https://user-images.githubusercontent.com/13513422/160721053-2103c3ef-9cfa-422f-adf5-15aae9c3bc33.png">

</details>

<details><summary><strong>Acceptance</strong></summary>

<img width="1743" alt="image" src="https://user-images.githubusercontent.com/13513422/160720951-11713ecb-124c-4981-b263-9dc8fbf9dfbf.png">

</details>
