### PR TITLE
test postgres source params

### DIFF
--- a/airbyte-integrations/connector-templates/source-java-jdbc/src/main/java/io/airbyte/integrations/source/{{snakeCase name}}/{{pascalCase name}}Source.java.hbs
+++ b/airbyte-integrations/connector-templates/source-java-jdbc/src/main/java/io/airbyte/integrations/source/{{snakeCase name}}/{{pascalCase name}}Source.java.hbs
@@ -11,6 +11,8 @@ import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
 import java.sql.JDBCType;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +42,12 @@ public class {{pascalCase name}}Source extends AbstractJdbcSource<JDBCType> impl
   public Set<String> getExcludedInternalNameSpaces() {
     // TODO Add tables to exclude, Ex "INFORMATION_SCHEMA", "sys", "spt_fallback_db", etc
     return Set.of("");
+  }
+
+  @Override
+  protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+    // TODO Add logic to set default JDBC parameters that Airbyte should try to set on a connection
+    return Collections.emptyMap();
   }
 
   public static void main(final String[] args) throws Exception {

--- a/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
@@ -109,6 +109,11 @@ public class ClickHouseSource extends AbstractJdbcSource<JDBCType> implements So
     return Collections.singleton("system");
   }
 
+  @Override
+  protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+    return Collections.emptyMap();
+  }
+
   public static void main(final String[] args) throws Exception {
     final Source source = ClickHouseSource.getWrappedSource();
     LOGGER.info("starting source: {}", ClickHouseSource.class);

--- a/airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSource.java
+++ b/airbyte-integrations/connectors/source-cockroachdb/src/main/java/io/airbyte/integrations/source/cockroachdb/CockroachDbSource.java
@@ -24,9 +24,7 @@ import java.sql.Connection;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -144,6 +142,11 @@ public class CockroachDbSource extends AbstractJdbcSource<JDBCType> {
         .schemaName(jsonNode.get("table_schema").asText())
         .tableName(jsonNode.get("table_name").asText())
         .build();
+  }
+
+  @Override
+  protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+    return Collections.emptyMap();
   }
 
   public static void main(final String[] args) throws Exception {

--- a/airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2Source.java
+++ b/airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2Source.java
@@ -33,6 +33,7 @@ public class Db2Source extends AbstractJdbcSource<JDBCType> implements Source {
   public static final String DRIVER_CLASS = "com.ibm.db2.jcc.DB2Driver";
   public static final String USERNAME = "username";
   public static final String PASSWORD = "password";
+  public static final String JDBC_URL_PARAMS_KEY = "jdbc_url_params";
   private static Db2SourceOperations operations;
 
   private static final String KEY_STORE_PASS = RandomStringUtils.randomAlphanumeric(8);

--- a/airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2Source.java
+++ b/airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2Source.java
@@ -33,7 +33,6 @@ public class Db2Source extends AbstractJdbcSource<JDBCType> implements Source {
   public static final String DRIVER_CLASS = "com.ibm.db2.jcc.DB2Driver";
   public static final String USERNAME = "username";
   public static final String PASSWORD = "password";
-  public static final String JDBC_URL_PARAMS_KEY = "jdbc_url_params";
   private static Db2SourceOperations operations;
 
   private static final String KEY_STORE_PASS = RandomStringUtils.randomAlphanumeric(8);

--- a/airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2Source.java
+++ b/airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2Source.java
@@ -20,9 +20,7 @@ import java.sql.Connection;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -159,6 +157,11 @@ public class Db2Source extends AbstractJdbcSource<JDBCType> implements Source {
       pr.destroy();
       throw new RuntimeException("Timeout while executing: " + cmd);
     }
+  }
+
+  @Override
+  protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+    return Collections.emptyMap();
   }
 
 }

--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -291,7 +291,7 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractRelationalDbS
         jdbcConfig.get("jdbc_url").asText(),
         driverClass,
         jdbcStreamingQueryConfiguration,
-        getConnectionProperties(jdbcConfig),
+        JdbcUtils.parseJdbcParameters(jdbcConfig, "connection_properties"),
         sourceOperations);
 
     quoteString = (quoteString == null ? database.getMetaData().getIdentifierQuoteString() : quoteString);

