### PR TITLE
Manually bump destination-oracle version

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -161,7 +161,7 @@
 - name: Oracle
   destinationDefinitionId: 3986776d-2319-4de9-8af8-db14c0996e72
   dockerRepository: airbyte/destination-oracle
-  dockerImageTag: 0.1.15
+  dockerImageTag: 0.1.16
   documentationUrl: https://docs.airbyte.io/integrations/destinations/oracle
   icon: oracle.svg
 - name: Postgres

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -2819,7 +2819,7 @@
     supported_destination_sync_modes:
     - "overwrite"
     - "append"
-- dockerImage: "airbyte/destination-oracle:0.1.15"
+- dockerImage: "airbyte/destination-oracle:0.1.16"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/oracle"
     connectionSpecification:

--- a/airbyte-integrations/connectors/destination-oracle/Dockerfile
+++ b/airbyte-integrations/connectors/destination-oracle/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-oracle
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.15
+LABEL io.airbyte.version=0.1.16
 LABEL io.airbyte.name=airbyte/destination-oracle

--- a/docs/integrations/destinations/oracle.md
+++ b/docs/integrations/destinations/oracle.md
@@ -92,6 +92,7 @@ Airbite has the ability to connect to the Oracle source with 3 network connectiv
 
 | Version | Date | Pull Request                                             | Subject                                                                                             |
 |:--------| :--- |:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| 0.1.16  | 2022-04-06 | [11514](https://github.com/airbytehq/airbyte/pull/11514) | Bump mina-sshd from 2.7.0 to 2.8.0                                                                  |
 | 0.1.15  | 2022-02-25 | [10421](https://github.com/airbytehq/airbyte/pull/10421) | Refactor JDBC parameters handling and remove DBT support                                            |
 | 0.1.14  | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | (unpublished) Add `-XX:+ExitOnOutOfMemoryError` JVM option                                          |
 | 0.1.13  | 2021-12-29 | [\#9177](https://github.com/airbytehq/airbyte/pull/9177) | Update connector fields title/description                                                           |


### PR DESCRIPTION
## What
Following up on https://github.com/airbytehq/airbyte/pull/11514
destination-oracle connector image with version 0.1.16 is already pushed to Dockerhub:

https://hub.docker.com/layers/destination-oracle/airbyte/destination-oracle/latest/images/sha256-353b06617d2ce000c65f7c64d8446ecd2965be698cd39a8209b5890295197ad5?context=explore

In this PR:
Update destination-oracle version to 0.1.16 in Dockerfile, docs, and seed conf