### PR TITLE
Ignore auto-disable activity if connection already inactive

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/AutoDisableConnectionActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/AutoDisableConnectionActivityImpl.java
@@ -13,7 +13,6 @@ import io.airbyte.commons.features.FeatureFlags;
 import io.airbyte.config.Configs;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSync.Status;
-import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.scheduler.models.Job;
 import io.airbyte.scheduler.models.JobStatus;
@@ -25,7 +24,6 @@ import io.airbyte.workers.temporal.exception.RetryableException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.AllArgsConstructor;
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/AutoDisableConnectionActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/AutoDisableConnectionActivityImpl.java
@@ -50,6 +50,12 @@ public class AutoDisableConnectionActivityImpl implements AutoDisableConnectionA
   public AutoDisableConnectionOutput autoDisableFailingConnection(final AutoDisableConnectionActivityInput input) {
     if (featureFlags.autoDisablesFailingConnections()) {
       try {
+        // if connection is already inactive, no need to disable
+        final StandardSync standardSync = configRepository.getStandardSync(input.getConnectionId());
+        if (standardSync.getStatus() == Status.INACTIVE) {
+          return new AutoDisableConnectionOutput(false);
+        }
+
         final int maxDaysOfOnlyFailedJobs = configs.getMaxDaysOfOnlyFailedJobsBeforeConnectionDisable();
         final int maxDaysOfOnlyFailedJobsBeforeWarning = maxDaysOfOnlyFailedJobs / 2;
         final int maxFailedJobsInARowBeforeConnectionDisableWarning = configs.getMaxFailedJobsInARowBeforeConnectionDisable() / 2;
@@ -82,7 +88,7 @@ public class AutoDisableConnectionActivityImpl implements AutoDisableConnectionA
           return new AutoDisableConnectionOutput(false);
         } else if (numFailures >= configs.getMaxFailedJobsInARowBeforeConnectionDisable()) {
           // disable connection if max consecutive failed jobs limit has been hit
-          disableConnection(input.getConnectionId(), lastJob);
+          disableConnection(standardSync, lastJob);
           return new AutoDisableConnectionOutput(true);
         } else if (numFailures == maxFailedJobsInARowBeforeConnectionDisableWarning && !warningPreviouslySentForMaxDays) {
           // warn if number of consecutive failures hits 50% of MaxFailedJobsInARow
@@ -102,7 +108,7 @@ public class AutoDisableConnectionActivityImpl implements AutoDisableConnectionA
 
         // disable connection if only failed jobs in the past maxDaysOfOnlyFailedJobs days
         if (firstReplicationOlderThanMaxDisableDays && noPreviousSuccess) {
-          disableConnection(input.getConnectionId(), lastJob);
+          disableConnection(standardSync, lastJob);
           return new AutoDisableConnectionOutput(true);
         }
 
@@ -172,8 +178,7 @@ public class AutoDisableConnectionActivityImpl implements AutoDisableConnectionA
     return Math.toIntExact(TimeUnit.SECONDS.toDays(currentTimestampInSeconds - timestampInSeconds));
   }
 
-  private void disableConnection(final UUID connectionId, final Job lastJob) throws JsonValidationException, IOException, ConfigNotFoundException {
-    final StandardSync standardSync = configRepository.getStandardSync(connectionId);
+  private void disableConnection(final StandardSync standardSync, final Job lastJob) throws JsonValidationException, IOException {
     standardSync.setStatus(Status.INACTIVE);
     configRepository.writeStandardSync(standardSync);
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/AutoDisableConnectionActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/AutoDisableConnectionActivityTest.java
@@ -82,7 +82,8 @@ class AutoDisableConnectionActivityTest {
   private final StandardSync standardSync = new StandardSync();
 
   @BeforeEach
-  void setUp() throws IOException {
+  void setUp() throws IOException, JsonValidationException, ConfigNotFoundException {
+    Mockito.when(mConfigRepository.getStandardSync(CONNECTION_ID)).thenReturn(standardSync);
     standardSync.setStatus(Status.ACTIVE);
     Mockito.when(mFeatureFlags.autoDisablesFailingConnections()).thenReturn(true);
     Mockito.when(mConfigs.getMaxDaysOfOnlyFailedJobsBeforeConnectionDisable()).thenReturn(MAX_DAYS_OF_ONLY_FAILED_JOBS);


### PR DESCRIPTION
## What
Ignore the auto-disable failing connections activity if the connection is already in an `Inactive` state.

Previously, a failing connection will run through the entire activity even if the connection's state is `Inactive`, such as when triggered by a manual sync. This in turn may result in auto-disable or warning notifications of no use since the connection is already disabled.

This PR helps reduce work and reduces irrelevant notifications to users in those previously mentioned situations.