### PR TITLE
Bump Airbyte version from 0.35.62-alpha to 0.35.63-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.35.62-alpha
+current_version = 0.35.63-alpha
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@
 
 
 ### SHARED ###
-VERSION=0.35.62-alpha
+VERSION=0.35.63-alpha
 
 # When using the airbyte-db via default docker image
 CONFIG_ROOT=/data

--- a/airbyte-bootloader/Dockerfile
+++ b/airbyte-bootloader/Dockerfile
@@ -5,6 +5,6 @@ ENV APPLICATION airbyte-bootloader
 
 WORKDIR /app
 
-ADD bin/${APPLICATION}-0.35.62-alpha.tar /app
+ADD bin/${APPLICATION}-0.35.63-alpha.tar /app
 
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.62-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.63-alpha/bin/${APPLICATION}"]

--- a/airbyte-container-orchestrator/Dockerfile
+++ b/airbyte-container-orchestrator/Dockerfile
@@ -26,12 +26,12 @@ RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] htt
 RUN apt-get update && apt-get install -y kubectl
 
 ENV APPLICATION airbyte-container-orchestrator
-ENV AIRBYTE_ENTRYPOINT "/app/${APPLICATION}-0.35.62-alpha/bin/${APPLICATION}"
+ENV AIRBYTE_ENTRYPOINT "/app/${APPLICATION}-0.35.63-alpha/bin/${APPLICATION}"
 
 WORKDIR /app
 
 # Move orchestrator app
-ADD bin/${APPLICATION}-0.35.62-alpha.tar /app
+ADD bin/${APPLICATION}-0.35.63-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "/app/${APPLICATION}-0.35.62-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "/app/${APPLICATION}-0.35.63-alpha/bin/${APPLICATION}"]

--- a/airbyte-metrics/reporter/Dockerfile
+++ b/airbyte-metrics/reporter/Dockerfile
@@ -5,7 +5,7 @@ ENV APPLICATION airbyte-metrics-reporter
 
 WORKDIR /app
 
-ADD bin/${APPLICATION}-0.35.62-alpha.tar /app
+ADD bin/${APPLICATION}-0.35.63-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.62-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.63-alpha/bin/${APPLICATION}"]

--- a/airbyte-scheduler/app/Dockerfile
+++ b/airbyte-scheduler/app/Dockerfile
@@ -5,7 +5,7 @@ ENV APPLICATION airbyte-scheduler
 
 WORKDIR /app
 
-ADD bin/${APPLICATION}-0.35.62-alpha.tar /app
+ADD bin/${APPLICATION}-0.35.63-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.62-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.63-alpha/bin/${APPLICATION}"]

--- a/airbyte-server/Dockerfile
+++ b/airbyte-server/Dockerfile
@@ -7,7 +7,7 @@ ENV APPLICATION airbyte-server
 
 WORKDIR /app
 
