### PR TITLE
Add CSP header to webapp

### DIFF
--- a/airbyte-webapp/nginx/default.conf.template
+++ b/airbyte-webapp/nginx/default.conf.template
@@ -10,6 +10,8 @@ server {
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;
 
+    add_header Content-Security-Policy "script-src * 'unsafe-inline';";
+
     location / {
         root   /usr/share/nginx/html;
         try_files $uri $uri/ /index.html;

--- a/airbyte-webapp/src/setupProxy.js
+++ b/airbyte-webapp/src/setupProxy.js
@@ -7,6 +7,12 @@
 const express = require("express");
 
 module.exports = (app) => {
+  // Set the CSP header in development to detect potential breakages.
+  // This should always match the header in airbyte-webapp/nginx/default.conf.template
+  app.use((req, resp, next) => {
+    resp.header("Content-Security-Policy", "script-src * 'unsafe-inline';");
+    next();
+  });
   // Serve the doc markdowns and assets that are also bundled into the docker image
   app.use("/docs/integrations", express.static(`${__dirname}/../../docs/integrations`));
   app.use("/docs/.gitbook", express.static(`${__dirname}/../../docs/.gitbook`));


### PR DESCRIPTION
## What

This adds CSP headers for the webapp in development mode and into the built docker image.

The used CSP headers are at the moment: `script-src: * 'unsafe-inline';`. This will prevent `unsafe-eval` execution, which will prevent executing any form of `eval`, `new Function`, etc. where code is executed from a string. This will increase security slightly.

We unfortunately can't go much beyond this, since several third-party libraries we're using are injecting script directly into HTML (and thus require `unsafe-inline`). Given that we have no pre-processing web server, we can't leverage dynamically generated nounces, to make those inline scripts potentially safer.

Another problem is, that we're using Google Tag Manager and Segment, which might pull in scripts dynamically configured in those systems. To keep those scripts working (and allow our Go-To-Market team to further use and add more scripts), we can't limit the source to more than `*`, since we'd otherwise need a new release for every new script/tool embedded via Google Tag Manager, which would defy the whole purpose of using tools like Google Tag Manager. Since all those libraries can or already do pull in styles we can't narrow that down any further.