### PR TITLE
[SAT] Fixed schema parsing when a JSONschema  was not present

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.49
+Fixed schema parsing when a JSONschema `type` was not present - we now assume `object` if the `type` is not present.
+
 ## 0.1.48
 Add checking that oneOf common property has only `const` keyword, no `default` and `enum` keywords: [#11704](https://github.com/airbytehq/airbyte/pull/11704)
 

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.48
+LABEL io.airbyte.version=0.1.49
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/README.md
+++ b/airbyte-integrations/bases/source-acceptance-test/README.md
@@ -57,3 +57,10 @@ Using Bash
 ./source-acceptance-test.sh -vv
 ```
 _Note: you can append any arguments to this command, they will be forwarded to pytest
+
+
+## Developing Locally
+
+To run the tests within this dir:
+* Ensure you have `venv` set up with `python3 -m venv .venv` & source it `source ./.venv/bin/activate`
+* Run tests with `python -m pytest -s unit_tests`

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/json_schema_helper.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/json_schema_helper.py
@@ -201,7 +201,7 @@ def get_expected_schema_structure(schema: dict, annotate_one_of: bool = False) -
                     for num, s in enumerate(subschema.get("oneOf") or subschema.get("anyOf"))
                 ]
             return [_scan_schema({"type": "object", **s}, path) for s in subschema.get("oneOf") or subschema.get("anyOf")]
-        schema_type = subschema.get("type", ["null"])
+        schema_type = subschema.get("type", ["object", "null"])
         if not isinstance(schema_type, list):
             schema_type = [schema_type]
         if "object" in schema_type:

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_json_schema_helper.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_json_schema_helper.py
@@ -178,6 +178,7 @@ def test_get_object_strucutre(object, pathes):
     "schema, pathes",
     [
         ({"type": "object", "properties": {"a": {"type": "string"}}}, ["/a"]),
+        ({"properties": {"a": {"type": "string"}}}, ["/a"]),
         ({"type": "object", "properties": {"a": {"type": "string"}, "b": {"type": "number"}}}, ["/a", "/b"]),
         (
             {


### PR DESCRIPTION
## What
Fixed schema parsing when a JSONschema `type` was not present - we now assume `object` if the `type` is not present.

## 🚨 User Impact 🚨
Now a previously valid test won't fail the build! This should make Airbyte developers happy.
