### PR TITLE
Fix `<CircleLoader />` svg props

### DIFF
--- a/airbyte-webapp/src/components/StatusIcon/CircleLoader.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/CircleLoader.tsx
@@ -47,15 +47,15 @@ const CircleLoader = ({ title }: Props): JSX.Element => (
       <g>
         <path
           d="M8,0.5C3.85775,0.5,0.5,3.85775,0.5,8s3.35775,7.5,7.5,7.5v-2c-3.03768,0-5.5-2.4623-5.5-5.5s2.46232-5.5,5.5-5.5v-2Z"
-          clip-rule="evenodd"
+          clipRule="evenodd"
           fill="url(#eDwmAshgIQE3-fill)"
-          fill-rule="evenodd"
+          fillRule="evenodd"
         />
         <path
           d="M8,15.5c4.1423,0,7.5-3.3577,7.5-7.5s-3.3577-7.5-7.5-7.5v2c3.0377,0,5.5,2.46232,5.5,5.5s-2.4623,5.5-5.5,5.5v2Z"
-          clip-rule="evenodd"
+          clipRule="evenodd"
           fill="#d1d1db"
-          fill-rule="evenodd"
+          fillRule="evenodd"
         />
       </g>
     </g>


### PR DESCRIPTION
## What
Fixes a couple of props in the CircleLoader svg that were not formatted correctly for React, causing errors while running the app:

![image](https://user-images.githubusercontent.com/168664/165962708-dfef2bc5-d6b0-4545-b13f-c9be6d3fe9b9.png)
