### PR TITLE
Adjust auto-disable connection logic for spam

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/AutoDisableConnectionActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/AutoDisableConnectionActivityImpl.java
@@ -76,7 +76,7 @@ public class AutoDisableConnectionActivityImpl implements AutoDisableConnectionA
         }
 
         final boolean warningPreviouslySentForMaxDays =
-            numFailures > 1 && warningPreviouslySentForMaxDays(successTimestamp, maxDaysOfOnlyFailedJobsBeforeWarning, firstJob, jobs);
+            warningPreviouslySentForMaxDays(numFailures, successTimestamp, maxDaysOfOnlyFailedJobsBeforeWarning, firstJob, jobs);
 
         if (numFailures == 0) {
           return new AutoDisableConnectionOutput(false);
@@ -138,11 +138,13 @@ public class AutoDisableConnectionActivityImpl implements AutoDisableConnectionA
   // maxDaysOfOnlyFailedJobsBeforeWarning days after the first job
   // 2. success found and the previous failure occurred maxDaysOfOnlyFailedJobsBeforeWarning days
   // after that success
-  private boolean warningPreviouslySentForMaxDays(final Optional<Long> successTimestamp,
+  private boolean warningPreviouslySentForMaxDays(final int numFailures,
+                                                  final Optional<Long> successTimestamp,
                                                   final int maxDaysOfOnlyFailedJobsBeforeWarning,
                                                   final Job firstJob,
                                                   final List<JobWithStatusAndTimestamp> jobs) {
-    if (jobs.size() <= 1)
+    // no previous warning sent if there was no previous failure
+    if (numFailures <= 1 || jobs.size() <= 1)
       return false;
 
     // get previous failed job (skipping first job since that's considered "current" job)

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/AutoDisableConnectionActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/AutoDisableConnectionActivityImpl.java
@@ -56,6 +56,8 @@ public class AutoDisableConnectionActivityImpl implements AutoDisableConnectionA
         final long currTimestampInSeconds = input.getCurrTimestamp().getEpochSecond();
         final Job lastJob = jobPersistence.getLastReplicationJob(input.getConnectionId())
             .orElseThrow(() -> new Exception("Auto-Disable Connection should not have been attempted if can't get latest replication job."));
+        final Job firstJob = jobPersistence.getFirstReplicationJob(input.getConnectionId())
+            .orElseThrow(() -> new Exception("Auto-Disable Connection should not have been attempted if no replication job has been run."));
 
         final List<JobWithStatusAndTimestamp> jobs = jobPersistence.listJobStatusAndTimestampWithConnection(input.getConnectionId(),
             REPLICATION_TYPES, input.getCurrTimestamp().minus(maxDaysOfOnlyFailedJobs, DAYS));
@@ -73,13 +75,16 @@ public class AutoDisableConnectionActivityImpl implements AutoDisableConnectionA
           }
         }
 
+        final boolean warningPreviouslySentForMaxDays =
+            numFailures > 1 && warningPreviouslySentForMaxDays(successTimestamp, maxDaysOfOnlyFailedJobsBeforeWarning, firstJob, jobs);
+
         if (numFailures == 0) {
           return new AutoDisableConnectionOutput(false);
         } else if (numFailures >= configs.getMaxFailedJobsInARowBeforeConnectionDisable()) {
           // disable connection if max consecutive failed jobs limit has been hit
           disableConnection(input.getConnectionId(), lastJob);
           return new AutoDisableConnectionOutput(true);
-        } else if (numFailures == maxFailedJobsInARowBeforeConnectionDisableWarning) {
+        } else if (numFailures == maxFailedJobsInARowBeforeConnectionDisableWarning && !warningPreviouslySentForMaxDays) {
           // warn if number of consecutive failures hits 50% of MaxFailedJobsInARow
           jobNotifier.autoDisableConnectionWarning(lastJob);
           // explicitly send to email if customer.io api key is set, since email notification cannot be set by
@@ -91,8 +96,6 @@ public class AutoDisableConnectionActivityImpl implements AutoDisableConnectionA
         // calculate the number of days this connection first tried a replication job, used to ensure not to
         // disable or warn for `maxDaysOfOnlyFailedJobs` if the first job is younger than
         // `maxDaysOfOnlyFailedJobs` days, This avoids cases such as "the very first job run was a failure".
-        final Job firstJob = jobPersistence.getFirstReplicationJob(input.getConnectionId())
-            .orElseThrow(() -> new Exception("Auto-Disable Connection should not have been attempted if no replication job has been run."));
         final int numDaysSinceFirstReplicationJob = getDaysSinceTimestamp(currTimestampInSeconds, firstJob.getCreatedAtInSecond());
         final boolean firstReplicationOlderThanMaxDisableDays = numDaysSinceFirstReplicationJob >= maxDaysOfOnlyFailedJobs;
         final boolean noPreviousSuccess = successTimestamp.isEmpty();
@@ -103,6 +106,11 @@ public class AutoDisableConnectionActivityImpl implements AutoDisableConnectionA
           return new AutoDisableConnectionOutput(true);
         }
 
+        // skip warning if previously sent
+        if (warningPreviouslySentForMaxDays || numFailures > maxFailedJobsInARowBeforeConnectionDisableWarning) {
+          return new AutoDisableConnectionOutput(false);
+        }
+
         final boolean firstReplicationOlderThanMaxDisableWarningDays = numDaysSinceFirstReplicationJob >= maxDaysOfOnlyFailedJobsBeforeWarning;
         final boolean successOlderThanPrevFailureByMaxWarningDays = // set to true if no previous success is found
             noPreviousSuccess || getDaysSinceTimestamp(currTimestampInSeconds, successTimestamp.get()) >= maxDaysOfOnlyFailedJobsBeforeWarning;
@@ -110,7 +118,10 @@ public class AutoDisableConnectionActivityImpl implements AutoDisableConnectionA
         // send warning if there are only failed jobs in the past maxDaysOfOnlyFailedJobsBeforeWarning days
         // _unless_ a warning should have already been sent in the previous failure
         if (firstReplicationOlderThanMaxDisableWarningDays && successOlderThanPrevFailureByMaxWarningDays) {
-          sendWarningIfNotPreviouslySent(successTimestamp, maxDaysOfOnlyFailedJobsBeforeWarning, firstJob, lastJob, jobs, numFailures);
+          jobNotifier.autoDisableConnectionWarning(lastJob);
+          // explicitly send to email if customer.io api key is set, since email notification cannot be set by
+          // configs through UI yet
+          jobNotifier.notifyJobByEmail(null, CONNECTION_DISABLED_WARNING_NOTIFICATION, lastJob);
         }
 
       } catch (final Exception e) {
@@ -120,21 +131,6 @@ public class AutoDisableConnectionActivityImpl implements AutoDisableConnectionA
     return new AutoDisableConnectionOutput(false);
   }
 
