### PR TITLE
Switch json libraries to jitpack

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/build.gradle
+++ b/airbyte-integrations/connectors/destination-bigquery/build.gradle
@@ -23,11 +23,15 @@ dependencies {
     implementation project(':airbyte-protocol:models')
     implementation project(':airbyte-integrations:connectors:destination-s3')
     implementation project(':airbyte-integrations:connectors:destination-gcs')
-    implementation group: 'com.github.airbytehq', name: 'json-avro-converter', version: '1.0.0'
+    implementation group: 'com.github.airbytehq', name: 'json-avro-converter', version: '1.0.1'
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-bigquery')
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
+}
+
+repositories {
+    maven { url 'https://jitpack.io' }
 }

--- a/airbyte-integrations/connectors/destination-bigquery/build.gradle
+++ b/airbyte-integrations/connectors/destination-bigquery/build.gradle
@@ -31,7 +31,3 @@ dependencies {
 
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }
-
-repositories {
-    maven { url 'https://jitpack.io' }
-}

--- a/airbyte-integrations/connectors/destination-bigquery/build.gradle
+++ b/airbyte-integrations/connectors/destination-bigquery/build.gradle
@@ -23,11 +23,7 @@ dependencies {
     implementation project(':airbyte-protocol:models')
     implementation project(':airbyte-integrations:connectors:destination-s3')
     implementation project(':airbyte-integrations:connectors:destination-gcs')
-    implementation('tech.allegro.schema.json2avro:converter') {
-        version {
-            branch = 'master'
-        }
-    }
+    implementation group: 'com.github.airbytehq', name: 'json-avro-converter', version: '1.0.0'
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)

--- a/airbyte-integrations/connectors/destination-databricks/build.gradle
+++ b/airbyte-integrations/connectors/destination-databricks/build.gradle
@@ -46,10 +46,6 @@ dependencies {
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-databricks')
 }
 
