### PR TITLE
Fix broken release stage labels/warnings

### DIFF
--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -469,7 +469,7 @@
   "connector.releaseStage.generally_available": "GA",
   "connector.releaseStage.alpha.description": "<b>Alpha connectors</b> are in development and support is not provided.",
   "connector.releaseStage.beta.description": "<b>Beta connectors</b> are in development but stable and reliable and support is provided.",
-  "component.releaseStage.generally_available.description": "<b>Generally Available (GA) connectors</b> have been deemed ready for use in a production environment and is officially supported by Airbyte. Their documentation is considered sufficient to support widespread adoption.",
+  "connector.releaseStage.generally_available.description": "<b>Generally Available (GA) connectors</b> have been deemed ready for use in a production environment and is officially supported by Airbyte. Their documentation is considered sufficient to support widespread adoption.",
   "connector.connectorsInDevelopment.docLink": "See our <lnk>documentation</lnk> for more details.",
   "credits.credits": "Credits",
   "credits.whatAreCredits": "What are credits?",

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/WarningMessage.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/WarningMessage.tsx
@@ -33,7 +33,7 @@ const WarningMessage: React.FC<WarningMessageProps> = ({ stage }) => {
     <Content>
       <FormattedMessage id={`connector.releaseStage.${stage}.description`} />{" "}
       <FormattedMessage
-        id={`connector.docsLink`}
+        id="connector.connectorsInDevelopment.docLink"
         values={{
           lnk: (node: React.ReactNode) => (
             <Link href={config.ui.productReleaseStages} target="_blank" rel="noreferrer">


### PR DESCRIPTION
## What

Fixes #12324 
Fixes #12321

https://github.com/airbytehq/airbyte/pull/12252 broke two labels by mistyped i18n ids. This PR fixes those ids.