### PR TITLE
🐙 octavia-cli: delete commands

### DIFF
--- a/octavia-cli/octavia_cli/delete/__init__.py
+++ b/octavia-cli/octavia_cli/delete/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#

--- a/octavia-cli/octavia_cli/delete/commands.py
+++ b/octavia-cli/octavia_cli/delete/commands.py
@@ -1,0 +1,91 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+from typing import List
+
+import click
+from octavia_cli.base_commands import OctaviaCommand
+
+from .deletings import Connections, DestinationConnectorsDefinitions, Destinations, SourceConnectorsDefinitions, Sources
+
+
+@click.group("delete", help="Delete existing Airbyte resources.")
+@click.pass_context
+def _delete(ctx: click.Context):  # pragma: no cover
+    pass
+
+
+@click.group("connectors", help="Delete specific source and destination connector available on your Airbyte instance.")
+@click.pass_context
+def connectors(ctx: click.Context):  # pragma: no cover
+    pass
+
+
+@click.group("workspace", help="Delete existing resorce in workspace.")
+@click.pass_context
+def workspace(ctx: click.Context):  # pragma: no cover
+    pass
+
+
+@connectors.command(cls=OctaviaCommand, name="sources", help="Delete specific source connector available on your Airbyte instance.")
+@click.option("--sourceDefinitionId", "-i", "source_definition_id", required=True, type=str)
+@click.pass_context
+def sources_connectors(ctx: click.Context, source_definition_id: str):
+    api_client = ctx.obj["API_CLIENT"]
+    definitions = SourceConnectorsDefinitions(api_client, source_definition_id)
+    click.echo(definitions)
+    pass
+
+
+@connectors.command(
+    cls=OctaviaCommand, name="destinations", help="Delete specific destination connector available on your Airbyte instance"
+)
+@click.option("--destinationDefinitionId", "-i", "destination_definition_id", required=True, type=str)
+@click.pass_context
+def destinations_connectors(ctx: click.Context, destination_definition_id: str):
+    api_client = ctx.obj["API_CLIENT"]
+    definitions = DestinationConnectorsDefinitions(api_client, destination_definition_id)
+    click.echo(definitions)
+    pass
+
+
+@workspace.command(cls=OctaviaCommand, help="Delete existing sources in a workspace.")
+@click.option("--sourceId", "-i", "source_id", required=True, type=str)
+@click.pass_context
+def sources(ctx: click.Context, source_id: str):
+    api_client = ctx.obj["API_CLIENT"]
+    sources = Sources(api_client, source_id)
+    click.echo(sources)
+    pass
+
+
+@workspace.command(cls=OctaviaCommand, help="Delete existing destinations in a workspace.")
+@click.option("--destinationId", "-i", "destination_id", required=True, type=str)
+@click.pass_context
+def destinations(ctx: click.Context, destination_id: str):
+    api_client = ctx.obj["API_CLIENT"]
+    destinations = Destinations(api_client, destination_id)
+    click.echo(destinations)
+    pass
+
+
+@workspace.command(cls=OctaviaCommand, help="Delete existing connections in a workspace.")
+@click.option("--connectionId", "-i", "connection_id", required=True, type=str)
+@click.pass_context
+def connections(ctx: click.Context, connection_id: str):
+    api_client = ctx.obj["API_CLIENT"]
+    connections = Connections(api_client, connection_id)
+    click.echo(connections)
+    pass
+
+
+AVAILABLE_COMMANDS: List[click.Command] = [connectors, workspace]
+
+
+def add_commands_to_list():
+    for command in AVAILABLE_COMMANDS:
+        _delete.add_command(command)
+
+
+add_commands_to_list()