-ADD bin/${APPLICATION}-0.35.62-alpha.tar /app
+ADD bin/${APPLICATION}-0.35.63-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.62-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.63-alpha/bin/${APPLICATION}"]

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.35.62-alpha",
+  "version": "0.35.63-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "airbyte-webapp",
-      "version": "0.35.62-alpha",
+      "version": "0.35.63-alpha",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-brands-svg-icons": "^5.15.4",

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.35.62-alpha",
+  "version": "0.35.63-alpha",
   "private": true,
   "engines": {
     "node": ">=16.0.0"

--- a/airbyte-workers/Dockerfile
+++ b/airbyte-workers/Dockerfile
@@ -30,7 +30,7 @@ ENV APPLICATION airbyte-workers
 WORKDIR /app
 
 # Move worker app
-ADD bin/${APPLICATION}-0.35.62-alpha.tar /app
+ADD bin/${APPLICATION}-0.35.63-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.62-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.63-alpha/bin/${APPLICATION}"]

--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.3.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.35.62-alpha"
+appVersion: "0.35.63-alpha"
 
 dependencies:
   - name: common

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -31,7 +31,7 @@ Helm charts for Airbyte.
 | `webapp.replicaCount`                       | Number of webapp replicas                                        | `1`              |
 | `webapp.image.repository`                   | The repository to use for the airbyte webapp image.              | `airbyte/webapp` |
 | `webapp.image.pullPolicy`                   | the pull policy to use for the airbyte webapp image              | `IfNotPresent`   |
-| `webapp.image.tag`                          | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.35.62-alpha`  |
+| `webapp.image.tag`                          | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.35.63-alpha`  |
 | `webapp.podAnnotations`                     | Add extra annotations to the webapp pod(s)                       | `{}`             |
 | `webapp.containerSecurityContext`           | Security context for the container                               | `{}`             |
 | `webapp.livenessProbe.enabled`              | Enable livenessProbe on the webapp                               | `true`           |
@@ -73,7 +73,7 @@ Helm charts for Airbyte.
 | `scheduler.replicaCount`       | Number of scheduler replicas                                        | `1`                 |
 | `scheduler.image.repository`   | The repository to use for the airbyte scheduler image.              | `airbyte/scheduler` |
 | `scheduler.image.pullPolicy`   | the pull policy to use for the airbyte scheduler image              | `IfNotPresent`      |
-| `scheduler.image.tag`          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.35.62-alpha`      |
+| `scheduler.image.tag`          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.35.63-alpha`      |
 | `scheduler.podAnnotations`     | Add extra annotations to the scheduler pod                          | `{}`                |
 | `scheduler.resources.limits`   | The resources limits for the scheduler container                    | `{}`                |
 | `scheduler.resources.requests` | The requested resources for the scheduler container                 | `{}`                |
@@ -120,7 +120,7 @@ Helm charts for Airbyte.
 | `server.replicaCount`                       | Number of server replicas                                        | `1`              |
 | `server.image.repository`                   | The repository to use for the airbyte server image.              | `airbyte/server` |
 | `server.image.pullPolicy`                   | the pull policy to use for the airbyte server image              | `IfNotPresent`   |
-| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.35.62-alpha`   |
+| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.35.63-alpha`   |
 | `server.podAnnotations`                     | Add extra annotations to the server pod                          | `{}`             |
 | `server.containerSecurityContext`           | Security context for the container                               | `{}`             |
 | `server.livenessProbe.enabled`              | Enable livenessProbe on the server                               | `true`           |
@@ -158,7 +158,7 @@ Helm charts for Airbyte.
 | `worker.replicaCount`                       | Number of worker replicas                                        | `1`              |
 | `worker.image.repository`                   | The repository to use for the airbyte worker image.              | `airbyte/worker` |
 | `worker.image.pullPolicy`                   | the pull policy to use for the airbyte worker image              | `IfNotPresent`   |
-| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.35.62-alpha`   |
+| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.35.63-alpha`   |
 | `worker.podAnnotations`                     | Add extra annotations to the worker pod(s)                       | `{}`             |
 | `worker.containerSecurityContext`           | Security context for the container                               | `{}`             |
 | `worker.livenessProbe.enabled`              | Enable livenessProbe on the worker                               | `true`           |
@@ -190,7 +190,7 @@ Helm charts for Airbyte.
 | ----------------------------- | -------------------------------------------------------------------- | -------------------- |
 | `bootloader.image.repository` | The repository to use for the airbyte bootloader image.              | `airbyte/bootloader` |
 | `bootloader.image.pullPolicy` | the pull policy to use for the airbyte bootloader image              | `IfNotPresent`       |
-| `bootloader.image.tag`        | The airbyte bootloader image tag. Defaults to the chart's AppVersion | `0.35.62-alpha`       |
+| `bootloader.image.tag`        | The airbyte bootloader image tag. Defaults to the chart's AppVersion | `0.35.63-alpha`       |
 
 
 ### Temporal parameters

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -43,7 +43,7 @@ webapp:
   image:
     repository: airbyte/webapp
     pullPolicy: IfNotPresent
-    tag: 0.35.62-alpha
+    tag: 0.35.63-alpha
 
   ## @param webapp.podAnnotations [object] Add extra annotations to the webapp pod(s)
   ##
@@ -209,7 +209,7 @@ scheduler:
   image:
     repository: airbyte/scheduler
     pullPolicy: IfNotPresent
-    tag: 0.35.62-alpha
+    tag: 0.35.63-alpha
 
   ## @param scheduler.podAnnotations [object] Add extra annotations to the scheduler pod
   ##
@@ -440,7 +440,7 @@ server:
   image:
     repository: airbyte/server
     pullPolicy: IfNotPresent
-    tag: 0.35.62-alpha
+    tag: 0.35.63-alpha
 
   ## @param server.podAnnotations [object] Add extra annotations to the server pod
   ##
@@ -581,7 +581,7 @@ worker:
   image:
     repository: airbyte/worker
     pullPolicy: IfNotPresent
-    tag: 0.35.62-alpha
+    tag: 0.35.63-alpha
 
   ## @param worker.podAnnotations [object] Add extra annotations to the worker pod(s)
   ##
@@ -699,7 +699,7 @@ bootloader:
   image:
     repository: airbyte/bootloader
     pullPolicy: IfNotPresent
-    tag: 0.35.62-alpha
+    tag: 0.35.63-alpha
   
   ## @param bootloader.podAnnotations [object] Add extra annotations to the bootloader pod
   ##

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -101,7 +101,7 @@ If you are upgrading from \(i.e. your current version of Airbyte is\) Airbyte ve
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.35.62-alpha --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.35.63-alpha --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/kube/overlays/stable-with-resource-limits/.env
+++ b/kube/overlays/stable-with-resource-limits/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.35.62-alpha
+AIRBYTE_VERSION=0.35.63-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -8,17 +8,17 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.35.62-alpha
+    newTag: 0.35.63-alpha
   - name: airbyte/bootloader
-    newTag: 0.35.62-alpha
+    newTag: 0.35.63-alpha
   - name: airbyte/scheduler
-    newTag: 0.35.62-alpha
+    newTag: 0.35.63-alpha
   - name: airbyte/server
-    newTag: 0.35.62-alpha
+    newTag: 0.35.63-alpha
   - name: airbyte/webapp
-    newTag: 0.35.62-alpha
+    newTag: 0.35.63-alpha
   - name: airbyte/worker
-    newTag: 0.35.62-alpha
+    newTag: 0.35.63-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.35.62-alpha
+AIRBYTE_VERSION=0.35.63-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -8,17 +8,17 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.35.62-alpha
+    newTag: 0.35.63-alpha
   - name: airbyte/bootloader
-    newTag: 0.35.62-alpha
+    newTag: 0.35.63-alpha
   - name: airbyte/scheduler
-    newTag: 0.35.62-alpha
+    newTag: 0.35.63-alpha
   - name: airbyte/server
-    newTag: 0.35.62-alpha
+    newTag: 0.35.63-alpha
   - name: airbyte/webapp
-    newTag: 0.35.62-alpha
+    newTag: 0.35.63-alpha
   - name: airbyte/worker
-    newTag: 0.35.62-alpha
+    newTag: 0.35.63-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 


### PR DESCRIPTION
*IMPORTANT: Only merge if the platform build is passing!*

Changelog:

6beccdabb get new version from bumpversion output
7741b77fc clean release_version_octavia.sh
bf04b8e8c clean workflox
43f347acb custom bumpversion for octavia
2ebc4e3fa separte job for octavia release
2c2fabc60 check if plaftorm build pollutes octavia build
f56b478e0 Merge branch 'augustin/octavia-cli/fix-release' of https://github.com/airbytehq/airbyte into augustin/octavia-cli/fix-release
b409a5bb1 disable push
7d8166921 Merge branch 'master' into augustin/octavia-cli/fix-release
80fb22f3d clean venv
88120ec8f fix typo
f940207d8 specific release step for octavia
fb85af034 specific release step for octavia
bb938fe7b specific release step for octavia

Steps After Merging PR:
1. Pull most recent version of master
2. Run ./tools/bin/tag_version.sh
3. Create a GitHub release with the changelog