### PR TITLE
📝 Update "Hard Way" incremental sync tutorial to pass SAT

### DIFF
--- a/docs/connector-development/tutorials/adding-incremental-sync.md
+++ b/docs/connector-development/tutorials/adding-incremental-sync.md
@@ -160,6 +160,66 @@ and paste it into a new file (i.e. `state.json`). Now you can run an incremental
 python source.py read --config secrets/valid_config.json --catalog incremental_configured_catalog.json --state state.json 
 ```
 
+## Run the incremental tests
+
+The [Source Acceptance Test (SAT) suite](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference) also includes test cases to ensure that incremental mode is working correctly. To enable them, modify the existing `acceptance-test-config.yml` by adding the following:
+
+```yaml
+  incremental:
+    - config_path: "secrets/valid_config.json"
+      configured_catalog_path: "incremental_configured_catalog.json"
+```
+
+Your full `acceptance-test-config.yml` should look something like this:
+
+```yaml
+# See [Source Acceptance Tests](https://docs.airbyte.io/connector-development/testing-connectors/source-acceptance-tests-reference)
+# for more information about how to configure these tests
+connector_image: airbyte/source-stock-ticker-api:dev
+tests:
+  spec:
+    - spec_path: "spec.json"
+      config_path: "secrets/valid_config.json"
+  connection:
+    - config_path: "secrets/valid_config.json"
+      status: "succeed"
+    - config_path: "secrets/invalid_config.json"
+      status: "failed"
+  discovery:
+    - config_path: "secrets/valid_config.json"
+  basic_read:
+    - config_path: "secrets/valid_config.json"
+      configured_catalog_path: "fullrefresh_configured_catalog.json"
+      empty_streams: []
+  full_refresh:
+    - config_path: "secrets/valid_config.json"
+      configured_catalog_path: "fullrefresh_configured_catalog.json"
+  incremental:
+    - config_path: "secrets/valid_config.json"
+      configured_catalog_path: "incremental_configured_catalog.json"
+```
+
+You can now run the tests once again:
+
+```bash
+./acceptance-test-docker.sh
+```
+
+Finally, you should see a successful test summary:
+
+```
+collecting ... 
+ test_core.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                         86% ████████▋ 
+ test_full_refresh.py ✓                                                                                                                                                                                                   91% █████████▏
+ test_incremental.py ✓s                                                                                                                                                                                                  100% ██████████
+
+======================================================================================================= short test summary info ========================================================================================================
+SKIPPED [1] source_acceptance_test/tests/test_incremental.py:21: `future_state_path` not specified, skipping
+
+Results (8.87s):
+      21 passed
+```
+
 That's all you need to do to add incremental functionality to the stock ticker Source.
 
 You can deploy the new version of your connector simply by running:

--- a/docs/understanding-airbyte/catalog.md
+++ b/docs/understanding-airbyte/catalog.md
@@ -16,8 +16,8 @@ This section will document the meaning of each field in an `AirbyteStream`
 
 * `json_schema` - This field contains a [JsonSchema](https://json-schema.org/understanding-json-schema) representation of the schema of the stream.
 * `supported_sync_modes` - The sync modes that the stream supports. By default, all sources support `FULL_REFRESH`. Even if this array is empty, it can be assumed that a source supports `FULL_REFRESH`. The allowed sync modes are `FULL_REFRESH` and `INCREMENTAL`.
-* `source_defined_cursor` - If a source supports the `INCREMENTAL` sync mode, and it sets this field to true, it is responsible for determining internally how it tracks which records in a source are new or updated since the last sync. It is an array of keys to a field in the schema.
-* `default_cursor_field` - If a source supports the `INCREMENTAL` sync mode, it may, optionally, set this field. If this field is set, and the user does not override it with the `cursor_field` attribute in the `ConfiguredAirbyteStream` \(described below\), this field will be used as the cursor. 
+* `source_defined_cursor` - If a source supports the `INCREMENTAL` sync mode, and it sets this field to true, it is responsible for determining internally how it tracks which records in a source are new or updated since the last sync. When set to `true`, `default_cursor_field` should also be set.
+* `default_cursor_field` - If a source supports the `INCREMENTAL` sync mode, it may, optionally, set this field. If this field is set, and the user does not override it with the `cursor_field` attribute in the `ConfiguredAirbyteStream` \(described below\), this field will be used as the cursor. It is an array of keys to a field in the schema.
 
 ## ConfiguredAirbyteStream
 


### PR DESCRIPTION
## What
Upon running the incremental source acceptance tests to the resulting connector from the [Hard Way tutorial part 2](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/tutorials/adding-incremental-sync.md), the tests were failing due to not defining a `default_source_cursor` and having an unexpected state structure.

## How
- [x] Update the tutorial code to pass the SAT
- [x] Add instructions for running the incremental SAT at the end of the tutorial
- [x] Update docs to say `default_source_cursor` should be defined if `source_defined_cursor=True`

