### PR TITLE
📝 CDK tutorial: fix incorrect variable in code example

### DIFF
--- a/docs/connector-development/tutorials/cdk-tutorial-python-http/6-read-data.md
+++ b/docs/connector-development/tutorials/cdk-tutorial-python-http/6-read-data.md
@@ -176,7 +176,7 @@ Update internal state `cursor_value` inside `read_records` method
     def read_records(self, *args, **kwargs) -> Iterable[Mapping[str, Any]]:
         for record in super().read_records(*args, **kwargs):
             if self._cursor_value:
-                latest_record_date = datetime.strptime(latest_record[self.cursor_field], '%Y-%m-%d')
+                latest_record_date = datetime.strptime(record[self.cursor_field], '%Y-%m-%d')
                 self._cursor_value = max(self._cursor_value, latest_record_date)
             yield record
 


### PR DESCRIPTION
## What
When explaining how to make an incremental source ([Step 6 of the CDK tutorial](https://docs.airbyte.com/connector-development/tutorials/cdk-tutorial-python-http/6-read-data#adding-incremental-sync)), a nonexistent variable is used in the code example for the `read_records` method. 

## How
* Use the correct variable (`record` instead of `latest_record`)



┆Issue is synchronized with this [Monday item](https://airbyte-bunch.monday.com/boards/2536787439/pulses/2537082091) by [Unito](https://www.unito.io)
