### PR TITLE
Revert redshift version bump

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -191,7 +191,7 @@
 - name: Redshift
   destinationDefinitionId: f7a7d195-377f-cf5b-70a5-be6b819019dc
   dockerRepository: airbyte/destination-redshift
-  dockerImageTag: 0.3.30
+  dockerImageTag: 0.3.29
   documentationUrl: https://docs.airbyte.io/integrations/destinations/redshift
   icon: redshift.svg
   resourceRequirements:

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -3414,7 +3414,7 @@
     supported_destination_sync_modes:
     - "overwrite"
     - "append"
-- dockerImage: "airbyte/destination-redshift:0.3.30"
+- dockerImage: "airbyte/destination-redshift:0.3.29"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/redshift"
     connectionSpecification:

--- a/airbyte-integrations/bases/base-normalization/docker-compose.build.yaml
+++ b/airbyte-integrations/bases/base-normalization/docker-compose.build.yaml
@@ -43,10 +43,3 @@ services:
       context: .
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
-  normalization-redshift:
-    image: airbyte/normalization-redshift:${VERSION}
-    build:
-      dockerfile: redshift.Dockerfile
-      context: .
-      labels:
-        io.airbyte.git-revision: ${GIT_REVISION}

--- a/airbyte-integrations/bases/base-normalization/docker-compose.yaml
+++ b/airbyte-integrations/bases/base-normalization/docker-compose.yaml
@@ -14,5 +14,3 @@ services:
     image: airbyte/normalization-clickhouse:${VERSION}
   normalization-snowflake:
     image: airbyte/normalization-snowflake:${VERSION}
-  normalization-redshift:
-    image: airbyte/normalization-redshift:${VERSION}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
@@ -32,7 +32,7 @@ public class NormalizationRunnerFactory {
           .put("airbyte/destination-oracle-strict-encrypt", ImmutablePair.of("airbyte/normalization-oracle", DestinationType.ORACLE))
           .put("airbyte/destination-postgres", ImmutablePair.of(BASE_NORMALIZATION_IMAGE_NAME, DestinationType.POSTGRES))
           .put("airbyte/destination-postgres-strict-encrypt", ImmutablePair.of(BASE_NORMALIZATION_IMAGE_NAME, DestinationType.POSTGRES))
-          .put("airbyte/destination-redshift", ImmutablePair.of("airbyte/normalization-redshift", DestinationType.REDSHIFT))
+          .put("airbyte/destination-redshift", ImmutablePair.of(BASE_NORMALIZATION_IMAGE_NAME, DestinationType.REDSHIFT))
           .put("airbyte/destination-snowflake", ImmutablePair.of("airbyte/normalization-snowflake", DestinationType.SNOWFLAKE))
           .build();
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 public class NormalizationRunnerFactory {
 
   public static final String BASE_NORMALIZATION_IMAGE_NAME = "airbyte/normalization";
-  public static final String NORMALIZATION_VERSION = "0.1.76";
+  public static final String NORMALIZATION_VERSION = "0.1.75";
 
   static final Map<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>> NORMALIZATION_MAPPING =
       ImmutableMap.<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>>builder()


### PR DESCRIPTION
https://github.com/airbytehq/airbyte/pull/9407 seems to have broken a few things; reverting version bumps for now. Depending on how the next few hours go I might revert the entire change, just want to get the immediate fix out for now.