### PR TITLE
Bump Airbyte version from 0.35.65-alpha to 0.35.66-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.35.65-alpha
+current_version = 0.35.66-alpha
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@
 
 
 ### SHARED ###
-VERSION=0.35.65-alpha
+VERSION=0.35.66-alpha
 
 # When using the airbyte-db via default docker image
 CONFIG_ROOT=/data

--- a/airbyte-bootloader/Dockerfile
+++ b/airbyte-bootloader/Dockerfile
@@ -5,6 +5,6 @@ ENV APPLICATION airbyte-bootloader
 
 WORKDIR /app
 
-ADD bin/${APPLICATION}-0.35.65-alpha.tar /app
+ADD bin/${APPLICATION}-0.35.66-alpha.tar /app
 
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.65-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.66-alpha/bin/${APPLICATION}"]

--- a/airbyte-container-orchestrator/Dockerfile
+++ b/airbyte-container-orchestrator/Dockerfile
@@ -26,12 +26,12 @@ RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] htt
 RUN apt-get update && apt-get install -y kubectl
 
 ENV APPLICATION airbyte-container-orchestrator
-ENV AIRBYTE_ENTRYPOINT "/app/${APPLICATION}-0.35.65-alpha/bin/${APPLICATION}"
+ENV AIRBYTE_ENTRYPOINT "/app/${APPLICATION}-0.35.66-alpha/bin/${APPLICATION}"
 
 WORKDIR /app
 
 # Move orchestrator app
-ADD bin/${APPLICATION}-0.35.65-alpha.tar /app
+ADD bin/${APPLICATION}-0.35.66-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "/app/${APPLICATION}-0.35.65-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "/app/${APPLICATION}-0.35.66-alpha/bin/${APPLICATION}"]

--- a/airbyte-metrics/reporter/Dockerfile
+++ b/airbyte-metrics/reporter/Dockerfile
@@ -5,7 +5,7 @@ ENV APPLICATION airbyte-metrics-reporter
 
 WORKDIR /app
 
-ADD bin/${APPLICATION}-0.35.65-alpha.tar /app
+ADD bin/${APPLICATION}-0.35.66-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.65-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.66-alpha/bin/${APPLICATION}"]

--- a/airbyte-scheduler/app/Dockerfile
+++ b/airbyte-scheduler/app/Dockerfile
@@ -5,7 +5,7 @@ ENV APPLICATION airbyte-scheduler
 
 WORKDIR /app
 
-ADD bin/${APPLICATION}-0.35.65-alpha.tar /app
+ADD bin/${APPLICATION}-0.35.66-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.65-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.66-alpha/bin/${APPLICATION}"]

--- a/airbyte-server/Dockerfile
+++ b/airbyte-server/Dockerfile
@@ -7,7 +7,7 @@ ENV APPLICATION airbyte-server
 
 WORKDIR /app
 
