### PR TITLE
Helm chart: add Kubernetes Auth options, fix k8s job tolerations

### DIFF
--- a/charts/airbyte/templates/_helpers.tpl
+++ b/charts/airbyte/templates/_helpers.tpl
@@ -238,3 +238,14 @@ Construct comma separated list of key/value pairs from object (useful for ENV va
 {{- end -}}
 {{ join "," $kvList }}
 {{- end -}}
+
+{{/*
+Construct semi-colon delimited list of comma separated key/value pairs from array of objects (useful for ENV var values)
+*/}}
+{{- define "airbyte.flattenArrayMap" -}}
+{{- $mapList := list -}}
+{{- range $element := . -}}
+{{- $mapList = include "airbyte.flattenMap" $element | mustAppend $mapList -}}
+{{- end -}}
+{{ join ";" $mapList }}
+{{- end -}}

--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -28,13 +28,15 @@ data:
   JOB_KUBE_NODE_SELECTORS: {{ $.Values.jobs.kube.nodeSelector | include "airbyte.flattenMap" | quote }}
 {{- end }}
 {{- if $.Values.jobs.kube.tolerations }}
-  JOB_KUBE_TOLERATIONS: {{ $.Values.jobs.kube.tolerations | include "airbyte.flattenMap" | quote }}
+  JOB_KUBE_TOLERATIONS: {{ $.Values.jobs.kube.tolerations | include "airbyte.flattenArrayMap" | quote }}
 {{- end }}
   JOB_MAIN_CONTAINER_CPU_LIMIT: {{ ((.Values.jobs.resources | default dict).limits | default dict).cpu | default "" | quote }}
   JOB_MAIN_CONTAINER_CPU_REQUEST: {{ ((.Values.jobs.resources | default dict).requests | default dict).cpu | default "" | quote }}
   JOB_MAIN_CONTAINER_MEMORY_LIMIT: {{ ((.Values.jobs.resources | default dict).limits | default dict).memory | default "" | quote }}
   JOB_MAIN_CONTAINER_MEMORY_REQUEST: {{ ((.Values.jobs.resources | default dict).requests | default dict).memory | default "" | quote }}
   JOBS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION: "0.29.15.001"
+  KUBERNETES_AUTH_TRYKUBECONFIG: {{ .Values.kubernetesAuth.tryKubeConfig | quote }}
+  KUBERNETES_AUTH_TRYSERVICEACCOUNT: {{ .Values.kubernetesAuth.tryServiceAccount | quote }}
   LOCAL_ROOT: /tmp/airbyte_local
   RUN_DATABASE_MIGRATION_ON_STARTUP: "true"
   S3_LOG_BUCKET: {{ .Values.logs.s3.bucket | quote }}

--- a/charts/airbyte/templates/pod-sweeper/deployment.yaml
+++ b/charts/airbyte/templates/pod-sweeper/deployment.yaml
@@ -22,6 +22,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "airbyte.serviceAccountName" . }}
+      {{- if and .Values.serviceAccount.create .Values.kubernetesAuth.tryServiceAccount }}
+      automountServiceAccountToken: true
+      {{- end }}
       {{- if .Values.podSweeper.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.podSweeper.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
@@ -40,6 +43,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_AUTH_TRYSERVICEACCOUNT
+          valueFrom:
+            configMapKeyRef:
+              name: airbyte-env
+              key: KUBERNETES_AUTH_TRYSERVICEACCOUNT
+        - name: KUBERNETES_AUTH_TRYKUBECONFIG
+          valueFrom:
+            configMapKeyRef:
+              name: airbyte-env
+              key: KUBERNETES_AUTH_TRYKUBECONFIG
         {{- if .Values.podSweeper.containerSecurityContext }}
         securityContext: {{- toYaml .Values.podSweeper.containerSecurityContext | nindent 10 }}
         {{- end }}

--- a/charts/airbyte/templates/worker/deployment.yaml
+++ b/charts/airbyte/templates/worker/deployment.yaml
@@ -112,27 +112,27 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-{{- if $.Values.jobs.kube.annotations }}
+        {{- if $.Values.jobs.kube.annotations }}
         - name: JOB_KUBE_ANNOTATIONS
           valueFrom:
             configMapKeyRef:
               name: airbyte-env
               key: JOB_KUBE_ANNOTATIONS
-{{- end }}
-{{- if $.Values.jobs.kube.nodeSelector }}
+        {{- end }}
+        {{- if $.Values.jobs.kube.nodeSelector }}
         - name: JOB_KUBE_NODE_SELECTORS
           valueFrom:
             configMapKeyRef:
               name: airbyte-env
               key: JOB_KUBE_NODE_SELECTORS
-{{- end }}
-{{- if $.Values.jobs.kube.tolerations }}
+        {{- end }}
+        {{- if $.Values.jobs.kube.tolerations }}
         - name: JOB_KUBE_TOLERATIONS
           valueFrom:
             configMapKeyRef:
               name: airbyte-env
               key: JOB_KUBE_TOLERATIONS
-{{- end }}
+        {{- end }}
         - name: SUBMITTER_NUM_THREADS
           valueFrom:
             configMapKeyRef:
@@ -239,6 +239,16 @@ spec:
             configMapKeyRef:
               name: {{ include "common.names.fullname" . }}-env
               key: INTERNAL_API_HOST
+        - name: KUBERNETES_AUTH_TRYSERVICEACCOUNT
+          valueFrom:
+            configMapKeyRef:
+              name: airbyte-env
+              key: KUBERNETES_AUTH_TRYSERVICEACCOUNT
+        - name: KUBERNETES_AUTH_TRYKUBECONFIG
+          valueFrom:
+            configMapKeyRef:
+              name: airbyte-env
+              key: KUBERNETES_AUTH_TRYKUBECONFIG
         {{- if .Values.worker.extraEnv }}
         {{ .Values.worker.extraEnv | toYaml | nindent 8 }}
         {{- end }}

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -27,6 +27,15 @@ serviceAccount:
   annotations: {}
   name: airbyte-admin
 
+## Kubernetes Authentication
+## Authentication method used by airbyte pods requiring cluster access, eg. worker/pod-sweeper
+## @param kubernetesAuth.tryKubeConfig if true, will try to use kube config mounted inside the pod (default: true)
+## @param kubernetesAuth.tryServiceAccount if true, will try to use serviceAccount credentials from serviceAccount.name (default: false)
+##
+kubernetesAuth:
+  tryKubeConfig: true
+  tryServiceAccount: false
+
 ## @param version Sets the AIRBYTE_VERSION environment variable. Defaults to Chart.AppVersion.
 ## If changing the image tags below, you should probably also update this.
 version: ""
@@ -976,4 +985,9 @@ jobs:
     ## JOB_KUBE_TOLERATIONS
     ## @param jobs.kube.tolerations [array] Tolerations for jobs.kube pod assignment.
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    ## any boolean values should be quoted to ensure the value is passed through as a string, eg:
+    ## - key: airbyte-server
+    ##   operator: Equal
+    ##   value: "true"
+    ##   effect: NoSchedule
     tolerations: []


### PR DESCRIPTION
## What

- Adds kubernetes authentication options:
  - use kube config inside pod
  - use service account/token inside pod
- Fix kube job tolerations

## How
Add 2 new ENV vars:
 - KUBERNETES_AUTH_TRYKUBECONFIG
 - KUBERNETES_AUTH_TRYSERVICEACCOUNT
If either is set to `true` then the pod will try to use the authentication method against kubernetes, afaik this is only `worker` and `pod_sweeper`

Fix kube job tolerations by making sure the `JOB_KUBE_TOLERATIONS` env var gets created via a list of maps (template helper functions takes care of this)

## Recommended reading order


## 🚨 User Impact 🚨
There should be no braking changes from the existing helm chart behaviour, the defaults are as they were

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