--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/JdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/JdbcSource.java
@@ -10,6 +10,8 @@ import io.airbyte.db.jdbc.PostgresJdbcStreamingQueryConfiguration;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import java.sql.JDBCType;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +33,11 @@ public class JdbcSource extends AbstractJdbcSource<JDBCType> implements Source {
   @Override
   public Set<String> getExcludedInternalNameSpaces() {
     return Set.of("information_schema", "pg_catalog", "pg_internal", "catalog_history");
+  }
+  
+  @Override
+  protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+    return Collections.emptyMap();
   }
 
   public static void main(final String[] args) throws Exception {

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceAcceptanceTest.java
@@ -16,6 +16,8 @@ import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.source.jdbc.test.JdbcSourceAcceptanceTest;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.sql.JDBCType;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -27,7 +29,7 @@ import org.testcontainers.utility.MountableFile;
 
 /**
  * Runs the acceptance tests in the source-jdbc test module. We want this module to run these tests
- * itself as a sanity check. The trade off here is that this class is duplicated from the one used
+ * itself as a sanity check. The trade-off here is that this class is duplicated from the one used
  * in source-postgres.
  */
 class AbstractJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest {
@@ -115,6 +117,11 @@ class AbstractJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest {
     @Override
     public Set<String> getExcludedInternalNameSpaces() {
       return Set.of("information_schema", "pg_catalog", "pg_internal", "catalog_history");
+    }
+
+    @Override
+    protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+      return Collections.emptyMap();
     }
 
     public static void main(final String[] args) throws Exception {

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceTest.java
@@ -1,0 +1,140 @@
+package io.airbyte.integrations.source.jdbc;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.db.jdbc.JdbcUtils;
+import io.airbyte.db.jdbc.PostgresJdbcStreamingQueryConfiguration;
+import io.airbyte.integrations.base.Source;
+import org.junit.jupiter.api.Test;
+
+import java.sql.JDBCType;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AbstractJdbcSourceTest {
+
+    private JsonNode buildConfigNoJdbcParameters() {
+        return Jsons.jsonNode(ImmutableMap.of(
+                "host", "localhost",
+                "port", 1337,
+                "username", "user",
+                "database", "db"));
+    }
+
+    private JsonNode buildConfigWithExtraJdbcParameters(final String extraParam) {
+        return Jsons.jsonNode(ImmutableMap.of(
+                "host", "localhost",
+                "port", 1337,
+                "username", "user",
+                "database", "db",
+                "jdbc_url_params", extraParam));
+    }
+
+    @Test
+    void testNoExtraParamsNoDefault() {
+        final Map<String, String> connectionProperties = new TestJdbcSource().getConnectionProperties(buildConfigNoJdbcParameters());
+
+        final Map<String, String> expectedProperties = ImmutableMap.of();
+        assertEquals(expectedProperties, connectionProperties);
+    }
+
+    @Test
+    void testNoExtraParamsWithDefault() {
+        final Map<String, String> defaultProperties = ImmutableMap.of("A_PARAMETER", "A_VALUE");
+
+        final Map<String, String> connectionProperties = new TestJdbcSource(defaultProperties).getConnectionProperties(
+                buildConfigNoJdbcParameters());
+
+        assertEquals(defaultProperties, connectionProperties);
+    }
+
+    @Test
+    void testExtraParamNoDefault() {
+        final String extraParam = "key1=value1&key2=value2&key3=value3";
+        final Map<String, String> connectionProperties = new TestJdbcSource().getConnectionProperties(
+                buildConfigWithExtraJdbcParameters(extraParam));
+        final Map<String, String> expectedProperties = ImmutableMap.of(
+                "key1", "value1",
+                "key2", "value2",
+                "key3", "value3");
+        assertEquals(expectedProperties, connectionProperties);
+    }
+
+    @Test
+    void testExtraParamWithDefault() {
+        final Map<String, String> defaultProperties = ImmutableMap.of("A_PARAMETER", "A_VALUE");
+        final String extraParam = "key1=value1&key2=value2&key3=value3";
+        final Map<String, String> connectionProperties = new TestJdbcSource(defaultProperties).getConnectionProperties(
+                buildConfigWithExtraJdbcParameters(extraParam));
+        final Map<String, String> expectedProperties = ImmutableMap.of(
+                "A_PARAMETER", "A_VALUE",
+                "key1", "value1",
+                "key2", "value2",
+                "key3", "value3");
+        assertEquals(expectedProperties, connectionProperties);
+    }
+
+    @Test
+    void testExtraParameterEqualToDefault() {
+        final Map<String, String> defaultProperties = ImmutableMap.of("key1", "value1");
+        final String extraParam = "key1=value1&key2=value2&key3=value3";
+        final Map<String, String> connectionProperties = new TestJdbcSource(defaultProperties).getConnectionProperties(
+                buildConfigWithExtraJdbcParameters(extraParam));
+        final Map<String, String> expectedProperties = ImmutableMap.of(
+                "key1", "value1",
+                "key2", "value2",
+                "key3", "value3");
+        assertEquals(expectedProperties, connectionProperties);
+    }
+
+    @Test
+    void testExtraParameterDiffersFromDefault() {
+        final Map<String, String> defaultProperties = ImmutableMap.of("key1", "value0");
+        final String extraParam = "key1=value1&key2=value2&key3=value3";
+
+        assertThrows(IllegalArgumentException.class, () -> new TestJdbcSource(defaultProperties).getConnectionProperties(
+                buildConfigWithExtraJdbcParameters(extraParam)));
+    }
+
+    @Test
+    void testInvalidExtraParam() {
+        final String extraParam = "key1=value1&sdf&";
+        assertThrows(IllegalArgumentException.class,
+                () -> new TestJdbcSource().getConnectionProperties(buildConfigWithExtraJdbcParameters(extraParam)));
+    }
+
+    static class TestJdbcSource extends AbstractJdbcSource<JDBCType> implements Source {
+
+        private final Map<String, String> defaultProperties;
+
+        public TestJdbcSource() {
+            this(new HashMap<>());
+        }
+
+        public TestJdbcSource(final Map<String, String> defaultProperties) {
+            super("", new PostgresJdbcStreamingQueryConfiguration(), JdbcUtils.getDefaultSourceOperations());
+            this.defaultProperties = defaultProperties;
+        }
+
+        @Override
+        protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+            return defaultProperties;
+        }
+
+        @Override
+        public JsonNode toDatabaseConfig(final JsonNode config) {
+            return config;
+        }
+
+        @Override
+        public Set<String> getExcludedInternalNameSpaces() {
+            return null;
+        }
+
+    }
+}

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceTest.java
@@ -9,6 +9,7 @@ import io.airbyte.integrations.base.Source;
 import org.junit.jupiter.api.Test;
 
 import java.sql.JDBCType;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -133,7 +134,7 @@ public class AbstractJdbcSourceTest {
 
         @Override
         public Set<String> getExcludedInternalNameSpaces() {
-            return null;
+            return Collections.emptySet();
         }
 
     }

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/DefaultJdbcStressTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/DefaultJdbcStressTest.java
@@ -16,6 +16,8 @@ import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.source.jdbc.test.JdbcStressTest;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.sql.JDBCType;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
@@ -120,6 +122,11 @@ class DefaultJdbcStressTest extends JdbcStressTest {
     @Override
     public Set<String> getExcludedInternalNameSpaces() {
       return Set.of("information_schema", "pg_catalog", "pg_internal", "catalog_history");
+    }
+
+    @Override
+    protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+      return Collections.emptyMap();
     }
 
     public static void main(final String[] args) throws Exception {

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/JdbcSourceStressTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/JdbcSourceStressTest.java
@@ -16,6 +16,8 @@ import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.source.jdbc.test.JdbcStressTest;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.sql.JDBCType;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
@@ -118,6 +120,11 @@ class JdbcSourceStressTest extends JdbcStressTest {
     @Override
     public Set<String> getExcludedInternalNameSpaces() {
       return Set.of("information_schema", "pg_catalog", "pg_internal", "catalog_history");
+    }
+
+    @Override
+    protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+      return Collections.emptyMap();
     }
 
     public static void main(final String[] args) throws Exception {

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
@@ -36,11 +36,7 @@ import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -449,6 +445,11 @@ public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source 
     LOGGER.info("starting source: {}", MssqlSource.class);
     new IntegrationRunner(source).run(args);
     LOGGER.info("completed source: {}", MssqlSource.class);
+  }
+
+  @Override
+  protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+    return Collections.emptyMap();
   }
 
   public enum ReplicationMethod {

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
@@ -34,11 +34,8 @@ import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.SyncMode;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -199,6 +196,11 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
         "mysql",
         "performance_schema",
         "sys");
+  }
+
+  @Override
+  protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+    return Collections.emptyMap();
   }
 
   public static void main(final String[] args) throws Exception {

--- a/airbyte-integrations/connectors/source-oracle/src/main/java/io/airbyte/integrations/source/oracle/OracleSource.java
+++ b/airbyte-integrations/connectors/source-oracle/src/main/java/io/airbyte/integrations/source/oracle/OracleSource.java
@@ -19,10 +19,7 @@ import io.airbyte.protocol.models.CommonField;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.sql.JDBCType;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
@@ -168,6 +165,11 @@ public class OracleSource extends AbstractJdbcSource<JDBCType> implements Source
   @Override
   public Set<String> getExcludedInternalNameSpaces() {
     return Set.of();
+  }
+
+  @Override
+  protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+    return Collections.emptyMap();
   }
 
   public static void main(final String[] args) throws Exception {

--- a/airbyte-integrations/connectors/source-oracle/src/test/java/io/airbyte/integrations/source/oracle/OracleStressTest.java
+++ b/airbyte-integrations/connectors/source-oracle/src/test/java/io/airbyte/integrations/source/oracle/OracleStressTest.java
@@ -14,6 +14,8 @@ import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
 import io.airbyte.integrations.source.jdbc.test.JdbcStressTest;
 import java.sql.JDBCType;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
@@ -116,6 +118,11 @@ class OracleStressTest extends JdbcStressTest {
     public Set<String> getExcludedInternalNameSpaces() {
       // need to add SYSTEM too but for that need create another user when creating the container.
       return Set.of("APEX_040000", "CTXSYS", "FLOWS_FILES", "HR", "MDSYS", "OUTLN", "SYS", "XDB");
+    }
+
+    @Override
+    protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+      return Collections.emptyMap();
     }
 
     public static void main(final String[] args) throws Exception {

--- a/airbyte-integrations/connectors/source-postgres/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-postgres
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.4.10
+LABEL io.airbyte.version=0.4.12
 LABEL io.airbyte.name=airbyte/source-postgres

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -100,7 +100,7 @@ public class PostgresSource extends AbstractJdbcSource<JDBCType> implements Sour
     }
 
     if (config.has(JDBC_URL_PARAMS_KEY)) {
-      configBuilder.put("connection_properties", config.get(JDBC_URL_PARAMS_KEY).asText());
+      configBuilder.put(JDBC_URL_PARAMS_KEY, config.get(JDBC_URL_PARAMS_KEY).asText());
     }
 
     return Jsons.jsonNode(configBuilder.build());

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -99,8 +99,8 @@ public class PostgresSource extends AbstractJdbcSource<JDBCType> implements Sour
       configBuilder.put("password", config.get("password").asText());
     }
 