-ADD bin/${APPLICATION}-0.35.65-alpha.tar /app
+ADD bin/${APPLICATION}-0.35.66-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.65-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.66-alpha/bin/${APPLICATION}"]

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.35.65-alpha",
+  "version": "0.35.66-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "airbyte-webapp",
-      "version": "0.35.65-alpha",
+      "version": "0.35.66-alpha",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-brands-svg-icons": "^5.15.4",

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.35.65-alpha",
+  "version": "0.35.66-alpha",
   "private": true,
   "engines": {
     "node": ">=16.0.0"

--- a/airbyte-workers/Dockerfile
+++ b/airbyte-workers/Dockerfile
@@ -30,7 +30,7 @@ ENV APPLICATION airbyte-workers
 WORKDIR /app
 
 # Move worker app
-ADD bin/${APPLICATION}-0.35.65-alpha.tar /app
+ADD bin/${APPLICATION}-0.35.66-alpha.tar /app
 
 # wait for upstream dependencies to become available before starting server
-ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.65-alpha/bin/${APPLICATION}"]
+ENTRYPOINT ["/bin/bash", "-c", "${APPLICATION}-0.35.66-alpha/bin/${APPLICATION}"]

--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.3.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.35.65-alpha"
+appVersion: "0.35.66-alpha"
 
 dependencies:
   - name: common

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -31,7 +31,7 @@ Helm charts for Airbyte.
 | `webapp.replicaCount`                       | Number of webapp replicas                                        | `1`              |
 | `webapp.image.repository`                   | The repository to use for the airbyte webapp image.              | `airbyte/webapp` |
 | `webapp.image.pullPolicy`                   | the pull policy to use for the airbyte webapp image              | `IfNotPresent`   |
-| `webapp.image.tag`                          | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.35.65-alpha`  |
+| `webapp.image.tag`                          | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.35.66-alpha`  |
 | `webapp.podAnnotations`                     | Add extra annotations to the webapp pod(s)                       | `{}`             |
 | `webapp.containerSecurityContext`           | Security context for the container                               | `{}`             |
 | `webapp.livenessProbe.enabled`              | Enable livenessProbe on the webapp                               | `true`           |
@@ -73,7 +73,7 @@ Helm charts for Airbyte.
 | `scheduler.replicaCount`       | Number of scheduler replicas                                        | `1`                 |
 | `scheduler.image.repository`   | The repository to use for the airbyte scheduler image.              | `airbyte/scheduler` |
 | `scheduler.image.pullPolicy`   | the pull policy to use for the airbyte scheduler image              | `IfNotPresent`      |
-| `scheduler.image.tag`          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.35.65-alpha`      |
+| `scheduler.image.tag`          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.35.66-alpha`      |
 | `scheduler.podAnnotations`     | Add extra annotations to the scheduler pod                          | `{}`                |
 | `scheduler.resources.limits`   | The resources limits for the scheduler container                    | `{}`                |
 | `scheduler.resources.requests` | The requested resources for the scheduler container                 | `{}`                |
@@ -120,7 +120,7 @@ Helm charts for Airbyte.
 | `server.replicaCount`                       | Number of server replicas                                        | `1`              |
 | `server.image.repository`                   | The repository to use for the airbyte server image.              | `airbyte/server` |
 | `server.image.pullPolicy`                   | the pull policy to use for the airbyte server image              | `IfNotPresent`   |
-| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.35.65-alpha`   |
+| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.35.66-alpha`   |
 | `server.podAnnotations`                     | Add extra annotations to the server pod                          | `{}`             |
 | `server.containerSecurityContext`           | Security context for the container                               | `{}`             |
 | `server.livenessProbe.enabled`              | Enable livenessProbe on the server                               | `true`           |
@@ -158,7 +158,7 @@ Helm charts for Airbyte.
 | `worker.replicaCount`                       | Number of worker replicas                                        | `1`              |
 | `worker.image.repository`                   | The repository to use for the airbyte worker image.              | `airbyte/worker` |
 | `worker.image.pullPolicy`                   | the pull policy to use for the airbyte worker image              | `IfNotPresent`   |
-| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.35.65-alpha`   |
+| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.35.66-alpha`   |
 | `worker.podAnnotations`                     | Add extra annotations to the worker pod(s)                       | `{}`             |
 | `worker.containerSecurityContext`           | Security context for the container                               | `{}`             |
 | `worker.livenessProbe.enabled`              | Enable livenessProbe on the worker                               | `true`           |
@@ -190,7 +190,7 @@ Helm charts for Airbyte.
 | ----------------------------- | -------------------------------------------------------------------- | -------------------- |
 | `bootloader.image.repository` | The repository to use for the airbyte bootloader image.              | `airbyte/bootloader` |
 | `bootloader.image.pullPolicy` | the pull policy to use for the airbyte bootloader image              | `IfNotPresent`       |
-| `bootloader.image.tag`        | The airbyte bootloader image tag. Defaults to the chart's AppVersion | `0.35.65-alpha`       |
+| `bootloader.image.tag`        | The airbyte bootloader image tag. Defaults to the chart's AppVersion | `0.35.66-alpha`       |
 
 
 ### Temporal parameters

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -43,7 +43,7 @@ webapp:
   image:
     repository: airbyte/webapp
     pullPolicy: IfNotPresent
-    tag: 0.35.65-alpha
+    tag: 0.35.66-alpha
 
   ## @param webapp.podAnnotations [object] Add extra annotations to the webapp pod(s)
   ##
@@ -209,7 +209,7 @@ scheduler:
   image:
     repository: airbyte/scheduler
     pullPolicy: IfNotPresent
-    tag: 0.35.65-alpha
+    tag: 0.35.66-alpha
 
   ## @param scheduler.podAnnotations [object] Add extra annotations to the scheduler pod
   ##
@@ -440,7 +440,7 @@ server:
   image:
     repository: airbyte/server
     pullPolicy: IfNotPresent
-    tag: 0.35.65-alpha
+    tag: 0.35.66-alpha
 
   ## @param server.podAnnotations [object] Add extra annotations to the server pod
   ##
@@ -581,7 +581,7 @@ worker:
   image:
     repository: airbyte/worker
     pullPolicy: IfNotPresent
-    tag: 0.35.65-alpha
+    tag: 0.35.66-alpha
 
   ## @param worker.podAnnotations [object] Add extra annotations to the worker pod(s)
   ##
@@ -699,7 +699,7 @@ bootloader:
   image:
     repository: airbyte/bootloader
     pullPolicy: IfNotPresent
-    tag: 0.35.65-alpha
+    tag: 0.35.66-alpha
   
   ## @param bootloader.podAnnotations [object] Add extra annotations to the bootloader pod
   ##

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -101,7 +101,7 @@ If you are upgrading from \(i.e. your current version of Airbyte is\) Airbyte ve
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.35.65-alpha --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.35.66-alpha --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/kube/overlays/stable-with-resource-limits/.env
+++ b/kube/overlays/stable-with-resource-limits/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.35.65-alpha
+AIRBYTE_VERSION=0.35.66-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -8,17 +8,17 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.35.65-alpha
+    newTag: 0.35.66-alpha
   - name: airbyte/bootloader
-    newTag: 0.35.65-alpha
+    newTag: 0.35.66-alpha
   - name: airbyte/scheduler
-    newTag: 0.35.65-alpha
+    newTag: 0.35.66-alpha
   - name: airbyte/server
-    newTag: 0.35.65-alpha
+    newTag: 0.35.66-alpha
   - name: airbyte/webapp
-    newTag: 0.35.65-alpha
+    newTag: 0.35.66-alpha
   - name: airbyte/worker
-    newTag: 0.35.65-alpha
+    newTag: 0.35.66-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.35.65-alpha
+AIRBYTE_VERSION=0.35.66-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -8,17 +8,17 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.35.65-alpha
+    newTag: 0.35.66-alpha
   - name: airbyte/bootloader
-    newTag: 0.35.65-alpha
+    newTag: 0.35.66-alpha
   - name: airbyte/scheduler
-    newTag: 0.35.65-alpha
+    newTag: 0.35.66-alpha
   - name: airbyte/server
-    newTag: 0.35.65-alpha
+    newTag: 0.35.66-alpha
   - name: airbyte/webapp
-    newTag: 0.35.65-alpha
+    newTag: 0.35.66-alpha
   - name: airbyte/worker
-    newTag: 0.35.65-alpha
+    newTag: 0.35.66-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 

--- a/octavia-cli/Dockerfile
+++ b/octavia-cli/Dockerfile
@@ -14,5 +14,5 @@ USER octavia-cli
 WORKDIR /home/octavia-project
 ENTRYPOINT ["octavia"]
 
-LABEL io.airbyte.version=0.35.65-alpha
+LABEL io.airbyte.version=0.35.66-alpha
 LABEL io.airbyte.name=airbyte/octavia-cli

--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -104,7 +104,7 @@ This script:
 ```bash
 touch ~/.octavia # Create a file to store env variables that will be mapped the octavia-cli container
 mkdir my_octavia_project_directory # Create your octavia project directory where YAML configurations will be stored.
-docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:0.35.65-alpha
+docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:0.35.66-alpha
 ```
 
 ### Using `docker-compose`

--- a/octavia-cli/install.sh
+++ b/octavia-cli/install.sh
@@ -3,7 +3,7 @@
 # This install scripts currently only works for ZSH and Bash profiles.
 # It creates an octavia alias in your profile bound to a docker run command and your current user.
 
-VERSION=0.35.65-alpha
+VERSION=0.35.66-alpha
 OCTAVIA_ENV_FILE=${HOME}/.octavia
 
 detect_profile() {


### PR DESCRIPTION
*IMPORTANT: Only merge if the platform build is passing!*

Changelog:

e312aee61 🐛 octavia-cli: handle array in types for generated comments (#11846)
ead335667 Use time zone that does not switch to DST (#11644)
c69d949b0 [SAT] Fixed schema parsing when a JSONschema was not present (#11842)
f512208af Introduce json path commons lib (#11680)
582baf3b6 gradle: create a separate sub build for all connectors (#11833)
d84df02f2 🎉Source-postgres: fixed roles for fetching materialized view processing (#11798)
cbed3205f Configuration changes for docs (#11834)
af1d087d2 Revert "DAT: verify that a destination is able to write any ISO8601-compliant date string (#9816)" (#11802)
ceef3e3f0 🐛 Source Amazon Ads: test coverage more than 90% + improve test speed (#11384)
83817cc33 Configure test retries in Cypress (#11816)
8bd2d9b51 🎉 BigQuery destination: use serialized buffer for gcs staging (#11776)
cb40ebc79 Fixed typo on registration page (#11821)
c8337ea3b Add docs sidebar (#11817)
85681cf51 Helm Chart: support for node selectors and tolerations in bootloader pod (#11782)
ded2b6524 clarity on version bump with /publish (#11813)
6a174e8f3 Update openapi schema. (#11807)
97aa603a8 Improve performance of connectionOperation functions (#11702)
3b46d669a Documentation update for insights start date (#11809)
eaa8b94e4 update building connector tutorial incorrect links and typo (#11769)
a0b7dd028 :bug: Destination Redshift and Postgres handle custom namespace with '-' (#11729)
b25c0de68 Format java connector code (#11793)
42adaeb50 Implement health check for server. (#11755)
6092bee71 SAT: check oneOf common property has only `const` keyword, no `default` and `enum` keywords (#11704)
d778ac708 🐞 S3 / GCS staging: use correct staging filename (#11768)
aa0ef1e33 Updsate option name (#11734)
4ae43089c Add Sidebar Popout for Support Links (#11745)
e5007be90 Source Facebook: upgrade SDK version to 13 (#11761)
7bb7d23e6 Fixing publish command gitref for bot push (#11767)
6870845f8 Added useSuspenseQuery hook, remove top-level suspense: true (#11746)
17407da1e Add docusaurus tool not pipeline logic (#11716)
5739ee872 🎉 New Source: ZohoCRM (#11193)
09d1c06cf Update prettier and add import sorting (#11742)
42fdebd1d 📖 Added section to docs about the /publish command (#11739)
4839a891c Update `supported-data-types` docs to use `date-time` (#11743)
d67e32b5d Documentation: add snowflake dest note (#11709)
55e3c1e05 Revert "Build OSS branch for deploying to Cloud env (#11474)"
f7d3a706b Publish connector command now auto bumps version (#11712)
189efe7b4 Build OSS branch for deploying to Cloud env (#11474)
2d0cc781f Fix pre-commit hook failing because of black (#11737)
f20b9f4b2 fix race condition in port reintroduction test (#11735)
72dcd8126 :bug: Destination bigquery denormalize "allOf" and "anyOf" fix (#11166)
2876fe7de Source Zendesk Support: updated source_spec.yaml after publish of the new version (#11736)
a8be296f0 🐛 Source Zendesk Support: fix the bug when state was not parsed correctly (#11727)
e49cd37ef add pod ip logging for orchestrator (#11714)
741fcb1bf Password length min is 12, translation matches, and init service typescript improvements. (#11733)
393ba3562 🐛 fix s3/gcs bucket cleanup (#11728)
0fa9f126d :tada: New Source: Pivotal Tracker (#11060)
99875c42c GCS Destination: MLP documentation (Beta) (#11499)
2f850b98a DAT: verify that a destination is able to write any ISO8601-compliant date string (#9816)
6a6031496 Format. (#11726)
5528d7d87 airbyte-workers: add support for kubernetes pod annotations (#10753)
399469ec4 📝 Source Zendesk Support: MLP documentation corrections (#11688)

Steps After Merging PR:
1. Pull most recent version of master
2. Run ./tools/bin/tag_version.sh
3. Create a GitHub release with the changelog