### PR TITLE
Source Zendesk Support: added articles and sections streams

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -849,7 +849,7 @@
 - name: Zendesk Support
   sourceDefinitionId: 79c1aa37-dae3-42ae-b333-d1c105477715
   dockerRepository: airbyte/source-zendesk-support
-  dockerImageTag: 0.2.5
+  dockerImageTag: 0.2.6
   documentationUrl: https://docs.airbyte.io/integrations/sources/zendesk-support
   icon: zendesk.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -9023,7 +9023,7 @@
               path_in_connector_config:
               - "credentials"
               - "client_secret"
-- dockerImage: "airbyte/source-zendesk-support:0.2.5"
+- dockerImage: "airbyte/source-zendesk-support:0.2.6"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/zendesk-support"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-zendesk-support/Dockerfile
+++ b/airbyte-integrations/connectors/source-zendesk-support/Dockerfile
@@ -25,5 +25,5 @@ COPY source_zendesk_support ./source_zendesk_support
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.5
+LABEL io.airbyte.version=0.2.6
 LABEL io.airbyte.name=airbyte/source-zendesk-support

--- a/airbyte-integrations/connectors/source-zendesk-support/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-zendesk-support/integration_tests/configured_catalog.json
@@ -192,24 +192,20 @@
       "stream": {
         "name": "articles",
         "json_schema": {},
-        "supported_sync_modes": ["full_refresh", "incremental"],
-        "source_defined_cursor": true,
-        "default_cursor_field": ["created_at"],
+        "supported_sync_modes": ["full_refresh"],
         "source_defined_primary_key": [["id"]]
       },
-      "sync_mode": "incremental",
+      "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
     },
     {
       "stream": {
         "name": "sections",
         "json_schema": {},
-        "supported_sync_modes": ["full_refresh", "incremental"],
-        "source_defined_cursor": true,
-        "default_cursor_field": ["created_at"],
+        "supported_sync_modes": ["full_refresh"],
         "source_defined_primary_key": [["id"]]
       },
-      "sync_mode": "incremental",
+      "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
     }
   ]

--- a/airbyte-integrations/connectors/source-zendesk-support/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-zendesk-support/integration_tests/configured_catalog.json
@@ -187,6 +187,30 @@
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "articles",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["created_at"],
+        "source_defined_primary_key": [["id"]]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "sections",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["created_at"],
+        "source_defined_primary_key": [["id"]]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/schemas/articles.json
+++ b/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/schemas/articles.json
@@ -1,0 +1,75 @@
+{
+    "type": ["null", "object"],
+    "properties": {
+      "id": {
+        "type": ["null", "integer"]
+      },
+      "title": {
+        "type": ["null", "string"]
+      },
+      "author_id": {
+        "type": ["null", "integer"]
+      },
+      "body": {
+        "type": ["null", "string"]
+      },
+      "comments_disabled": {
+        "type": ["null", "boolean"]
+      },
+      "draft": {
+        "type": ["null", "boolean"]
+      },
+      "edited_at": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      },
+      "html_url": {
+        "type": ["null", "string"]
+      },
+      "label_names": {
+        "type": ["null", "array"],
+        "items": {
+          "type": ["null", "string"]
+        }
+      },
+      "locale": {
+        "type": ["null", "string"]
+      },
+      "permission_group_id": {
+        "type": ["null", "integer"]
+      },
+      "position": {
+        "type": ["null", "integer"]
+      },
+      "promoted": {
+        "type": ["null", "boolean"]
+      },
+      "section_id": {
+        "type": ["null", "integer"]
+      },
+      "source_locale": {
+        "type": ["null", "string"]
+      },
+      "url": {
+        "type": ["null", "string"]
+      },
+      "user_segment_id": {
+        "type": ["null", "integer"]
+      },
+      "vote_count": {
+        "type": ["null", "integer"]
+      },
+      "vote_sum": {
+        "type": ["null", "integer"]
+      },
+      "created_at": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      },
+      "updated_at": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      }
+    }
+  }
+  

