### PR TITLE
register check activity in temporal for the sync job type

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -195,11 +195,15 @@ public class WorkerApp {
         defaultWorkerConfigs,
         defaultProcessFactory);
 
+    final CheckConnectionActivityImpl checkConnectionActivity =
+        new CheckConnectionActivityImpl(checkWorkerConfigs, checkProcessFactory, secretsHydrator, workspaceRoot, workerEnvironment, logConfigs,
+            jobPersistence, airbyteVersion);
+
     final PersistStateActivityImpl persistStateActivity = new PersistStateActivityImpl(workspaceRoot, configRepository);
 
     final Worker syncWorker = factory.newWorker(TemporalJobType.SYNC.name(), getWorkerOptions(maxWorkers.getMaxSyncWorkers()));
     syncWorker.registerWorkflowImplementationTypes(SyncWorkflowImpl.class);
-    syncWorker.registerActivitiesImplementations(replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
+    syncWorker.registerActivitiesImplementations(checkConnectionActivity, replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
   }
 
   private void registerDiscover(final WorkerFactory factory) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivity.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivity.java
@@ -15,8 +15,8 @@ import io.temporal.activity.ActivityMethod;
 public interface CheckConnectionActivity {
 
   @ActivityMethod
-  StandardCheckConnectionOutput run(JobRunConfig jobRunConfig,
-                                    IntegrationLauncherConfig launcherConfig,
-                                    StandardCheckConnectionInput connectionConfiguration);
+  StandardCheckConnectionOutput check(JobRunConfig jobRunConfig,
+                                      IntegrationLauncherConfig launcherConfig,
+                                      StandardCheckConnectionInput connectionConfiguration);
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionActivityImpl.java
@@ -55,9 +55,9 @@ public class CheckConnectionActivityImpl implements CheckConnectionActivity {
     this.airbyteVersion = airbyteVersion;
   }
 
-  public StandardCheckConnectionOutput run(final JobRunConfig jobRunConfig,
-                                           final IntegrationLauncherConfig launcherConfig,
-                                           final StandardCheckConnectionInput connectionConfiguration) {
+  public StandardCheckConnectionOutput check(final JobRunConfig jobRunConfig,
+                                             final IntegrationLauncherConfig launcherConfig,
+                                             final StandardCheckConnectionInput connectionConfiguration) {
 
     final JsonNode fullConfig = secretsHydrator.hydrate(connectionConfiguration.getConnectionConfiguration());
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/check/connection/CheckConnectionWorkflowImpl.java
@@ -18,7 +18,7 @@ public class CheckConnectionWorkflowImpl implements CheckConnectionWorkflow {
   public StandardCheckConnectionOutput run(final JobRunConfig jobRunConfig,
                                            final IntegrationLauncherConfig launcherConfig,
                                            final StandardCheckConnectionInput connectionConfiguration) {
-    return activity.run(jobRunConfig, launcherConfig, connectionConfiguration);
+    return activity.check(jobRunConfig, launcherConfig, connectionConfiguration);
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -17,7 +17,6 @@ import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.temporal.check.connection.CheckConnectionActivity;
 import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
-import io.temporal.activity.ActivityOptions;
 import io.temporal.workflow.Workflow;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -46,10 +45,11 @@ public class SyncWorkflowImpl implements SyncWorkflow {
                                 final IntegrationLauncherConfig destinationLauncherConfig,
                                 final StandardSyncInput syncInput,
                                 final UUID connectionId) {
+    final StandardCheckConnectionInput sourceConfiguration = new StandardCheckConnectionInput()
+        .withConnectionConfiguration(syncInput.getSourceConfiguration());
 
-    final StandardCheckConnectionInput sourceConfiguration = new StandardCheckConnectionInput().withConnectionConfiguration(syncInput.getSourceConfiguration());
     System.out.println(sourceConfiguration);
-    StandardCheckConnectionOutput sourceCheckOutput = checkActivity.run(jobRunConfig, sourceLauncherConfig, sourceConfiguration);
+    StandardCheckConnectionOutput sourceCheckOutput = checkActivity.check(jobRunConfig, sourceLauncherConfig, sourceConfiguration);
 
     final StandardCheckConnectionInput destinationConfiguration = new StandardCheckConnectionInput().withConnectionConfiguration(syncInput.getDestinationConfiguration());
     System.out.println(destinationConfiguration);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
@@ -23,6 +23,8 @@ import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.TestConfigHelpers;
+import io.airbyte.workers.temporal.check.connection.CheckConnectionActivity;
+import io.airbyte.workers.temporal.check.connection.CheckConnectionActivityImpl;
 import io.airbyte.workers.temporal.sync.DbtTransformationActivity;
 import io.airbyte.workers.temporal.sync.DbtTransformationActivityImpl;
 import io.airbyte.workers.temporal.sync.NormalizationActivity;
@@ -54,6 +56,7 @@ class SyncWorkflowTest {
   private TestWorkflowEnvironment testEnv;
   private Worker syncWorker;
   private WorkflowClient client;
+  private CheckConnectionActivityImpl checkActivity;
   private ReplicationActivityImpl replicationActivity;
   private NormalizationActivityImpl normalizationActivity;
   private DbtTransformationActivityImpl dbtTransformationActivity;
@@ -106,6 +109,7 @@ class SyncWorkflowTest {
         .withDestinationConfiguration(syncInput.getDestinationConfiguration())
         .withOperatorDbt(syncInput.getOperationSequence().get(1).getOperatorDbt());
 
+    checkActivity = mock(CheckConnectionActivityImpl.class);
     replicationActivity = mock(ReplicationActivityImpl.class);
     normalizationActivity = mock(NormalizationActivityImpl.class);
     dbtTransformationActivity = mock(DbtTransformationActivityImpl.class);
@@ -114,7 +118,7 @@ class SyncWorkflowTest {
 
   // bundle up all the temporal worker setup / execution into one method.
   private StandardSyncOutput execute() {
-    syncWorker.registerActivitiesImplementations(replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
+    syncWorker.registerActivitiesImplementations(checkActivity, replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
     testEnv.start();
     final SyncWorkflow workflow =
         client.newWorkflowStub(SyncWorkflow.class, WorkflowOptions.newBuilder().setTaskQueue(TemporalJobType.SYNC.name()).build());


### PR DESCRIPTION
TL;DR: Temporal has a concept of workers. Workers have types. Each worker type expects only a certain set of activities. It uses this information to serialize/deserialize configurations between the orchestrator and the actual worker runtime. The main issue with the upstream PR was that it didn't register the `CheckConnectionActivityImpl` as a valid activity that could be sent to the `SYNC` job/worker type. This caused the workflow to get confused about how to deserialize the input JSON sent to it. This PR registers the activity type. This problem ceased happening for me during unit test runs. I did not verify this in a proper docker image. 