### PR TITLE
Specifies a git user to address build error

### DIFF
--- a/tools/bin/deploy_docusaurus
+++ b/tools/bin/deploy_docusaurus
@@ -38,6 +38,8 @@ fi
 
 set -o xtrace
 
+GIT_USER="octavia-squidington-iii"
+
 cd docusaurus
 pwd
 


### PR DESCRIPTION
error:
[INFO] Deploy command invoked...
Error:  Error: Please set the GIT_USER environment variable,
or explicitly specify USE_SSH instead!

## What
Explicitly set git user as octavia to match token used

## How 
the one Line change with a shell variable