### PR TITLE
🐛 Source zoho-crm: remove nullable field

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -9441,9 +9441,7 @@
           - "Sandbox"
         start_datetime:
           title: "Start Date"
-          type:
-          - "null"
-          - "string"
+          type: "string"
           examples:
           - "2000-01-01"
           - "2000-01-01 13:00"

--- a/airbyte-integrations/connectors/source-zoho-crm/Dockerfile
+++ b/airbyte-integrations/connectors/source-zoho-crm/Dockerfile
@@ -34,5 +34,5 @@ COPY source_zoho_crm ./source_zoho_crm
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-zoho-crm

--- a/airbyte-integrations/connectors/source-zoho-crm/source_zoho_crm/spec.json
+++ b/airbyte-integrations/connectors/source-zoho-crm/source_zoho_crm/spec.json
@@ -5,7 +5,12 @@
     "title": "Zoho Crm Configuration",
     "type": "object",
     "required": [
-      "client_id", "client_secret", "refresh_token", "environment", "dc_region", "edition"
+      "client_id",
+      "client_secret",
+      "refresh_token",
+      "environment",
+      "dc_region",
+      "edition"
     ],
     "additionalProperties": false,
     "properties": {
@@ -41,8 +46,14 @@
       },
       "start_datetime": {
         "title": "Start Date",
-        "type": ["null", "string"],
-        "examples": ["2000-01-01", "2000-01-01 13:00", "2000-01-01 13:00:00", "2000-01-01T13:00+00:00", "2000-01-01T13:00:00-07:00"],
+        "type": "string",
+        "examples": [
+          "2000-01-01",
+          "2000-01-01 13:00",
+          "2000-01-01 13:00:00",
+          "2000-01-01T13:00+00:00",
+          "2000-01-01T13:00:00-07:00"
+        ],
         "description": "ISO 8601, for instance: `YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS+HH:MM`",
         "format": "date-time"
       },

--- a/docs/integrations/sources/zoho-crm.md
+++ b/docs/integrations/sources/zoho-crm.md
@@ -130,6 +130,7 @@ Make sure to complete the auth flow quickly, as the initial token granted by Zoh
 
 ## Changelog
 
-| Version | Date       | Pull Request                                             | Subject         |
-|:--------|:-----------|:---------------------------------------------------------|:----------------|
-| 0.1.0   | 2022-03-30 | [11193](https://github.com/airbytehq/airbyte/pull/11193) | Initial release |
+| Version | Date       | Pull Request                                             | Subject                               |
+|:--------|:-----------|:---------------------------------------------------------|:--------------------------------------|
+| 0.1.1   | 2022-04-08 | [11841](https://github.com/airbytehq/airbyte/pull/11841) | Change the type of the start_datetime |
+| 0.1.0   | 2022-03-30 | [11193](https://github.com/airbytehq/airbyte/pull/11193) | Initial release                       |


### PR DESCRIPTION
## What
`octavia-cli` does not expect an array in the `type` fields. 
This connector uses an array in the `type` field for the `start_datetime` field.
It makes octavia integration test fail and octavia won't work to generate config for this connector.

## How
Change `["null", "string"]` to `string`.

