### PR TITLE
🐛 octavia-cli: handle array in types

### DIFF
--- a/octavia-cli/octavia_cli/generate/renderers.py
+++ b/octavia-cli/octavia_cli/generate/renderers.py
@@ -90,6 +90,8 @@ class FieldToRender:
         return "REQUIRED" if self.required else "OPTIONAL"
 
     def _get_type_comment(self) -> str:
+        if isinstance(self.type, list):
+            return ", ".join(self.type)
         return self.type if self.type else None
 
     def _get_secret_comment(self) -> str:

--- a/octavia-cli/unit_tests/test_generate/test_renderers.py
+++ b/octavia-cli/unit_tests/test_generate/test_renderers.py
@@ -80,12 +80,14 @@ class TestFieldToRender:
         field_to_render.required = False
         assert field_to_render._get_required_comment() == "OPTIONAL"
 
-    def test__get_type_comment(self):
+    @pytest.mark.parametrize(
+        "_type,expected_comment",
+        [("string", "string"), (["string", "null"], "string, null"), (None, None)],
+    )
+    def test__get_type_comment(self, _type, expected_comment):
         field_to_render = renderers.FieldToRender("field_name", True, {"foo": "bar"})
-        field_to_render.type = "mytype"
-        assert field_to_render._get_type_comment() == "mytype"
-        field_to_render.type = None
-        assert field_to_render._get_type_comment() is None
+        field_to_render.type = _type
+        assert field_to_render._get_type_comment() == expected_comment
 
     def test__get_secret_comment(self):
         field_to_render = renderers.FieldToRender("field_name", True, {"foo": "bar"})


### PR DESCRIPTION
## What
Some connectors might use an array value for the `type` of a field. This is not something handled by octavia on the generation of yaml configuration's comments.
This is not something common and it was introduced in https://github.com/airbytehq/airbyte/pull/11193

## How
If the type is an array, create a comma-separated string.

