### PR TITLE
SAT: support yaml files in spec_path

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.50
+Added support for passing a `.yaml` file as `spec_path`.
+
 ## 0.1.49
 Fixed schema parsing when a JSONschema `type` was not present - we now assume `object` if the `type` is not present.
 

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.49
+LABEL io.airbyte.version=0.1.50
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/conftest.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/conftest.py
@@ -13,6 +13,7 @@ from subprocess import STDOUT, check_output, run
 from typing import Any, List, MutableMapping, Optional
 
 import pytest
+import yaml
 from airbyte_cdk.models import (
     AirbyteRecordMessage,
     AirbyteStream,
@@ -117,7 +118,16 @@ def malformed_connector_config_fixture(connector_config) -> MutableMapping[str, 
 
 @pytest.fixture(name="connector_spec")
 def connector_spec_fixture(connector_spec_path) -> ConnectorSpecification:
-    return ConnectorSpecification.parse_file(connector_spec_path)
+    with open(str(connector_spec_path), "r") as file:
+        raw_spec = file.read()
+        file_ext = connector_spec_path.suffix
+        if file_ext == ".json":
+            spec_obj = json.loads(raw_spec)
+        elif file_ext == ".yaml":
+            spec_obj = yaml.load(raw_spec, Loader=yaml.SafeLoader)
+        else:
+            raise RuntimeError(f"spec_path' must be a '.yaml' or '.json' file")
+        return ConnectorSpecification.parse_obj(spec_obj)
 
 
 @pytest.fixture(name="docker_runner")

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/conftest.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/conftest.py
@@ -126,7 +126,7 @@ def connector_spec_fixture(connector_spec_path) -> ConnectorSpecification:
         elif file_ext == ".yaml":
             spec_obj = yaml.load(raw_spec, Loader=yaml.SafeLoader)
         else:
-            raise RuntimeError(f"spec_path' must be a '.yaml' or '.json' file")
+            raise RuntimeError("spec_path' must be a '.yaml' or '.json' file")
         return ConnectorSpecification.parse_obj(spec_obj)
 
 

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/conftest.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/conftest.py
@@ -13,7 +13,6 @@ from subprocess import STDOUT, check_output, run
 from typing import Any, List, MutableMapping, Optional
 
 import pytest
-import yaml
 from airbyte_cdk.models import (
     AirbyteRecordMessage,
     AirbyteStream,
@@ -25,7 +24,7 @@ from airbyte_cdk.models import (
 )
 from docker import errors
 from source_acceptance_test.config import Config
-from source_acceptance_test.utils import ConnectorRunner, SecretDict, load_config
+from source_acceptance_test.utils import ConnectorRunner, SecretDict, load_config, load_yaml_or_json_path
 
 
 @pytest.fixture(name="base_path")
@@ -118,16 +117,8 @@ def malformed_connector_config_fixture(connector_config) -> MutableMapping[str, 
 
 @pytest.fixture(name="connector_spec")
 def connector_spec_fixture(connector_spec_path) -> ConnectorSpecification:
-    with open(str(connector_spec_path), "r") as file:
-        raw_spec = file.read()
-        file_ext = connector_spec_path.suffix
-        if file_ext == ".json":
-            spec_obj = json.loads(raw_spec)
-        elif file_ext == ".yaml":
-            spec_obj = yaml.load(raw_spec, Loader=yaml.SafeLoader)
-        else:
-            raise RuntimeError("spec_path' must be a '.yaml' or '.json' file")
-        return ConnectorSpecification.parse_obj(spec_obj)
+    spec_obj = load_yaml_or_json_path(connector_spec_path)
+    return ConnectorSpecification.parse_obj(spec_obj)
 
 
 @pytest.fixture(name="docker_runner")

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -59,7 +59,7 @@ class TestSpec(BaseTest):
     def test_match_expected(self, connector_spec: ConnectorSpecification, actual_connector_spec: ConnectorSpecification):
         """Check that spec call returns a spec equals to expected one"""
         if connector_spec:
-            assert actual_connector_spec == connector_spec, "Spec should be equal to the one in spec.json file"
+            assert actual_connector_spec == connector_spec, "Spec should be equal to the one in spec.yaml or spec.json file"
 
     def test_docker_env(self, actual_connector_spec: ConnectorSpecification, docker_runner: ConnectorRunner):
         """Check that connector's docker image has required envs"""

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/__init__.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
 from .asserts import verify_records_schema
-from .common import SecretDict, filter_output, full_refresh_only_catalog, incremental_only_catalog, load_config
+from .common import SecretDict, filter_output, full_refresh_only_catalog, incremental_only_catalog, load_config, load_yaml_or_json_path
 from .compare import diff_dicts, make_hashable
 from .connector_runner import ConnectorRunner
 from .json_schema_helper import JsonSchemaHelper
@@ -10,6 +10,7 @@ from .json_schema_helper import JsonSchemaHelper
 __all__ = [
     "JsonSchemaHelper",
     "load_config",
+    "load_yaml_or_json_path",
     "filter_output",
     "full_refresh_only_catalog",
     "incremental_only_catalog",

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/common.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/common.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
 
-
+import json
 from collections import UserDict
 from pathlib import Path
 from typing import Iterable, List, Union
@@ -102,3 +102,15 @@ def find_keyword_schema(schema: Union[dict, list, str], key: str) -> bool:
     except StopIteration:
         return True
     return False
+
+
+def load_yaml_or_json_path(path: Path):
+    with open(str(path), "r") as file:
+        file_data = file.read()
+        file_ext = path.suffix
+        if file_ext == ".json":
+            return json.loads(file_data)
+        elif file_ext == ".yaml":
+            return load(file_data, Loader=Loader)
+        else:
+            raise RuntimeError("path must be a '.yaml' or '.json' file")


### PR DESCRIPTION
## What
We now support loading the spec from a yaml file in the CDK (#12104), but the SAT still expects a json file as `spec_path` for one of the tests.

## How
Check if `spec_path` is a `.json` or `.yaml` file and load accordingly.
