### PR TITLE
Update Airbyte to use a service account and secret for Mixpanel authorization

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
@@ -40,6 +40,17 @@ def test_check_connection_ok(requests_mock, config):
     assert ok
     assert not error_msg
 
+def test_check_connection_service_account_ok(requests_mock, config):
+    responses = [
+        {"json": [], "status_code": 200},
+    ]
+
+    requests_mock.register_uri("GET", "/properties/v2/contact/properties", responses)
+    ok, error_msg = SourceHubspot().check_connection(logger, config=config)
+
+    assert ok
+    assert not error_msg
+
 
 def test_check_connection_empty_config(config):
     config = {}

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
@@ -40,17 +40,6 @@ def test_check_connection_ok(requests_mock, config):
     assert ok
     assert not error_msg
 
-def test_check_connection_service_account_ok(requests_mock, config):
-    responses = [
-        {"json": [], "status_code": 200},
-    ]
-
-    requests_mock.register_uri("GET", "/properties/v2/contact/properties", responses)
-    ok, error_msg = SourceHubspot().check_connection(logger, config=config)
-
-    assert ok
-    assert not error_msg
-
 
 def test_check_connection_empty_config(config):
     config = {}

--- a/airbyte-integrations/connectors/source-mixpanel/setup.py
+++ b/airbyte-integrations/connectors/source-mixpanel/setup.py
@@ -11,6 +11,7 @@ MAIN_REQUIREMENTS = [
 
 TEST_REQUIREMENTS = [
     "pytest~=6.1",
+    "requests_mock==1.8.0",
     "source-acceptance-test",
 ]
 

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
@@ -804,11 +804,17 @@ class SourceMixpanel(AbstractSource):
         :param logger:  logger object
         :return Tuple[bool, any]: (True, None) if the input config can be used to connect to the API successfully, (False, error) otherwise.
         """
-        if config["api_secret"] != None:
+        auth = None
+        try:
             auth = TokenAuthenticatorBase64(token=config["api_secret"])
+        except KeyError as key_error:
+            try:
+                auth = TokenAuthenticatorBase64(token=config["serviceaccount_username"] + ":" + config["serviceaccount_secret"])
+            except KeyError as key_error:
+                auth = None
 
-        if config["serviceaccount_username"] != None:
-            auth = TokenAuthenticatorBase64(token=config["serviceaccount_username"] + ":" + config["serviceaccount_secret"])
+        if auth == None:
+           return False, KeyError("The requested service account or api_secret was not found in the source.")
 
         funnels = FunnelsList(authenticator=auth, **config)
         try:

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
@@ -804,12 +804,12 @@ class SourceMixpanel(AbstractSource):
         :param logger:  logger object
         :return Tuple[bool, any]: (True, None) if the input config can be used to connect to the API successfully, (False, error) otherwise.
         """
-        if (config["api_secret"] ) {
+        if config["api_secret"] != None:
             auth = TokenAuthenticatorBase64(token=config["api_secret"])
-        }
-        if (config["serviceaccount_username"] ) {
+
+        if config["serviceaccount_username"] != None:
             auth = TokenAuthenticatorBase64(token=config["serviceaccount_username"] + ":" + config["serviceaccount_secret"])
-        }
+
         funnels = FunnelsList(authenticator=auth, **config)
         try:
             response = requests.request(

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
@@ -807,10 +807,10 @@ class SourceMixpanel(AbstractSource):
         auth = None
         try:
             auth = TokenAuthenticatorBase64(token=config["api_secret"])
-        except KeyError as key_error:
+        except KeyError:
             try:
                 auth = TokenAuthenticatorBase64(token=config["serviceaccount_username"] + ":" + config["serviceaccount_secret"])
-            except KeyError as key_error:
+            except KeyError:
                 auth = None
 
         if auth == None:

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
@@ -804,7 +804,12 @@ class SourceMixpanel(AbstractSource):
         :param logger:  logger object
         :return Tuple[bool, any]: (True, None) if the input config can be used to connect to the API successfully, (False, error) otherwise.
         """
-        auth = TokenAuthenticatorBase64(token=config["api_secret"])
+        if (config["api_secret"] ) {
+            auth = TokenAuthenticatorBase64(token=config["api_secret"])
+        }
+        if (config["serviceaccount_username"] ) {
+            auth = TokenAuthenticatorBase64(token=config["serviceaccount_username"] + ":" + config["serviceaccount_secret"])
+        }
         funnels = FunnelsList(authenticator=auth, **config)
         try:
             response = requests.request(

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
@@ -4,9 +4,19 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Source Mixpanel Spec",
     "type": "object",
-    "required": ["api_secret"],
     "additionalProperties": true,
     "properties": {
+      "serviceaccount_username": {
+        "title": "Mixpanel Service Account username",
+        "type": "string",
+        "description": "Mixpanel Service Account username"
+      },
+      "serviceaccount_secret": {
+        "title": "Mixpanel Service Account secret",
+        "type": "string",
+        "description": "Mixpanel Service Account secret",
+        "airbyte_secret": true
+      },
       "api_secret": {
         "title": "API Secret",
         "type": "string",

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/unit_test.py
@@ -50,7 +50,6 @@ def test_check_connection_service_account_ok(requests_mock):
 def test_date_slices():
 
     now = date.today()
-
     # Test with start_date now range
     stream_slices = Annotations(authenticator=NoAuth(), start_date=now, end_date=now, date_window_size=1, region="EU").stream_slices(
         sync_mode="any"

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/unit_test.py
@@ -11,9 +11,7 @@ from source_mixpanel.source import SourceMixpanel
 logger = logging.getLogger("test_client")
 
 def test_check_connection_api_secret_ok(requests_mock):
-    responses = [
-        {"json": [], "status_code": 200},
-    ]
+
     config = {}
     config["api_secret"] = "testApiSecret"
 
@@ -29,9 +27,7 @@ def test_check_connection_api_secret_ok(requests_mock):
     assert not error_msg
 
 def test_check_connection_service_account_ok(requests_mock):
-    responses = [
-        {"json": [], "status_code": 200},
-    ]
+
     config = {}
     config["serviceaccount_username"] = "testName"
     config["serviceaccount_secret"] = "testSecretName"

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/unit_test.py
@@ -12,8 +12,7 @@ logger = logging.getLogger("test_client")
 
 def test_check_connection_api_secret_ok(requests_mock):
 
-    config = {}
-    config["api_secret"] = "testApiSecret"
+    config = {"api_secret" : "testApiSecret"}
 
     service_account_headers = {
         "Authorization": "Basic api_secret:testApiSecret",
@@ -28,9 +27,10 @@ def test_check_connection_api_secret_ok(requests_mock):
 
 def test_check_connection_service_account_ok(requests_mock):
 
-    config = {}
-    config["serviceaccount_username"] = "testName"
-    config["serviceaccount_secret"] = "testSecretName"
+    config = {
+        "serviceaccount_username" : "testName",
+        "serviceaccount_secret" : "testSecretName"
+     }
 
     service_account_headers = {
         "Authorization": "Basic testName:testSecretName",

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/unit_test.py
@@ -11,6 +11,19 @@ from source_mixpanel.source import Annotations
 def test_date_slices():
 
     now = date.today()
+
+    # Test with service account
+    stream_slices = Annotations(authenticator=NoAuth(),
+                                serviceaccount_username="testName",
+                                serviceaccount_secret="testSecret",
+                                start_date=now,
+                                end_date=now,
+                                date_window_size=1,
+                                region="EU").stream_slices(
+        sync_mode="any"
+    )
+    assert 1 == len(stream_slices)
+
     # Test with start_date now range
     stream_slices = Annotations(authenticator=NoAuth(), start_date=now, end_date=now, date_window_size=1, region="EU").stream_slices(
         sync_mode="any"

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/unit_test.py
@@ -43,6 +43,22 @@ def test_check_connection_service_account_ok(requests_mock):
     assert ok
     assert not error_msg
 
+def test_check_connection_wrong_endpoint_not_ok(requests_mock):
+
+    config = {}
+    config["api_secret"] = "testApiSecret"
+
+    service_account_headers = {
+        "Authorization": "Basic api_secret:testApiSecret",
+        "Accept": "application/json",
+    }
+
+    requests_mock.register_uri("GET", "NOT https://mixpanel.com/api/2.0/funnels/list", headers=service_account_headers)
+    ok, error_msg = SourceMixpanel().check_connection(logger, config=config)
+
+    assert not ok
+    assert error_msg
+
 def test_date_slices():
 
     now = date.today()


### PR DESCRIPTION

Update Airbyte to use a service account and secret for Mixpanel authorization

## What
*Describe what the change is solving*
   Currently, Airbyte uses the api secret to authorize connections to Mixpanel, which will be deprecated in the future. This change allows both authorization methods. 

https://developer.mixpanel.com/reference/project-secret

*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

This solution adds `serviceaccount_username` and `serviceaccount_secret` and uses them is they are available.

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

No, this changes is backward compatible because it does not remove the previous `api_secret`.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
