### PR TITLE
Skip empty line output from gradle

### DIFF
--- a/tools/bin/ci_integration_workflow_launcher.sh
+++ b/tools/bin/ci_integration_workflow_launcher.sh
@@ -29,12 +29,14 @@ fi
 
 CONNECTORS=$(./gradlew integrationTest --dry-run | grep 'integrationTest SKIPPED' | cut -d: -f 4 | sort | uniq)
 echo "$CONNECTORS" | while read -r connector; do
-  echo "Issuing request for connector $connector..."
-  curl \
-    -i \
-    -X POST \
-    -H "Accept: application/vnd.github.v3+json" \
-    -H "Authorization: Bearer $GITHUB_TOKEN" \
-    "$REPO_API/actions/workflows/$WORKFLOW_ID/dispatches" \
-    -d "{\"ref\":\"master\", \"inputs\": { \"connector\": \"$connector\"} }"
+  if [ ! -z "$connector" ]; then
+    echo "Issuing request for connector $connector..."
+    curl \
+      -i \
+      -X POST \
+      -H "Accept: application/vnd.github.v3+json" \
+      -H "Authorization: Bearer $GITHUB_TOKEN" \
+      "$REPO_API/actions/workflows/$WORKFLOW_ID/dispatches" \
+      -d "{\"ref\":\"master\", \"inputs\": { \"connector\": \"$connector\"} }"
+  fi
 done


### PR DESCRIPTION
  Currently, every time this script attempts to launch a github action for an empty connector name
  see log output here: https://github.com/airbytehq/airbyte/runs/5786705935?check_suite_focus=true
  This change fixes this minor bug.