### PR TITLE
Update Input password component layout to avoid password manager button overlap with visibility button

### DIFF
--- a/airbyte-webapp/src/components/base/Input/Input.test.tsx
+++ b/airbyte-webapp/src/components/base/Input/Input.test.tsx
@@ -1,0 +1,34 @@
+import { render } from "@testing-library/react";
+
+import { Input } from "./Input";
+
+describe("<Input />", () => {
+  test("renders text input", () => {
+    const value = "aribyte@example.com";
+    const { getByTestId, queryByTestId } = render(<Input defaultValue={value} />);
+
+    expect(getByTestId("input")).toHaveAttribute("type", "text");
+    expect(getByTestId("input")).toHaveValue(value);
+    expect(queryByTestId("toggle-password-visibility-button")).toBeFalsy();
+  });
+
+  test("renders password input with visibilty button", () => {
+    const value = "eight888";
+    const { getByTestId, getByRole } = render(<Input type="password" defaultValue={value} />);
+
+    expect(getByTestId("input")).toHaveAttribute("type", "password");
+    expect(getByTestId("input")).toHaveValue(value);
+    expect(getByRole("img", { hidden: true })).toHaveAttribute("data-icon", "eye");
+  });
+
+  test("renders visible password when visibility button is clicked", () => {
+    const value = "eight888";
+    const { getByTestId, getByRole } = render(<Input type="password" defaultValue={value} />);
+
+    getByTestId("toggle-password-visibility-button").click();
+
+    expect(getByTestId("input")).toHaveAttribute("type", "text");
+    expect(getByTestId("input")).toHaveValue(value);
+    expect(getByRole("img", { hidden: true })).toHaveAttribute("data-icon", "eye-slash");
+  });
+});

