### PR TITLE
make sure VERSION is up to date after bumpversion

### DIFF
--- a/tools/bin/bump_version.sh
+++ b/tools/bin/bump_version.sh
@@ -7,6 +7,7 @@ pip install bumpversion
 bumpversion "$PART_TO_BUMP"
 
 NEW_VERSION=$(grep -w VERSION .env | cut -d"=" -f2)
+export VERSION=$NEW_VERSION # for safety, since lib.sh exports a VERSION that is now outdated
 
 echo "Bumped version from ${PREV_VERSION} to ${NEW_VERSION}"
 echo ::set-output name=PREV_VERSION::${PREV_VERSION}

--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -25,6 +25,6 @@ source ./tools/bin/bump_version.sh
 
 echo "Building and publishing PLATFORM version $NEW_VERSION for git revision $GIT_REVISION..."
 VERSION=$NEW_VERSION SUB_BUILD=PLATFORM ./gradlew clean build
-SUB_BUILD=PLATFORM ./gradlew publish
+VERSION=$NEW_VERSION SUB_BUILD=PLATFORM ./gradlew publish
 VERSION=$NEW_VERSION GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose.build.yaml push
 echo "Completed building and publishing PLATFORM..."


### PR DESCRIPTION
## What
The OSS gradle build was modified to read from the VERSION environment variable by default. Our publish command doesn't set an explicit VERSION env var, so it was falling back on the VERSION exported in `lib.sh`, which is out of date after the bumpversion script runs.

This PR exports an up-to-date VERSION after the bump, and also explicitly passes VERSION in our publish command

