### PR TITLE
patch time.sleep in unit tests to avoid actual sleeps

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/test_reports_streams_rate_limits.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/test_reports_streams_rate_limits.py
@@ -51,10 +51,10 @@ def test_reports_stream_send_request(mocker, reports_stream):
 
 
 def test_reports_stream_send_request_backoff_exception(mocker, caplog, reports_stream):
+    mocker.patch("time.sleep", lambda x: None)
     response = requests.Response()
     response.status_code = 429
     mocker.patch.object(requests.Session, "send", return_value=response)
-    mocker.patch.object(time, "sleep", return_value=None)
 
     with pytest.raises(DefaultBackoffException):
         reports_stream._send_request(request=requests.PreparedRequest())


### PR DESCRIPTION
I changed sleep time as suggested in source-amazon-seller-partner connector.