--- a/octavia-cli/octavia_cli/delete/deletings.py
+++ b/octavia-cli/octavia_cli/delete/deletings.py
@@ -1,0 +1,124 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+import abc
+
+import airbyte_api_client
+from airbyte_api_client.api import connection_api, destination_api, destination_definition_api, source_api, source_definition_api
+from airbyte_api_client.model.connection_id_request_body import ConnectionIdRequestBody
+from airbyte_api_client.model.destination_definition_id_request_body import DestinationDefinitionIdRequestBody
+from airbyte_api_client.model.destination_id_request_body import DestinationIdRequestBody
+from airbyte_api_client.model.source_definition_id_request_body import SourceDefinitionIdRequestBody
+from airbyte_api_client.model.source_id_request_body import SourceIdRequestBody
+from click import ClickException
+
+
+class FailedToDeleteError(ClickException):
+    pass
+
+
+class BaseDeleting(abc.ABC):
+    COMMON_DELETE_FUNCTION_KWARGS = {"_check_return_type": False}
+    id = None
+
+    @property
+    @abc.abstractmethod
+    def api(
+        self,
+    ):  # pragma: no cover
+        pass
+
+    @property
+    @abc.abstractmethod
+    def delete_function_name(
+        self,
+    ) -> str:  # pragma: no cover
+        pass
+
+    @property
+    def _delete_fn(self):
+        return getattr(self.api, self.delete_function_name)
+
+    @property
+    def delete_function_kwargs(self) -> dict:
+        return {}
+
+    def __init__(self, api_client: airbyte_api_client.ApiClient):
+        self.api_instance = self.api(api_client)
+
+    def deleting(self) -> str:
+        try:
+            self._delete_fn(self.api_instance, **self.delete_function_kwargs, **self.COMMON_DELETE_FUNCTION_KWARGS)
+            return "Successfully deleted Airbyte resource with ID: " + self.id
+        except airbyte_api_client.ApiException as api_error:
+            raise FailedToDeleteError(api_error.body)
+
+    def __repr__(self):
+        res = self.deleting()
+        return res
+
+
+class SourceConnectorsDefinitions(BaseDeleting):
+    api = source_definition_api.SourceDefinitionApi
+    delete_function_name = "delete_source_definition"
+
+    def __init__(self, api_client: airbyte_api_client.ApiClient, source_definition_id: str):
+        self.id = source_definition_id
+        super().__init__(api_client)
+
+    @property
+    def delete_function_kwargs(self) -> dict:
+        return {"source_definition_id_request_body": SourceDefinitionIdRequestBody(source_definition_id=self.id)}
+
+
+class DestinationConnectorsDefinitions(BaseDeleting):
+    api = destination_definition_api.DestinationDefinitionApi
+    delete_function_name = "delete_destination_definition"
+
+    def __init__(self, api_client: airbyte_api_client.ApiClient, destination_definition_id: str):
+        self.id = destination_definition_id
+        super().__init__(api_client)
+
+    @property
+    def delete_function_kwargs(self) -> dict:
+        return {"destination_definition_id_request_body": DestinationDefinitionIdRequestBody(destination_definition_id=self.id)}
+
+
+class Sources(BaseDeleting):
+    api = source_api.SourceApi
+    delete_function_name = "delete_source"
+
+    def __init__(self, api_client: airbyte_api_client.ApiClient, source_id: str):
+        self.id = source_id
+        super().__init__(api_client)
+
+    @property
+    def delete_function_kwargs(self) -> dict:
+        return {"source_id_request_body": SourceIdRequestBody(source_id=self.id)}
+
+
+class Destinations(BaseDeleting):
+    api = destination_api.DestinationApi
+    delete_function_name = "delete_destination"
+
+    def __init__(self, api_client: airbyte_api_client.ApiClient, destination_id: str):
+        self.id = destination_id
+        super().__init__(api_client)
+
+    @property
+    def delete_function_kwargs(self) -> dict:
+        return {"destination_id_request_body": DestinationIdRequestBody(destination_id=self.id)}
+
+
+class Connections(BaseDeleting):
+    api = connection_api.ConnectionApi
+    delete_function_name = "delete_connection"
+
+    def __init__(self, api_client: airbyte_api_client.ApiClient, connection_id: str):
+        self.id = connection_id
+        super().__init__(api_client)
+
+    @property
+    def delete_function_kwargs(self) -> dict:
+        return {"connection_id_request_body": ConnectionIdRequestBody(connection_id=self.id)}

