### PR TITLE
Source File: Update Dockerfile to latest Airbyte template

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -224,7 +224,7 @@
 - name: File
   sourceDefinitionId: 778daa7c-feaf-4db6-96f3-70fd645acc77
   dockerRepository: airbyte/source-file
-  dockerImageTag: 0.2.9
+  dockerImageTag: 0.2.10
   documentationUrl: https://docs.airbyte.io/integrations/sources/file
   icon: file.svg
   sourceType: file

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -2068,7 +2068,7 @@
         oauthFlowInitParameters: []
         oauthFlowOutputParameters:
         - - "access_token"
-- dockerImage: "airbyte/source-file:0.2.9"
+- dockerImage: "airbyte/source-file:0.2.10"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/file"
     connectionSpecification:
@@ -2125,9 +2125,6 @@
             properties:
               storage:
                 type: "string"
-                enum:
-                - "HTTPS"
-                default: "HTTPS"
                 const: "HTTPS"
           - title: "GCS: Google Cloud Storage"
             required:
@@ -2136,9 +2133,6 @@
               storage:
                 type: "string"
                 title: "Storage"
-                enum:
-                - "GCS"
-                default: "GCS"
                 const: "GCS"
               service_account_json:
                 type: "string"
@@ -2157,9 +2151,6 @@
               storage:
                 type: "string"
                 title: "Storage"
-                enum:
-                - "S3"
-                default: "S3"
                 const: "S3"
               aws_access_key_id:
                 type: "string"
@@ -2182,9 +2173,6 @@
               storage:
                 type: "string"
                 title: "Storage"
-                enum:
-                - "AzBlob"
-                default: "AzBlob"
                 const: "AzBlob"
               storage_account:
                 type: "string"
@@ -2217,24 +2205,25 @@
               storage:
                 type: "string"
                 title: "Storage"
-                enum:
-                - "SSH"
-                default: "SSH"
                 const: "SSH"
               user:
                 type: "string"
                 title: "User"
+                description: ""
               password:
                 type: "string"
                 title: "Password"
+                description: ""
                 airbyte_secret: true
               host:
                 type: "string"
                 title: "Host"
+                description: ""
               port:
                 type: "string"
                 title: "Port"
                 default: "22"
+                description: ""
           - title: "SCP: Secure copy protocol"
             required:
             - "storage"
@@ -2244,24 +2233,25 @@
               storage:
                 type: "string"
                 title: "Storage"
-                enum:
-                - "SCP"
-                default: "SCP"
                 const: "SCP"
               user:
                 type: "string"
                 title: "User"
+                description: ""
               password:
                 type: "string"
                 title: "Password"
+                description: ""
                 airbyte_secret: true
               host:
                 type: "string"
                 title: "Host"
+                description: ""
               port:
                 type: "string"
                 title: "Port"
                 default: "22"
+                description: ""
           - title: "SFTP: Secure File Transfer Protocol"
             required:
             - "storage"
@@ -2271,24 +2261,25 @@
               storage:
                 type: "string"
                 title: "Storage"
-                enum:
-                - "SFTP"
-                default: "SFTP"
                 const: "SFTP"
               user:
                 type: "string"
                 title: "User"
+                description: ""
               password:
                 type: "string"
                 title: "Password"
+                description: ""
                 airbyte_secret: true
               host:
                 type: "string"
                 title: "Host"
+                description: ""
               port:
                 type: "string"
                 title: "Port"
                 default: "22"
+                description: ""
           - title: "Local Filesystem (limited)"
             required:
             - "storage"
@@ -2299,9 +2290,6 @@
                 description: "WARNING: Note that the local storage URL available for\
                   \ reading must start with the local mount \"/local/\" at the moment\
                   \ until we implement more advanced docker mounting options."
-                enum:
-                - "local"
-                default: "local"
                 const: "local"
     supportsNormalization: false
     supportsDBT: false

