### PR TITLE
Add container orchestrator for cloud deploy

### DIFF
--- a/docker-compose-cloud.build.yaml
+++ b/docker-compose-cloud.build.yaml
@@ -36,6 +36,6 @@ services:
     image: airbyte/container-orchestrator:${VERSION}
     build:
       dockerfile: Dockerfile
-      context: airbyte/container-orchestrator
+      context: airbyte-container-orchestrator
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}

--- a/docker-compose-cloud.build.yaml
+++ b/docker-compose-cloud.build.yaml
@@ -32,3 +32,10 @@ services:
       context: airbyte-metrics/reporter
       labels:
         io.airbyte.git-revision: ${GIT_REVISION}
+  container-orchestrator:
+    image: airbyte/container-orchestrator:${VERSION}
+    build:
+      dockerfile: Dockerfile
+      context: airbyte/container-orchestrator
+      label:
+        io.airbyte.git-revision: ${GIT_REVISION}

--- a/docker-compose-cloud.build.yaml
+++ b/docker-compose-cloud.build.yaml
@@ -37,5 +37,5 @@ services:
     build:
       dockerfile: Dockerfile
       context: airbyte/container-orchestrator
-      label:
+      labels:
         io.airbyte.git-revision: ${GIT_REVISION}


### PR DESCRIPTION
## What
The container orchestrator should be deployed according to a version and/or git revision for testing cloud against different OSS versions and revisions