### PR TITLE
use new traversals for secrets handling

### DIFF
--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/split_secrets/JsonSecretsProcessor.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/split_secrets/JsonSecretsProcessor.java
@@ -12,11 +12,11 @@ import com.google.common.base.Preconditions;
 import io.airbyte.commons.json.JsonPaths;
 import io.airbyte.commons.json.JsonSchemas;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.json.Secrets;
 import io.airbyte.commons.util.MoreIterators;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import lombok.Builder;
 
 @Builder
@@ -51,12 +51,13 @@ public class JsonSecretsProcessor {
    */
   public JsonNode prepareSecretsForOutput(final JsonNode obj, final JsonNode schema) {
     if (maskSecrets) {
+      // todo (cgardens) this is not safe. should throw.
       // if schema is an object and has a properties field
       if (!isValidJsonSchema(schema)) {
-        throw new IllegalArgumentException("invalid schema");
+        return obj;
       }
 
-      return Secrets.maskAllSecrets(obj, schema);
+      return maskAllSecrets(obj, schema);
     }
 
     return obj;
@@ -100,8 +101,9 @@ public class JsonSecretsProcessor {
   // todo (cgardens) - figure out how to reused JsonSchemas and JsonPaths for this traversal as well.
   public JsonNode copySecrets(final JsonNode src, final JsonNode dst, final JsonNode schema) {
     if (copySecrets) {
+      // todo (cgardens) this is not safe. should throw.
       if (!isValidJsonSchema(schema)) {
-        throw new IllegalArgumentException("invalid schema");
+        return dst;
       }
       Preconditions.checkArgument(dst.isObject());
       Preconditions.checkArgument(src.isObject());

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/split_secrets/JsonSecretsProcessor.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/split_secrets/JsonSecretsProcessor.java
@@ -6,23 +6,18 @@ package io.airbyte.config.persistence.split_secrets;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.airbyte.commons.json.JsonPaths;
 import io.airbyte.commons.json.JsonSchemas;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.json.Secrets;
 import io.airbyte.commons.util.MoreIterators;
 import io.airbyte.validation.json.JsonSchemaValidator;
-import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Queue;
-import java.util.Set;
 import lombok.Builder;
-import lombok.Value;
 
 @Builder
 public class JsonSecretsProcessor {
@@ -57,12 +52,11 @@ public class JsonSecretsProcessor {
   public JsonNode prepareSecretsForOutput(final JsonNode obj, final JsonNode schema) {
     if (maskSecrets) {
       // if schema is an object and has a properties field
-      if (!canBeProcessed(schema)) {
-        return obj;
+      if (!isValidJsonSchema(schema)) {
+        throw new IllegalArgumentException("invalid schema");
       }
 
-      final SecretKeys secretKeys = getAllSecretKeys(schema);
-      return maskAllSecrets(obj, secretKeys);
+      return Secrets.maskAllSecrets(obj, schema);
     }
 
     return obj;
@@ -100,14 +94,14 @@ public class JsonSecretsProcessor {
    *
    * @param src The object potentially containing secrets
    * @param dst The object to absorb secrets into
-   * @param schema
-   * @return
+   * @param schema Schema of objects
+   * @return dst object with secrets absorbed from src object
    */
   // todo (cgardens) - figure out how to reused JsonSchemas and JsonPaths for this traversal as well.
   public JsonNode copySecrets(final JsonNode src, final JsonNode dst, final JsonNode schema) {
     if (copySecrets) {
-      if (!canBeProcessed(schema)) {
-        return dst;
+      if (!isValidJsonSchema(schema)) {
+        throw new IllegalArgumentException("invalid schema");
       }
       Preconditions.checkArgument(dst.isObject());
       Preconditions.checkArgument(src.isObject());
@@ -168,77 +162,6 @@ public class JsonSecretsProcessor {
     return obj.isObject() && obj.has(AIRBYTE_SECRET_FIELD) && obj.get(AIRBYTE_SECRET_FIELD).asBoolean();
   }
 
-  protected JsonNode maskAllSecrets(final JsonNode obj, final SecretKeys secretKeys) {
-    final JsonNode copiedObj = obj.deepCopy();
-    final Queue<JsonNode> toProcess = new LinkedList<>();
-    toProcess.add(copiedObj);
-
-    while (!toProcess.isEmpty()) {
-      final JsonNode currentNode = toProcess.remove();
-      for (final String key : Jsons.keys(currentNode)) {
-        if (secretKeys.fieldSecretKey.contains(key)) {
-          ((ObjectNode) currentNode).put(key, SECRETS_MASK);
-        } else if (currentNode.get(key).isObject()) {
-          toProcess.add(currentNode.get(key));
-        } else if (currentNode.get(key).isArray()) {
-          if (secretKeys.arraySecretKey.contains(key)) {
-            final ArrayNode sanitizedArrayNode = new ArrayNode(JsonNodeFactory.instance);
-            currentNode.get(key).forEach((secret) -> sanitizedArrayNode.add(SECRETS_MASK));
-            ((ObjectNode) currentNode).put(key, sanitizedArrayNode);
-          } else {
-            final ArrayNode arrayNode = (ArrayNode) currentNode.get(key);
-            arrayNode.forEach((node) -> {
-              toProcess.add(node);
-            });
-          }
-        }
-      }
-    }
-
-    return copiedObj;
-  }
-
-  @Value
-  protected class SecretKeys {
-
-    private final Set<String> fieldSecretKey;
-    private final Set<String> arraySecretKey;
-
-  }
-
-  protected SecretKeys getAllSecretKeys(final JsonNode schema) {
-    final Set<String> fieldSecretKeys = new HashSet<>();
-    final Set<String> arraySecretKeys = new HashSet<>();
-
-    final Queue<JsonNode> toProcess = new LinkedList<>();
-    toProcess.add(schema);
-
-    while (!toProcess.isEmpty()) {
-      final JsonNode currentNode = toProcess.remove();
-      for (final String key : Jsons.keys(currentNode)) {
-        if (isArrayDefinition(currentNode.get(key))) {
-          final JsonNode arrayItems = currentNode.get(key).get(ITEMS_FIELD);
-          if (arrayItems.has(AIRBYTE_SECRET_FIELD) && arrayItems.get(AIRBYTE_SECRET_FIELD).asBoolean()) {
-            arraySecretKeys.add(key);
-          } else {
-            toProcess.add(arrayItems);
-          }
-        } else if (JsonSecretsProcessor.isSecret(currentNode.get(key))) {
-          fieldSecretKeys.add(key);
-        } else if (currentNode.get(key).isObject()) {
-          toProcess.add(currentNode.get(key));
-        } else if (currentNode.get(key).isArray()) {
-          final ArrayNode arrayNode = (ArrayNode) currentNode.get(key);
-          arrayNode.forEach((node) -> {
-            toProcess.add(node);
-          });
-        }
-      }
-    }
-
-    return new SecretKeys(fieldSecretKeys, arraySecretKeys);
-  }
-
   private static Optional<String> findJsonCombinationNode(final JsonNode node) {
     for (final String combinationNode : List.of("allOf", "anyOf", "oneOf")) {
       if (node.has(combinationNode) && node.get(combinationNode).isArray()) {
@@ -248,15 +171,9 @@ public class JsonSecretsProcessor {
     return Optional.empty();
   }
 
-  private static boolean canBeProcessed(final JsonNode schema) {
+  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+  private static boolean isValidJsonSchema(final JsonNode schema) {
     return schema.isObject() && schema.has(PROPERTIES_FIELD) && schema.get(PROPERTIES_FIELD).isObject();
-  }
-
-  private static boolean isArrayDefinition(final JsonNode obj) {
-    return obj.isObject()
-        && obj.has(TYPE_FIELD)
-        && obj.get(TYPE_FIELD).asText().equals(ARRAY_TYPE_FIELD)
-        && obj.has(ITEMS_FIELD);
   }
 
 }

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/split_secrets/SecretsHelpers.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/split_secrets/SecretsHelpers.java
@@ -14,14 +14,12 @@ import io.airbyte.commons.json.JsonSchemas;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.util.MoreIterators;
 import io.airbyte.protocol.models.ConnectorSpecification;
-import io.airbyte.validation.json.JsonSchemaValidator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -167,103 +165,6 @@ public class SecretsHelpers {
     return internalSplitAndUpdateConfig(uuidSupplier, workspaceId, secretReader, oldPartialConfig, newFullConfig, spec.getConnectionSpecification());
   }
 
-  /**
-   * Internal method used to support both "split config" and "split and update config" operations.
-   *
-   * For splits that don't have a prior partial config (such as when a connector is created for a
-   * source or destination for the first time), the secret reader and old partial config can be set to
-   * empty (see {@link SecretsHelpers#splitConfig(UUID, JsonNode, ConnectorSpecification)}).
-   *
-   * IMPORTANT: This is used recursively. In the process, the partial config, full config, and spec
-   * inputs will represent internal json structures, not the entire configs/specs.
-   *
-   * @param uuidSupplier provided to allow a test case to produce known UUIDs in order for easy
-   *        fixture creation
-   * @param workspaceId workspace that will contain the source or destination this config will be
-   *        stored for
-   * @param secretReader provides a way to determine if a secret is the same or updated at a specific
-   *        location in a config
-   * @param oldPartialConfig previous partial config for this specific connector configuration
-   * @param originalFullConfig new config containing secrets that will be used to update the partial
-   *        config for this connector
-   * @param spec connector specification
-   * @return a partial config + a map of coordinates to secret payloads
-   */
-  private static SplitSecretConfig internalSplitAndUpdateConfig(final Supplier<UUID> uuidSupplier,
-                                                                final UUID workspaceId,
-                                                                final ReadOnlySecretPersistence secretReader,
-                                                                final JsonNode oldPartialConfig,
-                                                                final JsonNode originalFullConfig,
-                                                                final JsonNode spec) {
-    final var fullConfig = originalFullConfig.deepCopy();
-    final var secretMap = new HashMap<SecretCoordinate, String>();
-
-    // provide a lambda for hiding repeated arguments to improve readability
-    final InternalSplitter splitter =
-        (final JsonNode partialConfig, final JsonNode newFullConfig, final JsonNode newFullConfigSpec) -> internalSplitAndUpdateConfig(uuidSupplier,
-            workspaceId,
-            secretReader, partialConfig, newFullConfig, newFullConfigSpec);
-
-    final var specTypeToHandle = getSpecTypeToHandle(spec);
-
-    switch (specTypeToHandle) {
-      case STRING -> {
-        if (JsonSecretsProcessor.isSecret(spec)) {
-          final var oldFullSecretCoordinate = oldPartialConfig.has(COORDINATE_FIELD) ? oldPartialConfig.get(COORDINATE_FIELD).asText() : null;
-          final var secretCoordinate = getCoordinate(fullConfig.asText(), secretReader, workspaceId, uuidSupplier, oldFullSecretCoordinate);
-          final var newPartialConfig = Jsons.jsonNode(Map.of(COORDINATE_FIELD, secretCoordinate.getFullCoordinate()));
-
-          final var coordinateToPayload = Map.of(
-              secretCoordinate,
-              fullConfig.asText());
-
-          return new SplitSecretConfig(newPartialConfig, coordinateToPayload);
-        }
-      }
-      case OBJECT -> {
-        final var specPropertiesObject = (ObjectNode) spec.get(JsonSecretsProcessor.PROPERTIES_FIELD);
-        final var specProperties = Jsons.keys(specPropertiesObject).stream()
-            .filter(fullConfig::has)
-            .collect(Collectors.toList());
-
-        // if the input config is specified as an object, we go through and handle each type of property
-        for (final String specProperty : specProperties) {
-          final var nextOldPartialConfig = getFieldOrEmptyNode(oldPartialConfig, specProperty);
-
-          final var nestedSplitConfig =
-              splitter.splitAndUpdateConfig(nextOldPartialConfig, fullConfig.get(specProperty), spec.get("properties").get(specProperty));
-          ((ObjectNode) fullConfig).replace(specProperty, nestedSplitConfig.getPartialConfig());
-          secretMap.putAll(nestedSplitConfig.getCoordinateToPayload());
-        }
-      }
-      case ARRAY -> {
-        for (int i = 0; i < fullConfig.size(); i++) {
-          final var partialConfigElement = getFieldOrEmptyNode(oldPartialConfig, i);
-          final var fullConfigElement = fullConfig.get(i);
-          final var splitConfig = splitter.splitAndUpdateConfig(partialConfigElement, fullConfigElement, spec.get("items"));
-          secretMap.putAll(splitConfig.getCoordinateToPayload());
-          ((ArrayNode) fullConfig).set(i, splitConfig.getPartialConfig());
-        }
-      }
-      case ONE_OF -> {
-        final var possibleSchemas = (ArrayNode) spec.get("oneOf");
-
-        for (int i = 0; i < possibleSchemas.size(); i++) {
-          final var possibleSchema = possibleSchemas.get(i);
-          final var set = new JsonSchemaValidator().validate(possibleSchema, fullConfig);
-          if (set.isEmpty()) {
-            final var splitConfig = splitter.splitAndUpdateConfig(oldPartialConfig, fullConfig, possibleSchema);
-            if (!splitConfig.getPartialConfig().equals(fullConfig)) {
-              return splitConfig;
-            }
-          }
-        }
-      }
-    }
-
-    return new SplitSecretConfig(fullConfig, secretMap);
-  }
-
   private static Optional<String> getExistingCoordinateIfExists(final JsonNode json) {
     if (json.has(COORDINATE_FIELD)) {
       return Optional.ofNullable(json.get(COORDINATE_FIELD).asText());
@@ -282,14 +183,35 @@ public class SecretsHelpers {
     return getCoordinate(newJson.asText(), secretReader, workspaceId, uuidSupplier, existingCoordinateOptional.orElse(null));
   }
 
-  // todo need to make sure our traversal get down to string types! very replaceable.
+  /**
+   * Internal method used to support both "split config" and "split and update config" operations.
+   *
+   * For splits that don't have a prior partial config (such as when a connector is created for a
+   * source or destination for the first time), the secret reader and old partial config can be set to
+   * empty (see {@link SecretsHelpers#splitConfig(UUID, JsonNode, ConnectorSpecification)}).
+   *
+   * IMPORTANT: This is used recursively. In the process, the partial config, full config, and spec
+   * inputs will represent internal json structures, not the entire configs/specs.
+   *
+   * @param uuidSupplier provided to allow a test case to produce known UUIDs in order for easy
+   *        fixture creation
+   * @param workspaceId workspace that will contain the source or destination this config will be
+   *        stored for
+   * @param secretReader provides a way to determine if a secret is the same or updated at a specific
+   *        location in a config
+   * @param persistedPartialConfig previous partial config for this specific connector configuration
+   * @param newFullConfig new config containing secrets that will be used to update the partial config
+   *        for this connector
+   * @param spec connector specification
+   * @return a partial config + a map of coordinates to secret payloads
+   */
   @VisibleForTesting
-  static SplitSecretConfig internalSplitAndUpdateConfig2(final Supplier<UUID> uuidSupplier,
-                                                         final UUID workspaceId,
-                                                         final ReadOnlySecretPersistence secretReader,
-                                                         final JsonNode persistedPartialConfig,
-                                                         final JsonNode newFullConfig,
-                                                         final JsonNode spec) {
+  static SplitSecretConfig internalSplitAndUpdateConfig(final Supplier<UUID> uuidSupplier,
+                                                        final UUID workspaceId,
+                                                        final ReadOnlySecretPersistence secretReader,
+                                                        final JsonNode persistedPartialConfig,
+                                                        final JsonNode newFullConfig,
+                                                        final JsonNode spec) {
     var fullConfigCopy = newFullConfig.deepCopy();
     final var secretMap = new HashMap<SecretCoordinate, String>();
 
@@ -316,73 +238,6 @@ public class SecretsHelpers {
     }
 
     return new SplitSecretConfig(fullConfigCopy, secretMap);
-  }
-
-  /**
-   * Enum that allows us to switch on different types seen in a config / spec.
-   *
-   * Unrecognized types refers to values that cannot contain string airbyte_secret secrets such as
-   * numbers, binary fields, etc. They also may contain allOf or other mechanisms that aren't fully
-   * supported in Airbyte connector configurations.
-   */
-  private enum JsonSchemaSpecType {
-    OBJECT,
-    ARRAY,
-    STRING,
-    ONE_OF,
-    UNRECOGNIZED_TYPE
-  }
-
-  /**
-   * Determines what the spec is referring to.
-   *
-   * @param spec connector specification or a sub-node of the specification
-   * @return a type used to process a config or sub-node of a config
-   */
-  private static JsonSchemaSpecType getSpecTypeToHandle(final JsonNode spec) {
-    if (isObjectSchema(spec)) {
-      return JsonSchemaSpecType.OBJECT;
-    } else if (isArraySchema(spec)) {
-      return JsonSchemaSpecType.ARRAY;
-    } else if (isStringSchema(spec)) {
-      return JsonSchemaSpecType.STRING;
-    } else if (spec.has("oneOf") && spec.get("oneOf").isArray()) {
-      return JsonSchemaSpecType.ONE_OF;
-    } else {
-      return JsonSchemaSpecType.UNRECOGNIZED_TYPE;
-    }
-  }
-
-  /**
-   * Interface used to make calls to
-   * {@link SecretsHelpers#internalSplitAndUpdateConfig(Supplier, UUID, ReadOnlySecretPersistence, JsonNode, JsonNode, JsonNode)}
-   * more readable by arguments that are the same across the entire method.
-   */
-  @FunctionalInterface
-  public interface InternalSplitter {
-
-    SplitSecretConfig splitAndUpdateConfig(JsonNode oldPartialConfig, JsonNode fullConfig, JsonNode spec);
-
-  }
-
-  private static boolean isStringSchema(final JsonNode schema) {
-    return schema.has("type") && schema.get("type").asText().equals("string");
-  }
-
-  private static boolean isObjectSchema(final JsonNode schema) {
-    return schema.has("properties") && schema.get("properties").isObject();
-  }
-
-  private static boolean isArraySchema(final JsonNode schema) {
-    return schema.has("items") && schema.get("items").isObject();
-  }
-
-  private static JsonNode getFieldOrEmptyNode(final JsonNode node, final String field) {
-    return node.has(field) ? node.get(field) : Jsons.emptyObject();
-  }
-
-  private static JsonNode getFieldOrEmptyNode(final JsonNode node, final int field) {
-    return node.has(field) ? node.get(field) : Jsons.emptyObject();
   }
 
   /**

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/split_secrets/JsonSecretsProcessorTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/split_secrets/JsonSecretsProcessorTest.java
@@ -360,10 +360,6 @@ public class JsonSecretsProcessorTest {
 
     final JsonNode actual = processor.prepareSecretsForOutput(input, specs);
     assertEquals(expected, actual);
-
-    // todo (cgardens) - show that new implementation matches the old one. to be removed in next PR.
-    final JsonNode actual2 = JsonSecretsProcessor.maskAllSecrets(input, specs);
-    assertEquals(actual, actual2);
   }
 
   // todo (cgardens) - example of a case that is not properly handled. we should explicitly call out

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/split_secrets/SecretsHelpersTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/split_secrets/SecretsHelpersTest.java
@@ -131,38 +131,6 @@ public class SecretsHelpersTest {
     assertEquals(inputUpdateConfigCopy, inputUpdateConfig);
   }
 
-  // todo (cgardens) - verify the new implementation works the same as the old one. to be removed in
-  // next PR.
-  @ParameterizedTest
-  @MethodSource("provideTestCases")
-  void testSplitUpdate2(final SecretsTestCase testCase) {
-    final var uuidIterator = UUIDS.iterator();
-    final var inputPartialConfig = testCase.getPartialConfig();
-    final var inputUpdateConfig = testCase.getUpdateConfig();
-    final var inputPartialConfigCopy = inputPartialConfig.deepCopy();
-    final var inputUpdateConfigCopy = inputUpdateConfig.deepCopy();
-    final var secretPersistence = new MemorySecretPersistence();
-
-    for (final Map.Entry<SecretCoordinate, String> entry : testCase.getFirstSecretMap().entrySet()) {
-      secretPersistence.write(entry.getKey(), entry.getValue());
-    }
-
-    final var updatedSplit = SecretsHelpers.internalSplitAndUpdateConfig2(
-        uuidIterator::next,
-        WORKSPACE_ID,
-        secretPersistence,
-        inputPartialConfig,
-        inputUpdateConfig,
-        testCase.getSpec().getConnectionSpecification());
-
-    assertEquals(testCase.getUpdatedPartialConfig(), updatedSplit.getPartialConfig());
-    assertEquals(testCase.getSecondSecretMap(), updatedSplit.getCoordinateToPayload());
-
-    // check that we didn't mutate the input configs
-    assertEquals(inputPartialConfigCopy, inputPartialConfig);
-    assertEquals(inputUpdateConfigCopy, inputUpdateConfig);
-  }
-
   @ParameterizedTest
   @MethodSource("provideTestCases")
   void testCombine(final SecretsTestCase testCase) {


### PR DESCRIPTION
## What
* The PR that this branches off of demonstrates what using the new JsonSchemas traversal would look like and in unit tests verifies that the outputs are the same. This PR "turns it on" and removes the old implementations.



┆Issue is synchronized with this [Monday item](https://airbyte-bunch.monday.com/boards/2536787439/pulses/2537073956) by [Unito](https://www.unito.io)
