### PR TITLE
Explicitly exit to stop hung background threads in MySQL source connector

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
@@ -206,6 +206,12 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
     LOGGER.info("starting source: {}", MySqlSource.class);
     new IntegrationRunner(source).run(args);
     LOGGER.info("completed source: {}", MySqlSource.class);
+
+    // For larger tables the Debezium engine can fail to shut down cleanly. In this case extra threads are left running
+    // in the background which can cause this process to never exit. When this happens the entire AirByte pipeline will
+    // hang. This isn't the most ideal fix, but explicitly exiting will force any hung threads to close and allow the
+    // pipeline to complete.
+    System.exit(0);
   }
 
   public enum ReplicationMethod {


### PR DESCRIPTION
## What

I have been working with Airbyte for around a month now and encountered a problem when loading larger (50M+ record) tables from MySQL to Snowflake. For these loads the source connector would hang after the log message "completed source: class io.airbyte.integrations.source.mysql.MySqlSource". 

The problem I had matches this issue exactly: https://github.com/airbytehq/airbyte/issues/4322 . It also matches this issue: https://github.com/airbytehq/airbyte/issues/5754 . It is possibly related to this issue, though this is for a different connector (db2): https://github.com/airbytehq/airbyte/issues/8218 .

In the end I discovered that for certain MySQL loads (seemingly larger ones, though smaller loads failed for me at times too) the Debezium engine and executor both fail to shutdown and leave some remaining threads hanging in the background. These threads then prevent the JVM from exiting when the MySQL source connector's main() function exits. I am not a Java dev but to test this I added the following debugging code:

MySqlSource.java: 

```
  public static void main(final String[] args) throws Exception {
    final Source source = MySqlSource.sshWrappedSource();
    LOGGER.info("starting source: {}", MySqlSource.class);
    new IntegrationRunner(source).run(args);
    LOGGER.info("completed source: {}", MySqlSource.class);
    Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
    for (Thread th : threadSet) {
      LOGGER.info("");
      LOGGER.info("");
      LOGGER.info("Thread name {}", th.getName());
      LOGGER.info("Thread {} state {}", th.getName(), th.getState());
      LOGGER.info("Thread {} stacktrace {}", th.getName(), th.getStackTrace());
      LOGGER.info("Thread {} isAlive {}", th.getName(), th.isAlive());
      LOGGER.info("Thread {} isDaemon {}", th.getName(), th.isDaemon());
      LOGGER.info("Thread {} isInterrupted {}", th.getName(), th.isInterrupted());
    }
  }
```

DebeziumRecordPublisher.java:

```
  public void close() throws Exception {
    if (isClosing.compareAndSet(false, true)) {
      // consumers should assume records can be produced until engine has closed.
      if (engine != null) {
        engine.close();
      }

      // wait for closure before shutting down executor service
      if (engineLatch.await(5, TimeUnit.MINUTES)) {
        LOGGER.info("Debezium engine shutdown!");
      } else {
        LOGGER.info("Debezium engine did not shutdown!");
      }

      // shut down and await for thread to actually go down
      executor.shutdown();
              
      if (executor.awaitTermination(5, TimeUnit.MINUTES)) {
        LOGGER.info("Debezium executor shutdown!");
      } else {
        LOGGER.info("Debezium executor did not shutdown!");
      }

      // after the engine is completely off, we can mark this as closed
      hasClosed.set(true);
      
      if (thrownError.get() != null) {
        throw new RuntimeException(thrownError.get());
      }
    }
  }
```

I found that failed runs never closed the Debezium engine or executor properly (likewise, the message "Debezium engine shutdown." which comes from the completion callback to the Debezium engine above, is also never called in this situation). I also found that there were extra threads hanging around when the sync would fail, which were output by the changes to MySqlSource.java.

## How

I considered three options for a fix:

1) Understand why the Debezium engine is hanging and fix it.
2) Upgrade Debezium to 1.8 (from 1.4). From what I can see there is a new MySQL connector and I imagine it would be more reliable.
3) Take the quick way out and add a `System.exit(0)` to the end of the main method. 

I have taken option 3 and am submitting it in this PR. My reasoning is that I believe ultimately Debezium should be upgraded to 1.8, which is much more work than I am able to contribute right now. Adding a System.exit(0) to the end of the main method forces the JVM to close any background threads and allows the source container to exit without hanging. To my understanding AirByte only closes the engine once it has received all records of interest, which means there is very little risk that the background thread hasn't satisfactorily completed our goal.

Sadly I am not able to replicate this in a unit test, but if any additional supporting info is required I would be happy to provide.

## Recommended reading order
1. `MySqlSource.Java`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

No breaking changes.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
