### PR TITLE
Bump Airbyte version from 0.35.67-alpha to 0.35.68-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.35.67-alpha
+current_version = 0.35.68-alpha
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@
 
 
 ### SHARED ###
-VERSION=0.35.67-alpha
+VERSION=0.35.68-alpha
 
 # When using the airbyte-db via default docker image
 CONFIG_ROOT=/data

--- a/airbyte-bootloader/Dockerfile
+++ b/airbyte-bootloader/Dockerfile
@@ -1,7 +1,7 @@
 ARG JDK_VERSION=17.0.1
 FROM openjdk:${JDK_VERSION}-slim
 
-ARG VERSION=0.35.67-alpha
+ARG VERSION=0.35.68-alpha
 
 ENV APPLICATION airbyte-bootloader
 ENV VERSION ${VERSION}

--- a/airbyte-container-orchestrator/Dockerfile
+++ b/airbyte-container-orchestrator/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packa
 RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 RUN apt-get update && apt-get install -y kubectl
 
-ARG VERSION=0.35.67-alpha
+ARG VERSION=0.35.68-alpha
 
 ENV APPLICATION airbyte-container-orchestrator
 ENV VERSION=${VERSION}

--- a/airbyte-metrics/reporter/Dockerfile
+++ b/airbyte-metrics/reporter/Dockerfile
@@ -1,7 +1,7 @@
 ARG JDK_VERSION=17.0.1
 FROM openjdk:${JDK_VERSION}-slim AS metrics-reporter
 
-ARG VERSION=0.35.67-alpha
+ARG VERSION=0.35.68-alpha
 
 ENV APPLICATION airbyte-metrics-reporter
 ENV VERSION ${VERSION}

--- a/airbyte-scheduler/app/Dockerfile
+++ b/airbyte-scheduler/app/Dockerfile
@@ -1,7 +1,7 @@
 ARG JDK_VERSION=17.0.1
 FROM openjdk:${JDK_VERSION}-slim AS scheduler
 
-ARG VERSION=0.35.67-alpha
+ARG VERSION=0.35.68-alpha
 
 ENV APPLICATION airbyte-scheduler
 ENV VERSION ${VERSION}

--- a/airbyte-server/Dockerfile
+++ b/airbyte-server/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:${JDK_VERSION}-slim AS server
 
 EXPOSE 8000
 
