### PR TITLE
`CHECK` the Source an Destination before `SYNC` to denote `config_error`

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -203,11 +203,15 @@ public class WorkerApp {
         defaultWorkerConfigs,
         defaultProcessFactory);
 
+    final CheckConnectionActivityImpl checkConnectionActivity =
+        new CheckConnectionActivityImpl(checkWorkerConfigs, checkProcessFactory, secretsHydrator, workspaceRoot, workerEnvironment, logConfigs,
+            jobPersistence, airbyteVersion);
+
     final PersistStateActivityImpl persistStateActivity = new PersistStateActivityImpl(workspaceRoot, configRepository);
 
     final Worker syncWorker = factory.newWorker(TemporalJobType.SYNC.name(), getWorkerOptions(maxWorkers.getMaxSyncWorkers()));
     syncWorker.registerWorkflowImplementationTypes(SyncWorkflowImpl.class);
-    syncWorker.registerActivitiesImplementations(replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
+    syncWorker.registerActivitiesImplementations(checkConnectionActivity, replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
   }
 
   private void registerDiscover(final WorkerFactory factory) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -211,7 +211,8 @@ public class WorkerApp {
 
     final Worker syncWorker = factory.newWorker(TemporalJobType.SYNC.name(), getWorkerOptions(maxWorkers.getMaxSyncWorkers()));
     syncWorker.registerWorkflowImplementationTypes(SyncWorkflowImpl.class);
-    syncWorker.registerActivitiesImplementations(checkConnectionActivity, replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
+    syncWorker.registerActivitiesImplementations(checkConnectionActivity, replicationActivity, normalizationActivity, dbtTransformationActivity,
+        persistStateActivity);
   }
 
   private void registerDiscover(final WorkerFactory factory) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -189,6 +189,8 @@ public class WorkerApp {
             jobCreator),
         new ConfigFetchActivityImpl(configRepository, jobPersistence, configs, () -> Instant.now().getEpochSecond()),
         new ConnectionDeletionActivityImpl(connectionHelper),
+        new CheckConnectionActivityImpl(checkWorkerConfigs, checkProcessFactory, secretsHydrator, workspaceRoot, workerEnvironment, logConfigs,
+            jobPersistence, airbyteVersion),
         new AutoDisableConnectionActivityImpl(configRepository, jobPersistence, featureFlags, configs, jobNotifier));
   }
 
@@ -203,15 +205,11 @@ public class WorkerApp {
         defaultWorkerConfigs,
         defaultProcessFactory);
 
-    final CheckConnectionActivityImpl checkConnectionActivity =
-        new CheckConnectionActivityImpl(checkWorkerConfigs, checkProcessFactory, secretsHydrator, workspaceRoot, workerEnvironment, logConfigs,
-            jobPersistence, airbyteVersion);
-
     final PersistStateActivityImpl persistStateActivity = new PersistStateActivityImpl(workspaceRoot, configRepository);
 
     final Worker syncWorker = factory.newWorker(TemporalJobType.SYNC.name(), getWorkerOptions(maxWorkers.getMaxSyncWorkers()));
     syncWorker.registerWorkflowImplementationTypes(SyncWorkflowImpl.class);
-    syncWorker.registerActivitiesImplementations(checkConnectionActivity, replicationActivity, normalizationActivity, dbtTransformationActivity,
+    syncWorker.registerActivitiesImplementations(replicationActivity, normalizationActivity, dbtTransformationActivity,
         persistStateActivity);
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -189,8 +189,15 @@ public class WorkerApp {
             jobCreator),
         new ConfigFetchActivityImpl(configRepository, jobPersistence, configs, () -> Instant.now().getEpochSecond()),
         new ConnectionDeletionActivityImpl(connectionHelper),
-        new CheckConnectionActivityImpl(checkWorkerConfigs, checkProcessFactory, secretsHydrator, workspaceRoot, workerEnvironment, logConfigs,
-            jobPersistence, airbyteVersion),
+        new CheckConnectionActivityImpl(
+            checkWorkerConfigs,
+            checkProcessFactory,
+            secretsHydrator,
+            workspaceRoot,
+            workerEnvironment,
+            logConfigs,
+            jobPersistence,
+            airbyteVersion),
         new AutoDisableConnectionActivityImpl(configRepository, jobPersistence, featureFlags, configs, jobNotifier));
   }
 
