### PR TITLE
Update connection replication page fields layout

### DIFF
--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ReplicationView.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ReplicationView.tsx
@@ -21,10 +21,10 @@ import {
 import { equal } from "utils/objects";
 import ConnectionForm from "views/Connection/ConnectionForm";
 
-type IProps = {
+interface Props {
   onAfterSaveSchema: () => void;
   connectionId: string;
-};
+}
 
 const Content = styled.div`
   max-width: 1279px;
@@ -48,7 +48,7 @@ const Note = styled.span`
   color: ${({ theme }) => theme.dangerColor};
 `;
 
-const ReplicationView: React.FC<IProps> = ({ onAfterSaveSchema, connectionId }) => {
+const ReplicationView: React.FC<Props> = ({ onAfterSaveSchema, connectionId }) => {
   const [isModalOpen, setIsUpdateModalOpen] = useState(false);
   const [activeUpdatingSchemaMode, setActiveUpdatingSchemaMode] = useState(false);
   const [saved, setSaved] = useState(false);

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.tsx
@@ -51,8 +51,15 @@ export const FlexRow = styled.div`
   flex-direction: row;
   justify-content: flex-start;
   align-items: flex-start;
-
   gap: 10px;
+`;
+
+export const LeftFieldCol = styled.div`
+  width: 470px;
+`;
+
+export const RightFieldCol = styled.div`
+  width: 300px;
 `;
 
 const StyledSection = styled.div`
@@ -179,45 +186,78 @@ const ConnectionForm: React.FC<ConnectionFormProps> = ({
           <Section title={<FormattedMessage id="connection.transfer" />}>
             <Field name="schedule">
               {({ field, meta }: FieldProps<ScheduleProperties>) => (
-                <ConnectorLabel
-                  nextLine
-                  error={!!meta.error && meta.touched}
-                  label={formatMessage({
-                    id: "form.frequency",
-                  })}
-                  message={formatMessage({
-                    id: "form.frequency.message",
-                  })}
-                >
-                  <DropDown
-                    {...field}
-                    error={!!meta.error && meta.touched}
-                    options={frequencies}
-                    onChange={(item) => {
-                      if (onDropDownSelect) {
-                        onDropDownSelect(item);
-                      }
-                      setFieldValue(field.name, item.value);
-                    }}
-                  />
-                </ConnectorLabel>
+                <FlexRow>
+                  <LeftFieldCol>
+                    <ConnectorLabel
+                      nextLine
+                      error={!!meta.error && meta.touched}
+                      label={formatMessage({
+                        id: "form.frequency",
+                      })}
+                      message={formatMessage({
+                        id: "form.frequency.message",
+                      })}
+                    />
+                  </LeftFieldCol>
+                  <RightFieldCol>
+                    <DropDown
+                      {...field}
+                      error={!!meta.error && meta.touched}
+                      options={frequencies}
+                      onChange={(item) => {
+                        if (onDropDownSelect) {
+                          onDropDownSelect(item);
+                        }
+                        setFieldValue(field.name, item.value);
+                      }}
+                    />
+                  </RightFieldCol>
+                </FlexRow>
               )}
             </Field>
           </Section>
           <Section title={<FormattedMessage id="connection.streams" />}>
-            <FlexRow>
-              <Field name="namespaceDefinition" component={NamespaceDefinitionField} />
-              <Field name="prefix">
-                {({ field }: FieldProps<string>) => (
-                  <ControlLabels
-                    nextLine
-                    label={formatMessage({
-                      id: "form.prefix",
-                    })}
-                    message={formatMessage({
-                      id: "form.prefix.message",
-                    })}
-                  >
+            <Field name="namespaceDefinition" component={NamespaceDefinitionField} />
+            {values.namespaceDefinition === ConnectionNamespaceDefinition.CustomFormat && (
+              <Field name="namespaceFormat">
+                {({ field, meta }: FieldProps<string>) => (
+                  <FlexRow>
+                    <LeftFieldCol>
+                      <NamespaceFormatLabel
+                        nextLine
+                        error={!!meta.error}
+                        label={<FormattedMessage id="connectionForm.namespaceFormat.title" />}
+                        message={<FormattedMessage id="connectionForm.namespaceFormat.subtitle" />}
+                      />
+                    </LeftFieldCol>
+                    <RightFieldCol>
+                      <Input
+                        {...field}
+                        error={!!meta.error}
+                        placeholder={formatMessage({
+                          id: "connectionForm.namespaceFormat.placeholder",
+                        })}
+                      />
+                    </RightFieldCol>
+                  </FlexRow>
+                )}
+              </Field>
+            )}
+            <Field name="prefix">
+              {({ field }: FieldProps<string>) => (
+                <FlexRow>
+                  <LeftFieldCol>
+                    <ControlLabels
+                      nextLine
+                      label={formatMessage({
+                        id: "form.prefix",
+                      })}
+                      message={formatMessage({
+                        id: "form.prefix.message",
+                      })}
+                    />
+                  </LeftFieldCol>
+                  <RightFieldCol>
                     <Input
                       {...field}
                       type="text"
@@ -225,30 +265,10 @@ const ConnectionForm: React.FC<ConnectionFormProps> = ({
                         id: `form.prefix.placeholder`,
                       })}
                     />
-                  </ControlLabels>
-                )}
-              </Field>
-            </FlexRow>
-            {values.namespaceDefinition === ConnectionNamespaceDefinition.CustomFormat && (
-              <Field name="namespaceFormat">
-                {({ field, meta }: FieldProps<string>) => (
-                  <NamespaceFormatLabel
-                    nextLine
-                    error={!!meta.error}
-                    label={<FormattedMessage id="connectionForm.namespaceFormat.title" />}
-                    message={<FormattedMessage id="connectionForm.namespaceFormat.subtitle" />}
-                  >
-                    <Input
-                      {...field}
-                      error={!!meta.error}
-                      placeholder={formatMessage({
-                        id: "connectionForm.namespaceFormat.placeholder",
-                      })}
-                    />
-                  </NamespaceFormatLabel>
-                )}
-              </Field>
-            )}
+                  </RightFieldCol>
+                </FlexRow>
+              )}
+            </Field>
             <Field
               name="syncCatalog.streams"
               destinationSupportedSyncModes={destDefinition.supportedDestinationSyncModes}

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/NamespaceDefinitionField.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/NamespaceDefinitionField.tsx
@@ -6,6 +6,8 @@ import { ControlLabels, DropDown } from "components";
 
 import { ConnectionNamespaceDefinition } from "core/domain/connection";
 
+import { LeftFieldCol, RightFieldCol, FlexRow } from "../ConnectionForm";
+
 export const StreamOptions = [
   {
     value: ConnectionNamespaceDefinition.Source,
@@ -24,26 +26,29 @@ export const StreamOptions = [
   },
 ];
 
-const NamespaceDefinitionField: React.FC<FieldProps<string>> = ({ field, form }) => {
+export const NamespaceDefinitionField: React.FC<FieldProps<string>> = ({ field, form }) => {
   const [, meta] = useField(field.name);
 
   return (
-    <ControlLabels
-      nextLine
-      error={!!meta.error && meta.touched}
-      labelAdditionLength={0}
-      label={<FormattedMessage id="connectionForm.namespaceDefinition.title" />}
-      message={<FormattedMessage id="connectionForm.namespaceDefinition.subtitle" />}
-    >
-      <DropDown
-        name="namespaceDefinition"
-        error={!!meta.error && meta.touched}
-        options={StreamOptions}
-        value={field.value}
-        onChange={({ value }) => form.setFieldValue(field.name, value)}
-      />
-    </ControlLabels>
+    <FlexRow>
+      <LeftFieldCol>
+        <ControlLabels
+          nextLine
+          error={!!meta.error && meta.touched}
+          labelAdditionLength={0}
+          label={<FormattedMessage id="connectionForm.namespaceDefinition.title" />}
+          message={<FormattedMessage id="connectionForm.namespaceDefinition.subtitle" />}
+        />
+      </LeftFieldCol>
+      <RightFieldCol>
+        <DropDown
+          name="namespaceDefinition"
+          error={!!meta.error && meta.touched}
+          options={StreamOptions}
+          value={field.value}
+          onChange={({ value }) => form.setFieldValue(field.name, value)}
+        />
+      </RightFieldCol>
+    </FlexRow>
   );
 };
-
-export { NamespaceDefinitionField };


### PR DESCRIPTION
Updates fields to all start in a new row with a max-width of 810px

## What
Fixes #10797 

Updates the fields in the connection replication page with the updated design:
https://www.figma.com/file/etaOkOsnXMoKwbfhCD71kw/WEB-APP?node-id=33683%3A178171

Before:
<img width="1319" alt="image" src="https://user-images.githubusercontent.com/168664/164992535-7caa5423-5095-4f31-b679-d7f38b0064d9.png">


After:
<img width="1332" alt="image" src="https://user-images.githubusercontent.com/168664/164992508-6b96f634-dafc-4a51-9cd8-2575509b95a7.png">

## How
Splits the field label and the input into columns.

## Recommended reading order
Top to bottom

