### PR TITLE
Add 401 error message and cleanup error page

### DIFF
--- a/airbyte-webapp/src/components/BaseClearView/BaseClearView.tsx
+++ b/airbyte-webapp/src/components/BaseClearView/BaseClearView.tsx
@@ -13,10 +13,14 @@ const Content = styled.div`
   justify-content: space-between;
 `;
 
-const Img = styled.img`
+const LogoImg = styled.img`
   width: 90px;
   height: 94px;
   margin-bottom: 20px;
+
+  &.clickable:hover {
+    cursor: pointer;
+  }
 `;
 
 const MainInfo = styled.div`
@@ -25,12 +29,21 @@ const MainInfo = styled.div`
   flex-direction: column;
 `;
 
-const BaseClearView: React.FC = (props) => {
+interface BaseClearViewProps {
+  onLogoClick?: React.MouseEventHandler;
+}
+
+const BaseClearView: React.FC<BaseClearViewProps> = ({ children, onLogoClick }) => {
   return (
     <Content>
       <MainInfo>
-        <Img src="/logo.png" alt="logo" />
-        {props.children}
+        <LogoImg
+          src="/logo.png"
+          alt="Airbyte logo"
+          onClick={onLogoClick}
+          className={onLogoClick ? "clickable" : undefined}
+        />
+        {children}
       </MainInfo>
       <Version />
     </Content>

--- a/airbyte-webapp/src/components/BaseClearView/BaseClearView.tsx
+++ b/airbyte-webapp/src/components/BaseClearView/BaseClearView.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { useIntl } from "react-intl";
+import { Link } from "react-router-dom";
 import styled from "styled-components";
 
 import Version from "components/Version";
@@ -17,10 +19,6 @@ const LogoImg = styled.img`
   width: 90px;
   height: 94px;
   margin-bottom: 20px;
-
-  &.clickable:hover {
-    cursor: pointer;
-  }
 `;
 
 const MainInfo = styled.div`
@@ -30,19 +28,17 @@ const MainInfo = styled.div`
 `;
 
 interface BaseClearViewProps {
-  onLogoClick?: React.MouseEventHandler;
+  onBackClick?: React.MouseEventHandler;
 }
 
-const BaseClearView: React.FC<BaseClearViewProps> = ({ children, onLogoClick }) => {
+const BaseClearView: React.FC<BaseClearViewProps> = ({ children, onBackClick }) => {
+  const { formatMessage } = useIntl();
   return (
     <Content>
       <MainInfo>
-        <LogoImg
-          src="/logo.png"
-          alt="Airbyte logo"
-          onClick={onLogoClick}
-          className={onLogoClick ? "clickable" : undefined}
-        />
+        <Link to=".." onClick={onBackClick}>
+          <LogoImg src="/logo.png" alt={formatMessage({ id: "ui.goBack" })} />
+        </Link>
         {children}
       </MainInfo>
       <Version />

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -486,8 +486,8 @@
   "demo.message.body": "You cannot add or edit any connectors. You will see error messages on purpose if you try to do so.",
 
   "docs.notFoundError": "We were not able to receive docs. Please click the link above to open docs on our website",
-  "errorView.startOver": "Continue using the app",
-  "errorView.notFound": "Resource not found",
+  "errorView.notFound": "Resource not found.",
+  "errorView.notAuthorized": "You don’t have permission to access this page.",
   "errorView.unknown": "Unknown",
 
   "ui.input.showPassword": "Show password",

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -490,6 +490,7 @@
   "errorView.notAuthorized": "You don’t have permission to access this page.",
   "errorView.unknown": "Unknown",
 
+  "ui.goBack": "Go back",
   "ui.input.showPassword": "Show password",
   "ui.input.hidePassword": "Hide password",
   "ui.keyValuePair": "{key}: {value}",

--- a/airbyte-webapp/src/views/common/ErrorOccurredView.tsx
+++ b/airbyte-webapp/src/views/common/ErrorOccurredView.tsx
@@ -12,12 +12,12 @@ const Content = styled(ContentCard)`
 
 interface ErrorOccurredViewProps {
   message: React.ReactNode;
-  onLogoClick?: React.MouseEventHandler;
+  onBackClick?: React.MouseEventHandler;
 }
 
-const ErrorOccurredView: React.FC<ErrorOccurredViewProps> = ({ message, onLogoClick, children }) => {
+export const ErrorOccurredView: React.FC<ErrorOccurredViewProps> = ({ message, onBackClick, children }) => {
   return (
-    <BaseClearView onLogoClick={onLogoClick}>
+    <BaseClearView onBackClick={onBackClick}>
       <Content>
         <H4 center>{message}</H4>
         {children}
@@ -25,5 +25,3 @@ const ErrorOccurredView: React.FC<ErrorOccurredViewProps> = ({ message, onLogoCl
     </BaseClearView>
   );
 };
-
-export { ErrorOccurredView };

--- a/airbyte-webapp/src/views/common/ErrorOccurredView.tsx
+++ b/airbyte-webapp/src/views/common/ErrorOccurredView.tsx
@@ -10,9 +10,14 @@ const Content = styled(ContentCard)`
   padding: 50px 15px;
 `;
 
-const ErrorOccurredView: React.FC<{ message: React.ReactNode }> = ({ message, children }) => {
+interface ErrorOccurredViewProps {
+  message: React.ReactNode;
+  onLogoClick?: React.MouseEventHandler;
+}
+
+const ErrorOccurredView: React.FC<ErrorOccurredViewProps> = ({ message, onLogoClick, children }) => {
   return (
-    <BaseClearView>
+    <BaseClearView onLogoClick={onLogoClick}>
       <Content>
         <H4 center>{message}</H4>
         {children}

--- a/airbyte-webapp/src/views/common/ResorceNotFoundErrorBoundary.tsx
+++ b/airbyte-webapp/src/views/common/ResorceNotFoundErrorBoundary.tsx
@@ -15,7 +15,7 @@ export class ResourceNotFoundErrorBoundary extends React.Component<
   BoundaryState
 > {
   static getDerivedStateFromError(error: CommonRequestError): BoundaryState {
-    if (error.status === 422 || error.status === 404 || error.status === 401) {
+    if ([401, 404, 422].includes(error.status)) {
       const messageId = error.status === 401 ? "errorView.notAuthorized" : "errorView.notFound";
       return {
         hasError: true,

--- a/airbyte-webapp/src/views/common/ResorceNotFoundErrorBoundary.tsx
+++ b/airbyte-webapp/src/views/common/ResorceNotFoundErrorBoundary.tsx
@@ -15,11 +15,11 @@ export class ResourceNotFoundErrorBoundary extends React.Component<
   BoundaryState
 > {
   static getDerivedStateFromError(error: CommonRequestError): BoundaryState {
-    console.log(error.status);
-    if (error.status === 422 || error.status === 404) {
+    if (error.status === 422 || error.status === 404 || error.status === 401) {
+      const messageId = error.status === 401 ? "errorView.notAuthorized" : "errorView.notFound";
       return {
         hasError: true,
-        message: <FormattedMessage id="errorView.notFound" />,
+        message: <FormattedMessage id={messageId} />,
       };
     } else {
       throw error;

--- a/airbyte-webapp/src/views/common/StartOverErrorView.tsx
+++ b/airbyte-webapp/src/views/common/StartOverErrorView.tsx
@@ -1,17 +1,8 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
-import styled from "styled-components";
-
-import { Button } from "components";
 
 import useRouter from "hooks/useRouter";
 import { ErrorOccurredView } from "views/common/ErrorOccurredView";
-
-const ResetSection = styled.div`
-  margin-top: 30px;
-  display: flex;
-  justify-content: space-around;
-`;
 
 export const StartOverErrorView: React.FC<{
   message?: string;
@@ -19,17 +10,12 @@ export const StartOverErrorView: React.FC<{
 }> = ({ message, onReset }) => {
   const { push } = useRouter();
   return (
-    <ErrorOccurredView message={message ?? <FormattedMessage id="errorView.notFound" />}>
-      <ResetSection>
-        <Button
-          onClick={() => {
-            push("..");
-            onReset?.();
-          }}
-        >
-          <FormattedMessage id="errorView.startOver" />
-        </Button>
-      </ResetSection>
-    </ErrorOccurredView>
+    <ErrorOccurredView
+      message={message ?? <FormattedMessage id="errorView.notFound" />}
+      onLogoClick={() => {
+        push("..");
+        onReset?.();
+      }}
+    />
   );
 };

--- a/airbyte-webapp/src/views/common/StartOverErrorView.tsx
+++ b/airbyte-webapp/src/views/common/StartOverErrorView.tsx
@@ -1,19 +1,18 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
-import useRouter from "hooks/useRouter";
 import { ErrorOccurredView } from "views/common/ErrorOccurredView";
 
-export const StartOverErrorView: React.FC<{
+interface StartOverErrorViewProps {
   message?: string;
   onReset?: () => void;
-}> = ({ message, onReset }) => {
-  const { push } = useRouter();
+}
+
+export const StartOverErrorView: React.FC<StartOverErrorViewProps> = ({ message, onReset }) => {
   return (
     <ErrorOccurredView
       message={message ?? <FormattedMessage id="errorView.notFound" />}
-      onLogoClick={() => {
-        push("..");
+      onBackClick={() => {
         onReset?.();
       }}
     />


### PR DESCRIPTION
## What
Closes #10735

Displays an error message when the user hits a 401 http status instead of the generic "An error occurred". Additionally, the "Continue using the app" button is replaced with just a clickable Airbyte logo:

![image](https://user-images.githubusercontent.com/168664/166554869-9ad95e43-c844-4580-b57b-b375c6bb24fb.png)

## How
Just check if the status is 401 and displays the appropriate message. It also cleans up the error component so that we can pass a click handler.

## Recommended reading order
Top to bottom