-    if (config.has("jdbc_url_params")) {
-      configBuilder.put("jdbc_url_params", config.get("jdbc_url_params").asText());
+    if (config.has(JDBC_URL_PARAMS_KEY)) {
+      configBuilder.put("connection_properties", config.get(JDBC_URL_PARAMS_KEY).asText());
     }
 
     return Jsons.jsonNode(configBuilder.build());

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -99,6 +99,7 @@ public class PostgresSource extends AbstractJdbcSource<JDBCType> implements Sour
       configBuilder.put("password", config.get("password").asText());
     }
 
+    // Check for optional params
     if (config.has(JDBC_URL_PARAMS_KEY)) {
       configBuilder.put(JDBC_URL_PARAMS_KEY, config.get(JDBC_URL_PARAMS_KEY).asText());
     }

--- a/airbyte-integrations/connectors/source-postgres/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-postgres/src/main/resources/spec.json
@@ -61,11 +61,17 @@
         "default": false,
         "order": 6
       },
+      "jdbc_url_params": {
+        "description": "Additional properties to pass to the JDBC URL string when connecting to the database formatted as 'key=value' pairs separated by the symbol '&'. (example: key1=value1&key2=value2&key3=value3).",
+        "title": "JDBC URL Params",
+        "type": "string",
+        "order": 7
+      },
       "replication_method": {
         "type": "object",
         "title": "Replication Method",
         "description": "Replication method to use for extracting data from the database.",
-        "order": 7,
+        "order": 8,
         "oneOf": [
           {
             "title": "Standard",

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSpecTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSpecTest.java
@@ -37,6 +37,7 @@ public class PostgresSpecTest {
       + "\"port\" : 5432,  "
       + "\"host\" : \"localhost\",  "
       + "\"ssl\" : true, "
+      + "\"jdbc_url_params\" : \"foo=bar\", "
       + "\"replication_method\" : {    \"method\" : \"CDC\", \"replication_slot\" : \"ab_slot\", \"publication\" : \"ab_publication\"  }"
       + "}";
   private static JsonNode schema;

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresStressTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresStressTest.java
@@ -17,6 +17,8 @@ import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
 import io.airbyte.integrations.source.jdbc.test.JdbcStressTest;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.sql.JDBCType;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
@@ -115,6 +117,11 @@ class PostgresStressTest extends JdbcStressTest {
       }
 
       return Jsons.jsonNode(configBuilder.build());
+    }
+
+    @Override
+    protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+      return Collections.emptyMap();
     }
 
     @Override

--- a/airbyte-integrations/connectors/source-redshift/src/main/java/io/airbyte/integrations/source/redshift/RedshiftSource.java
+++ b/airbyte-integrations/connectors/source-redshift/src/main/java/io/airbyte/integrations/source/redshift/RedshiftSource.java
@@ -18,10 +18,8 @@ import io.airbyte.protocol.models.CommonField;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,6 +114,11 @@ public class RedshiftSource extends AbstractJdbcSource<JDBCType> implements Sour
               .tableName(json.get("tablename").asText())
               .build();
         }));
