### PR TITLE
Create and Persist Normalization Output

### DIFF
--- a/airbyte-config/models/src/main/resources/types/NormalizationSummary.yaml
+++ b/airbyte-config/models/src/main/resources/types/NormalizationSummary.yaml
@@ -1,7 +1,7 @@
 ---
 "$schema": http://json-schema.org/draft-07/schema#
 "$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/NormalizationSummary.yaml
-title: StandardNormalizationSummary
+title: NormalizationSummary
 description: information output by syncs for which a normalization step was performed
 type: object
 required:

--- a/airbyte-config/models/src/main/resources/types/NormalizationSummary.yaml
+++ b/airbyte-config/models/src/main/resources/types/NormalizationSummary.yaml
@@ -1,8 +1,8 @@
 ---
 "$schema": http://json-schema.org/draft-07/schema#
-"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardNormalizationSummary.yaml
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/NormalizationSummary.yaml
 title: StandardNormalizationSummary
-description: standard information output by ALL sources for a normalization step
+description: information output by syncs for which a normalization step was performed
 type: object
 required:
   - startTime

--- a/airbyte-config/models/src/main/resources/types/StandardNormalizationSummary.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardNormalizationSummary.yaml
@@ -1,0 +1,15 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardNormalizationSummary.yaml
+title: StandardNormalizationSummary
+description: standard information output by ALL sources for a normalization step
+type: object
+required:
+  - startTime
+  - endTime
+additionalProperties: false
+properties:
+  startTime:
+    type: integer
+  endTime:
+    type: integer

--- a/airbyte-config/models/src/main/resources/types/StandardSyncOutput.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSyncOutput.yaml
@@ -12,6 +12,8 @@ required:
 properties:
   standardSyncSummary:
     "$ref": StandardSyncSummary.yaml
+  standardNormalizationSummary:
+    "$ref": StandardNormalizationSummary.yaml
   state:
     "$ref": State.yaml
   output_catalog:

--- a/airbyte-config/models/src/main/resources/types/StandardSyncOutput.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSyncOutput.yaml
@@ -12,8 +12,8 @@ required:
 properties:
   standardSyncSummary:
     "$ref": StandardSyncSummary.yaml
-  standardNormalizationSummary:
-    "$ref": StandardNormalizationSummary.yaml
+  normalizationSummary:
+    "$ref": NormalizationSummary.yaml
   state:
     "$ref": State.yaml
   output_catalog:

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultNormalizationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultNormalizationWorker.java
@@ -6,7 +6,7 @@ package io.airbyte.workers;
 
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.NormalizationInput;
-import io.airbyte.config.StandardNormalizationSummary;
+import io.airbyte.config.NormalizationSummary;
 import io.airbyte.workers.normalization.NormalizationRunner;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -40,7 +40,7 @@ public class DefaultNormalizationWorker implements NormalizationWorker {
   }
 
   @Override
