### PR TITLE
Fix typo on `DATABASE_URL` comment

### DIFF
--- a/.env
+++ b/.env
@@ -40,7 +40,7 @@ DATABASE_PASSWORD=docker
 DATABASE_HOST=db
 DATABASE_PORT=5432
 DATABASE_DB=airbyte
-# translate manually DATABASE_URL=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT/${DATABASE_DB} (do not include the username or password here)
+# translate manually DATABASE_URL=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DB} (do not include the username or password here)
 DATABASE_URL=jdbc:postgresql://db:5432/airbyte
 JOBS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION=0.29.15.001
 


### PR DESCRIPTION
## What
When modifying the `.env` variables, I found out that the `DATABASE_URL` has to be manually translated.
I encountered a missing `}` at one of the variables when reading the comment on how to translate this variable.

## How
I just added the missing `}` to the mentioned comment.
I know this is a small change, but I hope it's useful for someone :)