### PR TITLE
Add experimental build-connector and publish-connector slash commands

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -22,6 +22,8 @@ jobs:
           commands: |
             test
             test-performance
+            build-connector
+            publish-connector
             publish
             publish-external
             publish-cdk


### PR DESCRIPTION
## What
Im experimenting with new slash commands `/build-connector` and `/publish-connector` here: https://github.com/airbytehq/airbyte/pull/12405

I cannot iterate and actually call these commands until they are merged into master lol

## How
*Describe the solution*

## Recommended reading order


## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

