### PR TITLE
Bump mina-sshd from 2.7.0 to 2.8.0

### DIFF
--- a/airbyte-integrations/bases/base-java/Dockerfile
+++ b/airbyte-integrations/bases/base-java/Dockerfile
@@ -18,5 +18,5 @@ ENV SENTRY_DSN="https://981e729cf92840628b29121e96e958f7@o1009025.ingest.sentry.
 ENV AIRBYTE_ENTRYPOINT "/airbyte/base.sh"
 ENTRYPOINT ["/airbyte/base.sh"]
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/integration-base-java

--- a/airbyte-integrations/bases/base-java/build.gradle
+++ b/airbyte-integrations/bases/base-java/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     api 'io.sentry:sentry:5.6.0'
 
     implementation 'commons-cli:commons-cli:1.4'
-    implementation 'org.apache.sshd:sshd-mina:2.7.0'
+    implementation 'org.apache.sshd:sshd-mina:2.8.0'
     // bouncycastle is pinned to version-match the transitive dependency from kubernetes client-java
     // because a version conflict causes "parameter object not a ECParameterSpec" on ssh tunnel initiation
     implementation 'org.bouncycastle:bcprov-jdk15on:1.66'


### PR DESCRIPTION
## What
This is an attempt to merge the main change from [11514](https://github.com/airbytehq/airbyte/pull/11514), which now has multiple conflicts.

### The gist of the change
(copied from the original [PR](https://github.com/airbytehq/airbyte/pull/11514))

When creating a Postgres destination connector with SSH tunnel method 'SSH Key Authentication', one is required to provide a RSA key. Creating a rsa-sha2-256 or rsa-sha2-512 key, will result in the error SshException: KeyExchange signature verification failed for key type=ssh-rsa, if you haven't enabled ssh-rsa in the SSH server's host key algorithms.

mina-sshd in version 2.7.0 uses the wrong server key signature algorithm during DH group key exchange. https://issues.apache.org/jira/browse/SSHD-1163.

Bumping mina-sshd to version 2.8.0 addresses this issue. Changelog https://github.com/apache/mina-sshd/blob/master/docs/changes/2.8.0.md.

## Note

> Connectors affected by this change have already been published to Docker Hub and seed files are already updated with new versions
