### PR TITLE
generate source_specs to fix build

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -87,7 +87,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-amazon-ads:0.1.3"
+- dockerImage: "airbyte/source-amazon-ads:0.1.4"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/amazon-ads"
     connectionSpecification:
@@ -150,6 +150,26 @@
           type: "array"
           items:
             type: "integer"
+        report_wait_timeout:
+          title: "Report Wait Timeout"
+          description: "Timeout duration in minutes for Reports. Eg. 30"
+          default: 30
+          name: "Report Wait Timeout"
+          examples:
+          - 30
+          - 120
+          type: "integer"
+        report_generation_max_retries:
+          title: "Report Generation Max Retries"
+          description: "Maximum retries Airbyte will attempt for fetching Report Data.\
+            \ Eg. 5"
+          default: 5
+          name: "Report Geration Maximum Retries"
+          examples:
+          - 5
+          - 10
+          - 15
+          type: "integer"
       required:
       - "client_id"
       - "client_secret"


### PR DESCRIPTION
@marcosmarxm community prs (like https://github.com/airbytehq/airbyte/pull/10513) still need to generate source_specs.yaml (or need a fix immediately pushed afterwards). Otherwise `master` will break.