-  public StandardNormalizationSummary run(final NormalizationInput input, final Path jobRoot) throws WorkerException {
+  public NormalizationSummary run(final NormalizationInput input, final Path jobRoot) throws WorkerException {
     final long startTime = System.currentTimeMillis();
 
     try (normalizationRunner) {
@@ -70,7 +70,7 @@ public class DefaultNormalizationWorker implements NormalizationWorker {
     final String durationDescription = DurationFormatUtils.formatDurationWords(duration.toMillis(), true, true);
     LOGGER.info("Normalization executed in {}.", durationDescription);
 
-    final StandardNormalizationSummary summary = new StandardNormalizationSummary()
+    final NormalizationSummary summary = new NormalizationSummary()
         .withStartTime(startTime)
         .withEndTime(endTime);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultNormalizationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultNormalizationWorker.java
@@ -6,6 +6,7 @@ package io.airbyte.workers;
 
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.NormalizationInput;
+import io.airbyte.config.StandardNormalizationSummary;
 import io.airbyte.workers.normalization.NormalizationRunner;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -39,7 +40,7 @@ public class DefaultNormalizationWorker implements NormalizationWorker {
   }
 
   @Override
-  public Void run(final NormalizationInput input, final Path jobRoot) throws WorkerException {
+  public StandardNormalizationSummary run(final NormalizationInput input, final Path jobRoot) throws WorkerException {
     final long startTime = System.currentTimeMillis();
 
     try (normalizationRunner) {
@@ -64,11 +65,16 @@ public class DefaultNormalizationWorker implements NormalizationWorker {
       LOGGER.info("Normalization was cancelled.");
     }
 
-    final Duration duration = Duration.ofMillis(System.currentTimeMillis() - startTime);
+    final long endTime = System.currentTimeMillis();
+    final Duration duration = Duration.ofMillis(endTime - startTime);
     final String durationDescription = DurationFormatUtils.formatDurationWords(duration.toMillis(), true, true);
     LOGGER.info("Normalization executed in {}.", durationDescription);
 
-    return null;
+    final StandardNormalizationSummary summary = new StandardNormalizationSummary()
+        .withStartTime(startTime)
+        .withEndTime(endTime);
+
+    return summary;
   }
 
   @Override

--- a/airbyte-workers/src/main/java/io/airbyte/workers/NormalizationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/NormalizationWorker.java
@@ -5,6 +5,6 @@
 package io.airbyte.workers;
 
 import io.airbyte.config.NormalizationInput;
-import io.airbyte.config.StandardNormalizationSummary;
+import io.airbyte.config.NormalizationSummary;
 
-public interface NormalizationWorker extends Worker<NormalizationInput, StandardNormalizationSummary> {}
+public interface NormalizationWorker extends Worker<NormalizationInput, NormalizationSummary> {}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/NormalizationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/NormalizationWorker.java
@@ -5,5 +5,6 @@
 package io.airbyte.workers;
 
 import io.airbyte.config.NormalizationInput;
+import io.airbyte.config.StandardNormalizationSummary;
 
-public interface NormalizationWorker extends Worker<NormalizationInput, Void> {}
+public interface NormalizationWorker extends Worker<NormalizationInput, StandardNormalizationSummary> {}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivity.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivity.java
@@ -16,7 +16,7 @@ public interface NormalizationActivity {
 
   @ActivityMethod
   StandardNormalizationSummary normalize(JobRunConfig jobRunConfig,
-                 IntegrationLauncherConfig destinationLauncherConfig,
-                 NormalizationInput input);
+                                         IntegrationLauncherConfig destinationLauncherConfig,
+                                         NormalizationInput input);
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivity.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivity.java
@@ -5,7 +5,7 @@
 package io.airbyte.workers.temporal.sync;
 
 import io.airbyte.config.NormalizationInput;
-import io.airbyte.config.StandardNormalizationSummary;
+import io.airbyte.config.NormalizationSummary;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.temporal.activity.ActivityInterface;
@@ -15,8 +15,8 @@ import io.temporal.activity.ActivityMethod;
 public interface NormalizationActivity {
 
   @ActivityMethod
-  StandardNormalizationSummary normalize(JobRunConfig jobRunConfig,
-                                         IntegrationLauncherConfig destinationLauncherConfig,
-                                         NormalizationInput input);
+  NormalizationSummary normalize(JobRunConfig jobRunConfig,
+                                 IntegrationLauncherConfig destinationLauncherConfig,
+                                 NormalizationInput input);
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivity.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivity.java
@@ -5,6 +5,7 @@
 package io.airbyte.workers.temporal.sync;
 
 import io.airbyte.config.NormalizationInput;
+import io.airbyte.config.StandardNormalizationSummary;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.temporal.activity.ActivityInterface;
@@ -14,7 +15,7 @@ import io.temporal.activity.ActivityMethod;
 public interface NormalizationActivity {
 
   @ActivityMethod
-  Void normalize(JobRunConfig jobRunConfig,
+  StandardNormalizationSummary normalize(JobRunConfig jobRunConfig,
                  IntegrationLauncherConfig destinationLauncherConfig,
                  NormalizationInput input);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivityImpl.java
@@ -67,8 +67,8 @@ public class NormalizationActivityImpl implements NormalizationActivity {
 
   @Override
   public StandardNormalizationSummary normalize(final JobRunConfig jobRunConfig,
-                        final IntegrationLauncherConfig destinationLauncherConfig,
-                        final NormalizationInput input) {
+                                                final IntegrationLauncherConfig destinationLauncherConfig,
+                                                final NormalizationInput input) {
     return TemporalUtils.withBackgroundHeartbeat(() -> {
       final var fullDestinationConfig = secretsHydrator.hydrate(input.getDestinationConfiguration());
       final var fullInput = Jsons.clone(input).withDestinationConfiguration(fullDestinationConfig);
@@ -101,9 +101,9 @@ public class NormalizationActivityImpl implements NormalizationActivity {
   }
 
   private CheckedSupplier<Worker<NormalizationInput, StandardNormalizationSummary>, Exception> getLegacyWorkerFactory(
-                                                                                              final WorkerConfigs workerConfigs,
-                                                                                              final IntegrationLauncherConfig destinationLauncherConfig,
-                                                                                              final JobRunConfig jobRunConfig) {
+                                                                                                                      final WorkerConfigs workerConfigs,
+                                                                                                                      final IntegrationLauncherConfig destinationLauncherConfig,
+                                                                                                                      final JobRunConfig jobRunConfig) {
     return () -> new DefaultNormalizationWorker(
         jobRunConfig.getJobId(),
         Math.toIntExact(jobRunConfig.getAttemptId()),
@@ -116,9 +116,9 @@ public class NormalizationActivityImpl implements NormalizationActivity {
   }
 
   private CheckedSupplier<Worker<NormalizationInput, StandardNormalizationSummary>, Exception> getContainerLauncherWorkerFactory(
-                                                                                                         final WorkerConfigs workerConfigs,
-                                                                                                         final IntegrationLauncherConfig destinationLauncherConfig,
-                                                                                                         final JobRunConfig jobRunConfig)
+                                                                                                                                 final WorkerConfigs workerConfigs,
+                                                                                                                                 final IntegrationLauncherConfig destinationLauncherConfig,
+                                                                                                                                 final JobRunConfig jobRunConfig)
       throws IOException {
     final var jobScope = jobPersistence.getJob(Long.parseLong(jobRunConfig.getJobId())).getScope();
     final var connectionId = UUID.fromString(jobScope);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivityImpl.java
@@ -10,7 +10,7 @@ import io.airbyte.config.AirbyteConfigValidator;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.NormalizationInput;
-import io.airbyte.config.StandardNormalizationSummary;
+import io.airbyte.config.NormalizationSummary;
 import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.config.persistence.split_secrets.SecretsHydrator;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
@@ -66,9 +66,9 @@ public class NormalizationActivityImpl implements NormalizationActivity {
   }
 
   @Override
-  public StandardNormalizationSummary normalize(final JobRunConfig jobRunConfig,
-                                                final IntegrationLauncherConfig destinationLauncherConfig,
-                                                final NormalizationInput input) {
+  public NormalizationSummary normalize(final JobRunConfig jobRunConfig,
+                                        final IntegrationLauncherConfig destinationLauncherConfig,
+                                        final NormalizationInput input) {
     return TemporalUtils.withBackgroundHeartbeat(() -> {
       final var fullDestinationConfig = secretsHydrator.hydrate(input.getDestinationConfiguration());
       final var fullInput = Jsons.clone(input).withDestinationConfiguration(fullDestinationConfig);
@@ -78,7 +78,7 @@ public class NormalizationActivityImpl implements NormalizationActivity {
         return fullInput;
       };
 
-      final CheckedSupplier<Worker<NormalizationInput, StandardNormalizationSummary>, Exception> workerFactory;
+      final CheckedSupplier<Worker<NormalizationInput, NormalizationSummary>, Exception> workerFactory;
 
       if (containerOrchestratorConfig.isPresent()) {
         workerFactory = getContainerLauncherWorkerFactory(workerConfigs, destinationLauncherConfig, jobRunConfig);
@@ -86,7 +86,7 @@ public class NormalizationActivityImpl implements NormalizationActivity {
         workerFactory = getLegacyWorkerFactory(workerConfigs, destinationLauncherConfig, jobRunConfig);
       }
 
-      final TemporalAttemptExecution<NormalizationInput, StandardNormalizationSummary> temporalAttemptExecution = new TemporalAttemptExecution<>(
+      final TemporalAttemptExecution<NormalizationInput, NormalizationSummary> temporalAttemptExecution = new TemporalAttemptExecution<>(
           workspaceRoot, workerEnvironment, logConfigs,
           jobRunConfig,
           workerFactory,
@@ -95,15 +95,15 @@ public class NormalizationActivityImpl implements NormalizationActivity {
           jobPersistence,
           airbyteVersion);
 
-      final StandardNormalizationSummary normalizationSummary = temporalAttemptExecution.get();
+      final NormalizationSummary normalizationSummary = temporalAttemptExecution.get();
       return normalizationSummary;
     });
   }
 
-  private CheckedSupplier<Worker<NormalizationInput, StandardNormalizationSummary>, Exception> getLegacyWorkerFactory(
-                                                                                                                      final WorkerConfigs workerConfigs,
-                                                                                                                      final IntegrationLauncherConfig destinationLauncherConfig,
-                                                                                                                      final JobRunConfig jobRunConfig) {
+  private CheckedSupplier<Worker<NormalizationInput, NormalizationSummary>, Exception> getLegacyWorkerFactory(
+                                                                                                              final WorkerConfigs workerConfigs,
+                                                                                                              final IntegrationLauncherConfig destinationLauncherConfig,
+                                                                                                              final JobRunConfig jobRunConfig) {
     return () -> new DefaultNormalizationWorker(
         jobRunConfig.getJobId(),
         Math.toIntExact(jobRunConfig.getAttemptId()),
@@ -115,10 +115,10 @@ public class NormalizationActivityImpl implements NormalizationActivity {
         workerEnvironment);
   }
 
-  private CheckedSupplier<Worker<NormalizationInput, StandardNormalizationSummary>, Exception> getContainerLauncherWorkerFactory(
-                                                                                                                                 final WorkerConfigs workerConfigs,
-                                                                                                                                 final IntegrationLauncherConfig destinationLauncherConfig,
-                                                                                                                                 final JobRunConfig jobRunConfig)
+  private CheckedSupplier<Worker<NormalizationInput, NormalizationSummary>, Exception> getContainerLauncherWorkerFactory(
+                                                                                                                         final WorkerConfigs workerConfigs,
+                                                                                                                         final IntegrationLauncherConfig destinationLauncherConfig,
+                                                                                                                         final JobRunConfig jobRunConfig)
       throws IOException {
     final var jobScope = jobPersistence.getJob(Long.parseLong(jobRunConfig.getJobId())).getScope();
     final var connectionId = UUID.fromString(jobScope);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationLauncherWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationLauncherWorker.java
@@ -6,7 +6,7 @@ package io.airbyte.workers.temporal.sync;
 
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.NormalizationInput;
-import io.airbyte.config.StandardNormalizationSummary;
+import io.airbyte.config.NormalizationSummary;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.WorkerApp;
@@ -14,7 +14,7 @@ import io.airbyte.workers.WorkerConfigs;
 import java.util.Map;
 import java.util.UUID;
 
-public class NormalizationLauncherWorker extends LauncherWorker<NormalizationInput, StandardNormalizationSummary> {
+public class NormalizationLauncherWorker extends LauncherWorker<NormalizationInput, NormalizationSummary> {
 
   public static final String NORMALIZATION = "normalization-orchestrator";
   private static final String POD_NAME_PREFIX = "orchestrator-norm";
@@ -34,7 +34,7 @@ public class NormalizationLauncherWorker extends LauncherWorker<NormalizationInp
             INIT_FILE_DESTINATION_LAUNCHER_CONFIG, Jsons.serialize(destinationLauncherConfig)),
         containerOrchestratorConfig,
         workerConfigs.getResourceRequirements(),
-        StandardNormalizationSummary.class);
+        NormalizationSummary.class);
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationLauncherWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationLauncherWorker.java
@@ -6,6 +6,7 @@ package io.airbyte.workers.temporal.sync;
 
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.NormalizationInput;
+import io.airbyte.config.StandardNormalizationSummary;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.WorkerApp;
@@ -13,7 +14,7 @@ import io.airbyte.workers.WorkerConfigs;
 import java.util.Map;
 import java.util.UUID;
 
-public class NormalizationLauncherWorker extends LauncherWorker<NormalizationInput, Void> {
+public class NormalizationLauncherWorker extends LauncherWorker<NormalizationInput, StandardNormalizationSummary> {
 
   public static final String NORMALIZATION = "normalization-orchestrator";
   private static final String POD_NAME_PREFIX = "orchestrator-norm";
@@ -33,7 +34,7 @@ public class NormalizationLauncherWorker extends LauncherWorker<NormalizationInp
             INIT_FILE_DESTINATION_LAUNCHER_CONFIG, Jsons.serialize(destinationLauncherConfig)),
         containerOrchestratorConfig,
         workerConfigs.getResourceRequirements(),
-        Void.class);
+        StandardNormalizationSummary.class);
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -5,8 +5,8 @@
 package io.airbyte.workers.temporal.sync;
 
 import io.airbyte.config.NormalizationInput;
+import io.airbyte.config.NormalizationSummary;
 import io.airbyte.config.OperatorDbtInput;
-import io.airbyte.config.StandardNormalizationSummary;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncOperation.OperatorType;
@@ -40,7 +40,7 @@ public class SyncWorkflowImpl implements SyncWorkflow {
                                 final StandardSyncInput syncInput,
                                 final UUID connectionId) {
 
-    final StandardSyncOutput run = replicationActivity.replicate(jobRunConfig, sourceLauncherConfig, destinationLauncherConfig, syncInput);
+    StandardSyncOutput syncOutput = replicationActivity.replicate(jobRunConfig, sourceLauncherConfig, destinationLauncherConfig, syncInput);
 
     final int version = Workflow.getVersion(VERSION_LABEL, Workflow.DEFAULT_VERSION, CURRENT_VERSION);
 
@@ -48,7 +48,7 @@ public class SyncWorkflowImpl implements SyncWorkflow {
       // the state is persisted immediately after the replication succeeded, because the
       // state is a checkpoint of the raw data that has been copied to the destination;
       // normalization & dbt does not depend on it
-      persistActivity.persist(connectionId, run);
+      persistActivity.persist(connectionId, syncOutput);
     }
 
     if (syncInput.getOperationSequence() != null && !syncInput.getOperationSequence().isEmpty()) {
@@ -56,12 +56,12 @@ public class SyncWorkflowImpl implements SyncWorkflow {
         if (standardSyncOperation.getOperatorType() == OperatorType.NORMALIZATION) {
           final NormalizationInput normalizationInput = new NormalizationInput()
               .withDestinationConfiguration(syncInput.getDestinationConfiguration())
-              .withCatalog(run.getOutputCatalog())
+              .withCatalog(syncOutput.getOutputCatalog())
               .withResourceRequirements(syncInput.getDestinationResourceRequirements());
 
-          final StandardNormalizationSummary normalizationSummary =
+          final NormalizationSummary normalizationSummary =
               normalizationActivity.normalize(jobRunConfig, destinationLauncherConfig, normalizationInput);
-          persistActivity.persist(connectionId, run.withStandardNormalizationSummary(normalizationSummary));
+          syncOutput = syncOutput.withNormalizationSummary(normalizationSummary);
         } else if (standardSyncOperation.getOperatorType() == OperatorType.DBT) {
           final OperatorDbtInput operatorDbtInput = new OperatorDbtInput()
               .withDestinationConfiguration(syncInput.getDestinationConfiguration())
@@ -76,7 +76,7 @@ public class SyncWorkflowImpl implements SyncWorkflow {
       }
     }
 
-    return run;
+    return syncOutput;
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -59,7 +59,8 @@ public class SyncWorkflowImpl implements SyncWorkflow {
               .withCatalog(run.getOutputCatalog())
               .withResourceRequirements(syncInput.getDestinationResourceRequirements());
 
-          final StandardNormalizationSummary normalizationSummary = normalizationActivity.normalize(jobRunConfig, destinationLauncherConfig, normalizationInput);
+          final StandardNormalizationSummary normalizationSummary =
+              normalizationActivity.normalize(jobRunConfig, destinationLauncherConfig, normalizationInput);
           persistActivity.persist(connectionId, run.withStandardNormalizationSummary(normalizationSummary));
         } else if (standardSyncOperation.getOperatorType() == OperatorType.DBT) {
           final OperatorDbtInput operatorDbtInput = new OperatorDbtInput()

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -6,6 +6,7 @@ package io.airbyte.workers.temporal.sync;
 
 import io.airbyte.config.NormalizationInput;
 import io.airbyte.config.OperatorDbtInput;
+import io.airbyte.config.StandardNormalizationSummary;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncOperation.OperatorType;
@@ -58,7 +59,8 @@ public class SyncWorkflowImpl implements SyncWorkflow {
               .withCatalog(run.getOutputCatalog())
               .withResourceRequirements(syncInput.getDestinationResourceRequirements());
 
-          normalizationActivity.normalize(jobRunConfig, destinationLauncherConfig, normalizationInput);
+          final StandardNormalizationSummary normalizationSummary = normalizationActivity.normalize(jobRunConfig, destinationLauncherConfig, normalizationInput);
+          persistActivity.persist(connectionId, run.withStandardNormalizationSummary(normalizationSummary));
         } else if (standardSyncOperation.getOperatorType() == OperatorType.DBT) {
           final OperatorDbtInput operatorDbtInput = new OperatorDbtInput()
               .withDestinationConfiguration(syncInput.getDestinationConfiguration())

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultNormalizationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultNormalizationWorkerTest.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.workers;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -11,6 +12,7 @@ import static org.mockito.Mockito.when;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.EnvConfigs;
 import io.airbyte.config.NormalizationInput;
+import io.airbyte.config.NormalizationSummary;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.workers.normalization.NormalizationRunner;
@@ -60,7 +62,7 @@ class DefaultNormalizationWorkerTest {
     final DefaultNormalizationWorker normalizationWorker =
         new DefaultNormalizationWorker(JOB_ID, JOB_ATTEMPT, normalizationRunner, WorkerEnvironment.DOCKER);
 
-    normalizationWorker.run(normalizationInput, jobRoot);
+    final NormalizationSummary normalizationOutput = normalizationWorker.run(normalizationInput, jobRoot);
 
     verify(normalizationRunner).start();
     verify(normalizationRunner).normalize(
@@ -70,6 +72,8 @@ class DefaultNormalizationWorkerTest {
         normalizationInput.getDestinationConfiguration(),
         normalizationInput.getCatalog(), workerConfigs.getResourceRequirements());
     verify(normalizationRunner).close();
+    assertNotNull(normalizationOutput.getStartTime());
+    assertNotNull(normalizationOutput.getEndTime());
   }
 
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.times;
 
 import io.airbyte.config.NormalizationInput;
 import io.airbyte.config.OperatorDbtInput;

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityTest.java
@@ -9,6 +9,7 @@ import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.FailureReason;
 import io.airbyte.config.FailureReason.FailureOrigin;
 import io.airbyte.config.JobOutput;
+import io.airbyte.config.NormalizationSummary;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.StandardSyncSummary;
@@ -88,7 +89,9 @@ public class JobCreationAndStatusUpdateActivityTest {
   private static final StandardSyncOutput standardSyncOutput = new StandardSyncOutput()
       .withStandardSyncSummary(
           new StandardSyncSummary()
-              .withStatus(ReplicationStatus.COMPLETED));
+              .withStatus(ReplicationStatus.COMPLETED))
+      .withNormalizationSummary(
+          new NormalizationSummary());
 
   private static final JobOutput jobOutput = new JobOutput().withSync(standardSyncOutput);
 


### PR DESCRIPTION
## What
We would like to start charging for the cost of normalization, so we need to persist data about normalization. This PR adds a StandardNormalizationOutput, updates the Normalization worker to return that output, and persists it to the db.

## How
StandardNormalizationOutput is nested within StandardSyncOutput. The normalization worker returns a StandardNormalizationSummary, and this is appended to the StandardSyncOutput and updated in the db.



┆Issue is synchronized with this [Monday item](https://airbyte-bunch.monday.com/boards/2536787439/pulses/2537101090) by [Unito](https://www.unito.io)
