### PR TITLE
🎉 CDK: support loading spec from yaml file

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.55
+Add support for reading the spec from a YAML file (`spec.yaml`) 
+
 ## 0.1.54
 - Add ability to import `IncrementalMixin` from `airbyte_cdk.sources.streams`.
 - Bumped minimum supported Python version to 3.9.

--- a/airbyte-cdk/python/airbyte_cdk/connector.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector.py
@@ -65,29 +65,6 @@ class Connector(ABC):
 
         package = self.__class__.__module__.split(".")[0]
 
-        # formats = [
-        #     {"extension": "yaml", "loader": lambda data: yaml.load(data, yaml.SafeLoader)},
-        #     {"extension": "yml", "loader": lambda data: yaml.load(data, yaml.SafeLoader)},
-        #     {"extension": "json", "loader": lambda data: json.loads(data)}
-        # ]
-        #
-        # spec_obj = None
-        # for spec_format in formats:
-        #     try:
-        #         raw_spec = pkgutil.get_data(package, f"spec.{spec_format['extension']}")
-        #         if not raw_spec:
-        #             continue
-        #         if spec_obj:
-        #             raise ValueError("Found multiple spec files in the package. Only one of spec.yaml or spec.json should be provided.")
-        #         spec_obj = spec_format["loader"](raw_spec)
-        #     except FileNotFoundError:
-        #         continue
-        #
-        # if not spec_obj:
-        #     raise ValueError("Unable to find spec.")
-        #
-        # return ConnectorSpecification.parse_obj(spec_obj)
-
         yaml_spec = load_optional_package_file(package, "spec.yaml")
         json_spec = load_optional_package_file(package, "spec.json")
 

--- a/airbyte-cdk/python/airbyte_cdk/connector.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector.py
@@ -60,7 +60,7 @@ class Connector(ABC):
     def spec(self, logger: logging.Logger) -> ConnectorSpecification:
         """
         Returns the spec for this integration. The spec is a JSON-Schema object describing the required configurations (e.g: username and password)
-        required to run this integration.
+        required to run this integration. By default, this will be loaded from a "spec.yaml" or a "spec.json" in the package root.
         """
 
         package = self.__class__.__module__.split(".")[0]

--- a/airbyte-cdk/python/airbyte_cdk/connector.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector.py
@@ -4,17 +4,18 @@
 
 
 import json
-import yaml
 import logging
 import os
 import pkgutil
 from abc import ABC, abstractmethod
 from typing import Any, Mapping, Optional
 
+import yaml
 from airbyte_cdk.models import AirbyteConnectionStatus, ConnectorSpecification
 
 
 def load_optional_package_file(package: str, filename: str) -> Optional[bytes]:
+    """Gets a resource from a package, returning None if it does not exist"""
     try:
         return pkgutil.get_data(package, filename)
     except FileNotFoundError:
