### PR TITLE
Bump Octavia version from 0.35.62-alpha to 0.35.62-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.35.62-alpha
+current_version = 0.35.63-alpha
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/octavia-cli/Dockerfile
+++ b/octavia-cli/Dockerfile
@@ -14,5 +14,5 @@ USER octavia-cli
 WORKDIR /home/octavia-project
 ENTRYPOINT ["octavia"]
 
-LABEL io.airbyte.version=0.35.62-alpha
+LABEL io.airbyte.version=0.35.63-alpha
 LABEL io.airbyte.name=airbyte/octavia-cli

--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -104,7 +104,7 @@ This script:
 ```bash
 touch ~/.octavia # Create a file to store env variables that will be mapped the octavia-cli container
 mkdir my_octavia_project_directory # Create your octavia project directory where YAML configurations will be stored.
-docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:0.35.62-alpha
+docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:0.35.63-alpha
 ```
 
 ### Using `docker-compose`

--- a/octavia-cli/install.sh
+++ b/octavia-cli/install.sh
@@ -3,7 +3,7 @@
 # This install scripts currently only works for ZSH and Bash profiles.
 # It creates an octavia alias in your profile bound to a docker run command and your current user.
 
-VERSION=0.35.62-alpha
+VERSION=0.35.63-alpha
 OCTAVIA_ENV_FILE=${HOME}/.octavia
 
 detect_profile() {


### PR DESCRIPTION
*IMPORTANT: Only merge if the platform build is passing!*

Changelog:

6beccdabb get new version from bumpversion output
7741b77fc clean release_version_octavia.sh
bf04b8e8c clean workflox
43f347acb custom bumpversion for octavia
2ebc4e3fa separte job for octavia release
2c2fabc60 check if plaftorm build pollutes octavia build
f56b478e0 Merge branch 'augustin/octavia-cli/fix-release' of https://github.com/airbytehq/airbyte into augustin/octavia-cli/fix-release
b409a5bb1 disable push
7d8166921 Merge branch 'master' into augustin/octavia-cli/fix-release
80fb22f3d clean venv
88120ec8f fix typo
f940207d8 specific release step for octavia
fb85af034 specific release step for octavia
bb938fe7b specific release step for octavia

Steps After Merging PR:
1. Pull most recent version of master
2. Run ./tools/bin/tag_version.sh
3. Create a GitHub release with the changelog