### PR TITLE
Add schema validation to replication worker

### DIFF
--- a/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/ReplicationJobOrchestrator.java
+++ b/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/ReplicationJobOrchestrator.java
@@ -11,6 +11,7 @@ import io.airbyte.config.StandardSyncInput;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.DefaultReplicationWorker;
+import io.airbyte.workers.RecordSchemaValidator;
 import io.airbyte.workers.ReplicationWorker;
 import io.airbyte.workers.WorkerConfigs;
 import io.airbyte.workers.WorkerConstants;
@@ -95,7 +96,8 @@ public class ReplicationJobOrchestrator implements JobOrchestrator<StandardSyncI
         airbyteSource,
         new NamespacingMapper(syncInput.getNamespaceDefinition(), syncInput.getNamespaceFormat(), syncInput.getPrefix()),
         new DefaultAirbyteDestination(workerConfigs, destinationLauncher),
-        new AirbyteMessageTracker());
+        new AirbyteMessageTracker(),
+        new RecordSchemaValidator(syncInput));
 
     log.info("Running replication worker...");
     final Path jobRoot = WorkerUtils.getJobRoot(configs.getWorkspaceRoot(), jobRunConfig.getJobId(), jobRunConfig.getAttemptId());

--- a/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/ReplicationJobOrchestrator.java
+++ b/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/ReplicationJobOrchestrator.java
@@ -97,7 +97,7 @@ public class ReplicationJobOrchestrator implements JobOrchestrator<StandardSyncI
         new NamespacingMapper(syncInput.getNamespaceDefinition(), syncInput.getNamespaceFormat(), syncInput.getPrefix()),
         new DefaultAirbyteDestination(workerConfigs, destinationLauncher),
         new AirbyteMessageTracker(),
-        new RecordSchemaValidator(syncInput, WorkerUtils.mapStreamNamesToSchemas(syncInput)));
+        new RecordSchemaValidator(WorkerUtils.mapStreamNamesToSchemas(syncInput)));
 
     log.info("Running replication worker...");
     final Path jobRoot = WorkerUtils.getJobRoot(configs.getWorkspaceRoot(), jobRunConfig.getJobId(), jobRunConfig.getAttemptId());

--- a/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/ReplicationJobOrchestrator.java
+++ b/airbyte-container-orchestrator/src/main/java/io/airbyte/container_orchestrator/ReplicationJobOrchestrator.java
@@ -97,7 +97,7 @@ public class ReplicationJobOrchestrator implements JobOrchestrator<StandardSyncI
         new NamespacingMapper(syncInput.getNamespaceDefinition(), syncInput.getNamespaceFormat(), syncInput.getPrefix()),
         new DefaultAirbyteDestination(workerConfigs, destinationLauncher),
         new AirbyteMessageTracker(),
-        new RecordSchemaValidator(syncInput));
+        new RecordSchemaValidator(syncInput, WorkerUtils.mapStreamNamesToSchemas(syncInput)));
 
     log.info("Running replication worker...");
     final Path jobRoot = WorkerUtils.getJobRoot(configs.getWorkspaceRoot(), jobRunConfig.getJobId(), jobRunConfig.getAttemptId());

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -4,9 +4,6 @@
 
 package io.airbyte.workers;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.config.FailureReason;
 import io.airbyte.config.ReplicationAttemptSummary;
 import io.airbyte.config.ReplicationOutput;
@@ -17,24 +14,17 @@ import io.airbyte.config.StreamSyncStats;
 import io.airbyte.config.SyncStats;
 import io.airbyte.config.WorkerDestinationConfig;
 import io.airbyte.config.WorkerSourceConfig;
-import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.protocol.models.AirbyteMessage;
-import io.airbyte.protocol.models.ConfiguredAirbyteStream;
-import io.airbyte.validation.json.JsonSchemaValidator;
-import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.helper.FailureHelper;
 import io.airbyte.workers.protocols.airbyte.AirbyteDestination;
 import io.airbyte.workers.protocols.airbyte.AirbyteMapper;
 import io.airbyte.workers.protocols.airbyte.AirbyteSource;
 import io.airbyte.workers.protocols.airbyte.MessageTracker;
