### PR TITLE
Add job pending/running state and update default state for connection status icon

### DIFF
--- a/airbyte-webapp/src/components/EntityTable/components/NameCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/NameCell.tsx
@@ -8,13 +8,13 @@ import { ConnectorIcon } from "components/ConnectorIcon";
 
 import { Status } from "../types";
 
-type IProps = {
+interface Props {
   value: string;
   enabled?: boolean;
   status?: string | null;
   icon?: boolean;
   img?: string;
-};
+}
 
 const Content = styled.div`
   display: flex;
@@ -40,7 +40,7 @@ const Image = styled(ConnectorIcon)`
   margin-right: 6px;
 `;
 
-const NameCell: React.FC<IProps> = ({ value, enabled, status, icon, img }) => {
+const NameCell: React.FC<Props> = ({ value, enabled, status, icon, img }) => {
   const formatMessage = useIntl().formatMessage;
   const statusIconStatus = useMemo<StatusIconStatus | undefined>(
     () =>
@@ -50,6 +50,8 @@ const NameCell: React.FC<IProps> = ({ value, enabled, status, icon, img }) => {
         ? "success"
         : status === Status.INACTIVE
         ? "inactive"
+        : status === Status.PENDING
+        ? "running"
         : undefined,
     [status]
   );
@@ -65,6 +67,10 @@ const NameCell: React.FC<IProps> = ({ value, enabled, status, icon, img }) => {
       : status === Status.ACTIVE
       ? formatMessage({
           id: "connection.successSync",
+        })
+      : status === Status.PENDING
+      ? formatMessage({
+          id: "connection.pendingSync",
         })
       : formatMessage({
           id: "connection.failedSync",

--- a/airbyte-webapp/src/components/EntityTable/components/NameCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/NameCell.tsx
@@ -51,7 +51,7 @@ const NameCell: React.FC<Props> = ({ value, enabled, status, icon, img }) => {
         : status === Status.INACTIVE
         ? "inactive"
         : status === Status.PENDING
-        ? "running"
+        ? "loading"
         : undefined,
     [status]
   );

--- a/airbyte-webapp/src/components/EntityTable/hooks.tsx
+++ b/airbyte-webapp/src/components/EntityTable/hooks.tsx
@@ -1,9 +1,7 @@
 import FrequencyConfig from "config/FrequencyConfig.json";
-import { Connection } from "core/domain/connection";
+import { Connection, ConnectionStatus } from "core/domain/connection";
 import { useSyncConnection, useUpdateConnection } from "hooks/services/useConnectionHook";
 import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
-
-import { Status } from "./types";
 
 const useSyncActions = (): {
   changeStatus: (connection: Connection) => Promise<void>;
@@ -22,7 +20,7 @@ const useSyncActions = (): {
       namespaceDefinition: connection.namespaceDefinition,
       namespaceFormat: connection.namespaceFormat,
       operations: connection.operations,
-      status: connection.status === Status.ACTIVE ? Status.INACTIVE : Status.ACTIVE,
+      status: connection.status === ConnectionStatus.ACTIVE ? ConnectionStatus.INACTIVE : ConnectionStatus.ACTIVE,
     });
 
     const frequency = FrequencyConfig.find(

--- a/airbyte-webapp/src/components/EntityTable/types.ts
+++ b/airbyte-webapp/src/components/EntityTable/types.ts
@@ -34,6 +34,7 @@ enum Status {
   INACTIVE = "inactive",
   FAILED = "failed",
   EMPTY = "empty",
+  PENDING = "pending",
 }
 
 enum SortOrderEnum {

--- a/airbyte-webapp/src/components/EntityTable/utils.tsx
+++ b/airbyte-webapp/src/components/EntityTable/utils.tsx
@@ -1,8 +1,8 @@
-import { Connection } from "core/domain/connection";
+import { Connection, ConnectionStatus } from "core/domain/connection";
 import Status from "core/statuses";
 import { Destination, DestinationDefinition, Source, SourceDefinition } from "core/domain/connector";
 
-import { ITableDataItem, EntityTableDataItem, Status as ConnectionStatus } from "./types";
+import { ITableDataItem, EntityTableDataItem, Status as ConnectionSyncStatus } from "./types";
 
 // TODO: types in next methods look a bit ugly
 export function getEntityTableData<
@@ -106,10 +106,10 @@ export const getConnectionTableData = (
   });
 };
 
-export const getConnectionSyncStatus = (status: string, lastSyncStatus: string | null): string | null => {
-  if (status === ConnectionStatus.INACTIVE) return ConnectionStatus.INACTIVE;
-  if (!lastSyncStatus) return ConnectionStatus.EMPTY;
-  if (lastSyncStatus === Status.FAILED) return ConnectionStatus.FAILED;
+export const getConnectionSyncStatus = (status: ConnectionStatus, lastSyncJobStatus: string | null): string => {
+  if (status === ConnectionStatus.INACTIVE) return ConnectionSyncStatus.INACTIVE;
+  if (!lastSyncJobStatus) return ConnectionSyncStatus.EMPTY;
+  if (lastSyncJobStatus === Status.FAILED) return ConnectionSyncStatus.FAILED;
 
-  return ConnectionStatus.ACTIVE;
+  return ConnectionSyncStatus.ACTIVE;
 };

--- a/airbyte-webapp/src/components/EntityTable/utils.tsx
+++ b/airbyte-webapp/src/components/EntityTable/utils.tsx
@@ -106,10 +106,25 @@ export const getConnectionTableData = (
   });
 };
 
-export const getConnectionSyncStatus = (status: ConnectionStatus, lastSyncJobStatus: string | null): string => {
+export const getConnectionSyncStatus = (
+  status: ConnectionStatus,
+  lastSyncJobStatus: Status | null
+): ConnectionSyncStatus => {
   if (status === ConnectionStatus.INACTIVE) return ConnectionSyncStatus.INACTIVE;
-  if (!lastSyncJobStatus) return ConnectionSyncStatus.EMPTY;
-  if (lastSyncJobStatus === Status.FAILED) return ConnectionSyncStatus.FAILED;
 
-  return ConnectionSyncStatus.ACTIVE;
+  switch (lastSyncJobStatus) {
+    case Status.SUCCEEDED:
+      return ConnectionSyncStatus.ACTIVE;
+
+    case Status.FAILED:
+    case Status.CANCELLED:
+      return ConnectionSyncStatus.FAILED;
+
+    case Status.PENDING:
+    case Status.RUNNING:
+      return ConnectionSyncStatus.PENDING;
+
+    default:
+      return ConnectionSyncStatus.EMPTY;
+  }
 };

--- a/airbyte-webapp/src/components/StatusIcon/CircleLoader.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/CircleLoader.tsx
@@ -24,6 +24,8 @@ const CircleLoader = ({ title }: Props): JSX.Element => (
     height="18"
     shape-rendering="geometricPrecision"
     text-rendering="geometricPrecision"
+    role="img"
+    data-icon="circle-loader"
   >
     <defs>
       <linearGradient

--- a/airbyte-webapp/src/components/StatusIcon/CircleLoader.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/CircleLoader.tsx
@@ -1,0 +1,63 @@
+import styled, { keyframes } from "styled-components";
+
+const spinAnimation = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+const SpinnerSVG = styled.svg`
+  animation: ${spinAnimation} 1000ms linear infinite normal forwards;
+`;
+
+interface Props {
+  title?: string;
+}
+
+const CircleLoader = ({ title }: Props): JSX.Element => (
+  <SpinnerSVG
+    viewBox="0 0 16 16"
+    width="18"
+    height="18"
+    shape-rendering="geometricPrecision"
+    text-rendering="geometricPrecision"
+  >
+    <defs>
+      <linearGradient
+        id="eDwmAshgIQE3-fill"
+        x1="4.25"
+        y1="0.5"
+        x2="4.25"
+        y2="15.5"
+        spreadMethod="pad"
+        gradientUnits="userSpaceOnUse"
+        gradientTransform="translate(0 0)"
+      >
+        <stop id="eDwmAshgIQE3-fill-0" offset="17.9167%" stop-color="#d1d1db" />
+        <stop id="eDwmAshgIQE3-fill-1" offset="100%" stop-color="rgba(209,209,219,0)" />
+      </linearGradient>
+    </defs>
+    {title && <title>{title}</title>}
+    <g>
+      <g>
+        <path
+          d="M8,0.5C3.85775,0.5,0.5,3.85775,0.5,8s3.35775,7.5,7.5,7.5v-2c-3.03768,0-5.5-2.4623-5.5-5.5s2.46232-5.5,5.5-5.5v-2Z"
+          clip-rule="evenodd"
+          fill="url(#eDwmAshgIQE3-fill)"
+          fill-rule="evenodd"
+        />
+        <path
+          d="M8,15.5c4.1423,0,7.5-3.3577,7.5-7.5s-3.3577-7.5-7.5-7.5v2c3.0377,0,5.5,2.46232,5.5,5.5s-2.4623,5.5-5.5,5.5v2Z"
+          clip-rule="evenodd"
+          fill="#d1d1db"
+          fill-rule="evenodd"
+        />
+      </g>
+    </g>
+  </SpinnerSVG>
+);
+
+export default CircleLoader;

--- a/airbyte-webapp/src/components/StatusIcon/StatusIcon.test.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/StatusIcon.test.tsx
@@ -19,6 +19,7 @@ describe("<StatusIcon />", () => {
     { status: "inactive", icon: "pause" },
     { status: "empty", icon: "ban" },
     { status: "warning", icon: "triangle-exclamation" },
+    { status: "loading", icon: "circle-loader" },
   ];
 
   test.each(statusCases)("renders $status status", ({ status, icon }) => {

--- a/airbyte-webapp/src/components/StatusIcon/StatusIcon.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/StatusIcon.tsx
@@ -44,7 +44,6 @@ const Container = styled.div<Props>`
 
 const Badge = styled(Container)<Props>`
   background: ${(props) => props.theme[(props.status && _themeByStatus[props.status]) || "dangerColor"]};
-  box-shadow: 0 1px 2px ${({ theme }) => theme.shadowColor};
   border-radius: ${({ value }) => (value ? "15px" : "50%")};
   color: ${({ theme }) => theme.whiteColor};
   padding-top: 4px;

--- a/airbyte-webapp/src/components/StatusIcon/StatusIcon.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/StatusIcon.tsx
@@ -4,8 +4,9 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheck, faTimes, faBan, faExclamationTriangle, IconDefinition } from "@fortawesome/free-solid-svg-icons";
 
 import PauseIcon from "./PauseIcon";
+import CircleLoader from "./CircleLoader";
 
-export type StatusIconStatus = "empty" | "inactive" | "success" | "warning";
+export type StatusIconStatus = "empty" | "inactive" | "success" | "warning" | "running";
 
 interface Props {
   className?: string;
@@ -23,27 +24,30 @@ const _iconByStatus: Partial<Record<StatusIconStatus, IconDefinition | undefined
   warning: faExclamationTriangle,
 };
 
-const _themeByStatus: Record<StatusIconStatus, string> = {
+const _themeByStatus: Partial<Record<StatusIconStatus, string>> = {
   empty: "attentionColor",
   inactive: "lightTextColor",
   success: "successColor",
   warning: "warningColor",
 };
 
-const Badge = styled.div<Props>`
+const Container = styled.div<Props>`
   width: ${(props) => getBadgeWidth(props)}px;
   height: ${({ big }) => (big ? 40 : 20)}px;
-  background: ${(props) => props.theme[(props.status && _themeByStatus[props.status]) || "dangerColor"]};
-  box-shadow: 0 1px 2px ${({ theme }) => theme.shadowColor};
-  border-radius: ${({ value }) => (value ? "15px" : "50%")};
   margin-right: 10px;
-  padding-top: 4px;
-  color: ${({ theme }) => theme.whiteColor};
   font-size: ${({ big }) => (big ? 24 : 12)}px;
   line-height: ${({ big }) => (big ? 33 : 12)}px;
   text-align: center;
   display: inline-block;
   vertical-align: top;
+`;
+
+const Badge = styled(Container)<Props>`
+  background: ${(props) => props.theme[(props.status && _themeByStatus[props.status]) || "dangerColor"]};
+  box-shadow: 0 1px 2px ${({ theme }) => theme.shadowColor};
+  border-radius: ${({ value }) => (value ? "15px" : "50%")};
+  color: ${({ theme }) => theme.whiteColor};
+  padding-top: 4px;
 `;
 
 const Value = styled.span`
@@ -54,6 +58,17 @@ const Value = styled.span`
 `;
 
 const StatusIcon: React.FC<Props> = ({ title, status, ...props }) => {
+  const valueElement = props.value ? <Value>{props.value}</Value> : null;
+
+  if (status === "running") {
+    return (
+      <Container>
+        <CircleLoader title={title} />
+        {valueElement}
+      </Container>
+    );
+  }
+
   return (
     <Badge {...props} status={status}>
       {status === "inactive" ? (
@@ -61,7 +76,7 @@ const StatusIcon: React.FC<Props> = ({ title, status, ...props }) => {
       ) : (
         <FontAwesomeIcon icon={(status && _iconByStatus[status]) || faTimes} title={title} />
       )}
-      {props.value && <Value>{props.value}</Value>}
+      {valueElement}
     </Badge>
   );
 };

--- a/airbyte-webapp/src/components/StatusIcon/StatusIcon.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/StatusIcon.tsx
@@ -6,7 +6,7 @@ import { faCheck, faTimes, faBan, faExclamationTriangle, IconDefinition } from "
 import PauseIcon from "./PauseIcon";
 import CircleLoader from "./CircleLoader";
 
-export type StatusIconStatus = "empty" | "inactive" | "success" | "warning" | "running";
+export type StatusIconStatus = "empty" | "inactive" | "success" | "warning" | "loading";
 
 interface Props {
   className?: string;
@@ -60,7 +60,7 @@ const Value = styled.span`
 const StatusIcon: React.FC<Props> = ({ title, status, ...props }) => {
   const valueElement = props.value ? <Value>{props.value}</Value> : null;
 
-  if (status === "running") {
+  if (status === "loading") {
     return (
       <Container>
         <CircleLoader title={title} />

--- a/airbyte-webapp/src/core/domain/connection/types.ts
+++ b/airbyte-webapp/src/core/domain/connection/types.ts
@@ -29,13 +29,19 @@ export type ScheduleProperties = {
   timeUnit: ConnectionSchedule;
 };
 
+export enum ConnectionStatus {
+  ACTIVE = "active",
+  INACTIVE = "inactive",
+  DEPRECATED = "depreacted",
+}
+
 export interface Connection {
   connectionId: string;
   name: string;
   prefix: string;
   sourceId: string;
   destinationId: string;
-  status: string;
+  status: ConnectionStatus;
   schedule: ScheduleProperties | null;
   syncCatalog: SyncSchema;
   latestSyncJobCreatedAt?: number | null;

--- a/airbyte-webapp/src/core/domain/connection/types.ts
+++ b/airbyte-webapp/src/core/domain/connection/types.ts
@@ -1,5 +1,6 @@
 import { SyncSchema } from "core/domain/catalog";
 import { AirbyteJSONSchema } from "core/jsonSchema";
+import Status from "core/statuses";
 
 import { Destination, Source } from "../connector";
 import { Operation } from "./operation";
@@ -48,7 +49,7 @@ export interface Connection {
   namespaceDefinition: ConnectionNamespaceDefinition;
   namespaceFormat: string;
   isSyncing?: boolean;
-  latestSyncJobStatus: string | null;
+  latestSyncJobStatus: Status | null;
   operationIds: string[];
 
   // WebBackend connection specific fields

--- a/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
@@ -5,6 +5,7 @@ import { useConfig } from "config";
 import {
   Connection,
   ConnectionNamespaceDefinition,
+  ConnectionStatus,
   ScheduleProperties,
   WebBackendConnectionService,
 } from "core/domain/connection";
@@ -51,7 +52,7 @@ type UpdateConnection = {
   syncCatalog?: SyncSchema;
   namespaceDefinition: ConnectionNamespaceDefinition;
   namespaceFormat?: string;
-  status: string;
+  status: ConnectionStatus;
   prefix: string;
   schedule?: ScheduleProperties | null;
   operations?: Operation[];

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -333,6 +333,7 @@
   "connection.failedSync": "Failed sync",
   "connection.successSync": "Succeeded sync",
   "connection.noSyncData": "Sync was not started",
+  "connection.pendingSync": "Sync is pending or running",
   "connection.refreshSchema": "Refresh schema",
   "connection.replication": "Replication",
   "connection.streams": "Streams",

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/EnabledControl.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/EnabledControl.tsx
@@ -3,9 +3,8 @@ import { FormattedMessage } from "react-intl";
 import styled from "styled-components";
 
 import { Toggle } from "components";
-import { Status } from "components/EntityTable/types";
 
-import { Connection } from "core/domain/connection";
+import { Connection, ConnectionStatus } from "core/domain/connection";
 import { useUpdateConnection } from "hooks/services/useConnectionHook";
 import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
 
@@ -45,11 +44,11 @@ const EnabledControl: React.FC<IProps> = ({ connection, disabled, frequencyText 
       namespaceFormat: connection.namespaceFormat,
       prefix: connection.prefix,
       operations: connection.operations,
-      status: connection.status === Status.ACTIVE ? Status.INACTIVE : Status.ACTIVE,
+      status: connection.status === ConnectionStatus.ACTIVE ? ConnectionStatus.INACTIVE : ConnectionStatus.ACTIVE,
     });
 
     analyticsService.track("Source - Action", {
-      action: connection.status === Status.ACTIVE ? "Disable connection" : "Reenable connection",
+      action: connection.status === ConnectionStatus.ACTIVE ? "Disable connection" : "Reenable connection",
       connector_source: connection.source?.sourceName,
       connector_source_id: connection.source?.sourceDefinitionId,
       connector_destination: connection.destination?.name,
@@ -61,12 +60,12 @@ const EnabledControl: React.FC<IProps> = ({ connection, disabled, frequencyText 
   return (
     <Content>
       <ToggleLabel htmlFor="toggle-enabled-source">
-        <FormattedMessage id={connection.status === Status.ACTIVE ? "tables.enabled" : "tables.disabled"} />
+        <FormattedMessage id={connection.status === ConnectionStatus.ACTIVE ? "tables.enabled" : "tables.disabled"} />
       </ToggleLabel>
       <Toggle
         disabled={disabled}
         onChange={onChangeStatus}
-        checked={connection.status === Status.ACTIVE}
+        checked={connection.status === ConnectionStatus.ACTIVE}
         id="toggle-enabled-source"
       />
     </Content>


### PR DESCRIPTION
## What
This fixes an issue described #10842 when a job shows the "success" icon under, pending, running, or has not run yet. Now pending and running will show a loading indicator while the default value, when no sync jobs have run, will be the "empty" state.

![image](https://user-images.githubusercontent.com/168664/164054110-0105aeb9-1404-424d-9319-484f8f7e1a90.png)



## How
The logic to determine which status to show has been updated to include these new states. Additionally, a new icon and state were introduced in `StatusIcon` to indicate the pending/running state. This state is called "loading" because the StatusIcon is shared for different functions.

Additionally, there is a cleanup of the status enums because there's a lot of mixed purposes. Now more clearly the connection status has its own enum.

## Recommended reading order
1. `StatusIcon`
2. `EntityTable` utils
3. `NameCell`
4. Rest

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Tests

<details><summary><strong>Unit</strong></summary>

```
  <StatusIcon />
    ✓ renders with title and default icon (50 ms)
    ✓ renders success status (10 ms)
    ✓ renders inactive status (10 ms)
    ✓ renders empty status (6 ms)
    ✓ renders warning status (5 ms)
    ✓ renders loading status (283 ms)
```

</details>

