### PR TITLE
Remove `POSTGRES_IMAGE` environment variable from Docker build process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,6 @@ def Task getDockerBuildTask(String artifactName, String projectDir, String build
 
         def buildPlatform = System.getenv('DOCKER_BUILD_PLATFORM') ?: isArm64 ? 'linux/arm64' : 'linux/amd64'
         def alpineImage = System.getenv('ALPINE_IMAGE') ?: isArm64 ? 'arm64v8/alpine:3.14' : 'amd64/alpine:3.14'
-        def postgresImage = System.getenv('POSTGRES_IMAGE') ?: isArm64 ? 'arm64v8/postgres:13-alpine' : 'amd64/postgres:13-alpine'
         def buildArch = System.getenv('DOCKER_BUILD_ARCH') ?: isArm64 ? 'arm64' : 'amd64'
 
         inputDir = file("$projectDir/build/docker")
@@ -156,7 +155,6 @@ def Task getDockerBuildTask(String artifactName, String projectDir, String build
         buildArgs.put('JDK_VERSION', jdkVersion)
         buildArgs.put('DOCKER_BUILD_ARCH', buildArch)
         buildArgs.put('ALPINE_IMAGE', alpineImage)
-        buildArgs.put('POSTGRES_IMAGE', postgresImage)
         buildArgs.put('VERSION', buildVersion)
     })
 }


### PR DESCRIPTION
The `POSTGRES_IMAGE` environment variable is not in use anywhere in the project.  This PR removes this variable from the Gradle steps that build Docker images.

This was discovered as part of the M1 compatibility research.