-ARG VERSION=0.35.67-alpha
+ARG VERSION=0.35.68-alpha
 
 ENV APPLICATION airbyte-server
 ENV VERSION ${VERSION}

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.35.67-alpha",
+  "version": "0.35.68-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "airbyte-webapp",
-      "version": "0.35.67-alpha",
+      "version": "0.35.68-alpha",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-brands-svg-icons": "^5.15.4",

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.35.67-alpha",
+  "version": "0.35.68-alpha",
   "private": true,
   "engines": {
     "node": ">=16.0.0"

--- a/airbyte-workers/Dockerfile
+++ b/airbyte-workers/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packa
 RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 RUN apt-get update && apt-get install -y kubectl
 
-ARG VERSION=0.35.67-alpha
+ARG VERSION=0.35.68-alpha
 
 ENV APPLICATION airbyte-workers
 ENV VERSION ${VERSION}

--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.3.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.35.67-alpha"
+appVersion: "0.35.68-alpha"
 
 dependencies:
   - name: common

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -31,7 +31,7 @@ Helm charts for Airbyte.
 | `webapp.replicaCount`                       | Number of webapp replicas                                        | `1`              |
 | `webapp.image.repository`                   | The repository to use for the airbyte webapp image.              | `airbyte/webapp` |
 | `webapp.image.pullPolicy`                   | the pull policy to use for the airbyte webapp image              | `IfNotPresent`   |
-| `webapp.image.tag`                          | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.35.67-alpha`  |
+| `webapp.image.tag`                          | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.35.68-alpha`  |
 | `webapp.podAnnotations`                     | Add extra annotations to the webapp pod(s)                       | `{}`             |
 | `webapp.containerSecurityContext`           | Security context for the container                               | `{}`             |
 | `webapp.livenessProbe.enabled`              | Enable livenessProbe on the webapp                               | `true`           |
@@ -73,7 +73,7 @@ Helm charts for Airbyte.
 | `scheduler.replicaCount`       | Number of scheduler replicas                                        | `1`                 |
 | `scheduler.image.repository`   | The repository to use for the airbyte scheduler image.              | `airbyte/scheduler` |
 | `scheduler.image.pullPolicy`   | the pull policy to use for the airbyte scheduler image              | `IfNotPresent`      |
-| `scheduler.image.tag`          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.35.67-alpha`      |
+| `scheduler.image.tag`          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.35.68-alpha`      |
 | `scheduler.podAnnotations`     | Add extra annotations to the scheduler pod                          | `{}`                |
 | `scheduler.resources.limits`   | The resources limits for the scheduler container                    | `{}`                |
 | `scheduler.resources.requests` | The requested resources for the scheduler container                 | `{}`                |
@@ -120,7 +120,7 @@ Helm charts for Airbyte.
 | `server.replicaCount`                       | Number of server replicas                                        | `1`              |
 | `server.image.repository`                   | The repository to use for the airbyte server image.              | `airbyte/server` |
 | `server.image.pullPolicy`                   | the pull policy to use for the airbyte server image              | `IfNotPresent`   |
-| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.35.67-alpha`   |
+| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.35.68-alpha`   |
 | `server.podAnnotations`                     | Add extra annotations to the server pod                          | `{}`             |
 | `server.containerSecurityContext`           | Security context for the container                               | `{}`             |
 | `server.livenessProbe.enabled`              | Enable livenessProbe on the server                               | `true`           |
@@ -158,7 +158,7 @@ Helm charts for Airbyte.
 | `worker.replicaCount`                       | Number of worker replicas                                        | `1`              |
 | `worker.image.repository`                   | The repository to use for the airbyte worker image.              | `airbyte/worker` |
 | `worker.image.pullPolicy`                   | the pull policy to use for the airbyte worker image              | `IfNotPresent`   |
-| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.35.67-alpha`   |
+| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.35.68-alpha`   |
 | `worker.podAnnotations`                     | Add extra annotations to the worker pod(s)                       | `{}`             |
 | `worker.containerSecurityContext`           | Security context for the container                               | `{}`             |
 | `worker.livenessProbe.enabled`              | Enable livenessProbe on the worker                               | `true`           |
@@ -190,7 +190,7 @@ Helm charts for Airbyte.
 | ----------------------------- | -------------------------------------------------------------------- | -------------------- |
 | `bootloader.image.repository` | The repository to use for the airbyte bootloader image.              | `airbyte/bootloader` |
 | `bootloader.image.pullPolicy` | the pull policy to use for the airbyte bootloader image              | `IfNotPresent`       |
-| `bootloader.image.tag`        | The airbyte bootloader image tag. Defaults to the chart's AppVersion | `0.35.67-alpha`       |
+| `bootloader.image.tag`        | The airbyte bootloader image tag. Defaults to the chart's AppVersion | `0.35.68-alpha`       |
 
 
 ### Temporal parameters

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -43,7 +43,7 @@ webapp:
   image:
     repository: airbyte/webapp
     pullPolicy: IfNotPresent
-    tag: 0.35.67-alpha
+    tag: 0.35.68-alpha
 
   ## @param webapp.podAnnotations [object] Add extra annotations to the webapp pod(s)
   ##
@@ -209,7 +209,7 @@ scheduler:
   image:
     repository: airbyte/scheduler
     pullPolicy: IfNotPresent
-    tag: 0.35.67-alpha
+    tag: 0.35.68-alpha
 
   ## @param scheduler.podAnnotations [object] Add extra annotations to the scheduler pod
   ##
@@ -440,7 +440,7 @@ server:
   image:
     repository: airbyte/server
     pullPolicy: IfNotPresent
-    tag: 0.35.67-alpha
+    tag: 0.35.68-alpha
 
   ## @param server.podAnnotations [object] Add extra annotations to the server pod
   ##
@@ -581,7 +581,7 @@ worker:
   image:
     repository: airbyte/worker
     pullPolicy: IfNotPresent
-    tag: 0.35.67-alpha
+    tag: 0.35.68-alpha
 
   ## @param worker.podAnnotations [object] Add extra annotations to the worker pod(s)
   ##
@@ -699,7 +699,7 @@ bootloader:
   image:
     repository: airbyte/bootloader
     pullPolicy: IfNotPresent
-    tag: 0.35.67-alpha
+    tag: 0.35.68-alpha
   
   ## @param bootloader.podAnnotations [object] Add extra annotations to the bootloader pod
   ##

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -103,7 +103,7 @@ If you are upgrading from \(i.e. your current version of Airbyte is\) Airbyte ve
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.35.67-alpha --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.35.68-alpha --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/kube/overlays/stable-with-resource-limits/.env
+++ b/kube/overlays/stable-with-resource-limits/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.35.67-alpha
+AIRBYTE_VERSION=0.35.68-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -8,17 +8,17 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.35.67-alpha
+    newTag: 0.35.68-alpha
   - name: airbyte/bootloader
-    newTag: 0.35.67-alpha
+    newTag: 0.35.68-alpha
   - name: airbyte/scheduler
-    newTag: 0.35.67-alpha
+    newTag: 0.35.68-alpha
   - name: airbyte/server
-    newTag: 0.35.67-alpha
+    newTag: 0.35.68-alpha
   - name: airbyte/webapp
-    newTag: 0.35.67-alpha
+    newTag: 0.35.68-alpha
   - name: airbyte/worker
-    newTag: 0.35.67-alpha
+    newTag: 0.35.68-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.35.67-alpha
+AIRBYTE_VERSION=0.35.68-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -8,17 +8,17 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.35.67-alpha
+    newTag: 0.35.68-alpha
   - name: airbyte/bootloader
-    newTag: 0.35.67-alpha
+    newTag: 0.35.68-alpha
   - name: airbyte/scheduler
-    newTag: 0.35.67-alpha
+    newTag: 0.35.68-alpha
   - name: airbyte/server
-    newTag: 0.35.67-alpha
+    newTag: 0.35.68-alpha
   - name: airbyte/webapp
-    newTag: 0.35.67-alpha
+    newTag: 0.35.68-alpha
   - name: airbyte/worker
-    newTag: 0.35.67-alpha
+    newTag: 0.35.68-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 

--- a/octavia-cli/Dockerfile
+++ b/octavia-cli/Dockerfile
@@ -14,5 +14,5 @@ USER octavia-cli
 WORKDIR /home/octavia-project
 ENTRYPOINT ["octavia"]
 
-LABEL io.airbyte.version=0.35.67-alpha
+LABEL io.airbyte.version=0.35.68-alpha
 LABEL io.airbyte.name=airbyte/octavia-cli

--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -105,7 +105,7 @@ This script:
 ```bash
 touch ~/.octavia # Create a file to store env variables that will be mapped the octavia-cli container
 mkdir my_octavia_project_directory # Create your octavia project directory where YAML configurations will be stored.
-docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:0.35.67-alpha
+docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:0.35.68-alpha
 ```
 
 ### Using `docker-compose`

--- a/octavia-cli/install.sh
+++ b/octavia-cli/install.sh
@@ -3,7 +3,7 @@
 # This install scripts currently only works for ZSH and Bash profiles.
 # It creates an octavia alias in your profile bound to a docker run command and your current user.
 
-VERSION=0.35.67-alpha
+VERSION=0.35.68-alpha
 OCTAVIA_ENV_FILE=${HOME}/.octavia
 
 detect_profile() {

--- a/octavia-cli/setup.py
+++ b/octavia-cli/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="octavia-cli",
-    version="0.35.67",
+    version="0.35.68",
     description="A command line interface to manage Airbyte configurations",
     long_description=README,
     author="Airbyte",


### PR DESCRIPTION
*IMPORTANT: Only merge if the platform build is passing!*

Changelog:

acfb606ce Actually remember to remove the force failure. (#12011)
e3583d3a3 Remove force failure for Slack notification testing. (#12009)
5d4a3636b fix check operation for Redshift destination (#12002)
ae8c4f2b3 Notify Slack Build Failure. (#12007)
0964c83ea 🎁 octavia-cli: add telemetry (#11896)
fa9c46709 Use Firebase Auth Emulator host if present (#11958)
5e003583a Issue: 11867 add option for sidecar pull policy (#11868)
7bb4baec2 Docs: correct minor mistakes (#11848)
1cf52f62a doc: update troubleshooting for discourse forum (#11970)
35005541f source-bigquery: escape column names and update google cloud bigquery artifact (#11484)
14dfc1d41 fix parentheses and info/warning/danger formatting in docs (#11981)
2881d6248 Fix the count connections method (#11955)
644ace403 🐛 [On call / 171] Source Salesforce: fixed the bug when `Bulk` fetch took all memory of kube pods (#11692)
1613904eb Upgrade webapp dependencies (#11940)
26aa43b31 Source File: Update Dockerfile to latest Airbyte template (#11969)
6adaf7154 Update on-kubernetes.md (#11962)
a673a479d #10938 fix docs and spec (#11803)

Steps After Merging PR:
1. Pull most recent version of master
2. Run ./tools/bin/tag_version.sh
3. Create a GitHub release with the changelog