### PR TITLE
Fixed typo in postgres destination documentation

### DIFF
--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -40,7 +40,7 @@ You need a Postgres user with the following permissions:
 * can create tables and write rows.
 * can create schemas e.g:
 
-You can create such a user by runnig:
+You can create such a user by running:
 
 ```
 CREATE USER airbyte_user PASSWORD <password>;


### PR DESCRIPTION
## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*
There was a spelling error in the documentation for the Postgres destination. This PR fixes the error.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

None of the checklists are relevant to this typo fix. I have removed them. 

## Tests

There are no changes to the tests in this PR. Its just a documentation fix.