### PR TITLE
🎁 octavia-cli: improve telemetry

### DIFF
--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -352,17 +352,18 @@ $ octavia apply
 
 ## Telemetry
 This CLI has some telemetry tooling to send Airbyte some data about the usage of this tool.
-We use this data to measure the tool's adoption and detect common errors users encounter to improve it.
+We will use this data to improve the CLI and measure its adoption.
 The telemetry sends data about:
 * Which command was run (not the arguments or options used).
-* Success or failure of the command run and the error type.
-* The workspace id. It is unique to each Airbyte instance.
+* Success or failure of the command run and the error type (not the error payload).
+* The current Airbyte workspace id if the user has not set the *anonymous data collection* on their Airbyte instance.
 
-You can disable telemetry by setting the `OCTAVIA_ENABLE_TELEMETRY` environment to `false` or using the `--disable-telemetry` flag.
+You can disable telemetry by setting the `OCTAVIA_ENABLE_TELEMETRY` environment to `False` or using the `--disable-telemetry` flag.
 
 ## Changelog
 
-| Version | Date       | Description      | PR                                                       |
-|---------|------------|------------------|----------------------------------------------------------|
-| 0.35.68 | 2022-04-12 | Add telemetry    | [#11896](https://github.com/airbytehq/airbyte/issues/11896)|
-| 0.35.61 | 2022-04-07 | Alpha release    | [EPIC](https://github.com/airbytehq/airbyte/issues/10704)|
+| Version | Date       | Description       | PR                                                       |
+|---------|------------|-------------------|----------------------------------------------------------|
+| 0.36.1  | 2022-04-15 | Improve telemetry | [#12072](https://github.com/airbytehq/airbyte/issues/11896)|
+| 0.35.68 | 2022-04-12 | Add telemetry     | [#11896](https://github.com/airbytehq/airbyte/issues/11896)|
+| 0.35.61 | 2022-04-07 | Alpha release     | [EPIC](https://github.com/airbytehq/airbyte/issues/10704)|

--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -358,12 +358,12 @@ The telemetry sends data about:
 * Success or failure of the command run and the error type (not the error payload).
 * The current Airbyte workspace id if the user has not set the *anonymous data collection* on their Airbyte instance.
 
-You can disable telemetry by setting the `OCTAVIA_ENABLE_TELEMETRY` environment to `False` or using the `--disable-telemetry` flag.
+You can disable telemetry by setting the `OCTAVIA_ENABLE_TELEMETRY` environment variable to `False` or using the `--disable-telemetry` flag.
 
 ## Changelog
 
 | Version | Date       | Description       | PR                                                       |
 |---------|------------|-------------------|----------------------------------------------------------|
-| 0.36.1  | 2022-04-15 | Improve telemetry | [#12072](https://github.com/airbytehq/airbyte/issues/11896)|
+| 0.36.2  | 2022-04-15 | Improve telemetry | [#12072](https://github.com/airbytehq/airbyte/issues/11896)|
 | 0.35.68 | 2022-04-12 | Add telemetry     | [#11896](https://github.com/airbytehq/airbyte/issues/11896)|
 | 0.35.61 | 2022-04-07 | Alpha release     | [EPIC](https://github.com/airbytehq/airbyte/issues/10704)|

--- a/octavia-cli/install.sh
+++ b/octavia-cli/install.sh
@@ -40,11 +40,13 @@ delete_previous_alias() {
 
 
 pull_image() {
+    echo "🐙 - Pulling image for octavia ${VERSION}"
     docker pull airbyte/octavia-cli:${VERSION} > /dev/null 2>&1
+    echo "🐙 - 🎉 octavia ${VERSION} image was pulled"
 }
 
 add_octavia_comment_to_profile() {
-    printf "\n# OCTAVIA CLI\n" >> ${DETECTED_PROFILE}
+    printf "\n# OCTAVIA CLI ${VERSION}\n" >> ${DETECTED_PROFILE}
 }
 
 create_octavia_env_file() {
@@ -53,10 +55,15 @@ create_octavia_env_file() {
     echo "🐙 - 💾 The octavia env file was created at ${OCTAVIA_ENV_FILE}"
 }
 
+enable_telemetry() {
+    echo "export OCTAVIA_ENABLE_TELEMETRY=$1"  >> ${DETECTED_PROFILE}
+    echo "OCTAVIA_ENABLE_TELEMETRY=$1"  >> ${OCTAVIA_ENV_FILE}
+}
 
 add_alias() {
     echo 'alias octavia="docker run -i --rm -v \$(pwd):/home/octavia-project --network host --env-file \${OCTAVIA_ENV_FILE} --user \$(id -u):\$(id -g) airbyte/octavia-cli:'${VERSION}'"'  >> ${DETECTED_PROFILE}
-    echo "🐙 - 🎉 octavia alias was added to ${DETECTED_PROFILE}, please open a new terminal window or run source ${DETECTED_PROFILE}"
+    echo "🐙 - 🎉 octavia alias was added to ${DETECTED_PROFILE}!"
+    echo "🐙 - Please open a new terminal window or run source ${DETECTED_PROFILE}"
 }
 
 install() {
@@ -64,10 +71,20 @@ install() {
     add_alias
 }
 
+telemetry_consent() {
+    read -p "❓ - Allow Airbyte to collect telemetry to improve the CLI? (Y/n)" -n 1 -r </dev/tty
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        enable_telemetry "True"
+    else
+        enable_telemetry "False"
+    fi
+}
+
 update_or_install() {
     if grep -q "^alias octavia=*" ${DETECTED_PROFILE}; then
         read -p "❓ - You already have an octavia alias in your profile. Do you want to update? (Y/n)" -n 1 -r </dev/tty
-        echo    # (optional) move to a new line
+        echo
         if [[ $REPLY =~ ^[Yy]$ ]]
         then
             delete_previous_alias
@@ -76,6 +93,7 @@ update_or_install() {
     else
         add_octavia_comment_to_profile
         create_octavia_env_file
+        telemetry_consent
         install
     fi
 }

--- a/octavia-cli/octavia_cli/telemetry.py
+++ b/octavia-cli/octavia_cli/telemetry.py
@@ -10,17 +10,16 @@ import analytics
 import click
 
 
-def build_user_agent(octavia_version: str, workspace_id: str) -> str:
-    """Build user-agent for the API client according to octavia version and workspace id.
+def build_user_agent(octavia_version: str) -> str:
+    """Build user-agent for the API client according to octavia version.
 
     Args:
         octavia_version (str): Current octavia version.
-        workspace_id (str): Current workspace id.
 
     Returns:
         str: the user-agent string.
     """
-    return f"octavia-cli/{octavia_version}/{workspace_id}"
+    return f"octavia-cli/{octavia_version}"
 
 
 class TelemetryClient:
@@ -75,7 +74,7 @@ class TelemetryClient:
             error (Optional[Exception], optional): The error that was raised. Defaults to None.
             extra_info_name (Optional[str], optional): Extra info name if the context was not built yet. Defaults to None.
         """
-        user_id = ctx.obj.get("WORKSPACE_ID")
+        user_id = ctx.obj.get("WORKSPACE_ID") if ctx.obj.get("ANONYMOUS_DATA_COLLECTION", True) is False else None
         anonymous_id = None if user_id else str(uuid.uuid1())
 
         segment_context = {"app": {"name": "octavia-cli", "version": ctx.obj.get("OCTAVIA_VERSION")}}
@@ -83,7 +82,7 @@ class TelemetryClient:
             "success": error is None,
             "error_type": error.__class__.__name__ if error is not None else None,
             "project_is_initialized": ctx.obj.get("PROJECT_IS_INITIALIZED"),
-            "airbyte_role": os.getenv("AIRBYTE_ROLE"),
+            "airbyter": os.getenv("AIRBYTE_ROLE") == "airbyter",
         }
         command_name = self._create_command_name(ctx, extra_info_name)
         self.segment_client.track(


### PR DESCRIPTION
## What
I try to improve the telemetry feature to comply with data privacy best practices.

## How
* Prompt for telemetry consent on apply: if no consent is given no telemetry is sent
* Retrieve Airbyte's `anomymousDataCollection` settings on current workspace. If the user has enabled `anomymousDataCollection` the telemetry does not the current workspace id but generates an *anonymous id* (`uuid`)
* Do not send the content of the `AIRBYTE_ROLE` env var, but send a boolean `airbyter` flag if `AIRBYTE_ROLE == "airbyter"`
* Remove the workspace id from the user-agent

## Recommended reading order
1. [octavia-cli/install.sh](https://github.com/airbytehq/airbyte/pull/12072/files#diff-8546a8b1f79f192a3374c13f65623849524b5ab297aa9d82acd82ea5f2ad9f99)
2. [octavia-cli/octavia_cli/entrypoint.py](https://github.com/airbytehq/airbyte/pull/12072/files#diff-ff6d243a6fcf989e22f752a84725de5a2239d8cef2b52670f4ebad524a7af7dd)
3. [octavia-cli/octavia_cli/telemetry.py](https://github.com/airbytehq/airbyte/pull/12072/files#diff-5565880d836d770c2ea6c96b9ceb1bbda3822ce3ad62ca1e39412c50d898916e)

## 🚨 User Impact 🚨
Users are now prompted for the consent for telemetry on install.