### PR TITLE
fix: various nullable resources in OpenAPI config

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2323,6 +2323,7 @@ components:
           type: string
     CustomerioNotificationConfiguration:
       type: object
+      nullable: true
     NotificationType:
       type: string
       enum:
@@ -3498,6 +3499,7 @@ components:
             #- unnesting
     OperatorDbt:
       type: object
+      nullable: true
       required:
         - gitRepoUrl
       properties:
@@ -3772,6 +3774,7 @@ components:
           $ref: "#/components/schemas/AttemptFailureSummary"
     AttemptStats:
       type: object
+      nullable: true
       properties:
         recordsEmitted:
           type: integer
@@ -3797,6 +3800,7 @@ components:
           $ref: "#/components/schemas/AttemptStats"
     AttemptFailureSummary:
       type: object
+      nullable: true
       required:
         - failures
       properties:
@@ -4007,6 +4011,7 @@ components:
     ResourceRequirements:
       description: optional resource requirements to run workers (blank for unbounded allocations)
       type: object
+      nullable: true
       properties:
         cpu_request:
           type: string


### PR DESCRIPTION
## What
Fixes a few instances of the problem mentioned in [#10774](https://github.com/airbytehq/airbyte/issues/10774) by setting the OpenAPI component schemas as `nullable: true`

Specifically adds nullability to the following:
- `CustomerioNotificationConfiguration`
- `OperatorDbt`
- `AttemptStats`
- `AttemptFailureSummary`
- `ResourceRequirements`

## How
Simply add `nullable: true` to the base component so that any operation that uses the component accepts the null version.

## Recommended reading order
N/A

## 🚨 User Impact 🚨
Will allow users to better rely on generated clients from the Airbyte OpenAPI config - no breaking changes.

## Pre-merge Checklist
N/A