### PR TITLE
Normalization redshift - bugfix, remove `public` from search_path

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -28,5 +28,5 @@ WORKDIR /airbyte
 ENV AIRBYTE_ENTRYPOINT "/airbyte/entrypoint.sh"
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.1.76
+LABEL io.airbyte.version=0.1.77
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template/macros/configuration.sql
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template/macros/configuration.sql
@@ -6,7 +6,7 @@
     {%- set schemaname, _, tablename = var("models_to_source")[this.identifier].partition(".") -%}
 
     {%- call statement("get_column_type", fetch_result=True) -%}
-        set search_path to '$user', public, {{ schemaname }};
+        set search_path to '$user', {{ schemaname }};
         select type from pg_table_def where tablename = '{{ tablename }}' and "column" = '{{ var("json_column") }}' and schemaname = '{{ schemaname }}';
     {%- endcall -%}
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 public class NormalizationRunnerFactory {
 
   public static final String BASE_NORMALIZATION_IMAGE_NAME = "airbyte/normalization";
-  public static final String NORMALIZATION_VERSION = "0.1.76";
+  public static final String NORMALIZATION_VERSION = "0.1.77";
 
   static final Map<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>> NORMALIZATION_MAPPING =
       ImmutableMap.<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>>builder()

--- a/docs/understanding-airbyte/basic-normalization.md
+++ b/docs/understanding-airbyte/basic-normalization.md
@@ -352,7 +352,7 @@ Therefore, in order to "upgrade" to the desired normalization version, you need 
 
 | Airbyte Version | Normalization Version | Date | Pull Request | Subject |
 |:----------------| :--- | :--- | :--- | :--- |
-|                 | 0.1.77 | 2022-04-14 | [\#](https://github.com/airbytehq/airbyte/pull/) | |
+|                 | 0.1.77 | 2022-04-14 | [\#12005](https://github.com/airbytehq/airbyte/pull/12005) | Fix issue with redundant `public` schema in search_path |
 |                 | 0.1.76 | 2022-04-12 | [\#9610](https://github.com/airbytehq/airbyte/pull/9610) | Add support redshift SUPER type |
 | 0.35.65-alpha   | 0.1.75 | 2022-04-09 | [\#11511](https://github.com/airbytehq/airbyte/pull/11511) | Move DBT modules from `/tmp/dbt_modules` to `/dbt` |
 | 0.35.61-alpha   | 0.1.74 | 2022-03-24 | [\#10905](https://github.com/airbytehq/airbyte/pull/10905) | Update clickhouse dbt version |

--- a/docs/understanding-airbyte/basic-normalization.md
+++ b/docs/understanding-airbyte/basic-normalization.md
@@ -352,6 +352,7 @@ Therefore, in order to "upgrade" to the desired normalization version, you need 
 
 | Airbyte Version | Normalization Version | Date | Pull Request | Subject |
 |:----------------| :--- | :--- | :--- | :--- |
+|                 | 0.1.77 | 2022-04-14 | [\#](https://github.com/airbytehq/airbyte/pull/) | |
 |                 | 0.1.76 | 2022-04-12 | [\#9610](https://github.com/airbytehq/airbyte/pull/9610) | Add support redshift SUPER type |
 | 0.35.65-alpha   | 0.1.75 | 2022-04-09 | [\#11511](https://github.com/airbytehq/airbyte/pull/11511) | Move DBT modules from `/tmp/dbt_modules` to `/dbt` |
 | 0.35.61-alpha   | 0.1.74 | 2022-03-24 | [\#10905](https://github.com/airbytehq/airbyte/pull/10905) | Update clickhouse dbt version |

--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -19,7 +19,7 @@ else
     export SUB_BUILD="CONNECTORS_BASE"
     # avoid schema conflicts when multiple tests for normalization are run concurrently
     export RANDOM_TEST_SCHEMA="true"
-    ./gradlew --no-daemon --scan airbyteDocker
+    ./gradlew --max-workers=1 --no-daemon --scan airbyteDocker
   elif [[ "$connector" == *"bases"* ]]; then
     connector_name=$(echo $connector | cut -d / -f 2)
     selected_integration_test=$(echo "$all_integration_tests" | grep "^$connector_name$" || echo "")


### PR DESCRIPTION
Signed-off-by: Sergey Chvalyuk <grubberr@gmail.com>

## What
According to this https://docs.aws.amazon.com/redshift/latest/dg/r_search_path.html
we can safely SET such search_path
```
set search_path to '$user', public;
```
*If public is present and no schema with the name public exists, it is ignored.*

But it's looks like it's not true:
```
grubberr_test=# drop schema public;
DROP SCHEMA
grubberr_test=# set search_path to '$user', public;
ERROR:  schema "public" does not exist
```

## How
We can just remove `public` schema from search_path because we in really we don't need it
