### PR TITLE
Update cdk-speedrun.md

### DIFF
--- a/docs/connector-development/tutorials/cdk-speedrun.md
+++ b/docs/connector-development/tutorials/cdk-speedrun.md
@@ -6,7 +6,7 @@ This is a blazing fast guide to building an HTTP source connector. Think of it a
 
 If you are a visual learner and want to see a video version of this guide going over each part in detail, check it out below.
 
-{% embed url="https://www.youtube.com/watch?v=kJ3hLoNfz_E" caption="A speedy CDK overview." %}
+[A speedy CDK overview.](https://www.youtube.com/watch?v=kJ3hLoNfz_E)
 
 ## Dependencies
 


### PR DESCRIPTION
Changes Embed of url to use simple link in markdown for Python CDK docs

## What
Issue in the docs for python CDK page showing {% embed... string

## How
Changed to use a simple markdown linking 

## Recommended reading order
## 🚨 User Impact 🚨
No breaking changes
