### PR TITLE
Fix navigation paths for source and destination item pages

### DIFF
--- a/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/DestinationItemPage.tsx
+++ b/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/DestinationItemPage.tsx
@@ -38,8 +38,8 @@ const DestinationItemPage: React.FC = () => {
   const onClickBack = () => push("..");
 
   const onSelectStep = (id: string) => {
-    const path = id === StepsTypes.OVERVIEW ? "/" : `/${id.toLowerCase()}`;
-    push(`/destination/${destination.destinationId}${path}`);
+    const path = id === StepsTypes.OVERVIEW ? "." : id.toLowerCase();
+    push(path);
   };
 
   const breadcrumbsData = [

--- a/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/SourceItemPage.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/SourceItemPage.tsx
@@ -63,8 +63,8 @@ const SourceItemPage: React.FC = () => {
   );
 
   const onSelectStep = (id: string) => {
-    const path = id === StepsTypes.OVERVIEW ? "/" : `/${id.toLowerCase()}`;
-    push(`/source/${source.sourceId}${path}`);
+    const path = id === StepsTypes.OVERVIEW ? "." : id.toLowerCase();
+    push(path);
   };
 
   const onSelect = (data: DropDownRow.IDataItem) => {


### PR DESCRIPTION
## What
Fixes an issue introduced in #12186 where the navigation to the settings page was no longer working as expected

## How
Fixes the path such that it navigates to the relative path of the current page. root is the landing page, and `/settings/` is the settings page. Tested in cloud and OSS.

## Recommended reading order
As-is
