### PR TITLE
check should upload data into the bucket path provided

### DIFF
--- a/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/GcsDestination.java
+++ b/airbyte-integrations/connectors/destination-gcs/src/main/java/io/airbyte/integrations/destination/gcs/GcsDestination.java
@@ -46,10 +46,10 @@ public class GcsDestination extends BaseConnector implements Destination {
       final AmazonS3 s3Client = destinationConfig.getS3Client();
 
       // Test single upload (for small files) permissions
-      S3Destination.testSingleUpload(s3Client, destinationConfig.getBucketName());
+      S3Destination.testSingleUpload(s3Client, destinationConfig.getBucketName(), destinationConfig.getBucketPath());
 
       // Test multipart upload with stream transfer manager
-      S3Destination.testMultipartUpload(s3Client, destinationConfig.getBucketName());
+      S3Destination.testMultipartUpload(s3Client, destinationConfig.getBucketName(), destinationConfig.getBucketPath());
 
       return new AirbyteConnectionStatus().withStatus(Status.SUCCEEDED);
     } catch (final Exception e) {


### PR DESCRIPTION
In GCS/S3 when we run the check process we try to upload data into the bucket but we are not taking the bucket path provided by the user into consideration. This causes failure if a user has granted the service account they are using with Airbyte only access to that specific folder path.