### PR TITLE
Addressing docusaurus deploy

### DIFF
--- a/tools/bin/deploy_docusaurus
+++ b/tools/bin/deploy_docusaurus
@@ -38,7 +38,11 @@ fi
 
 set -o xtrace
 
-GIT_USER="octavia-squidington-iii"
+if ! git config --list --global | grep --silent user.email; then
+  echo -e "$blue_text""github email not found adding Octavia's""$default_text"
+  git config --global user.email=davin@airbyte.io
+  git config --global user.name=octavia-squidington-iii
+fi
 
 cd docusaurus
 pwd


### PR DESCRIPTION
error is unclear and only happens in cloud

## What
we see the error:
```
[INFO] Deploy command invoked...
Error:  Error: Please set the GIT_USER environment variable, or explicitly specify USE_SSH instead!
```

## How
set a git user and email

honestly hopefully this works we don't have a test workflow for actions locally
