### PR TITLE
Manually bump source-clickhouse version

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -133,7 +133,7 @@
 - name: ClickHouse
   sourceDefinitionId: bad83517-5e54-4a3d-9b53-63e85fbd4d7c
   dockerRepository: airbyte/source-clickhouse
-  dockerImageTag: 0.1.8
+  dockerImageTag: 0.1.10
   documentationUrl: https://docs.airbyte.io/integrations/sources/clickhouse
   icon: cliskhouse.svg
   sourceType: database

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -1126,7 +1126,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-clickhouse:0.1.8"
+- dockerImage: "airbyte/source-clickhouse:0.1.10"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/clickhouse"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-clickhouse/Dockerfile
+++ b/airbyte-integrations/connectors/source-clickhouse/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-clickhouse
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.9
+LABEL io.airbyte.version=0.1.10
 LABEL io.airbyte.name=airbyte/source-clickhouse

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -78,6 +78,7 @@ Using this feature requires additional configuration, when creating the source. 
 
 | Version | Date | Pull Request                                             | Subject                                                          |
 |:--------| :--- |:---------------------------------------------------------|:-----------------------------------------------------------------|
+| 0.1.10  | 2022-04-12 | [11729](https://github.com/airbytehq/airbyte/pull/11514) | Bump mina-sshd from 2.7.0 to 2.8.0                         |
 | 0.1.9   | 2022-02-09 | [\#10214](https://github.com/airbytehq/airbyte/pull/10214) | Fix exception in case `password` field is not provided |
 | 0.1.8   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option |
 | 0.1.7   | 2021-12-24 | [\#8958](https://github.com/airbytehq/airbyte/pull/8958) | Add support for JdbcType.ARRAY |


### PR DESCRIPTION
## What
Following up on https://github.com/airbytehq/airbyte/pull/11514
source-clickhouse connector image with version 0.1.10 is already pushed to Dockerhub: 

https://hub.docker.com/layers/source-clickhouse/airbyte/source-clickhouse/latest/images/sha256-39459ae394de9aaaff42664af5ed089c17c205a1ac8f9b7e84a41cbb6a439e03?context=explore

In this PR:
Update source-clickhouse version to 0.1.10 in Dockerfile, docs, and seed config