@@ -63,6 +64,30 @@ class Connector(ABC):
         """
 
         package = self.__class__.__module__.split(".")[0]
+
+        # formats = [
+        #     {"extension": "yaml", "loader": lambda data: yaml.load(data, yaml.SafeLoader)},
+        #     {"extension": "yml", "loader": lambda data: yaml.load(data, yaml.SafeLoader)},
+        #     {"extension": "json", "loader": lambda data: json.loads(data)}
+        # ]
+        #
+        # spec_obj = None
+        # for spec_format in formats:
+        #     try:
+        #         raw_spec = pkgutil.get_data(package, f"spec.{spec_format['extension']}")
+        #         if not raw_spec:
+        #             continue
+        #         if spec_obj:
+        #             raise ValueError("Found multiple spec files in the package. Only one of spec.yaml or spec.json should be provided.")
+        #         spec_obj = spec_format["loader"](raw_spec)
+        #     except FileNotFoundError:
+        #         continue
+        #
+        # if not spec_obj:
+        #     raise ValueError("Unable to find spec.")
+        #
+        # return ConnectorSpecification.parse_obj(spec_obj)
+
         yaml_spec = load_optional_package_file(package, "spec.yaml")
         json_spec = load_optional_package_file(package, "spec.json")
 

--- a/airbyte-cdk/python/airbyte_cdk/connector.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector.py
@@ -69,14 +69,14 @@ class Connector(ABC):
         json_spec = load_optional_package_file(package, "spec.json")
 
         if yaml_spec and json_spec:
-            raise ValueError("Found multiple spec files in the package. Only one of spec.yaml or spec.json should be provided.")
+            raise RuntimeError("Found multiple spec files in the package. Only one of spec.yaml or spec.json should be provided.")
 
         if yaml_spec:
             spec_obj = yaml.load(yaml_spec, Loader=yaml.SafeLoader)
         elif json_spec:
             spec_obj = json.loads(json_spec)
         else:
-            raise ValueError("Unable to find spec.yaml or spec.json in the package.")
+            raise FileNotFoundError("Unable to find spec.yaml or spec.json in the package.")
 
         return ConnectorSpecification.parse_obj(spec_obj)
 

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.54",
+    version="0.1.55",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/unit_tests/test_connector.py
+++ b/airbyte-cdk/python/unit_tests/test_connector.py
@@ -124,9 +124,9 @@ class TestConnectorSpec:
         assert connector_spec.connectionSpecification == self.CONNECTION_SPECIFICATION
 
     def test_multiple_spec_files_raises_exception(self, integration, use_yaml_spec, use_json_spec):
-        with pytest.raises(ValueError, match="spec.yaml or spec.json"):
+        with pytest.raises(RuntimeError, match="spec.yaml or spec.json"):
             integration.spec(logger)
 
     def test_no_spec_file_raises_exception(self, integration):
-        with pytest.raises(ValueError, match="Unable to find spec."):
+        with pytest.raises(FileNotFoundError, match="Unable to find spec."):
             integration.spec(logger)

--- a/airbyte-cdk/python/unit_tests/test_connector.py
+++ b/airbyte-cdk/python/unit_tests/test_connector.py
@@ -3,6 +3,8 @@
 #
 
 
+import sys
+import os
 import json
 import logging
 import tempfile
@@ -10,8 +12,17 @@ from pathlib import Path
 from typing import Any, Mapping
 
 import pytest
+import yaml
+
 from airbyte_cdk import AirbyteSpec, Connector
 from airbyte_cdk.models import AirbyteConnectionStatus
+
+
+logger = logging.getLogger('airbyte')
+
+MODULE = sys.modules[__name__]
+MODULE_PATH = os.path.abspath(MODULE.__file__)
+SPEC_ROOT = os.path.dirname(MODULE_PATH)
 
 
 class TestAirbyteSpec:
@@ -71,3 +82,56 @@ def test_write_config(integration, mock_config):
     integration.write_config(mock_config, str(config_path))
     with open(config_path, "r") as actual:
         assert mock_config == json.loads(actual.read())
+
+
+class TestConnectorSpec:
+    CONNECTION_SPECIFICATION = {
+        "type": "object",
+        "required": ["api_token"],
+        "additionalProperties": False,
+        "properties": {"api_token": {"type": "string"}},
+    }
+
+    @pytest.fixture
+    def use_json_spec(self):
+        spec = {
+            "documentationUrl": "https://airbyte.com/#json",
+            "connectionSpecification": self.CONNECTION_SPECIFICATION,
+        }
+
+        json_path = os.path.join(SPEC_ROOT, "spec.json")
+        with open(json_path, "w") as f:
+            f.write(json.dumps(spec))
+        yield
+        os.remove(json_path)
+
+    @pytest.fixture
+    def use_yaml_spec(self):
+        spec = {
+            "documentationUrl": "https://airbyte.com/#yaml",
+            "connectionSpecification": self.CONNECTION_SPECIFICATION
+        }
+
+        yaml_path = os.path.join(SPEC_ROOT, "spec.yaml")
+        with open(yaml_path, "w") as f:
+            f.write(yaml.dump(spec))
+        yield
+        os.remove(yaml_path)
+
+    def test_spec_from_json_file(self, integration, use_json_spec):
+        connector_spec = integration.spec(logger)
+        assert connector_spec.documentationUrl == "https://airbyte.com/#json"
+        assert connector_spec.connectionSpecification == self.CONNECTION_SPECIFICATION
+
+    def test_spec_from_yaml_file(self, integration, use_yaml_spec):
+        connector_spec = integration.spec(logger)
+        assert connector_spec.documentationUrl == "https://airbyte.com/#yaml"
+        assert connector_spec.connectionSpecification == self.CONNECTION_SPECIFICATION
+
+    def test_multiple_spec_files_raises_exception(self, integration, use_yaml_spec, use_json_spec):
+        with pytest.raises(ValueError, match="spec.yaml or spec.json"):
+            integration.spec(logger)
+
+    def test_no_spec_file_raises_exception(self, integration):
+        with pytest.raises(ValueError, match="Unable to find spec."):
+            integration.spec(logger)

--- a/airbyte-cdk/python/unit_tests/test_connector.py
+++ b/airbyte-cdk/python/unit_tests/test_connector.py
@@ -3,22 +3,20 @@
 #
 
 
-import sys
-import os
 import json
 import logging
+import os
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any, Mapping
 
 import pytest
 import yaml
-
 from airbyte_cdk import AirbyteSpec, Connector
 from airbyte_cdk.models import AirbyteConnectionStatus
 
-
-logger = logging.getLogger('airbyte')
+logger = logging.getLogger("airbyte")
 
 MODULE = sys.modules[__name__]
 MODULE_PATH = os.path.abspath(MODULE.__file__)
@@ -107,10 +105,7 @@ class TestConnectorSpec:
 
     @pytest.fixture
     def use_yaml_spec(self):
-        spec = {
-            "documentationUrl": "https://airbyte.com/#yaml",
-            "connectionSpecification": self.CONNECTION_SPECIFICATION
-        }
+        spec = {"documentationUrl": "https://airbyte.com/#yaml", "connectionSpecification": self.CONNECTION_SPECIFICATION}
 
         yaml_path = os.path.join(SPEC_ROOT, "spec.yaml")
         with open(yaml_path, "w") as f:


### PR DESCRIPTION
## What
Solves #11888 by adding support for loading the connector spec from a `spec.yaml` file in addition to the existing `spec.json`.

## How
- Look for `spec.yaml` and use that if present. Existing support for json files remains unchanged.
- If both a `spec.yaml` and `spec.json` exist, an exception will be raised.
- Added tests around the connector `spec` method.

## Tests

<details><summary><strong>Unit</strong></summary>

 391 passed, 537 warnings in 4.14s

</details>
