### PR TITLE
Cleanup StatusIcon component states

### DIFF
--- a/airbyte-webapp/src/components/CreateConnectionContent/components/TryAfterErrorBlock.tsx
+++ b/airbyte-webapp/src/components/CreateConnectionContent/components/TryAfterErrorBlock.tsx
@@ -24,7 +24,7 @@ type TryAfterErrorBlockProps = {
 
 const TryAfterErrorBlock: React.FC<TryAfterErrorBlockProps> = ({ message, onClick }) => (
   <Block>
-    <StatusIcon success={false} big />
+    <StatusIcon big />
     <Title center>{message || <FormattedMessage id="form.schemaFailed" />}</Title>
     <AgainButton onClick={onClick} danger>
       <FormattedMessage id="form.tryAgain" />

--- a/airbyte-webapp/src/components/EntityTable/components/AllConnectionsStatusCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/AllConnectionsStatusCell.tsx
@@ -2,84 +2,51 @@ import React, { useMemo } from "react";
 import { useIntl } from "react-intl";
 
 import StatusIcon from "components/StatusIcon";
+import { StatusIconStatus } from "components/StatusIcon/StatusIcon";
 
 import { Status } from "../types";
 
-type AllConnectionsStatusCellProps = {
-  connectEntities: {
-    name: string;
-    connector: string;
-    status: string;
-    lastSyncStatus: string;
-  }[];
-};
+const _statusConfig: { status: Status; statusIconStatus?: StatusIconStatus; titleId: string }[] = [
+  { status: Status.ACTIVE, statusIconStatus: "success", titleId: "connection.successSync" },
+  { status: Status.INACTIVE, statusIconStatus: "inactive", titleId: "connection.disabledConnection" },
+  { status: Status.FAILED, titleId: "connection.failedSync" },
+  { status: Status.EMPTY, statusIconStatus: "empty", titleId: "connection.noSyncData" },
+];
+
+interface AllConnectionStatusConnectEntity {
+  name: string;
+  connector: string;
+  status: string;
+  lastSyncStatus: string;
+}
+
+interface AllConnectionsStatusCellProps {
+  connectEntities: AllConnectionStatusConnectEntity[];
+}
 
 const AllConnectionsStatusCell: React.FC<AllConnectionsStatusCellProps> = ({ connectEntities }) => {
-  const formatMessage = useIntl().formatMessage;
+  const { formatMessage } = useIntl();
 
-  const active = useMemo(
-    () => connectEntities.filter((entity) => entity.lastSyncStatus === Status.ACTIVE),
-    [connectEntities]
-  );
+  const statusIconProps = useMemo(() => {
+    if (connectEntities.length) {
+      for (const { status, statusIconStatus, titleId } of _statusConfig) {
+        const filteredEntities = connectEntities.filter((entity) => entity.lastSyncStatus === status);
+        if (filteredEntities.length) {
+          return {
+            status: statusIconStatus,
+            value: filteredEntities.length,
+            title: titleId,
+          };
+        }
+      }
+    }
 
-  const inactive = useMemo(
-    () => connectEntities.filter((entity) => entity.lastSyncStatus === Status.INACTIVE),
-    [connectEntities]
-  );
+    return undefined;
+  }, [connectEntities]);
 
-  const failed = useMemo(
-    () => connectEntities.filter((entity) => entity.lastSyncStatus === Status.FAILED),
-    [connectEntities]
-  );
-
-  const empty = useMemo(
-    () => connectEntities.filter((entity) => entity.lastSyncStatus === Status.EMPTY),
-    [connectEntities]
-  );
-
-  if (!connectEntities.length) {
-    return null;
-  }
-
-  return (
-    <>
-      {active.length ? (
-        <StatusIcon
-          status="success"
-          value={active.length}
-          title={formatMessage({
-            id: "connection.successSync",
-          })}
-        />
-      ) : null}
-      {inactive.length ? (
-        <StatusIcon
-          status="inactive"
-          value={inactive.length}
-          title={formatMessage({
-            id: "connection.disabledConnection",
-          })}
-        />
-      ) : null}
-      {failed.length ? (
-        <StatusIcon
-          value={failed.length}
-          title={formatMessage({
-            id: "connection.failedSync",
-          })}
-        />
-      ) : null}
-      {empty.length ? (
-        <StatusIcon
-          status="empty"
-          value={empty.length}
-          title={formatMessage({
-            id: "connection.noSyncData",
-          })}
-        />
-      ) : null}
-    </>
-  );
+  return statusIconProps ? (
+    <StatusIcon {...statusIconProps} title={formatMessage({ id: statusIconProps.title })} />
+  ) : null;
 };
 
 export default AllConnectionsStatusCell;

--- a/airbyte-webapp/src/components/EntityTable/components/AllConnectionsStatusCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/AllConnectionsStatusCell.tsx
@@ -45,7 +45,7 @@ const AllConnectionsStatusCell: React.FC<AllConnectionsStatusCellProps> = ({ con
     <>
       {active.length ? (
         <StatusIcon
-          success
+          status="success"
           value={active.length}
           title={formatMessage({
             id: "connection.successSync",
@@ -54,7 +54,7 @@ const AllConnectionsStatusCell: React.FC<AllConnectionsStatusCellProps> = ({ con
       ) : null}
       {inactive.length ? (
         <StatusIcon
-          inactive
+          status="inactive"
           value={inactive.length}
           title={formatMessage({
             id: "connection.disabledConnection",
@@ -71,7 +71,7 @@ const AllConnectionsStatusCell: React.FC<AllConnectionsStatusCellProps> = ({ con
       ) : null}
       {empty.length ? (
         <StatusIcon
-          empty
+          status="empty"
           value={empty.length}
           title={formatMessage({
             id: "connection.noSyncData",

--- a/airbyte-webapp/src/components/EntityTable/components/NameCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/NameCell.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useMemo } from "react";
 import styled from "styled-components";
 import { useIntl } from "react-intl";
 
 import StatusIcon from "components/StatusIcon";
 import ImageBlock from "components/ImageBlock";
+import { StatusIconStatus } from "components/StatusIcon/StatusIcon";
 
 import { Status } from "../types";
 
@@ -41,6 +42,17 @@ const Image = styled(ImageBlock)`
 
 const NameCell: React.FC<IProps> = ({ value, enabled, status, icon, img }) => {
   const formatMessage = useIntl().formatMessage;
+  const statusIconStatus = useMemo<StatusIconStatus | undefined>(
+    () =>
+      status === Status.EMPTY
+        ? "empty"
+        : status === Status.ACTIVE
+        ? "success"
+        : status === Status.INACTIVE
+        ? "inactive"
+        : undefined,
+    [status]
+  );
   const title =
     status === Status.EMPTY
       ? formatMessage({
@@ -60,16 +72,7 @@ const NameCell: React.FC<IProps> = ({ value, enabled, status, icon, img }) => {
 
   return (
     <Content>
-      {status ? (
-        <StatusIcon
-          title={title}
-          empty={status === Status.EMPTY}
-          success={status === Status.ACTIVE}
-          inactive={status === Status.INACTIVE}
-        />
-      ) : (
-        <Space />
-      )}
+      {status ? <StatusIcon title={title} status={statusIconStatus} /> : <Space />}
       {icon && <Image small img={img} />}
       <Name enabled={enabled}>{value}</Name>
     </Content>

--- a/airbyte-webapp/src/components/JobItem/components/MainInfo.tsx
+++ b/airbyte-webapp/src/components/JobItem/components/MainInfo.tsx
@@ -114,7 +114,7 @@ const MainInfo: React.FC<IProps> = ({
 
   const getIcon = () => {
     if (isPartialSuccess) {
-      return <ErrorSign warning />;
+      return <ErrorSign status="warning" />;
     } else if (isFailed && !shortInfo) {
       return <ErrorSign />;
     }

--- a/airbyte-webapp/src/components/StatusIcon/PauseIcon.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/PauseIcon.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  color?: string;
+  title?: string;
+}
+
+const PauseIcon = ({ color = "currentColor", title }: Props): JSX.Element => (
+  <svg width="6" height="11" viewBox="0 0 6 11" fill="none" role="img" data-icon="pause">
+    {title && <title>{title}</title>}
+    <line x1="1" y1="1.5" x2="1" y2="10.5" stroke={color} strokeWidth="2" />
+    <line x1="5" y1="1.5" x2="5" y2="10.5" stroke={color} strokeWidth="2" />
+  </svg>
+);
+
+export default PauseIcon;

--- a/airbyte-webapp/src/components/StatusIcon/StatusIcon.test.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/StatusIcon.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+
+import StatusIcon from "./StatusIcon";
+
+describe("<StatusIcon />", () => {
+  test("renders with title and default icon", () => {
+    const title = "Pulpo";
+    const value = 888;
+
+    const component = render(<StatusIcon title={title} value={value} />);
+
+    expect(component.getByTitle(title)).toBeDefined();
+    expect(component.getByRole("img")).toHaveAttribute("data-icon", "times");
+    expect(component.getByText(`${value}`)).toBeDefined();
+  });
+
+  const statusCases = [
+    { status: "success", icon: "check" },
+    { status: "inactive", icon: "pause" },
+    { status: "empty", icon: "ban" },
+    { status: "warning", icon: "exclamation-triangle" },
+  ];
+
+  test.each(statusCases)("renders $status status", ({ status, icon }) => {
+    const title = `Status is ${status}`;
+    const value = 888;
+    const props = {
+      title,
+      value,
+      [status]: true,
+    };
+
+    const component = render(<StatusIcon {...props} />);
+
+    expect(component.getByTitle(title)).toBeDefined();
+    expect(component.getByRole("img")).toHaveAttribute("data-icon", icon);
+    expect(component.getByText(`${value}`)).toBeDefined();
+  });
+});

--- a/airbyte-webapp/src/components/StatusIcon/StatusIcon.test.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/StatusIcon.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/react";
 
-import StatusIcon from "./StatusIcon";
+import StatusIcon, { StatusIconStatus } from "./StatusIcon";
 
 describe("<StatusIcon />", () => {
   test("renders with title and default icon", () => {
@@ -14,7 +14,7 @@ describe("<StatusIcon />", () => {
     expect(component.getByText(`${value}`)).toBeDefined();
   });
 
-  const statusCases = [
+  const statusCases: { status: StatusIconStatus; icon: string }[] = [
     { status: "success", icon: "check" },
     { status: "inactive", icon: "pause" },
     { status: "empty", icon: "ban" },
@@ -27,7 +27,7 @@ describe("<StatusIcon />", () => {
     const props = {
       title,
       value,
-      [status]: true,
+      status,
     };
 
     const component = render(<StatusIcon {...props} />);

--- a/airbyte-webapp/src/components/StatusIcon/StatusIcon.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/StatusIcon.tsx
@@ -17,9 +17,8 @@ interface Props {
 
 const getBadgeWidth = (props: Props) => (props.big ? (props.value ? 57 : 40) : props.value ? 37 : 20);
 
-const _iconByStatus: Record<StatusIconStatus, IconDefinition | undefined> = {
+const _iconByStatus: Partial<Record<StatusIconStatus, IconDefinition | undefined>> = {
   empty: faBan,
-  inactive: undefined,
   success: faCheck,
   warning: faExclamationTriangle,
 };

--- a/airbyte-webapp/src/components/StatusIcon/StatusIcon.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/StatusIcon.tsx
@@ -3,9 +3,9 @@ import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheck, faTimes, faBan, faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 
-import PauseIcon from "./components/Pause";
+import PauseIcon from "./PauseIcon";
 
-type IProps = {
+interface Props {
   success?: boolean;
   warning?: boolean;
   title?: string;
@@ -14,18 +14,12 @@ type IProps = {
   className?: string;
   big?: boolean;
   value?: string | number;
-};
+}
 
-const getWidth = (props: IProps) => {
-  if (props.big) {
-    return props.value ? 57 : 40;
-  }
+const getBadgeWidth = (props: Props) => (props.big ? (props.value ? 57 : 40) : props.value ? 37 : 20);
 
-  return props.value ? 37 : 20;
-};
-
-const Badge = styled.div<IProps>`
-  width: ${(props) => getWidth(props)}px;
+const Badge = styled.div<Props>`
+  width: ${(props) => getBadgeWidth(props)}px;
   height: ${({ big }) => (big ? 40 : 20)}px;
   background: ${(props) =>
     props.success
@@ -56,21 +50,23 @@ const Value = styled.span`
   vertical-align: top;
 `;
 
-const StatusIcon: React.FC<IProps> = (props) => (
-  <Badge {...props}>
-    {props.success ? (
-      <FontAwesomeIcon icon={faCheck} title={props.title} />
-    ) : props.inactive ? (
-      <PauseIcon />
-    ) : props.empty ? (
-      <FontAwesomeIcon icon={faBan} title={props.title} />
-    ) : props.warning ? (
-      <FontAwesomeIcon icon={faExclamationTriangle} title={props.title} />
-    ) : (
-      <FontAwesomeIcon icon={faTimes} title={props.title} />
-    )}
-    {props.value && <Value>{props.value}</Value>}
-  </Badge>
-);
+const StatusIcon: React.FC<Props> = ({ title, ...props }) => {
+  return (
+    <Badge {...props}>
+      {props.success ? (
+        <FontAwesomeIcon icon={faCheck} title={title} />
+      ) : props.inactive ? (
+        <PauseIcon title={title} />
+      ) : props.empty ? (
+        <FontAwesomeIcon icon={faBan} title={title} />
+      ) : props.warning ? (
+        <FontAwesomeIcon icon={faExclamationTriangle} title={title} />
+      ) : (
+        <FontAwesomeIcon icon={faTimes} title={title} />
+      )}
+      {props.value && <Value>{props.value}</Value>}
+    </Badge>
+  );
+};
 
 export default StatusIcon;

--- a/airbyte-webapp/src/components/StatusIcon/StatusIcon.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/StatusIcon.tsx
@@ -1,36 +1,40 @@
 import React from "react";
 import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCheck, faTimes, faBan, faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+import { faCheck, faTimes, faBan, faExclamationTriangle, IconDefinition } from "@fortawesome/free-solid-svg-icons";
 
 import PauseIcon from "./PauseIcon";
 
+export type StatusIconStatus = "empty" | "inactive" | "success" | "warning";
+
 interface Props {
-  success?: boolean;
-  warning?: boolean;
-  title?: string;
-  inactive?: boolean;
-  empty?: boolean;
   className?: string;
+  status?: StatusIconStatus;
+  title?: string;
   big?: boolean;
   value?: string | number;
 }
 
 const getBadgeWidth = (props: Props) => (props.big ? (props.value ? 57 : 40) : props.value ? 37 : 20);
 
+const _iconByStatus: Record<StatusIconStatus, IconDefinition | undefined> = {
+  empty: faBan,
+  inactive: undefined,
+  success: faCheck,
+  warning: faExclamationTriangle,
+};
+
+const _themeByStatus: Record<StatusIconStatus, string> = {
+  empty: "attentionColor",
+  inactive: "lightTextColor",
+  success: "successColor",
+  warning: "warningColor",
+};
+
 const Badge = styled.div<Props>`
   width: ${(props) => getBadgeWidth(props)}px;
   height: ${({ big }) => (big ? 40 : 20)}px;
-  background: ${(props) =>
-    props.success
-      ? props.theme.successColor
-      : props.inactive
-      ? props.theme.lightTextColor
-      : props.empty
-      ? props.theme.attentionColor
-      : props.warning
-      ? props.theme.warningColor
-      : props.theme.dangerColor};
+  background: ${(props) => props.theme[(props.status && _themeByStatus[props.status]) || "dangerColor"]};
   box-shadow: 0 1px 2px ${({ theme }) => theme.shadowColor};
   border-radius: ${({ value }) => (value ? "15px" : "50%")};
   margin-right: 10px;
@@ -50,19 +54,13 @@ const Value = styled.span`
   vertical-align: top;
 `;
 
-const StatusIcon: React.FC<Props> = ({ title, ...props }) => {
+const StatusIcon: React.FC<Props> = ({ title, status, ...props }) => {
   return (
-    <Badge {...props}>
-      {props.success ? (
-        <FontAwesomeIcon icon={faCheck} title={title} />
-      ) : props.inactive ? (
+    <Badge {...props} status={status}>
+      {status === "inactive" ? (
         <PauseIcon title={title} />
-      ) : props.empty ? (
-        <FontAwesomeIcon icon={faBan} title={title} />
-      ) : props.warning ? (
-        <FontAwesomeIcon icon={faExclamationTriangle} title={title} />
       ) : (
-        <FontAwesomeIcon icon={faTimes} title={title} />
+        <FontAwesomeIcon icon={(status && _iconByStatus[status]) || faTimes} title={title} />
       )}
       {props.value && <Value>{props.value}</Value>}
     </Badge>

--- a/airbyte-webapp/src/components/StatusIcon/components/Pause.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/components/Pause.tsx
@@ -1,8 +1,0 @@
-const PauseIcon = ({ color = "currentColor" }: { color?: string }): JSX.Element => (
-  <svg width="6" height="11" viewBox="0 0 6 11" fill="none">
-    <line x1="1" y1="1.5" x2="1" y2="10.5" stroke={color} strokeWidth="2" />
-    <line x1="5" y1="1.5" x2="5" y2="10.5" stroke={color} strokeWidth="2" />
-  </svg>
-);
-
-export default PauseIcon;

--- a/airbyte-webapp/src/components/StepsMenu/components/Step.tsx
+++ b/airbyte-webapp/src/components/StepsMenu/components/Step.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import styled from "styled-components";
 
 import StatusIcon from "components/StatusIcon";
@@ -64,8 +64,10 @@ const Step: React.FC<IProps> = ({ name, id, isActive, onClick, num, lightMode, s
     }
   };
 
-  const statusIconStatus: StatusIconStatus | undefined =
-    status !== Status.FAILED && !isPartialSuccess ? "success" : isPartialSuccess ? "warning" : undefined;
+  const statusIconStatus: StatusIconStatus | undefined = useMemo(
+    () => (status !== Status.FAILED && !isPartialSuccess ? "success" : isPartialSuccess ? "warning" : undefined),
+    [status, isPartialSuccess]
+  );
 
   return (
     <StepView

--- a/airbyte-webapp/src/components/StepsMenu/components/Step.tsx
+++ b/airbyte-webapp/src/components/StepsMenu/components/Step.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 import StatusIcon from "components/StatusIcon";
+import { StatusIconStatus } from "components/StatusIcon/StatusIcon";
 
 import Status from "core/statuses";
 
@@ -63,6 +64,9 @@ const Step: React.FC<IProps> = ({ name, id, isActive, onClick, num, lightMode, s
     }
   };
 
+  const statusIconStatus: StatusIconStatus | undefined =
+    status !== Status.FAILED && !isPartialSuccess ? "success" : isPartialSuccess ? "warning" : undefined;
+
   return (
     <StepView
       data-id={`${id.toLowerCase()}-step`}
@@ -72,9 +76,7 @@ const Step: React.FC<IProps> = ({ name, id, isActive, onClick, num, lightMode, s
       lightMode={lightMode}
     >
       {lightMode ? null : <Num isActive={isActive}>{num}</Num>}
-      {status ? (
-        <StatusIcon success={status !== Status.FAILED && !isPartialSuccess} warning={isPartialSuccess} />
-      ) : null}
+      {status ? <StatusIcon status={statusIconStatus} /> : null}
       {name}
     </StepView>
   );

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/CreationFormPage/components/CheckConnection.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/CreationFormPage/components/CheckConnection.tsx
@@ -48,7 +48,7 @@ const CheckConnection: React.FC<IProps> = ({ isLoading, type, error, retry, link
 
     return (
       <Content>
-        <StatusIcon success={false} big />
+        <StatusIcon big />
         <Title>
           <FormattedMessage id="connection.testsFailed" />
         </Title>
@@ -79,7 +79,7 @@ const CheckConnection: React.FC<IProps> = ({ isLoading, type, error, retry, link
 
   return (
     <Content>
-      <StatusIcon success big />
+      <StatusIcon status="success" big />
       <Title>
         <FormattedMessage id="connection.testsPassed" />
       </Title>

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/TestingConnectionSuccess.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/TestingConnectionSuccess.tsx
@@ -25,7 +25,7 @@ const Success = styled(StatusIcon)`
 
 const TestingConnectionSuccess: React.FC = () => (
   <LoadingContainer data-id="success-result">
-    <Success success />
+    <Success status="success" />
     <FormattedMessage id="form.successTests" />
   </LoadingContainer>
 );


### PR DESCRIPTION
## What
The current implementation of `<StatusIcon />` uses booleans to determine different states instead of a status enum or type. This changes it such that it's based on a status prop.

This is in preparation to apply the changes described in #10842

```tsx
// Before:
<StatusIcon success />
<StatusIcon inactive />
<StatusIcon active />
// etc.

// After:
<StatusIcon status="success" />
<StatusIcon status="inactive" />
<StatusIcon status="active" />
// etc.
```

## How
Adds testing of the component and updates the different boolean props to a single status prop.

## Recommended reading order
1. `StatusIcon.test.tsx`
2. `StatusIcon.tsx`
3. The rest of the code

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Tests

<details><summary><strong>Unit</strong></summary>

  <StatusIcon />
    ✓ renders with title and default icon (31 ms)
    ✓ renders success status (17 ms)
    ✓ renders inactive status (17 ms)
    ✓ renders empty status (12 ms)
    ✓ renders warning status (16 ms)

</details>

