### PR TITLE
Adds error message for missing homebrew

### DIFF
--- a/tools/bin/deploy_docusaurus
+++ b/tools/bin/deploy_docusaurus
@@ -43,10 +43,18 @@ pwd
 
 # Yarn check (which is commonly used to check for program existance)
 # -s/--silent doesn't exist in cloud's Ubuntu
-if ! which yarn > /dev/null; then
-  echo -e "$red_text""yarn not found HALP!!\n\n""$default_text"
+if ! which brew > /dev/null; then
+  echo -e "$red_text""homebrew not found HALP!!\n\n""$default_text"
+  echo -e "$red_text""try this:  https://brew.sh\n\n""$default_text"
   exit 1
 fi
+
+if ! which yarn > /dev/null; then
+  echo -e "$red_text""yarn not found HALP!!\n\n""$default_text"
+  echo -e "$red_text""try this:  brew install yarn\n\n""$default_text"
+  exit 1
+fi
+
 
 set -o xtrace
 
@@ -114,7 +122,8 @@ echo "docs.airbyte.com" > CNAME
 
 git add CNAME
 
-git commit --message "Adds CNAME to deploy for $revision"
+# Skip pre-commit hooks fire_elmo.jpg
+PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit --message "Adds CNAME to deploy for $revision"
 
 # non functional. for debugging
 git branch


### PR DESCRIPTION
## What
if you have pre-commits this script gets mad.  the docusaurus generated commit is also 100% generated content so YOLO on the commit hooks for that command anyway

also checks for homebrews

## How tho
ignore pre commit hook
check for home-brew