### PR TITLE
Add react-query devtools

### DIFF
--- a/airbyte-webapp/src/views/common/StoreProvider.tsx
+++ b/airbyte-webapp/src/views/common/StoreProvider.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from "react-query";
 import React from "react";
 import { CacheProvider } from "rest-hooks";
+import { ReactQueryDevtools } from "react-query/devtools";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -14,7 +15,10 @@ const queryClient = new QueryClient({
 
 const StoreProvider: React.FC = ({ children }) => (
   <CacheProvider>
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools initialIsOpen={false} />
+      {children}
+    </QueryClientProvider>
   </CacheProvider>
 );
 

--- a/airbyte-webapp/src/views/common/StoreProvider.tsx
+++ b/airbyte-webapp/src/views/common/StoreProvider.tsx
@@ -16,7 +16,7 @@ const queryClient = new QueryClient({
 const StoreProvider: React.FC = ({ children }) => (
   <CacheProvider>
     <QueryClientProvider client={queryClient}>
-      <ReactQueryDevtools initialIsOpen={false} />
+      <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />
       {children}
     </QueryClientProvider>
   </CacheProvider>


### PR DESCRIPTION
## What
Adds react-query devtools. After the merge of https://github.com/airbytehq/airbyte/pull/11524 which removes `rest-hooks` and migrates everything to react-query, it will be very convenient to use builtin dev-tools.
