### PR TITLE
Only build CDK with supported python versions

### DIFF
--- a/.github/workflows/publish-cdk-command.yml
+++ b/.github/workflows/publish-cdk-command.yml
@@ -22,8 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # 3.7.1 - is a minimal of 3.7.X version supported by github actions
-        python-version: [3.7.1, 3.7, 3.8, 3.9]
+        python-version: [3.9]
     steps:
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/publish-cdk-command.yml
+++ b/.github/workflows/publish-cdk-command.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10]
+        python-version: ["3.9", "3.10"]
     steps:
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/publish-cdk-command.yml
+++ b/.github/workflows/publish-cdk-command.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9, 3.10]
     steps:
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/publish-cdk-command.yml
+++ b/.github/workflows/publish-cdk-command.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9"]
     steps:
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
## What
After the upgrade to python 3.9 (#11657), the minimum python version for the CDK was also bumped to 3.9. This caused the `/publish-cdk` command to start failing, since it was trying to build the CDK on unsupported python versions ([see example](https://github.com/airbytehq/airbyte/runs/6016040587?check_suite_focus=true#step:5:67)).

## How
This PR removes the unsupported python versions from the `build-cdk` step.
A new version of the CDK will be published via #11858.

I tried to also build with python 3.10 on a fork, but [the build is failing](https://github.com/pedroslopez/airbyte/runs/6026220360?check_suite_focus=true), seemingly due to `pytest` needing to be upgraded to[ 3.2.5](https://docs.pytest.org/en/7.1.x/changelog.html#pytest-6-2-5-2021-08-29) for proper python 3.10 support, which I think we should do separately.