### PR TITLE
Remove stale required key in OpenAPI config

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -3143,7 +3143,6 @@ components:
     WebBackendConnectionCreate:
       type: object
       required:
-        - connection
         - sourceId
         - destinationId
         - status


### PR DESCRIPTION
## What
There is a key in required list, but not in properties config, issue: #12340  

## How
Remove the key in required list.

## Recommended reading order
1. `src/main/openapi/config.yaml`: `components.schemas.WebBackendConnectionCreate`
