### PR TITLE
Add one more error boundary layer for not found

### DIFF
--- a/airbyte-webapp/src/components/ApiErrorBoundary/ApiErrorBoundary.tsx
+++ b/airbyte-webapp/src/components/ApiErrorBoundary/ApiErrorBoundary.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 import { isVersionError } from "core/request/VersionError";
 import { ErrorOccurredView } from "views/common/ErrorOccurredView";
+import { StartOverErrorView } from "../../views/common/StartOverErrorView";
+import { ResourceNotFoundErrorBoundary } from "../../views/common/ResorceNotFoundErrorBoundary";
 
 type BoundaryState = { errorId?: string; message?: string };
 
@@ -55,7 +57,9 @@ class ApiErrorBoundary extends React.Component<unknown, BoundaryState> {
     }
 
     return !this.state.errorId ? (
-      this.props.children
+      <ResourceNotFoundErrorBoundary errorComponent={<StartOverErrorView />}>
+        {this.props.children}
+      </ResourceNotFoundErrorBoundary>
     ) : (
       <ErrorOccurredView message="Unknown error occurred" />
     );

--- a/airbyte-webapp/src/components/ApiErrorBoundary/ApiErrorBoundary.tsx
+++ b/airbyte-webapp/src/components/ApiErrorBoundary/ApiErrorBoundary.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 import { isVersionError } from "core/request/VersionError";
 import { ErrorOccurredView } from "views/common/ErrorOccurredView";
-import { StartOverErrorView } from "../../views/common/StartOverErrorView";
-import { ResourceNotFoundErrorBoundary } from "../../views/common/ResorceNotFoundErrorBoundary";
+import { StartOverErrorView } from "views/common/StartOverErrorView";
+import { ResourceNotFoundErrorBoundary } from "views/common/ResorceNotFoundErrorBoundary";
 
 type BoundaryState = { errorId?: string; message?: string };
 

--- a/airbyte-webapp/src/views/common/ResorceNotFoundErrorBoundary.tsx
+++ b/airbyte-webapp/src/views/common/ResorceNotFoundErrorBoundary.tsx
@@ -15,7 +15,8 @@ export class ResourceNotFoundErrorBoundary extends React.Component<
   BoundaryState
 > {
   static getDerivedStateFromError(error: CommonRequestError): BoundaryState {
-    if (error.status === 422) {
+    console.log(error.status);
+    if (error.status === 422 || error.status === 404) {
       return {
         hasError: true,
         message: <FormattedMessage id="errorView.notFound" />,


### PR DESCRIPTION
Fix regression when common error view was displayed for not found resource instead of proper one.

<img width="510" alt="image" src="https://user-images.githubusercontent.com/3767150/161056894-506a7b9f-d513-4cc4-9a06-9e8bbb5dbd41.png">