-  private void sendWarningIfNotPreviouslySent(final Optional<Long> successTimestamp,
-                                              final int maxDaysOfOnlyFailedJobsBeforeWarning,
-                                              final Job firstJob,
-                                              final Job lastJob,
-                                              final List<JobWithStatusAndTimestamp> jobs,
-                                              final int numFailures) {
-    if (numFailures > 1 && checkIfWarningPreviouslySent(successTimestamp, maxDaysOfOnlyFailedJobsBeforeWarning, firstJob, jobs)) {
-      return;
-    }
-    jobNotifier.autoDisableConnectionWarning(lastJob);
-    // explicitly send to email if customer.io api key is set, since email notification cannot be set by
-    // configs through UI yet
-    jobNotifier.notifyJobByEmail(null, CONNECTION_DISABLED_WARNING_NOTIFICATION, lastJob);
-  }
-
   // Checks to see if warning should have been sent in the previous failure, if so skip sending of
   // warning to avoid spam
   // Assume warning has been sent if either of the following is true:
@@ -142,10 +138,10 @@ public class AutoDisableConnectionActivityImpl implements AutoDisableConnectionA
   // maxDaysOfOnlyFailedJobsBeforeWarning days after the first job
   // 2. success found and the previous failure occurred maxDaysOfOnlyFailedJobsBeforeWarning days
   // after that success
-  private boolean checkIfWarningPreviouslySent(final Optional<Long> successTimestamp,
-                                               final int maxDaysOfOnlyFailedJobsBeforeWarning,
-                                               final Job firstJob,
-                                               final List<JobWithStatusAndTimestamp> jobs) {
+  private boolean warningPreviouslySentForMaxDays(final Optional<Long> successTimestamp,
+                                                  final int maxDaysOfOnlyFailedJobsBeforeWarning,
+                                                  final Job firstJob,
+                                                  final List<JobWithStatusAndTimestamp> jobs) {
     if (jobs.size() <= 1)
       return false;
 


### PR DESCRIPTION
## What
address #12287 

tldr: adds logic so if we send a warning for 50 failures in a row, we don't send another warning if there have been only failures in the past 7 days, and vice-versa.