### PR TITLE
Toph docs deployment workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,3 +30,7 @@ jobs:
       # Install and build Docusaurus website
       - name: Check for docusaurus changes
         run: ./tools/bin/check_docusaurus_build_changes
+      # Install and build Docusaurus website
+      - name: Do some crazy deployment workflow
+        run: ./tools/bin/deploy_docusaurus
+

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
 
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -27,10 +26,11 @@ jobs:
           node-version: '16.13.0'
           cache: 'yarn'
           cache-dependency-path: docusaurus
-      # Install and build Docusaurus website
+      # Build Docusaurus website
       - name: Check for docusaurus changes
         run: ./tools/bin/check_docusaurus_build_changes
       # Install and build Docusaurus website
-      - name: Do some crazy deployment workflow
+      - name: Deploy docs to production (it's weird)
         run: ./tools/bin/deploy_docusaurus
+        env: GITHUB_TOKEN: ${{ secrets.OCTAVIA_PAT }}
 

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -11,7 +11,7 @@ const config = {
         'Airbyte is an open-source data integration platform to build ELT pipelines. Consolidate your data in your data warehouses, lakes and databases.',
     // this is non-functional, just a link back to OSS docs right now
     url: 'https://airbytehq.github.io',
-    baseUrl: '/airbyte/',
+    baseUrl: '/',
     onBrokenLinks: 'warn',
     onBrokenMarkdownLinks: 'warn',
     favicon: 'img/favicon.png',

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -9,8 +9,9 @@ const config = {
     title: 'Airbyte Documentation',
     tagline:
         'Airbyte is an open-source data integration platform to build ELT pipelines. Consolidate your data in your data warehouses, lakes and databases.',
-    // this is non-functional, just a link back to OSS docs right now
     url: 'https://airbytehq.github.io',
+    // Assumed relative path.  If you are using airbytehq.github.io use /
+    // anything else should match the repo name
     baseUrl: '/',
     onBrokenLinks: 'warn',
     onBrokenMarkdownLinks: 'warn',

--- a/tools/bin/deploy_docusaurus
+++ b/tools/bin/deploy_docusaurus
@@ -59,6 +59,8 @@ pwd
 git fetch
 git switch gh-pages
 
+revision=$(git rev-parse --short HEAD)
+
 set +o xtrace
 echo -e "$blue_text""Writing CNAME file!\n\n""$default_text"
 set -o xtrace
@@ -68,13 +70,13 @@ echo "docs.airbyte.com" > CNAME
 
 git add CNAME
 
-git commit --message "Adds CNAME to deploy"
+git commit --message "Adds CNAME to deploy for $revision"
 
 # non functional. for debugging
 git branch
 
 # note that this is NOT airbyte repo
-git push --force https://$GITHUB_TOKEN@github.com/airbytehq/airbytehq.github.io.git gh_pages
+git push --force https://$GITHUB_TOKEN@github.com/airbytehq/airbytehq.github.io.git
 
 # Want to push from your own computer? uncomment this line and comment out the push above
 # git push --force https://git@github.com/airbytehq/airbytehq.github.io.git

--- a/tools/bin/deploy_docusaurus
+++ b/tools/bin/deploy_docusaurus
@@ -59,9 +59,18 @@ pwd
 git checkout gh-pages
 git pull
 
-# adding another remote seems less gross then double cloning to force push
-git remote add org_level_gh_pages_repo git@github.com:airbytehq/airbytehq.github.io.git
+# github expects this CNAME file for pages
+echo "docs.airbyte.com" > CNAME
 
-exit 0
-git push org_level_gh_pages_repo/gh_pages
+git add CNAME
 
+git commit --message "Adds CNAME to deploy"
+
+
+git branch
+
+# note that this is NOT airbyte repo
+git push --force https://$GITHUB_TOKEN@github.com/airbytehq/airbytehq.github.io.git
+
+
+echo -e "$blue_text""Script exiting 0 GREAT SUCCESS!!!?""$default_text"

--- a/tools/bin/deploy_docusaurus
+++ b/tools/bin/deploy_docusaurus
@@ -57,15 +57,20 @@ pwd
 
 # We should be here but we are playing with fire
 git fetch
+# checkout the branch tracking it's remote
 git switch gh-pages
 
+# For tracking in the commit message
 revision=$(git rev-parse --short HEAD)
 
+# explained at length below
 set +o xtrace
 echo -e "$blue_text""Writing CNAME file!\n\n""$default_text"
 set -o xtrace
 
-# github expects this CNAME file for pages
+# This is a weird one.  GH Pages expects a CNAME file when redirecting
+# we redirect docs.airbyte.io to airbytehq.github.io
+# this tells github to expect docs.airbyte.com points to us
 echo "docs.airbyte.com" > CNAME
 
 git add CNAME

--- a/tools/bin/deploy_docusaurus
+++ b/tools/bin/deploy_docusaurus
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# ------------- Import some defaults for the shell
+
+# Source shell defaults
+# $0 is the currently running program (this file)
+this_file_directory=$(dirname $0)
+relative_path_to_defaults=$this_file_directory/../shell_defaults
+
+# if a file exists there, source it. otherwise complain
+if test -f $relative_path_to_defaults; then
+  # source and '.' are the same program
+  source $relative_path_to_defaults
+else
+  echo -e "\033[31m\nFAILED TO SOURCE TEST RUNNING OPTIONS.\033[39m"
+  echo -e "\033[31mTried $relative_path_to_defaults\033[39m"
+  exit 1
+fi
+
+
+# ------------- Start Main
+set +o xtrace
+echo -e "$blue_text""This script pushes changes (somewhat pointlessly) to ""$default_text"
+echo -e "$blue_text""airbyte's gh_pages branch\n""$default_text"
+echo -e "$blue_text""It also actually deploys by copying those assets to""$default_text"
+echo -e "$blue_text""the repo airbytehq/airbytehq.github.io\n\n""$default_text"
+
+
+echo -e "$blue_text""Current path:""$default_text"
+pwd
+
+
+# Yarn check (which is commonly used to check for program existance)
+if ! which -s yarn; then
+  echo -e "$red_text""yarn not found HALP!!\n\n""$default_text"
+  exit 1
+fi
+
+set -o xtrace
+
+cd docusaurus
+pwd
+
+# install packages
+yarn install
+
+# generate static content
+yarn build
+
+# write a prod website to airbytehq/airbyte gh_pages branch
+yarn deploy
+
+
+# Git makes more sense from /
+cd ..
+pwd
+
+# We should be here but we are playing with fire
+git checkout gh-pages
+git pull
+
+# adding another remote seems less gross then double cloning to force push
+git remote add org_level_gh_pages_repo git@github.com:airbytehq/airbytehq.github.io.git
+
+exit 0
+git push org_level_gh_pages_repo/gh_pages
+

--- a/tools/bin/deploy_docusaurus
+++ b/tools/bin/deploy_docusaurus
@@ -74,7 +74,7 @@ git commit --message "Adds CNAME to deploy"
 git branch
 
 # note that this is NOT airbyte repo
-git push --force https://$GITHUB_TOKEN@github.com/airbytehq/airbytehq.github.io.git
+git push --force https://$GITHUB_TOKEN@github.com/airbytehq/airbytehq.github.io.git gh_pages
 
 # Want to push from your own computer? uncomment this line and comment out the push above
 # git push --force https://git@github.com/airbytehq/airbytehq.github.io.git

--- a/tools/bin/deploy_docusaurus
+++ b/tools/bin/deploy_docusaurus
@@ -56,8 +56,8 @@ cd ..
 pwd
 
 # We should be here but we are playing with fire
-git checkout gh-pages
-git pull
+git fetch
+git switch gh-pages
 
 set +o xtrace
 echo -e "$blue_text""Writing CNAME file!\n\n""$default_text"

--- a/tools/bin/deploy_docusaurus
+++ b/tools/bin/deploy_docusaurus
@@ -59,6 +59,10 @@ pwd
 git checkout gh-pages
 git pull
 
+set +o xtrace
+echo -e "$blue_text""Writing CNAME file!\n\n""$default_text"
+set -o xtrace
+
 # github expects this CNAME file for pages
 echo "docs.airbyte.com" > CNAME
 
@@ -66,11 +70,14 @@ git add CNAME
 
 git commit --message "Adds CNAME to deploy"
 
-
+# non functional. for debugging
 git branch
 
 # note that this is NOT airbyte repo
 git push --force https://$GITHUB_TOKEN@github.com/airbytehq/airbytehq.github.io.git
 
+# Want to push from your own computer? uncomment this line and comment out the push above
+# git push --force https://git@github.com/airbytehq/airbytehq.github.io.git
 
+set +o xtrace
 echo -e "$blue_text""Script exiting 0 GREAT SUCCESS!!!?""$default_text"

--- a/tools/shell_defaults
+++ b/tools/shell_defaults
@@ -29,7 +29,7 @@ red_text='\033[31m'
 default_text='\033[39m'
 
 # set -x/xtrace' uses a Sony PS4 for more info
-PS4="$blue_text"'${BASH_SOURCE}:${LINENO}:default_text '
+PS4="$blue_text"'${BASH_SOURCE}:${LINENO}:'"$default_text "
 
 # Last for more pretty output
 set -o xtrace  # -x display every line before exectution; enables PS4


### PR DESCRIPTION
## What
publish docs to docs.airbyte.io with docusaurus

## How 
This is a weird one.
gh-pages has ORG and REPO level hosting.  In order to keep the docs here in OSS and publish them in the "magic" ORG level repo we are doing some strange things.  Basically to make it seems easy for the docs team we have a boatload of complexity right here.

Docs are hosted on GH pages branch both in this repo and the ORG repo.

we generate docs in OSS and then force push that branch to the special repo

output from local run 

```
./tools/bin/deploy_docusaurus:22: set +o xtrace
This script pushes changes (somewhat pointlessly) to
airbyte's gh_pages branch

It also actually deploys by copying those assets to
the repo airbytehq/airbytehq.github.io


Current path:
/Users/topher/workspace/airbyte
./tools/bin/deploy_docusaurus:41: cd docusaurus
./tools/bin/deploy_docusaurus:42: pwd
/Users/topher/workspace/airbyte/docusaurus
./tools/bin/deploy_docusaurus:45: yarn install
yarn install v1.22.17
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.16s.
./tools/bin/deploy_docusaurus:48: yarn build
yarn run v1.22.17
$ docusaurus build
[INFO] [en] Creating an optimized production build...

✔ Client


✔ Server
  Compiled successfully in 7.00s

[Local Search] [INFO]: Gathering documents
[Local Search] [INFO]: Parsing documents
[Local Search] [INFO]: 1 indexes will be created.
[Local Search] [INFO]: Building index docs-default-current (2805 documents)
[Local Search] [INFO]: Index docs-default-current written to disk
[WARNING] Docusaurus found broken links!

Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken links found:

- On source page path = /:
   -> linking to docs/integrations/ (resolved as: /docs/integrations/)
   -> linking to docs/contributing-to-airbyte/ (resolved as: /docs/contributing-to-airbyte/)
   -> linking to docs/project-overview/roadmap.md (resolved as: /docs/project-overview/roadmap.md)
   -> linking to docs/project-overview/licenses/ (resolved as: /docs/project-overview/licenses/)
   -> linking to docs/project-overview/licenses/license-faq.md (resolved as: /docs/project-overview/licenses/license-faq.md)

- On source page path = /archive/examples/slack-history:
   -> linking to ../../deploying-airbyte (resolved as: /deploying-airbyte)

- On source page path = /archive/faq/getting-started:
   -> linking to ../../deploying-airbyte/ (resolved as: /deploying-airbyte/)

- On source page path = /connector-development/tutorials/build-a-connector-the-hard-way:
   -> linking to ../../../airbyte-cdk/python/docs/tutorials/README.md (resolved as: /airbyte-cdk/python/docs/tutorials/README.md)

- On source page path = /contributing-to-airbyte/updating-documentation:
   -> linking to github.com/airbytehq/airbyte (resolved as: /contributing-to-airbyte/github.com/airbytehq/airbyte)

- On source page path = /integrations/:
   -> linking to sources/google-adwords.md (resolved as: /integrations/sources/google-adwords.md)
   -> linking to sources/cassandra.md (resolved as: /integrations/sources/cassandra.md)
   -> linking to sources/dynamodb.md (resolved as: /integrations/sources/dynamodb.md)
   -> linking to destinations/firestore.md (resolved as: /integrations/destinations/firestore.md)
   -> linking to sources/redis.md (resolved as: /integrations/sources/redis.md)
   -> linking to sources/scylla.md (resolved as: /integrations/sources/scylla.md)

- On source page path = /integrations/destinations/s3:
   -> linking to /airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json

- On source page path = /integrations/sources/lemlist:
   -> linking to %60api.lemlist.com/api/team%60 (resolved as: /integrations/sources/%60api.lemlist.com/api/team%60)
   -> linking to %60api.lemlist.com/api/campaigns%60 (resolved as: /integrations/sources/%60api.lemlist.com/api/campaigns%60)
   -> linking to %60api.lemlist.com/api/activities%60 (resolved as: /integrations/sources/%60api.lemlist.com/api/activities%60)
   -> linking to %60api.lemlist.com/api/unsubscribes%60 (resolved as: /integrations/sources/%60api.lemlist.com/api/unsubscribes%60)

- On source page path = /operator-guides/configuring-sync-notifications:
   -> linking to ../deploying-airbyte/README.md (resolved as: /deploying-airbyte/README.md)

- On source page path = /project-overview/changelog/connectors:
   -> linking to ../../integrations/sources/google-adwords.md (resolved as: /integrations/sources/google-adwords.md)

- On source page path = /project-overview/licenses/license-faq:
   -> linking to ../project-overview/licenses/elv2-license (resolved as: /project-overview/project-overview/licenses/elv2-license)

- On source page path = /SUMMARY:
   -> linking to ../README.md (resolved as: /README.md)
   -> linking to quickstart/README.md (resolved as: /quickstart/README.md)
   -> linking to deploying-airbyte/README.md (resolved as: /deploying-airbyte/README.md)
   -> linking to operator-guides/README.md (resolved as: /operator-guides/README.md)
   -> linking to integrations/destinations/README.md (resolved as: /integrations/destinations/README.md)
   -> linking to integrations/destinations/firestore.md (resolved as: /integrations/destinations/firestore.md)
   -> linking to connector-development/tutorials/README.md (resolved as: /connector-development/tutorials/README.md)

- On source page path = /understanding-airbyte/glossary:
   -> linking to ../integrations/destinations/ (resolved as: /integrations/destinations/)

[SUCCESS] Generated static files in build.
[INFO] Use `npm run serve` command to test your build locally.
✨  Done in 11.93s.
./tools/bin/deploy_docusaurus:51: yarn deploy
yarn run v1.22.17
$ docusaurus deploy
[WARNING] When deploying to GitHub Pages, it is better to use an explicit "trailingSlash" site config.
Otherwise, GitHub Pages will add an extra trailing slash to your site urls only on direct-access (not when navigation) with a server redirect.
This behavior can have SEO impacts and create relative link issues.

[INFO] Deploy command invoked...
[INFO] organizationName: airbytehq
[INFO] projectName: airbyte
[INFO] deploymentBranch: gh-pages
[INFO] Remote repo URL: git@github.com:airbytehq/airbyte.git
b873ae1433315107c51203284e358ef67986f05d
[INFO] `git rev-parse HEAD` code: 0
[INFO] [en] Creating an optimized production build...

✔ Client


✔ Server
  Compiled successfully in 7.05s

[Local Search] [INFO]: Gathering documents
[Local Search] [INFO]: Parsing documents
[Local Search] [INFO]: 1 indexes will be created.
[Local Search] [INFO]: Building index docs-default-current (2805 documents)
[Local Search] [INFO]: Index docs-default-current written to disk
[WARNING] Docusaurus found broken links!

Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken links found:

- On source page path = /:
   -> linking to docs/integrations/ (resolved as: /docs/integrations/)
   -> linking to docs/contributing-to-airbyte/ (resolved as: /docs/contributing-to-airbyte/)
   -> linking to docs/project-overview/roadmap.md (resolved as: /docs/project-overview/roadmap.md)
   -> linking to docs/project-overview/licenses/ (resolved as: /docs/project-overview/licenses/)
   -> linking to docs/project-overview/licenses/license-faq.md (resolved as: /docs/project-overview/licenses/license-faq.md)

- On source page path = /archive/examples/slack-history:
   -> linking to ../../deploying-airbyte (resolved as: /deploying-airbyte)

- On source page path = /archive/faq/getting-started:
   -> linking to ../../deploying-airbyte/ (resolved as: /deploying-airbyte/)

- On source page path = /connector-development/tutorials/build-a-connector-the-hard-way:
   -> linking to ../../../airbyte-cdk/python/docs/tutorials/README.md (resolved as: /airbyte-cdk/python/docs/tutorials/README.md)

- On source page path = /contributing-to-airbyte/updating-documentation:
   -> linking to github.com/airbytehq/airbyte (resolved as: /contributing-to-airbyte/github.com/airbytehq/airbyte)

- On source page path = /integrations/:
   -> linking to sources/google-adwords.md (resolved as: /integrations/sources/google-adwords.md)
   -> linking to sources/cassandra.md (resolved as: /integrations/sources/cassandra.md)
   -> linking to sources/dynamodb.md (resolved as: /integrations/sources/dynamodb.md)
   -> linking to destinations/firestore.md (resolved as: /integrations/destinations/firestore.md)
   -> linking to sources/redis.md (resolved as: /integrations/sources/redis.md)
   -> linking to sources/scylla.md (resolved as: /integrations/sources/scylla.md)

- On source page path = /integrations/destinations/s3:
   -> linking to /airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json

- On source page path = /integrations/sources/lemlist:
   -> linking to %60api.lemlist.com/api/team%60 (resolved as: /integrations/sources/%60api.lemlist.com/api/team%60)
   -> linking to %60api.lemlist.com/api/campaigns%60 (resolved as: /integrations/sources/%60api.lemlist.com/api/campaigns%60)
   -> linking to %60api.lemlist.com/api/activities%60 (resolved as: /integrations/sources/%60api.lemlist.com/api/activities%60)
   -> linking to %60api.lemlist.com/api/unsubscribes%60 (resolved as: /integrations/sources/%60api.lemlist.com/api/unsubscribes%60)

- On source page path = /operator-guides/configuring-sync-notifications:
   -> linking to ../deploying-airbyte/README.md (resolved as: /deploying-airbyte/README.md)

- On source page path = /project-overview/changelog/connectors:
   -> linking to ../../integrations/sources/google-adwords.md (resolved as: /integrations/sources/google-adwords.md)

- On source page path = /project-overview/licenses/license-faq:
   -> linking to ../project-overview/licenses/elv2-license (resolved as: /project-overview/project-overview/licenses/elv2-license)

- On source page path = /SUMMARY:
   -> linking to ../README.md (resolved as: /README.md)
   -> linking to quickstart/README.md (resolved as: /quickstart/README.md)
   -> linking to deploying-airbyte/README.md (resolved as: /deploying-airbyte/README.md)
   -> linking to operator-guides/README.md (resolved as: /operator-guides/README.md)
   -> linking to integrations/destinations/README.md (resolved as: /integrations/destinations/README.md)
   -> linking to integrations/destinations/firestore.md (resolved as: /integrations/destinations/firestore.md)
   -> linking to connector-development/tutorials/README.md (resolved as: /connector-development/tutorials/README.md)

- On source page path = /understanding-airbyte/glossary:
   -> linking to ../integrations/destinations/ (resolved as: /integrations/destinations/)

[SUCCESS] Generated static files in build.
[INFO] Use `npm run serve` command to test your build locally.
Cloning into '/var/folders/_g/8v6vfrsn6yz8mm_1llkvjc780000gn/T/airbyte-gh-pageszR5RBv'...
[INFO] `git clone --depth 1 --branch gh-pages git@github.com:airbytehq/airbyte.git "/var/folders/_g/8v6vfrsn6yz8mm_1llkvjc780000gn/T/airbyte-gh-pageszR5RBv"` code: 0
rm '.nojekyll'
rm '404.html'
rm 'SUMMARY/index.html'
rm 'api-documentation/index.html'
rm 'archive/examples/build-a-slack-activity-dashboard/index.html'

Removing truly long git rm list here

rm 'understanding-airbyte/supported-data-types/index.html'
rm 'understanding-airbyte/tech-stack/index.html'
[INFO] `git rm -rf .` code: 0
[INFO] `git add --all` code: 0
[gh-pages 518d3c1] Deploy website - based on b873ae1433315107c51203284e358ef67986f05d
 1 file changed, 1 insertion(+), 1 deletion(-)
[INFO] `git commit -m "Deploy website - based on b873ae1433315107c51203284e358ef67986f05d"` code: 0
remote:
remote: GitHub found 13 vulnerabilities on airbytehq/airbyte's default branch (2 critical, 6 high, 5 moderate). To find out more, visit:
remote:      https://github.com/airbytehq/airbyte/security/dependabot
remote:
To github.com:airbytehq/airbyte.git
   3697f75..518d3c1  gh-pages -> gh-pages
[INFO] `git push --force origin gh-pages` code: 0
Website is live at "https://airbytehq.github.io/airbyte/".
✨  Done in 18.22s.
./tools/bin/deploy_docusaurus:55: cd ..
./tools/bin/deploy_docusaurus:56: pwd
/Users/topher/workspace/airbyte
./tools/bin/deploy_docusaurus:59: git fetch
remote: Enumerating objects: 5, done.
remote: Counting objects: 100% (5/5), done.
remote: Compressing objects: 100% (1/1), done.
remote: Total 3 (delta 2), reused 3 (delta 2), pack-reused 0
Unpacking objects: 100% (3/3), 311.50 KiB | 3.02 MiB/s, done.
From github.com:airbytehq/airbyte
   3697f756ad..518d3c140b  gh-pages   -> origin/gh-pages
./tools/bin/deploy_docusaurus:60: git switch gh-pages
Updating files: 100% (10515/10515), done.
Switched to branch 'gh-pages'
Your branch and 'origin/gh-pages' have diverged,
and have 2 and 2 different commits each, respectively.
  (use "git pull" to merge the remote branch into yours)
./tools/bin/deploy_docusaurus:62: git rev-parse --short HEAD
./tools/bin/deploy_docusaurus:62: revision=a2623ef72a
./tools/bin/deploy_docusaurus:64: set +o xtrace
Writing CNAME file!


./tools/bin/deploy_docusaurus:69: echo docs.airbyte.com
./tools/bin/deploy_docusaurus:71: git add CNAME
./tools/bin/deploy_docusaurus:73: git commit --message 'Adds CNAME to deploy for a2623ef72a'
[gh-pages b8d52974f9] Adds CNAME to deploy for a2623ef72a
 1 file changed, 1 insertion(+), 1 deletion(-)
./tools/bin/deploy_docusaurus:76: git branch
  add_docs_sidebar
  consolidate_documentation
  diverse_secrets
  doc_pipeline
  docs_config_updates_for_docusaurus
  docs_domain_change
  docusaurus_migration
  ec2_runner_fun
  find_non_rate_limited_PAT
* gh-pages
  gitbook/v1
  gitbook_pipeline_docs_revert
  github_PAT_rotation
  increase_AWS_runner_limit_timer
  increase_ec2_timer_to_5_minutes_part2
  java_intelij_code_style_document_update
  labeler_PAT_rotation
  longer_wait_for_new_runners
  master
  more_PATs
  more_clear_integreation_test_output
  more_valid_PATS_more_places
  more_valid_PATS_more_places2
  octocat_throttling
  push_docs_changes_to_gh_pages
  revert_5_minute_change_to_fix_prod
  rotate_slash_PAT
  specify-java-for-integration-tests
  toph_docs_deployment_workflow
  topher_add_docusaurus_tool_not_pipeline
  topher_fire_integration_tests_with_more_clear_feedback
  tophers_ec2_runner_rate_limiter
  trigger_gitbook
  use_more_than_one_PAT_for_higher_rps
./tools/bin/deploy_docusaurus:79: git push --force https://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@github.com/airbytehq/airbytehq.github.io.git
Enumerating objects: 16, done.
Counting objects: 100% (15/15), done.
Delta compression using up to 10 threads
Compressing objects: 100% (10/10), done.
Writing objects: 100% (11/11), 611.81 KiB | 4.78 MiB/s, done.
Total 11 (delta 6), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (6/6), completed with 2 local objects.
To https://github.com/airbytehq/airbytehq.github.io.git
   c104af9e38..b8d52974f9  gh-pages -> gh-pages
./tools/bin/deploy_docusaurus:84: set +o xtrace
Script exiting 0 GREAT SUCCESS!!!?
```