### PR TITLE
fix race condition in port reintroduction test

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePortManagerSingleton.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePortManagerSingleton.java
@@ -4,12 +4,14 @@
 
 package io.airbyte.workers.process;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,6 +65,11 @@ public class KubePortManagerSingleton {
 
   public Integer take() throws InterruptedException {
     return workerPorts.poll(10, TimeUnit.MINUTES);
+  }
+
+  @VisibleForTesting
+  public @Nullable Integer takeImmediately() {
+    return workerPorts.poll();
   }
 
   public void offer(final Integer port) {

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
@@ -4,9 +4,7 @@
 
 package io.airbyte.workers.process;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -33,8 +31,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -184,16 +184,20 @@ public class KubePodProcessIntegrationTest {
     // run a background process to continuously consume available ports
     final var portsTaken = new ArrayList<Integer>();
     final var executor = Executors.newSingleThreadExecutor();
+    final var shouldContinueTakingPorts = new AtomicBoolean(true);
+    final var doneTakingPorts = new CountDownLatch(1);
 
     executor.submit(() -> {
-      try {
-        while (true) {
-          portsTaken.add(KubePortManagerSingleton.getInstance().take());
+      while (shouldContinueTakingPorts.get()) {
+        final var portTaken = KubePortManagerSingleton.getInstance().takeImmediately();
+
+        if (portTaken != null) {
+          LOGGER.info("portTaken = " + portTaken);
+          portsTaken.add(portTaken);
         }
-      } catch (final InterruptedException e) {
-        e.printStackTrace();
-        throw new RuntimeException(e);
       }
+
+      doneTakingPorts.countDown();
     });
 
     // repeatedly call exitValue (and therefore the close method)
@@ -207,7 +211,13 @@ public class KubePodProcessIntegrationTest {
     // wait for the background loop to actually take the ports re-offered by the closure of the process
     Thread.sleep(1000);
 
-    // interrupt background thread
+    // tell the thread to stop taking ports
+    shouldContinueTakingPorts.set(false);
+
+    // wait for the thread to actually stop taking ports
+    assertTrue(doneTakingPorts.await(5, TimeUnit.SECONDS));
+
+    // interrupt thread
     executor.shutdownNow();
 
     // prior to fixing this race condition, the close method would offer ports every time it was called.

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
@@ -4,7 +4,10 @@
 
 package io.airbyte.workers.process;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
fixes https://github.com/airbytehq/airbyte/issues/9650#issuecomment-1088490888

This locks properly around accessing the ports now. The problem before was that it could be in the middle of a `take` in the background thread when it wasn't supposed to be.