### PR TITLE
add pod ip logging for orchestrator

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/AsyncOrchestratorPodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/AsyncOrchestratorPodProcess.java
@@ -289,7 +289,7 @@ public class AsyncOrchestratorPodProcess implements KubePod {
         .withVolumeMounts(volumeMounts)
         .build();
 
-    final Pod pod = new PodBuilder()
+    final Pod podToCreate = new PodBuilder()
         .withApiVersion("v1")
         .withNewMetadata()
         .withName(getInfo().name())
@@ -307,7 +307,7 @@ public class AsyncOrchestratorPodProcess implements KubePod {
     // should only create after the kubernetes API creates the pod
     final var createdPod = kubernetesClient.pods()
         .inNamespace(getInfo().namespace())
-        .createOrReplace(pod);
+        .createOrReplace(podToCreate);
 
     log.info("Waiting for pod to be running...");
     try {
@@ -321,11 +321,13 @@ public class AsyncOrchestratorPodProcess implements KubePod {
       throw new RuntimeException(e);
     }
 
-    final var containerState = kubernetesClient.pods()
+    final var podStatus = kubernetesClient.pods()
         .inNamespace(kubePodInfo.namespace())
         .withName(kubePodInfo.name())
         .get()
-        .getStatus()
+        .getStatus();
+
+    final var containerState = podStatus
         .getContainerStatuses()
         .get(0)
         .getState();
@@ -333,6 +335,8 @@ public class AsyncOrchestratorPodProcess implements KubePod {
     if (containerState.getRunning() == null) {
       throw new RuntimeException("Pod was not running, state was: " + containerState);
     }
+
+    log.info(String.format("Pod %s/%s is running on %s", kubePodInfo.namespace(), kubePodInfo.name(), podStatus.getPodIP()));
 
     final var updatedFileMap = new HashMap<>(fileMap);
     updatedFileMap.put(KUBE_POD_INFO, Jsons.serialize(kubePodInfo));


### PR DESCRIPTION
It's much easier to debug https://github.com/airbytehq/airbyte/issues/11621 from past examples if we log the pod IPs for:
- sources (already logged)
- destinations (already logged)
- orchestrator (this PR)

Then we can easily identify from logs for a run with a `SocketException` if all of the pods involved were node-local.