### PR TITLE
Docs post-migration cleanup

### DIFF
--- a/docs/archive/examples/zoom-activity-dashboard.md
+++ b/docs/archive/examples/zoom-activity-dashboard.md
@@ -246,8 +246,6 @@ The rest of the charts will be needing the **webinars** and `report_webinar_part
 
 For this chart, as for the meeting’s counterpart, we will get a calculated field off the Duration field to get the **Webinar Duration in Hours**, and then plot **Created At** against the **Sum of Webinar Duration in Hours**, as shown in the screenshot below. Note: Make sure you create a new sheet for each of these graphs.
 
-![](../../.gitbook/assets/duration-spent-in-weekly-webinars%20(3)%20(3).png)
-
 ### Participants for all webinars per week
 
 This calculation is the same as the number of participants for all meetings per week, but instead of using the **meetings** and `report_meeting_participants` tables, we will use the webinars and `report_webinar_participants` tables.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -14,7 +14,7 @@ Airbyte is on a mission to make data integration pipelines a commodity.
 * **No more security compliance process** to go through as Airbyte is self-hosted. 
 * **No more pricing indexed on volume**, as cloud-based solutions offer. 
 
-Here's a list of our [connectors with their health status](docs/integrations/).
+Here's a list of our [connectors with their health status](integrations/README.md).
 
 ## Quick start
 
@@ -44,7 +44,7 @@ Here is a [step-by-step guide](https://github.com/airbytehq/airbyte/tree/e378d40
 
 We love contributions to Airbyte, big or small.
 
-See our [Contributing guide](docs/contributing-to-airbyte/) on how to get started. Not sure where to start? We’ve listed some [good first issues](https://github.com/airbytehq/airbyte/labels/good%20first%20issue) to start with. If you have any questions, please open a draft PR or visit our [slack channel](https://github.com/airbytehq/airbyte/tree/a9b1c6c0420550ad5069aca66c295223e0d05e27/slack.airbyte.io) where the core team can help answer your questions.
+See our [Contributing guide](contributing-to-airbyte/README.md) on how to get started. Not sure where to start? We’ve listed some [good first issues](https://github.com/airbytehq/airbyte/labels/good%20first%20issue) to start with. If you have any questions, please open a draft PR or visit our [slack channel](https://slack.airbyte.io/) where the core team can help answer your questions.
 
 **Note that you are able to create connectors using the language you want, as Airbyte connections run as Docker containers.**
 
@@ -62,9 +62,9 @@ For general help using Airbyte, please refer to the official Airbyte documentati
 
 ## Roadmap
 
-Check out our [roadmap](docs/project-overview/roadmap.md) to get informed on what we are currently working on, and what we have in mind for the next weeks, months and years.
+Check out our [roadmap](https://app.harvestr.io/roadmap/view/pQU6gdCyc/airbyte-roadmap) to get informed on what we are currently working on, and what we have in mind for the next weeks, months and years.
 
 ## License
 
-See the [LICENSE](docs/project-overview/licenses/) file for licensing information, and our [FAQ](docs/project-overview/licenses/license-faq.md) for any questions you may have on that topic. 
+See the [LICENSE](project-overview/licenses/README.md) file for licensing information, and our [FAQ](project-overview/licenses/license-faq.md) for any questions you may have on that topic. 
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -128,10 +128,6 @@ module.exports = {
           items: [
             {
               type: 'doc',
-              id: "operator-guides/transformation-and-normalization/README",
-            },
-            {
-              type: 'doc',
               id: "operator-guides/transformation-and-normalization/transformations-with-sql",
             },
             {
@@ -177,736 +173,732 @@ module.exports = {
       label: 'Connector Catalog',
       items: [
         {
-          type: 'category',
-          label: 'Sources',
-          items: [
-            {
-              type: 'doc',
-              id: "integrations/README",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/README",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/tplcentral",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/airtable",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/amazon-sqs",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/amazon-seller-partner",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/amazon-ads",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/amplitude",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/apify-dataset",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/appstore",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/asana",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/aws-cloudtrail",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/azure-table",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/bamboo-hr",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/bing-ads",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/bigcommerce",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/bigquery",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/braintree",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/cart",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/chargebee",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/chartmogul",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/clickhouse",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/close-com",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/cockroachdb",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/confluence",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/customer-io",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/delighted",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/db2",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/dixa",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/drift",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/drupal",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/e2e-test",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/exchangeratesapi",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/facebook-marketing",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/facebook-pages",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/file",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/flexport",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/freshdesk",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/freshsales",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/freshservice",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/github",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/gitlab",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/google-ads",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/google-analytics-v4",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/google-directory",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/google-search-console",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/google-sheets",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/google-workspace-admin-reports",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/greenhouse",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/harvest",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/harness",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/http-request",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/hubspot",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/instagram",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/intercom",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/iterable",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/jenkins",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/jira",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/kafka",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/klaviyo",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/kustomer",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/lemlist",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/linkedin-ads",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/linnworks",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/lever-hiring",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/looker",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/magento",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/mailchimp",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/marketo",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/microsoft-dynamics-ax",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/microsoft-dynamics-customer-engagement",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/microsoft-dynamics-gp",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/microsoft-dynamics-nav",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/mssql",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/microsoft-teams",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/mixpanel",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/monday",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/mongodb-v2",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/my-hours",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/mysql",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/notion",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/okta",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/onesignal",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/openweather",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/oracle",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/oracle-peoplesoft",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/oracle-siebel-crm",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/orb",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/outreach",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/pagerduty",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/paypal-transaction",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/paystack",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/persistiq",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/plaid",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/pinterest",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/pipedrive",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/pokeapi",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/postgres",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/posthog",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/presta-shop",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/qualaroo",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/quickbooks",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/recharge",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/recurly",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/redshift",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/s3",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/sap-business-one",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/search-metrics",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/salesforce",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/salesloft",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/sendgrid",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/sentry",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/shopify",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/shortio",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/slack",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/smartsheets",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/snapchat-marketing",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/snowflake",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/spree-commerce",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/square",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/strava",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/stripe",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/sugar-crm",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/surveymonkey",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/tempo",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/tiktok-marketing",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/trello",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/twilio",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/typeform",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/us-census",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/victorops",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/woocommerce",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/wordpress",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/youtube-analytics",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/zencart",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/zendesk-chat",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/zendesk-sunshine",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/zendesk-support",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/zendesk-talk",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/zenloop",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/zoho-crm",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/zoom",
-            },
-            {
-              type: 'doc',
-              id: "integrations/sources/zuora",
-            },
-          ]
-        },
-        {
-          type: 'category',
-          label: 'Destinations',
-          items: [
-            {
-              type: 'doc',
-              id: "integrations/destinations/amazon-sqs",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/azureblobstorage",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/bigquery",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/clickhouse",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/databricks",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/dynamodb",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/elasticsearch",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/e2e-test",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/chargify",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/gcs",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/pubsub",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/kafka",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/keen",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/local-csv",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/local-json",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/mariadb-columnstore",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/meilisearch",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/mongodb",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/mqtt",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/mssql",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/mysql",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/oracle",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/postgres",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/pulsar",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/rabbitmq",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/redshift",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/rockset",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/s3",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/sftp-json",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/snowflake",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/cassandra",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/scylla",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/redis",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/kinesis",
-            },
-            {
-              type: 'doc',
-              id: "integrations/destinations/streamr",
-            },
-          ]
-        },
-        {
-          type: 'doc',
-          id: "integrations/custom-connectors",
-        },
-      ]
+            type: 'doc',
+            id: "integrations/README",
+          },
+          {
+            type: 'category',
+            label: 'Sources',
+            items: [
+              {
+                type: 'doc',
+                id: "integrations/sources/tplcentral",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/airtable",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/amazon-sqs",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/amazon-seller-partner",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/amazon-ads",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/amplitude",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/apify-dataset",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/appstore",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/asana",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/aws-cloudtrail",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/azure-table",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/bamboo-hr",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/bing-ads",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/bigcommerce",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/bigquery",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/braintree",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/cart",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/chargebee",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/chartmogul",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/clickhouse",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/close-com",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/cockroachdb",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/confluence",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/customer-io",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/delighted",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/db2",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/dixa",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/drift",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/drupal",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/e2e-test",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/exchangeratesapi",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/facebook-marketing",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/facebook-pages",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/file",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/flexport",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/freshdesk",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/freshsales",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/freshservice",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/github",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/gitlab",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/google-ads",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/google-analytics-v4",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/google-directory",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/google-search-console",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/google-sheets",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/google-workspace-admin-reports",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/greenhouse",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/harvest",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/harness",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/http-request",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/hubspot",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/instagram",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/intercom",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/iterable",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/jenkins",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/jira",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/kafka",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/klaviyo",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/kustomer",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/lemlist",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/linkedin-ads",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/linnworks",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/lever-hiring",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/looker",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/magento",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/mailchimp",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/marketo",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/microsoft-dynamics-ax",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/microsoft-dynamics-customer-engagement",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/microsoft-dynamics-gp",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/microsoft-dynamics-nav",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/mssql",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/microsoft-teams",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/mixpanel",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/monday",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/mongodb-v2",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/my-hours",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/mysql",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/notion",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/okta",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/onesignal",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/openweather",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/oracle",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/oracle-peoplesoft",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/oracle-siebel-crm",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/orb",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/outreach",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/pagerduty",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/paypal-transaction",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/paystack",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/persistiq",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/plaid",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/pinterest",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/pipedrive",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/pokeapi",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/postgres",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/posthog",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/presta-shop",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/qualaroo",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/quickbooks",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/recharge",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/recurly",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/redshift",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/s3",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/sap-business-one",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/search-metrics",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/salesforce",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/salesloft",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/sendgrid",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/sentry",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/shopify",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/shortio",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/slack",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/smartsheets",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/snapchat-marketing",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/snowflake",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/spree-commerce",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/square",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/strava",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/stripe",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/sugar-crm",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/surveymonkey",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/tempo",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/tiktok-marketing",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/trello",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/twilio",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/typeform",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/us-census",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/victorops",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/woocommerce",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/wordpress",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/youtube-analytics",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/zencart",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/zendesk-chat",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/zendesk-sunshine",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/zendesk-support",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/zendesk-talk",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/zenloop",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/zoho-crm",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/zoom",
+              },
+              {
+                type: 'doc',
+                id: "integrations/sources/zuora",
+              },
+            ]
+          },
+          {
+            type: 'category',
+            label: 'Destinations',
+            items: [
+              {
+                type: 'doc',
+                id: "integrations/destinations/amazon-sqs",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/azureblobstorage",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/bigquery",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/clickhouse",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/databricks",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/dynamodb",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/elasticsearch",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/e2e-test",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/chargify",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/gcs",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/pubsub",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/kafka",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/keen",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/local-csv",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/local-json",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/mariadb-columnstore",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/meilisearch",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/mongodb",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/mqtt",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/mssql",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/mysql",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/oracle",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/postgres",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/pulsar",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/rabbitmq",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/redshift",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/rockset",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/s3",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/sftp-json",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/snowflake",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/cassandra",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/scylla",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/redis",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/kinesis",
+              },
+              {
+                type: 'doc',
+                id: "integrations/destinations/streamr",
+              },
+            ]
+          },
+          {
+            type: 'doc',
+            id: "integrations/custom-connectors",
+          },
+        ]
 
-    },
+      },
     {
       type: 'category',
       label: 'Connector Development',
@@ -923,10 +915,6 @@ module.exports = {
           type: 'category',
           label: 'Python CDK: Creating a HTTP API Source',
           items: [
-            {
-              type: 'doc',
-              id: "connector-development/tutorials/cdk-tutorial-python-http/README",
-            },
             {
               type: 'doc',
               id: "connector-development/tutorials/cdk-tutorial-python-http/getting-started",
@@ -1105,10 +1093,6 @@ module.exports = {
       items: [
         {
           type: 'doc',
-          id: "understanding-airbyte/README",
-        },
-        {
-          type: 'doc',
           id: "understanding-airbyte/beginners-guide-to-catalog",
         },
         {
@@ -1192,16 +1176,18 @@ module.exports = {
       id: "api-documentation",
     },
     {
+      type: 'link',
+      label: 'CLI documentation',
+      href: 'https://github.com/airbytehq/airbyte/blob/master/octavia-cli/README.md',
+    },
+    {
       type: 'category',
       label: 'Project Overview',
       items: [
         {
-          type: 'doc',
-          id: "project-overview/README",
-        },
-        {
-          type: 'doc',
-          id: "project-overview/roadmap",
+          type: 'link',
+          label: 'Roadmap',
+          href: 'https://app.harvestr.io/roadmap/view/pQU6gdCyc/airbyte-roadmap',
         },
         {
           type: 'category',
@@ -1293,4 +1279,4 @@ module.exports = {
       href: 'https://github.com/airbytehq/airbyte',
     },
   ],
-};
+}


### PR DESCRIPTION
Fixing the following post-migration issues:

- Roadmap link should go to harvestr
- None of the docs links work on https://docs.airbyte.com/ (connector health, stepby step…).
- Transformation and Normalization landing page doesn’t show content
- Connector catalog page is now under Sources
- CLI docs link is missing
- Other misc issues


