### PR TITLE
[docs] fix edit link url

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -32,7 +32,7 @@ const config = {
                 docs: {
                     routeBasePath: '/',
                     sidebarPath: require.resolve('./sidebars.js'),
-                    editUrl: 'https://github.com/airbytehq/airbyte/docs',
+                    editUrl: 'https://github.com/airbytehq/airbyte/blob/master/docs',
                     path: '../docs'
                 },
                 blog: false,


### PR DESCRIPTION
## What
_Describe what the change is solving_

currently each doc has an edit link at the bottom, but it leads to a broken URL

![image](https://user-images.githubusercontent.com/6764957/162801961-f18cf116-30e6-4ace-80dd-2d8e5c2eef56.png)



┆Issue is synchronized with this [Monday item](https://airbyte-bunch.monday.com/boards/2536787439/pulses/2537070025) by [Unito](https://www.unito.io)
