### PR TITLE
Store the identifier of the catalog of the source when creating a new connection

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2784,6 +2784,9 @@ components:
           $ref: "#/components/schemas/AirbyteCatalog"
         jobInfo:
           $ref: "#/components/schemas/SynchronousJobRead"
+        catalogId:
+          type: string
+          format: uuid
     SourceSearch:
       type: object
       properties:
@@ -3134,6 +3137,9 @@ components:
           $ref: "#/components/schemas/ConnectionStatus"
         resourceRequirements:
           $ref: "#/components/schemas/ResourceRequirements"
+        sourceCatalogId:
+          type: string
+          format: uuid
     WebBackendConnectionCreate:
       type: object
       required:
@@ -3175,6 +3181,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/OperationCreate"
+        sourceCatalogId:
+          type: string
+          format: uuid
     ConnectionUpdate:
       type: object
       required:

--- a/airbyte-config/models/src/main/resources/types/StandardSync.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSync.yaml
@@ -69,5 +69,8 @@ properties:
   # When manual is true, schedule should be null, and will be ignored.
   manual:
     type: boolean
+  source_catalog_id:
+    type: string
+    format: uuid
   resourceRequirements:
     "$ref": ResourceRequirements.yaml

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -870,9 +870,9 @@ public class ConfigRepository {
       throws IOException {
     final OffsetDateTime timestamp = OffsetDateTime.now();
     final UUID fetchEventID = UUID.randomUUID();
-    database.transaction(ctx -> {
+    return database.transaction(ctx -> {
       final UUID catalogId = getOrInsertActorCatalog(catalog, ctx);
-      return ctx.insertInto(ACTOR_CATALOG_FETCH_EVENT)
+      ctx.insertInto(ACTOR_CATALOG_FETCH_EVENT)
           .set(ACTOR_CATALOG_FETCH_EVENT.ID, fetchEventID)
           .set(ACTOR_CATALOG_FETCH_EVENT.ACTOR_ID, actorId)
           .set(ACTOR_CATALOG_FETCH_EVENT.ACTOR_CATALOG_ID, catalogId)
@@ -880,9 +880,8 @@ public class ConfigRepository {
           .set(ACTOR_CATALOG_FETCH_EVENT.ACTOR_VERSION, connectorVersion)
           .set(ACTOR_CATALOG_FETCH_EVENT.MODIFIED_AT, timestamp)
           .set(ACTOR_CATALOG_FETCH_EVENT.CREATED_AT, timestamp).execute();
+      return catalogId;
     });
-
-    return fetchEventID;
   }
 
   public int countConnectionsForWorkspace(final UUID workspaceId) throws IOException {

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -1044,6 +1044,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
             .set(CONNECTION.SCHEDULE, JSONB.valueOf(Jsons.serialize(standardSync.getSchedule())))
             .set(CONNECTION.MANUAL, standardSync.getManual())
             .set(CONNECTION.RESOURCE_REQUIREMENTS, JSONB.valueOf(Jsons.serialize(standardSync.getResourceRequirements())))
+            .set(CONNECTION.SOURCE_CATALOG_ID, standardSync.getSourceCatalogId())
             .set(CONNECTION.CREATED_AT, timestamp)
             .set(CONNECTION.UPDATED_AT, timestamp)
             .execute();

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -125,7 +125,8 @@ public class ConnectionsHandler {
         .withSourceId(connectionCreate.getSourceId())
         .withDestinationId(connectionCreate.getDestinationId())
         .withOperationIds(connectionCreate.getOperationIds())
-        .withStatus(ApiPojoConverters.toPersistenceStatus(connectionCreate.getStatus()));
+        .withStatus(ApiPojoConverters.toPersistenceStatus(connectionCreate.getStatus()))
+        .withSourceCatalogId(connectionCreate.getSourceCatalogId());
     if (connectionCreate.getResourceRequirements() != null) {
       standardSync.withResourceRequirements(ApiPojoConverters.resourceRequirementsToInternal(connectionCreate.getResourceRequirements()));
     }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -266,8 +266,12 @@ public class SchedulerHandler {
     final boolean bustActorCatalogCache = discoverSchemaRequestBody.getDisableCache() != null && discoverSchemaRequestBody.getDisableCache();
     if (currentCatalog.isEmpty() || bustActorCatalogCache) {
       final SynchronousResponse<AirbyteCatalog> response = synchronousSchedulerClient.createDiscoverSchemaJob(source, imageName);
-      configRepository.writeActorCatalogFetchEvent(response.getOutput(), source.getSourceId(), connectorVersion, configHash);
-      return discoverJobToOutput(response);
+      final SourceDiscoverSchemaRead returnValue = discoverJobToOutput(response);
+      if (response.isSuccess()) {
+        final UUID catalogId = configRepository.writeActorCatalogFetchEvent(response.getOutput(), source.getSourceId(), connectorVersion, configHash);
+        returnValue.catalogId(catalogId);
+      }
+      return returnValue;
     }
     final AirbyteCatalog airbyteCatalog = Jsons.object(currentCatalog.get().getCatalog(), AirbyteCatalog.class);
     final SynchronousJobRead emptyJob = new SynchronousJobRead()
@@ -280,7 +284,8 @@ public class SchedulerHandler {
         .succeeded(true);
     return new SourceDiscoverSchemaRead()
         .catalog(CatalogConverter.toApi(airbyteCatalog))
-        .jobInfo(emptyJob);
+        .jobInfo(emptyJob)
+        .catalogId(currentCatalog.get().getId());
   }
 
   public SourceDiscoverSchemaRead discoverSchemaForSourceFromSourceCreate(final SourceCoreConfig sourceCreate)

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -380,6 +380,7 @@ public class WebBackendConnectionsHandler {
     connectionCreate.schedule(webBackendConnectionCreate.getSchedule());
     connectionCreate.status(webBackendConnectionCreate.getStatus());
     connectionCreate.resourceRequirements(webBackendConnectionCreate.getResourceRequirements());
+    connectionCreate.sourceCatalogId(webBackendConnectionCreate.getSourceCatalogId());
 
     return connectionCreate;
   }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -384,6 +384,7 @@ class WebBackendConnectionsHandlerTest {
     final UUID newSourceId = UUID.randomUUID();
     final UUID newDestinationId = UUID.randomUUID();
     final UUID newOperationId = UUID.randomUUID();
+    final UUID sourceCatalogId = UUID.randomUUID();
     final WebBackendConnectionCreate input = new WebBackendConnectionCreate()
         .name("testConnectionCreate")
         .namespaceDefinition(Enums.convertTo(standardSync.getNamespaceDefinition(), NamespaceDefinitionType.class))
@@ -394,7 +395,8 @@ class WebBackendConnectionsHandlerTest {
         .operationIds(List.of(newOperationId))
         .status(ConnectionStatus.INACTIVE)
         .schedule(schedule)
-        .syncCatalog(catalog);
+        .syncCatalog(catalog)
+        .sourceCatalogId(sourceCatalogId);
 
     final List<UUID> operationIds = List.of(newOperationId);
 
@@ -408,7 +410,8 @@ class WebBackendConnectionsHandlerTest {
         .operationIds(operationIds)
         .status(ConnectionStatus.INACTIVE)
         .schedule(schedule)
-        .syncCatalog(catalog);
+        .syncCatalog(catalog)
+        .sourceCatalogId(sourceCatalogId);
 
     final ConnectionCreate actual = WebBackendConnectionsHandler.toConnectionCreate(input, operationIds);
 
@@ -460,7 +463,7 @@ class WebBackendConnectionsHandlerTest {
   public void testForConnectionCreateCompleteness() {
     final Set<String> handledMethods =
         Set.of("name", "namespaceDefinition", "namespaceFormat", "prefix", "sourceId", "destinationId", "operationIds", "syncCatalog", "schedule",
-            "status", "resourceRequirements");
+            "status", "resourceRequirements", "sourceCatalogId");
 
     final Set<String> methods = Arrays.stream(ConnectionCreate.class.getMethods())
         .filter(method -> method.getReturnType() == ConnectionCreate.class)

--- a/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
+++ b/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
@@ -51,15 +51,16 @@ const CreateConnectionContent: React.FC<IProps> = ({
   const { mutateAsync: createConnection } = useCreateConnection();
   const analyticsService = useAnalyticsService();
 
-  const { schema, isLoading, schemaErrorStatus, onDiscoverSchema } = useDiscoverSchema(source.sourceId);
+  const { schema, isLoading, schemaErrorStatus, catalogId, onDiscoverSchema } = useDiscoverSchema(source.sourceId);
 
   const connection = useMemo(
     () => ({
       syncCatalog: schema,
       destination,
       source,
+      catalogId,
     }),
-    [schema, destination, source]
+    [schema, destination, source, catalogId]
   );
 
   const onSubmitConnectionStep = async (values: ValuesProps) => {
@@ -75,6 +76,7 @@ const CreateConnectionContent: React.FC<IProps> = ({
         name: destination?.name ?? "",
         destinationDefinitionId: destination?.destinationDefinitionId ?? "",
       },
+      sourceCatalogId: catalogId,
     });
 
     return {

--- a/airbyte-webapp/src/core/domain/catalog/api.ts
+++ b/airbyte-webapp/src/core/domain/catalog/api.ts
@@ -5,6 +5,7 @@ import { JobInfo } from "../job";
 export interface SourceDiscoverSchemaRead {
   catalog: SyncSchema;
   jobInfo?: JobInfo;
+  catalogId: string;
 }
 
 export type SchemaFields = JSONSchema7;

--- a/airbyte-webapp/src/core/domain/connector/SourceService.ts
+++ b/airbyte-webapp/src/core/domain/connector/SourceService.ts
@@ -94,6 +94,7 @@ class SourceService extends AirbyteRequestService {
     return {
       catalog: result.catalog,
       jobInfo: result.jobInfo,
+      catalogId: result.catalogId,
       id: sourceId,
     };
   }

--- a/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
@@ -140,7 +140,6 @@ const useCreateConnection = () => {
   return useMutation(
     async (conn: CreateConnectionProps) => {
       const { values, source, destination, sourceDefinition, destinationDefinition, sourceCatalogId } = conn;
-      
       const response = await service.create({
         sourceId: source?.sourceId,
         destinationId: destination?.destinationId,

--- a/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
@@ -43,6 +43,7 @@ type CreateConnectionProps = {
   destination?: Destination;
   sourceDefinition?: SourceDefinition | { name: string; sourceDefinitionId: string };
   destinationDefinition?: { name: string; destinationDefinitionId: string };
+  sourceCatalogId: string;
 };
 
 type UpdateConnection = {
@@ -138,13 +139,14 @@ const useCreateConnection = () => {
 
   return useMutation(
     async (conn: CreateConnectionProps) => {
-      const { values, source, destination, sourceDefinition, destinationDefinition } = conn;
-
+      const { values, source, destination, sourceDefinition, destinationDefinition, sourceCatalogId } = conn;
+      
       const response = await service.create({
         sourceId: source?.sourceId,
         destinationId: destination?.destinationId,
         ...values,
         status: "active",
+        sourceCatalogId: sourceCatalogId,
       });
 
       const enabledStreams = values.syncCatalog.streams.filter((stream) => stream.config.selected).length;

--- a/airbyte-webapp/src/hooks/services/useSourceHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useSourceHook.tsx
@@ -175,10 +175,12 @@ const useDiscoverSchema = (
   isLoading: boolean;
   schema: SyncSchema;
   schemaErrorStatus: { status: number; response: JobInfo } | null;
+  catalogId: string;
   onDiscoverSchema: () => Promise<void>;
 } => {
   const service = useSourceService();
   const [schema, setSchema] = useState<SyncSchema>({ streams: [] });
+  const [catalogId, setCatalogId] = useState<string>("");
   const [isLoading, setIsLoading] = useState(false);
   const [schemaErrorStatus, setSchemaErrorStatus] = useState<{
     status: number;
@@ -191,6 +193,7 @@ const useDiscoverSchema = (
     try {
       const data = await service.discoverSchema(sourceId || "");
       setSchema(data.catalog);
+      setCatalogId(data.catalogId);
     } catch (e) {
       setSchemaErrorStatus(e);
     } finally {
@@ -207,7 +210,7 @@ const useDiscoverSchema = (
     })();
   }, [onDiscoverSchema, sourceId]);
 
-  return { schemaErrorStatus, isLoading, schema, onDiscoverSchema };
+  return { schemaErrorStatus, isLoading, schema, catalogId, onDiscoverSchema };
 };
 
 export { useSourceList, useGetSource, useCreateSource, useDeleteSource, useUpdateSource, useDiscoverSchema };

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -5747,6 +5747,7 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
+  "catalogId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "catalog" : {
     "streams" : [ {
       "stream" : {
@@ -6158,6 +6159,7 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
+  "catalogId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "catalog" : {
     "streams" : [ {
       "stream" : {
@@ -10072,6 +10074,7 @@ font-style: italic;
 <div class="param">schedule (optional)</div><div class="param-desc"><span class="param-type"><a href="#ConnectionSchedule">ConnectionSchedule</a></span>  </div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
 <div class="param">resourceRequirements (optional)</div><div class="param-desc"><span class="param-type"><a href="#ResourceRequirements">ResourceRequirements</a></span>  </div>
+<div class="param">sourceCatalogId (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -10897,6 +10900,7 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
     <div class="field-items">
       <div class="param">catalog (optional)</div><div class="param-desc"><span class="param-type"><a href="#AirbyteCatalog">AirbyteCatalog</a></span>  </div>
 <div class="param">jobInfo </div><div class="param-desc"><span class="param-type"><a href="#SynchronousJobRead">SynchronousJobRead</a></span>  </div>
+<div class="param">catalogId (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -11009,6 +11013,7 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
 <div class="param">resourceRequirements (optional)</div><div class="param-desc"><span class="param-type"><a href="#ResourceRequirements">ResourceRequirements</a></span>  </div>
 <div class="param">operations (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperationCreate">array[OperationCreate]</a></span>  </div>
+<div class="param">sourceCatalogId (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
closes #9901

Modify the backend code to return the identifier of the source catalog when a source is created or selected to build a connection.
Modify the front-end to send that information back when a connection is created.
That information is then stored in the `sourceCatalogId` column of the database.