### PR TITLE
Introduce json path commons lib

### DIFF
--- a/airbyte-commons/build.gradle
+++ b/airbyte-commons/build.gradle
@@ -4,4 +4,7 @@ plugins {
 
 dependencies {
     // Dependencies for this module should be specified in the top-level build.gradle. See readme for more explanation.
+
+    // this dependency is an exception to the above rule because it is only used INTERNALLY to the commons library.
+    implementation 'com.jayway.jsonpath:json-path:2.7.0'
 }

--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonPaths.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonPaths.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.api.client.util.Preconditions;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+import io.airbyte.commons.util.MoreIterators;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// todo (cgardens) - needs a test.
+/**
+ * JSONPath is specification for querying JSON objects. More information about the specification can
+ * be found here: https://goessner.net/articles/JsonPath/. For those familiar with jq, JSONPath will
+ * be most recognizable as "that DSL that jq uses".
+ *
+ * We use a java implementation of this specification (repo: https://github.com/json-path/JsonPath).
+ * This class wraps that implementation to make it easier to leverage this tool internally.
+ *
+ * GOTCHA: Keep in mind with JSONPath, depending on the query, 0, 1, or N values may be returned.
+ * The pattern for handling return values is very much like writing SQL queries. When using it, you
+ * must consider what the number of return values for your query might be. e.g. for this object: {
+ * "alpha": [1, 2, 3] }, this JSONPath "$.alpha[*]", would return: [1, 2, 3], but this one
+ * "$.alpha[0]" would return: [1]. The Java interface we place over this query system defaults to
+ * returning a list for query results. In addition, we provide helper functions that will just
+ * return a single value (see: {@link JsonPaths#getSingleValue(JsonNode, String)}. These should only
+ * be used if it is not possible for a query to return more than one value.
+ */
+public class JsonPaths {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JsonPaths.class);
+
+  // set default configurations at start up to match our JSON setup.
+  static {
+    Configuration.setDefaults(new Configuration.Defaults() {
+
+      // allows us to pass in Jackson JsonNode
+      private static final JsonProvider jsonProvider = new JacksonJsonNodeJsonProvider();
+      private static final MappingProvider mappingProvider = new JacksonMappingProvider();
+
+      @Override
+      public JsonProvider jsonProvider() {
+        return jsonProvider;
+      }
+
+      @Override
+      public MappingProvider mappingProvider() {
+        return mappingProvider;
+      }
+
+      @Override
+      public Set<Option> options() {
+        /*
+         * All JsonPath queries will return a list of values. This makes parsing the outputs much easier. In
+         * cases where it is not a list, helpers in this class can assert that. See
+         * https://github.com/json-path/JsonPath in the JsonPath documentation.
+         */
+        return EnumSet.of(Option.ALWAYS_RETURN_LIST);
+      }
+
+    });
+  }
+
+  /*
+   * This version of the JsonPath Configuration object allows queries to return to the path of values
+   * instead of the values that were found.
+   */
+  private static final Configuration GET_PATHS_CONFIGURATION = Configuration.defaultConfiguration().addOptions(Option.AS_PATH_LIST);
+
+  /**
+   * Attempt to validate if a string is a valid JSONPath string. This assertion does NOT handle all
+   * cases, but at least a common on. We can add to it as we detect others.
+   *
+   * @param jsonPath - path to validate
+   */
+  public static void assertIsJsonPath(final String jsonPath) {
+    Preconditions.checkArgument(jsonPath.startsWith("$"));
+  }
+
+  /**
+   * Attempt to detect if a JSONPath query could return more than 1 value. This assertion does NOT
+   * handle all cases, but at least a common on. We can add to it as we detect others.
+   *
+   * @param jsonPath - path to validate
+   */
+  public static void assertIsSingleReturnQuery(final String jsonPath) {
+    Preconditions.checkArgument(jsonPath.contains("*"), "Cannot accept paths with wildcards because they may return more than one item.");
+  }
+
+  /**
+   * Traverses into a json object and replaces all values that match the input path with the provided
+   * string. Throws if no existing fields match the path.
+   *
+   * @param json - json object
+   * @param jsonPath - path into the json object. must be in the format of JSONPath.
+   * @param replacement - a string value to replace the current value at the jsonPath
+   * @throws PathNotFoundException throws if the path is not present in the object
+   */
+  public static void replaceAtWithStringLoud(final JsonNode json, final String jsonPath, final String replacement) {
+    assertIsJsonPath(jsonPath);
+    JsonPath.parse(json).set(jsonPath, replacement).json();
+  }
+
+  /**
+   * Traverses into a json object and replaces all values that match the input path with the provided
+   * string . Does nothing if no existing fields match the path.
+   *
+   * @param json - json object
+   * @param jsonPath - path into the json object. must be in the format of JSONPath.
+   * @param replacement - a string value to replace the current value at the jsonPath
+   */
+  public static void replaceAtWithString(final JsonNode json, final String jsonPath, final String replacement) {
+    try {
+      replaceAtWithStringLoud(json, jsonPath, replacement);
+    } catch (final PathNotFoundException e) {
+      LOGGER.debug("Path not found", e);
+    }
+  }
+
+  /**
+   * Traverses into a json object and replaces all values that match the input path with the provided
+   * json object. Does nothing if no existing fields match the path.
+   *
+   * @param json - json object
+   * @param jsonPath - path into the json object. must be in the format of JSONPath.
+   * @param replacement - a json node to replace the current value at the jsonPath
+   */
+  public static void replaceAtJsonNode(final JsonNode json, final String jsonPath, final JsonNode replacement) {
+    assertIsJsonPath(jsonPath);
+    try {
+      JsonPath.parse(json).set(jsonPath, replacement).json();
+    } catch (final PathNotFoundException e) {
+      LOGGER.debug("Path not found", e);
+    }
+  }
+
+  /**
+   * Traverses into a json object and replaces all values that match the input path with the output of
+   * the provided function. Does nothing if no existing fields match the path.
+   *
+   * @param json - json object
+   * @param jsonPath - path into the json object. must be in the format of JSONPath.
+   * @param replacementFunction - a function that takes in a node that matches the path as well as the
+   *        path to the node itself. the return of this function will replace the current node.
+   */
+  public static void replaceAt(final JsonNode json, final String jsonPath, final BiFunction<JsonNode, String, JsonNode> replacementFunction) {
+    assertIsJsonPath(jsonPath);
+    try {
+      final List<String> foundPaths = getPaths(json, jsonPath);
+      for (final String foundPath : foundPaths) {
+        getSingleValue(json, foundPath).ifPresent(node -> {
+          final JsonNode replacement = replacementFunction.apply(node, foundPath);
+          replaceAtJsonNode(json, foundPath, replacement);
+        });
+
+      }
+    } catch (final PathNotFoundException e) {
+      LOGGER.debug("Path not found", e);
+    }
+  }
+
+  /**
+   * Given a JSONPath, returns all the values that match that path.
+   *
+   * e.g. for this object: { "alpha": [1, 2, 3] }, if the input JSONPath were "$.alpha[*]", this
+   * function would return: [1, 2, 3].
+   *
+   * @param json - json object
+   * @param jsonPath - path into the json object. must be in the format of JSONPath.
+   * @return all values that match the input query
+   */
+  public static List<JsonNode> getValues(final JsonNode json, final String jsonPath) {
+    return getInternal(Configuration.defaultConfiguration(), json, jsonPath);
+  }
+
+  /**
+   * Given a JSONPath, returns all the path of all values that match that path.
+   *
+   * e.g. for this object: { "alpha": [1, 2, 3] }, if the input JSONPath were "$.alpha[*]", this
+   * function would return: ["$.alpha[0]", "$.alpha[1]", "$.alpha[2]"].
+   *
+   * @param json - json object
+   * @param jsonPath - path into the json object. must be in the format of JSONPath.
+   * @return all paths that are present that match the input query
+   */
+  public static List<String> getPaths(final JsonNode json, final String jsonPath) {
+    return getInternal(GET_PATHS_CONFIGURATION, json, jsonPath)
+        .stream()
+        .map(JsonNode::asText)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Given a JSONPath, returns 1 or 0 values that match the path. Throws is more than 1 value is
+   * found.
+   *
+   * THIS SHOULD ONLY BE USED IF THE JSONPATH CAN ONLY EVER RETURN 0 OR 1 VALUES. e.g. don't do
+   * "$.alpha[*]"
+   *
+   * @param json - json object
+   * @param jsonPath - path into the json object. must be in the format of JSONPath.
+   * @return value if present, otherwise empty.
+   */
+  public static Optional<JsonNode> getSingleValue(final JsonNode json, final String jsonPath) {
+    assertIsSingleReturnQuery(jsonPath);
+
+    final List<JsonNode> jsonNodes = getValues(json, jsonPath);
+
+    Preconditions.checkState(jsonNodes.size() <= 1, String.format("Path returned more than one item. path: %s items: %s", jsonPath, jsonNodes));
+    return jsonNodes.isEmpty() ? Optional.empty() : Optional.of(jsonNodes.get(0));
+  }
+
+  /**
+   * Given a JSONPath, true if path is present in the object, otherwise false. Throws is more than 1
+   * path is found.
+   *
+   * THIS SHOULD ONLY BE USED IF THE JSONPATH CAN ONLY EVER RETURN 0 OR 1 VALUES. e.g. don't do
+   * "$.alpha[*]"
+   *
+   * @param json - json object
+   * @param jsonPath - path into the json object. must be in the format of JSONPath.
+   * @return true if path is present in the object, otherwise false.
+   */
+  public static boolean isPathPresent(final JsonNode json, final String jsonPath) {
+    assertIsSingleReturnQuery(jsonPath);
+
+    final List<String> foundPaths = getPaths(json, jsonPath);
+
+    Preconditions.checkState(foundPaths.size() <= 1, String.format("Path returned more than one item. path: %s items: %s", jsonPath, foundPaths));
+    return !foundPaths.isEmpty();
+  }
+
+  /**
+   *
+   * @param conf - JsonPath configuration. Primarily used to reuse code to allow fetching values or
+   *        paths from a json object
+   * @param json - json object
+   * @param jsonPath - path into the json object. must be in the format of JSONPath.
+   * @return all values that match the input query (whether the values are paths or actual values in
+   *         the json object is determined by the conf)
+   */
+  private static List<JsonNode> getInternal(final Configuration conf, final JsonNode json, final String jsonPath) {
+    assertIsJsonPath(jsonPath);
+    try {
+      return MoreIterators.toList(JsonPath.using(conf).parse(json).read(jsonPath, ArrayNode.class).iterator());
+    } catch (final PathNotFoundException e) {
+      return Collections.emptyList();
+    }
+  }
+
+}

--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonPaths.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonPaths.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// todo (cgardens) - needs a test.
 /**
  * JSONPath is specification for querying JSON objects. More information about the specification can
  * be found here: https://goessner.net/articles/JsonPath/. For those familiar with jq, JSONPath will
@@ -41,8 +40,8 @@ import org.slf4j.LoggerFactory;
  * "alpha": [1, 2, 3] }, this JSONPath "$.alpha[*]", would return: [1, 2, 3], but this one
  * "$.alpha[0]" would return: [1]. The Java interface we place over this query system defaults to
  * returning a list for query results. In addition, we provide helper functions that will just
- * return a single value (see: {@link JsonPaths#getSingleValue(JsonNode, String)}. These should only
- * be used if it is not possible for a query to return more than one value.
+ * return a single value (see: {@link JsonPaths#getSingleValue(JsonNode, String)}). These should
+ * only be used if it is not possible for a query to return more than one value.
  */
 public class JsonPaths {
 
@@ -187,8 +186,6 @@ public class JsonPaths {
    */
   public static JsonNode replaceAtStringLoud(final JsonNode json, final String jsonPath, final String replacement) {
     return replaceAtJsonNodeLoud(json, jsonPath, Jsons.jsonNode(replacement));
-    // assertIsJsonPath(jsonPath);
-    // return JsonPath.parse(Jsons.clone(json)).set(jsonPath, replacement).json();
   }
 
   /**

--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonPaths.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonPaths.java
@@ -136,7 +136,7 @@ public class JsonPaths {
   }
 
   /**
-   * Given a JSONPath, returns 1 or 0 values that match the path. Throws is more than 1 value is
+   * Given a JSONPath, returns 1 or 0 values that match the path. Throws if more than 1 value is
    * found.
    *
    * THIS SHOULD ONLY BE USED IF THE JSONPATH CAN ONLY EVER RETURN 0 OR 1 VALUES. e.g. don't do

--- a/airbyte-commons/src/test/java/io/airbyte/commons/json/JsonPathsTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/json/JsonPathsTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.jayway.jsonpath.PathNotFoundException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class JsonPathsTest {
+
+  private static final String JSON = """
+                                     {
+                                       "one": [0,1,2],
+                                       "two": { "nested": 10}
+                                     }""";
+  private static final JsonNode JSON_NODE = Jsons.deserialize(JSON);
+  private static final String LIST_ALL_QUERY = "$.one[*]";
+  private static final String LIST_ONE_QUERY = "$.one[1]";
+  private static final String NESTED_FIELD_QUERY = "$.two.nested";
+  private static final String JSON_OBJECT_QUERY = "$.two";
+  private static final String EMPTY_RETURN_QUERY = "$.three";
+  private static final String REPLACEMENT_STRING = "replaced";
+  private static final JsonNode REPLACEMENT_JSON = Jsons.deserialize("{ \"replacement\": \"replaced\" }");
+
+  @Test
+  void testGetValues() {
+    assertEquals(List.of(0, 1, 2), JsonPaths.getValues(JSON_NODE, LIST_ALL_QUERY).stream().map(JsonNode::asInt).collect(Collectors.toList()));
+    assertEquals(List.of(1), JsonPaths.getValues(JSON_NODE, LIST_ONE_QUERY).stream().map(JsonNode::asInt).collect(Collectors.toList()));
+    assertEquals(List.of(10), JsonPaths.getValues(JSON_NODE, NESTED_FIELD_QUERY).stream().map(JsonNode::asInt).collect(Collectors.toList()));
+    assertEquals(JSON_NODE.get("two"), JsonPaths.getValues(JSON_NODE, JSON_OBJECT_QUERY).stream().findFirst().orElse(null));
+    assertEquals(Collections.emptyList(), JsonPaths.getValues(JSON_NODE, EMPTY_RETURN_QUERY));
+  }
+
+  @Test
+  void testGetSingleValue() {
+    assertThrows(IllegalArgumentException.class, () -> JsonPaths.getSingleValue(JSON_NODE, LIST_ALL_QUERY));
+    assertEquals(1, JsonPaths.getSingleValue(JSON_NODE, LIST_ONE_QUERY).map(JsonNode::asInt).orElse(null));
+    assertEquals(10, JsonPaths.getSingleValue(JSON_NODE, NESTED_FIELD_QUERY).map(JsonNode::asInt).orElse(null));
+    assertEquals(JSON_NODE.get("two"), JsonPaths.getSingleValue(JSON_NODE, JSON_OBJECT_QUERY).orElse(null));
+    assertNull(JsonPaths.getSingleValue(JSON_NODE, EMPTY_RETURN_QUERY).orElse(null));
+  }
+
+  @Test
+  void testGetPaths() {
+    assertEquals(List.of("$['one'][0]", "$['one'][1]", "$['one'][2]"), JsonPaths.getPaths(JSON_NODE, LIST_ALL_QUERY));
+    assertEquals(List.of("$['one'][1]"), JsonPaths.getPaths(JSON_NODE, LIST_ONE_QUERY));
+    assertEquals(List.of("$['two']['nested']"), JsonPaths.getPaths(JSON_NODE, NESTED_FIELD_QUERY));
+    assertEquals(List.of("$['two']"), JsonPaths.getPaths(JSON_NODE, JSON_OBJECT_QUERY));
+    assertEquals(Collections.emptyList(), JsonPaths.getPaths(JSON_NODE, EMPTY_RETURN_QUERY));
+  }
+
+  @Test
+  void testIsPathPresent() {
+    assertThrows(IllegalArgumentException.class, () -> JsonPaths.isPathPresent(JSON_NODE, LIST_ALL_QUERY));
+    assertTrue(JsonPaths.isPathPresent(JSON_NODE, LIST_ONE_QUERY));
+    assertTrue(JsonPaths.isPathPresent(JSON_NODE, NESTED_FIELD_QUERY));
+    assertTrue(JsonPaths.isPathPresent(JSON_NODE, JSON_OBJECT_QUERY));
+    assertFalse(JsonPaths.isPathPresent(JSON_NODE, EMPTY_RETURN_QUERY));
+  }
+
+  @Test
+  void testReplaceAtStringLoud() {
+    assertOriginalObjectNotModified(JSON_NODE, () -> {
+      final JsonNode expected = Jsons.clone(JSON_NODE);
+      ((ArrayNode) expected.get("one")).set(1, REPLACEMENT_STRING);
+
+      final JsonNode actual = JsonPaths.replaceAtStringLoud(JSON_NODE, LIST_ONE_QUERY, REPLACEMENT_STRING);
+      assertEquals(expected, actual);
+    });
+  }
+
+  @SuppressWarnings("CodeBlock2Expr")
+  @Test
+  void testReplaceAtStringLoudEmptyPathThrows() {
+    assertOriginalObjectNotModified(JSON_NODE, () -> {
+      assertThrows(PathNotFoundException.class, () -> JsonPaths.replaceAtStringLoud(JSON_NODE, EMPTY_RETURN_QUERY, REPLACEMENT_STRING));
+    });
+  }
+
+  @Test
+  void testReplaceAtString() {
+    assertOriginalObjectNotModified(JSON_NODE, () -> {
+      final JsonNode expected = Jsons.clone(JSON_NODE);
+      ((ArrayNode) expected.get("one")).set(1, REPLACEMENT_STRING);
+
+      final JsonNode actual = JsonPaths.replaceAtString(JSON_NODE, LIST_ONE_QUERY, REPLACEMENT_STRING);
+      assertEquals(expected, actual);
+    });
+  }
+
+  @Test
+  void testReplaceAtStringEmptyReturnNoOp() {
+    assertOriginalObjectNotModified(JSON_NODE, () -> {
+      final JsonNode expected = Jsons.clone(JSON_NODE);
+
+      final JsonNode actual = JsonPaths.replaceAtString(JSON_NODE, EMPTY_RETURN_QUERY, REPLACEMENT_STRING);
+      assertEquals(expected, actual);
+    });
+  }
+
+  @Test
+  void testReplaceAtJsonNodeLoud() {
+    assertOriginalObjectNotModified(JSON_NODE, () -> {
+      final JsonNode expected = Jsons.clone(JSON_NODE);
+      ((ArrayNode) expected.get("one")).set(1, REPLACEMENT_JSON);
+
+      final JsonNode actual = JsonPaths.replaceAtJsonNodeLoud(JSON_NODE, LIST_ONE_QUERY, REPLACEMENT_JSON);
+      assertEquals(expected, actual);
+    });
+  }
+
+  @SuppressWarnings("CodeBlock2Expr")
+  @Test
+  void testReplaceAtJsonNodeLoudEmptyPathThrows() {
+    assertOriginalObjectNotModified(JSON_NODE, () -> {
+      assertThrows(PathNotFoundException.class, () -> JsonPaths.replaceAtJsonNodeLoud(JSON_NODE, EMPTY_RETURN_QUERY, REPLACEMENT_JSON));
+    });
+  }
+
+  @Test
+  void testReplaceAtJsonNodeLoudMultipleReplace() {
+    assertOriginalObjectNotModified(JSON_NODE, () -> {
+      final JsonNode expected = Jsons.clone(JSON_NODE);
+      ((ArrayNode) expected.get("one")).set(0, REPLACEMENT_JSON);
+      ((ArrayNode) expected.get("one")).set(1, REPLACEMENT_JSON);
+      ((ArrayNode) expected.get("one")).set(2, REPLACEMENT_JSON);
+
+      final JsonNode actual = JsonPaths.replaceAtJsonNodeLoud(JSON_NODE, LIST_ALL_QUERY, REPLACEMENT_JSON);
+      assertEquals(expected, actual);
+    });
+  }
+
+  // todo (cgardens) - this behavior is a little unintuitive, but based on the docs, there's not an
+  // obvious workaround. in this case, i would expect this to silently do nothing instead of throwing.
+  // for now just documenting it with a test. to avoid this, use the non-loud version of this method.
+  @SuppressWarnings("CodeBlock2Expr")
+  @Test
+  void testReplaceAtJsonNodeLoudMultipleReplaceSplatInEmptyArrayThrows() {
+    final JsonNode expected = Jsons.clone(JSON_NODE);
+    ((ArrayNode) expected.get("one")).removeAll();
+
+    assertOriginalObjectNotModified(expected, () -> {
+      assertThrows(PathNotFoundException.class, () -> JsonPaths.replaceAtJsonNodeLoud(expected, "$.one[*]", REPLACEMENT_JSON));
+    });
+  }
+
+  @Test
+  void testReplaceAtJsonNode() {
+    assertOriginalObjectNotModified(JSON_NODE, () -> {
+      final JsonNode expected = Jsons.clone(JSON_NODE);
+      ((ArrayNode) expected.get("one")).set(1, REPLACEMENT_JSON);
+
+      final JsonNode actual = JsonPaths.replaceAtJsonNode(JSON_NODE, LIST_ONE_QUERY, REPLACEMENT_JSON);
+      assertEquals(expected, actual);
+    });
+  }
+
+  @Test
+  void testReplaceAtJsonNodeEmptyReturnNoOp() {
+    assertOriginalObjectNotModified(JSON_NODE, () -> {
+      final JsonNode expected = Jsons.clone(JSON_NODE);
+
+      final JsonNode actual = JsonPaths.replaceAtJsonNode(JSON_NODE, EMPTY_RETURN_QUERY, REPLACEMENT_JSON);
+      assertEquals(expected, actual);
+    });
+  }
+
+  @Test
+  void testReplaceAt() {
+    assertOriginalObjectNotModified(JSON_NODE, () -> {
+      final JsonNode expected = Jsons.clone(JSON_NODE);
+      ((ArrayNode) expected.get("one")).set(1, "1-$['one'][1]");
+
+      final JsonNode actual = JsonPaths.replaceAt(JSON_NODE, LIST_ONE_QUERY, (node, path) -> Jsons.jsonNode(node + "-" + path));
+      assertEquals(expected, actual);
+    });
+  }
+
+  @Test
+  void testReplaceAtMultiple() {
+    assertOriginalObjectNotModified(JSON_NODE, () -> {
+      final JsonNode expected = Jsons.clone(JSON_NODE);
+      ((ArrayNode) expected.get("one")).set(0, "0-$['one'][0]");
+      ((ArrayNode) expected.get("one")).set(1, "1-$['one'][1]");
+      ((ArrayNode) expected.get("one")).set(2, "2-$['one'][2]");
+
+      final JsonNode actual = JsonPaths.replaceAt(JSON_NODE, LIST_ALL_QUERY, (node, path) -> Jsons.jsonNode(node + "-" + path));
+      assertEquals(expected, actual);
+    });
+  }
+
+  @Test
+  void testReplaceAtEmptyReturnNoOp() {
+    assertOriginalObjectNotModified(JSON_NODE, () -> {
+      final JsonNode expected = Jsons.clone(JSON_NODE);
+
+      final JsonNode actual = JsonPaths.replaceAt(JSON_NODE, EMPTY_RETURN_QUERY, (node, path) -> Jsons.jsonNode(node + "-" + path));
+      assertEquals(expected, actual);
+    });
+  }
+
+  /**
+   * For all replacement functions, they should NOT mutate in place. Helper assertion to verify that
+   * invariant.
+   *
+   * @param json - json object used for testing
+   * @param runnable - the rest of the test code that does the replacement
+   */
+  private static void assertOriginalObjectNotModified(final JsonNode json, final Runnable runnable) {
+    final JsonNode originalJsonNode = Jsons.clone(json);
+    runnable.run();
+    // verify the original object was not mutated.
+    assertEquals(originalJsonNode, json);
+  }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -272,6 +272,7 @@ subprojects {
         implementation 'com.fasterxml.jackson.core:jackson-annotations'
         implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
         implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+        implementation 'com.jayway.jsonpath:json-path:2.7.0'
 
         implementation 'com.google.guava:guava:30.1.1-jre'
 

--- a/build.gradle
+++ b/build.gradle
@@ -272,7 +272,6 @@ subprojects {
         implementation 'com.fasterxml.jackson.core:jackson-annotations'
         implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
         implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
-        implementation 'com.jayway.jsonpath:json-path:2.7.0'
 
         implementation 'com.google.guava:guava:30.1.1-jre'
 


### PR DESCRIPTION
## What
With our heavy use of JSON, having a way query into JSON objects is valuable. The main case it has come up recently is being able to convert paths in JSONSchema into queries that we can use to query into configuration objects. For example if the json schema is something like:
```json
"connectionSpecification": {
    "type": "object",
    "properties": {
      "username": {
        "type": "string"
      },
      "password": {
        "type": "string",
        "airbyte_secret": true
      }
    }
  }
```
We want to be able to say something like, give me all of the paths for a potential configuration object that matches this schema that is a secret. In this case it is just "$.password". We would then use that information to perform queries or replacements on the actual configuration object itself. e.g. `{ "username": "charles", "password": "hunter2" }` => `{ "username": "charles", "password": "********" }`. This gets more complicated as you have more complex JSON objects with nesting, arrays, etc. Right now we are pretty haphazard in solving this problem and have multiple implementations of how try to handle it. Introducing this will help consolidate it.

In order to do this we need some query language for json. The JSONPath specification does exactly that. More information about the specification can be found [here](https://goessner.net/articles/JsonPath/). For those familiar with jq, JSONPath will be most recognizable as pretty much "that DSL that jq uses". 

This PR introduces a java implementation of that specification ([repository](https://github.com/json-path/JsonPath))  called JsonPath. The goal of this PR is to introduce this library in such a way that JSONPath can be easily used by our developers _without_ them having to be experts on that underlying library. Thus, I'm introducing common helper functions. I will be using these directly in subsequent PR for secrets improvements, but for now, I'm doing these as a separate PR for clarity.

## Recommended reading order
1. `JsonPaths.java`
2. `JsonPathsTest.java`
