### PR TITLE
Relax `codecov` target coverage to 90%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,13 +6,13 @@ coverage:
   status:
     patch:
       default:
-        target: 100%
+        target: 90%
         if_no_uploads: error
         if_not_found: failure
         if_ci_failed: failure
     project:
       default:
-        target: 100%
+        target: 90%
         if_no_uploads: error
         if_not_found: failure
         if_ci_failed: failure


### PR DESCRIPTION
Relaxes the target for passing `codecov` tests from 100% code coverage to 90%