### PR TITLE
Clean up normalization logs; make mysql tests run on m1

### DIFF
--- a/airbyte-integrations/bases/base-normalization/entrypoint.sh
+++ b/airbyte-integrations/bases/base-normalization/entrypoint.sh
@@ -116,7 +116,7 @@ function main() {
 
     # We don't run dbt 1.0.x on all destinations (because their plugins don't support it yet)
     # So we need to only pass `--event-buffer-size` if it's supported by DBT.
-    dbt --help | grep -E -- '--event-buffer-size'
+    dbt --help | grep -E -- '--event-buffer-size' > /dev/null
     if [ $? -eq 0 ]; then
       echo -e "\nDBT >=1.0.0 detected; using 10K event buffer size\n"
       dbt_additional_args="--event-buffer-size=10000"

--- a/airbyte-integrations/bases/base-normalization/integration_tests/dbt_integration_test.py
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/dbt_integration_test.py
@@ -130,10 +130,12 @@ class DbtIntegrationTest(object):
                 "MYSQL_INITDB_SKIP_TZINFO=yes",
                 "-e",
                 f"MYSQL_DATABASE={config['database']}",
+                "-e",
+                "MYSQL_ROOT_HOST=%",
                 "-p",
                 f"{config['port']}:3306",
                 "-d",
-                "mysql",
+                "mysql/mysql-server",
             ]
             print("Executing: ", " ".join(commands))
             subprocess.call(commands)


### PR DESCRIPTION
Two unrelated changes:


* Switch the integration tests to use `mysql/mysql-server`, as `mysql` does not publish an arm64 image.
  * The new environment variable is to explicitly allow the host machine to connect; by default the container will only accept connections from within the container
* Discard the grep output to make logs a little bit clearer (https://airbytehq-team.slack.com/archives/C02TL38U5L7/p1649334973481429?thread_ts=1649288373.551859&cid=C02TL38U5L7)



┆Issue is synchronized with this [Monday item](https://airbyte-bunch.monday.com/boards/2536787439/pulses/2537092213) by [Unito](https://www.unito.io)
