### PR TITLE
Remove background/shadow from connector icon

### DIFF
--- a/airbyte-webapp/src/components/ConnectionBlock/components/ConnectionBlockItem.tsx
+++ b/airbyte-webapp/src/components/ConnectionBlock/components/ConnectionBlockItem.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import ImageBlock from "components/ImageBlock";
+import { ConnectorIcon } from "components/ConnectorIcon";
 
 type IProps = {
   name: string;
@@ -31,7 +31,7 @@ const Name = styled.div`
 const ConnectionBlockItem: React.FC<IProps> = (props) => {
   return (
     <Content>
-      <ImageBlock img={props.icon} />
+      <ConnectorIcon icon={props.icon} />
       <Name>{props.name}</Name>
     </Content>
   );

--- a/airbyte-webapp/src/components/ConnectorIcon/ConnectorIcon.tsx
+++ b/airbyte-webapp/src/components/ConnectorIcon/ConnectorIcon.tsx
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+import React from "react";
+
+import { getIcon } from "utils/imageUtils";
+
+type Props = {
+  icon?: string;
+  className?: string;
+  small?: boolean;
+};
+
+export const Content = styled.div<{ $small?: boolean }>`
+  height: 25px;
+  width: 25px;
+  border-radius: ${({ $small }) => ($small ? 0 : 50)}%;
+  overflow: hidden;
+`;
+
+export const ConnectorIcon: React.FC<Props> = ({ icon, className, small }) => (
+  <Content className={className} $small={small} aria-hidden="true">
+    {getIcon(icon)}
+  </Content>
+);

--- a/airbyte-webapp/src/components/ConnectorIcon/ConnectorIcon.tsx
+++ b/airbyte-webapp/src/components/ConnectorIcon/ConnectorIcon.tsx
@@ -3,11 +3,11 @@ import React from "react";
 
 import { getIcon } from "utils/imageUtils";
 
-type Props = {
+interface Props {
   icon?: string;
   className?: string;
   small?: boolean;
-};
+}
 
 export const Content = styled.div<{ $small?: boolean }>`
   height: 25px;

--- a/airbyte-webapp/src/components/ConnectorIcon/index.ts
+++ b/airbyte-webapp/src/components/ConnectorIcon/index.ts
@@ -1,0 +1,1 @@
+export { ConnectorIcon } from "./ConnectorIcon";

--- a/airbyte-webapp/src/components/EntityTable/components/ConnectorCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/ConnectorCell.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import ImageBlock from "components/ImageBlock";
+import { ConnectorIcon } from "components/ConnectorIcon";
 
 type IProps = {
   value: string;
@@ -16,14 +16,14 @@ const Content = styled.div<{ enabled?: boolean }>`
   font-weight: 500;
 `;
 
-const Image = styled(ImageBlock)`
+const Image = styled(ConnectorIcon)`
   margin-right: 6px;
 `;
 
 const ConnectorCell: React.FC<IProps> = ({ value, enabled, img }) => {
   return (
     <Content enabled={enabled}>
-      <Image small img={img} />
+      <Image small icon={img} />
       {value}
     </Content>
   );

--- a/airbyte-webapp/src/components/EntityTable/components/NameCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/NameCell.tsx
@@ -3,8 +3,8 @@ import styled from "styled-components";
 import { useIntl } from "react-intl";
 
 import StatusIcon from "components/StatusIcon";
-import ImageBlock from "components/ImageBlock";
 import { StatusIconStatus } from "components/StatusIcon/StatusIcon";
+import { ConnectorIcon } from "components/ConnectorIcon";
 
 import { Status } from "../types";
 
@@ -36,7 +36,7 @@ const Space = styled.div`
   opacity: 0;
 `;
 
-const Image = styled(ImageBlock)`
+const Image = styled(ConnectorIcon)`
   margin-right: 6px;
 `;
 
@@ -73,7 +73,7 @@ const NameCell: React.FC<IProps> = ({ value, enabled, status, icon, img }) => {
   return (
     <Content>
       {status ? <StatusIcon title={title} status={statusIconStatus} /> : <Space />}
-      {icon && <Image small img={img} />}
+      {icon && <Image small icon={img} />}
       <Name enabled={enabled}>{value}</Name>
     </Content>
   );

--- a/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/ConnectionCell.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/ConnectionCell.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
 
-import ImageBlock from "components/ImageBlock";
+import { ConnectorIcon } from "components/ConnectorIcon";
 
 type ConnectionCellProps = {
   sourceDefinitionName: string;
@@ -12,7 +12,7 @@ type ConnectionCellProps = {
   destinationIcon?: string;
 };
 
-const Icon = styled(ImageBlock)`
+const Icon = styled(ConnectorIcon)`
   margin-right: 12px;
   display: inline-block;
   vertical-align: middle;
@@ -40,12 +40,12 @@ const ConnectionCell: React.FC<ConnectionCellProps> = ({
   return (
     <>
       <Connector>
-        <Icon small img={sourceIcon} />
+        <Icon small icon={sourceIcon} />
         {sourceDefinitionName}
       </Connector>
       <Connector>
         <Arrow icon={faArrowRight} />
-        <Icon small img={destinationIcon} />
+        <Icon small icon={destinationIcon} />
         {destinationDefinitionName}
       </Connector>
     </>

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StatusMainInfo.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StatusMainInfo.tsx
@@ -2,9 +2,10 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 import styled from "styled-components";
 
-import { ContentCard, ImageBlock } from "components";
+import { ContentCard } from "components";
 import { Header, Row, Cell } from "components/SimpleTableComponents";
 import { ReleaseStageBadge } from "components/ReleaseStageBadge";
+import { ConnectorIcon } from "components/ConnectorIcon";
 
 import { DestinationDefinition, SourceDefinition } from "core/domain/connector";
 import { Connection } from "core/domain/connection";
@@ -16,7 +17,7 @@ const MainInfo = styled(ContentCard)`
   padding: 23px 20px 20px 23px;
 `;
 
-const Img = styled(ImageBlock)`
+const Img = styled(ConnectorIcon)`
   display: inline-block;
 `;
 
@@ -63,12 +64,12 @@ const StatusMainInfo: React.FC<IProps> = ({
       </Header>
       <Row>
         <SourceCell flex={2}>
-          <Img img={sourceDefinition?.icon} />
+          <Img icon={sourceDefinition?.icon} />
           {connection.source?.sourceName}
           <ReleaseStageBadge stage={sourceDefinition?.releaseStage} />
         </SourceCell>
         <SourceCell flex={2}>
-          <Img img={destinationDefinition?.icon} />
+          <Img icon={destinationDefinition?.icon} />
           {connection.destination?.destinationName}
           <ReleaseStageBadge stage={destinationDefinition?.releaseStage} />
         </SourceCell>

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/CreationFormPage/components/ExistingEntityForm.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/CreationFormPage/components/ExistingEntityForm.tsx
@@ -6,7 +6,7 @@ import * as yup from "yup";
 
 import ContentCard from "components/ContentCard";
 import { Button, ControlLabels, DropDown } from "components";
-import ImageBlock from "components/ImageBlock";
+import { ConnectorIcon } from "components/ConnectorIcon";
 
 import { useSourceDefinitionList } from "services/connector/SourceDefinitionService";
 import { useDestinationDefinitionList } from "services/connector/DestinationDefinitionService";
@@ -56,7 +56,7 @@ const ExistingEntityForm: React.FC<IProps> = ({ type, onSubmit }) => {
         return {
           label: item.name,
           value: item.sourceId,
-          img: <ImageBlock img={sourceDef?.icon} />,
+          img: <ConnectorIcon icon={sourceDef?.icon} />,
         };
       });
     } else {
@@ -67,7 +67,7 @@ const ExistingEntityForm: React.FC<IProps> = ({ type, onSubmit }) => {
         return {
           label: item.name,
           value: item.destinationId,
-          img: <ImageBlock img={destinationDef?.icon} />,
+          img: <ConnectorIcon icon={destinationDef?.icon} />,
         };
       });
     }

--- a/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/DestinationItemPage.tsx
+++ b/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/DestinationItemPage.tsx
@@ -5,7 +5,8 @@ import Placeholder, { ResourceTypes } from "components/Placeholder";
 import Breadcrumbs from "components/Breadcrumbs";
 import { ItemTabs, StepsTypes, TableItemTitle } from "components/ConnectorBlocks";
 import HeadTitle from "components/HeadTitle";
-import { DropDownRow, ImageBlock, LoadingPage, MainPageWithScroll, PageTitle } from "components";
+import { DropDownRow, LoadingPage, MainPageWithScroll, PageTitle } from "components";
+import { ConnectorIcon } from "components/ConnectorIcon";
 
 import { getIcon } from "utils/imageUtils";
 import useRouter from "hooks/useRouter";
@@ -55,7 +56,7 @@ const DestinationItemPage: React.FC = () => {
         return {
           label: item.name,
           value: item.sourceId,
-          img: <ImageBlock img={sourceDef?.icon} />,
+          img: <ConnectorIcon icon={sourceDef?.icon} />,
         };
       }),
     [sources, sourceDefinitions]

--- a/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/SourceItemPage.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/SourceItemPage.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
 
-import { DropDownRow, ImageBlock } from "components";
+import { DropDownRow } from "components";
 import PageTitle from "components/PageTitle";
 import Breadcrumbs from "components/Breadcrumbs";
 import { ItemTabs, StepsTypes, TableItemTitle } from "components/ConnectorBlocks";
@@ -9,6 +9,7 @@ import LoadingPage from "components/LoadingPage";
 import MainPageWithScroll from "components/MainPageWithScroll";
 import HeadTitle from "components/HeadTitle";
 import Placeholder, { ResourceTypes } from "components/Placeholder";
+import { ConnectorIcon } from "components/ConnectorIcon";
 
 import { getIcon } from "utils/imageUtils";
 import useRouter from "hooks/useRouter";
@@ -55,7 +56,7 @@ const SourceItemPage: React.FC = () => {
         return {
           label: item.name,
           value: item.destinationId,
-          img: <ImageBlock img={destinationDef?.icon} />,
+          img: <ConnectorIcon icon={destinationDef?.icon} />,
         };
       }),
     [destinations, destinationDefinitions]

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -5,13 +5,14 @@ import { components } from "react-select";
 import { MenuListComponentProps } from "react-select/src/components/Menu";
 import styled from "styled-components";
 
-import { ControlLabels, DropDown, DropDownRow, ImageBlock } from "components";
+import { ControlLabels, DropDown, DropDownRow } from "components";
 import { IDataItem, IProps as OptionProps, OptionView } from "components/base/DropDown/components/Option";
 import {
   IProps as SingleValueProps,
   Icon as SingleValueIcon,
   ItemView as SingleValueView,
 } from "components/base/DropDown/components/SingleValue";
+import { ConnectorIcon } from "components/ConnectorIcon";
 
 import { useCurrentWorkspace } from "hooks/services/useWorkspace";
 import { FormBaseItem } from "core/form/types";
@@ -193,7 +194,7 @@ const ConnectorServiceTypeControl: React.FC<{
         .map((item) => ({
           label: item.name,
           value: Connector.id(item),
-          img: <ImageBlock img={item.icon} />,
+          img: <ConnectorIcon icon={item.icon} />,
           releaseStage: item.releaseStage,
         }))
         .sort((a, b) => {


### PR DESCRIPTION
## What

Removes the shadow and background color from the connector icon as discussed with Nico. This will also pull out the `ConnectorIcon` into its own (clearly named) component, separating it away from the `ImageBlock` component that also could render numbers inside those circle.

Using the `ConnectorIcon` component now in all places a connector icon is shown, e.g.


![screenshot-20220419-175546](https://user-images.githubusercontent.com/877229/164046153-1e7c06d2-5a22-4a96-9297-3de94aefacc7.png)

![screenshot-20220419-175635](https://user-images.githubusercontent.com/877229/164046148-d377890f-fd18-415b-a44f-5abfbb5535d3.png)
