### PR TITLE
Fix changing connection name when editing connections

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
@@ -235,7 +235,7 @@ const ServiceForm: React.FC<ServiceFormProps> = (props) => {
           isEditMode={props.isEditMode}
           isLoadingSchema={props.isLoading}
         >
-          <SetDefaultName />
+          {!props.isEditMode && <SetDefaultName />}
           <FormikPatch />
           <PatchInitialValuesWithWidgetConfig schema={jsonSchema} />
           <FormRoot


### PR DESCRIPTION
## What

Fixes the problem, that at the moment when editing any connectin the name it has saved will be overwritten by the connectors name, because the "selected connector" changed when loading the page. This PR makes sure to only apply the "SetDefaultName" logic when we're creating a connector and not when editing one.