-import io.airbyte.workers.RecordSchemaValidator;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -81,11 +71,11 @@ public class DefaultReplicationWorker implements ReplicationWorker {
   private final RecordSchemaValidator recordSchemaValidator;
 
   public DefaultReplicationWorker(final String jobId,
-      final int attempt,
-      final AirbyteSource source,
-      final AirbyteMapper mapper,
-      final AirbyteDestination destination,
-      final MessageTracker messageTracker) {
+                                  final int attempt,
+                                  final AirbyteSource source,
+                                  final AirbyteMapper mapper,
+                                  final AirbyteDestination destination,
+                                  final MessageTracker messageTracker) {
     this(jobId, attempt, source, mapper, destination, messageTracker, new RecordSchemaValidator());
   }
 
@@ -316,7 +306,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
             if (message.getRecord() != null) {
               try {
                 recordSchemaValidator.validateSchema(message, syncInput);
-              } catch(final RecordSchemaValidationException e) {
+              } catch (final RecordSchemaValidationException e) {
                 LOGGER.warn(e.getMessage());
               }
             }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -292,15 +292,15 @@ public class DefaultReplicationWorker implements ReplicationWorker {
             throw new SourceException("Source process read attempt failed", e);
           }
           if (messageOptional.isPresent()) {
-            final AirbyteMessage message = mapper.mapMessage(messageOptional.get());
-
-            if (message.getRecord() != null) {
+            if (messageOptional.get().getRecord() != null) {
               try {
-                recordSchemaValidator.validateSchema(message.getRecord());
+                recordSchemaValidator.validateSchema(messageOptional.get().getRecord());
               } catch (final RecordSchemaValidationException e) {
                 LOGGER.warn(e.getMessage());
               }
             }
+
+            final AirbyteMessage message = mapper.mapMessage(messageOptional.get());
 
             messageTracker.acceptFromSource(message);
             try {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -75,15 +75,6 @@ public class DefaultReplicationWorker implements ReplicationWorker {
                                   final AirbyteSource source,
                                   final AirbyteMapper mapper,
                                   final AirbyteDestination destination,
-                                  final MessageTracker messageTracker) {
-    this(jobId, attempt, source, mapper, destination, messageTracker, new RecordSchemaValidator());
-  }
-
-  public DefaultReplicationWorker(final String jobId,
-                                  final int attempt,
-                                  final AirbyteSource source,
-                                  final AirbyteMapper mapper,
-                                  final AirbyteDestination destination,
                                   final MessageTracker messageTracker,
                                   final RecordSchemaValidator recordSchemaValidator) {
     this.jobId = jobId;
@@ -305,7 +296,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
 
             if (message.getRecord() != null) {
               try {
-                recordSchemaValidator.validateSchema(message, syncInput);
+                recordSchemaValidator.validateSchema(message.getRecord());
               } catch (final RecordSchemaValidationException e) {
                 LOGGER.warn(e.getMessage());
               }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -145,7 +145,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
             });
 
         final CompletableFuture<?> replicationThreadFuture = CompletableFuture.runAsync(
-            getReplicationRunnable(source, destination, cancelled, mapper, messageTracker, mdc, syncInput, recordSchemaValidator),
+            getReplicationRunnable(source, destination, cancelled, mapper, messageTracker, mdc, recordSchemaValidator),
             executors).whenComplete((msg, ex) -> {
               if (ex != null) {
                 if (ex.getCause() instanceof SourceException) {
@@ -277,7 +277,6 @@ public class DefaultReplicationWorker implements ReplicationWorker {
                                                  final AirbyteMapper mapper,
                                                  final MessageTracker messageTracker,
                                                  final Map<String, String> mdc,
-                                                 final StandardSyncInput syncInput,
                                                  final RecordSchemaValidator recordSchemaValidator) {
     return () -> {
       MDC.setContextMap(mdc);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidationException.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidationException.java
@@ -1,0 +1,10 @@
+package io.airbyte.workers;
+
+public class RecordSchemaValidationException extends Exception {
+  public RecordSchemaValidationException(final String message) {
+    super(message);
+  }
+  public RecordSchemaValidationException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidationException.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidationException.java
@@ -5,8 +5,8 @@
 package io.airbyte.workers;
 
 /**
- * Exception thrown by the RecordSchemaValidator during a sync when AirbyteRecordMessage data does not conform
- * to its stream's defined JSON schema
+ * Exception thrown by the RecordSchemaValidator during a sync when AirbyteRecordMessage data does
+ * not conform to its stream's defined JSON schema
  */
 
 public class RecordSchemaValidationException extends Exception {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidationException.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidationException.java
@@ -1,10 +1,17 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.workers;
 
 public class RecordSchemaValidationException extends Exception {
+
   public RecordSchemaValidationException(final String message) {
     super(message);
   }
+
   public RecordSchemaValidationException(final String message, final Throwable cause) {
     super(message, cause);
   }
+
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidationException.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidationException.java
@@ -4,6 +4,11 @@
 
 package io.airbyte.workers;
 
+/**
+ * Exception thrown by the RecordSchemaValidator during a sync when AirbyteRecordMessage data does not conform
+ * to its stream's defined JSON schema
+ */
+
 public class RecordSchemaValidationException extends Exception {
 
   public RecordSchemaValidationException(final String message) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -1,0 +1,37 @@
+package io.airbyte.workers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
+import io.airbyte.config.StandardSyncInput;
+import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.ConfiguredAirbyteStream;
+import io.airbyte.validation.json.JsonSchemaValidator;
+import io.airbyte.validation.json.JsonValidationException;
+
+public class RecordSchemaValidator {
+
+  public void validateSchema(final AirbyteMessage message, final StandardSyncInput syncInput)  throws RecordSchemaValidationException {
+    // the stream this message corresponds to
+    final String messageStream = message.getRecord().getStream();
+    final JsonNode messageData = message.getRecord().getData();
+
+    // the stream name and json schema
+    final ConfiguredAirbyteStream matchingAirbyteStream = syncInput.getCatalog().getStreams().stream()
+        .filter(s -> (s.getStream().getName().trim().equals((messageStream.trim())))).findFirst().orElse(null);
+
+    final JsonNode matchingSchema = matchingAirbyteStream.getStream().getJsonSchema();
+
+    final JsonSchemaValidator validator = new JsonSchemaValidator();
+
+    // We must choose a JSON validator version for validating the schema
+    // Rather than allowing connectors to use any version, we enforce validation using V7
+    ((ObjectNode) matchingSchema).put("$schema", "http://json-schema.org/draft-07/schema#");
+
+    try {
+      validator.ensure(matchingSchema, messageData);
+    } catch(final JsonValidationException e) {
+      throw new RecordSchemaValidationException(String.format("Record schema validation failed. Errors: %s", e.getMessage(), e));
+    }
+  }
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -36,7 +36,7 @@ public class RecordSchemaValidator {
    */
   public void validateSchema(final AirbyteRecordMessage message) throws RecordSchemaValidationException {
     // the stream this message corresponds to
-    final String messageStream = message.getStream();
+    final String messageStream = message.getNamespace() + message.getStream();
     final JsonNode messageData = message.getData();
     final JsonNode matchingSchema = streams.get(messageStream);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -11,7 +11,6 @@ import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Validates that AirbyteRecordMessage data conforms to the JSON schema defined by the source's
@@ -22,13 +21,10 @@ public class RecordSchemaValidator {
 
   private final Map<String, JsonNode> streams;
 
-  public RecordSchemaValidator(final StandardSyncInput syncInput) {
-    final String streamPrefix = syncInput.getPrefix();
-
+  public RecordSchemaValidator(final StandardSyncInput syncInput, final Map<String, JsonNode> streamNamesToSchemas) {
     // streams is Map of a stream name (including prefix) and stream schema
     // for easy access when we check each record's schema
-    this.streams = syncInput.getCatalog().getStreams().stream().collect(
-        Collectors.toMap(k -> String.format(streamPrefix + k.getStream().getName().trim()), v -> v.getStream().getJsonSchema()));
+    this.streams = streamNamesToSchemas;
   }
 
   /**

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -10,7 +10,8 @@ import io.airbyte.config.StandardSyncInput;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
-import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Validates that AirbyteRecordMessage data conforms to the JSON schema defined by the source's
@@ -19,17 +20,15 @@ import java.util.HashMap;
 
 public class RecordSchemaValidator {
 
-  private final HashMap<String, JsonNode> streams;
+  private final Map<String, JsonNode> streams;
 
   public RecordSchemaValidator(final StandardSyncInput syncInput) {
     final String streamPrefix = syncInput.getPrefix();
 
-    // streams is populated with a stream name (including prefix) and stream schema
+    // streams is Map of a stream name (including prefix) and stream schema
     // for easy access when we check each record's schema
-    this.streams = new HashMap<String, JsonNode>();
-    syncInput.getCatalog().getStreams().forEach(s -> {
-      streams.put(String.format(streamPrefix + s.getStream().getName().trim()), s.getStream().getJsonSchema());
-    });
+    this.streams = syncInput.getCatalog().getStreams().stream().collect(
+        Collectors.toMap(k -> String.format(streamPrefix + k.getStream().getName().trim()), v -> v.getStream().getJsonSchema()));
   }
 
   /**

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -13,7 +13,8 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.util.HashMap;
 
 /**
- * Validates that AirbyteRecordMessage data conforms to the JSON schema defined by the source's configured catalog
+ * Validates that AirbyteRecordMessage data conforms to the JSON schema defined by the source's
+ * configured catalog
  */
 
 public class RecordSchemaValidator {
@@ -32,8 +33,9 @@ public class RecordSchemaValidator {
   }
 
   /**
-   * Takes an AirbyteRecordMessage and uses the JsonSchemaValidator to validate that its data conforms to the stream's schema
-   * If it does not, this method throws a RecordSchemaValidationException
+   * Takes an AirbyteRecordMessage and uses the JsonSchemaValidator to validate that its data conforms
+   * to the stream's schema If it does not, this method throws a RecordSchemaValidationException
+   *
    * @param message
    * @throws RecordSchemaValidationException
    */

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -11,6 +11,7 @@ import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Validates that AirbyteRecordMessage data conforms to the JSON schema defined by the source's
@@ -35,8 +36,8 @@ public class RecordSchemaValidator {
    * @throws RecordSchemaValidationException
    */
   public void validateSchema(final AirbyteRecordMessage message) throws RecordSchemaValidationException {
-    // the stream this message corresponds to
-    final String messageStream = message.getNamespace() + message.getStream();
+    // the stream this message corresponds to, including the stream namespace
+    final String messageStream = String.format("%s" + message.getStream(), Objects.toString(message.getNamespace(), ""));
     final JsonNode messageData = message.getData();
     final JsonNode matchingSchema = streams.get(messageStream);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -6,7 +6,6 @@ package io.airbyte.workers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.airbyte.config.StandardSyncInput;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
@@ -22,7 +21,7 @@ public class RecordSchemaValidator {
 
   private final Map<String, JsonNode> streams;
 
-  public RecordSchemaValidator(final StandardSyncInput syncInput, final Map<String, JsonNode> streamNamesToSchemas) {
+  public RecordSchemaValidator(final Map<String, JsonNode> streamNamesToSchemas) {
     // streams is Map of a stream name (including prefix) and stream schema
     // for easy access when we check each record's schema
     this.streams = streamNamesToSchemas;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -8,12 +8,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
-import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.util.HashMap;
 
 public class RecordSchemaValidator {
+
   private final HashMap<String, JsonNode> streams;
 
   public RecordSchemaValidator(final StandardSyncInput syncInput) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -12,6 +12,10 @@ import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.util.HashMap;
 
+/**
+ * Validates that AirbyteRecordMessage data conforms to the JSON schema defined by the source's configured catalog
+ */
+
 public class RecordSchemaValidator {
 
   private final HashMap<String, JsonNode> streams;
@@ -27,6 +31,12 @@ public class RecordSchemaValidator {
     });
   }
 
+  /**
+   * Takes an AirbyteRecordMessage and uses the JsonSchemaValidator to validate that its data conforms to the stream's schema
+   * If it does not, this method throws a RecordSchemaValidationException
+   * @param message
+   * @throws RecordSchemaValidationException
+   */
   public void validateSchema(final AirbyteRecordMessage message) throws RecordSchemaValidationException {
     // the stream this message corresponds to
     final String messageStream = message.getStream();

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -35,7 +35,7 @@ public class RecordSchemaValidator {
     try {
       validator.ensure(matchingSchema, messageData);
     } catch (final JsonValidationException e) {
-      throw new RecordSchemaValidationException(String.format("Record schema validation failed. Errors: %s", e.getMessage(), e));
+      throw new RecordSchemaValidationException(String.format("Record schema validation failed. Errors: %s", e.getMessage()), e);
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -1,8 +1,11 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.workers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
@@ -11,7 +14,7 @@ import io.airbyte.validation.json.JsonValidationException;
 
 public class RecordSchemaValidator {
 
-  public void validateSchema(final AirbyteMessage message, final StandardSyncInput syncInput)  throws RecordSchemaValidationException {
+  public void validateSchema(final AirbyteMessage message, final StandardSyncInput syncInput) throws RecordSchemaValidationException {
     // the stream this message corresponds to
     final String messageStream = message.getRecord().getStream();
     final JsonNode messageData = message.getRecord().getData();
@@ -31,8 +34,9 @@ public class RecordSchemaValidator {
 
     try {
       validator.ensure(matchingSchema, messageData);
-    } catch(final JsonValidationException e) {
+    } catch (final JsonValidationException e) {
       throw new RecordSchemaValidationException(String.format("Record schema validation failed. Errors: %s", e.getMessage(), e));
     }
   }
+
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -15,10 +15,11 @@ public class RecordSchemaValidator {
     // the stream this message corresponds to
     final String messageStream = message.getRecord().getStream();
     final JsonNode messageData = message.getRecord().getData();
+    final String streamPrefix = syncInput.getPrefix();
 
     // the stream name and json schema
     final ConfiguredAirbyteStream matchingAirbyteStream = syncInput.getCatalog().getStreams().stream()
-        .filter(s -> (s.getStream().getName().trim().equals((messageStream.trim())))).findFirst().orElse(null);
+        .filter(s -> (String.format(streamPrefix + s.getStream().getName().trim()).equals((messageStream.trim())))).findFirst().orElse(null);
 
     final JsonNode matchingSchema = matchingAirbyteStream.getStream().getJsonSchema();
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -22,7 +22,7 @@ public class RecordSchemaValidator {
   private final Map<String, JsonNode> streams;
 
   public RecordSchemaValidator(final Map<String, JsonNode> streamNamesToSchemas) {
-    // streams is Map of a stream name (including prefix) and stream schema
+    // streams is Map of a stream source namespace + name mapped to the stream schema
     // for easy access when we check each record's schema
     this.streams = streamNamesToSchemas;
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -101,7 +101,8 @@ public class WorkerUtils {
   public static Map<String, JsonNode> mapStreamNamesToSchemas(final StandardSyncInput syncInput) {
     final String streamPrefix = syncInput.getPrefix();
     return syncInput.getCatalog().getStreams().stream().collect(
-        Collectors.toMap(k -> String.format(k.getStream().getNamespace().trim() + streamPrefix + k.getStream().getName().trim()), v -> v.getStream().getJsonSchema()));
+        Collectors.toMap(k -> String.format(k.getStream().getNamespace().trim() + streamPrefix + k.getStream().getName().trim()),
+            v -> v.getStream().getJsonSchema()));
 
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -101,7 +101,7 @@ public class WorkerUtils {
   public static Map<String, JsonNode> mapStreamNamesToSchemas(final StandardSyncInput syncInput) {
     final String streamPrefix = syncInput.getPrefix();
     return syncInput.getCatalog().getStreams().stream().collect(
-        Collectors.toMap(k -> String.format(streamPrefix + k.getStream().getName().trim()), v -> v.getStream().getJsonSchema()));
+        Collectors.toMap(k -> String.format(k.getStream().getNamespace().trim() + streamPrefix + k.getStream().getName().trim()), v -> v.getStream().getJsonSchema()));
 
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -101,7 +101,7 @@ public class WorkerUtils {
   public static Map<String, JsonNode> mapStreamNamesToSchemas(final StandardSyncInput syncInput) {
     final String streamPrefix = syncInput.getPrefix();
     return syncInput.getCatalog().getStreams().stream().collect(
-        Collectors.toMap(k -> String.format(k.getStream().getNamespace().trim() + streamPrefix + k.getStream().getName().trim()),
+        Collectors.toMap(k -> String.format(k.getStream().getNamespace() + streamPrefix + k.getStream().getName().trim()),
             v -> v.getStream().getJsonSchema()));
 
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -101,7 +102,8 @@ public class WorkerUtils {
   public static Map<String, JsonNode> mapStreamNamesToSchemas(final StandardSyncInput syncInput) {
     final String streamPrefix = syncInput.getPrefix();
     return syncInput.getCatalog().getStreams().stream().collect(
-        Collectors.toMap(k -> String.format(k.getStream().getNamespace() + streamPrefix + k.getStream().getName().trim()),
+        Collectors.toMap(
+            k -> String.format("%s".trim() + streamPrefix + k.getStream().getName().trim(), Objects.toString(k.getStream().getNamespace(), "")),
             v -> v.getStream().getJsonSchema()));
 
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -103,7 +103,11 @@ public class WorkerUtils {
     final String streamPrefix = syncInput.getPrefix();
     return syncInput.getCatalog().getStreams().stream().collect(
         Collectors.toMap(
-            k -> String.format("%s".trim() + k.getStream().getName().trim(), Objects.toString(k.getStream().getNamespace(), "")),
+            k -> {
+              final String namespace = Objects.toString(k.getStream().getNamespace(), "").trim();
+              final String name = k.getStream().getName().trim();
+              return namespace + name;
+            },
             v -> v.getStream().getJsonSchema()));
 
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -103,7 +103,7 @@ public class WorkerUtils {
     final String streamPrefix = syncInput.getPrefix();
     return syncInput.getCatalog().getStreams().stream().collect(
         Collectors.toMap(
-            k -> String.format("%s".trim() + streamPrefix + k.getStream().getName().trim(), Objects.toString(k.getStream().getNamespace(), "")),
+            k -> String.format("%s".trim() + k.getStream().getName().trim(), Objects.toString(k.getStream().getNamespace(), "")),
             v -> v.getStream().getJsonSchema()));
 
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.workers;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.WorkerDestinationConfig;
@@ -13,7 +14,9 @@ import io.airbyte.scheduler.models.JobRunConfig;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,6 +96,13 @@ public class WorkerUtils {
         .withDestinationConnectionConfiguration(sync.getDestinationConfiguration())
         .withCatalog(sync.getCatalog())
         .withState(sync.getState());
+  }
+
+  public static Map<String, JsonNode> mapStreamNamesToSchemas(final StandardSyncInput syncInput) {
+    final String streamPrefix = syncInput.getPrefix();
+    return syncInput.getCatalog().getStreams().stream().collect(
+        Collectors.toMap(k -> String.format(streamPrefix + k.getStream().getName().trim()), v -> v.getStream().getJsonSchema()));
+
   }
 
   // todo (cgardens) - there are 2 sources of truth for job path. we need to reduce this down to one,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationActivityImpl.java
@@ -27,6 +27,7 @@ import io.airbyte.workers.WorkerApp;
 import io.airbyte.workers.WorkerApp.ContainerOrchestratorConfig;
 import io.airbyte.workers.WorkerConfigs;
 import io.airbyte.workers.WorkerConstants;
+import io.airbyte.workers.WorkerUtils;
 import io.airbyte.workers.process.AirbyteIntegrationLauncher;
 import io.airbyte.workers.process.IntegrationLauncher;
 import io.airbyte.workers.process.ProcessFactory;
@@ -212,7 +213,7 @@ public class ReplicationActivityImpl implements ReplicationActivity {
           new NamespacingMapper(syncInput.getNamespaceDefinition(), syncInput.getNamespaceFormat(), syncInput.getPrefix()),
           new DefaultAirbyteDestination(workerConfigs, destinationLauncher),
           new AirbyteMessageTracker(),
-          new RecordSchemaValidator(syncInput));
+          new RecordSchemaValidator(syncInput, WorkerUtils.mapStreamNamesToSchemas(syncInput)));
     };
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationActivityImpl.java
@@ -213,7 +213,7 @@ public class ReplicationActivityImpl implements ReplicationActivity {
           new NamespacingMapper(syncInput.getNamespaceDefinition(), syncInput.getNamespaceFormat(), syncInput.getPrefix()),
           new DefaultAirbyteDestination(workerConfigs, destinationLauncher),
           new AirbyteMessageTracker(),
-          new RecordSchemaValidator(syncInput, WorkerUtils.mapStreamNamesToSchemas(syncInput)));
+          new RecordSchemaValidator(WorkerUtils.mapStreamNamesToSchemas(syncInput)));
     };
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/ReplicationActivityImpl.java
@@ -21,6 +21,7 @@ import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.workers.DefaultReplicationWorker;
+import io.airbyte.workers.RecordSchemaValidator;
 import io.airbyte.workers.Worker;
 import io.airbyte.workers.WorkerApp;
 import io.airbyte.workers.WorkerApp.ContainerOrchestratorConfig;
@@ -210,7 +211,8 @@ public class ReplicationActivityImpl implements ReplicationActivity {
           airbyteSource,
           new NamespacingMapper(syncInput.getNamespaceDefinition(), syncInput.getNamespaceFormat(), syncInput.getPrefix()),
           new DefaultAirbyteDestination(workerConfigs, destinationLauncher),
-          new AirbyteMessageTracker());
+          new AirbyteMessageTracker(),
+          new RecordSchemaValidator(syncInput));
     };
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
@@ -123,7 +123,7 @@ class DefaultReplicationWorkerTest {
 
   @Test
   void test() throws Exception {
-    final DefaultReplicationWorker worker = new DefaultReplicationWorker(
+    final ReplicationWorker worker = new DefaultReplicationWorker(
         JOB_ID,
         JOB_ATTEMPT,
         source,

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
@@ -140,8 +140,8 @@ class DefaultReplicationWorkerTest {
     verify(destination).accept(RECORD_MESSAGE2);
     verify(source).close();
     verify(destination).close();
-    verify(recordSchemaValidator).validateSchema(RECORD_MESSAGE1, syncInput);
-    verify(recordSchemaValidator).validateSchema(RECORD_MESSAGE2, syncInput);
+    verify(recordSchemaValidator).validateSchema(RECORD_MESSAGE1.getRecord());
+    verify(recordSchemaValidator).validateSchema(RECORD_MESSAGE2.getRecord());
   }
 
   @Test
@@ -163,11 +163,27 @@ class DefaultReplicationWorkerTest {
     verify(destination).start(destinationConfig, jobRoot);
     verify(destination).accept(RECORD_MESSAGE1);
     verify(destination).accept(RECORD_MESSAGE2);
-    verify(recordSchemaValidator).validateSchema(RECORD_MESSAGE1, syncInput);
-    verify(recordSchemaValidator).validateSchema(RECORD_MESSAGE2, syncInput);
-    verify(recordSchemaValidator).validateSchema(RECORD_MESSAGE3, syncInput);
+    verify(recordSchemaValidator).validateSchema(RECORD_MESSAGE1.getRecord());
+    verify(recordSchemaValidator).validateSchema(RECORD_MESSAGE2.getRecord());
+    verify(recordSchemaValidator).validateSchema(RECORD_MESSAGE3.getRecord());
     verify(source).close();
     verify(destination).close();
+  }
+
+  @Test
+  void testSourceNonZeroExitValue() throws Exception {
+    when(source.getExitValue()).thenReturn(1);
+    final ReplicationWorker worker = new DefaultReplicationWorker(
+        JOB_ID,
+        JOB_ATTEMPT,
+        source,
+        mapper,
+        destination,
+        messageTracker,
+        recordSchemaValidator);
+    final ReplicationOutput output = worker.run(syncInput, jobRoot);
+    assertEquals(ReplicationStatus.FAILED, output.getReplicationAttemptSummary().getStatus());
+    assertTrue(output.getFailures().stream().anyMatch(f -> f.getFailureOrigin().equals(FailureOrigin.SOURCE)));
   }
 
   @Test
@@ -182,7 +198,8 @@ class DefaultReplicationWorkerTest {
         source,
         mapper,
         destination,
-        messageTracker);
+        messageTracker,
+        recordSchemaValidator);
 
     final ReplicationOutput output = worker.run(syncInput, jobRoot);
     assertEquals(ReplicationStatus.FAILED, output.getReplicationAttemptSummary().getStatus());
@@ -202,7 +219,8 @@ class DefaultReplicationWorkerTest {
         source,
         mapper,
         destination,
-        messageTracker);
+        messageTracker,
+        recordSchemaValidator);
 
     final ReplicationOutput output = worker.run(syncInput, jobRoot);
     assertEquals(ReplicationStatus.FAILED, output.getReplicationAttemptSummary().getStatus());
@@ -222,7 +240,8 @@ class DefaultReplicationWorkerTest {
         source,
         mapper,
         destination,
-        messageTracker);
+        messageTracker,
+        recordSchemaValidator);
 
     final ReplicationOutput output = worker.run(syncInput, jobRoot);
     assertEquals(ReplicationStatus.FAILED, output.getReplicationAttemptSummary().getStatus());
@@ -240,7 +259,8 @@ class DefaultReplicationWorkerTest {
         source,
         mapper,
         destination,
-        messageTracker);
+        messageTracker,
+        recordSchemaValidator);
 
     final ReplicationOutput output = worker.run(syncInput, jobRoot);
     assertEquals(ReplicationStatus.FAILED, output.getReplicationAttemptSummary().getStatus());
@@ -259,7 +279,8 @@ class DefaultReplicationWorkerTest {
         source,
         mapper,
         destination,
-        messageTracker);
+        messageTracker,
+        recordSchemaValidator);
 
     final ReplicationOutput output = worker.run(syncInput, jobRoot);
     assertEquals(ReplicationStatus.FAILED, output.getReplicationAttemptSummary().getStatus());
@@ -279,7 +300,8 @@ class DefaultReplicationWorkerTest {
         source,
         mapper,
         destination,
-        messageTracker);
+        messageTracker,
+        recordSchemaValidator);
 
     final ReplicationOutput output = worker.run(syncInput, jobRoot);
     assertEquals(ReplicationStatus.FAILED, output.getReplicationAttemptSummary().getStatus());
@@ -300,7 +322,8 @@ class DefaultReplicationWorkerTest {
         source,
         mapper,
         destination,
-        messageTracker);
+        messageTracker,
+        recordSchemaValidator);
 
     worker.run(syncInput, jobRoot);
 
@@ -339,7 +362,8 @@ class DefaultReplicationWorkerTest {
         source,
         mapper,
         destination,
-        messageTracker);
+        messageTracker,
+        recordSchemaValidator);
 
     final Thread workerThread = new Thread(() -> {
       try {
@@ -379,7 +403,8 @@ class DefaultReplicationWorkerTest {
         source,
         mapper,
         destination,
-        messageTracker);
+        messageTracker,
+        recordSchemaValidator);
 
     final ReplicationOutput actual = worker.run(syncInput, jobRoot);
     final ReplicationOutput replicationOutput = new ReplicationOutput()
@@ -431,7 +456,8 @@ class DefaultReplicationWorkerTest {
         source,
         mapper,
         destination,
-        messageTracker);
+        messageTracker,
+        recordSchemaValidator);
 
     final ReplicationOutput actual = worker.run(syncInput, jobRoot);
     assertNotNull(actual);
@@ -448,7 +474,8 @@ class DefaultReplicationWorkerTest {
         source,
         mapper,
         destination,
-        messageTracker);
+        messageTracker,
+        recordSchemaValidator);
 
     final ReplicationOutput actual = worker.run(syncInput, jobRoot);
 
@@ -473,7 +500,8 @@ class DefaultReplicationWorkerTest {
         source,
         mapper,
         destination,
-        messageTracker);
+        messageTracker,
+        recordSchemaValidator);
 
     final ReplicationOutput actual = worker.run(syncInput, jobRoot);
     final SyncStats expectedTotalStats = new SyncStats()
@@ -508,7 +536,8 @@ class DefaultReplicationWorkerTest {
         source,
         mapper,
         destination,
-        messageTracker);
+        messageTracker,
+        recordSchemaValidator);
 
     final ReplicationOutput actual = worker.run(syncInputWithoutState, jobRoot);
 
@@ -526,7 +555,8 @@ class DefaultReplicationWorkerTest {
         source,
         mapper,
         destination,
-        messageTracker);
+        messageTracker,
+        recordSchemaValidator);
     assertThrows(WorkerException.class, () -> worker.run(syncInput, jobRoot));
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
@@ -70,7 +70,7 @@ class DefaultReplicationWorkerTest {
   private static final String JOB_ID = "0";
   private static final int JOB_ATTEMPT = 0;
   private static final Path WORKSPACE_ROOT = Path.of("workspaces/10");
-  private static final String STREAM_NAME = "favorite_color_pipeuser_preferences";
+  private static final String STREAM_NAME = "user_preferences";
   private static final String FIELD_NAME = "favorite_color";
   private static final AirbyteMessage RECORD_MESSAGE1 = AirbyteMessageUtils.createRecordMessage(STREAM_NAME, FIELD_NAME, "blue");
   private static final AirbyteMessage RECORD_MESSAGE2 = AirbyteMessageUtils.createRecordMessage(STREAM_NAME, FIELD_NAME, "yellow");

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
@@ -169,7 +169,7 @@ class DefaultReplicationWorkerTest {
     verify(source).close();
     verify(destination).close();
   }
-}
+
   @Test
   void testReplicationRunnableSourceFailure() throws Exception {
     final String SOURCE_ERROR_MESSAGE = "the source had a failure";

--- a/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/DefaultReplicationWorkerTest.java
@@ -70,7 +70,7 @@ class DefaultReplicationWorkerTest {
   private static final String JOB_ID = "0";
   private static final int JOB_ATTEMPT = 0;
   private static final Path WORKSPACE_ROOT = Path.of("workspaces/10");
-  private static final String STREAM_NAME = "user_preferences";
+  private static final String STREAM_NAME = "favorite_color_pipeuser_preferences";
   private static final String FIELD_NAME = "favorite_color";
   private static final AirbyteMessage RECORD_MESSAGE1 = AirbyteMessageUtils.createRecordMessage(STREAM_NAME, FIELD_NAME, "blue");
   private static final AirbyteMessage RECORD_MESSAGE2 = AirbyteMessageUtils.createRecordMessage(STREAM_NAME, FIELD_NAME, "yellow");

--- a/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
@@ -30,13 +30,13 @@ public class RecordSchemaValidatorTest {
 
   @Test
   void testValidateValidSchema() throws Exception {
-    final RecordSchemaValidator recordSchemaValidator = new RecordSchemaValidator(syncInput);
+    final RecordSchemaValidator recordSchemaValidator = new RecordSchemaValidator(syncInput, WorkerUtils.mapStreamNamesToSchemas(syncInput));
     recordSchemaValidator.validateSchema(VALID_RECORD.getRecord());
   }
 
   @Test
   void testValidateInvalidSchema() throws Exception {
-    final RecordSchemaValidator recordSchemaValidator = new RecordSchemaValidator(syncInput);
+    final RecordSchemaValidator recordSchemaValidator = new RecordSchemaValidator(syncInput, WorkerUtils.mapStreamNamesToSchemas(syncInput));
     assertThrows(RecordSchemaValidationException.class, () -> recordSchemaValidator.validateSchema(INVALID_RECORD.getRecord()));
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 public class RecordSchemaValidatorTest {
 
   private StandardSyncInput syncInput;
-  private static final String STREAM_NAME = "favorite_color_pipeuser_preferences";
+  private static final String STREAM_NAME = "user_preferences";
   private static final String FIELD_NAME = "favorite_color";
   private static final AirbyteMessage VALID_RECORD = AirbyteMessageUtils.createRecordMessage(STREAM_NAME, FIELD_NAME, "blue");
   private static final AirbyteMessage INVALID_RECORD = AirbyteMessageUtils.createRecordMessage(STREAM_NAME, FIELD_NAME, 3);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
@@ -1,4 +1,11 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.workers;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncInput;
@@ -7,11 +14,9 @@ import io.airbyte.workers.protocols.airbyte.AirbyteMessageUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-
 
 public class RecordSchemaValidatorTest {
+
   private StandardSyncInput syncInput;
   private static final String STREAM_NAME = "favorite_color_pipeuser_preferences";
   private static final String FIELD_NAME = "favorite_color";
@@ -35,4 +40,5 @@ public class RecordSchemaValidatorTest {
     final RecordSchemaValidator recordSchemaValidator = new RecordSchemaValidator();
     assertThrows(RecordSchemaValidationException.class, () -> recordSchemaValidator.validateSchema(INVALID_RECORD, syncInput));
   }
+
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
@@ -1,7 +1,5 @@
 package io.airbyte.workers;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.protocol.models.AirbyteMessage;
@@ -15,8 +13,7 @@ import static org.mockito.Mockito.mock;
 
 public class RecordSchemaValidatorTest {
   private StandardSyncInput syncInput;
-  private JsonNode expectedSchema;
-  private static final String STREAM_NAME = "user_preferences";
+  private static final String STREAM_NAME = "favorite_color_pipeuser_preferences";
   private static final String FIELD_NAME = "favorite_color";
   private static final AirbyteMessage VALID_RECORD = AirbyteMessageUtils.createRecordMessage(STREAM_NAME, FIELD_NAME, "blue");
   private static final AirbyteMessage INVALID_RECORD = AirbyteMessageUtils.createRecordMessage(STREAM_NAME, FIELD_NAME, 3);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
@@ -1,0 +1,41 @@
+package io.airbyte.workers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSyncInput;
+import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.workers.protocols.airbyte.AirbyteMessageUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+
+public class RecordSchemaValidatorTest {
+  private StandardSyncInput syncInput;
+  private JsonNode expectedSchema;
+  private static final String STREAM_NAME = "user_preferences";
+  private static final String FIELD_NAME = "favorite_color";
+  private static final AirbyteMessage VALID_RECORD = AirbyteMessageUtils.createRecordMessage(STREAM_NAME, FIELD_NAME, "blue");
+  private static final AirbyteMessage INVALID_RECORD = AirbyteMessageUtils.createRecordMessage(STREAM_NAME, FIELD_NAME, 3);
+
+  @BeforeEach
+  void setup() throws Exception {
+    final ImmutablePair<StandardSync, StandardSyncInput> syncPair = TestConfigHelpers.createSyncConfig();
+    syncInput = syncPair.getValue();
+  }
+
+  @Test
+  void testValidateValidSchema() throws Exception {
+    final RecordSchemaValidator recordSchemaValidator = mock(RecordSchemaValidator.class);
+    recordSchemaValidator.validateSchema(VALID_RECORD, syncInput);
+  }
+
+  @Test
+  void testValidateInvalidSchema() throws Exception {
+    final RecordSchemaValidator recordSchemaValidator = new RecordSchemaValidator();
+    assertThrows(RecordSchemaValidationException.class, () -> recordSchemaValidator.validateSchema(INVALID_RECORD, syncInput));
+  }
+}

--- a/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
@@ -5,7 +5,6 @@
 package io.airbyte.workers;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncInput;

--- a/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
@@ -30,13 +30,13 @@ public class RecordSchemaValidatorTest {
 
   @Test
   void testValidateValidSchema() throws Exception {
-    final RecordSchemaValidator recordSchemaValidator = new RecordSchemaValidator(syncInput, WorkerUtils.mapStreamNamesToSchemas(syncInput));
+    final RecordSchemaValidator recordSchemaValidator = new RecordSchemaValidator(WorkerUtils.mapStreamNamesToSchemas(syncInput));
     recordSchemaValidator.validateSchema(VALID_RECORD.getRecord());
   }
 
   @Test
   void testValidateInvalidSchema() throws Exception {
-    final RecordSchemaValidator recordSchemaValidator = new RecordSchemaValidator(syncInput, WorkerUtils.mapStreamNamesToSchemas(syncInput));
+    final RecordSchemaValidator recordSchemaValidator = new RecordSchemaValidator(WorkerUtils.mapStreamNamesToSchemas(syncInput));
     assertThrows(RecordSchemaValidationException.class, () -> recordSchemaValidator.validateSchema(INVALID_RECORD.getRecord()));
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/RecordSchemaValidatorTest.java
@@ -31,14 +31,14 @@ public class RecordSchemaValidatorTest {
 
   @Test
   void testValidateValidSchema() throws Exception {
-    final RecordSchemaValidator recordSchemaValidator = mock(RecordSchemaValidator.class);
-    recordSchemaValidator.validateSchema(VALID_RECORD, syncInput);
+    final RecordSchemaValidator recordSchemaValidator = new RecordSchemaValidator(syncInput);
+    recordSchemaValidator.validateSchema(VALID_RECORD.getRecord());
   }
 
   @Test
   void testValidateInvalidSchema() throws Exception {
-    final RecordSchemaValidator recordSchemaValidator = new RecordSchemaValidator();
-    assertThrows(RecordSchemaValidationException.class, () -> recordSchemaValidator.validateSchema(INVALID_RECORD, syncInput));
+    final RecordSchemaValidator recordSchemaValidator = new RecordSchemaValidator(syncInput);
+    assertThrows(RecordSchemaValidationException.class, () -> recordSchemaValidator.validateSchema(INVALID_RECORD.getRecord()));
   }
 
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/TestConfigHelpers.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/TestConfigHelpers.java
@@ -37,6 +37,10 @@ public class TestConfigHelpers {
   private static final long LAST_SYNC_TIME = 1598565106;
 
   public static ImmutablePair<StandardSync, StandardSyncInput> createSyncConfig() {
+    return createSyncConfig(false);
+  }
+
+  public static ImmutablePair<StandardSync, StandardSyncInput> createSyncConfig(final Boolean multipleNamespaces) {
     final UUID workspaceId = UUID.randomUUID();
     final UUID sourceDefinitionId = UUID.randomUUID();
     final UUID sourceId = UUID.randomUUID();
@@ -90,9 +94,21 @@ public class TestConfigHelpers {
             .withGitRepoBranch("git url"))
         .withTombstone(false);
 
-    final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream()
-        .withStream(CatalogHelpers.createAirbyteStream(STREAM_NAME, Field.of(FIELD_NAME, JsonSchemaType.STRING)));
-    final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(Collections.singletonList(stream));
+    final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog();
+    if (multipleNamespaces) {
+      final ConfiguredAirbyteStream streamOne = new ConfiguredAirbyteStream()
+          .withStream(CatalogHelpers.createAirbyteStream(STREAM_NAME, "namespace", Field.of(FIELD_NAME, JsonSchemaType.STRING)));
+      final ConfiguredAirbyteStream streamTwo = new ConfiguredAirbyteStream()
+          .withStream(CatalogHelpers.createAirbyteStream(STREAM_NAME, "namespace2", Field.of(FIELD_NAME, JsonSchemaType.STRING)));
+
+      final List<ConfiguredAirbyteStream> streams = List.of(streamOne, streamTwo);
+      catalog.withStreams(streams);
+
+    } else {
+      final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream()
+          .withStream(CatalogHelpers.createAirbyteStream(STREAM_NAME, Field.of(FIELD_NAME, JsonSchemaType.STRING)));
+      catalog.withStreams(Collections.singletonList(stream));
+    }
 
     final StandardSync standardSync = new StandardSync()
         .withConnectionId(connectionId)

--- a/airbyte-workers/src/test/java/io/airbyte/workers/WorkerUtilsTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/WorkerUtilsTest.java
@@ -4,20 +4,26 @@
 
 package io.airbyte.workers;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.config.Configs;
 import io.airbyte.config.EnvConfigs;
+import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSyncInput;
 import io.airbyte.workers.protocols.airbyte.HeartbeatMonitor;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -114,6 +120,23 @@ class WorkerUtilsTest {
       verifyNoInteractions(forceShutdown);
     }
 
+  }
+
+  @Test
+  void testMapStreamNamesToSchemasWithNullNamespace() {
+    final ImmutablePair<StandardSync, StandardSyncInput> syncPair = TestConfigHelpers.createSyncConfig();
+    final StandardSyncInput syncInput = syncPair.getValue();
+    final Map<String, JsonNode> mapOutput = WorkerUtils.mapStreamNamesToSchemas(syncInput);
+    assertNotNull(mapOutput.get("favorite_color_pipeuser_preferences"));
+  }
+
+  @Test
+  void testMapStreamNamesToSchemasWithMultipleNamespaces() {
+    final ImmutablePair<StandardSync, StandardSyncInput> syncPair = TestConfigHelpers.createSyncConfig(true);
+    final StandardSyncInput syncInput = syncPair.getValue();
+    final Map<String, JsonNode> mapOutput = WorkerUtils.mapStreamNamesToSchemas(syncInput);
+    assertNotNull(mapOutput.get("namespacefavorite_color_pipeuser_preferences"));
+    assertNotNull(mapOutput.get("namespace2favorite_color_pipeuser_preferences"));
   }
 
   /**

--- a/airbyte-workers/src/test/java/io/airbyte/workers/WorkerUtilsTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/WorkerUtilsTest.java
@@ -127,7 +127,7 @@ class WorkerUtilsTest {
     final ImmutablePair<StandardSync, StandardSyncInput> syncPair = TestConfigHelpers.createSyncConfig();
     final StandardSyncInput syncInput = syncPair.getValue();
     final Map<String, JsonNode> mapOutput = WorkerUtils.mapStreamNamesToSchemas(syncInput);
-    assertNotNull(mapOutput.get("favorite_color_pipeuser_preferences"));
+    assertNotNull(mapOutput.get("user_preferences"));
   }
 
   @Test
@@ -135,8 +135,8 @@ class WorkerUtilsTest {
     final ImmutablePair<StandardSync, StandardSyncInput> syncPair = TestConfigHelpers.createSyncConfig(true);
     final StandardSyncInput syncInput = syncPair.getValue();
     final Map<String, JsonNode> mapOutput = WorkerUtils.mapStreamNamesToSchemas(syncInput);
-    assertNotNull(mapOutput.get("namespacefavorite_color_pipeuser_preferences"));
-    assertNotNull(mapOutput.get("namespace2favorite_color_pipeuser_preferences"));
+    assertNotNull(mapOutput.get("namespaceuser_preferences"));
+    assertNotNull(mapOutput.get("namespace2user_preferences"));
   }
 
   /**

--- a/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/AirbyteMessageUtils.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/protocols/airbyte/AirbyteMessageUtils.java
@@ -46,7 +46,13 @@ public class AirbyteMessageUtils {
   }
 
   public static AirbyteMessage createRecordMessage(final String tableName,
-                                                   final Map<String, String> record) {
+                                                   final String key,
+                                                   final Integer value) {
+    return createRecordMessage(tableName, ImmutableMap.of(key, value));
+  }
+
+  public static AirbyteMessage createRecordMessage(final String tableName,
+                                                   final Map<String, ?> record) {
     return createRecordMessage(tableName, Jsons.jsonNode(record), Instant.EPOCH);
   }
 


### PR DESCRIPTION
## What
Update to the DefaultReplicationWorker to use a new RecordSchemaValidation class to validate each AirbyteRecord from the source to ensure that the schema of each record is the same as what is declared in the ConfiguredAirbyteCatalog. For now, we are logging results instead of raising an error when the record schema is invalid.

The RecordSchemaValidator is a new class for validating record message schemas. This class is initialized with a map of source stream names to json schemas, so that when we validate a record, we can easily access the schema it should be validated against.

The record validation happens within the DefaultReplicationWorker before we update the Record Message's attributes with `mapMessage`.