--- a/airbyte-integrations/connectors/source-file/Dockerfile
+++ b/airbyte-integrations/connectors/source-file/Dockerfile
@@ -1,16 +1,21 @@
-FROM python:3.9-slim
+FROM python:3.9-slim as base
+FROM base as builder
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y jq curl bash && rm -rf /var/lib/apt/lists/*
-
+RUN apt-get update
 WORKDIR /airbyte/integration_code
-COPY source_file ./source_file
-COPY main.py ./
 COPY setup.py ./
-RUN pip install .
+RUN pip install --prefix=/install .
+
+FROM base
+WORKDIR /airbyte/integration_code
+COPY --from=builder /install /usr/local
+
+COPY main.py ./
+COPY source_file ./source_file
+
 
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.9
+LABEL io.airbyte.version=0.2.10
 LABEL io.airbyte.name=airbyte/source-file

--- a/airbyte-integrations/connectors/source-file/source_file/spec.json
+++ b/airbyte-integrations/connectors/source-file/source_file/spec.json
@@ -43,8 +43,6 @@
             "properties": {
               "storage": {
                 "type": "string",
-                "enum": ["HTTPS"],
-                "default": "HTTPS",
                 "const": "HTTPS"
               }
             }
@@ -56,8 +54,6 @@
               "storage": {
                 "type": "string",
                 "title": "Storage",
-                "enum": ["GCS"],
-                "default": "GCS",
                 "const": "GCS"
               },
               "service_account_json": {
@@ -74,8 +70,6 @@
               "storage": {
                 "type": "string",
                 "title": "Storage",
-                "enum": ["S3"],
-                "default": "S3",
                 "const": "S3"
               },
               "aws_access_key_id": {
@@ -98,8 +92,6 @@
               "storage": {
                 "type": "string",
                 "title": "Storage",
-                "enum": ["AzBlob"],
-                "default": "AzBlob",
                 "const": "AzBlob"
               },
               "storage_account": {
@@ -128,27 +120,29 @@
               "storage": {
                 "type": "string",
                 "title": "Storage",
-                "enum": ["SSH"],
-                "default": "SSH",
                 "const": "SSH"
               },
               "user": {
                 "type": "string",
-                "title": "User"
+                "title": "User",
+                "description": ""
               },
               "password": {
                 "type": "string",
                 "title": "Password",
+                "description": "",
                 "airbyte_secret": true
               },
               "host": {
                 "type": "string",
-                "title": "Host"
+                "title": "Host",
+                "description": ""
               },
               "port": {
                 "type": "string",
                 "title": "Port",
-                "default": "22"
+                "default": "22",
+                "description": ""
               }
             }
           },
@@ -159,27 +153,29 @@
               "storage": {
                 "type": "string",
                 "title": "Storage",
-                "enum": ["SCP"],
-                "default": "SCP",
                 "const": "SCP"
               },
               "user": {
                 "type": "string",
-                "title": "User"
+                "title": "User",
+                "description": ""
               },
               "password": {
                 "type": "string",
                 "title": "Password",
+                "description": "",
                 "airbyte_secret": true
               },
               "host": {
                 "type": "string",
-                "title": "Host"
+                "title": "Host",
+                "description": ""
               },
               "port": {
                 "type": "string",
                 "title": "Port",
-                "default": "22"
+                "default": "22",
+                "description": ""
               }
             }
           },
@@ -190,27 +186,29 @@
               "storage": {
                 "type": "string",
                 "title": "Storage",
-                "enum": ["SFTP"],
-                "default": "SFTP",
                 "const": "SFTP"
               },
               "user": {
                 "type": "string",
-                "title": "User"
+                "title": "User",
+                "description": ""
               },
               "password": {
                 "type": "string",
                 "title": "Password",
+                "description": "",
                 "airbyte_secret": true
               },
               "host": {
                 "type": "string",
-                "title": "Host"
+                "title": "Host",
+                "description": ""
               },
               "port": {
                 "type": "string",
                 "title": "Port",
-                "default": "22"
+                "default": "22",
+                "description": ""
               }
             }
           },
@@ -222,8 +220,6 @@
                 "type": "string",
                 "title": "Storage",
                 "description": "WARNING: Note that the local storage URL available for reading must start with the local mount \"/local/\" at the moment until we implement more advanced docker mounting options.",
-                "enum": ["local"],
-                "default": "local",
                 "const": "local"
               }
             }


### PR DESCRIPTION
## What
As a POC part of https://github.com/airbytehq/airbyte/issues/6455, I'm going to have source-file-secure use the new intra-repo dependency method to inherit from source-file.

This PR simply updates source-file's Dockerfile to our current layout so that this will actually work. This is because the intra-repo dependency method (at least the template example) relies on py libs & module code files from the dependency module being in a particular directory in its docker image.

note: this isn't going to be a necessity, the paths can be changed to suit the dependency docker image locations, however I want this as a look-at-me example in the docs so best to use standard layout.

also, updated the spec.json so it passes acceptance tests