### PR TITLE
Do not bail out in dbt version check

### DIFF
--- a/airbyte-integrations/bases/base-normalization/entrypoint.sh
+++ b/airbyte-integrations/bases/base-normalization/entrypoint.sh
@@ -114,6 +114,7 @@ function main() {
     openssh "${PROJECT_DIR}/ssh.json"
     trap 'closessh' EXIT
 
+    set +e # allow script to continue running even if next commands fail to run properly
     # We don't run dbt 1.0.x on all destinations (because their plugins don't support it yet)
     # So we need to only pass `--event-buffer-size` if it's supported by DBT.
     dbt --help | grep -E -- '--event-buffer-size'
@@ -124,7 +125,6 @@ function main() {
       dbt_additional_args=""
     fi
 
-    set +e # allow script to continue running even if next commands fail to run properly
     # Run dbt to compile and execute the generated normalization models
     dbt ${dbt_additional_args} run --profiles-dir "${PROJECT_DIR}" --project-dir "${PROJECT_DIR}"
     DBT_EXIT_CODE=$?


### PR DESCRIPTION
## What

#11267 seems to introduce a regression where normalization with MySQL did not longer work. This is a one-line fix.

<img width="1471" alt="image" src="https://user-images.githubusercontent.com/1872314/160817710-35881aba-bde9-4a34-9823-b83e10173960.png">

## How
* move set +e statement up to not bail out while checking whether dbt supports --event-buffer-size flag

## Recommended reading order
1. `entrypoint.sh`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

Should only fix an issue.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

None of the check lists really applied as it refers to generic normalization logic.

/cc @edgao potential regression in #11267 ?

