### PR TITLE
#10938 fix docs and spec

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -273,7 +273,7 @@
 - name: Google Analytics
   sourceDefinitionId: eff3616a-f9c3-11eb-9a03-0242ac130003
   dockerRepository: airbyte/source-google-analytics-v4
-  dockerImageTag: 0.1.17
+  dockerImageTag: 0.1.18
   documentationUrl: https://docs.airbyte.io/integrations/sources/google-analytics-v4
   icon: google-analytics.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -2754,7 +2754,7 @@
         oauthFlowOutputParameters:
         - - "access_token"
         - - "refresh_token"
-- dockerImage: "airbyte/source-google-analytics-v4:0.1.17"
+- dockerImage: "airbyte/source-google-analytics-v4:0.1.18"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/google-analytics-v4"
     connectionSpecification:
@@ -2783,7 +2783,7 @@
           - "2020-06-01"
         window_in_days:
           type: "integer"
-          title: "Window in days"
+          title: "Window in days (Optional)"
           description: "The amount of days for each data-chunk beginning from start_date.\
             \ Bigger the value - faster the fetch. (Min=1, as for a Day; Max=364,\
             \ as for a Year)."
@@ -2798,7 +2798,7 @@
         custom_reports:
           order: 3
           type: "string"
-          title: "Custom Reports (optional)"
+          title: "Custom Reports (Optional)"
           description: "A JSON array describing the custom reports you want to sync\
             \ from GA. Check out the <a href=\"https://docs.airbyte.io/integrations/sources/google-analytics-v4\"\
             >docs</a> to get more information about this field."
@@ -2818,31 +2818,32 @@
               auth_type:
                 type: "string"
                 const: "Client"
-                enum:
-                - "Client"
-                default: "Client"
                 order: 0
               client_id:
                 title: "Client ID"
                 type: "string"
                 description: "The Client ID of your Google Analytics developer application."
                 airbyte_secret: true
+                order: 1
               client_secret:
                 title: "Client Secret"
                 type: "string"
                 description: "The Client Secret of your Google Analytics developer\
                   \ application."
                 airbyte_secret: true
+                order: 2
               refresh_token:
                 title: "Refresh Token"
                 type: "string"
                 description: "The token for obtaining a new access token."
                 airbyte_secret: true
+                order: 3
               access_token:
-                title: "Access Token"
+                title: "Access Token (Optional)"
                 type: "string"
                 description: "Access Token for making authenticated requests."
                 airbyte_secret: true
+                order: 4
           - type: "object"
             title: "Service Account Key Authentication"
             required:
@@ -2851,9 +2852,6 @@
               auth_type:
                 type: "string"
                 const: "Service"
-                enum:
-                - "Service"
-                default: "Service"
                 order: 0
               credentials_json:
                 title: "JSON credentials"

--- a/airbyte-integrations/connectors/source-google-analytics-v4/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/Dockerfile
@@ -12,5 +12,5 @@ COPY main.py ./
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.17
+LABEL io.airbyte.version=0.1.18
 LABEL io.airbyte.name=airbyte/source-google-analytics-v4

--- a/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
@@ -523,21 +523,20 @@ class SourceGoogleAnalyticsV4(AbstractSource):
         if config.get("credentials_json"):
             return GoogleAnalyticsServiceOauth2Authenticator(config)
 
-        auth_params = config.get("credentials")
+        auth_params = config["credentials"]
 
-        if auth_params.get("auth_type") == "Service" or auth_params.get("credentials_json"):
+        if auth_params["auth_type"] == "Service" or auth_params.get("credentials_json"):
             return GoogleAnalyticsServiceOauth2Authenticator(auth_params)
         else:
             return Oauth2Authenticator(
                 token_refresh_endpoint="https://oauth2.googleapis.com/token",
-                client_secret=auth_params.get("client_secret"),
-                client_id=auth_params.get("client_id"),
-                refresh_token=auth_params.get("refresh_token"),
+                client_secret=auth_params["client_secret"],
+                client_id=auth_params["client_id"],
+                refresh_token=auth_params["refresh_token"],
                 scopes=["https://www.googleapis.com/auth/analytics.readonly"],
             )
 
     def check_connection(self, logger: logging.Logger, config: MutableMapping) -> Tuple[bool, Any]:
-
         # declare additional variables
         authenticator = self.get_authenticator(config)
         config["authenticator"] = authenticator

