### PR TITLE
Add acceptance test for deleting connetion

### DIFF
--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1157,7 +1157,11 @@ public class AcceptanceTests {
   @DisabledIfEnvironmentVariable(named = "KUBE",
                                  matches = "true")
   public void testActionsWhenTemporalIsInTerminalState() throws Exception {
-    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService("airbyte-temporal:7233");
+    String temporalHost = "localhost:7233";
+    if (!USE_EXTERNAL_DEPLOYMENT) {
+      temporalHost = "airbyte-temporal:7233";
+    }
+    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService(temporalHost);
     final WorkflowClient workflowCLient = WorkflowClient.newInstance(temporalService);
 
     final String connectionName = "test-connection";

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1153,12 +1153,16 @@ public class AcceptanceTests {
   }
 
   @Test
-  @Order(-3)
+  @Order(22)
   @DisabledIfEnvironmentVariable(named = "KUBE",
                                  matches = "true")
-  @EnabledIfEnvironmentVariable(named = "NEW_SCHEDULER",
-                                matches = "true")
   public void testActionsWhenTemporalIsInTerminalState() throws Exception {
+    final FeatureFlags featureFlags = new EnvVariableFeatureFlags();
+    if (!featureFlags.usesNewScheduler()) {
+      LOGGER.info("Skipping test since not using new temporal scheduler");
+      return;
+    }
+
     final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService("localhost:7233");
     final WorkflowClient workflowCLient = WorkflowClient.newInstance(temporalService);
 

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1176,6 +1176,12 @@ public class AcceptanceTests {
 
     LOGGER.info("Waiting for connection to be available in Temporal...");
 
+    LOGGER.info("Run manual sync...");
+    final JobInfoRead connectionSyncRead = apiClient.getConnectionApi().syncConnection(new ConnectionIdRequestBody().connectionId(connectionId));
+
+    LOGGER.info("Waiting for job to run...");
+    waitWhileJobHasStatus(apiClient.getJobsApi(), connectionSyncRead.getJob(), Set.of(JobStatus.RUNNING));
+
     // Terminate workflow
     LOGGER.info("Terminating temporal workflow...");
     workflowCLient.newUntypedWorkflowStub("connection_manager_" + connectionId).terminate("");

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1153,6 +1153,8 @@ public class AcceptanceTests {
 
   @Test
   @Order(22)
+  @DisabledIfEnvironmentVariable(named = "KUBE",
+                                 matches = "true")
   public void testActionsWhenTemporalIsInTerminalState() throws Exception {
     final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService("localhost:7233");
     final WorkflowClient workflowCLient = WorkflowClient.newInstance(temporalService);

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1157,11 +1157,7 @@ public class AcceptanceTests {
   @DisabledIfEnvironmentVariable(named = "KUBE",
                                  matches = "true")
   public void testActionsWhenTemporalIsInTerminalState() throws Exception {
-    String temporalHost = "localhost:7233";
-    if (!USE_EXTERNAL_DEPLOYMENT) {
-      temporalHost = "airbyte-temporal:7233";
-    }
-    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService(temporalHost);
+    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService("localhost:7233");
     final WorkflowClient workflowCLient = WorkflowClient.newInstance(temporalService);
 
     final String connectionName = "test-connection";

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1156,11 +1156,7 @@ public class AcceptanceTests {
   @DisabledIfEnvironmentVariable(named = "KUBE",
                                  matches = "true")
   public void testActionsWhenTemporalIsInTerminalState() throws Exception {
-    String temporalHost = "localhost:7233";
-    if (!USE_EXTERNAL_DEPLOYMENT) {
-      temporalHost = "airbyte-temporal:7233";
-    }
-    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService(temporalHost);
+    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService("localhost:7233");
     final WorkflowClient workflowCLient = WorkflowClient.newInstance(temporalService);
 
     final String connectionName = "test-connection";
@@ -1177,6 +1173,8 @@ public class AcceptanceTests {
         .primaryKey(List.of(List.of(COLUMN_NAME))));
     final UUID connectionId =
         createConnection(connectionName, sourceId, destinationId, List.of(operationId), catalog, null).getConnectionId();
+
+    LOGGER.info("Waiting for connection to be available in Temporal...");
 
     // Terminate workflow
     LOGGER.info("Terminating temporal workflow...");

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1177,6 +1177,8 @@ public class AcceptanceTests {
         createConnection(connectionName, sourceId, destinationId, List.of(operationId), catalog, null).getConnectionId();
     waitForConnectionState(apiClient, connectionId);
 
+    Thread.sleep(5000);
+
     // check if temporal workflow is reachable
     final ConnectionManagerWorkflow connectionManagerWorkflow =
         workflowCLient.newWorkflowStub(ConnectionManagerWorkflow.class, "connection_manager_" + connectionId);

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1156,6 +1156,8 @@ public class AcceptanceTests {
   @Order(-3)
   @DisabledIfEnvironmentVariable(named = "KUBE",
                                  matches = "true")
+  @EnabledIfEnvironmentVariable(named = "NEW_SCHEDULER",
+                                matches = "true")
   public void testActionsWhenTemporalIsInTerminalState() throws Exception {
     final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService("localhost:7233");
     final WorkflowClient workflowCLient = WorkflowClient.newInstance(temporalService);
@@ -1176,8 +1178,6 @@ public class AcceptanceTests {
     final UUID connectionId =
         createConnection(connectionName, sourceId, destinationId, List.of(operationId), catalog, null).getConnectionId();
     waitForConnectionState(apiClient, connectionId);
-
-    Thread.sleep(5000);
 
     // check if temporal workflow is reachable
     final ConnectionManagerWorkflow connectionManagerWorkflow =

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1176,7 +1176,8 @@ public class AcceptanceTests {
         createConnection(connectionName, sourceId, destinationId, List.of(operationId), catalog, null).getConnectionId();
     
     // check if temporal workflow is reachable
-    final ConnectionManagerWorkflow connectionManagerWorkflow = workflowCLient.newWorkflowStub(ConnectionManagerWorkflow.class, "connection_manager_" + connectionId);
+    final ConnectionManagerWorkflow connectionManagerWorkflow =
+        workflowCLient.newWorkflowStub(ConnectionManagerWorkflow.class, "connection_manager_" + connectionId);
     connectionManagerWorkflow.getState();
 
     // Terminate workflow

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1156,7 +1156,11 @@ public class AcceptanceTests {
   @DisabledIfEnvironmentVariable(named = "KUBE",
                                  matches = "true")
   public void testActionsWhenTemporalIsInTerminalState() throws Exception {
-    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService("localhost:7233");
+    String temporalHost = "localhost:7233";
+    if (!USE_EXTERNAL_DEPLOYMENT) {
+      temporalHost = "airbyte-temporal:7233";
+    }
+    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService(temporalHost);
     final WorkflowClient workflowCLient = WorkflowClient.newInstance(temporalService);
 
     final String connectionName = "test-connection";

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1157,11 +1157,7 @@ public class AcceptanceTests {
   @DisabledIfEnvironmentVariable(named = "KUBE",
                                  matches = "true")
   public void testActionsWhenTemporalIsInTerminalState() throws Exception {
-    String temporalHost = "localhost:7233";
-    if (!USE_EXTERNAL_DEPLOYMENT) {
-      temporalHost = "airbyte-temporal:7233";
-    }
-    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService(temporalHost);
+    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService("airbyte-temporal:7233");
     final WorkflowClient workflowCLient = WorkflowClient.newInstance(temporalService);
 
     final String connectionName = "test-connection";

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1174,7 +1174,6 @@ public class AcceptanceTests {
         .primaryKey(List.of(List.of(COLUMN_NAME))));
     final UUID connectionId =
         createConnection(connectionName, sourceId, destinationId, List.of(operationId), catalog, null).getConnectionId();
-    
     // check if temporal workflow is reachable
     final ConnectionManagerWorkflow connectionManagerWorkflow =
         workflowCLient.newWorkflowStub(ConnectionManagerWorkflow.class, "connection_manager_" + connectionId);


### PR DESCRIPTION
## What
Add an acceptance test to check that we are able to delete a connection during a normal state and even when the state of the temporal workflow is in a terminal state. This behavior was originally committed in this PR: https://github.com/airbytehq/airbyte/pull/11302 with unit tests and verified manually, but lacked an acceptance test.