### PR TITLE
Platform Kubernetes add option for sidecar pull policy

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
@@ -338,6 +338,11 @@ public interface Configs {
   String getJobKubeMainContainerImagePullPolicy();
 
   /**
+   * Define the Job pod connector sidecar image pull policy.
+   */
+  String getJobKubeSidecarContainerImagePullPolicy();
+
+  /**
    * Define the Job pod connector image pull secret. Useful when hosting private images.
    */
   String getJobKubeMainContainerImagePullSecret();

--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -59,6 +59,7 @@ public class EnvConfigs implements Configs {
   public static final String RUN_DATABASE_MIGRATION_ON_STARTUP = "RUN_DATABASE_MIGRATION_ON_STARTUP";
   public static final String WEBAPP_URL = "WEBAPP_URL";
   public static final String JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_POLICY = "JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_POLICY";
+  public static final String JOB_KUBE_SIDECAR_CONTAINER_IMAGE_PULL_POLICY = "JOB_KUBE_SIDECAR_CONTAINER_IMAGE_PULL_POLICY";
   public static final String JOB_KUBE_TOLERATIONS = "JOB_KUBE_TOLERATIONS";
   public static final String JOB_KUBE_NODE_SELECTORS = "JOB_KUBE_NODE_SELECTORS";
   public static final String JOB_KUBE_ANNOTATIONS = "JOB_KUBE_ANNOTATIONS";
@@ -148,6 +149,7 @@ public class EnvConfigs implements Configs {
   private static final String DEFAULT_JOB_CPU_REQUIREMENT = null;
   private static final String DEFAULT_JOB_MEMORY_REQUIREMENT = null;
   private static final String DEFAULT_JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_POLICY = "IfNotPresent";
+  private static final String DEFAULT_JOB_KUBE_SIDECAR_CONTAINER_IMAGE_PULL_POLICY = "IfNotPresent";
   private static final String SECRET_STORE_GCP_PROJECT_ID = "SECRET_STORE_GCP_PROJECT_ID";
   private static final String SECRET_STORE_GCP_CREDENTIALS = "SECRET_STORE_GCP_CREDENTIALS";
   private static final String DEFAULT_JOB_KUBE_SOCAT_IMAGE = "alpine/socat:1.7.4.1-r1";
@@ -593,6 +595,11 @@ public class EnvConfigs implements Configs {
   @Override
   public String getJobKubeMainContainerImagePullPolicy() {
     return getEnvOrDefault(JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_POLICY, DEFAULT_JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_POLICY);
+  }
+
+  @Override
+  public String getJobKubeSidecarContainerImagePullPolicy() {
+    return getEnvOrDefault(JOB_KUBE_SIDECAR_CONTAINER_IMAGE_PULL_POLICY, DEFAULT_JOB_KUBE_SIDECAR_CONTAINER_IMAGE_PULL_POLICY);
   }
 
   /**

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerConfigs.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerConfigs.java
@@ -21,6 +21,7 @@ public class WorkerConfigs {
   private final Map<String, String> workerKubeAnnotations;
   private final String jobImagePullSecret;
   private final String jobImagePullPolicy;
+  private final String sidecarImagePullPolicy;
   private final String jobSocatImage;
   private final String jobBusyboxImage;
   private final String jobCurlImage;
@@ -43,6 +44,7 @@ public class WorkerConfigs {
         configs.getJobKubeAnnotations(),
         configs.getJobKubeMainContainerImagePullSecret(),
         configs.getJobKubeMainContainerImagePullPolicy(),
+        configs.getJobKubeSidecarContainerImagePullPolicy(),
         configs.getJobKubeSocatImage(),
         configs.getJobKubeBusyboxImage(),
         configs.getJobKubeCurlImage(),
@@ -73,6 +75,7 @@ public class WorkerConfigs {
         annotations,
         configs.getJobKubeMainContainerImagePullSecret(),
         configs.getJobKubeMainContainerImagePullPolicy(),
+        configs.getJobKubeSidecarContainerImagePullPolicy(),
         configs.getJobKubeSocatImage(),
         configs.getJobKubeBusyboxImage(),
         configs.getJobKubeCurlImage(),
@@ -103,6 +106,7 @@ public class WorkerConfigs {
         annotations,
         configs.getJobKubeMainContainerImagePullSecret(),
         configs.getJobKubeMainContainerImagePullPolicy(),
+        configs.getJobKubeSidecarContainerImagePullPolicy(),
         configs.getJobKubeSocatImage(),
         configs.getJobKubeBusyboxImage(),
         configs.getJobKubeCurlImage(),
@@ -133,6 +137,7 @@ public class WorkerConfigs {
         annotations,
         configs.getJobKubeMainContainerImagePullSecret(),
         configs.getJobKubeMainContainerImagePullPolicy(),
+        configs.getJobKubeSidecarContainerImagePullPolicy(),
         configs.getJobKubeSocatImage(),
         configs.getJobKubeBusyboxImage(),
         configs.getJobKubeCurlImage(),
@@ -152,6 +157,7 @@ public class WorkerConfigs {
         configs.getJobKubeAnnotations(),
         configs.getJobKubeMainContainerImagePullSecret(),
         configs.getJobKubeMainContainerImagePullPolicy(),
+        configs.getJobKubeSidecarContainerImagePullPolicy(),
         configs.getJobKubeSocatImage(),
         configs.getJobKubeBusyboxImage(),
         configs.getJobKubeCurlImage(),
@@ -184,6 +190,10 @@ public class WorkerConfigs {
 
   public String getJobImagePullPolicy() {
     return jobImagePullPolicy;
+  }
+
+  public String getSidecarImagePullPolicy() {
+    return sidecarImagePullPolicy;
   }
 
   public String getJobSocatImage() {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -357,6 +357,7 @@ public class KubePodProcess extends Process implements KubePod {
                         final String namespace,
                         final String image,
                         final String imagePullPolicy,
+                        final String sidecarImagePullPolicy,
                         final int stdoutLocalPort,
                         final int stderrLocalPort,
                         final String kubeHeartbeatUrl,
@@ -441,6 +442,7 @@ public class KubePodProcess extends Process implements KubePod {
         .withCommand("sh", "-c", "socat -d TCP-L:9001 STDOUT > " + STDIN_PIPE_FILE)
         .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
         .withResources(sidecarResources)
+        .withImagePullPolicy(sidecarImagePullPolicy)
         .build();
 
     final Container relayStdout = new ContainerBuilder()
@@ -449,6 +451,7 @@ public class KubePodProcess extends Process implements KubePod {
         .withCommand("sh", "-c", String.format("cat %s | socat -d - TCP:%s:%s", STDOUT_PIPE_FILE, processRunnerHost, stdoutLocalPort))
         .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
         .withResources(sidecarResources)
+        .withImagePullPolicy(sidecarImagePullPolicy)
         .build();
 
     final Container relayStderr = new ContainerBuilder()
@@ -457,6 +460,7 @@ public class KubePodProcess extends Process implements KubePod {
         .withCommand("sh", "-c", String.format("cat %s | socat -d - TCP:%s:%s", STDERR_PIPE_FILE, processRunnerHost, stderrLocalPort))
         .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
         .withResources(sidecarResources)
+        .withImagePullPolicy(sidecarImagePullPolicy)
         .build();
 
     // communicates via a file if it isn't able to reach the heartbeating server and succeeds if the
@@ -473,6 +477,7 @@ public class KubePodProcess extends Process implements KubePod {
         .withArgs("-c", heartbeatCommand)
         .withVolumeMounts(terminationVolumeMount)
         .withResources(sidecarResources)
+        .withImagePullPolicy(sidecarImagePullPolicy)
         .build();
 
     final List<Container> containers = usesStdin ? List.of(main, remoteStdin, relayStdout, relayStderr, callHeartbeatServer)

--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
@@ -128,6 +128,7 @@ public class KubeProcessFactory implements ProcessFactory {
           namespace,
           imageName,
           workerConfigs.getJobImagePullPolicy(),
+          workerConfigs.getSidecarImagePullPolicy(),
           stdoutLocalPort,
           stderrLocalPort,
           kubeHeartbeatUrl,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/OrchestratorConstants.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/OrchestratorConstants.java
@@ -28,6 +28,7 @@ public class OrchestratorConstants {
           EnvConfigs.JOB_KUBE_SOCAT_IMAGE,
           EnvConfigs.JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_POLICY,
           EnvConfigs.JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_SECRET,
+          EnvConfigs.JOB_KUBE_SIDECAR_CONTAINER_IMAGE_PULL_POLICY,
           EnvConfigs.JOB_KUBE_NODE_SELECTORS,
           EnvConfigs.DOCKER_NETWORK,
           EnvConfigs.LOCAL_DOCKER_MOUNT,

--- a/docs/operator-guides/configuring-airbyte.md
+++ b/docs/operator-guides/configuring-airbyte.md
@@ -100,7 +100,7 @@ The following variables are relevant to both Docker and Kubernetes.
 3. `JOB_KUBE_ANNOTATIONS` - Define one or more Job pod annotations. Each k=v pair is separated by a `,`. For example: `key1=value1,key2=value2`. It is the pod annotations of the sync job and the default pod annotations fallback for others jobs.
 4. `JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_POLICY` - Define the Job pod connector image pull policy.
 5. `JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_SECRET` - Define the Job pod connector image pull secret. Useful when hosting private images.
-6. `JOB_KUBE_SIDECAR_CONTAINER_IMAGE_PULL_POLICY` - Define the image pull policy on the sidecar containers in the Job pod.
+6. `JOB_KUBE_SIDECAR_CONTAINER_IMAGE_PULL_POLICY` - Define the image pull policy on the sidecar containers in the Job pod. Useful when there are cluster policies enforcing to pull latest.
 7. `JOB_KUBE_SOCAT_IMAGE` - Define the Job pod socat image.
 8. `JOB_KUBE_BUSYBOX_IMAGE` - Define the Job pod busybox image.
 9. `JOB_KUBE_CURL_IMAGE` - Define the Job pod curl image pull.

--- a/docs/operator-guides/configuring-airbyte.md
+++ b/docs/operator-guides/configuring-airbyte.md
@@ -100,7 +100,7 @@ The following variables are relevant to both Docker and Kubernetes.
 3. `JOB_KUBE_ANNOTATIONS` - Define one or more Job pod annotations. Each k=v pair is separated by a `,`. For example: `key1=value1,key2=value2`. It is the pod annotations of the sync job and the default pod annotations fallback for others jobs.
 4. `JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_POLICY` - Define the Job pod connector image pull policy.
 5. `JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_SECRET` - Define the Job pod connector image pull secret. Useful when hosting private images.
-6. `JOB_KUBE_SIDECAR_CONTAINER_IMAGE_PULL_POLICY` - Define the image pull policy on the sidecar containers in the Job pod. Useful when there are cluster policies enforcing to pull latest.
+6. `JOB_KUBE_SIDECAR_CONTAINER_IMAGE_PULL_POLICY` - Define the image pull policy on the sidecar containers in the Job pod. Useful when there are cluster policies enforcing to always pull.
 7. `JOB_KUBE_SOCAT_IMAGE` - Define the Job pod socat image.
 8. `JOB_KUBE_BUSYBOX_IMAGE` - Define the Job pod busybox image.
 9. `JOB_KUBE_CURL_IMAGE` - Define the Job pod curl image pull.

--- a/docs/operator-guides/configuring-airbyte.md
+++ b/docs/operator-guides/configuring-airbyte.md
@@ -100,10 +100,11 @@ The following variables are relevant to both Docker and Kubernetes.
 3. `JOB_KUBE_ANNOTATIONS` - Define one or more Job pod annotations. Each k=v pair is separated by a `,`. For example: `key1=value1,key2=value2`. It is the pod annotations of the sync job and the default pod annotations fallback for others jobs.
 4. `JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_POLICY` - Define the Job pod connector image pull policy.
 5. `JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_SECRET` - Define the Job pod connector image pull secret. Useful when hosting private images.
-6. `JOB_KUBE_SOCAT_IMAGE` - Define the Job pod socat image.
-7. `JOB_KUBE_BUSYBOX_IMAGE` - Define the Job pod busybox image.
-8. `JOB_KUBE_CURL_IMAGE` - Define the Job pod curl image pull.
-9. `JOB_KUBE_NAMESPACE` - Define the Kubernetes namespace Job pods are created in.
+6. `JOB_KUBE_SIDECAR_CONTAINER_IMAGE_PULL_POLICY` - Define the image pull policy on the sidecar containers in the Job pod.
+7. `JOB_KUBE_SOCAT_IMAGE` - Define the Job pod socat image.
+8. `JOB_KUBE_BUSYBOX_IMAGE` - Define the Job pod busybox image.
+9. `JOB_KUBE_CURL_IMAGE` - Define the Job pod curl image pull.
+10. `JOB_KUBE_NAMESPACE` - Define the Kubernetes namespace Job pods are created in.
 
 #### Jobs specific
 


### PR DESCRIPTION
## What
The ability to configure the image pull policy on the sidecar container for those Kubernetes clusters that have policies around them.

Closes https://github.com/airbytehq/airbyte/issues/11867

## How
Add an environment variable configuration `JOB_KUBE_SIDECAR_CONTAINER_IMAGE_PULL_POLICY` that gets passed to the worker config and the `KubePodProcess`

## Recommended reading order
1. `EnvConfigs.java`
2. `WorkerConfigs.java`
3. `KubePodProcess.java`

## 🚨 User Impact 🚨
No user impact. Defaulting this setting to `IfNotPresent`, which is the default value for the `ContainerBuilder`

## Kubernetes Example
This screenshot was taken from splunk audit logs from an actual deployment with `JOB_KUBE_SIDECAR_CONTAINER_IMAGE_PULL_POLICY` set to `Always`

![Screen Shot 2022-04-10 at 2 55 35 AM](https://user-images.githubusercontent.com/4413427/162606375-975ae31b-3234-40cd-8f58-712e68d32bac.png)

