### PR TITLE
Add object methods for json schema type

### DIFF
--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -135,7 +135,7 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractRelationalDbS
                 .map(f -> {
                   final Datatype datatype = getFieldType(f);
                   final JsonSchemaType jsonType = getType(datatype);
-                  LOGGER.info("Table {} column {} (type {}[{}]) -> Json type {}",
+                  LOGGER.info("Table {} column {} (type {}[{}]) -> {}",
                       fields.get(0).get(INTERNAL_TABLE_NAME).asText(),
                       f.get(INTERNAL_COLUMN_NAME).asText(),
                       f.get(INTERNAL_COLUMN_TYPE_NAME).asText(),

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/JsonSchemaType.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/JsonSchemaType.java
@@ -6,6 +6,7 @@ package io.airbyte.protocol.models;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class JsonSchemaType {
 
@@ -51,17 +52,17 @@ public class JsonSchemaType {
       typeMapBuilder.put(TYPE, type.name().toLowerCase());
     }
 
-    public Builder withFormat(String value) {
+    public Builder withFormat(final String value) {
       typeMapBuilder.put(FORMAT, value);
       return this;
     }
 
-    public Builder withContentEncoding(String value) {
+    public Builder withContentEncoding(final String value) {
       typeMapBuilder.put(CONTENT_ENCODING, value);
       return this;
     }
 
-    public Builder withAirbyteType(String value) {
+    public Builder withAirbyteType(final String value) {
       typeMapBuilder.put(AIRBYTE_TYPE, value);
       return this;
     }
@@ -70,6 +71,27 @@ public class JsonSchemaType {
       return new JsonSchemaType(typeMapBuilder.build());
     }
 
+  }
+
+  @Override
+  public String toString() {
+    return String.format("JsonSchemaType(%s)", jsonSchemaTypeMap.toString());
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (other == null) {
+      return false;
+    }
+    if (!(other instanceof final JsonSchemaType that)) {
+      return false;
+    }
+    return Objects.equals(this.jsonSchemaTypeMap, that.jsonSchemaTypeMap);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(this.jsonSchemaTypeMap);
   }
 
 }


### PR DESCRIPTION
- Currently `JsonSchemaType` has no `toString` method. So when it is logged, the logs are not useful.
- This PR adds the missing `toString` method to this class.
