### PR TITLE
cdk: remove false error logging in _send

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -5,7 +5,6 @@ Remove a false positive error logging during the send process.
 
 ## 0.1.52
 Fix BaseBackoffException constructor
->>>>>>> master
 
 ## 0.1.50
 Improve logging for Error handling during send process.

--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
+## 0.1.51
+Remove a false positive error logging during the send process.
+
 ## 0.1.50
 Improve logging for Error handling during send process.
+
 ## 0.1.49
 Add support for streams with explicit state attribute.
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
@@ -7,6 +7,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Union
+from urllib.error import HTTPError
 from urllib.parse import urljoin
 
 import requests
@@ -294,8 +295,11 @@ class HttpStream(Stream, ABC):
                 raise DefaultBackoffException(request=request, response=response)
         elif self.raise_on_http_errors:
             # Raise any HTTP exceptions that happened in case there were unexpected ones
-            response.raise_for_status()
-
+            try:
+                response.raise_for_status()
+            except HTTPError as exc:
+                self.logger.error(response.text)
+                raise exc
         return response
 
     def _send_request(self, request: requests.PreparedRequest, request_kwargs: Mapping[str, Any]) -> requests.Response:

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
@@ -294,7 +294,6 @@ class HttpStream(Stream, ABC):
                 raise DefaultBackoffException(request=request, response=response)
         elif self.raise_on_http_errors:
             # Raise any HTTP exceptions that happened in case there were unexpected ones
-            self.logger.error(f"Request raised an error with response: {response.text}")
             response.raise_for_status()
 
         return response

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.50",
+    version="0.1.51",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/pull/11629 introduced a new error log line in the `_send` method which is a false positive error: in the context of it's execution there's no error, the `raise_for_status` is responsible to check if an unexpected error happened.

## How
* Remove the `logger.error` call