--- a/octavia-cli/octavia_cli/entrypoint.py
+++ b/octavia-cli/octavia_cli/entrypoint.py
@@ -12,12 +12,19 @@ from airbyte_api_client.model.workspace_id_request_body import WorkspaceIdReques
 
 from .apply import commands as apply_commands
 from .check_context import check_api_health, check_is_initialized, check_workspace_exists
+from .delete import commands as delete_commands
 from .generate import commands as generate_commands
 from .init import commands as init_commands
 from .list import commands as list_commands
 from .telemetry import TelemetryClient, build_user_agent
 
-AVAILABLE_COMMANDS: List[click.Command] = [list_commands._list, init_commands.init, generate_commands.generate, apply_commands.apply]
+AVAILABLE_COMMANDS: List[click.Command] = [
+    list_commands._list,
+    delete_commands._delete,
+    init_commands.init,
+    generate_commands.generate,
+    apply_commands.apply,
+]
 
 
 def set_context_object(ctx: click.Context, airbyte_url: str, workspace_id: str, enable_telemetry: bool) -> click.Context:

--- a/octavia-cli/unit_tests/test_delete/__init__.py
+++ b/octavia-cli/unit_tests/test_delete/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#

--- a/octavia-cli/unit_tests/test_delete/test_commands.py
+++ b/octavia-cli/unit_tests/test_delete/test_commands.py
@@ -1,0 +1,94 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+import pytest
+from click.testing import CliRunner
+from octavia_cli.delete import commands
+
+
+@pytest.fixture
+def context_object(mock_api_client, mock_telemetry_client):
+    return {
+        "API_CLIENT": mock_api_client,
+        "WORKSPACE_ID": "my_workspace_id",
+        "TELEMETRY_CLIENT": mock_telemetry_client,
+        "SOURCE_CONNECTOR_DEFINITION": "my_source_conn_def",
+    }
+
+
+@pytest.fixture
+def source_definition_id():
+    return "Bob"
+
+
+@pytest.fixture
+def source_id():
+    return "Bob"
+
+
+@pytest.fixture
+def destination_definition_id():
+    return "Alice"
+
+
+@pytest.fixture
+def destination_id():
+    return "Alice"
+
+
+@pytest.fixture
+def connection_id():
+    return "MyConnection"
+
+
+def test_available_commands():
+    assert commands.AVAILABLE_COMMANDS == [commands.connectors, commands.workspace]
+
+
+def test_commands_in_list_group():
+    delete_commands = commands._delete.commands.values()
+    for command in commands.AVAILABLE_COMMANDS:
+        assert command in delete_commands
+
+
+def test_source_connector(mocker, context_object, source_definition_id):
+    mocker.patch.object(commands, "SourceConnectorsDefinitions", mocker.Mock(return_value="SourceConnectorsDefinitionsRepr"))
+    runner = CliRunner()
+    result = runner.invoke(commands.sources_connectors, args=["--sourceDefinitionId", source_definition_id], obj=context_object)
+    commands.SourceConnectorsDefinitions.assert_called_with(context_object["API_CLIENT"], source_definition_id)
+    assert result.output == "SourceConnectorsDefinitionsRepr\n"
+
+
+def test_destination_connector(mocker, context_object, destination_definition_id):
+    mocker.patch.object(commands, "DestinationConnectorsDefinitions", mocker.Mock(return_value="DestinationConnectorsDefinitionsRepr"))
+    runner = CliRunner()
+    result = runner.invoke(
+        commands.destinations_connectors, args=["--destinationDefinitionId", destination_definition_id], obj=context_object
+    )
+    commands.DestinationConnectorsDefinitions.assert_called_with(context_object["API_CLIENT"], destination_definition_id)
+    assert result.output == "DestinationConnectorsDefinitionsRepr\n"
+
+
+def test_sources(mocker, context_object, source_id):
+    mocker.patch.object(commands, "Sources", mocker.Mock(return_value="SourcesRepr"))
+    runner = CliRunner()
+    result = runner.invoke(commands.sources, args=["--sourceId", source_id], obj=context_object)
+    commands.Sources.assert_called_with(context_object["API_CLIENT"], source_id)
+    assert result.output == "SourcesRepr\n"
+
+
+def test_destinations(mocker, context_object, destination_id):
+    mocker.patch.object(commands, "Destinations", mocker.Mock(return_value="DestinationsRepr"))
+    runner = CliRunner()
+    result = runner.invoke(commands.destinations, args=["--destinationId", destination_id], obj=context_object)
+    commands.Destinations.assert_called_with(context_object["API_CLIENT"], destination_id)
+    assert result.output == "DestinationsRepr\n"
+
+
+def test_connectionss(mocker, context_object, connection_id):
+    mocker.patch.object(commands, "Connections", mocker.Mock(return_value="ConnectionsRepr"))
+    runner = CliRunner()
+    result = runner.invoke(commands.connections, args=["--connectionId", connection_id], obj=context_object)
+    commands.Connections.assert_called_with(context_object["API_CLIENT"], connection_id)
+    assert result.output == "ConnectionsRepr\n"

