### PR TITLE
🐞 Destination databricks: fix destination config

### DIFF
--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksConstants.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksConstants.java
@@ -15,4 +15,7 @@ public class DatabricksConstants {
       "delta.autoOptimize.optimizeWrite = true",
       "delta.autoOptimize.autoCompact = true");
 
+  private DatabricksConstants() {
+  }
+
 }

--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksDestinationConfig.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksDestinationConfig.java
@@ -63,6 +63,9 @@ public class DatabricksDestinationConfig {
         dataSource.get("s3_bucket_name").asText(),
         dataSource.get("s3_bucket_path").asText(),
         dataSource.get("s3_bucket_region").asText())
+        .withAccessKeyCredential(
+            dataSource.get("s3_access_key_id").asText(),
+            dataSource.get("s3_secret_access_key").asText())
         .withFormatConfig(new S3ParquetFormatConfig(new ObjectMapper().createObjectNode()))
         .get();
   }


### PR DESCRIPTION
- The Databricks destination config was broken https://github.com/airbytehq/airbyte/pull/11686. The integration test fails because the S3 credentials are not correctly passed into the destination config. This PR fixes it.
- No Databricks version has been published since the bug. So this does not affect any production users.