@@ -209,8 +216,7 @@ public class WorkerApp {
 
     final Worker syncWorker = factory.newWorker(TemporalJobType.SYNC.name(), getWorkerOptions(maxWorkers.getMaxSyncWorkers()));
     syncWorker.registerWorkflowImplementationTypes(SyncWorkflowImpl.class);
-    syncWorker.registerActivitiesImplementations(replicationActivity, normalizationActivity, dbtTransformationActivity,
-        persistStateActivity);
+    syncWorker.registerActivitiesImplementations(replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
   }
 
   private void registerDiscover(final WorkerFactory factory) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
@@ -92,7 +92,8 @@ public class FailureHelper {
         .withFailureOrigin(origin)
         .withFailureType(FailureReason.FailureType.CONFIG_ERROR)
         .withRetryable(false)
-        .withExternalMessage(String.format("Checking %s connection failed - please review this connection's configuration to prevent future syncs from failing", origin));
+        .withExternalMessage(String
+            .format("Checking %s connection failed - please review this connection's configuration to prevent future syncs from failing", origin));
   }
 
   public static FailureReason replicationFailure(final Throwable t, final Long jobId, final Integer attemptNumber) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
@@ -91,7 +91,7 @@ public class FailureHelper {
     return genericFailure(t, jobId, attemptNumber)
         .withFailureOrigin(origin)
         .withFailureType(FailureReason.FailureType.CONFIG_ERROR)
-        .withRetryable(false)
+//        .withRetryable(false)
         .withExternalMessage(String.format("%s check failed", origin));
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
@@ -9,7 +9,6 @@ import io.airbyte.config.FailureReason;
 import io.airbyte.config.FailureReason.FailureOrigin;
 import io.airbyte.config.FailureReason.FailureType;
 import io.airbyte.config.Metadata;
-import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.protocol.models.AirbyteTraceMessage;
 import java.util.Comparator;
 import java.util.List;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
@@ -92,7 +92,7 @@ public class FailureHelper {
         .withFailureOrigin(origin)
         .withFailureType(FailureReason.FailureType.CONFIG_ERROR)
         .withRetryable(false)
-        .withExternalMessage(String.format("%s check failed", origin));
+        .withExternalMessage(String.format("Checking %s connection failed - please review this connection's configuration to prevent future syncs from failing", origin));
   }
 
   public static FailureReason replicationFailure(final Throwable t, final Long jobId, final Integer attemptNumber) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
@@ -9,6 +9,7 @@ import io.airbyte.config.FailureReason;
 import io.airbyte.config.FailureReason.FailureOrigin;
 import io.airbyte.config.FailureReason.FailureType;
 import io.airbyte.config.Metadata;
+import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.protocol.models.AirbyteTraceMessage;
 import java.util.Comparator;
 import java.util.List;
@@ -84,6 +85,14 @@ public class FailureHelper {
     return genericFailure(m, jobId, attemptNumber)
         .withFailureOrigin(FailureOrigin.DESTINATION)
         .withExternalMessage(m.getError().getMessage());
+  }
+
+  public static FailureReason checkFailure(final Throwable t, final Long jobId, final Integer attemptNumber, FailureReason.FailureOrigin origin) {
+    return genericFailure(t, jobId, attemptNumber)
+        .withFailureOrigin(origin)
+        .withFailureType(FailureReason.FailureType.CONFIG_ERROR)
+        .withRetryable(false)
+        .withExternalMessage(String.format("%s check failed", origin));
   }
 
   public static FailureReason replicationFailure(final Throwable t, final Long jobId, final Integer attemptNumber) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/FailureHelper.java
@@ -91,7 +91,7 @@ public class FailureHelper {
     return genericFailure(t, jobId, attemptNumber)
         .withFailureOrigin(origin)
         .withFailureType(FailureReason.FailureType.CONFIG_ERROR)
-//        .withRetryable(false)
+        .withRetryable(false)
         .withExternalMessage(String.format("%s check failed", origin));
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/SyncCheckConnectionFailure.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/SyncCheckConnectionFailure.java
@@ -14,12 +14,14 @@ import java.util.List;
 
 public class SyncCheckConnectionFailure {
 
-  private final JobRunConfig jobRunConfig;
+  private final Long jobId;
+  private final Integer attemptId;
   private StandardCheckConnectionOutput failureOutput;
   private FailureReason.FailureOrigin origin = null;
 
-  public SyncCheckConnectionFailure(JobRunConfig jobRunConfig) {
-    this.jobRunConfig = jobRunConfig;
+  public SyncCheckConnectionFailure(Long jobId, Integer attemptId) {
+    this.jobId = jobId;
+    this.attemptId = attemptId;
   }
 
   public boolean isFailed() {
@@ -40,10 +42,7 @@ public class SyncCheckConnectionFailure {
     }
 
     final Exception ex = new IllegalArgumentException(failureOutput.getMessage());
-    // TODO: Why are these values null and needing a default?
-    final String jobId = jobRunConfig.getJobId() != null ? jobRunConfig.getJobId() : "1";
-    final long attemptId = jobRunConfig.getAttemptId() != null ? jobRunConfig.getAttemptId() : 1L;
-    final FailureReason checkFailureReason = FailureHelper.checkFailure(ex, Long.valueOf(jobId), Math.toIntExact(attemptId), origin);
+    final FailureReason checkFailureReason = FailureHelper.checkFailure(ex, jobId, attemptId, origin);
     return new StandardSyncOutput()
         .withFailures(List.of(checkFailureReason))
         .withStandardSyncSummary(

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/SyncCheckConnectionFailure.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/SyncCheckConnectionFailure.java
@@ -9,7 +9,6 @@ import io.airbyte.config.StandardCheckConnectionOutput;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.StandardSyncSummary;
 import io.airbyte.config.SyncStats;
-import io.airbyte.scheduler.models.JobRunConfig;
 import java.util.List;
 
 public class SyncCheckConnectionFailure {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/SyncCheckConnectionFailure.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/SyncCheckConnectionFailure.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.helper;
+
+import io.airbyte.config.FailureReason;
+import io.airbyte.config.StandardCheckConnectionOutput;
+import io.airbyte.config.StandardSyncOutput;
+import io.airbyte.config.StandardSyncSummary;
+import io.airbyte.config.SyncStats;
+import io.airbyte.scheduler.models.JobRunConfig;
+import java.util.List;
+
+public class SyncCheckConnectionFailure {
+
+  private final JobRunConfig jobRunConfig;
+  private StandardCheckConnectionOutput failureOutput;
+  private FailureReason.FailureOrigin origin = null;
+
+  public SyncCheckConnectionFailure(JobRunConfig jobRunConfig) {
+    this.jobRunConfig = jobRunConfig;
+  }
+
+  public boolean isFailed() {
+    return this.origin != null && this.failureOutput != null;
+  }
+
+  public void setFailureOrigin(FailureReason.FailureOrigin origin) {
+    this.origin = origin;
+  }
+
+  public void setFailureOutput(StandardCheckConnectionOutput failureOutput) {
+    this.failureOutput = failureOutput;
+  }
+
+  public StandardSyncOutput buildFailureOutput() {
+    if (!this.isFailed()) {
+      throw new RuntimeException("Cannot build failure output without a failure origin and output");
+    }
+
+    final Exception ex = new IllegalArgumentException(failureOutput.getMessage());
+    // TODO: Why are these values null and needing a default?
+    final String jobId = jobRunConfig.getJobId() != null ? jobRunConfig.getJobId() : "1";
+    final long attemptId = jobRunConfig.getAttemptId() != null ? jobRunConfig.getAttemptId() : 1L;
+    final FailureReason checkFailureReason = FailureHelper.checkFailure(ex, Long.valueOf(jobId), Math.toIntExact(attemptId), origin);
+    return new StandardSyncOutput()
+        .withFailures(List.of(checkFailureReason))
+        .withStandardSyncSummary(
+            new StandardSyncSummary()
+                .withStatus(StandardSyncSummary.ReplicationStatus.FAILED)
+                .withStartTime(System.currentTimeMillis())
+                .withEndTime(System.currentTimeMillis())
+                .withRecordsSynced(0L)
+                .withBytesSynced(0L)
+                .withTotalStats(new SyncStats()
+                    .withRecordsEmitted(0L)
+                    .withBytesEmitted(0L)
+                    .withStateMessagesEmitted(0L)
+                    .withRecordsCommitted(0L)));
+  }
+
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/SyncCheckConnectionFailure.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/SyncCheckConnectionFailure.java
@@ -9,8 +9,11 @@ import io.airbyte.config.StandardCheckConnectionOutput;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.StandardSyncSummary;
 import io.airbyte.config.SyncStats;
+import io.airbyte.scheduler.models.JobRunConfig;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class SyncCheckConnectionFailure {
 
   private final Long jobId;
@@ -18,7 +21,18 @@ public class SyncCheckConnectionFailure {
   private StandardCheckConnectionOutput failureOutput;
   private FailureReason.FailureOrigin origin = null;
 
-  public SyncCheckConnectionFailure(Long jobId, Integer attemptId) {
+  public SyncCheckConnectionFailure(JobRunConfig jobRunConfig) {
+    Long jobId = 0L;
+    Integer attemptId = 0;
+
+    try {
+      jobId = Long.valueOf(jobRunConfig.getJobId());
+      attemptId = Math.toIntExact(jobRunConfig.getAttemptId());
+    } catch (Exception e) {
+      // In tests, the jobId and attemptId may not be available
+      log.warn("Cannot determine jobId or attemptId: " + e.getMessage());
+    }
+
     this.jobId = jobId;
     this.attemptId = attemptId;
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivity.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivity.java
@@ -10,13 +10,25 @@ import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @ActivityInterface
 public interface CheckConnectionActivity {
 
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  class CheckConnectionInput {
+
+    private JobRunConfig jobRunConfig;
+    private IntegrationLauncherConfig launcherConfig;
+    private StandardCheckConnectionInput connectionConfiguration;
+
+  }
+
   @ActivityMethod
-  StandardCheckConnectionOutput check(JobRunConfig jobRunConfig,
-                                      IntegrationLauncherConfig launcherConfig,
-                                      StandardCheckConnectionInput connectionConfiguration);
+  StandardCheckConnectionOutput check(CheckConnectionInput input);
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivity.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivity.java
@@ -15,8 +15,8 @@ import io.temporal.activity.ActivityMethod;
 public interface CheckConnectionActivity {
 
   @ActivityMethod
-  StandardCheckConnectionOutput run(JobRunConfig jobRunConfig,
-                                    IntegrationLauncherConfig launcherConfig,
-                                    StandardCheckConnectionInput connectionConfiguration);
+  StandardCheckConnectionOutput check(JobRunConfig jobRunConfig,
+                                      IntegrationLauncherConfig launcherConfig,
+                                      StandardCheckConnectionInput connectionConfiguration);
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivity.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivity.java
@@ -29,6 +29,6 @@ public interface CheckConnectionActivity {
   }
 
   @ActivityMethod
-  StandardCheckConnectionOutput check(CheckConnectionInput input);
+  StandardCheckConnectionOutput run(CheckConnectionInput input);
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivityImpl.java
@@ -12,7 +12,6 @@ import io.airbyte.config.StandardCheckConnectionOutput;
 import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.config.persistence.split_secrets.SecretsHydrator;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
-import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.workers.DefaultCheckConnectionWorker;
 import io.airbyte.workers.Worker;
@@ -55,11 +54,8 @@ public class CheckConnectionActivityImpl implements CheckConnectionActivity {
     this.airbyteVersion = airbyteVersion;
   }
 
-  public StandardCheckConnectionOutput check(final JobRunConfig jobRunConfig,
-                                             final IntegrationLauncherConfig launcherConfig,
-                                             final StandardCheckConnectionInput connectionConfiguration) {
-
-    final JsonNode fullConfig = secretsHydrator.hydrate(connectionConfiguration.getConnectionConfiguration());
+  public StandardCheckConnectionOutput check(CheckConnectionInput args) {
+    final JsonNode fullConfig = secretsHydrator.hydrate(args.getConnectionConfiguration().getConnectionConfiguration());
 
     final StandardCheckConnectionInput input = new StandardCheckConnectionInput()
         .withConnectionConfiguration(fullConfig);
@@ -69,8 +65,8 @@ public class CheckConnectionActivityImpl implements CheckConnectionActivity {
     final TemporalAttemptExecution<StandardCheckConnectionInput, StandardCheckConnectionOutput> temporalAttemptExecution =
         new TemporalAttemptExecution<>(
             workspaceRoot, workerEnvironment, logConfigs,
-            jobRunConfig,
-            getWorkerFactory(launcherConfig),
+            args.getJobRunConfig(),
+            getWorkerFactory(args.getLauncherConfig()),
             () -> input,
             new CancellationHandler.TemporalCancellationHandler(context),
             jobPersistence,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivityImpl.java
@@ -55,9 +55,9 @@ public class CheckConnectionActivityImpl implements CheckConnectionActivity {
     this.airbyteVersion = airbyteVersion;
   }
 
-  public StandardCheckConnectionOutput run(final JobRunConfig jobRunConfig,
-                                           final IntegrationLauncherConfig launcherConfig,
-                                           final StandardCheckConnectionInput connectionConfiguration) {
+  public StandardCheckConnectionOutput check(final JobRunConfig jobRunConfig,
+                                             final IntegrationLauncherConfig launcherConfig,
+                                             final StandardCheckConnectionInput connectionConfiguration) {
 
     final JsonNode fullConfig = secretsHydrator.hydrate(connectionConfiguration.getConnectionConfiguration());
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivityImpl.java
@@ -54,7 +54,7 @@ public class CheckConnectionActivityImpl implements CheckConnectionActivity {
     this.airbyteVersion = airbyteVersion;
   }
 
-  public StandardCheckConnectionOutput check(CheckConnectionInput args) {
+  public StandardCheckConnectionOutput run(CheckConnectionInput args) {
     final JsonNode fullConfig = secretsHydrator.hydrate(args.getConnectionConfiguration().getConnectionConfiguration());
 
     final StandardCheckConnectionInput input = new StandardCheckConnectionInput()

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
@@ -8,6 +8,7 @@ import io.airbyte.config.StandardCheckConnectionInput;
 import io.airbyte.config.StandardCheckConnectionOutput;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
+import io.airbyte.workers.temporal.check.connection.CheckConnectionActivity.CheckConnectionInput;
 import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
 import io.temporal.workflow.Workflow;
 
@@ -21,7 +22,7 @@ public class CheckConnectionWorkflowImpl implements CheckConnectionWorkflow {
                                            final IntegrationLauncherConfig launcherConfig,
                                            final StandardCheckConnectionInput connectionConfiguration) {
 
-    return activity.check(jobRunConfig, launcherConfig, connectionConfiguration);
+    return activity.check(new CheckConnectionInput(jobRunConfig, launcherConfig, connectionConfiguration));
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
@@ -12,13 +12,21 @@ import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
 import io.temporal.workflow.Workflow;
 
 public class CheckConnectionWorkflowImpl implements CheckConnectionWorkflow {
-  private final CheckConnectionActivity activity = Workflow.newActivityStub(CheckConnectionActivity.class, ActivityConfiguration.CHECK_ACTIVITY_OPTIONS);
+  private final CheckConnectionActivity activity =
+      Workflow.newActivityStub(CheckConnectionActivity.class, ActivityConfiguration.CHECK_ACTIVITY_OPTIONS);
 
   @Override
   public StandardCheckConnectionOutput run(final JobRunConfig jobRunConfig,
                                            final IntegrationLauncherConfig launcherConfig,
                                            final StandardCheckConnectionInput connectionConfiguration) {
+
+    // try {
     return activity.check(jobRunConfig, launcherConfig, connectionConfiguration);
+    // } catch (Exception e) {
+    // throw Activity.wrap(e);
+    // throw ApplicationFailure.newNonRetryableFailure("CHECK failed", "check", e);
+    // throw ApplicationFailure.newNonRetryableFailure(e.toString(), "check-failure", e);
+    // }
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
@@ -18,7 +18,7 @@ public class CheckConnectionWorkflowImpl implements CheckConnectionWorkflow {
   public StandardCheckConnectionOutput run(final JobRunConfig jobRunConfig,
                                            final IntegrationLauncherConfig launcherConfig,
                                            final StandardCheckConnectionInput connectionConfiguration) {
-    return activity.run(jobRunConfig, launcherConfig, connectionConfiguration);
+    return activity.check(jobRunConfig, launcherConfig, connectionConfiguration);
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
@@ -20,13 +20,7 @@ public class CheckConnectionWorkflowImpl implements CheckConnectionWorkflow {
                                            final IntegrationLauncherConfig launcherConfig,
                                            final StandardCheckConnectionInput connectionConfiguration) {
 
-    // try {
     return activity.check(jobRunConfig, launcherConfig, connectionConfiguration);
-    // } catch (Exception e) {
-    // throw Activity.wrap(e);
-    // throw ApplicationFailure.newNonRetryableFailure("CHECK failed", "check", e);
-    // throw ApplicationFailure.newNonRetryableFailure(e.toString(), "check-failure", e);
-    // }
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
@@ -8,18 +8,11 @@ import io.airbyte.config.StandardCheckConnectionInput;
 import io.airbyte.config.StandardCheckConnectionOutput;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
-import io.airbyte.workers.temporal.TemporalUtils;
-import io.temporal.activity.ActivityOptions;
+import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
 import io.temporal.workflow.Workflow;
-import java.time.Duration;
 
 public class CheckConnectionWorkflowImpl implements CheckConnectionWorkflow {
-
-  final ActivityOptions options = ActivityOptions.newBuilder()
-      .setScheduleToCloseTimeout(Duration.ofHours(1))
-      .setRetryOptions(TemporalUtils.NO_RETRY)
-      .build();
-  private final CheckConnectionActivity activity = Workflow.newActivityStub(CheckConnectionActivity.class, options);
+  private final CheckConnectionActivity activity = Workflow.newActivityStub(CheckConnectionActivity.class, ActivityConfiguration.CHECK_ACTIVITY_OPTIONS);
 
   @Override
   public StandardCheckConnectionOutput run(final JobRunConfig jobRunConfig,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
@@ -12,6 +12,7 @@ import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
 import io.temporal.workflow.Workflow;
 
 public class CheckConnectionWorkflowImpl implements CheckConnectionWorkflow {
+
   private final CheckConnectionActivity activity =
       Workflow.newActivityStub(CheckConnectionActivity.class, ActivityConfiguration.CHECK_ACTIVITY_OPTIONS);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
@@ -22,7 +22,7 @@ public class CheckConnectionWorkflowImpl implements CheckConnectionWorkflow {
                                            final IntegrationLauncherConfig launcherConfig,
                                            final StandardCheckConnectionInput connectionConfiguration) {
 
-    return activity.check(new CheckConnectionInput(jobRunConfig, launcherConfig, connectionConfiguration));
+    return activity.run(new CheckConnectionInput(jobRunConfig, launcherConfig, connectionConfiguration));
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -342,7 +342,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
     } else {
       log.info("SOURCE CHECK: Starting");
       final StandardCheckConnectionOutput sourceCheckResponse = runMandatoryActivityWithOutput(checkActivity::run, checkSourceInput);
-      if (sourceCheckResponse != null && sourceCheckResponse.getStatus() == Status.FAILED) {
+      if (sourceCheckResponse.getStatus() == Status.FAILED) {
         checkFailure.setFailureOrigin(FailureReason.FailureOrigin.SOURCE);
         checkFailure.setFailureOutput(sourceCheckResponse);
         log.info("SOURCE CHECK: Failed");
@@ -359,7 +359,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
     } else {
       log.info("DESTINATION CHECK: Starting");
       final StandardCheckConnectionOutput destinationCheckResponse = runMandatoryActivityWithOutput(checkActivity::run, checkDestinationInput);
-      if (destinationCheckResponse != null && destinationCheckResponse.getStatus() == Status.FAILED) {
+      if (destinationCheckResponse.getStatus() == Status.FAILED) {
         checkFailure.setFailureOrigin(FailureReason.FailureOrigin.DESTINATION);
         checkFailure.setFailureOutput(destinationCheckResponse);
         log.info("DESTINATION CHECK: Failed");

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -181,11 +181,13 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
         workflowState.setFailed(getFailStatus(standardSyncOutput));
 
         if (workflowState.isFailed()) {
-          final FailureType failureType = standardSyncOutput.getFailures().isEmpty() ? null : standardSyncOutput.getFailures().get(0).getFailureType();
+          final FailureType failureType =
+              standardSyncOutput.getFailures().isEmpty() ? null : standardSyncOutput.getFailures().get(0).getFailureType();
           reportFailure(connectionUpdaterInput, standardSyncOutput, failureType == FailureType.CONFIG_ERROR ? "Check Failed" + connectionId : null);
           if (failureType == FailureType.CONFIG_ERROR) {
             // In the case that the failure is attributable to config_error, we will not retry again
-            // The first time we fail in this way (from a new connection or a success) we will allow 2 attempts, but only one with repeated failures
+            // The first time we fail in this way (from a new connection or a success) we will allow 2 attempts,
+            // but only one with repeated failures
             log.info("Not retrying due to config_error");
             final int maxAttempt = configFetchActivity.getMaxAttempt().getMaxAttempt();
             connectionUpdaterInput.setAttemptNumber(maxAttempt);
@@ -246,7 +248,9 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
     resetNewConnectionInput(connectionUpdaterInput);
   }
 
-  private void reportFailure(final ConnectionUpdaterInput connectionUpdaterInput, final StandardSyncOutput standardSyncOutput, final String failureReason) {
+  private void reportFailure(final ConnectionUpdaterInput connectionUpdaterInput,
+                             final StandardSyncOutput standardSyncOutput,
+                             final String failureReason) {
     final int attemptCreationVersion =
         Workflow.getVersion(RENAME_ATTEMPT_ID_TO_NUMBER_TAG, Workflow.DEFAULT_VERSION, RENAME_ATTEMPT_ID_TO_NUMBER_CURRENT_VERSION);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -325,7 +325,9 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
     final JsonNode destinationConfig = syncInput.getDestinationConfiguration();
     final IntegrationLauncherConfig sourceLauncherConfig = jobInputs.getSourceLauncherConfig();
     final IntegrationLauncherConfig destinationLauncherConfig = jobInputs.getDestinationLauncherConfig();
-    SyncCheckConnectionFailure checkFailure = new SyncCheckConnectionFailure(jobRunConfig);
+    final Long jobId = jobRunConfig.getJobId() != null ? Long.valueOf(jobRunConfig.getJobId()) : 1L;
+    final Integer attemptId = jobRunConfig.getAttemptId() != null ? Math.toIntExact(jobRunConfig.getAttemptId()) : 1;
+    SyncCheckConnectionFailure checkFailure = new SyncCheckConnectionFailure(jobId, attemptId);
 
     final int attemptCreationVersion =
         Workflow.getVersion(CHECK_BEFORE_SYNC_TAG, Workflow.DEFAULT_VERSION, CHECK_BEFORE_SYNC_CURRENT_VERSION);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -270,7 +270,8 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
       connectionUpdaterInput.setAttemptNumber(attemptNumber + 1);
       connectionUpdaterInput.setFromFailure(true);
     } else {
-      final String failureReason = failureType == FailureType.CONFIG_ERROR ? "Check Failed " + connectionId :  "Job failed after too many retries for connection " + connectionId;
+      final String failureReason = failureType == FailureType.CONFIG_ERROR ? "Check Failed " + connectionId
+          : "Job failed after too many retries for connection " + connectionId;
       runMandatoryActivity(jobCreationAndStatusUpdateActivity::jobFailure, new JobFailureInput(connectionUpdaterInput.getJobId(), failureReason));
 
       final int autoDisableConnectionVersion =

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -264,7 +264,8 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
     }
 
     final FailureType failureType =
-        standardSyncOutput.getFailures().isEmpty() ? null : standardSyncOutput.getFailures().get(0).getFailureType();
+        standardSyncOutput != null ? standardSyncOutput.getFailures().isEmpty() ? null : standardSyncOutput.getFailures().get(0).getFailureType()
+            : null;
     if (maxAttempt > attemptNumber && failureType != FailureType.CONFIG_ERROR) {
       // restart from failure
       connectionUpdaterInput.setAttemptNumber(attemptNumber + 1);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -329,7 +329,11 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
     final CheckConnectionInput checkSourceInput =
         new CheckConnectionInput(jobInputs.getJobRunConfig(), jobInputs.getSourceLauncherConfig(), sourceConfiguration);
     final String launchSourceDockerImage = jobInputs.getSourceLauncherConfig().getDockerImage();
-    if (launchSourceDockerImage != WorkerConstants.RESET_JOB_SOURCE_DOCKER_IMAGE_STUB) {
+
+    if (launchSourceDockerImage.equals(WorkerConstants.RESET_JOB_SOURCE_DOCKER_IMAGE_STUB)) {
+      log.info("SOURCE CHECK: Skipped");
+    } else {
+      log.info("SOURCE CHECK: Starting");
       final StandardCheckConnectionOutput sourceCheckResponse = runMandatoryActivityWithOutput(checkActivity::run, checkSourceInput);
       if (sourceCheckResponse != null && sourceCheckResponse.getStatus() == Status.FAILED) {
         log.info("SOURCE CHECK: Failed");
@@ -337,8 +341,6 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
       } else {
         log.info("SOURCE CHECK: Successful");
       }
-    } else {
-      log.info("SOURCE CHECK: Skipped");
     }
 
     final StandardCheckConnectionInput destinationConfiguration =
@@ -347,7 +349,10 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
         new CheckConnectionInput(jobInputs.getJobRunConfig(), jobInputs.getDestinationLauncherConfig(), destinationConfiguration);
     final String launchDestinationDockerImage = jobInputs.getSourceLauncherConfig().getDockerImage();
 
-    if (launchDestinationDockerImage != WorkerConstants.RESET_JOB_SOURCE_DOCKER_IMAGE_STUB) {
+    if (launchDestinationDockerImage.equals(WorkerConstants.RESET_JOB_SOURCE_DOCKER_IMAGE_STUB)) {
+      log.info("DESTINATION CHECK: Skipped");
+    } else {
+      log.info("DESTINATION CHECK: Starting");
       final StandardCheckConnectionOutput destinationCheckResponse = runMandatoryActivityWithOutput(checkActivity::run, checkDestinationInput);
       if (destinationCheckResponse != null && destinationCheckResponse.getStatus() == Status.FAILED) {
         log.info("DESTINATION CHECK: Failed");
@@ -355,8 +360,6 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
       } else {
         log.info("DESTINATION CHECK: Successful");
       }
-    } else {
-      log.info("DESTINATION CHECK: Skipped");
     }
 
     // return no failure response if the CHECKS succeed

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -318,7 +318,6 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
   }
 
   private SyncCheckConnectionFailure checkConnections(GenerateInputActivity.GeneratedJobInput jobInputs) {
-    System.out.println(jobInputs);
     final JobRunConfig jobRunConfig = jobInputs.getJobRunConfig();
     final StandardSyncInput syncInput = jobInputs.getSyncInput();
     final JsonNode sourceConfig = syncInput.getSourceConfiguration();
@@ -330,14 +329,13 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
     final int attemptCreationVersion =
         Workflow.getVersion(CHECK_BEFORE_SYNC_TAG, Workflow.DEFAULT_VERSION, CHECK_BEFORE_SYNC_CURRENT_VERSION);
 
-    if (attemptCreationVersion >= CHECK_BEFORE_SYNC_CURRENT_VERSION) {
+    if (attemptCreationVersion < CHECK_BEFORE_SYNC_CURRENT_VERSION) {
       // return early if this instance of the workflow was created beforehand
       return checkFailure;
     }
 
     final StandardCheckConnectionInput sourceConfiguration = new StandardCheckConnectionInput().withConnectionConfiguration(sourceConfig);
     final CheckConnectionInput checkSourceInput = new CheckConnectionInput(jobRunConfig, sourceLauncherConfig, sourceConfiguration);
-    final String launchSourceDockerImage = sourceLauncherConfig.getDockerImage();
 
     if (workflowState.isResetConnection() || checkFailure.isFailed()) {
       log.info("SOURCE CHECK: Skipped");
@@ -355,7 +353,6 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
 
     final StandardCheckConnectionInput destinationConfiguration = new StandardCheckConnectionInput().withConnectionConfiguration(destinationConfig);
     final CheckConnectionInput checkDestinationInput = new CheckConnectionInput(jobRunConfig, destinationLauncherConfig, destinationConfiguration);
-    final String launchDestinationDockerImage = destinationLauncherConfig.getDockerImage();
 
     if (checkFailure.isFailed()) {
       log.info("DESTINATION CHECK: Skipped");

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -318,15 +318,14 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
   }
 
   private SyncCheckConnectionFailure checkConnections(GenerateInputActivity.GeneratedJobInput jobInputs) {
+    System.out.println(jobInputs);
     final JobRunConfig jobRunConfig = jobInputs.getJobRunConfig();
     final StandardSyncInput syncInput = jobInputs.getSyncInput();
     final JsonNode sourceConfig = syncInput.getSourceConfiguration();
     final JsonNode destinationConfig = syncInput.getDestinationConfiguration();
     final IntegrationLauncherConfig sourceLauncherConfig = jobInputs.getSourceLauncherConfig();
     final IntegrationLauncherConfig destinationLauncherConfig = jobInputs.getDestinationLauncherConfig();
-    final Long jobId = Long.valueOf(jobRunConfig.getJobId());
-    final Integer attemptId = Math.toIntExact(jobRunConfig.getAttemptId());
-    SyncCheckConnectionFailure checkFailure = new SyncCheckConnectionFailure(jobId, attemptId);
+    SyncCheckConnectionFailure checkFailure = new SyncCheckConnectionFailure(jobRunConfig);
 
     final int attemptCreationVersion =
         Workflow.getVersion(CHECK_BEFORE_SYNC_TAG, Workflow.DEFAULT_VERSION, CHECK_BEFORE_SYNC_CURRENT_VERSION);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -183,7 +183,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
         if (workflowState.isFailed()) {
           final FailureType failureType =
               standardSyncOutput.getFailures().isEmpty() ? null : standardSyncOutput.getFailures().get(0).getFailureType();
-          reportFailure(connectionUpdaterInput, standardSyncOutput, failureType == FailureType.CONFIG_ERROR ? "Check Failed" + connectionId : null);
+          reportFailure(connectionUpdaterInput, standardSyncOutput, failureType == FailureType.CONFIG_ERROR ? "Check Failed " + connectionId : null);
           if (failureType == FailureType.CONFIG_ERROR) {
             // In the case that the failure is attributable to config_error, we will not retry again
             // The first time we fail in this way (from a new connection or a success) we will allow 2 attempts,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -82,6 +82,9 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
   private static final String ENSURE_CLEAN_JOB_STATE = "ensure_clean_job_state";
   private static final int ENSURE_CLEAN_JOB_STATE_CURRENT_VERSION = 1;
 
+  private static final String CHECK_BEFORE_SYNC_TAG = "check_before_sync";
+  private static final int CHECK_BEFORE_SYNC_CURRENT_VERSION = 1;
+
   private WorkflowState workflowState = new WorkflowState(UUID.randomUUID(), new NoopStateListener());
 
   private final WorkflowInternalState workflowInternalState = new WorkflowInternalState();
@@ -313,6 +316,13 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
   }
 
   private StandardSyncOutput checkConnections(GenerateInputActivity.GeneratedJobInput jobInputs) {
+    final int attemptCreationVersion =
+        Workflow.getVersion(CHECK_BEFORE_SYNC_TAG, Workflow.DEFAULT_VERSION, CHECK_BEFORE_SYNC_CURRENT_VERSION);
+
+    if (attemptCreationVersion < CHECK_BEFORE_SYNC_CURRENT_VERSION) {
+      return null;
+    }
+
     final StandardCheckConnectionInput sourceConfiguration = new StandardCheckConnectionInput()
         .withConnectionConfiguration(jobInputs.getSyncInput().getSourceConfiguration());
     final CheckConnectionInput checkSourceInput =
@@ -338,6 +348,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
       log.info("DESTINATION CHECK: Successful");
     }
 
+    // return no failure response if the CHECKS succeed
     return null;
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -182,11 +182,13 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
 
         if (workflowState.isFailed()) {
           reportFailure(connectionUpdaterInput, standardSyncOutput);
-        } else {
-          reportSuccess(connectionUpdaterInput, standardSyncOutput);
+          prepareForNextRunAndContinueAsNew(connectionUpdaterInput);
         }
 
+        // If we don't fail, it's a success.
+        reportSuccess(connectionUpdaterInput, standardSyncOutput);
         prepareForNextRunAndContinueAsNew(connectionUpdaterInput);
+
       } catch (final ChildWorkflowFailure childWorkflowFailure) {
         // when we cancel a method, we call the cancel method of the cancellation scope. This will throw an
         // exception since we expect it, we just

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -337,6 +337,8 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
       } else {
         log.info("SOURCE CHECK: Successful");
       }
+    } else {
+      log.info("SOURCE CHECK: Skipped");
     }
 
     final StandardCheckConnectionInput destinationConfiguration =
@@ -353,6 +355,8 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
       } else {
         log.info("DESTINATION CHECK: Successful");
       }
+    } else {
+      log.info("DESTINATION CHECK: Skipped");
     }
 
     // return no failure response if the CHECKS succeed

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -131,9 +131,6 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
 
   private CancellationScope generateSyncWorkflowRunnable(final ConnectionUpdaterInput connectionUpdaterInput) {
     return Workflow.newCancellationScope(() -> {
-      System.out.println("----- TICK");
-      System.out.println(connectionUpdaterInput);
-
       connectionId = connectionUpdaterInput.getConnectionId();
 
       // Clean the job state by failing any jobs for this connection that are currently non-terminal.
@@ -188,13 +185,11 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
           reportFailure(connectionUpdaterInput, standardSyncOutput);
 
           final FailureType failureType = standardSyncOutput.getFailures().isEmpty() ? null : standardSyncOutput.getFailures().get(0).getFailureType();
-          System.out.println(failureType);
           if (failureType == FailureType.CONFIG_ERROR) {
             // In the case that the failure is attributable to config_error, we will not retry again
-            // TODO: In the UI, the job still appears to be "retrying".  The Job is state=incomplete and the attempt=failed
-            workflowState.setFailed(true);
-            workflowState.setRetryFailedActivity(false);
-            cancellableSyncWorkflow.cancel();
+            runMandatoryActivity(jobCreationAndStatusUpdateActivity::jobFailure, new JobFailureInput(
+                connectionUpdaterInput.getJobId(),
+                "Check Failed" + connectionId));
           } else {
             prepareForNextRunAndContinueAsNew(connectionUpdaterInput);
           }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -182,13 +182,11 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
 
         if (workflowState.isFailed()) {
           reportFailure(connectionUpdaterInput, standardSyncOutput);
-          prepareForNextRunAndContinueAsNew(connectionUpdaterInput);
+        } else {
+          reportSuccess(connectionUpdaterInput, standardSyncOutput);
         }
 
-        // If we don't fail, it's a success.
-        reportSuccess(connectionUpdaterInput, standardSyncOutput);
         prepareForNextRunAndContinueAsNew(connectionUpdaterInput);
-
       } catch (final ChildWorkflowFailure childWorkflowFailure) {
         // when we cancel a method, we call the cancel method of the cancellation scope. This will throw an
         // exception since we expect it, we just

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -292,7 +292,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
       connectionUpdaterInput.setAttemptNumber(attemptNumber + 1);
       connectionUpdaterInput.setFromFailure(true);
     } else {
-      final String failureReason = failureType == FailureType.CONFIG_ERROR ? "Check Failed " + connectionId
+      final String failureReason = failureType == FailureType.CONFIG_ERROR ? "Connection Check Failed " + connectionId
           : "Job failed after too many retries for connection " + connectionId;
       runMandatoryActivity(jobCreationAndStatusUpdateActivity::jobFailure, new JobFailureInput(connectionUpdaterInput.getJobId(), failureReason));
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/shared/ActivityConfiguration.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/shared/ActivityConfiguration.java
@@ -43,10 +43,10 @@ public class ActivityConfiguration {
       .setHeartbeatTimeout(TemporalUtils.HEARTBEAT_TIMEOUT)
       .build();
 
- public static final ActivityOptions CHECK_ACTIVITY_OPTIONS = ActivityOptions.newBuilder()
-     .setScheduleToCloseTimeout(Duration.ofMinutes(5))
-     .setRetryOptions(TemporalUtils.NO_RETRY)
-     .build();
+  public static final ActivityOptions CHECK_ACTIVITY_OPTIONS = ActivityOptions.newBuilder()
+      .setScheduleToCloseTimeout(Duration.ofMinutes(5))
+      .setRetryOptions(TemporalUtils.NO_RETRY)
+      .build();
 
   public static final ActivityOptions SHORT_ACTIVITY_OPTIONS = ActivityOptions.newBuilder()
       .setStartToCloseTimeout(DB_INTERACTION_TIMEOUT)

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/shared/ActivityConfiguration.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/shared/ActivityConfiguration.java
@@ -43,6 +43,11 @@ public class ActivityConfiguration {
       .setHeartbeatTimeout(TemporalUtils.HEARTBEAT_TIMEOUT)
       .build();
 
+ public static final ActivityOptions CHECK_ACTIVITY_OPTIONS = ActivityOptions.newBuilder()
+     .setScheduleToCloseTimeout(Duration.ofMinutes(5))
+     .setRetryOptions(TemporalUtils.NO_RETRY)
+     .build();
+
   public static final ActivityOptions SHORT_ACTIVITY_OPTIONS = ActivityOptions.newBuilder()
       .setStartToCloseTimeout(DB_INTERACTION_TIMEOUT)
       .setCancellationType(ActivityCancellationType.WAIT_CANCELLATION_COMPLETED)

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -7,14 +7,12 @@ package io.airbyte.workers.temporal.sync;
 import io.airbyte.config.NormalizationInput;
 import io.airbyte.config.NormalizationSummary;
 import io.airbyte.config.OperatorDbtInput;
-import io.airbyte.config.StandardCheckConnectionInput;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncOperation.OperatorType;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
-import io.airbyte.workers.temporal.check.connection.CheckConnectionActivity;
 import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
 import io.temporal.workflow.Workflow;
 import java.util.UUID;
@@ -26,9 +24,6 @@ public class SyncWorkflowImpl implements SyncWorkflow {
   private static final Logger LOGGER = LoggerFactory.getLogger(SyncWorkflowImpl.class);
   private static final String VERSION_LABEL = "sync-workflow";
   private static final int CURRENT_VERSION = 1;
-
-  private final CheckConnectionActivity checkActivity =
-      Workflow.newActivityStub(CheckConnectionActivity.class, ActivityConfiguration.CHECK_ACTIVITY_OPTIONS);
   private final ReplicationActivity replicationActivity =
       Workflow.newActivityStub(ReplicationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
   private final NormalizationActivity normalizationActivity =
@@ -45,13 +40,8 @@ public class SyncWorkflowImpl implements SyncWorkflow {
                                 final StandardSyncInput syncInput,
                                 final UUID connectionId) {
 
-    final int version = Workflow.getVersion(VERSION_LABEL, Workflow.DEFAULT_VERSION, CURRENT_VERSION);
-    final StandardCheckConnectionInput sourceConfiguration = new StandardCheckConnectionInput()
-        .withConnectionConfiguration(syncInput.getSourceConfiguration());
-    final StandardCheckConnectionInput destinationConfiguration =
-        new StandardCheckConnectionInput().withConnectionConfiguration(syncInput.getDestinationConfiguration());
-
     StandardSyncOutput syncOutput = replicationActivity.replicate(jobRunConfig, sourceLauncherConfig, destinationLauncherConfig, syncInput);
+    final int version = Workflow.getVersion(VERSION_LABEL, Workflow.DEFAULT_VERSION, CURRENT_VERSION);
 
     if (version > Workflow.DEFAULT_VERSION) {
       // the state is persisted immediately after the replication succeeded, because the

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -61,7 +61,7 @@ public class SyncWorkflowImpl implements SyncWorkflow {
 
     if (version >= VERSION_INTRODUCING_CHECK_BEFORE_SYNC) {
       final StandardCheckConnectionOutput sourceCheckResponse = checkActivity.check(jobRunConfig, sourceLauncherConfig, sourceConfiguration);
-      if (sourceCheckResponse.getStatus() == Status.FAILED) {
+      if (sourceCheckResponse != null && sourceCheckResponse.getStatus() == Status.FAILED) {
         LOGGER.info("SOURCE CHECK: Failed");
         return CheckFailureSyncOutput(FailureReason.FailureOrigin.SOURCE, jobRunConfig, sourceCheckResponse);
       } else {
@@ -70,7 +70,7 @@ public class SyncWorkflowImpl implements SyncWorkflow {
 
       final StandardCheckConnectionOutput destinationCheckResponse =
           checkActivity.check(jobRunConfig, destinationLauncherConfig, destinationConfiguration);
-      if (destinationCheckResponse.getStatus() == Status.FAILED) {
+      if (destinationCheckResponse != null && destinationCheckResponse.getStatus() == Status.FAILED) {
         LOGGER.info("DESTINATION CHECK: Failed");
         return CheckFailureSyncOutput(FailureReason.FailureOrigin.DESTINATION, jobRunConfig, destinationCheckResponse);
       } else {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -135,8 +135,6 @@ public class SyncWorkflowImpl implements SyncWorkflow {
                     .withStateMessagesEmitted(0L)
                     .withRecordsCommitted(0L))
         );
-    System.out.println("--- FAILURE REASON:");
-    System.out.println(output);
     return output;
   }
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -121,7 +121,7 @@ public class SyncWorkflowImpl implements SyncWorkflow {
     final Exception ex = new IllegalArgumentException(checkResponse.getMessage());
     final FailureReason checkFailureReason = FailureHelper.checkFailure(ex, Long.valueOf(jobRunConfig.getJobId()),
         Math.toIntExact(jobRunConfig.getAttemptId()), origin);
-    final StandardSyncOutput output = new StandardSyncOutput()
+    return new StandardSyncOutput()
         .withFailures(List.of(checkFailureReason))
         .withStandardSyncSummary(
             new StandardSyncSummary()
@@ -135,7 +135,5 @@ public class SyncWorkflowImpl implements SyncWorkflow {
                     .withBytesEmitted(0L)
                     .withStateMessagesEmitted(0L)
                     .withRecordsCommitted(0L)));
-    return output;
   }
-
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -61,24 +61,22 @@ public class SyncWorkflowImpl implements SyncWorkflow {
 
 
     if (version >= VERSION_INTRODUCING_CHECK_BEFORE_SYNC) {
-      System.out.println("--- START SOURCE CHECK");
       final StandardCheckConnectionOutput sourceCheckResponse = checkActivity.check(jobRunConfig, sourceLauncherConfig, sourceConfiguration);
       if (sourceCheckResponse.getStatus() == Status.FAILED) {
-        System.out.println("--- SOURCE CHECK FAILED");
-        System.out.println(sourceCheckResponse);
+        LOGGER.info("SOURCE CHECK: Failed");
         return CheckFailureSyncOutput(FailureReason.FailureOrigin.SOURCE, jobRunConfig, sourceCheckResponse);
+      } else {
+        LOGGER.info("SOURCE CHECK: Successful");
       }
-      System.out.println("--- SOURCE CHECK OK");
 
-      System.out.println("--- START DESTINATION CHECK");
       final StandardCheckConnectionOutput destinationCheckResponse =
           checkActivity.check(jobRunConfig, destinationLauncherConfig, destinationConfiguration);
       if (destinationCheckResponse.getStatus() == Status.FAILED) {
-        System.out.println("--- DESTINATION CHECK FAILED");
-        System.out.println(destinationCheckResponse);
+        LOGGER.info("DESTINATION CHECK: Failed");
         return CheckFailureSyncOutput(FailureReason.FailureOrigin.DESTINATION, jobRunConfig, destinationCheckResponse);
+      } else {
+        LOGGER.info("DESTINATION CHECK: Successful");
       }
-      System.out.println("--- DESTINATION CHECK OK");
     }
 
     StandardSyncOutput syncOutput = replicationActivity.replicate(jobRunConfig, sourceLauncherConfig, destinationLauncherConfig, syncInput);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -136,4 +136,5 @@ public class SyncWorkflowImpl implements SyncWorkflow {
                     .withStateMessagesEmitted(0L)
                     .withRecordsCommitted(0L)));
   }
+
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -17,7 +17,6 @@ import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.temporal.check.connection.CheckConnectionActivity;
 import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
-import io.temporal.activity.ActivityOptions;
 import io.temporal.workflow.Workflow;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -46,10 +45,11 @@ public class SyncWorkflowImpl implements SyncWorkflow {
                                 final IntegrationLauncherConfig destinationLauncherConfig,
                                 final StandardSyncInput syncInput,
                                 final UUID connectionId) {
+    final StandardCheckConnectionInput sourceConfiguration = new StandardCheckConnectionInput()
+        .withConnectionConfiguration(syncInput.getSourceConfiguration());
 
-    final StandardCheckConnectionInput sourceConfiguration = new StandardCheckConnectionInput().withConnectionConfiguration(syncInput.getSourceConfiguration());
     System.out.println(sourceConfiguration);
-    StandardCheckConnectionOutput sourceCheckOutput = checkActivity.run(jobRunConfig, sourceLauncherConfig, sourceConfiguration);
+    StandardCheckConnectionOutput sourceCheckOutput = checkActivity.check(jobRunConfig, sourceLauncherConfig, sourceConfiguration);
 
     final StandardCheckConnectionInput destinationConfiguration = new StandardCheckConnectionInput().withConnectionConfiguration(syncInput.getDestinationConfiguration());
     System.out.println(destinationConfiguration);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -4,20 +4,24 @@
 
 package io.airbyte.workers.temporal.sync;
 
+import io.airbyte.config.FailureReason;
 import io.airbyte.config.NormalizationInput;
 import io.airbyte.config.NormalizationSummary;
 import io.airbyte.config.OperatorDbtInput;
+import io.airbyte.config.StandardCheckConnectionInput;
+import io.airbyte.config.StandardCheckConnectionOutput;
+import io.airbyte.config.StandardCheckConnectionOutput.Status;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncOperation.OperatorType;
 import io.airbyte.config.StandardSyncOutput;
-import io.airbyte.config.StandardCheckConnectionInput;
-import io.airbyte.config.StandardCheckConnectionOutput;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.temporal.check.connection.CheckConnectionActivity;
 import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
 import io.temporal.workflow.Workflow;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,9 +33,9 @@ public class SyncWorkflowImpl implements SyncWorkflow {
   private static final int CURRENT_VERSION = 1;
 
   private final CheckConnectionActivity checkActivity =
-    Workflow.newActivityStub(CheckConnectionActivity.class, ActivityConfiguration.CHECK_ACTIVITY_OPTIONS);
+      Workflow.newActivityStub(CheckConnectionActivity.class, ActivityConfiguration.CHECK_ACTIVITY_OPTIONS);
   private final ReplicationActivity replicationActivity =
-    Workflow.newActivityStub(ReplicationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
+      Workflow.newActivityStub(ReplicationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
   private final NormalizationActivity normalizationActivity =
       Workflow.newActivityStub(NormalizationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
   private final DbtTransformationActivity dbtTransformationActivity =
@@ -45,15 +49,53 @@ public class SyncWorkflowImpl implements SyncWorkflow {
                                 final IntegrationLauncherConfig destinationLauncherConfig,
                                 final StandardSyncInput syncInput,
                                 final UUID connectionId) {
+
     final StandardCheckConnectionInput sourceConfiguration = new StandardCheckConnectionInput()
         .withConnectionConfiguration(syncInput.getSourceConfiguration());
+    final StandardCheckConnectionInput destinationConfiguration =
+        new StandardCheckConnectionInput().withConnectionConfiguration(syncInput.getDestinationConfiguration());
 
-    System.out.println(sourceConfiguration);
     StandardCheckConnectionOutput sourceCheckOutput = checkActivity.check(jobRunConfig, sourceLauncherConfig, sourceConfiguration);
+    StandardCheckConnectionOutput destinationCheckOutput = checkActivity.check(jobRunConfig, destinationLauncherConfig, destinationConfiguration);
 
-    final StandardCheckConnectionInput destinationConfiguration = new StandardCheckConnectionInput().withConnectionConfiguration(syncInput.getDestinationConfiguration());
-    System.out.println(destinationConfiguration);
-    StandardCheckConnectionOutput destinationCheckOutput = checkActivity.run(jobRunConfig, destinationLauncherConfig, destinationConfiguration);
+    // if (sourceCheckOutput.getStatus() == Status.FAILED) {
+    // ThrowAndLogError("Source check failed");
+    // }
+    // else if (destinationCheckOutput.getStatus() == Status.FAILED) {
+    // ThrowAndLogError("Destination check failed");
+    // }
+
+    // boolean source_check_passed = true;
+    // boolean destination_check_passed = true;
+    // try {
+    //// System.out.println("----- SOURCE START");
+    // StandardCheckConnectionOutput sourceCheckOutput = checkActivity.check(jobRunConfig,
+    // sourceLauncherConfig, sourceConfiguration);
+    //// System.out.println("----- SOURCE RESPONSE");
+    //// System.out.println(sourceCheckOutput);
+    // } catch (ActivityFailure e) {
+    // source_check_passed = false;
+    // }
+    //
+    // try {
+    //// System.out.println("----- DESTINATION START");
+    // StandardCheckConnectionOutput destinationCheckOutput = checkActivity.check(jobRunConfig,
+    // destinationLauncherConfig, destinationConfiguration);
+    //// System.out.println("----- DESTINATION RESPONSE");
+    //// System.out.println(destinationCheckOutput);
+    // } catch (ActivityFailure e) {
+    // destination_check_passed = false;
+    // }
+
+    /*
+     * If there is an error with either of the connection CHECKs, return early with a FailureReason
+     */
+    if (sourceCheckOutput.getStatus() != Status.SUCCEEDED || destinationCheckOutput.getStatus() != Status.SUCCEEDED) {
+      StandardSyncOutput failureSyncOutput = new StandardSyncOutput();
+      List<FailureReason> failures = new ArrayList<FailureReason>();
+      failureSyncOutput.setFailures(failures);
+      return failureSyncOutput;
+    }
 
     StandardSyncOutput syncOutput = replicationActivity.replicate(jobRunConfig, sourceLauncherConfig, destinationLauncherConfig, syncInput);
 
@@ -84,14 +126,17 @@ public class SyncWorkflowImpl implements SyncWorkflow {
 
           dbtTransformationActivity.run(jobRunConfig, destinationLauncherConfig, syncInput.getResourceRequirements(), operatorDbtInput);
         } else {
-          final String message = String.format("Unsupported operation type: %s", standardSyncOperation.getOperatorType());
-          LOGGER.error(message);
-          throw new IllegalArgumentException(message);
+          ThrowAndLogError(String.format("Unsupported operation type: %s", standardSyncOperation.getOperatorType()));
         }
       }
     }
 
     return syncOutput;
+  }
+
+  private void ThrowAndLogError(String message) {
+    LOGGER.error(message);
+    throw new IllegalArgumentException(message);
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -59,7 +59,6 @@ public class SyncWorkflowImpl implements SyncWorkflow {
     final StandardCheckConnectionInput destinationConfiguration =
         new StandardCheckConnectionInput().withConnectionConfiguration(syncInput.getDestinationConfiguration());
 
-
     if (version >= VERSION_INTRODUCING_CHECK_BEFORE_SYNC) {
       final StandardCheckConnectionOutput sourceCheckResponse = checkActivity.check(jobRunConfig, sourceLauncherConfig, sourceConfiguration);
       if (sourceCheckResponse.getStatus() == Status.FAILED) {
@@ -116,10 +115,12 @@ public class SyncWorkflowImpl implements SyncWorkflow {
     return syncOutput;
   }
 
-  private StandardSyncOutput CheckFailureSyncOutput(FailureReason.FailureOrigin origin, JobRunConfig jobRunConfig, StandardCheckConnectionOutput checkResponse) {
+  private StandardSyncOutput CheckFailureSyncOutput(FailureReason.FailureOrigin origin,
+                                                    JobRunConfig jobRunConfig,
+                                                    StandardCheckConnectionOutput checkResponse) {
     final Exception ex = new IllegalArgumentException(checkResponse.getMessage());
     final FailureReason checkFailureReason = FailureHelper.checkFailure(ex, Long.valueOf(jobRunConfig.getJobId()),
-          Math.toIntExact(jobRunConfig.getAttemptId()), origin);
+        Math.toIntExact(jobRunConfig.getAttemptId()), origin);
     final StandardSyncOutput output = new StandardSyncOutput()
         .withFailures(List.of(checkFailureReason))
         .withStandardSyncSummary(
@@ -133,8 +134,8 @@ public class SyncWorkflowImpl implements SyncWorkflow {
                     .withRecordsEmitted(0L)
                     .withBytesEmitted(0L)
                     .withStateMessagesEmitted(0L)
-                    .withRecordsCommitted(0L))
-        );
+                    .withRecordsCommitted(0L)));
     return output;
   }
+
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/worker_run/WorkerRun.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/worker_run/WorkerRun.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 
 /*
  * This class represents a single run of a worker. It handles making sure the correct inputs and
- * outputs are passed to the selected worker. It also makes sures that the outputs of the worker are
+ * outputs are passed to the selected worker. It also makes sure that the outputs of the worker are
  * persisted to the db.
  */
 public class WorkerRun implements Callable<OutputAndStatus<JobOutput>> {

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
@@ -291,7 +291,6 @@ class SyncWorkflowTest {
     testEnv.getWorkflowService().blockingStub().requestCancelWorkflowExecution(cancelRequest);
   }
 
-
   private static void verifySourceCheck(final CheckConnectionActivity checkActivity, final StandardSyncInput syncInput) {
     final StandardCheckConnectionInput sourceConfiguration = new StandardCheckConnectionInput()
         .withConnectionConfiguration(syncInput.getSourceConfiguration());

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
@@ -17,14 +17,12 @@ import io.airbyte.config.NormalizationInput;
 import io.airbyte.config.NormalizationSummary;
 import io.airbyte.config.OperatorDbtInput;
 import io.airbyte.config.ResourceRequirements;
-import io.airbyte.config.StandardCheckConnectionInput;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.TestConfigHelpers;
-import io.airbyte.workers.temporal.check.connection.CheckConnectionActivity;
 import io.airbyte.workers.temporal.check.connection.CheckConnectionActivityImpl;
 import io.airbyte.workers.temporal.sync.DbtTransformationActivity;
 import io.airbyte.workers.temporal.sync.DbtTransformationActivityImpl;
@@ -143,47 +141,11 @@ class SyncWorkflowTest {
 
     final StandardSyncOutput actualOutput = execute();
 
-    verifySourceCheck(checkActivity, syncInput);
-    verifyDestinationCheck(checkActivity, syncInput);
     verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
     verifyPersistState(persistStateActivity, sync, replicationSuccessOutput);
     verifyNormalize(normalizationActivity, normalizationInput);
     verifyDbtTransform(dbtTransformationActivity, syncInput.getResourceRequirements(), operatorDbtInput);
     assertEquals(replicationSuccessOutput.withNormalizationSummary(normalizationSummary), actualOutput);
-  }
-
-  @Test
-  void testSourceCheckFailure() {
-    final StandardCheckConnectionInput sourceConfiguration = new StandardCheckConnectionInput()
-        .withConnectionConfiguration(syncInput.getSourceConfiguration());
-    doThrow(new IllegalArgumentException("source check exception")).when(checkActivity).check(
-        JOB_RUN_CONFIG,
-        SOURCE_LAUNCHER_CONFIG,
-        sourceConfiguration);
-
-    assertThrows(WorkflowFailedException.class, this::execute);
-
-    verifyNoInteractions(replicationActivity);
-    verifyNoInteractions(persistStateActivity);
-    verifyNoInteractions(normalizationActivity);
-    verifyNoInteractions(dbtTransformationActivity);
-  }
-
-  @Test
-  void testDestinationCheckFailure() {
-    final StandardCheckConnectionInput destinationConfiguration = new StandardCheckConnectionInput()
-        .withConnectionConfiguration(syncInput.getDestinationConfiguration());
-    doThrow(new IllegalArgumentException("destination check exception")).when(checkActivity).check(
-        JOB_RUN_CONFIG,
-        DESTINATION_LAUNCHER_CONFIG,
-        destinationConfiguration);
-
-    assertThrows(WorkflowFailedException.class, this::execute);
-
-    verifyNoInteractions(replicationActivity);
-    verifyNoInteractions(persistStateActivity);
-    verifyNoInteractions(normalizationActivity);
-    verifyNoInteractions(dbtTransformationActivity);
   }
 
   @Test
@@ -196,8 +158,6 @@ class SyncWorkflowTest {
 
     assertThrows(WorkflowFailedException.class, this::execute);
 
-    verifySourceCheck(checkActivity, syncInput);
-    verifyDestinationCheck(checkActivity, syncInput);
     verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
     verifyNoInteractions(persistStateActivity);
     verifyNoInteractions(normalizationActivity);
@@ -219,8 +179,6 @@ class SyncWorkflowTest {
 
     assertThrows(WorkflowFailedException.class, this::execute);
 
-    verifySourceCheck(checkActivity, syncInput);
-    verifyDestinationCheck(checkActivity, syncInput);
     verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
     verifyPersistState(persistStateActivity, sync, replicationSuccessOutput);
     verifyNormalize(normalizationActivity, normalizationInput);
@@ -240,8 +198,6 @@ class SyncWorkflowTest {
 
     assertThrows(WorkflowFailedException.class, this::execute);
 
-    verifySourceCheck(checkActivity, syncInput);
-    verifyDestinationCheck(checkActivity, syncInput);
     verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
     verifyNoInteractions(persistStateActivity);
     verifyNoInteractions(normalizationActivity);
@@ -266,8 +222,6 @@ class SyncWorkflowTest {
 
     assertThrows(WorkflowFailedException.class, this::execute);
 
-    verifySourceCheck(checkActivity, syncInput);
-    verifyDestinationCheck(checkActivity, syncInput);
     verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
     verifyPersistState(persistStateActivity, sync, replicationSuccessOutput);
     verifyNormalize(normalizationActivity, normalizationInput);
@@ -289,24 +243,6 @@ class SyncWorkflowTest {
         .build();
 
     testEnv.getWorkflowService().blockingStub().requestCancelWorkflowExecution(cancelRequest);
-  }
-
-  private static void verifySourceCheck(final CheckConnectionActivity checkActivity, final StandardSyncInput syncInput) {
-    final StandardCheckConnectionInput sourceConfiguration = new StandardCheckConnectionInput()
-        .withConnectionConfiguration(syncInput.getSourceConfiguration());
-    verify(checkActivity).check(
-        JOB_RUN_CONFIG,
-        SOURCE_LAUNCHER_CONFIG,
-        sourceConfiguration);
-  }
-
-  private static void verifyDestinationCheck(final CheckConnectionActivity checkActivity, final StandardSyncInput syncInput) {
-    final StandardCheckConnectionInput destinationConfiguration = new StandardCheckConnectionInput()
-        .withConnectionConfiguration(syncInput.getDestinationConfiguration());
-    verify(checkActivity).check(
-        JOB_RUN_CONFIG,
-        DESTINATION_LAUNCHER_CONFIG,
-        destinationConfiguration);
   }
 
   private static void verifyReplication(final ReplicationActivity replicationActivity, final StandardSyncInput syncInput, final UUID connectionId) {

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
@@ -23,7 +23,6 @@ import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.TestConfigHelpers;
-import io.airbyte.workers.temporal.check.connection.CheckConnectionActivityImpl;
 import io.airbyte.workers.temporal.sync.DbtTransformationActivity;
 import io.airbyte.workers.temporal.sync.DbtTransformationActivityImpl;
 import io.airbyte.workers.temporal.sync.NormalizationActivity;
@@ -55,7 +54,6 @@ class SyncWorkflowTest {
   private TestWorkflowEnvironment testEnv;
   private Worker syncWorker;
   private WorkflowClient client;
-  private CheckConnectionActivityImpl checkActivity;
   private ReplicationActivityImpl replicationActivity;
   private NormalizationActivityImpl normalizationActivity;
   private DbtTransformationActivityImpl dbtTransformationActivity;
@@ -108,7 +106,6 @@ class SyncWorkflowTest {
         .withDestinationConfiguration(syncInput.getDestinationConfiguration())
         .withOperatorDbt(syncInput.getOperationSequence().get(1).getOperatorDbt());
 
-    checkActivity = mock(CheckConnectionActivityImpl.class);
     replicationActivity = mock(ReplicationActivityImpl.class);
     normalizationActivity = mock(NormalizationActivityImpl.class);
     dbtTransformationActivity = mock(DbtTransformationActivityImpl.class);
@@ -117,7 +114,7 @@ class SyncWorkflowTest {
 
   // bundle up all the temporal worker setup / execution into one method.
   private StandardSyncOutput execute() {
-    syncWorker.registerActivitiesImplementations(checkActivity, replicationActivity, normalizationActivity, dbtTransformationActivity,
+    syncWorker.registerActivitiesImplementations(replicationActivity, normalizationActivity, dbtTransformationActivity,
         persistStateActivity);
     testEnv.start();
     final SyncWorkflow workflow =

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
@@ -23,7 +23,6 @@ import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.TestConfigHelpers;
-import io.airbyte.workers.temporal.check.connection.CheckConnectionActivity;
 import io.airbyte.workers.temporal.check.connection.CheckConnectionActivityImpl;
 import io.airbyte.workers.temporal.sync.DbtTransformationActivity;
 import io.airbyte.workers.temporal.sync.DbtTransformationActivityImpl;
@@ -118,7 +117,8 @@ class SyncWorkflowTest {
 
   // bundle up all the temporal worker setup / execution into one method.
   private StandardSyncOutput execute() {
-    syncWorker.registerActivitiesImplementations(checkActivity, replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
+    syncWorker.registerActivitiesImplementations(checkActivity, replicationActivity, normalizationActivity, dbtTransformationActivity,
+        persistStateActivity);
     testEnv.start();
     final SyncWorkflow workflow =
         client.newWorkflowStub(SyncWorkflow.class, WorkflowOptions.newBuilder().setTaskQueue(TemporalJobType.SYNC.name()).build());

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
@@ -23,6 +23,8 @@ import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.TestConfigHelpers;
+import io.airbyte.workers.temporal.check.connection.CheckConnectionActivity;
+import io.airbyte.workers.temporal.check.connection.CheckConnectionActivityImpl;
 import io.airbyte.workers.temporal.sync.DbtTransformationActivity;
 import io.airbyte.workers.temporal.sync.DbtTransformationActivityImpl;
 import io.airbyte.workers.temporal.sync.NormalizationActivity;
@@ -54,6 +56,7 @@ class SyncWorkflowTest {
   private TestWorkflowEnvironment testEnv;
   private Worker syncWorker;
   private WorkflowClient client;
+  private CheckConnectionActivityImpl checkActivity;
   private ReplicationActivityImpl replicationActivity;
   private NormalizationActivityImpl normalizationActivity;
   private DbtTransformationActivityImpl dbtTransformationActivity;
@@ -106,6 +109,7 @@ class SyncWorkflowTest {
         .withDestinationConfiguration(syncInput.getDestinationConfiguration())
         .withOperatorDbt(syncInput.getOperationSequence().get(1).getOperatorDbt());
 
+    checkActivity = mock(CheckConnectionActivityImpl.class);
     replicationActivity = mock(ReplicationActivityImpl.class);
     normalizationActivity = mock(NormalizationActivityImpl.class);
     dbtTransformationActivity = mock(DbtTransformationActivityImpl.class);
@@ -114,7 +118,7 @@ class SyncWorkflowTest {
 
   // bundle up all the temporal worker setup / execution into one method.
   private StandardSyncOutput execute() {
-    syncWorker.registerActivitiesImplementations(replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
+    syncWorker.registerActivitiesImplementations(checkActivity, replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
     testEnv.start();
     final SyncWorkflow workflow =
         client.newWorkflowStub(SyncWorkflow.class, WorkflowOptions.newBuilder().setTaskQueue(TemporalJobType.SYNC.name()).build());

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
@@ -114,8 +114,7 @@ class SyncWorkflowTest {
 
   // bundle up all the temporal worker setup / execution into one method.
   private StandardSyncOutput execute() {
-    syncWorker.registerActivitiesImplementations(replicationActivity, normalizationActivity, dbtTransformationActivity,
-        persistStateActivity);
+    syncWorker.registerActivitiesImplementations(replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
     testEnv.start();
     final SyncWorkflow workflow =
         client.newWorkflowStub(SyncWorkflow.class, WorkflowOptions.newBuilder().setTaskQueue(TemporalJobType.SYNC.name()).build());

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowTest.java
@@ -144,7 +144,7 @@ public class ConnectionManagerWorkflowTest {
                 new IntegrationLauncherConfig(),
                 new StandardSyncInput()));
 
-    Mockito.when(mCheckConnectionActivity.check(Mockito.any()))
+    Mockito.when(mCheckConnectionActivity.run(Mockito.any()))
         .thenReturn(new StandardCheckConnectionOutput().withStatus(Status.SUCCEEDED).withMessage("check worked"));
 
     Mockito.when(mAutoDisableConnectionActivity.autoDisableFailingConnection(Mockito.any()))
@@ -863,7 +863,7 @@ public class ConnectionManagerWorkflowTest {
           .thenReturn(new JobCreationOutput(JOB_ID));
       Mockito.when(mJobCreationAndStatusUpdateActivity.createNewAttemptNumber(Mockito.any()))
           .thenReturn(new AttemptNumberCreationOutput(ATTEMPT_ID));
-      Mockito.when(mCheckConnectionActivity.check(Mockito.any()))
+      Mockito.when(mCheckConnectionActivity.run(Mockito.any()))
           .thenReturn(new StandardCheckConnectionOutput().withStatus(Status.FAILED).withMessage("nope"));
 
       testEnv.start();
@@ -903,7 +903,7 @@ public class ConnectionManagerWorkflowTest {
           .thenReturn(new JobCreationOutput(JOB_ID));
       Mockito.when(mJobCreationAndStatusUpdateActivity.createNewAttemptNumber(Mockito.any()))
           .thenReturn(new AttemptNumberCreationOutput(ATTEMPT_ID));
-      Mockito.when(mCheckConnectionActivity.check(Mockito.any()))
+      Mockito.when(mCheckConnectionActivity.run(Mockito.any()))
           .thenReturn(new StandardCheckConnectionOutput().withStatus(Status.SUCCEEDED).withMessage("all good")) // First call (source) succeeds
           .thenReturn(new StandardCheckConnectionOutput().withStatus(Status.FAILED).withMessage("nope")); // Second call (destination) fails
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/WorkflowReplayingTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/WorkflowReplayingTest.java
@@ -14,6 +14,8 @@ public class WorkflowReplayingTest {
 
   @Test
   public void replaySimpleSuccessfulWorkflow() throws Exception {
+    // This test ensures that a new version of the workflow doesn't break an in-progress execution
+    // This JSON file is exported from Temporal directly (e.g. `http://${temporal-ui}/namespaces/default/workflows/connection_manager_-${uuid}/${uuid}/history`) and export
     final URL historyPath = getClass().getClassLoader().getResource("workflowHistory.json");
 
     final File historyFile = new File(historyPath.toURI());

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/WorkflowReplayingTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/WorkflowReplayingTest.java
@@ -15,7 +15,9 @@ public class WorkflowReplayingTest {
   @Test
   public void replaySimpleSuccessfulWorkflow() throws Exception {
     // This test ensures that a new version of the workflow doesn't break an in-progress execution
-    // This JSON file is exported from Temporal directly (e.g. `http://${temporal-ui}/namespaces/default/workflows/connection_manager_-${uuid}/${uuid}/history`) and export
+    // This JSON file is exported from Temporal directly (e.g.
+    // `http://${temporal-ui}/namespaces/default/workflows/connection_manager_-${uuid}/${uuid}/history`)
+    // and export
     final URL historyPath = getClass().getClassLoader().getResource("workflowHistory.json");
 
     final File historyFile = new File(historyPath.toURI());


### PR DESCRIPTION
## What

This change runs the CHECK command of both the Source and Destination connector as the first step of the SYNC workflow.  This will allow the worker to quickly exit the sync and share with the user that an update to the connection's configuration is required, saving time and credits.  This PR will assign the `"config_error"` failure reason so these types of errors can be excluded from our connector metrics. 

<img width="1545" alt="Screen Shot 2022-05-16 at 3 26 46 PM" src="https://user-images.githubusercontent.com/303226/168692520-75cf0ea4-aa7a-4a9b-af7a-e08252028fe3.png">


## How

The main changes are to [SyncWorkflowImpl.java](https://github.com/airbytehq/airbyte/pull/12423/files#diff-02b4bddd2bfda0f2932300bcc1295e245b17db6f0590aa3abd204d5a7242b654) and [ConnectionManagerWorkflowImpl.java](https://github.com/airbytehq/airbyte/pull/12423/files#diff-2102e7d563f0b8fb72189ff673f62872acd77615dd743da7f45f5e57323422ef) to:
* Run the CHECK activities for the source and destination
* Craft a `StandardSyncOutput` response for those CHECK failures that has the same properties as a failed sync - `CheckFailureSyncOutput` 
* Various renames and utility classes

## User Impact

There will be a slight slow-down when starting every sync going forward.  Future work can choose to only run these CHECKs periodically.  Situations where CHECK will fail will also fail the sync, but this will be quicker now. 

## Notes

To run this PR, you will need to use the new scheduler: `NEW_SCHEDULER=true VERSION=dev docker-compose -f docker-compose.yaml -f docker-compose.debug.yaml up`.  The new scheduler will make it to OSS Airbyte soon, via https://github.com/airbytehq/airbyte/issues/10021

Closes #12281
Closes #12282

## TODO: 
- [x] Get it working
- [x] Prevent subsequent attempts
- [x] Test it
- [x] Check on any special considerations when running on K8s 🤷 

