### PR TITLE
Docs: Google Analytics source doc now specifies v4 

### DIFF
--- a/docs/integrations/sources/google-analytics-v4.md
+++ b/docs/integrations/sources/google-analytics-v4.md
@@ -2,6 +2,8 @@
 
 This page guides you through the process of setting up the Google Analytics source connector.
 
+This connector supports [Google Analytics v4](https://developers.google.com/analytics/devguides/collection/ga4).
+
 ## Prerequisites
 
 * A [Google Analytics](https://analytics.google.com/analytics/web/provision/#/provision) Account


### PR DESCRIPTION
## What
It wasn't clear in the docs that this connector is built for google analytics API v4, added a line to rectify that.