### PR TITLE
Add NoMatchingConnector event

### DIFF
--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -34,6 +34,7 @@
   "form.selectConnector": "Type to search for a connector",
   "form.searchName": "search by name...",
   "form.noResult": "No result",
+  "form.noConnectorFound": "No matching connector found",
   "form.sourceName.placeholder": "Your source name",
   "form.destinationName.placeholder": "Your destination name",
   "form.connectionName.placeholder": "Name",

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -162,7 +162,7 @@ const ConnectorServiceTypeControl: React.FC<{
   documentationUrl,
   onOpenRequestConnectorModal,
 }) => {
-  const formatMessage = useIntl().formatMessage;
+  const { formatMessage } = useIntl();
   const [field, fieldMeta, { setValue }] = useField(property.path);
   const analytics = useAnalyticsService();
 
@@ -212,6 +212,22 @@ const ConnectorServiceTypeControl: React.FC<{
     [availableServices]
   );
 
+  const getNoOptionsMessage = useCallback(
+    ({ inputValue }: { inputValue: string }) => {
+      console.log("Analytics events send!", inputValue);
+      analytics.track(
+        formType === "source"
+          ? "Airbyte.UI.NewSource.NoMatchingConnector"
+          : "Airbyte.UI.NewDestination.NoMatchingConnector",
+        {
+          query: inputValue,
+        }
+      );
+      return formatMessage({ id: "form.noConnectorFound" });
+    },
+    [analytics, formType, formatMessage]
+  );
+
   const selectedService = React.useMemo(
     () => availableServices.find((s) => Connector.id(s) === field.value),
     [field.value, availableServices]
@@ -259,6 +275,7 @@ const ConnectorServiceTypeControl: React.FC<{
           options={sortedDropDownData}
           onChange={handleSelect}
           onMenuOpen={onMenuOpen}
+          noOptionsMessage={getNoOptionsMessage}
         />
       </ControlLabels>
       {selectedService && documentationUrl && (

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -214,7 +214,6 @@ const ConnectorServiceTypeControl: React.FC<{
 
   const getNoOptionsMessage = useCallback(
     ({ inputValue }: { inputValue: string }) => {
-      console.log("Analytics events send!", inputValue);
       analytics.track(
         formType === "source"
           ? "Airbyte.UI.NewSource.NoMatchingConnector"


### PR DESCRIPTION
## What

Fixes #12033

Adds an analytics event if a user searches for a specific connector in the selectbox, but doesn't retrieve any results.