+  }
+
+  @Override
+  protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+    return Collections.emptyMap();
   }
 
   public static void main(final String[] args) throws Exception {

--- a/airbyte-integrations/connectors/source-scaffold-java-jdbc/src/main/java/io/airbyte/integrations/source/scaffold_java_jdbc/ScaffoldJavaJdbcSource.java
+++ b/airbyte-integrations/connectors/source-scaffold-java-jdbc/src/main/java/io/airbyte/integrations/source/scaffold_java_jdbc/ScaffoldJavaJdbcSource.java
@@ -11,6 +11,8 @@ import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
 import java.sql.JDBCType;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +42,12 @@ public class ScaffoldJavaJdbcSource extends AbstractJdbcSource<JDBCType> impleme
   public Set<String> getExcludedInternalNameSpaces() {
     // TODO Add tables to exclude, Ex "INFORMATION_SCHEMA", "sys", "spt_fallback_db", etc
     return Set.of("");
+  }
+
+  @Override
+  protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+    // TODO Add logic to set default JDBC parameters that Airbyte should try to set on a connection
+    return Collections.emptyMap();
   }
 
   public static void main(final String[] args) throws Exception {

--- a/airbyte-integrations/connectors/source-scaffold-java-jdbc/src/main/java/io/airbyte/integrations/source/scaffold_java_jdbc/ScaffoldJavaJdbcSource.java
+++ b/airbyte-integrations/connectors/source-scaffold-java-jdbc/src/main/java/io/airbyte/integrations/source/scaffold_java_jdbc/ScaffoldJavaJdbcSource.java
@@ -11,8 +11,6 @@ import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
 import java.sql.JDBCType;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,12 +40,6 @@ public class ScaffoldJavaJdbcSource extends AbstractJdbcSource<JDBCType> impleme
   public Set<String> getExcludedInternalNameSpaces() {
     // TODO Add tables to exclude, Ex "INFORMATION_SCHEMA", "sys", "spt_fallback_db", etc
     return Set.of("");
-  }
-
-  @Override
-  protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
-    // TODO Add logic to set default JDBC parameters that Airbyte should try to set on a connection
-    return Collections.emptyMap();
   }
 
   public static void main(final String[] args) throws Exception {

--- a/airbyte-integrations/connectors/source-snowflake/src/main/java/io.airbyte.integrations.source.snowflake/SnowflakeSource.java
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/java/io.airbyte.integrations.source.snowflake/SnowflakeSource.java
@@ -11,6 +11,8 @@ import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
 import java.sql.JDBCType;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,6 +69,11 @@ public class SnowflakeSource extends AbstractJdbcSource<JDBCType> implements Sou
   public Set<String> getExcludedInternalNameSpaces() {
     return Set.of(
         "INFORMATION_SCHEMA");
+  }
+
+  @Override
+    protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+      return Collections.emptyMap();
   }
 
 }

