### PR TITLE
Add env variable to disable version check on custom connectors during bootloader execution

### DIFF
--- a/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
@@ -403,6 +403,11 @@ public interface Configs {
   String getDDDogStatsDPort();
 
   /**
+   * Run version check on custom connectors during bootloader execution.
+   */
+  boolean getRunVersionCheckOnCustomConnectors();
+
+  /**
    * Define whether to publish tracking events to Segment or log-only. Airbyte internal use.
    */
   TrackingStrategy getTrackingStrategy();

--- a/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -100,6 +100,7 @@ public class EnvConfigs implements Configs {
   private static final String CONTAINER_ORCHESTRATOR_IMAGE = "CONTAINER_ORCHESTRATOR_IMAGE";
   private static final String DD_AGENT_HOST = "DD_AGENT_HOST";
   private static final String DD_DOGSTATSD_PORT = "DD_DOGSTATSD_PORT";
+  private static final String RUN_VERSION_CHECK_ON_CUSTOM_CONNECTORS = "RUN_VERSION_CHECK_ON_CUSTOM_CONNECTORS";
 
   public static final String STATE_STORAGE_S3_BUCKET_NAME = "STATE_STORAGE_S3_BUCKET_NAME";
   public static final String STATE_STORAGE_S3_REGION = "STATE_STORAGE_S3_REGION";
@@ -731,6 +732,11 @@ public class EnvConfigs implements Configs {
   @Override
   public String getDDDogStatsDPort() {
     return getEnvOrDefault(DD_DOGSTATSD_PORT, "");
+  }
+
+  @Override
+  public boolean getRunVersionCheckOnCustomConnectors() {
+    return getEnvOrDefault(RUN_VERSION_CHECK_ON_CUSTOM_CONNECTORS, true);
   }
 
   @Override

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -32,6 +32,7 @@ import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.ConfigWithMetadata;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.DestinationOAuthParameter;
+import io.airbyte.config.EnvConfigs;
 import io.airbyte.config.OperatorDbt;
 import io.airbyte.config.OperatorNormalization;
 import io.airbyte.config.SourceConnection;
@@ -49,6 +50,7 @@ import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
 import io.airbyte.db.Database;
 import io.airbyte.db.ExceptionWrappingDatabase;
 import io.airbyte.db.instance.configs.jooq.enums.ActorType;
+import io.airbyte.db.instance.configs.jooq.enums.ReleaseStage;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
@@ -1592,6 +1594,9 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
         .from(ACTOR_DEFINITION)
         .fetch()
         .stream()
+        .filter(
+            row -> new EnvConfigs().getRunVersionCheckOnCustomConnectors() || row.get(ACTOR_DEFINITION.RELEASE_STAGE) != ReleaseStage.custom
+        )
         .collect(Collectors.toMap(
             row -> row.getValue(ACTOR_DEFINITION.DOCKER_REPOSITORY),
             row -> {

--- a/docs/operator-guides/configuring-airbyte.md
+++ b/docs/operator-guides/configuring-airbyte.md
@@ -88,6 +88,9 @@ The following variables are relevant to both Docker and Kubernetes.
 3. `MAXIMUM_WORKSPACE_RETENTION_DAYS` - Defines the oldest un-swept configuration file age. Files older than this will definitely be swept. Defaults to 60 days.
 4. `MAXIMUM_WORKSPACE_SIZE_MB` - Defines the workspace size sweeping will continue until. Defaults to 5GB.
 
+#### Bootloader
+1. `RUN_VERSION_CHECK_ON_CUSTOM_CONNECTORS` - Set to `false` to disable version check on custom connectors during bootloader execution.
+
 ### Docker-Only
 1. `WORKSPACE_DOCKER_MOUNT` - Defines the name of the Airbyte docker volume.
 2. `DOCKER_NETWORK` - Defines the docker network the new Scheduler launches jobs on.


### PR DESCRIPTION
## What
This PRs allows to disable version check on custom connectors during bootloader execution. 

## How
A new env variable is added, `RUN_VERSION_CHECK_ON_CUSTOM_CONNECTORS`, which defaults to `true`, but can be overriden (in the docker-compose.yaml file or in the k8s deployment file)
In the DatabaseConfigPersistence, we can then filter out custom connectors if this env variable is `false`

## Recommended reading order
1. `x.java`
2. `y.md`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.
No breaking changes.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>
I added a custom connector to my local Airbyte instance with a tag not following semantic versioning
[logs.txt](https://github.com/airbytehq/airbyte/files/8513206/logs.txt)
<img width="1162" alt="Capture d’écran 2022-04-19 à 15 04 06" src="https://user-images.githubusercontent.com/49887823/164010588-fc6698af-5e58-4d0f-b327-97a1850171ae.png">
Then added `RUN_VERSION_CHECK_ON_CUSTOM_CONNECTORS=false` to my local `docker-compose.yaml` file, in the bootloader section, then ran `docker-compose up`
In the bootloader logs, we can see that the bootloader ignored the custom connector, and eventually succeed 

</details>
