### PR TITLE
Fixes typo in docs deployment workflows

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,5 +32,6 @@ jobs:
       # Install and build Docusaurus website
       - name: Deploy docs to production (it's weird)
         run: ./tools/bin/deploy_docusaurus
-        env: GITHUB_TOKEN: ${{ secrets.OCTAVIA_PAT }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.OCTAVIA_PAT }}
 


### PR DESCRIPTION
adds newline for proper yml syntax

## What
* YML is not valid on 35
* make it more valid

# How 
* copy pasta syntax from another workflow