### PR TITLE
CI publish command: remove `--ignore-empty` option from sentry-cli v2.0.0

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -147,9 +147,7 @@ jobs:
       - name: Create Sentry Release
         if: startsWith(github.event.inputs.connector, 'connectors')
         run: |
-          # The --ignore-empty flag is not ideal but necessary, because we need to run this command from forked repos,
-          # which do not have Sentry integration, and thus Sentry cannot find the proper commit history.
-          sentry-cli releases set-commits "${{ env.IMAGE_NAME }}@${{ env.IMAGE_VERSION }}" --auto --ignore-missing --ignore-empty
+          sentry-cli releases set-commits "${{ env.IMAGE_NAME }}@${{ env.IMAGE_VERSION }}" --auto --ignore-missing
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CONNECTOR_RELEASE_AUTH_TOKEN }}
           SENTRY_ORG: airbyte-5j


### PR DESCRIPTION
## What
We don't need to use `--ignore-empty` flag because it's default on behaviour 
https://github.com/getsentry/sentry-cli/releases/tag/2.0.0

Breaking Changes
 - Make ignore-empty for releases set-commits a default behavior and remove --ignore-empty flag (remove --ignore-empty usage) (breaking)