### PR TITLE
Attempting to fix failing java integration tests

### DIFF
--- a/.github/workflows/connector_integration_tests.yml
+++ b/.github/workflows/connector_integration_tests.yml
@@ -10,7 +10,7 @@ jobs:
   launch_integration_tests:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/specify-java-for-integration-tests'
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2

--- a/.github/workflows/connector_integration_tests.yml
+++ b/.github/workflows/connector_integration_tests.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
       - name: Install Java
-          uses: actions/setup-java@v1
-          with:
-            java-version: '17'
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17'
       - name: Launch Integration Tests
         run: ./tools/bin/ci_integration_workflow_launcher.sh
         env:

--- a/.github/workflows/connector_integration_tests.yml
+++ b/.github/workflows/connector_integration_tests.yml
@@ -10,7 +10,7 @@ jobs:
   launch_integration_tests:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    if: github.ref == 'specify-java-for-integration-tests'
+    # if: github.ref == 'specify-java-for-integration-tests'
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2

--- a/.github/workflows/connector_integration_tests.yml
+++ b/.github/workflows/connector_integration_tests.yml
@@ -10,7 +10,7 @@ jobs:
   launch_integration_tests:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/specify-java-for-integration-tests'
+    if: github.ref == 'specify-java-for-integration-tests'
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2

--- a/.github/workflows/connector_integration_tests.yml
+++ b/.github/workflows/connector_integration_tests.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
+      - name: Install Java
+          uses: actions/setup-java@v1
+          with:
+            java-version: '17'
       - name: Launch Integration Tests
         run: ./tools/bin/ci_integration_workflow_launcher.sh
         env:

--- a/.github/workflows/connector_integration_tests.yml
+++ b/.github/workflows/connector_integration_tests.yml
@@ -10,7 +10,7 @@ jobs:
   launch_integration_tests:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    # if: github.ref == 'specify-java-for-integration-tests'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2


### PR DESCRIPTION
some failing tests
https://github.com/airbytehq/airbyte/runs/5463368404?check_suite_focus=true

Greg also has context here, but we think the underlying java version
has been changed

## What
Fix failing pipelines by specifying java version

## How
Use existing pattern from other actions

![image](https://user-images.githubusercontent.com/2591516/161311842-f15e52df-8a09-4648-aa28-f52eafbfb2a9.png)