--- a/octavia-cli/unit_tests/test_delete/test_deleting.py
+++ b/octavia-cli/unit_tests/test_delete/test_deleting.py
@@ -1,0 +1,148 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+import pytest
+from airbyte_api_client.api import connection_api, destination_api, destination_definition_api, source_api, source_definition_api
+from click import ClickException
+
+# connection_api, destination_api, destination_definition_api, source_api, source_definition_api
+from octavia_cli.delete import deletings
+from octavia_cli.delete.deletings import (  # Connections,; DestinationConnectorsDefinitions,; Destinations,; SourceConnectorsDefinitions,; Sources,
+    BaseDeleting,
+    Connections,
+    DestinationConnectorsDefinitions,
+    Destinations,
+    FailedToDeleteError,
+    SourceConnectorsDefinitions,
+    Sources,
+)
+
+
+class TestFailedToDeleteError:
+    def test_init(self):
+        assert FailedToDeleteError.__base__ == ClickException
+
+
+class TestBaseDeleting:
+    @pytest.fixture
+    def patch_base_class(self, mocker):
+        # Mock abstract methods to enable instantiating abstract class
+        mocker.patch.object(BaseDeleting, "__abstractmethods__", set())
+        mocker.patch.object(BaseDeleting, "delete_function_name", "my_delete_function_name")
+        mocker.patch.object(BaseDeleting, "api", mocker.Mock(my_delete_function_name=mocker.Mock()))
+
+    def test_init(self, patch_base_class, mock_api_client):
+        base_deleting = BaseDeleting(mock_api_client)
+        assert base_deleting._delete_fn == BaseDeleting.api.my_delete_function_name
+        assert base_deleting.delete_function_kwargs == {}
+        assert base_deleting.api_instance == base_deleting.api.return_value
+        base_deleting.api.assert_called_with(mock_api_client)
+        assert base_deleting.COMMON_DELETE_FUNCTION_KWARGS == {"_check_return_type": False}
+        assert base_deleting.id is None
+
+    def test_abstract_methods(self, mock_api_client):
+        assert BaseDeleting.__abstractmethods__ == {"api", "delete_function_name"}
+        with pytest.raises(TypeError):
+            BaseDeleting(mock_api_client)
+
+    def test_deleting(self, patch_base_class, mocker, mock_api_client):
+        mocker.patch.object(BaseDeleting, "_delete_fn")
+        mocker.patch.object(BaseDeleting, "id", "my_test_id")
+        base_deleting = BaseDeleting(mock_api_client)
+        deleting = base_deleting.deleting()
+        base_deleting._delete_fn.assert_called_with(
+            base_deleting.api_instance, **base_deleting.delete_function_kwargs, **base_deleting.COMMON_DELETE_FUNCTION_KWARGS
+        )
+        assert deleting == "Successfully deleted Airbyte resource with ID: my_test_id"
+
+    def test_deleting_exception(self, patch_base_class, mocker, mock_api_client):
+        mocker.patch.object(BaseDeleting, "_delete_fn")
+        mocker.patch.object(BaseDeleting, "id", "my_test_id")
+        mocker.patch.object(BaseDeleting, "deleting", mocker.Mock(side_effect=[FailedToDeleteError("Error")]))
+        with pytest.raises(FailedToDeleteError) as e:
+            base_deleting = BaseDeleting(mock_api_client)
+            base_deleting.deleting()
+            assert e == "Error"
+
+    def test_repr(self, patch_base_class, mocker, mock_api_client):
+        api_response_deleting = "Successfully deleted Airbyte resource with ID: my_test_id"
+        mocker.patch.object(BaseDeleting, "deleting", mocker.Mock(return_value=api_response_deleting))
+        base_deleting = BaseDeleting(mock_api_client)
+        representation = base_deleting.__repr__()
+        assert representation == api_response_deleting
+
+    def test_repr_exception(self, patch_base_class, mocker, mock_api_client):
+        mocker.patch.object(BaseDeleting, "deleting", mocker.Mock(side_effect=[FailedToDeleteError("Error")]))
+        base_deleting = BaseDeleting(mock_api_client)
+        with pytest.raises(FailedToDeleteError):
+            base_deleting.__repr__()
+
+
+class TestSourceConnectorsDefinitions:
+    def test_init(self, mocker, mock_api_client):
+        mocker.patch.object(deletings, "SourceDefinitionIdRequestBody")
+        mocker.patch.object(BaseDeleting, "__init__")
+        assert SourceConnectorsDefinitions.__base__ == BaseDeleting
+        source_connectors_definition = SourceConnectorsDefinitions(mock_api_client, "my_source_definition_id")
+        assert source_connectors_definition.delete_function_kwargs == {
+            "source_definition_id_request_body": deletings.SourceDefinitionIdRequestBody.return_value
+        }
+        assert source_connectors_definition.api == source_definition_api.SourceDefinitionApi
+        assert source_connectors_definition.delete_function_name == "delete_source_definition"
+        deletings.SourceDefinitionIdRequestBody.assert_called_with(source_definition_id="my_source_definition_id")
+        BaseDeleting.__init__.assert_called_with(mock_api_client)
+
+
+class TestDestinationConnectorsDefinitions:
+    def test_init(self, mocker, mock_api_client):
+        mocker.patch.object(deletings, "DestinationDefinitionIdRequestBody")
+        mocker.patch.object(BaseDeleting, "__init__")
+        assert DestinationConnectorsDefinitions.__base__ == BaseDeleting
+        destination_connectors_definition = DestinationConnectorsDefinitions(mock_api_client, "my_destination_definition_id")
+        assert destination_connectors_definition.delete_function_kwargs == {
+            "destination_definition_id_request_body": deletings.DestinationDefinitionIdRequestBody.return_value
+        }
+        assert destination_connectors_definition.api == destination_definition_api.DestinationDefinitionApi
+        assert destination_connectors_definition.delete_function_name == "delete_destination_definition"
+        deletings.DestinationDefinitionIdRequestBody.assert_called_with(destination_definition_id="my_destination_definition_id")
+        BaseDeleting.__init__.assert_called_with(mock_api_client)
+
+
+class TestSources:
+    def test_init(self, mocker, mock_api_client):
+        mocker.patch.object(deletings, "SourceIdRequestBody")
+        mocker.patch.object(BaseDeleting, "__init__")
+        assert Sources.__base__ == BaseDeleting
+        sources = Sources(mock_api_client, "my_source_id")
+        assert sources.delete_function_kwargs == {"source_id_request_body": deletings.SourceIdRequestBody.return_value}
+        assert sources.api == source_api.SourceApi
+        assert sources.delete_function_name == "delete_source"
+        deletings.SourceIdRequestBody.assert_called_with(source_id="my_source_id")
+        BaseDeleting.__init__.assert_called_with(mock_api_client)
+
+
+class TestDestinations:
+    def test_init(self, mocker, mock_api_client):
+        mocker.patch.object(deletings, "DestinationIdRequestBody")
+        mocker.patch.object(BaseDeleting, "__init__")
+        assert Destinations.__base__ == BaseDeleting
+        destinations = Destinations(mock_api_client, "my_destination_id")
+        assert destinations.delete_function_kwargs == {"destination_id_request_body": deletings.DestinationIdRequestBody.return_value}
+        assert destinations.api == destination_api.DestinationApi
+        assert destinations.delete_function_name == "delete_destination"
+        deletings.DestinationIdRequestBody.assert_called_with(destination_id="my_destination_id")
+        BaseDeleting.__init__.assert_called_with(mock_api_client)
+
+
+class TestConnections:
+    def test_init(self, mocker, mock_api_client):
+        mocker.patch.object(deletings, "ConnectionIdRequestBody")
+        mocker.patch.object(BaseDeleting, "__init__")
+        assert Connections.__base__ == BaseDeleting
+        connections = Connections(mock_api_client, "my_connection_id")
+        assert connections.delete_function_kwargs == {"connection_id_request_body": deletings.ConnectionIdRequestBody.return_value}
+        assert connections.api == connection_api.ConnectionApi
+        assert connections.delete_function_name == "delete_connection"
+        deletings.ConnectionIdRequestBody.assert_called_with(connection_id="my_connection_id")
+        BaseDeleting.__init__.assert_called_with(mock_api_client)

