### PR TITLE
Fixing publish command gitref for bot push

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -227,7 +227,7 @@ jobs:
         run: |
           git add -u
           git commit -m "auto-bump connector version"
-          git push origin ${{ github.ref }}
+          git push origin ${{ github.event.inputs.gitref }}
       - name: Add Version Bump Success Comment
         if: github.event.inputs.comment-id && github.event.inputs.auto-bump-version == 'true' && success()
         uses: peter-evans/create-or-update-comment@v1

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -523,7 +523,7 @@
 - name: OpenWeather
   sourceDefinitionId: d8540a80-6120-485d-b7d6-272bca477d9b
   dockerRepository: airbyte/source-openweather
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   documentationUrl: https://docs.airbyte.io/integrations/sources/openweather
   sourceType: api
 - name: Oracle DB

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -5610,7 +5610,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-openweather:0.1.0"
+- dockerImage: "airbyte/source-openweather:0.1.1"
   spec:
     documentationUrl: "https://docsurl.com"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-openweather/Dockerfile
+++ b/airbyte-integrations/connectors/source-openweather/Dockerfile
@@ -34,5 +34,5 @@ COPY source_openweather ./source_openweather
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-openweather


### PR DESCRIPTION
## What
@alafanechere pointed out an issue with the new publish command (found while publishing in [this PR](https://github.com/airbytehq/airbyte/pull/11765)). The git push from Octavia is trying to push to master rather than the relevant branch. This PR fixes that so we use the right gitref.