--- a/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/spec.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/spec.json
@@ -22,7 +22,7 @@
       },
       "window_in_days": {
         "type": "integer",
-        "title": "Window in days",
+        "title": "Window in days (Optional)",
         "description": "The amount of days for each data-chunk beginning from start_date. Bigger the value - faster the fetch. (Min=1, as for a Day; Max=364, as for a Year).",
         "examples": [30, 60, 90, 120, 200, 364],
         "default": 1
@@ -30,7 +30,7 @@
       "custom_reports": {
         "order": 3,
         "type": "string",
-        "title": "Custom Reports (optional)",
+        "title": "Custom Reports (Optional)",
         "description": "A JSON array describing the custom reports you want to sync from GA. Check out the <a href=\"https://docs.airbyte.io/integrations/sources/google-analytics-v4\">docs</a> to get more information about this field."
       },
       "credentials": {
@@ -47,33 +47,35 @@
               "auth_type": {
                 "type": "string",
                 "const": "Client",
-                "enum": ["Client"],
-                "default": "Client",
                 "order": 0
               },
               "client_id": {
                 "title": "Client ID",
                 "type": "string",
                 "description": "The Client ID of your Google Analytics developer application.",
-                "airbyte_secret": true
+                "airbyte_secret": true,
+                "order": 1
               },
               "client_secret": {
                 "title": "Client Secret",
                 "type": "string",
                 "description": "The Client Secret of your Google Analytics developer application.",
-                "airbyte_secret": true
+                "airbyte_secret": true,
+                "order": 2
               },
               "refresh_token": {
                 "title": "Refresh Token",
                 "type": "string",
                 "description": "The token for obtaining a new access token.",
-                "airbyte_secret": true
+                "airbyte_secret": true,
+                "order": 3
               },
               "access_token": {
-                "title": "Access Token",
+                "title": "Access Token (Optional)",
                 "type": "string",
                 "description": "Access Token for making authenticated requests.",
-                "airbyte_secret": true
+                "airbyte_secret": true,
+                "order": 4
               }
             }
           },
