### PR TITLE
S3 / GCS staging: use correct staging filename

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/S3StorageOperationsTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/S3StorageOperationsTest.java
@@ -99,4 +99,12 @@ public class S3StorageOperationsTest {
     assertEquals(OBJECT_TO_DELETE, deleteRequest.getValue().getKeys().get(0).getKey());
   }
 
+  @Test
+  void testGetFilename() {
+    assertEquals("filename", S3StorageOperations.getFilename("filename"));
+    assertEquals("filename", S3StorageOperations.getFilename("/filename"));
+    assertEquals("filename", S3StorageOperations.getFilename("/p1/p2/filename"));
+    assertEquals("filename.csv", S3StorageOperations.getFilename("/p1/p2/filename.csv"));
+  }
+
 }

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeS3StagingSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeS3StagingSqlOperations.java
@@ -64,12 +64,8 @@ public class SnowflakeS3StagingSqlOperations extends SnowflakeSqlOperations impl
                                      final SerializableBuffer recordsData,
                                      final String schemaName,
                                      final String stageName,
-                                     final String stagingPath)
-      throws Exception {
-    AirbyteSentry.executeWithTracing("UploadRecordsToStage",
-        () -> s3StorageOperations.uploadRecordsToBucket(recordsData, schemaName, stageName, stagingPath),
-        Map.of("stage", stageName, "path", stagingPath));
-    return recordsData.getFilename();
+                                     final String stagingPath) {
+    return s3StorageOperations.uploadRecordsToBucket(recordsData, schemaName, stageName, stagingPath);
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeS3StagingSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeS3StagingSqlOperations.java
@@ -65,7 +65,9 @@ public class SnowflakeS3StagingSqlOperations extends SnowflakeSqlOperations impl
                                      final String schemaName,
                                      final String stageName,
                                      final String stagingPath) {
-    return s3StorageOperations.uploadRecordsToBucket(recordsData, schemaName, stageName, stagingPath);
+    return AirbyteSentry.queryWithTracing("UploadRecordsToStage", () ->
+        s3StorageOperations.uploadRecordsToBucket(recordsData, schemaName, stageName, stagingPath),
+        Map.of("stage", stageName, "path", stagingPath));
   }
 
   @Override


### PR DESCRIPTION
## What
- When serialized buffer file is uploaded to blob storage, its UUID filename is simplified to `<partId>.<extension>`. However, the original UUID filename was used in the following steps, resulting in empty data.
- This PR fixes this bug by returning the new filename.

## 🚨 User Impact 🚨
- Currently, only Snowflake S3 staging is affected by this bug. But the buggy version is not published.
- So no user impact is expected.