--- a/airbyte-webapp/src/components/base/Input/Input.test.tsx
+++ b/airbyte-webapp/src/components/base/Input/Input.test.tsx
@@ -5,9 +5,19 @@ import { Input } from "./Input";
 describe("<Input />", () => {
   test("renders text input", () => {
     const value = "aribyte@example.com";
-    const { getByTestId, queryByTestId } = render(<Input defaultValue={value} />);
+    const { getByTestId, queryByTestId } = render(<Input type="text" defaultValue={value} />);
 
     expect(getByTestId("input")).toHaveAttribute("type", "text");
+    expect(getByTestId("input")).toHaveValue(value);
+    expect(queryByTestId("toggle-password-visibility-button")).toBeFalsy();
+  });
+
+  test("renders other type of input", () => {
+    const type = "number";
+    const value = 888;
+    const { getByTestId, queryByTestId } = render(<Input type={type} defaultValue={value} />);
+
+    expect(getByTestId("input")).toHaveAttribute("type", type);
     expect(getByTestId("input")).toHaveValue(value);
     expect(queryByTestId("toggle-password-visibility-button")).toBeFalsy();
   });

--- a/airbyte-webapp/src/components/base/Input/Input.test.tsx
+++ b/airbyte-webapp/src/components/base/Input/Input.test.tsx
@@ -1,41 +1,41 @@
-import { render } from "@testing-library/react";
+import { render } from "utils/testutils";
 
 import { Input } from "./Input";
 
 describe("<Input />", () => {
-  test("renders text input", () => {
+  test("renders text input", async () => {
     const value = "aribyte@example.com";
-    const { getByTestId, queryByTestId } = render(<Input type="text" defaultValue={value} />);
+    const { getByTestId, queryByTestId } = await render(<Input type="text" defaultValue={value} />);
 
     expect(getByTestId("input")).toHaveAttribute("type", "text");
     expect(getByTestId("input")).toHaveValue(value);
     expect(queryByTestId("toggle-password-visibility-button")).toBeFalsy();
   });
 
-  test("renders other type of input", () => {
+  test("renders another type of input", async () => {
     const type = "number";
     const value = 888;
-    const { getByTestId, queryByTestId } = render(<Input type={type} defaultValue={value} />);
+    const { getByTestId, queryByTestId } = await render(<Input type={type} defaultValue={value} />);
 
     expect(getByTestId("input")).toHaveAttribute("type", type);
     expect(getByTestId("input")).toHaveValue(value);
     expect(queryByTestId("toggle-password-visibility-button")).toBeFalsy();
   });
 
-  test("renders password input with visibilty button", () => {
+  test("renders password input with visibilty button", async () => {
     const value = "eight888";
-    const { getByTestId, getByRole } = render(<Input type="password" defaultValue={value} />);
+    const { getByTestId, getByRole } = await render(<Input type="password" defaultValue={value} />);
 
     expect(getByTestId("input")).toHaveAttribute("type", "password");
     expect(getByTestId("input")).toHaveValue(value);
     expect(getByRole("img", { hidden: true })).toHaveAttribute("data-icon", "eye");
   });
 
-  test("renders visible password when visibility button is clicked", () => {
+  test("renders visible password when visibility button is clicked", async () => {
     const value = "eight888";
-    const { getByTestId, getByRole } = render(<Input type="password" defaultValue={value} />);
+    const { getByTestId, getByRole } = await render(<Input type="password" defaultValue={value} />);
 
-    getByTestId("toggle-password-visibility-button").click();
+    getByTestId("toggle-password-visibility-button")?.click();
 
     expect(getByTestId("input")).toHaveAttribute("type", "text");
     expect(getByTestId("input")).toHaveValue(value);

--- a/airbyte-webapp/src/components/base/Input/Input.tsx
+++ b/airbyte-webapp/src/components/base/Input/Input.tsx
@@ -19,10 +19,10 @@ const getBackgroundColor = (props: IStyleProps) => {
   return props.theme.greyColor0;
 };
 
-export type InputProps = {
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   error?: boolean;
   light?: boolean;
-} & React.InputHTMLAttributes<HTMLInputElement>;
+}
 
 const InputContainer = styled.div<InputProps>`
   width: 100%;

--- a/airbyte-webapp/src/components/base/Input/Input.tsx
+++ b/airbyte-webapp/src/components/base/Input/Input.tsx
@@ -1,6 +1,7 @@
 import { faEye, faEyeSlash } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import React, { useState } from "react";
+import React from "react";
+import { useIntl } from "react-intl";
 import { useToggle } from "react-use";
 import styled from "styled-components";
 import { Theme } from "theme";
@@ -77,7 +78,8 @@ const VisibilityButton = styled(Button)`
 `;
 
 const Input: React.FC<InputProps> = (props) => {
-  const [isContentVisible, setIsContentVisible] = useState(false);
+  const { formatMessage } = useIntl();
+  const [isContentVisible, setIsContentVisible] = useToggle(false);
   const [focused, toggleFocused] = useToggle(false);
 
   const isPassword = props.type === "password";
@@ -98,8 +100,11 @@ const Input: React.FC<InputProps> = (props) => {
       {isVisibilityButtonVisible ? (
         <VisibilityButton
           iconOnly
-          onClick={() => setIsContentVisible(!isContentVisible)}
+          onClick={() => setIsContentVisible()}
           type="button"
+          aria-label={formatMessage({
+            id: `ui.input.${isContentVisible ? "hide" : "show"}Password`,
+          })}
           data-testid="toggle-password-visibility-button"
         >
           <FontAwesomeIcon icon={isContentVisible ? faEyeSlash : faEye} fixedWidth />

--- a/airbyte-webapp/src/components/base/Input/Input.tsx
+++ b/airbyte-webapp/src/components/base/Input/Input.tsx
@@ -1,6 +1,7 @@
 import { faEye, faEyeSlash } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { useState } from "react";
+import { useToggle } from "react-use";
 import styled from "styled-components";
 import { Theme } from "theme";
 
@@ -23,31 +24,38 @@ export type InputProps = {
   light?: boolean;
 } & React.InputHTMLAttributes<HTMLInputElement>;
 
-const InputComponent = styled.input<InputProps>`
-  outline: none;
+const InputContainer = styled.div<InputProps>`
   width: 100%;
-  padding: 7px 18px 7px 8px;
-  border-radius: 4px;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: normal;
-  border: 1px solid ${(props) => (props.error ? props.theme.dangerColor : props.theme.greyColor0)};
+  position: relative;
   background: ${(props) => getBackgroundColor(props)};
-  color: ${({ theme }) => theme.textColor};
-  caret-color: ${({ theme }) => theme.primaryColor};
-
-  &::placeholder {
-    color: ${({ theme }) => theme.greyColor40};
-  }
+  border: 1px solid ${(props) => (props.error ? props.theme.dangerColor : props.theme.greyColor0)};
+  border-radius: 4px;
 
   &:hover {
     background: ${({ theme, light }) => (light ? theme.whiteColor : theme.greyColor20)};
     border-color: ${(props) => (props.error ? props.theme.dangerColor : props.theme.greyColor20)};
   }
 
-  &:focus {
+  &.input-container--focused {
     background: ${({ theme, light }) => (light ? theme.whiteColor : theme.primaryColor12)};
     border-color: ${({ theme }) => theme.primaryColor};
+  }
+`;
+
+const InputComponent = styled.input<InputProps & { isPassword?: boolean }>`
+  outline: none;
+  width: ${({ isPassword }) => (isPassword ? "calc(100% - 22px)" : "100%")};
+  padding: 7px 8px 7px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: normal;
+  border: none;
+  background: none;
+  color: ${({ theme }) => theme.textColor};
+  caret-color: ${({ theme }) => theme.primaryColor};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.greyColor40};
   }
 
   &:disabled {
@@ -56,34 +64,42 @@ const InputComponent = styled.input<InputProps>`
   }
 `;
 
-const Container = styled.div`
-  width: 100%;
-  position: relative;
-`;
-
 const VisibilityButton = styled(Button)`
   position: absolute;
-  right: 2px;
-  top: 7px;
+  right: 0px;
+  top: 0;
+  display: flex;
+  height: 100%;
+  width: 30px;
+  align-items: center;
+  justify-content: center;
+  border: none;
 `;
 
 const Input: React.FC<InputProps> = (props) => {
   const [isContentVisible, setIsContentVisible] = useState(false);
+  const [focused, toggleFocused] = useToggle(false);
 
-  if (props.type === "password") {
-    return (
-      <Container>
-        <InputComponent {...props} type={isContentVisible ? "text" : "password"} />
-        {props.disabled ? null : (
-          <VisibilityButton iconOnly onClick={() => setIsContentVisible(!isContentVisible)} type="button">
-            <FontAwesomeIcon icon={isContentVisible ? faEyeSlash : faEye} />
-          </VisibilityButton>
-        )}
-      </Container>
-    );
-  }
+  const isPassword = props.type === "password";
+  const isVisibilityButtonVisible = isPassword && !props.disabled;
+  const onInputFocusChange = () => toggleFocused();
 
-  return <InputComponent {...props} />;
+  return (
+    <InputContainer {...props} className={focused ? "input-container--focused" : undefined}>
+      <InputComponent
+        {...props}
+        type={!isPassword || isContentVisible ? "text" : "password"}
+        isPassword={isPassword}
+        onFocus={onInputFocusChange}
+        onBlur={onInputFocusChange}
+      />
+      {isVisibilityButtonVisible ? (
+        <VisibilityButton iconOnly onClick={() => setIsContentVisible(!isContentVisible)} type="button">
+          <FontAwesomeIcon icon={isContentVisible ? faEyeSlash : faEye} fixedWidth />
+        </VisibilityButton>
+      ) : null}
+    </InputContainer>
+  );
 };
 
 export default Input;

--- a/airbyte-webapp/src/components/base/Input/Input.tsx
+++ b/airbyte-webapp/src/components/base/Input/Input.tsx
@@ -92,9 +92,15 @@ const Input: React.FC<InputProps> = (props) => {
         isPassword={isPassword}
         onFocus={onInputFocusChange}
         onBlur={onInputFocusChange}
+        data-testid="input"
       />
       {isVisibilityButtonVisible ? (
-        <VisibilityButton iconOnly onClick={() => setIsContentVisible(!isContentVisible)} type="button">
+        <VisibilityButton
+          iconOnly
+          onClick={() => setIsContentVisible(!isContentVisible)}
+          type="button"
+          data-testid="toggle-password-visibility-button"
+        >
           <FontAwesomeIcon icon={isContentVisible ? faEyeSlash : faEye} fixedWidth />
         </VisibilityButton>
       ) : null}

--- a/airbyte-webapp/src/components/base/Input/Input.tsx
+++ b/airbyte-webapp/src/components/base/Input/Input.tsx
@@ -82,13 +82,14 @@ const Input: React.FC<InputProps> = (props) => {
 
   const isPassword = props.type === "password";
   const isVisibilityButtonVisible = isPassword && !props.disabled;
+  const type = isPassword ? (isContentVisible ? "text" : "password") : props.type;
   const onInputFocusChange = () => toggleFocused();
 
   return (
     <InputContainer {...props} className={focused ? "input-container--focused" : undefined}>
       <InputComponent
         {...props}
-        type={!isPassword || isContentVisible ? "text" : "password"}
+        type={type}
         isPassword={isPassword}
         onFocus={onInputFocusChange}
         onBlur={onInputFocusChange}

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -487,6 +487,8 @@
   "errorView.notFound": "Resource not found",
   "errorView.unknown": "Unknown",
 
+  "ui.input.showPassword": "Show password",
+  "ui.input.hidePassword": "Hide password",
   "ui.keyValuePair": "{key}: {value}",
   "ui.keyValuePairV2": "{key} ({value})",
   "ui.keyValuePairV3": "{key}, {value}",

--- a/airbyte-webapp/src/utils/testutils.tsx
+++ b/airbyte-webapp/src/utils/testutils.tsx
@@ -1,5 +1,4 @@
-import { act, Queries, render as rtlRender, RenderResult } from "@testing-library/react";
-import { History } from "history";
+import { act, Queries, queries, render as rtlRender, RenderOptions, RenderResult } from "@testing-library/react";
 import React from "react";
 import { IntlProvider } from "react-intl";
 import { MemoryRouter } from "react-router-dom";
@@ -9,20 +8,14 @@ import { configContext, defaultConfig } from "config";
 import { FeatureService } from "hooks/services/Feature";
 import en from "locales/en.json";
 
-export type RenderOptions = {
-  // optionally pass in a history object to control routes in the test
-  history?: History;
-  container?: HTMLElement;
-};
-
 type WrapperProps = {
-  children?: React.ReactNode;
+  children?: React.ReactElement;
 };
 
-export async function render(
-  ui: React.ReactNode,
-  renderOptions?: RenderOptions
-): Promise<RenderResult<Queries, HTMLElement>> {
+export async function render<
+  Q extends Queries = typeof queries,
+  Container extends Element | DocumentFragment = HTMLElement
+>(ui: React.ReactNode, renderOptions?: RenderOptions<Q, Container>): Promise<RenderResult<Q, Container>> {
   function Wrapper({ children }: WrapperProps) {
     return (
       <TestWrapper>
@@ -35,9 +28,9 @@ export async function render(
     );
   }
 
-  let renderResult: RenderResult<Queries, HTMLElement>;
+  let renderResult: RenderResult<Q, Container>;
   await act(async () => {
-    renderResult = await rtlRender(<div>{ui}</div>, { wrapper: Wrapper, ...renderOptions });
+    renderResult = await rtlRender<Q, Container>(<div>{ui}</div>, { wrapper: Wrapper, ...renderOptions });
   });
 
   return renderResult!;


### PR DESCRIPTION
## What
Fixes #12202 

This fixes an issue where a password manager's button would overlap with the password field's show/hide password button.

Before:
![image](https://user-images.githubusercontent.com/168664/165528282-b09bf620-55f8-4f25-a84a-3b4c3fea9e3e.png)

![image](https://user-images.githubusercontent.com/168664/165528150-31ffa61c-c56c-4d70-b024-3eaebaf2b305.png)

After:
![image](https://user-images.githubusercontent.com/168664/165528358-8b14ae4e-6447-45f3-96f5-3275acb4df79.png)

![image](https://user-images.githubusercontent.com/168664/165528509-32de9dfb-5c94-42b2-8112-e50030ee6b11.png)

## How
Updates how the Input field is laid out. Instead of having the button overlap the input, the input is not split into two parts wrapped around a container.

Also added a unit test to test the behavior of the input component.