### PR TITLE
Update destination-postgres version in Dockerfile and docs

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -167,7 +167,7 @@
 - name: Postgres
   destinationDefinitionId: 25c5221d-dce2-4163-ade9-739ef790f503
   dockerRepository: airbyte/destination-postgres
-  dockerImageTag: 0.3.17
+  dockerImageTag: 0.3.18
   documentationUrl: https://docs.airbyte.io/integrations/destinations/postgres
   icon: postgresql.svg
 - name: Pulsar

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -3047,7 +3047,7 @@
     supported_destination_sync_modes:
     - "overwrite"
     - "append"
-- dockerImage: "airbyte/destination-postgres:0.3.17"
+- dockerImage: "airbyte/destination-postgres:0.3.18"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/postgres"
     connectionSpecification:

--- a/airbyte-integrations/connectors/destination-postgres/Dockerfile
+++ b/airbyte-integrations/connectors/destination-postgres/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-postgres
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.3.17
+LABEL io.airbyte.version=0.3.18
 LABEL io.airbyte.name=airbyte/destination-postgres

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -82,8 +82,9 @@ Therefore, Airbyte Postgres destination will create tables and schemas using the
 
 ## Changelog
 
-| Version | Date | Pull Request | Subject                                                                                             |
-|:--------| :--- | :--- |:----------------------------------------------------------------------------------------------------|
+| Version | Date       | Pull Request | Subject                                                                                             |
+|:--------|:-----------| :--- |:----------------------------------------------------------------------------------------------------|
+| 0.3.18  | 2022-04-12 | [11729](https://github.com/airbytehq/airbyte/pull/11514) | Bump mina-sshd from 2.7.0 to 2.8.0                                                                   |
 | 0.3.17  | 2022-04-05 | [11729](https://github.com/airbytehq/airbyte/pull/11729) | Fixed bug with dashes in schema name                                                                   |
 | 0.3.15  | 2022-02-25 | [10421](https://github.com/airbytehq/airbyte/pull/10421) | Refactor JDBC parameters handling                                                                   |
 | 0.3.14  | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | (unpublished) Add `-XX:+ExitOnOutOfMemoryError` JVM option                                          |


### PR DESCRIPTION
## What
Following up on https://github.com/airbytehq/airbyte/pull/11514
destination-postgres connector image with version 0.3.18 is already pushed to Dockerhub: https://hub.docker.com/layers/airbyte/destination-postgres/latest/images/sha256-ed695ca5dd742e708efcdfa909ab65e8620723a75e63a2d744aca9d8030333b8?context=explore

In this PR: 
Update destination-postgres version in Dockerfile and docs