@@ -85,8 +87,6 @@
               "auth_type": {
                 "type": "string",
                 "const": "Service",
-                "enum": ["Service"],
-                "default": "Service",
                 "order": 0
               },
               "credentials_json": {

--- a/docs/integrations/sources/google-analytics-v4.md
+++ b/docs/integrations/sources/google-analytics-v4.md
@@ -1,50 +1,38 @@
 # Google Analytics
 
-## Features
+This page guides you through the process of setting up the Google Analytics source connector.
 
-| Feature                       | Supported? |
-|:------------------------------|:-----------|
-| Full Refresh Sync             | Yes        |
-| Incremental Sync              | Yes        |
-| Replicate Incremental Deletes | No         |
-| SSL connection                | Yes        |
-| Custom Reports                | Yes        |
+## Prerequisites
 
-### Supported Tables
+* A [Google Analytics](https://analytics.google.com/analytics/web/provision/#/provision) Account
+* View ID
+* Start date
 
-This source is capable of syncing the following tables and their data:
+## Step 1: Set up Source
 
-* website\_overview
-* traffic\_sources
-* pages
-* locations
-* monthly\_active\_users
-* four\_weekly\_active\_users
-* two\_weekly\_active\_users
-* weekly\_active\_users
-* daily\_active\_users
-* devices
-* Any custom reports. See [below](https://docs.airbyte.io/integrations/sources/google-analytics-v4#reading-custom-reports-from-google-analytics) for details.
+Decide which Views you'd like to sync, prepare View IDs. Decide what date you'd like to start your data sync from.
 
-Please reach out to us on Slack or [create an issue](https://github.com/airbytehq/airbyte/issues) if you need to send custom Google Analytics report data with Airbyte.
+## Step 2: Set up the source connector in Airbyte
 
-## Getting Started \(Airbyte Cloud\)
+**For Airbyte Cloud:**
 
-1. Click `OAuth2.0 authorization` then `Authenticate your Google Analytics account`.
-2. Find your View ID for the view you want to fetch data from. Find it [here](https://ga-dev-tools.web.app/account-explorer/).
-3. Enter a start date, and custom report information.
-4. You're done.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
+3. On the Set up the source page, enter the name for the Google Analytics connector and select **Google Analytics** from the Source type dropdown.
+4. Click `OAuth2.0 authorization` then `Authenticate your Google Analytics account`.
+5. Find your View ID for the view you want to fetch data from. Find it [here](https://ga-dev-tools.web.app/account-explorer/).
+6. Enter a start date, and custom report information.
 
-## Getting Started \(Airbyte Open-Source\)
+**For Airbyte OSS:**
 
 There are 2 options of setting up authorization for this source:
 
-* Create service account specifically for Airbyte and authorize with JWT. Select "JWT authorization" from the "Authentication mechanism" dropdown list.
-* Use your Google account and authorize over Google's OAuth on connection setup. Select "Default OAuth2.0 authorization" from dropdown list.
+* Create service account specifically for Airbyte and authorize with JWT. Select `JWT authorization` from the `Authentication mechanism` dropdown list.
+* Use your Google account and authorize over Google's OAuth on connection setup. Select `Default OAuth2.0 authorization` from dropdown list.
 
 #### Create a Service Account
 
-First, need to select or create a project in the Google Developers Console:
+First, you need to select existing or create a new project in the Google Developers Console:
 
 1. Sign in to the Google Account you are using for Google Analytics as an admin.
 2. Go to the [Service accounts page](https://console.developers.google.com/iam-admin/serviceaccounts).
@@ -60,6 +48,53 @@ Use the service account email address to [add a user](https://support.google.com
 1. Go to the [Google Analytics Reporting API dashboard](https://console.developers.google.com/apis/api/analyticsreporting.googleapis.com/overview) in the project for your service user. Enable the API for your account. You can set quotas and check usage.
 2. Go to the [Google Analytics API dashboard](https://console.developers.google.com/apis/api/analytics.googleapis.com/overview) in the project for your service user. Enable the API for your account.
 
+## Supported sync modes
+
+The Google Analytics source connector supports the following [sync modes](https://docs.airbyte.com/getting-started-with-airbyte-cloud/core-concepts#connection-sync-modes):
+ - Full Refresh
+ - Incremental
+
+## Rate Limits & Performance Considerations \(Airbyte Open-Source\)
+
+[Analytics Reporting API v4](https://developers.google.com/analytics/devguides/reporting/core/v4/limits-quotas)
+
+* Number of requests per day per project: 50,000
+* Number of requests per view \(profile\) per day: 10,000 \(cannot be increased\)
+* Number of requests per 100 seconds per project: 2,000
+* Number of requests per 100 seconds per user per project: 100 \(can be increased in Google API Console to 1,000\).
+
+The Google Analytics connector should not run into Google Analytics API limitations under normal usage. Please [create an issue](https://github.com/airbytehq/airbyte/issues) if you see any rate limit issues that are not automatically retried successfully.
+
+## Supported streams
+
+This source is capable of syncing the following tables and their data:
+
+| Stream name                  | Schema                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+|:-----------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| website_overview             | `{"ga_date":"2021-02-11","ga_users":1,"ga_newUsers":0,"ga_sessions":9,"ga_sessionsPerUser":9.0,"ga_avgSessionDuration":28.77777777777778,"ga_pageviews":63,"ga_pageviewsPerSession":7.0,"ga_avgTimeOnPage":4.685185185185185,"ga_bounceRate":0.0,"ga_exitRate":14.285714285714285,"view_id":"211669975"}`                                                                                                                                                         |
+| traffic_sources              | `{"ga_date":"2021-02-11","ga_source":"(direct)","ga_medium":"(none)","ga_socialNetwork":"(not set)","ga_users":1,"ga_newUsers":0,"ga_sessions":9,"ga_sessionsPerUser":9.0,"ga_avgSessionDuration":28.77777777777778,"ga_pageviews":63,"ga_pageviewsPerSession":7.0,"ga_avgTimeOnPage":4.685185185185185,"ga_bounceRate":0.0,"ga_exitRate":14.285714285714285,"view_id":"211669975"}`                                                                              |
+| pages                        | `{"ga_date":"2021-02-11","ga_hostname":"mydemo.com","ga_pagePath":"/home5","ga_pageviews":63,"ga_uniquePageviews":9,"ga_avgTimeOnPage":4.685185185185185,"ga_entrances":9,"ga_entranceRate":14.285714285714285,"ga_bounceRate":0.0,"ga_exits":9,"ga_exitRate":14.285714285714285,"view_id":"211669975"}`                                                                                                                                                          |
+| locations                    | `{"ga_date":"2021-02-11","ga_continent":"Americas","ga_subContinent":"Northern America","ga_country":"United States","ga_region":"Iowa","ga_metro":"Des Moines-Ames IA","ga_city":"Des Moines","ga_users":1,"ga_newUsers":0,"ga_sessions":1,"ga_sessionsPerUser":1.0,"ga_avgSessionDuration":29.0,"ga_pageviews":7,"ga_pageviewsPerSession":7.0,"ga_avgTimeOnPage":4.666666666666667,"ga_bounceRate":0.0,"ga_exitRate":14.285714285714285,"view_id":"211669975"}` |
+| monthly_active_users         | `{"ga_date":"2021-02-11","ga_30dayUsers":1,"view_id":"211669975"}`                                                                                                                                                                                                                                                                                                                                                                                                |
+| four_weekly_active_users     | `{"ga_date":"2021-02-11","ga_28dayUsers":1,"view_id":"211669975"}`                                                                                                                                                                                                                                                                                                                                                                                                |
+| two_weekly_active_users      | `{"ga_date":"2021-02-11","ga_14dayUsers":1,"view_id":"211669975"}`                                                                                                                                                                                                                                                                                                                                                                                                |
+| weekly_active_users          | `{"ga_date":"2021-02-11","ga_7dayUsers":1,"view_id":"211669975"}`                                                                                                                                                                                                                                                                                                                                                                                                 |
+| daily_active_users           | `{"ga_date":"2021-02-11","ga_1dayUsers":1,"view_id":"211669975"}`                                                                                                                                                                                                                                                                                                                                                                                                 |
+| devices                      | `{"ga_date":"2021-02-11","ga_deviceCategory":"desktop","ga_operatingSystem":"Macintosh","ga_browser":"Chrome","ga_users":1,"ga_newUsers":0,"ga_sessions":9,"ga_sessionsPerUser":9.0,"ga_avgSessionDuration":28.77777777777778,"ga_pageviews":63,"ga_pageviewsPerSession":7.0,"ga_avgTimeOnPage":4.685185185185185,"ga_bounceRate":0.0,"ga_exitRate":14.285714285714285,"view_id":"211669975"}`                                                                    |
+| Any custom reports           | See [below](https://docs.airbyte.com/integrations/sources/google-analytics-v4#reading-custom-reports) for details.                                                                                                                                                                                                                                                                                                                                                |
+
+Please reach out to us on Slack or [create an issue](https://github.com/airbytehq/airbyte/issues) if you need to send custom Google Analytics report data with Airbyte.
+
+## Sampling in reports 
+
+Google Analytics API may, under certain circumstances, limit the returned data based on sampling. This is done to reduce the amount of data that is returned as described in [Sampling](https://developers.google.com/analytics/devguides/reporting/core/v4/basics#sampling) section of the Reporting API docs.
+The `window_in_day` parameter is used to specify the number of days to look back and can be used to avoid sampling.
+When sampling occurs, a warning is logged to the sync log.
+
+## IsDataGolden
+
+Google Analytics API may return provisional or incomplete data. When this occurs, the returned data will set the flag `isDataGolden` to false, and the connector will log a warning to the sync log.
+
 ## Reading Custom Reports
 
 You can replicate Google Analytics [Custom Reports](https://support.google.com/analytics/answer/1033013?hl=en) using this source. To do this, input a JSON object as a string in the "Custom Reports" field when setting up the connector. The JSON is an array of objects where each object has the following schema:
@@ -74,7 +109,7 @@ Here is an example input "Custom Reports" field:
 [{"name": "new_users_per_day", "dimensions": ["ga:date","ga:country","ga:region"], "metrics": ["ga:newUsers"]}, {"name": "users_per_city", "dimensions": ["ga:city"], "metrics": ["ga:users"]}]
 ```
 
-To create a list of dimensions, you can use default GA dimensions \(listed below\) or custom dimensions if you have some defined. Each report can contain no more than 7 dimensions, and they must all be unique. The default GA dimensions are:
+To create a list of dimensions, you can use default GA dimensions (listed below) or custom dimensions if you have some defined. Each report can contain no more than 7 dimensions, and they must all be unique. The default GA dimensions are:
 
 * `ga:browser`
 * `ga:city`
@@ -92,7 +127,7 @@ To create a list of dimensions, you can use default GA dimensions \(listed below
 * `ga:source`
 * `ga:subContinent`
 
-To create a list of metrics, use a default GA metric \(values from the list below\) or custom metrics if you have defined them.  
+To create a list of metrics, use a default GA metric (values from the list below) or custom metrics if you have defined them.  
 A custom report can contain no more than 10 unique metrics. The default available GA metrics are:
 
 * `ga:14dayUsers`
@@ -115,47 +150,26 @@ A custom report can contain no more than 10 unique metrics. The default availabl
 * `ga:uniquePageviews`
 * `ga:users`
 
-Incremental sync supports only if you add `ga:date` dimension to your custom report.
-
-## Rate Limits & Performance Considerations \(Airbyte Open-Source\)
-
-[Analytics Reporting API v4](https://developers.google.com/analytics/devguides/reporting/core/v4/limits-quotas)
-
-* Number of requests per day per project: 50,000
-* Number of requests per view \(profile\) per day: 10,000 \(cannot be increased\)
-* Number of requests per 100 seconds per project: 2,000
-* Number of requests per 100 seconds per user per project: 100 \(can be increased in Google API Console to 1,000\).
-
-The Google Analytics connector should not run into Google Analytics API limitations under normal usage. Please [create an issue](https://github.com/airbytehq/airbyte/issues) if you see any rate limit issues that are not automatically retried successfully.
-
-## Sampling in reports 
-
-Google Analytics API may, under certain circumstances, limit the returned data based on sampling. This is done to reduce the amount of data that is returned as described in https://developers.google.com/analytics/devguides/reporting/core/v4/basics#sampling
-The window_in_day parameter is used to specify the number of days to look back and can be used to avoid sampling.
-When sampling occurs, a warning is logged to the sync log.
-
-## IsDataGolden
-
-Google Analytics API may return provisional or incomplete data. When this occurs, the returned data will set the fleg isDataGolden to false, and the connector will log a warning to the sync log.
+Incremental sync is supported only if you add `ga:date` dimension to your custom report.
 
 ## Changelog
 
-| Version | Date       | Pull Request                                                                                          | Subject                                                                                    |
-|:--------|:-----------|:------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------------|
-| 0.1.17  | 2022-03-31 | [11512](https://github.com/airbytehq/airbyte/pull/11512)                                              | Improved Unit and Acceptance tests coverage, fix `read` with abnormally large state values |
-| 0.1.16  | 2022-01-26 | [9480](https://github.com/airbytehq/airbyte/pull/9480)                                                | Reintroduce `window_in_days` and log warning when sampling occurs                          |
-| 0.1.15  | 2021-12-28 | [9165](https://github.com/airbytehq/airbyte/pull/9165)                                                | Update titles and descriptions                                                             |
-| 0.1.14  | 2021-12-09 | [8656](https://github.com/airbytehq/airbyte/pull/8656)                                                | Fix date-format in schemas                                                                 |
-| 0.1.13  | 2021-12-09 | [8676](https://github.com/airbytehq/airbyte/pull/8676)                                                | Fix `window_in_days` validation issue                                                      |
-| 0.1.12  | 2021-12-03 | [8175](https://github.com/airbytehq/airbyte/pull/8175)                                                | Fix validation of unknown metric(s) or dimension(s) error                                  |
-| 0.1.11  | 2021-11-30 | [8264](https://github.com/airbytehq/airbyte/pull/8264)                                                | Corrected date range                                                                       |
-| 0.1.10  | 2021-11-19 | [8087](https://github.com/airbytehq/airbyte/pull/8087)                                                | Support `start_date` before the account has any data                                       |
-| 0.1.9   | 2021-10-27 | [7410](https://github.com/airbytehq/airbyte/pull/7410)                                                | Add check for correct permission for requested `view_id`                                   |
-| 0.1.8   | 2021-10-13 | [7020](https://github.com/airbytehq/airbyte/pull/7020)                                                | Add intermediary auth config support                                                       |
-| 0.1.7   | 2021-10-07 | [6414](https://github.com/airbytehq/airbyte/pull/6414)                                                | Declare oauth parameters in google sources                                                 |
-| 0.1.6   | 2021-09-27 | [6459](https://github.com/airbytehq/airbyte/pull/6459)                                                | Update OAuth Spec File                                                                     |
-| 0.1.3   | 2021-09-21 | [6357](https://github.com/airbytehq/airbyte/pull/6357)                                                | Fix oauth workflow parameters                                                              |
-| 0.1.2   | 2021-09-20 | [6306](https://github.com/airbytehq/airbyte/pull/6306)                                                | Support of airbyte OAuth initialization flow                                               |
-| 0.1.1   | 2021-08-25 | [5655](https://github.com/airbytehq/airbyte/pull/5655)                                                | Corrected validation of empty custom report                                                |
-| 0.1.0   | 2021-08-10 | [5290](https://github.com/airbytehq/airbyte/pull/5290)                                                | Initial Release                                                                            |
-
+| Version | Date       | Pull Request                                             | Subject                                                                                      |
+|:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|
+| 0.1.18  | 2022-04-07 |                                                          | Improved documentation                                                                       |
+| 0.1.17  | 2022-03-31 | [11512](https://github.com/airbytehq/airbyte/pull/11512) | Improved Unit and Acceptance tests coverage, fixed `read` with abnormally large state values |
+| 0.1.16  | 2022-01-26 | [9480](https://github.com/airbytehq/airbyte/pull/9480)   | Reintroduce `window_in_days` and log warning when sampling occurs                            |
+| 0.1.15  | 2021-12-28 | [9165](https://github.com/airbytehq/airbyte/pull/9165)   | Update titles and descriptions                                                               |
+| 0.1.14  | 2021-12-09 | [8656](https://github.com/airbytehq/airbyte/pull/8656)   | Fix date format in schemas                                                                   |
+| 0.1.13  | 2021-12-09 | [8676](https://github.com/airbytehq/airbyte/pull/8676)   | Fix `window_in_days` validation issue                                                        |
+| 0.1.12  | 2021-12-03 | [8175](https://github.com/airbytehq/airbyte/pull/8175)   | Fix validation of unknown metric(s) or dimension(s) error                                    |
+| 0.1.11  | 2021-11-30 | [8264](https://github.com/airbytehq/airbyte/pull/8264)   | Corrected date range                                                                         |
+| 0.1.10  | 2021-11-19 | [8087](https://github.com/airbytehq/airbyte/pull/8087)   | Support `start_date` before the account has any data                                         |
+| 0.1.9   | 2021-10-27 | [7410](https://github.com/airbytehq/airbyte/pull/7410)   | Add check for correct permission for requested `view_id`                                     |
+| 0.1.8   | 2021-10-13 | [7020](https://github.com/airbytehq/airbyte/pull/7020)   | Add intermediary auth config support                                                         |
+| 0.1.7   | 2021-10-07 | [6414](https://github.com/airbytehq/airbyte/pull/6414)   | Declare OAuth parameters in Google sources                                                   |
+| 0.1.6   | 2021-09-27 | [6459](https://github.com/airbytehq/airbyte/pull/6459)   | Update OAuth Spec File                                                                       |
+| 0.1.3   | 2021-09-21 | [6357](https://github.com/airbytehq/airbyte/pull/6357)   | Fix OAuth workflow parameters                                                                |
+| 0.1.2   | 2021-09-20 | [6306](https://github.com/airbytehq/airbyte/pull/6306)   | Support of Airbyte OAuth initialization flow                                                 |
+| 0.1.1   | 2021-08-25 | [5655](https://github.com/airbytehq/airbyte/pull/5655)   | Corrected validation of empty custom report                                                  |
+| 0.1.0   | 2021-08-10 | [5290](https://github.com/airbytehq/airbyte/pull/5290)   | Initial Release                                                                              |

--- a/docs/integrations/sources/google-analytics-v4.md
+++ b/docs/integrations/sources/google-analytics-v4.md
@@ -156,7 +156,7 @@ Incremental sync is supported only if you add `ga:date` dimension to your custom
 
 | Version | Date       | Pull Request                                             | Subject                                                                                      |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|
-| 0.1.18  | 2022-04-07 |                                                          | Improved documentation                                                                       |
+| 0.1.18  | 2022-04-07 | [11803](https://github.com/airbytehq/airbyte/pull/11803) | Improved documentation                                                                       |
 | 0.1.17  | 2022-03-31 | [11512](https://github.com/airbytehq/airbyte/pull/11512) | Improved Unit and Acceptance tests coverage, fixed `read` with abnormally large state values |
 | 0.1.16  | 2022-01-26 | [9480](https://github.com/airbytehq/airbyte/pull/9480)   | Reintroduce `window_in_days` and log warning when sampling occurs                            |
 | 0.1.15  | 2021-12-28 | [9165](https://github.com/airbytehq/airbyte/pull/9165)   | Update titles and descriptions                                                               |


### PR DESCRIPTION
## Source GA to Beta: fix specs and doc
* fix doc in accordance with new template
* fix input config: mark optional fields `Optional`, set fields' order explicitly
* treat `config["credentials"]` as required in the code (actually it is not required in spec, but will always be present due to `oneOf`)
* remove an odd fixture in unit tests



┆Issue is synchronized with this [Monday item](https://airbyte-bunch.monday.com/boards/2536787439/pulses/2537092805) by [Unito](https://www.unito.io)
