### PR TITLE
Publish command: call docker hub api  to check the tag was registered

### DIFF
--- a/airbyte-integrations/connectors/destination-e2e-test/Dockerfile
+++ b/airbyte-integrations/connectors/destination-e2e-test/Dockerfile
@@ -17,5 +17,5 @@ ENV ENABLE_SENTRY true
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.2.3
+LABEL io.airbyte.version=0.2.4
 LABEL io.airbyte.name=airbyte/destination-e2e-test

--- a/airbyte-integrations/connectors/destination-e2e-test/Dockerfile
+++ b/airbyte-integrations/connectors/destination-e2e-test/Dockerfile
@@ -17,5 +17,5 @@ ENV ENABLE_SENTRY true
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.2.2
+LABEL io.airbyte.version=0.2.3
 LABEL io.airbyte.name=airbyte/destination-e2e-test

--- a/airbyte-integrations/connectors/destination-e2e-test/Dockerfile
+++ b/airbyte-integrations/connectors/destination-e2e-test/Dockerfile
@@ -17,5 +17,5 @@ ENV ENABLE_SENTRY true
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.2.4
+LABEL io.airbyte.version=0.2.2
 LABEL io.airbyte.name=airbyte/destination-e2e-test

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -121,9 +121,7 @@ cmd_publish() {
   # Checking if the image was successfully registered on DockerHub
   # see the description of this PR to understand why this is needed https://github.com/airbytehq/airbyte/pull/11654/
   sleep 5
-  #TAG_URL="https://hub.docker.com/v2/repositories/${image_name}/tags/${image_version}"
-  # SETTING A 404 URL JUST TO TRY
-  TAG_URL="https://hub.docker.com/v2/repositories/airbyte/source-bing-ads/tags/0.1.4"
+  TAG_URL="https://hub.docker.com/v2/repositories/${image_name}/tags/${image_version}"
   DOCKERHUB_RESPONSE_CODE=$(curl --silent --output /dev/null --write-out "%{http_code}" ${TAG_URL})
   if [[ "${DOCKERHUB_RESPONSE_CODE}" == "404" ]]; then
     echo "Tag ${image_version} was not registered on DockerHub for image ${image_name}, please try to bump the version again." && exit 1

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -120,7 +120,7 @@ cmd_publish() {
   
   # Checking it the image was successfully registered on DockerHub
   TAG_URL="https://hub.docker.com/v2/repositories/${image_name}/tags/${image_version}"
-  DOCKERHUB_RESPONSE_CODE=$(curl --silent --output /dev/null --write-out "%{http_code}" ${URL})
+  DOCKERHUB_RESPONSE_CODE=$(curl --silent --output /dev/null --write-out "%{http_code}" ${TAG_URL})
   if [[ "${DOCKERHUB_RESPONSE_CODE}" == "404" ]]; then
     echo "Tag ${image_version} was not registered on DockerHub for image ${image_name}" && exit 1
   fi

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -121,7 +121,9 @@ cmd_publish() {
   # Checking if the image was successfully registered on DockerHub
   # see the description of this PR to understand why this is needed https://github.com/airbytehq/airbyte/pull/11654/
   sleep 5
-  TAG_URL="https://hub.docker.com/v2/repositories/${image_name}/tags/${image_version}"
+  #TAG_URL="https://hub.docker.com/v2/repositories/${image_name}/tags/${image_version}"
+  # SETTING A 404 URL JUST TO TRY
+  TAG_URL="https://hub.docker.com/v2/repositories/airbyte/source-bing-ads/tags/0.1.4"
   DOCKERHUB_RESPONSE_CODE=$(curl --silent --output /dev/null --write-out "%{http_code}" ${TAG_URL})
   if [[ "${DOCKERHUB_RESPONSE_CODE}" == "404" ]]; then
     echo "Tag ${image_version} was not registered on DockerHub for image ${image_name}, please try to bump the version again." && exit 1

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -117,6 +117,13 @@ cmd_publish() {
     docker push "$versioned_image"
     docker push "$latest_image"
   fi
+  
+  # Checking it the image was successfully registered on DockerHub
+  TAG_URL="https://hub.docker.com/v2/repositories/${image_name}/tags/${image_version}"
+  DOCKERHUB_RESPONSE_CODE=$(curl --silent --output /dev/null --write-out "%{http_code}" ${URL})
+  if [[ "${DOCKERHUB_RESPONSE_CODE}" == "404" ]]; then
+    echo "Tag ${image_version} was not registered on DockerHub for image ${image_name}" && exit 1
+  fi
 
   if [[ "true" == "${publish_spec_to_cache}" ]]; then
     echo "Publishing and writing to spec cache."

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -118,11 +118,13 @@ cmd_publish() {
     docker push "$latest_image"
   fi
   
-  # Checking it the image was successfully registered on DockerHub
+  # Checking if the image was successfully registered on DockerHub
+  # see the description of this PR to understand why this is needed https://github.com/airbytehq/airbyte/pull/11654/
+  sleep 5
   TAG_URL="https://hub.docker.com/v2/repositories/${image_name}/tags/${image_version}"
   DOCKERHUB_RESPONSE_CODE=$(curl --silent --output /dev/null --write-out "%{http_code}" ${TAG_URL})
   if [[ "${DOCKERHUB_RESPONSE_CODE}" == "404" ]]; then
-    echo "Tag ${image_version} was not registered on DockerHub for image ${image_name}" && exit 1
+    echo "Tag ${image_version} was not registered on DockerHub for image ${image_name}, please try to bump the version again." && exit 1
   fi
 
   if [[ "true" == "${publish_spec_to_cache}" ]]; then


### PR DESCRIPTION
## What
In some rare situations, it can happen that a docker tag was successfully published but that the DockerHub does not register this tag, making the tag not available in the UI nor in the API we call to check if the image exists.

This problem happened for `source-bing-ads:0.1.4`: 
* We published a new version in this PR https://github.com/airbytehq/airbyte/pull/11311
* The docker hub returns a 404 for this tag: `https://hub.docker.com/v2/repositories/airbyte/source-bing-ads/tags/0.1.4`
* The release workflow fails: https://github.com/airbytehq/airbyte/runs/5784144121?check_suite_focus=true#step:3:4194

([related Slack conversation for fellow Airbyters](https://airbytehq-team.slack.com/archives/C02TL38U5L7/p1648799649812529))

## How
I want to detect this error early in our release process by making the `/publish` command fails if this problem occurs.
It will allow us to detect it before merging a connector PR and avoid breaking the Airbyte release.
