### PR TITLE
Source Gitlab: allow `container_expiration_policy` to be nullable + fix null projects list

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -259,7 +259,7 @@
 - name: Gitlab
   sourceDefinitionId: 5e6175e5-68e1-4c17-bff9-56103bbb0d80
   dockerRepository: airbyte/source-gitlab
-  dockerImageTag: 0.1.4
+  dockerImageTag: 0.1.5
   documentationUrl: https://docs.airbyte.io/integrations/sources/gitlab
   icon: gitlab.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -2552,7 +2552,7 @@
               path_in_connector_config:
               - "credentials"
               - "client_secret"
-- dockerImage: "airbyte/source-gitlab:0.1.4"
+- dockerImage: "airbyte/source-gitlab:0.1.5"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/gitlab"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-gitlab/Dockerfile
+++ b/airbyte-integrations/connectors/source-gitlab/Dockerfile
@@ -13,5 +13,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.4
+LABEL io.airbyte.version=0.1.5
 LABEL io.airbyte.name=airbyte/source-gitlab

--- a/airbyte-integrations/connectors/source-gitlab/source_gitlab/schemas/projects.json
+++ b/airbyte-integrations/connectors/source-gitlab/source_gitlab/schemas/projects.json
@@ -138,7 +138,7 @@
       "type": ["null", "boolean"]
     },
     "container_expiration_policy": {
-      "type": "object",
+      "type": ["null", "object"],
       "properties": {
         "cadence": {
           "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-gitlab/source_gitlab/source.py
+++ b/airbyte-integrations/connectors/source-gitlab/source_gitlab/source.py
@@ -43,7 +43,7 @@ class SourceGitlab(AbstractSource):
         auth = TokenAuthenticator(token=config["private_token"])
         auth_params = dict(authenticator=auth, api_url=config["api_url"])
 
-        pids = list(filter(None, config.get("projects").split(" ")))
+        pids = list(filter(None, config.get("projects", "").split(" ")))
         gids = config.get("groups")
 
         if gids:

--- a/docs/integrations/sources/gitlab.md
+++ b/docs/integrations/sources/gitlab.md
@@ -63,6 +63,7 @@ GitLab source is working with GitLab API v4. It can also work with self-hosted G
 
 | Version | Date       | Pull Request                                             | Subject |
 |:--------|:-----------|:---------------------------------------------------------| :--- |
+| 0.1.5   | 2022-05-02 | [11907](https://github.com/airbytehq/airbyte/pull/11907) | Fix null projects param and `container_expiration_policy` |
 | 0.1.4   | 2022-03-23 | [11140](https://github.com/airbytehq/airbyte/pull/11140) | Ingest All Accessible Groups if not Specified in Config |
 | 0.1.3   | 2021-12-21 | [8991](https://github.com/airbytehq/airbyte/pull/8991)   | Update connector fields title/description |
 | 0.1.2   | 2021-10-18 | [7108](https://github.com/airbytehq/airbyte/pull/7108)   | Allow all domains to be used as `api_url` |


### PR DESCRIPTION
## What
Update `projects` stream to allow `container_expiration_policy` to be NULL. This appears to be consistent with the GitLab REST API and also observations from running the following tests on a database being used by a live GitLab EE installation:

1. Extract an ID for a project causing an error for the `container_expiration_policies` value being NULL.
2. Run a query looking for a row in the `container_expiration_policies` table for that ID (response below).

![image](https://user-images.githubusercontent.com/65691557/162857963-4909c8ec-37d9-4bcf-b480-45655b092649.png)

3. A further query which demonstrates this is a simple left-join with `row_to_json` for the `projects` table (as below):

![image](https://user-images.githubusercontent.com/65691557/162858187-27dd52cd-27ea-458e-93f9-4f5ed71f518f.png)

It would appear that sufficiently old projects which were created before the introduction of the GitLab Registry are not necessarily migrated to include an entry in the `container_expiration_policies` table.

---

If no projects are specified in the source configuration, the following error is sporadically hit:
```
AttributeError("'NoneType' object has no attribute 'split'")
```

## How
* Update `type` of `container_expiration_policy` field in `projects` stream to include NULL type.
* Set default value for "projects" to be the empty string.

## Recommended reading order
N/A

## 🚨 User Impact 🚨
None

## Pre-merge Checklist
N/A
