### PR TITLE
notify cloud repo on push to master

### DIFF
--- a/.github/actions/build-and-push-branch/action.yml
+++ b/.github/actions/build-and-push-branch/action.yml
@@ -10,44 +10,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: "Parse Input"
-      id: parse-input
-      shell: bash
-      run: |-
-        # if the *branch_version_tag* input param is not specified, then generate it as 'dev-<commit_hash>`
-        #
-        [[ "${{ inputs.branch_version_tag }}" != '' ]] && echo "::set-output name=branch_version_tag::${{ inputs.branch_version_tag }}" \
-          || { short_hash=$(git rev-parse --short HEAD); echo "::set-output name=branch_version_tag::dev-$short_hash"; }
-
-    - uses: actions/setup-java@v1
-      with:
-        java-version: "17"
-
-    - uses: actions/setup-node@v1
-      with:
-        node-version: "16.13.0"
-
-    - name: Set up CI Gradle Properties
-      run: |
-        mkdir -p ~/.gradle/
-        cat > ~/.gradle/gradle.properties <<EOF
-        org.gradle.jvmargs=-Xmx8g -Xss4m --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
-          --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
-          --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
-          --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-          --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-        org.gradle.workers.max=8
-        org.gradle.vfs.watch=false
-        EOF
-      shell: bash
-
     - name: Build
-      run: VERSION=${{ steps.parse-input.outputs.branch_version_tag }} SUB_BUILD=PLATFORM ./gradlew build --scan
-      shell: bash
-
-    - name: Publish to Maven Local
-      run: VERSION=${{ steps.parse-input.outputs.branch_version_tag }} SUB_BUILD=PLATFORM ./gradlew publishToMavenLocal
-      shell: bash
+      id: build
+      uses: ./.github/actions/build-branch
+      with:
+        branch_version_tag: ${{ inputs.branch_version_tag }}
 
     - name: Login to Docker (on Master)
       uses: docker/login-action@v1
@@ -59,5 +26,5 @@ runs:
       run: |
         GIT_REVISION=$(git rev-parse HEAD)
         [ [ -z "$GIT_REVISION" ] ] && echo "Couldn't get the git revision..." && exit 1
-        VERSION=${{ steps.parse-input.outputs.branch_version_tag }} GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose-cloud.build.yaml push
+        VERSION=${{ steps.build.outputs.branch_version_tag }} GIT_REVISION=$GIT_REVISION docker-compose -f docker-compose-cloud.build.yaml push
       shell: bash

--- a/.github/actions/build-branch/action.yml
+++ b/.github/actions/build-branch/action.yml
@@ -1,0 +1,52 @@
+name: "Build OSS Branch"
+description: "Build jars and docker images tagged for a particular branch. Primarily used for running OSS branch code in Cloud."
+inputs:
+  branch_version_tag:
+    description: 'Used to tag jars and docker images with a branch-specific version (should use the form "dev-<commit_hash>" to pass AirbyteVersion validation)'
+    required: false
+outputs:
+  branch_version_tag:
+    description: 'Tag used for jars and docker images. Either user specified or auto generated as `dev-<commit_hash>`'
+    value: ${{ steps.parse-input.outputs.branch_version_tag }}
+runs:
+  using: "composite"
+  steps:
+    - name: "Parse Input"
+      id: parse-input
+      shell: bash
+      run: |-
+        # if the *branch_version_tag* input param is not specified, then generate it as 'dev-<commit_hash>`
+        #
+        [[ "${{ inputs.branch_version_tag }}" != '' ]] && echo "::set-output name=branch_version_tag::${{ inputs.branch_version_tag }}" \
+          || { short_hash=$(git rev-parse --short HEAD); echo "::set-output name=branch_version_tag::dev-$short_hash"; }
+
+    - uses: actions/setup-java@v1
+      with:
+        java-version: "17"
+
+    - uses: actions/setup-node@v1
+      with:
+        node-version: "16.13.0"
+
+    - name: Set up CI Gradle Properties
+      run: |
+        mkdir -p ~/.gradle/
+        cat > ~/.gradle/gradle.properties <<EOF
+        org.gradle.jvmargs=-Xmx8g -Xss4m --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+          --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+          --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+          --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+          --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+        org.gradle.workers.max=8
+        org.gradle.vfs.watch=false
+        EOF
+      shell: bash
+
+    - name: Build
+      run: VERSION=${{ steps.parse-input.outputs.branch_version_tag }} SUB_BUILD=PLATFORM ./gradlew build --scan
+      shell: bash
+
+    - name: Publish to Maven Local
+      run: VERSION=${{ steps.parse-input.outputs.branch_version_tag }} SUB_BUILD=PLATFORM ./gradlew publishToMavenLocal
+      shell: bash
+

--- a/.github/workflows/notify-on-push-to-master.yml
+++ b/.github/workflows/notify-on-push-to-master.yml
@@ -1,0 +1,18 @@
+name: Notify Cloud of OSS Push to Master
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+      
+jobs:
+  repo-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.OCTAVIA_PAT }}
+          repository: airbytehq/airbyte-cloud
+          event-type: oss-push-to-master
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## What
part of https://github.com/airbytehq/airbyte/issues/11137

## How
Uses https://github.com/marketplace/actions/repository-dispatch to notify cloud when a commit is pushed to oss master.
We can then trigger a cloud workflow to try building cloud with the latest oss master.

Also splits out the build-and-push action so that the build part can be called without pushing images to docker hub.