### PR TITLE
Fix pre-commit hook failing because of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     hooks:
       - id: licenseheaders
         args: ["--tmpl=LICENSE_SHORT", "--ext=py", "-f"]
-  - repo: https://github.com/ambv/black
+  - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
       - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: licenseheaders
         args: ["--tmpl=LICENSE_SHORT", "--ext=py", "-f"]
   - repo: https://github.com/ambv/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: ["--config", "pyproject.toml"]


### PR DESCRIPTION
## What
See [this issue](https://github.com/airbytehq/airbyte/issues/11493) and [this PR](https://github.com/airbytehq/airbyte/pull/11494).

I've just updated the black version in the pre-commit hook to match the upgrade done there.