-repositories {
-    maven { url 'https://jitpack.io' }
-}
-
 task downloadJdbcDriverZip(type: Download) {
     src 'https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/jdbc/2.6.21/SimbaSparkJDBC42-2.6.21.1039.zip'
     dest new File(buildDir, 'SimbaSparkJDBC42-2.6.21.1039.zip')

--- a/airbyte-integrations/connectors/destination-databricks/build.gradle
+++ b/airbyte-integrations/connectors/destination-databricks/build.gradle
@@ -40,10 +40,14 @@ dependencies {
     implementation group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.3.0'
     implementation group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: '3.3.0'
     implementation group: 'org.apache.parquet', name: 'parquet-avro', version: '1.12.0'
-    implementation group: 'com.github.airbytehq', name: 'json-avro-converter', version: '1.0.0'
+    implementation group: 'com.github.airbytehq', name: 'json-avro-converter', version: '1.0.1'
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-databricks')
+}
+
+repositories {
+    maven { url 'https://jitpack.io' }
 }
 
 task downloadJdbcDriverZip(type: Download) {

--- a/airbyte-integrations/connectors/destination-databricks/build.gradle
+++ b/airbyte-integrations/connectors/destination-databricks/build.gradle
@@ -40,11 +40,7 @@ dependencies {
     implementation group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.3.0'
     implementation group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: '3.3.0'
     implementation group: 'org.apache.parquet', name: 'parquet-avro', version: '1.12.0'
-    implementation('tech.allegro.schema.json2avro:converter') {
-        version {
-            branch = 'master'
-        }
-    }
+    implementation group: 'com.github.airbytehq', name: 'json-avro-converter', version: '1.0.0'
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-databricks')

--- a/airbyte-integrations/connectors/destination-gcs/build.gradle
+++ b/airbyte-integrations/connectors/destination-gcs/build.gradle
@@ -38,7 +38,3 @@ dependencies {
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-gcs')
     integrationTestJavaImplementation project(':airbyte-workers')
 }
-
-repositories {
-    maven { url 'https://jitpack.io' }
-}

--- a/airbyte-integrations/connectors/destination-gcs/build.gradle
+++ b/airbyte-integrations/connectors/destination-gcs/build.gradle
@@ -30,11 +30,15 @@ dependencies {
     implementation group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.3.0'
     implementation group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: '3.3.0'
     implementation group: 'org.apache.parquet', name: 'parquet-avro', version: '1.12.0'
-    implementation group: 'com.github.airbytehq', name: 'json-avro-converter', version: '1.0.0'
+    implementation group: 'com.github.airbytehq', name: 'json-avro-converter', version: '1.0.1'
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-gcs')
     integrationTestJavaImplementation project(':airbyte-workers')
+}
+
+repositories {
+    maven { url 'https://jitpack.io' }
 }

--- a/airbyte-integrations/connectors/destination-gcs/build.gradle
+++ b/airbyte-integrations/connectors/destination-gcs/build.gradle
@@ -30,11 +30,7 @@ dependencies {
     implementation group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.3.0'
     implementation group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: '3.3.0'
     implementation group: 'org.apache.parquet', name: 'parquet-avro', version: '1.12.0'
-    implementation('tech.allegro.schema.json2avro:converter') {
-        version {
-            branch = 'master'
-        }
-    }
+    implementation group: 'com.github.airbytehq', name: 'json-avro-converter', version: '1.0.0'
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
 

--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -33,7 +33,3 @@ dependencies {
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-s3')
 }
-
-repositories {
-    maven { url 'https://jitpack.io' }
-}

--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -25,11 +25,15 @@ dependencies {
     implementation group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.3.0'
     implementation group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: '3.3.0'
     implementation group: 'org.apache.parquet', name: 'parquet-avro', version: '1.12.0'
-    implementation group: 'com.github.airbytehq', name: 'json-avro-converter', version: '1.0.0'
+    implementation group: 'com.github.airbytehq', name: 'json-avro-converter', version: '1.0.1'
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
     testImplementation "org.mockito:mockito-inline:4.1.0"
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-s3')
+}
+
+repositories {
+    maven { url 'https://jitpack.io' }
 }

--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -25,11 +25,7 @@ dependencies {
     implementation group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.3.0'
     implementation group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: '3.3.0'
     implementation group: 'org.apache.parquet', name: 'parquet-avro', version: '1.12.0'
-    implementation('tech.allegro.schema.json2avro:converter') {
-        version {
-            branch = 'master'
-        }
-    }
+    implementation group: 'com.github.airbytehq', name: 'json-avro-converter', version: '1.0.0'
 
     testImplementation 'org.apache.commons:commons-lang3:3.11'
     testImplementation "org.mockito:mockito-inline:4.1.0"

--- a/airbyte-integrations/connectors/source-e2e-test-cloud/build.gradle
+++ b/airbyte-integrations/connectors/source-e2e-test-cloud/build.gradle
@@ -20,9 +20,3 @@ dependencies {
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-e2e-test-cloud')
 }
-
-allprojects {
-    repositories {
-        maven { url 'https://jitpack.io' }
-    }
-}

--- a/airbyte-integrations/connectors/source-e2e-test/build.gradle
+++ b/airbyte-integrations/connectors/source-e2e-test/build.gradle
@@ -20,11 +20,7 @@ dependencies {
     // https://github.com/airbytehq/jsongenerator
     implementation 'net.jimblackler.jsonschemafriend:core:0.11.2'
     implementation 'org.mozilla:rhino-engine:1.7.14'
-    implementation('net.jimblackler:jsongenerator') {
-        version {
-            branch = 'master'
-        }
-    }
+    implementation group: 'com.github.airbytehq', name: 'jsongenerator', version: '1.0.0-pre'
 
     testImplementation project(":airbyte-json-validation")
     testImplementation project(':airbyte-test-utils')

--- a/airbyte-integrations/connectors/source-e2e-test/build.gradle
+++ b/airbyte-integrations/connectors/source-e2e-test/build.gradle
@@ -29,7 +29,3 @@ dependencies {
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-e2e-test')
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }
-
-repositories {
-    maven { url 'https://jitpack.io' }
-}

--- a/airbyte-integrations/connectors/source-e2e-test/build.gradle
+++ b/airbyte-integrations/connectors/source-e2e-test/build.gradle
@@ -30,8 +30,6 @@ dependencies {
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }
 
-allprojects {
-    repositories {
-        maven { url 'https://jitpack.io' }
-    }
+repositories {
+    maven { url 'https://jitpack.io' }
 }

--- a/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedConstants.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedConstants.java
@@ -10,7 +10,14 @@ import net.jimblackler.jsongenerator.DefaultConfig;
 public final class ContinuousFeedConstants {
 
   public static final int MOCK_JSON_MAX_TREE_SIZE = 100;
-  public static final Configuration MOCK_JSON_CONFIG = new DefaultConfig();
+  public static final Configuration MOCK_JSON_CONFIG = DefaultConfig.build()
+      .setPedanticTypes(true)
+      .setGenerateNulls(false)
+      .setGenerateMinimal(false)
+      .setGenerateAdditionalProperties(false)
+      .setUseRomanCharsOnly(true)
+      .setNonRequiredPropertyChance(1.0f)
+      .get();
 
   private ContinuousFeedConstants() {}
 

--- a/airbyte-integrations/connectors/source-e2e-test/src/test/java/io/airbyte/integrations/source/e2e_test/GeneratorTest.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/test/java/io/airbyte/integrations/source/e2e_test/GeneratorTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 public class GeneratorTest {
 
   private static final JsonSchemaValidator JSON_VALIDATOR = new JsonSchemaValidator();
-  private static final Configuration CONFIG = new DefaultConfig();
+  private static final Configuration CONFIG = ContinuousFeedConstants.MOCK_JSON_CONFIG;
   private static final ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
 
   public static class GeneratorSchemaProvider implements ArgumentsProvider {

--- a/build.gradle
+++ b/build.gradle
@@ -200,6 +200,9 @@ subprojects {
             // TODO(Issue-4915): Remove this when upstream is merged in.
             url 'https://airbyte.mycloudrepo.io/public/repositories/airbyte-public-jars/'
         }
+        maven {
+            url 'https://jitpack.io'
+        }
     }
 
     pmd {

--- a/build.gradle
+++ b/build.gradle
@@ -200,9 +200,6 @@ subprojects {
             // TODO(Issue-4915): Remove this when upstream is merged in.
             url 'https://airbyte.mycloudrepo.io/public/repositories/airbyte-public-jars/'
         }
-        maven {
-            url 'https://jitpack.io'
-        }
     }
 
     pmd {

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,12 +11,6 @@ gradleEnterprise {
     }
 }
 
-sourceControl {
-    gitRepository("https://github.com/airbytehq/jsongenerator.git") {
-        producesModule("net.jimblackler:jsongenerator")
-    }
-}
-
 rootProject.name = 'airbyte'
 
 // SUB_BUILD is an enum of <blank>, PLATFORM, CONNECTORS_BASE, ALL_CONNECTORS and OCTAVIA_CLI. Blank is equivalent to all.

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,9 +12,6 @@ gradleEnterprise {
 }
 
 sourceControl {
-    gitRepository("https://github.com/airbytehq/json-avro-converter.git") {
-        producesModule("tech.allegro.schema.json2avro:converter")
-    }
     gitRepository("https://github.com/airbytehq/jsongenerator.git") {
         producesModule("net.jimblackler:jsongenerator")
     }


### PR DESCRIPTION
## What
- Currently two libraries, `json-avro-converter` and `jsongenerator`, depend on git repo directly.
- We should depend on maven repositories instead.
- Relate to https://github.com/airbytehq/airbyte/issues/10608.

## How
- The underlying libraries have been published to JitPack.
- Switch the dependencies to JitPack repositories directly.

## 🚨 User Impact 🚨
- None expected.

## TODO
- [x] Run integration tests for all affected connectors.