--- a/octavia-cli/unit_tests/test_entrypoint.py
+++ b/octavia-cli/unit_tests/test_entrypoint.py
@@ -130,7 +130,7 @@ def test_commands_in_octavia_group():
 
 @pytest.mark.parametrize(
     "command",
-    [entrypoint.delete, entrypoint._import],
+    [entrypoint._import],
 )
 def test_not_implemented_commands(command):
     runner = CliRunner()
@@ -142,6 +142,7 @@ def test_not_implemented_commands(command):
 def test_available_commands():
     assert entrypoint.AVAILABLE_COMMANDS == [
         entrypoint.list_commands._list,
+        entrypoint.delete_commands._delete,
         entrypoint.init_commands.init,
         entrypoint.generate_commands.generate,
         entrypoint.apply_commands.apply,


### PR DESCRIPTION
## What
Resolving airbytehq/airbyte#11316

## How
* declare delete commands
* add delete command into octavia's entrypoint
* implement delete commands
* implement unit tests for commands and delete functions testing
* add unit tests into test entrypoint

## Recommended reading order
1. ```octavia-cli/octavia_cli/delete/commands.py```
2. ```octavia-cli/octavia_cli/entrypoint.py```
3. ```octavia-cli/octavia_cli/delete/deletings.py```
4. ```octavia-cli/unit_tests/test_delete/test_commands.py```
5. ```octavia-cli/unit_tests/test_delete/test_deleting.py```
6. ```octavia-cli/unit_tests/test_entrypoint.py```

## 🚨 User Impact 🚨
```octavia --airbyte-url="https://demo.airbyte.io" delete``` and its subcommand is available.

## Tests

<details><summary><strong>Unit</strong></summary>

| Name    |                               Stmts  | Miss | Cover |
|----------|-----------------------------|------|--------|
| octavia_cli/telemetry.py       |           28  |    0 |  100% |
| octavia_cli/list/listings.py      |        65   |   0  | 100%
| octavia_cli/list/formatting.py   |         17   |   0  | 100%
| octavia_cli/list/commands.py   |           48  |     0  | 100%
| octavia_cli/init/commands.py   |           26  |    0  | 100%
| octavia_cli/generate/yaml_dumpers.py   |    4  |    0 |  100%
| octavia_cli/generate/definitions.py    |   86   |   0 |  100%
| octavia_cli/generate/commands.py    |      45  |    0  | 100%
| octavia_cli/delete/commands.py     |       55   |   0  | 100%
| octavia_cli/check_context.py        |      38    |  0  | 100%
| octavia_cli/base_commands.py     |         19   |   0  | 100%
| octavia_cli/apply/yaml_loaders.py   |      11   |   0  | 100%
| octavia_cli/apply/resources.py       |    240    |  0  | 100%
| octavia_cli/apply/diff_helpers.py    |     28    |  0  | 100%
| octavia_cli/apply/commands.py     |        71  |    0  | 100%
| octavia_cli/generate/renderers.py  |      123   |   1 |   99%
| octavia_cli/entrypoint.py            |     66    |  1  |  98%
| octavia_cli/delete/deletings.py   |        80  |    2  |  98%
| TOTAL  |                                  1050   |   4  |  99% |

</details>