--- a/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/schemas/sections.json
+++ b/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/schemas/sections.json
@@ -1,0 +1,47 @@
+{
+    "type": ["null", "object"],
+    "properties": {
+      "id": {
+        "type": ["null", "integer"]
+      },
+      "name": {
+        "type": ["null", "string"]
+      },
+      "category_id": {
+        "type": ["null", "integer"]
+      },
+      "description": {
+        "type": ["null", "string"]
+      },
+      "html_url": {
+        "type": ["null", "string"]
+      },
+      "locale": {
+        "type": ["null", "string"]
+      },
+      "outdated": {
+        "type": ["null", "boolean"]
+      },
+      "parent_section_id": {
+        "type": ["null", "integer"]
+      },
+      "position": {
+        "type": ["null", "integer"]
+      },
+      "source_locale": {
+        "type": ["null", "string"]
+      },
+      "url": {
+        "type": ["null", "string"]
+      },
+      "created_at": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      },
+      "updated_at": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      }
+    }
+  }
+  

--- a/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/source.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/source.py
@@ -12,6 +12,7 @@ from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthentic
 from source_zendesk_support.streams import SourceZendeskException
 
 from .streams import (
+    Articles,
     Brands,
     CustomRoles,
     GroupMemberships,
@@ -20,6 +21,7 @@ from .streams import (
     Organizations,
     SatisfactionRatings,
     Schedules,
+    Sections,
     SlaPolicies,
     Tags,
     TicketAudits,
@@ -124,4 +126,6 @@ class SourceZendeskSupport(AbstractSource):
             Brands(**args),
             CustomRoles(**args),
             Schedules(**args),
+            Articles(**args),
+            Sections(**args),
         ]

--- a/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/streams.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/streams.py
@@ -594,3 +594,17 @@ class UserSettingsStream(SourceZendeskSupportFullRefreshStream):
         for resp in self.read_records(SyncMode.full_refresh):
             return resp
         raise SourceZendeskException("not found settings")
+
+
+class Articles(SourceZendeskSupportFullRefreshStream):
+    """Articles stream: https://developer.zendesk.com/api-reference/help_center/help-center-api/articles/#list-articles"""
+
+    def path(self, *args, **kwargs) -> str:
+        return "help_center/articles.json"
+
+
+class Sections(SourceZendeskSupportFullRefreshStream):
+    """Sections stream: https://developer.zendesk.com/api-reference/help_center/help-center-api/sections/#list-sections"""
+
+    def path(self, *args, **kwargs) -> str:
+        return "help_center/sections.json"

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -10,6 +10,7 @@ This source can sync data for the [Zendesk Support API](https://developer.zendes
 
 This Source is capable of syncing the following core Streams:
 
+* [Articles](https://developer.zendesk.com/api-reference/help_center/help-center-api/articles)
 * [Brands](https://developer.zendesk.com/api-reference/ticketing/account-configuration/brands/#list-brands)
 * [Custom Roles](https://developer.zendesk.com/api-reference/ticketing/account-configuration/custom_roles/#list-custom-roles)
 * [Groups](https://developer.zendesk.com/rest_api/docs/support/groups)
@@ -18,6 +19,7 @@ This Source is capable of syncing the following core Streams:
 * [Organizations](https://developer.zendesk.com/rest_api/docs/support/organizations)
 * [Satisfaction Ratings](https://developer.zendesk.com/rest_api/docs/support/satisfaction_ratings)
 * [Schedules](https://developer.zendesk.com/api-reference/ticketing/ticket-management/schedules/#list-schedules)
+* [Sections](https://developer.zendesk.com/api-reference/help_center/help-center-api/sections)
 * [SLA Policies](https://developer.zendesk.com/rest_api/docs/support/sla_policies)
 * [Tags](https://developer.zendesk.com/rest_api/docs/support/tags)
 * [Tickets](https://developer.zendesk.com/api-reference/ticketing/ticket-management/incremental_exports/#incremental-ticket-export-time-based)
@@ -74,6 +76,7 @@ The Zendesk connector should not run into Zendesk API limitations under normal u
 
 | Version  | Date       | Pull Request | Subject                                                |
 |:---------|:-----------| :-----       |:-------------------------------------------------------|
+| `0.2.6`  | 2022-04-13 | [TBC](https://github.com/airbytehq/airbyte/pull/TBC) | Added Articles and Sections                              |
 | `0.2.5`  | 2022-04-05 | [11727](https://github.com/airbytehq/airbyte/pull/11727) | Fixed the bug when state was not parsed correctly
 | `0.2.4`  | 2022-04-04 | [11688](https://github.com/airbytehq/airbyte/pull/11688) | Small documentation corrections
 | `0.2.3`  | 2022-03-23 | [11349](https://github.com/airbytehq/airbyte/pull/11349) | Fixed the bug when Tickets stream didn't return deleted records

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -76,7 +76,7 @@ The Zendesk connector should not run into Zendesk API limitations under normal u
 
 | Version  | Date       | Pull Request | Subject                                                |
 |:---------|:-----------| :-----       |:-------------------------------------------------------|
-| `0.2.6`  | 2022-04-13 | [TBC](https://github.com/airbytehq/airbyte/pull/TBC) | Added Articles and Sections                              |
+| `0.2.6`  | 2022-04-13 | [11960](https://github.com/airbytehq/airbyte/pull/11960) | Added Articles and Sections                          |
 | `0.2.5`  | 2022-04-05 | [11727](https://github.com/airbytehq/airbyte/pull/11727) | Fixed the bug when state was not parsed correctly
 | `0.2.4`  | 2022-04-04 | [11688](https://github.com/airbytehq/airbyte/pull/11688) | Small documentation corrections
 | `0.2.3`  | 2022-03-23 | [11349](https://github.com/airbytehq/airbyte/pull/11349) | Fixed the bug when Tickets stream didn't return deleted records


### PR DESCRIPTION
## What
Added new Articles and Sections on Zendesk Support

## How
* edited `source.py`
* edited `streams.py`
* added integration tests

## 🚨 User Impact 🚨
No impact expected

## Pre-merge Checklist

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [x] Code reviews completed
- [x] Documentation updated
    - [x] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

(.venv) 192-168-1-101:source-zendesk-support eric.hartono$ python -m pytest unit_tests
Test session starts (platform: darwin, Python 3.10.4, pytest 6.2.5, pytest-sugar 0.9.4)
cachedir: .pytest_cache
rootdir: /Users/eric.hartono/Projects/airbyte, configfile: pytest.ini
plugins: sugar-0.9.4, requests-mock-1.9.3, timeout-1.4.2
collecting ... 
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_futures.py::test_proper_number_of_future_requests_generated[1000-100-10] ✓                                                                                                                 5% ▌         
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_futures.py::test_proper_number_of_future_requests_generated[1000-10-100] ✓                                                                                                                 9% ▉         
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_futures.py::test_proper_number_of_future_requests_generated[0-100-0] ✓                                                                                                                    14% █▍        
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_futures.py::test_proper_number_of_future_requests_generated[1-100-1] ✓                                                                                                                    18% █▊        
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_futures.py::test_proper_number_of_future_requests_generated[101-100-2] ✓                                                                                                                  23% ██▍       
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_futures.py::test_parse_future_records[10-10-10] ✓                                                                                                                                         27% ██▊       
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_futures.py::test_parse_future_records[10-100-10] ✓                                                                                                                                        32% ███▎      
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_futures.py::test_parse_future_records[10-10-0] ✓                                                                                                                                          36% ███▋      
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_futures.py::test_read_records[1000-100-10-True] ✓                                                                                                                                         41% ████▏     
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_futures.py::test_read_records[1000-10-100-True] ✓                                                                                                                                         45% ████▋     
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py::test_str2datetime ✓                                                                                                                                                              50% █████     
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py::test_datetime2str ✓                                                                                                                                                              55% █████▌    
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py::test_str2unixtime ✓                                                                                                                                                              59% █████▉    
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py::test_check_start_time_param ✓                                                                                                                                                    64% ██████▍   
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py::test_parse_next_page_number ✓                                                                                                                                                    68% ██████▊   
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py::test_next_page_token ✓                                                                                                                                                           73% ███████▍  
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py::test_check_stream_state[state present] ✓                                                                                                                                         77% ███████▊  
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py::test_check_stream_state[empty string in state] ✓                                                                                                                                 82% ████████▎ 
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py::test_check_stream_state[state is None] ✓                                                                                                                                         86% ████████▋ 
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py::test_check_stream_state[cursor is not in the state object] ✓                                                                                                                     91% █████████▏
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py::test_request_params ✓                                                                                                                                                            95% █████████▋
 airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py::test_parse_response ✓                                                                                                                                                           100% ██████████
=============================================================================================================================== warnings summary ===============================================================================================================================
.venv/lib/python3.10/site-packages/airbyte_cdk/sources/utils/transform.py:12
  /Users/eric.hartono/Projects/airbyte/airbyte-integrations/connectors/source-zendesk-support/.venv/lib/python3.10/site-packages/airbyte_cdk/sources/utils/transform.py:12: DeprecationWarning: Call to deprecated class AirbyteLogger. (Use logging.getLogger('airbyte') instead) -- Deprecated since version 0.1.47.
    logger = AirbyteLogger()

.venv/lib/python3.10/site-packages/airbyte_cdk/sources/streams/http/rate_limiting.py:19
  /Users/eric.hartono/Projects/airbyte/airbyte-integrations/connectors/source-zendesk-support/.venv/lib/python3.10/site-packages/airbyte_cdk/sources/streams/http/rate_limiting.py:19: DeprecationWarning: Call to deprecated class AirbyteLogger. (Use logging.getLogger('airbyte') instead) -- Deprecated since version 0.1.47.
    logger = AirbyteLogger()

.venv/lib/python3.10/site-packages/airbyte_cdk/utils/event_timing.py:13
  /Users/eric.hartono/Projects/airbyte/airbyte-integrations/connectors/source-zendesk-support/.venv/lib/python3.10/site-packages/airbyte_cdk/utils/event_timing.py:13: DeprecationWarning: Call to deprecated class AirbyteLogger. (Use logging.getLogger('airbyte') instead) -- Deprecated since version 0.1.47.
    logger = AirbyteLogger()

.venv/lib/python3.10/site-packages/airbyte_cdk/sources/streams/http/http.py:43: 1 warning
airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_futures.py: 10 warnings
airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py: 4 warnings
  /Users/eric.hartono/Projects/airbyte/airbyte-integrations/connectors/source-zendesk-support/.venv/lib/python3.10/site-packages/airbyte_cdk/sources/streams/http/http.py:43: DeprecationWarning: Call to deprecated class NoAuth. (Set `authenticator=None` instead) -- Deprecated since version 0.1.20.
    self._authenticator: HttpAuthenticator = NoAuth()

.venv/lib/python3.10/site-packages/deprecated/classic.py:173: 1 warning
airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_futures.py: 10 warnings
airbyte-integrations/connectors/source-zendesk-support/unit_tests/unit_test.py: 4 warnings
  /Users/eric.hartono/Projects/airbyte/airbyte-integrations/connectors/source-zendesk-support/.venv/lib/python3.10/site-packages/deprecated/classic.py:173: DeprecationWarning: Call to deprecated class HttpAuthenticator. (Use requests.auth.AuthBase instead) -- Deprecated since version 0.1.20.
    return old_new1(cls, *args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/warnings.html

Results (86.83s):
      22 passed

</details>
