### PR TITLE
generate `AirbyeTraceMessage.type` enum with descriptive class name

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
+++ b/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
@@ -60,7 +60,7 @@ class AirbyteLogMessage(BaseModel):
     message: str = Field(..., description="the log message")
 
 
-class Type1(Enum):
+class TraceType(Enum):
     ERROR = "ERROR"
 
 
@@ -161,7 +161,7 @@ class AirbyteTraceMessage(BaseModel):
     class Config:
         extra = Extra.allow
 
-    type: Type1 = Field(..., description="the type of trace message")
+    type: TraceType = Field(..., description="the type of trace message", title="trace type")
     emitted_at: float = Field(..., description="the time in ms that the message was emitted")
     error: Optional[AirbyteErrorTraceMessage] = Field(None, description="error trace message: the error object")
 

--- a/airbyte-cdk/python/bin/generate-protocol-files.sh
+++ b/airbyte-cdk/python/bin/generate-protocol-files.sh
@@ -18,6 +18,7 @@ function main() {
     docker run --user "$(id -u):$(id -g)" -v "$ROOT_DIR":/airbyte airbyte/code-generator:dev \
       --input "/airbyte/$YAML_DIR/$filename_wo_ext.yaml" \
       --output "/airbyte/$OUTPUT_DIR/$filename_wo_ext.py" \
+      --use-title-as-name \
       --disable-timestamp
   done
 }

--- a/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
+++ b/airbyte-integrations/bases/airbyte-protocol/airbyte_protocol/models/airbyte_protocol.py
@@ -57,7 +57,7 @@ class AirbyteLogMessage(BaseModel):
     message: str = Field(..., description="the log message")
 
 
-class Type1(Enum):
+class TraceType(Enum):
     ERROR = "ERROR"
 
 
@@ -157,7 +157,7 @@ class AirbyteTraceMessage(BaseModel):
     class Config:
         extra = Extra.allow
 
-    type: Type1 = Field(..., description="the type of trace message")
+    type: TraceType = Field(..., description="the type of trace message", title="trace type")
     emitted_at: float = Field(..., description="the time in ms that the message was emitted")
     error: Optional[AirbyteErrorTraceMessage] = Field(None, description="error trace message: the error object")
 

--- a/airbyte-integrations/bases/airbyte-protocol/bin/generate-protocol-files.sh
+++ b/airbyte-integrations/bases/airbyte-protocol/bin/generate-protocol-files.sh
@@ -18,6 +18,7 @@ function main() {
     docker run --user "$(id -u):$(id -g)" -v "$ROOT_DIR":/airbyte airbyte/code-generator:dev \
       --input "/airbyte/$YAML_DIR/$filename_wo_ext.yaml" \
       --output "/airbyte/$OUTPUT_DIR/$filename_wo_ext.py" \
+      --use-title-as-name \
       --disable-timestamp
   done
 }

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -106,7 +106,7 @@ definitions:
       - emitted_at
     properties:
       type:
-        title: "trace type"
+        title: "trace type" # this title is required to avoid python codegen conflicts with the "type" parameter in AirbyteMessage. See https://github.com/airbytehq/airbyte/pull/12581
         description: "the type of trace message"
         type: string
         enum:

--- a/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -106,6 +106,7 @@ definitions:
       - emitted_at
     properties:
       type:
+        title: "trace type"
         description: "the type of trace message"
         type: string
         enum:


### PR DESCRIPTION
## What
The autogenerated enum for `AirbyteTraceMessage`'s `type` property was named `Type1` because of a conflict with the existing `AirbyteMessage` type enum (named `Type`). This class name is not very descriptive.

## How
Set a `title` on the protocol definition and pass the `--use-title-as-class-name` flag to generate a better name for the enum class (`TraceType`
