### PR TITLE
source-twilio: fixes to make acceptance tests pass

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -806,7 +806,7 @@
 - name: Twilio
   sourceDefinitionId: b9dc6155-672e-42ea-b10d-9f1f1fb95ab1
   dockerRepository: airbyte/source-twilio
-  dockerImageTag: 0.1.2
+  dockerImageTag: 0.1.3
   documentationUrl: https://docs.airbyte.io/integrations/sources/twilio
   icon: twilio.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -8609,9 +8609,9 @@
         oauthFlowOutputParameters:
         - - "token"
         - - "key"
-- dockerImage: "airbyte/source-twilio:0.1.2"
+- dockerImage: "airbyte/source-twilio:0.1.3"
   spec:
-    documentationUrl: "https://hub.docker.com/r/airbyte/source-twilio"
+    documentationUrl: "https://docs.airbyte.io/integrations/sources/twilio"
     connectionSpecification:
       $schema: "http://json-schema.org/draft-07/schema#"
       title: "Twilio Spec"

--- a/airbyte-integrations/connectors/source-twilio/Dockerfile
+++ b/airbyte-integrations/connectors/source-twilio/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/source-twilio

--- a/airbyte-integrations/connectors/source-twilio/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-twilio/acceptance-test-config.yml
@@ -12,6 +12,7 @@ tests:
   basic_read:
     - config_path: "secrets/config.json"
       configured_catalog_path: "integration_tests/no_empty_streams_catalog.json"
+      empty_streams: ["message_media", "conferences"]
   incremental:
     - config_path: "secrets/config.json"
       # usage records stream produces and error if cursor date gte than current date

--- a/airbyte-integrations/connectors/source-twilio/source_twilio/schemas/calls.json
+++ b/airbyte-integrations/connectors/source-twilio/source_twilio/schemas/calls.json
@@ -106,6 +106,9 @@
         },
         "feedback_summaries": {
           "type": ["null", "string"]
+        },
+        "streams": {
+          "type": ["null", "string"]
         }
       }
     }

--- a/airbyte-integrations/connectors/source-twilio/source_twilio/streams.py
+++ b/airbyte-integrations/connectors/source-twilio/source_twilio/streams.py
@@ -285,6 +285,7 @@ class ConferenceParticipants(TwilioNestedStream):
     which are on conference call at the moment request is made).
     """
 
+    primary_key = ["account_sid", "conference_sid"]
     parent_stream = Conferences
     data_field = "participants"
 

--- a/docs/integrations/sources/twilio.md
+++ b/docs/integrations/sources/twilio.md
@@ -66,6 +66,7 @@ See [docs](https://www.twilio.com/docs/iam/api) for more details.
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.3 | 2022-04-20 | [12183](https://github.com/airbytehq/airbyte/pull/12183) | Add new subresource on the call stream + declare a valid primary key for conference_participants stream |
 | 0.1.2 | 2021-12-23 | [9092](https://github.com/airbytehq/airbyte/pull/9092) | Correct specification doc URL |
 | 0.1.1 | 2021-10-18 | [7034](https://github.com/airbytehq/airbyte/pull/7034) | Update schemas and transform data types according to the API schema |
 | 0.1.0 | 2021-07-02 | [4070](https://github.com/airbytehq/airbyte/pull/4070) | Native Twilio connector implemented |


### PR DESCRIPTION
## What
Acceptance tests run on `source-twilio` were failing. I try to make the required fix in this PR.
Closes https://github.com/airbytehq/airbyte/issues/9225

## How
* Fix schemas: Add a new `streams` property in the `calls` stream's `subresource_uris` (probably a new subresource that is now returned by the Twilio API.
* Declare a valid primary key for the `conference_participants` stream
* Define `message_medias` and `conferences` as empty stream in the acceptance test config as our sandbox account does not have data for these streams