### PR TITLE
allow importing `IncrementalMixin` from `airbyte_cdk.sources.streams`

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 0.1.54
-Add ability to import `IncrementalMixin` from `airbyte_cdk.sources.streams`.
+- Add ability to import `IncrementalMixin` from `airbyte_cdk.sources.streams`.
+- Bumped minimum supported Python version to 3.9.
 
 ## 0.1.53
 Remove a false positive error logging during the send process.

--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.54
+Add ability to import `IncrementalMixin` from `airbyte_cdk.sources.streams`.
+
 ## 0.1.53
 Remove a false positive error logging during the send process.
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/__init__.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/__init__.py
@@ -3,6 +3,6 @@
 #
 
 # Initialize Streams Package
-from .core import Stream
+from .core import Stream, IncrementalMixin
 
-__all__ = ["Stream"]
+__all__ = ["Stream", "IncrementalMixin"]

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/__init__.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/__init__.py
@@ -3,6 +3,6 @@
 #
 
 # Initialize Streams Package
-from .core import Stream, IncrementalMixin
+from .core import IncrementalMixin, Stream
 
-__all__ = ["Stream", "IncrementalMixin"]
+__all__ = ["IncrementalMixin", "Stream"]

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.53",
+    version="0.1.54",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -33,8 +33,6 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: MIT License",
         # Python Version Support
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],
     keywords="airbyte connector-development-kit cdk",

--- a/docs/connector-development/tutorials/cdk-tutorial-python-http/6-read-data.md
+++ b/docs/connector-development/tutorials/cdk-tutorial-python-http/6-read-data.md
@@ -137,6 +137,7 @@ Let's also add this parameter to the constructor and declare the `cursor_field`:
 
 ```python
 from datetime import datetime, timedelta
+from airbyte_cdk.sources.streams import IncrementalMixin
 
 
 class ExchangeRates(HttpStream, IncrementalMixin):


### PR DESCRIPTION
## What
The [docs](https://docs.airbyte.com/connector-development/tutorials/cdk-tutorial-python-http/read-data#adding-incremental-sync) mention using `IncrementalMixin` when creating an incremental stream, however, it could not be imported directly from Airbyte CDK's streams package. 

Sidenote: I noticed that `IncrementalMixin` isn't really being used in actual connectors. Maybe it should be used if this is the way we're recommending people do it.

## How
Allow importing `IncrementalMixin` from `airbyte_cdk.sources.streams`. 

Example:
`from airbyte_cdk.sources.streams import Stream, IncrementalMixin`

IDEs can also now pick this up and offer to import it.



┆Issue is synchronized with this [Monday item](https://airbyte-bunch.monday.com/boards/2536787439/pulses/2537073635) by [Unito](https://www.unito.io)