--- a/airbyte-integrations/connectors/source-tidb/src/main/java/io/airbyte/integrations/source/tidb/TiDBSource.java
+++ b/airbyte-integrations/connectors/source-tidb/src/main/java/io/airbyte/integrations/source/tidb/TiDBSource.java
@@ -13,7 +13,10 @@ import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.base.ssh.SshWrappedSource;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
+
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,6 +74,11 @@ public class TiDBSource extends AbstractJdbcSource<MysqlType> implements Source 
         "metrics_schema",
         "performance_schema",
         "mysql");
+  }
+
+  @Override
+  protected Map<String, String> getDefaultConnectionProperties(final JsonNode config) {
+    return Collections.emptyMap();
   }
 
   public static void main(final String[] args) throws Exception {

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -270,11 +270,12 @@ According to Postgres [documentation](https://www.postgresql.org/docs/14/datatyp
 
 | Version | Date       | Pull Request                                           | Subject                                                                                                         |
 |:--------|:-----------|:-------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
-| 0.4.10  | 2022-04-08 | [11798](https://github.com/airbytehq/airbyte/pull/11798) | Fixed roles for fetching materialized view processing |
-| 0.4.8   | 2022-02-21 | [10242](https://github.com/airbytehq/airbyte/pull/10242) | Fixed cursor for old connectors that use non-microsecond format. Now connectors work with both formats |
-| 0.4.7   | 2022-02-18 | [10242](https://github.com/airbytehq/airbyte/pull/10242) | Updated timestamp transformation with microseconds |
-| 0.4.6   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | (unpublished) Add `-XX:+ExitOnOutOfMemoryError` JVM option |
-| 0.4.5   | 2022-02-08 | [10173](https://github.com/airbytehq/airbyte/pull/10173) | Improved  discovering tables in case if user does not have permissions to any table                                                                       |
+| 0.4.12  | 2022-04-21 | [12195](https://github.com/airbytehq/airbyte/pull/12195) | (unpublished) Add additional JDBC URL Params input                                                              |
+| 0.4.10  | 2022-04-08 | [11798](https://github.com/airbytehq/airbyte/pull/11798) | Fixed roles for fetching materialized view processing                                                           |
+| 0.4.8   | 2022-02-21 | [10242](https://github.com/airbytehq/airbyte/pull/10242) | Fixed cursor for old connectors that use non-microsecond format. Now connectors work with both formats          |
+| 0.4.7   | 2022-02-18 | [10242](https://github.com/airbytehq/airbyte/pull/10242) | Updated timestamp transformation with microseconds                                                              |
+| 0.4.6   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | (unpublished) Add `-XX:+ExitOnOutOfMemoryError` JVM option                                                      |
+| 0.4.5   | 2022-02-08 | [10173](https://github.com/airbytehq/airbyte/pull/10173) | Improved  discovering tables in case if user does not have permissions to any table                             |
 | 0.4.4   | 2022-01-26 | [9807](https://github.com/airbytehq/airbyte/pull/9807) | Update connector fields title/description                                                                       |
 | 0.4.3   | 2022-01-24 | [9554](https://github.com/airbytehq/airbyte/pull/9554) | Allow handling of java sql date in CDC                                                                          |
 | 0.4.2   | 2022-01-13 | [9360](https://github.com/airbytehq/airbyte/pull/9360) | Added schema selection                                                                                          |


### PR DESCRIPTION
## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. [AbstractJdbcSource.java](https://github.com/airbytehq/airbyte/pull/12215/files#diff-3c487b53052b70ba33ec30187926b31ee94a9dffcfbccdb37e43bdd226545ad2)
2. [AbstractJdbcSourceTest.java](https://github.com/airbytehq/airbyte/pull/12215/files#diff-c6dc4e02eb7669157ce8dad00ce18bab1c085e2bb299f88f7cc8054d9ae721c1)
3. [PostgresSource.java](https://github.com/airbytehq/airbyte/pull/12215/files#diff-f14bc8e9216a505150004f54d41ca7aeeba9a9460fc4a660b11225dd7abb274f)
4. [PostgresSpecTest.java](https://github.com/airbytehq/airbyte/pull/12215/files#diff-e5d1d403bd34baa6ece4e952fa4c3e66724659642b46b2328fdda310891d2205)
5. Everything else is overriding new abstract `getDefaultConnectionProperties` with an empty collection map

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [x] Documentation updated
    - [x] Connector's `README.md`
    - [x] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
