### PR TITLE
Add Google Analytics tracking to docs

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -41,6 +41,12 @@ const config = {
                     customCss: require.resolve('./src/css/custom.css'),
                 },
             }),
+            {
+                gtag: {
+                    trackingID: 'UA-156258629-2',
+                    anonymizeIP: true,
+                },
+            },
         ],
     ],
 

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -40,13 +40,11 @@ const config = {
                 theme: {
                     customCss: require.resolve('./src/css/custom.css'),
                 },
-            }),
-            {
                 gtag: {
                     trackingID: 'UA-156258629-2',
                     anonymizeIP: true,
                 },
-            },
+            }),
         ],
     ],
 


### PR DESCRIPTION
We already had [plugin-google-gtag](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag) as a dependency in  [package.json](https://github.com/airbytehq/airbyte/blob/master/docusaurus/package.json) but we haven't set the trackingID in the docusaurus config.

This PR configures the plugin-google-gtag.