### PR TITLE
Destination Postgres : Enable DAT and fix the data fetch.

### DIFF
--- a/airbyte-integrations/bases/standard-destination-test/build.gradle
+++ b/airbyte-integrations/bases/standard-destination-test/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java-library'
 }
 dependencies {
+    implementation project(':airbyte-db:lib')
     implementation project(':airbyte-config:models')
     implementation project(':airbyte-integrations:bases:base-java')
     implementation project(':airbyte-protocol:models')

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/JdbcDestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/JdbcDestinationAcceptanceTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.standardtest.destination;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.airbyte.commons.json.Jsons;
+import java.util.Arrays;
+import org.jooq.Record;
+
+public abstract class JdbcDestinationAcceptanceTest extends DestinationAcceptanceTest {
+
+  protected final ObjectMapper mapper = new ObjectMapper();
+
+  protected JsonNode getJsonFromRecord(Record record) {
+    ObjectNode node = mapper.createObjectNode();
+
+    Arrays.stream(record.fields()).forEach(field -> {
+      var value = record.get(field);
+
+      switch (field.getDataType().getTypeName()) {
+        case "varchar", "other":
+          var stringValue = (value != null ? value.toString() : null);
+          if (stringValue != null && (stringValue.replaceAll("[^\\x00-\\x7F]", "").matches("^\\[.*\\]$")
+              || stringValue.replaceAll("[^\\x00-\\x7F]", "").matches("^\\{.*\\}$"))) {
+            node.set(field.getName(), Jsons.deserialize(stringValue));
+          } else {
+            node.put(field.getName(), stringValue);
+          }
+          break;
+        default:
+          node.put(field.getName(), (value != null ? value.toString() : null));
+      }
+    });
+    return node;
+  }
+
+}

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/JdbcDestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/JdbcDestinationAcceptanceTest.java
@@ -22,7 +22,7 @@ public abstract class JdbcDestinationAcceptanceTest extends DestinationAcceptanc
       var value = record.get(field);
 
       switch (field.getDataType().getTypeName()) {
-        case "varchar", "other":
+        case "varchar", "jsonb", "other":
           var stringValue = (value != null ? value.toString() : null);
           if (stringValue != null && (stringValue.replaceAll("[^\\x00-\\x7F]", "").matches("^\\[.*\\]$")
               || stringValue.replaceAll("[^\\x00-\\x7F]", "").matches("^\\{.*\\}$"))) {

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresDestinationAcceptanceTest.java
@@ -61,7 +61,7 @@ public class PostgresDestinationAcceptanceTest extends JdbcDestinationAcceptance
       throws Exception {
     return retrieveRecordsFromTable(namingResolver.getRawTableName(streamName), namespace)
         .stream()
-        .map(r -> Jsons.deserialize(r.get(JavaBaseConstants.COLUMN_NAME_DATA).asText()))
+        .map(r -> r.get(JavaBaseConstants.COLUMN_NAME_DATA))
         .collect(Collectors.toList());
   }
 
@@ -104,12 +104,6 @@ public class PostgresDestinationAcceptanceTest extends JdbcDestinationAcceptance
   protected List<JsonNode> retrieveNormalizedRecords(final TestDestinationEnv env, final String streamName, final String namespace)
       throws Exception {
     final String tableName = namingResolver.getIdentifier(streamName);
-    // Temporarily disabling the behavior of the ExtendedNameTransformer, see (issue #1785) so we don't
-    // use quoted names
-    // if (!tableName.startsWith("\"")) {
-    // // Currently, Normalization always quote tables identifiers
-    // //tableName = "\"" + tableName + "\"";
-    // }
     return retrieveRecordsFromTable(tableName, namespace);
   }
 

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresTestDataComparator.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresTestDataComparator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.postgres;
+
+import io.airbyte.integrations.destination.ExtendedNameTransformer;
+import io.airbyte.integrations.standardtest.destination.comparator.AdvancedTestDataComparator;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PostgresTestDataComparator extends AdvancedTestDataComparator {
+
+  private final ExtendedNameTransformer namingResolver = new ExtendedNameTransformer();
+
+  private static final String POSTGRES_DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+  private static final String POSTGRES_DATETIME_WITH_TZ_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+
+  @Override
+  protected List<String> resolveIdentifier(final String identifier) {
+    final List<String> result = new ArrayList<>();
+    final String resolved = namingResolver.getIdentifier(identifier);
+    result.add(identifier);
+    result.add(resolved);
+    if (!resolved.startsWith("\"")) {
+      result.add(resolved.toLowerCase());
+      result.add(resolved.toUpperCase());
+    }
+    return result;
+  }
+
+  @Override
+  protected boolean compareDateTimeValues(String expectedValue, String actualValue) {
+    var destinationDate = LocalDate.parse(actualValue, DateTimeFormatter.ofPattern(POSTGRES_DATETIME_FORMAT));
+    var expectedDate = LocalDate.parse(expectedValue, DateTimeFormatter.ofPattern(AIRBYTE_DATETIME_FORMAT));
+    return expectedDate.equals(destinationDate);
+  }
+
+  @Override
+  protected ZonedDateTime parseDestinationDateWithTz(String destinationValue) {
+    return ZonedDateTime.of(LocalDateTime.parse(destinationValue, DateTimeFormatter.ofPattern(POSTGRES_DATETIME_WITH_TZ_FORMAT)), ZoneOffset.UTC);
+  }
+
+}

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresTestDataComparator.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/PostgresTestDataComparator.java
@@ -34,9 +34,18 @@ public class PostgresTestDataComparator extends AdvancedTestDataComparator {
     return result;
   }
 
+  private LocalDate parseLocalDate(String dateTimeValue) {
+    if (dateTimeValue != null) {
+      var format = (dateTimeValue.matches(".+Z") ? POSTGRES_DATETIME_FORMAT : AIRBYTE_DATETIME_FORMAT);
+      return LocalDate.parse(dateTimeValue, DateTimeFormatter.ofPattern(format));
+    } else {
+      return null;
+    }
+  }
+
   @Override
   protected boolean compareDateTimeValues(String expectedValue, String actualValue) {
-    var destinationDate = LocalDate.parse(actualValue, DateTimeFormatter.ofPattern(POSTGRES_DATETIME_FORMAT));
+    var destinationDate = parseLocalDate(actualValue);
     var expectedDate = LocalDate.parse(expectedValue, DateTimeFormatter.ofPattern(AIRBYTE_DATETIME_FORMAT));
     return expectedDate.equals(destinationDate);
   }

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/SshPostgresDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/java/io/airbyte/integrations/destination/postgres/SshPostgresDestinationAcceptanceTest.java
@@ -62,7 +62,7 @@ public abstract class SshPostgresDestinationAcceptanceTest extends JdbcDestinati
       throws Exception {
     return retrieveRecordsFromTable(namingResolver.getRawTableName(streamName), namespace)
         .stream()
-        .map(r -> Jsons.deserialize(r.get(JavaBaseConstants.COLUMN_NAME_DATA).asText()))
+        .map(r -> r.get(JavaBaseConstants.COLUMN_NAME_DATA))
         .collect(Collectors.toList());
   }
 
@@ -105,12 +105,6 @@ public abstract class SshPostgresDestinationAcceptanceTest extends JdbcDestinati
   protected List<JsonNode> retrieveNormalizedRecords(final TestDestinationEnv env, final String streamName, final String namespace)
       throws Exception {
     final String tableName = namingResolver.getIdentifier(streamName);
-    // Temporarily disabling the behavior of the ExtendedNameTransformer, see (issue #1785) so we don't
-    // use quoted names
-    // if (!tableName.startsWith("\"")) {
-    // // Currently, Normalization always quote tables identifiers
-    // //tableName = "\"" + tableName + "\"";
-    // }
     return retrieveRecordsFromTable(tableName, namespace);
   }
 

--- a/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftCopyDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftCopyDestinationAcceptanceTest.java
@@ -13,14 +13,12 @@ import io.airbyte.commons.string.Strings;
 import io.airbyte.db.Database;
 import io.airbyte.db.Databases;
 import io.airbyte.integrations.base.JavaBaseConstants;
-import io.airbyte.integrations.standardtest.destination.DestinationAcceptanceTest;
+import io.airbyte.integrations.standardtest.destination.JdbcDestinationAcceptanceTest;
 import io.airbyte.integrations.standardtest.destination.comparator.TestDataComparator;
 import java.nio.file.Path;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.jooq.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +26,7 @@ import org.slf4j.LoggerFactory;
  * Integration test testing {@link RedshiftCopyS3Destination}. The default Redshift integration test
  * credentials contain S3 credentials - this automatically causes COPY to be selected.
  */
-public class RedshiftCopyDestinationAcceptanceTest extends DestinationAcceptanceTest {
+public class RedshiftCopyDestinationAcceptanceTest extends JdbcDestinationAcceptanceTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RedshiftCopyDestinationAcceptanceTest.class);
 
@@ -119,29 +117,6 @@ public class RedshiftCopyDestinationAcceptanceTest extends DestinationAcceptance
       tableName = "\"" + tableName + "\"";
     }
     return retrieveRecordsFromTable(tableName, namespace);
-  }
-
-  private JsonNode getJsonFromRecord(Record record) {
-    ObjectNode node = mapper.createObjectNode();
-
-    Arrays.stream(record.fields()).forEach(field -> {
-      var value = record.get(field);
-
-      switch (field.getDataType().getTypeName()) {
-        case "varchar", "other":
-          var stringValue = (value != null ? value.toString() : null);
-          if (stringValue != null && (stringValue.replaceAll("[^\\x00-\\x7F]", "").matches("^\\[.*\\]$")
-              || stringValue.replaceAll("[^\\x00-\\x7F]", "").matches("^\\{.*\\}$"))) {
-            node.set(field.getName(), Jsons.deserialize(stringValue));
-          } else {
-            node.put(field.getName(), stringValue);
-          }
-          break;
-        default:
-          node.put(field.getName(), (value != null ? value.toString() : null));
-      }
-    });
-    return node;
   }
 
   private List<JsonNode> retrieveRecordsFromTable(final String tableName, final String schemaName) throws SQLException {


### PR DESCRIPTION
## What
The Postgres destination fails the DAT tests. It means that we can't guarantee full data type compliance.

## How
Enable DAT tests and fix all errors.

## Recommended reading order
1. `JdbcDestinationAcceptanceTest.java`
2. `PostgresDestinationAcceptanceTest.java`